### PR TITLE
chore: update builds to Fedora:34

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -30,6 +30,13 @@
 #      class in order to document it as part of the public API, that will
 #      trigger a redundant declaration warning from this check.
 #
+#  -readability-function-cognitive-complexity: too many false positives with
+#      clang-tidy-12. We need to disable this check in macros, and that setting
+#      only appears in clang-tidy-13.
+#
+#  -bugprone-narrowing-conversions: too many false positives around
+#      `std::size_t`  vs. `*::difference_type`.
+#
 Checks: >
   -*,
   bugprone-*,
@@ -50,7 +57,9 @@ Checks: >
   -readability-braces-around-statements,
   -readability-magic-numbers,
   -readability-named-parameter,
-  -readability-redundant-declaration
+  -readability-redundant-declaration,
+  -readability-function-cognitive-complexity,
+  -bugprone-narrowing-conversions
 
 # Turn all the warnings from the checks above into errors.
 WarningsAsErrors: "*"

--- a/bazel/google_cloud_cpp_deps.bzl
+++ b/bazel/google_cloud_cpp_deps.bzl
@@ -70,6 +70,20 @@ def google_cloud_cpp_deps():
             sha256 = "e4fbb85eec69e6668ad397ec71a3a3ab165903abe98a8327db920b94508f720e",
         )
 
+    # Load BoringSSL.
+    if "boringssl" not in native.existing_rules():
+        http_archive(
+            name = "boringssl",
+            # Use github mirror instead of https://boringssl.googlesource.com/boringssl
+            # to obtain a boringssl archive with consistent sha256
+            sha256 = "f8616dff15cb8aad6705af53c7caf7a5f1103b6aaf59c76b55995e179d47f89c",
+            strip_prefix = "boringssl-688fc5cf5428868679d2ae1072cad81055752068",
+            urls = [
+                "https://storage.googleapis.com/grpc-bazel-mirror/github.com/google/boringssl/archive/688fc5cf5428868679d2ae1072cad81055752068.tar.gz",
+                "https://github.com/google/boringssl/archive/688fc5cf5428868679d2ae1072cad81055752068.tar.gz",
+            ],
+        )
+
     # Load the googleapis dependency.
     if "com_google_googleapis" not in native.existing_rules():
         http_archive(

--- a/bazel/google_cloud_cpp_deps.bzl
+++ b/bazel/google_cloud_cpp_deps.bzl
@@ -76,11 +76,10 @@ def google_cloud_cpp_deps():
             name = "boringssl",
             # Use github mirror instead of https://boringssl.googlesource.com/boringssl
             # to obtain a boringssl archive with consistent sha256
-            sha256 = "f8616dff15cb8aad6705af53c7caf7a5f1103b6aaf59c76b55995e179d47f89c",
-            strip_prefix = "boringssl-688fc5cf5428868679d2ae1072cad81055752068",
+            sha256 = "bdccd60acff8a6334c3f221d78582470e3300dafa3befc153635251b2b2e9d54",
+            strip_prefix = "boringssl-c3db502c5ca7b5a69beb65f41a3a1dc8db3d58b3",
             urls = [
-                "https://storage.googleapis.com/grpc-bazel-mirror/github.com/google/boringssl/archive/688fc5cf5428868679d2ae1072cad81055752068.tar.gz",
-                "https://github.com/google/boringssl/archive/688fc5cf5428868679d2ae1072cad81055752068.tar.gz",
+                "https://github.com/google/boringssl/archive/c3db502c5ca7b5a69beb65f41a3a1dc8db3d58b3.tar.gz",
             ],
         )
 

--- a/ci/cloudbuild/dockerfiles/fedora.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/fedora.Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG DISTRO_VERSION=33
+ARG DISTRO_VERSION=34
 FROM fedora:${DISTRO_VERSION}
 ARG NCPU=4
 

--- a/google/cloud/bigtable/app_profile_config_test.cc
+++ b/google/cloud/bigtable/app_profile_config_test.cc
@@ -26,10 +26,10 @@ TEST(AppProfileConfig, MultiClusterUseAny) {
   EXPECT_TRUE(proto.app_profile().has_multi_cluster_routing_use_any());
 
   // Verify that as_proto() for rvalue-references returns the right type.
-  static_assert(
-      std::is_rvalue_reference<decltype(
-          std::move(std::declval<AppProfileConfig>()).as_proto())>::value,
-      "Return type from as_proto() must be rvalue-reference");
+  static_assert(std::is_rvalue_reference<
+                    decltype(std::move(std::declval<AppProfileConfig>())
+                                 .as_proto())>::value,
+                "Return type from as_proto() must be rvalue-reference");
 }
 
 TEST(AppProfileConfig, SetIgnoreWarnings) {

--- a/google/cloud/bigtable/async_row_reader.h
+++ b/google/cloud/bigtable/async_row_reader.h
@@ -226,7 +226,7 @@ class AsyncRowReader : public std::enable_shared_from_this<
             "exception");
         return;
       }
