### PR TITLE
feat(storage): support service account impersonation

### DIFF
--- a/google/cloud/internal/credentials.h
+++ b/google/cloud/internal/credentials.h
@@ -84,6 +84,7 @@ class CredentialsVisitor {
   virtual ~CredentialsVisitor() = default;
   virtual void visit(GoogleDefaultCredentialsConfig&) = 0;
   virtual void visit(AccessTokenConfig&) = 0;
+  virtual void visit(ImpersonateServiceAccountConfig&) = 0;
 
   static void dispatch(Credentials& credentials, CredentialsVisitor& visitor);
 };
@@ -128,8 +129,7 @@ class ImpersonateServiceAccountConfig : public Credentials {
   std::vector<std::string> const& delegates() const { return delegates_; }
 
  private:
-  // TODO(#6309) - keep unimplemented until the rest of the code is ready
-  void dispatch(CredentialsVisitor&) override {}
+  void dispatch(CredentialsVisitor& v) override { v.visit(*this); }
 
   std::shared_ptr<Credentials> base_credentials_;
   std::string target_service_account_;

--- a/google/cloud/internal/unified_grpc_credentials.h
+++ b/google/cloud/internal/unified_grpc_credentials.h
@@ -40,10 +40,11 @@ class GrpcAuthenticationStrategy {
   AsyncConfigureContext(std::unique_ptr<grpc::ClientContext> context) = 0;
 };
 
-std::unique_ptr<GrpcAuthenticationStrategy> CreateAuthenticationStrategy(
-    std::shared_ptr<Credentials> const& credentials);
+std::shared_ptr<GrpcAuthenticationStrategy> CreateAuthenticationStrategy(
+    std::shared_ptr<Credentials> const& credentials, CompletionQueue cq,
+    Options options = {});
 
-std::unique_ptr<GrpcAuthenticationStrategy> CreateAuthenticationStrategy(
+std::shared_ptr<GrpcAuthenticationStrategy> CreateAuthenticationStrategy(
     std::shared_ptr<grpc::ChannelCredentials> const& credentials);
 
 }  // namespace internal

--- a/google/cloud/internal/unified_grpc_credentials_test.cc
+++ b/google/cloud/internal/unified_grpc_credentials_test.cc
@@ -41,7 +41,9 @@ TEST(UnifiedGrpcCredentialsTest, WithDefaultCredentials) {
   // the test.
   ScopedEnvironment env("GOOGLE_APPLICATION_CREDENTIALS", "unused.json");
 
-  auto result = CreateAuthenticationStrategy(MakeGoogleDefaultCredentials());
+  CompletionQueue cq;
+  auto result =
+      CreateAuthenticationStrategy(MakeGoogleDefaultCredentials(), cq);
   ASSERT_NE(nullptr, result.get());
   grpc::ClientContext context;
   auto status = result->ConfigureContext(context);
@@ -52,8 +54,9 @@ TEST(UnifiedGrpcCredentialsTest, WithDefaultCredentials) {
 TEST(UnifiedGrpcCredentialsTest, WithAccessTokenCredentials) {
   auto const expiration =
       std::chrono::system_clock::now() + std::chrono::hours(1);
+  CompletionQueue cq;
   auto result = CreateAuthenticationStrategy(
-      MakeAccessTokenCredentials("test-token", expiration));
+      MakeAccessTokenCredentials("test-token", expiration), cq);
   ASSERT_NE(nullptr, result.get());
   grpc::ClientContext context;
   auto status = result->ConfigureContext(context);

--- a/google/cloud/storage/internal/grpc_client.h
+++ b/google/cloud/storage/internal/grpc_client.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/storage/internal/raw_client.h"
 #include "google/cloud/storage/version.h"
+#include "google/cloud/background_threads.h"
 #include "google/cloud/internal/streaming_write_rpc.h"
 #include <google/storage/v1/storage.pb.h>
 #include <memory>
@@ -325,6 +326,7 @@ class GrpcClient : public RawClient,
 
  private:
   ClientOptions backwards_compatibility_options_;
+  std::unique_ptr<google::cloud::BackgroundThreads> background_;
   std::shared_ptr<StorageStub> stub_;
 };
 

--- a/google/cloud/storage/internal/grpc_client_failures_test.cc
+++ b/google/cloud/storage/internal/grpc_client_failures_test.cc
@@ -59,9 +59,9 @@ class GrpcClientFailuresTest
                 oauth2::CreateAnonymousCredentials())
             .set<GrpcCredentialOption>(grpc::InsecureChannelCredentials());
     if (grpc_config == "metadata") {
-      client_ = GrpcClient::Create(std::move(options));
+      client_ = GrpcClient::Create(DefaultOptionsGrpc(std::move(options)));
     } else {
-      client_ = HybridClient::Create(std::move(options));
+      client_ = HybridClient::Create(DefaultOptionsGrpc(std::move(options)));
     }
   }
 

