### PR TITLE
ci: move `cmake-oldest-deps` build to Ubuntu:20.04

### DIFF
--- a/ci/cloudbuild/dockerfiles/ubuntu-focal.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/ubuntu-focal.Dockerfile
@@ -1,0 +1,71 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG DISTRO_VERSION=20.04
+FROM ubuntu:${DISTRO_VERSION}
+ARG NCPU=4
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && \
+    apt-get --no-install-recommends install -y \
+        automake \
+        build-essential \
+        ccache \
+        clang \
+        clang-9 \
+        cmake \
+        ctags \
+        curl \
+        gawk \
+        git \
+        gcc \
+        g++ \
+        cmake \
+        libcurl4-openssl-dev \
+        libssl-dev \
+        libtool \
+        llvm-9 \
+        lsb-release \
+        make \
+        ninja-build \
+        patch \
+        pkg-config \
+        python3 \
+        python3-dev \
+        python3-pip \
+        tar \
+        unzip \
+        zip \
+        wget \
+        zlib1g-dev \
+        apt-utils \
+        ca-certificates \
+        apt-transport-https
+
+# Install Python packages used in the integration tests.
+RUN update-alternatives --install /usr/bin/python python $(which python3) 10
+RUN pip3 install setuptools wheel
+
+# Install the Cloud SDK and some of the emulators. We use the emulators to run
+# integration tests for the client libraries.
+COPY . /var/tmp/ci
+WORKDIR /var/tmp/downloads
+RUN /var/tmp/ci/install-cloud-sdk.sh
+ENV CLOUD_SDK_LOCATION=/usr/local/google-cloud-sdk
+ENV PATH=${CLOUD_SDK_LOCATION}/bin:${PATH}
+# The Cloud Pub/Sub emulator needs Java :shrug:
+RUN apt update && (apt install -y openjdk-11-jre || apt install -y openjdk-9-jre)
+
+# Install Bazel because some of the builds need it.
+RUN /var/tmp/ci/install-bazel.sh

--- a/ci/cloudbuild/triggers/cmake-oldest-deps-ci.yaml
+++ b/ci/cloudbuild/triggers/cmake-oldest-deps-ci.yaml
@@ -7,7 +7,7 @@ github:
 name: cmake-oldest-deps-ci
 substitutions:
   _BUILD_NAME: cmake-oldest-deps
-  _DISTRO: fedora
+  _DISTRO: ubuntu-focal
   _TRIGGER_TYPE: ci
 tags:
 - ci

--- a/ci/cloudbuild/triggers/cmake-oldest-deps-pr.yaml
+++ b/ci/cloudbuild/triggers/cmake-oldest-deps-pr.yaml
@@ -8,7 +8,7 @@ github:
 name: cmake-oldest-deps-pr
 substitutions:
   _BUILD_NAME: cmake-oldest-deps
-  _DISTRO: fedora
+  _DISTRO: ubuntu-focal
   _TRIGGER_TYPE: pr
 tags:
 - pr


### PR DESCRIPTION
Picking Fedora to run the `cmake-oldest-deps` build was not a great idea
(it was mine). Fedora moves fast, picking new compilers very 6 months,
and dropping support every 12 months. We want this build to use
something more stable. This change moves the build to Ubuntu:20.04
(Focal Fossa), it was released in 2020-04, should remain supported until
2025-04. Most likely we will be forced to update the minimum version for
our deps before then.

In case you are wondering: yes, the older versions of our deps do not
compile with Fedora:34.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6497)
<!-- Reviewable:end -->