-#else  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+#else   // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
       should_cancel = !fut.get();
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
       if (should_cancel) {

--- a/google/cloud/bigtable/async_row_reader_test.cc
+++ b/google/cloud/bigtable/async_row_reader_test.cc
@@ -826,7 +826,7 @@ TEST_P(TableAsyncReadRowsCancelMidStreamTest, CancelMidStream) {
 INSTANTIATE_TEST_SUITE_P(CancelMidStream, TableAsyncReadRowsCancelMidStreamTest,
                          Values(CancelMode::kFalseValue, CancelMode::kStdExcept,
                                 CancelMode::kOtherExcept));
-#else  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+#else   // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 INSTANTIATE_TEST_SUITE_P(CancelMidStream, TableAsyncReadRowsCancelMidStreamTest,
                          Values(CancelMode::kFalseValue));
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS

--- a/google/cloud/bigtable/cell.h
+++ b/google/cloud/bigtable/cell.h
@@ -51,8 +51,8 @@ Mutation SetCell(Cell);
  * write `std::string` where this type appears. For Google projects that must
  * compile both inside and outside Google, this alias may be convenient.
  */
-using ColumnQualifierType = std::decay<decltype(
-    std::declval<google::bigtable::v2::Column>().qualifier())>::type;
+using ColumnQualifierType = std::decay<
+    decltype(std::declval<google::bigtable::v2::Column>().qualifier())>::type;
 
 /**
  * Defines the type for cell values.
@@ -73,8 +73,8 @@ using ColumnQualifierType = std::decay<decltype(
  * write `std::string` where this type appears. For Google projects that must
  * compile both inside and outside Google, this alias may be convenient.
  */
-using CellValueType = std::decay<decltype(
-    std::declval<google::bigtable::v2::Cell>().value())>::type;
+using CellValueType = std::decay<
+    decltype(std::declval<google::bigtable::v2::Cell>().value())>::type;
 
 /**
  * The in-memory representation of a Bigtable cell.

--- a/google/cloud/bigtable/cluster_config_test.cc
+++ b/google/cloud/bigtable/cluster_config_test.cc
@@ -39,8 +39,8 @@ TEST(ClusterConfigTest, Move) {
   auto proto = std::move(config).as_proto();
   // Verify that as_proto() for rvalue-references returns the right type.
   static_assert(
-      std::is_rvalue_reference<decltype(
-          std::move(std::declval<ClusterConfig>()).as_proto())>::value,
+      std::is_rvalue_reference<
+          decltype(std::move(std::declval<ClusterConfig>()).as_proto())>::value,
       "Return type from as_proto() must be rvalue-reference");
   EXPECT_EQ("somewhere", proto.location());
   EXPECT_EQ(7, proto.serve_nodes());

--- a/google/cloud/bigtable/filters_test.cc
+++ b/google/cloud/bigtable/filters_test.cc
@@ -392,8 +392,8 @@ TEST(FiltersTest, MoveProto) {
   ASSERT_FALSE(filter.as_proto().has_chain());
 
   // Verify that as_proto() for rvalue-references returns the right type.
-  static_assert(std::is_rvalue_reference<decltype(
-                    std::move(std::declval<F>()).as_proto())>::value,
+  static_assert(std::is_rvalue_reference<
+                    decltype(std::move(std::declval<F>()).as_proto())>::value,
                 "Return type from as_proto() must be rvalue-reference");
 
   EXPECT_THAT(proto_copy, IsProtoEqual(proto_move));

--- a/google/cloud/internal/invoke_result.h
+++ b/google/cloud/internal/invoke_result.h
@@ -154,8 +154,8 @@ template <typename F, typename... ArgTypes>
 struct invoke_result_impl<decltype(void(invoker_function(
                               std::declval<F>(), std::declval<ArgTypes>()...))),
                           F, ArgTypes...> {
-  using type = decltype(
-      invoker_function(std::declval<F>(), std::declval<ArgTypes>()...));
+  using type = decltype(invoker_function(std::declval<F>(),
+                                         std::declval<ArgTypes>()...));
 };
 
 /**

--- a/google/cloud/pubsub/message.h
+++ b/google/cloud/pubsub/message.h
@@ -65,8 +65,8 @@ class MessageBuilder;
  * write `std::string` where this type appears. For Google projects that must
  * compile both inside and outside Google, this alias may be convenient.
  */
-using PubsubMessageDataType = std::decay<decltype(
-    std::declval<google::pubsub::v1::PubsubMessage>().data())>::type;
+using PubsubMessageDataType = std::decay<
+    decltype(std::declval<google::pubsub::v1::PubsubMessage>().data())>::type;
 
 /**
  * The C++ representation for a Cloud Pub/Sub messages.

--- a/google/cloud/spanner/mutations_test.cc
+++ b/google/cloud/spanner/mutations_test.cc
@@ -362,11 +362,11 @@ TEST(MutationsTest, FluentUpdateBuilder) {
 
 TEST(MutationsTest, FluentInsertOrUpdateBuilder) {
   static_assert(
-      std::is_rvalue_reference<decltype(
-          std::declval<InsertOrUpdateMutationBuilder>()
-              .EmplaceRow()
-              .AddRow({})
-              .Build())>::value,
+      std::is_rvalue_reference<
+          decltype(std::declval<InsertOrUpdateMutationBuilder>()
+                       .EmplaceRow()
+                       .AddRow({})
+                       .Build())>::value,
       "Build() should return an rvalue if called fluently on a temporary");
 
   std::string const data(128, 'x');
@@ -403,8 +403,8 @@ TEST(MutationsTest, FluentReplaceBuilder) {
 
 TEST(MutationsTest, FluentDeleteBuilder) {
   static_assert(
-      std::is_rvalue_reference<decltype(
-          std::declval<DeleteMutationBuilder>().Build())>::value,
+      std::is_rvalue_reference<
+          decltype(std::declval<DeleteMutationBuilder>().Build())>::value,
       "Build() should return an rvalue if called fluently on a temporary");
 
   auto ks = KeySet().AddKey(MakeKey("key-to-delete"));

--- a/google/cloud/storage/client.cc
+++ b/google/cloud/storage/client.cc
@@ -129,9 +129,9 @@ StatusOr<ObjectMetadata> Client::UploadFileSimple(
        << ") is bigger than the size of file source (" << file_size << ")";
     return Status(StatusCode::kInvalidArgument, std::move(os).str());
   }
-  auto upload_size = (std::min)(
-      request.GetOption<UploadLimit>().value_or(file_size - upload_offset),
-      file_size - upload_offset);
+  auto upload_size = (std::min)(request.GetOption<UploadLimit>().value_or(
+                                    file_size - upload_offset),
+                                file_size - upload_offset);
 
   std::ifstream is(file_name, std::ios::binary);
   if (!is.is_open()) {
@@ -189,9 +189,9 @@ integrity checks using the DisableMD5Hash() and DisableCrc32cChecksum() options.
       return Status(StatusCode::kInvalidArgument, std::move(os).str());
     }
 
-    auto upload_size = (std::min)(
-        request.GetOption<UploadLimit>().value_or(file_size - upload_offset),
-        file_size - upload_offset);
+    auto upload_size = (std::min)(request.GetOption<UploadLimit>().value_or(
+                                      file_size - upload_offset),
+                                  file_size - upload_offset);
     request.set_option(UploadContentLength(upload_size));
   }
   std::ifstream source(file_name, std::ios::binary);

--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -3358,10 +3358,10 @@ Status DeleteByPrefix(Client& client, std::string const& bucket_name,
   auto all_options = std::tie(options...);
 
   static_assert(
-      std::tuple_size<decltype(
-              StaticTupleFilter<
-                  NotAmong<QuotaUser, UserIp, UserProject, Versions>::TPred>(
-                  all_options))>::value == 0,
+      std::tuple_size<
+          decltype(StaticTupleFilter<
+                   NotAmong<QuotaUser, UserIp, UserProject, Versions>::TPred>(
+              all_options))>::value == 0,
       "This functions accepts only options of type QuotaUser, UserIp, "
       "UserProject or Versions.");
   for (auto const& object :
@@ -3494,12 +3494,13 @@ StatusOr<ObjectMetadata> ComposeMany(
 
   // TODO(#3247): this list of type should somehow be generated
   static_assert(
-      std::tuple_size<decltype(
-              StaticTupleFilter<NotAmong<
-                  DestinationPredefinedAcl, EncryptionKey, IfGenerationMatch,
-                  IfMetagenerationMatch, KmsKeyName, QuotaUser, UserIp,
-                  UserProject, WithObjectMetadata>::TPred>(
-                  all_options))>::value == 0,
+      std::tuple_size<
+          decltype(StaticTupleFilter<
+                   NotAmong<DestinationPredefinedAcl, EncryptionKey,
+                            IfGenerationMatch, IfMetagenerationMatch,
+                            KmsKeyName, QuotaUser, UserIp, UserProject,
+                            WithObjectMetadata>::TPred>(all_options))>::value ==
+          0,
       "This functions accepts only options of type DestinationPredefinedAcl, "
       "EncryptionKey, IfGenerationMatch, IfMetagenerationMatch, KmsKeyName, "
       "QuotaUser, UserIp, UserProject or WithObjectMetadata.");

--- a/google/cloud/storage/internal/policy_document_request.cc
+++ b/google/cloud/storage/internal/policy_document_request.cc
@@ -97,7 +97,7 @@ StatusOr<std::string> PostPolicyV4EscapeUTF8(std::string const& utf8_bytes) {
   // Context:
   // https://social.msdn.microsoft.com/Forums/en-US/8f40dcd8-c67f-4eba-9134-a19b9178e481/vs-2015-rc-linker-stdcodecvt-error?forum=vcgeneral
   using WideChar = __int32;
-#else  // (_MSC_VER >= 1900)
+#else   // (_MSC_VER >= 1900)
   using WideChar = char32_t;
 #endif  // (_MSC_VER >= 1900)
   std::wstring_convert<std::codecvt_utf8<WideChar>, WideChar> conv;
@@ -121,7 +121,7 @@ StatusOr<std::string> PostPolicyV4EscapeUTF8(std::string const& utf8_bytes) {
   }
   return result;
 }
-#else  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+#else   // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 StatusOr<std::string> PostPolicyV4EscapeUTF8(std::string const&) {
   return Status(StatusCode::kUnimplemented,
                 "Signing POST policies is unavailable with this compiler due "

--- a/google/cloud/storage/internal/policy_document_request_test.cc
+++ b/google/cloud/storage/internal/policy_document_request_test.cc
@@ -77,7 +77,7 @@ TEST(PostPolicyV4EscapeTest, Simple) {
   EXPECT_EQ("\127\065abcd$", *PostPolicyV4Escape("\127\065abcd$"));
   EXPECT_EQ("\\\\b\\f\\n\\r\\t\\v\\u0080\\u0119",
             *PostPolicyV4Escape(u8"\\\b\f\n\r\t\v\u0080\u0119"));
-#else  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+#else   // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
   EXPECT_THAT(PostPolicyV4Escape("ąę"), StatusIs(StatusCode::kUnimplemented));
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 }

--- a/google/cloud/storage/lifecycle_rule.cc
+++ b/google/cloud/storage/lifecycle_rule.cc
@@ -165,8 +165,9 @@ void LifecycleRule::MergeConditions(LifecycleRuleCondition& result,
   }
   if (rhs.days_since_noncurrent_time.has_value()) {
     if (result.days_since_noncurrent_time.has_value()) {
-      result.days_since_noncurrent_time = (std::max)(
-          *result.days_since_noncurrent_time, *rhs.days_since_noncurrent_time);
+      result.days_since_noncurrent_time =
+          (std::max)(*result.days_since_noncurrent_time,
+                     *rhs.days_since_noncurrent_time);
     } else {
       result.days_since_noncurrent_time = *rhs.days_since_noncurrent_time;
     }

--- a/google/cloud/storage/testing/object_integration_test.cc
+++ b/google/cloud/storage/testing/object_integration_test.cc
@@ -42,7 +42,7 @@ StatusOr<std::size_t> GetNumEntries(std::string const& path) {
   }
   closedir(dir);
   return count;
-#else  // __unix__
+#else   // __unix__
   return Status(StatusCode::kUnimplemented,
                 "Can't check #entries in " + path +
                     ", because only UNIX systems are supported");


### PR DESCRIPTION
Change the dockerfile to use Fedora:34. Turned off noisy warnings in
clang-tidy. Reformat the code using the latest clang-format.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6493)
<!-- Reviewable:end -->