--- a/google/cloud/storage/internal/grpc_client_object_request_test.cc
+++ b/google/cloud/storage/internal/grpc_client_object_request_test.cc
@@ -433,10 +433,10 @@ TEST(GrpcClientObjectRequest, ReadObjectRangeRequestReadLastZero) {
   auto const actual = GrpcClient::ToProto(req);
   EXPECT_THAT(actual, IsProtoEqual(expected));
 
-  testing_util::ScopedEnvironment grpc_endpoint{
-      "GOOGLE_CLOUD_CPP_STORAGE_GRPC_ENDPOINT", "locahost:1"};
-  auto client = GrpcClient::Create(
-      Options{}.set<GrpcCredentialOption>(grpc::InsecureChannelCredentials()));
+  auto client = GrpcClient::Create(DefaultOptionsGrpc(
+      Options{}
+          .set<GrpcCredentialOption>(grpc::InsecureChannelCredentials())
+          .set<EndpointOption>("localhost:1")));
   StatusOr<std::unique_ptr<ObjectReadSource>> reader = client->ReadObject(req);
   EXPECT_THAT(reader, StatusIs(StatusCode::kOutOfRange));
 }

--- a/google/cloud/storage/internal/grpc_resumable_upload_session_test.cc
+++ b/google/cloud/storage/internal/grpc_resumable_upload_session_test.cc
@@ -49,8 +49,8 @@ class MockGrpcClient : public GrpcClient {
   }
 
   MockGrpcClient()
-      : GrpcClient(Options{}.set<GrpcCredentialOption>(
-                       grpc::InsecureChannelCredentials()),
+      : GrpcClient(DefaultOptionsGrpc(Options{}.set<GrpcCredentialOption>(
+                       grpc::InsecureChannelCredentials())),
                    /*channel_id=*/0) {}
 
   MOCK_METHOD(std::unique_ptr<GrpcClient::InsertStream>, CreateUploadWriter,

--- a/google/cloud/storage/internal/unified_rest_credentials.cc
+++ b/google/cloud/storage/internal/unified_rest_credentials.cc
@@ -15,6 +15,7 @@
 #include "google/cloud/storage/internal/unified_rest_credentials.h"
 #include "google/cloud/storage/internal/access_token_credentials.h"
 #include "google/cloud/storage/internal/error_credentials.h"
+#include "google/cloud/storage/internal/impersonate_service_account_credentials.h"
 #include "google/cloud/storage/oauth2/google_credentials.h"
 
 namespace google {
@@ -23,9 +24,10 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace internal {
 
-using google::cloud::internal::AccessTokenConfig;
-using google::cloud::internal::CredentialsVisitor;
-using google::cloud::internal::GoogleDefaultCredentialsConfig;
+using ::google::cloud::internal::AccessTokenConfig;
+using ::google::cloud::internal::CredentialsVisitor;
+using ::google::cloud::internal::GoogleDefaultCredentialsConfig;
+using ::google::cloud::internal::ImpersonateServiceAccountConfig;
 
 std::shared_ptr<oauth2::Credentials> MapCredentials(
     std::shared_ptr<google::cloud::internal::Credentials> const& credentials) {
@@ -44,6 +46,9 @@ std::shared_ptr<oauth2::Credentials> MapCredentials(
     }
     void visit(AccessTokenConfig& config) override {
       result = std::make_shared<AccessTokenCredentials>(config.access_token());
+    }
+    void visit(ImpersonateServiceAccountConfig& config) override {
+      result = std::make_shared<ImpersonateServiceAccountCredentials>(config);
     }
   } visitor;
 


### PR DESCRIPTION
This weaves the support for service account impersonation through the
gRPC and REST adapters. This change includes an integration test for
`google::cloud::storage` using this new credential type.

Part of the work for #6309, some cleanup afterwards and I can close it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6488)
<!-- Reviewable:end -->
