### PR TITLE
cleanup: consolidate unified credentials public APIs

### DIFF
--- a/ci/custom-words.txt
+++ b/ci/custom-words.txt
@@ -19,6 +19,7 @@ GCPCXX
 goog
 grpc
 gtest
+GUAC
 INPROCESS
 i'th
 JWTs

--- a/google/cloud/internal/credentials.cc
+++ b/google/cloud/internal/credentials.cc
@@ -36,15 +36,15 @@ std::shared_ptr<Credentials> MakeAccessTokenCredentials(
   return std::make_shared<AccessTokenConfig>(access_token, expiration);
 }
 
-std::shared_ptr<ImpersonateServiceAccountConfig>
-MakeImpersonateServiceAccountCredentials(
+std::shared_ptr<Credentials> MakeImpersonateServiceAccountCredentials(
     std::shared_ptr<Credentials> base_credentials,
     std::string target_service_account, Options opts) {
   opts = MergeOptions(
       std::move(opts),
       Options{}
           .set<ScopesOption>({"https://www.googleapis.com/auth/cloud-platform"})
-          .set<LifetimeOption>(std::chrono::seconds(std::chrono::hours(1))));
+          .set<AccessTokenLifetimeOption>(
+              std::chrono::seconds(std::chrono::hours(1))));
   return std::make_shared<ImpersonateServiceAccountConfig>(
       std::move(base_credentials), std::move(target_service_account),
       std::move(opts));
@@ -55,7 +55,7 @@ ImpersonateServiceAccountConfig::ImpersonateServiceAccountConfig(
     std::string target_service_account, Options opts)
     : base_credentials_(std::move(base_credentials)),
       target_service_account_(std::move(target_service_account)),
-      lifetime_(opts.get<LifetimeOption>()),
+      lifetime_(opts.get<AccessTokenLifetimeOption>()),
       scopes_(std::move(opts.lookup<ScopesOption>())),
       delegates_(std::move(opts.lookup<DelegatesOption>())) {}
 

--- a/google/cloud/internal/credentials.h
+++ b/google/cloud/internal/credentials.h
@@ -34,6 +34,30 @@ class CredentialsVisitor;
 
 // TODO(#6293) - move unified credentials out of internal namespace
 namespace internal {
+/**
+ * The public interface for Google's Unified Auth Client (GUAC) library.
+ *
+ * The Unified Auth Client library allows C++ applications to configure
+ * authentication for both REST-based and gRPC-based client libraries. The
+ * library public interface is (intentionally) very narrow. Applications
+ * describe the type of authentication they want, the libraries used this
+ * description to initialize the internal components used in the authentication
+ * flows.
+ *
+ * @par Limitations
+ * The C++ GUAC library does not allow applications to create their own
+ * credential types. It is not possible to extend the GUAC library without
+ * changing internal components. If you need additional functionality please
+ * file a [feature request] on GitHub. Likewise, creating the components that
+ * implement (as opposed to *describing*) authentication flows are also
+ * considered implementation details. If you would like to use them in your
+ * own libraries please file a [feature request].
+ *
+ * @see https://cloud.google.com/docs/authentication for more information on
+ *     authentication in GCP.
+ *
+ * [feature request]: https://github.com/googleapis/google-cloud-cpp/issues
+ */
 class Credentials {
  public:
   virtual ~Credentials() = 0;
@@ -43,20 +67,99 @@ class Credentials {
   virtual void dispatch(CredentialsVisitor& visitor) = 0;
 };
 
+/**
+ * Creates the default credentials.
+ *
+ * These are the most commonly used credentials, and are expected to meet the
+ * needs of most applications. The Google Default Credentials conform to
+ * [aip/4110]. Consider using these credentials when:
+ *
+ * - Your application is deployed to a GCP environment such as GCE, GKE, or
+ *   Cloud Run. Each of these deployment environments provides a default service
+ *   account to the application, and offers mechanisms to change the default
+ *   credentials without any code changes to your application.
+ * - You are testing or developing the application on a workstation (physical or
+ *   virtual). These credentials will use your preferences as set with
+ *   [gcloud auth application-default]. These preferences can be your own GCP
+ *   user credentials, or some service account.
+ * - Regardless of where your application is running, you can use the
+ *   `GOOGLE_APPLICATION_CREDENTIALS` environment variable to override the
+ *   defaults. This environment variable should point to a file containing a
+ *   service account key file, or a JSON object describing your user
+ *   credentials.
+ *
+ * @see https://cloud.google.com/docs/authentication for more information on
+ *     authentication in GCP.
+ *
+ * [aip/4110]: https://google.aip.dev/auth/4110
+ * [gcloud auth application-default]:
+ * https://cloud.google.com/sdk/gcloud/reference/auth/application-default
+ */
 std::shared_ptr<Credentials> MakeGoogleDefaultCredentials();
+
+/**
+ * Creates credentials with a fixed access token.
+ *
+ * These credentials are useful when using an out-of-band mechanism to fetch
+ * access tokens. Note that access tokens are time limited, you will need to
+ * manually refresh the tokens created by the
+ *
+ * @see https://cloud.google.com/docs/authentication for more information on
+ *     authentication in GCP.
+ */
 std::shared_ptr<Credentials> MakeAccessTokenCredentials(
     std::string const& access_token,
     std::chrono::system_clock::time_point expiration);
 
+/**
+ * Creates credentials for service account impersonation.
+ *
+ * Service account impersonation allows one account (user or service account)
+ * to *act as* a second account. This can be useful in multi-tenant services,
+ * where the service may perform some actions with an specific account
+ * associated with a tenant. The tenant can grant or restrict permissions to
+ * this tenant account.
+ *
+ * When using service account impersonation is important to distinguish between
+ * the credentials used to *obtain* the target account credentials (the
+ * @p base_credentials) parameter, and the credentials representing the
+ * @p target_service_account.
+ *
+ * Use `AccessTokenLifetimeOption` to configure the maximum lifetime of the
+ * obtained credentials.  The default is 1h (3600s), see [IAM quotas] for the
+ * limits set by the platform and how to override them.
+ *
+ * Use `DelegatesOption` to configure a sequence of intermediate service
+ * account, each of which has permissions to impersonate the next and the
+ * last one has permissions to impersonate @p target_service_account.
+ *
+ * Use `ScopesOption` to restrict the authentication scope for the obtained
+ * credentials. See below for possible values.
+ *
+ * [IAM quotas]: https://cloud.google.com/iam/quotas
+ * @see https://cloud.google.com/docs/authentication for more information on
+ *     authentication in GCP.
+ * @see https://cloud.google.com/iam/docs/impersonating-service-accounts for
+ *     information on managing service account impersonation.
+ * @see https://developers.google.com/identity/protocols/oauth2/scopes for
+ *     authentication scopes in Google Cloud Platform.
+ */
+std::shared_ptr<Credentials> MakeImpersonateServiceAccountCredentials(
+    std::shared_ptr<Credentials> base_credentials,
+    std::string target_service_account, Options opts = {});
+
+/// Configure the delegates for `MakeImpersonateServiceAccountCredentials()`
 struct DelegatesOption {
   using Type = std::vector<std::string>;
 };
 
+/// Configure the scopes for `MakeImpersonateServiceAccountCredentials()`
 struct ScopesOption {
   using Type = std::vector<std::string>;
 };
 
-struct LifetimeOption {
+/// Configure the access token lifetime
+struct AccessTokenLifetimeOption {
   using Type = std::chrono::seconds;
 };
 
@@ -137,11 +240,6 @@ class ImpersonateServiceAccountConfig : public Credentials {
   std::vector<std::string> scopes_;
   std::vector<std::string> delegates_;
 };
-
-std::shared_ptr<ImpersonateServiceAccountConfig>
-MakeImpersonateServiceAccountCredentials(
-    std::shared_ptr<Credentials> base_credentials,
-    std::string target_service_account, Options opts = {});
 
 }  // namespace internal
 }  // namespace GOOGLE_CLOUD_CPP_NS

--- a/google/cloud/internal/credentials_test.cc
+++ b/google/cloud/internal/credentials_test.cc
@@ -24,6 +24,7 @@ namespace {
 
 using ::testing::ElementsAre;
 using ::testing::IsEmpty;
+using ::testing::IsNull;
 
 struct Visitor : public CredentialsVisitor {
   std::string name;
@@ -65,36 +66,33 @@ TEST(Credentials, AccessTokenCredentials) {
 TEST(Credentials, ImpersonateServiceAccountCredentialsDefault) {
   auto credentials = MakeImpersonateServiceAccountCredentials(
       MakeGoogleDefaultCredentials(), "invalid-test-only@invalid.address");
+  Visitor visitor;
+  CredentialsVisitor::dispatch(*credentials, visitor);
+  ASSERT_THAT(visitor.impersonate, Not(IsNull()));
   EXPECT_EQ("invalid-test-only@invalid.address",
-            credentials->target_service_account());
-  EXPECT_EQ(std::chrono::hours(1), credentials->lifetime());
-  EXPECT_THAT(credentials->scopes(),
+            visitor.impersonate->target_service_account());
+  EXPECT_EQ(std::chrono::hours(1), visitor.impersonate->lifetime());
+  EXPECT_THAT(visitor.impersonate->scopes(),
               ElementsAre("https://www.googleapis.com/auth/cloud-platform"));
-  EXPECT_THAT(credentials->delegates(), IsEmpty());
+  EXPECT_THAT(visitor.impersonate->delegates(), IsEmpty());
 }
 
 TEST(Credentials, ImpersonateServiceAccountCredentialsDefaultWithOptions) {
   auto credentials = MakeImpersonateServiceAccountCredentials(
       MakeGoogleDefaultCredentials(), "invalid-test-only@invalid.address",
       Options{}
-          .set<LifetimeOption>(std::chrono::minutes(15))
+          .set<AccessTokenLifetimeOption>(std::chrono::minutes(15))
           .set<ScopesOption>({"scope1", "scope2"})
           .set<DelegatesOption>({"delegate1", "delegate2"}));
-  EXPECT_EQ("invalid-test-only@invalid.address",
-            credentials->target_service_account());
-  EXPECT_EQ(std::chrono::minutes(15), credentials->lifetime());
-  EXPECT_THAT(credentials->scopes(), ElementsAre("scope1", "scope2"));
-  EXPECT_THAT(credentials->delegates(), ElementsAre("delegate1", "delegate2"));
-}
-
-TEST(Credentials, ImpersonateServiceAccountCredentialsVisit) {
   Visitor visitor;
-
-  auto credentials = MakeImpersonateServiceAccountCredentials(
-      MakeGoogleDefaultCredentials(), "invalid-test-only@invalid.address");
   CredentialsVisitor::dispatch(*credentials, visitor);
-  ASSERT_EQ("ImpersonateServiceAccountConfig", visitor.name);
-  EXPECT_EQ(visitor.impersonate, credentials.get());
+  ASSERT_THAT(visitor.impersonate, Not(IsNull()));
+  EXPECT_EQ("invalid-test-only@invalid.address",
+            visitor.impersonate->target_service_account());
+  EXPECT_EQ(std::chrono::minutes(15), visitor.impersonate->lifetime());
+  EXPECT_THAT(visitor.impersonate->scopes(), ElementsAre("scope1", "scope2"));
+  EXPECT_THAT(visitor.impersonate->delegates(),
+              ElementsAre("delegate1", "delegate2"));
 }
 
 }  // namespace

--- a/google/cloud/internal/grpc_impersonate_service_account_integration_test.cc
+++ b/google/cloud/internal/grpc_impersonate_service_account_integration_test.cc
@@ -31,9 +31,13 @@ inline namespace GOOGLE_CLOUD_CPP_NS {
 namespace internal {
 namespace {
 
-using google::bigtable::admin::v2::GetTableRequest;
-using google::bigtable::admin::v2::Table;
-using google::cloud::internal::LogWrapper;
+using ::google::bigtable::admin::v2::GetTableRequest;
+using ::google::bigtable::admin::v2::Table;
+using ::google::cloud::internal::ImpersonateServiceAccountConfig;
+using ::google::cloud::internal::LogWrapper;
+using ::google::cloud::internal::MakeImpersonateServiceAccountCredentials;
+using ::testing::IsNull;
+using ::testing::Not;
 
 class GrpcImpersonateServiceAccountIntegrationTest
     : public ::google::cloud::testing_util::IntegrationTest {
@@ -196,8 +200,11 @@ std::shared_ptr<TestStub> MakeTestStub(
 
 TEST_F(GrpcImpersonateServiceAccountIntegrationTest, BlockingCallWithToken) {
   AutomaticallyCreatedBackgroundThreads background;
-  auto config = MakeImpersonateServiceAccountCredentials(
-      MakeGoogleDefaultCredentials(), iam_service_account());
+  auto credentials = MakeImpersonateServiceAccountCredentials(
+      MakeGoogleDefaultCredentials(), iam_service_account(), Options{});
+  auto* config =
+      dynamic_cast<ImpersonateServiceAccountConfig*>(credentials.get());
+  ASSERT_THAT(config, Not(IsNull()));
   auto under_test = GrpcImpersonateServiceAccount::Create(
       background.cq(), *config,
       Options{}.set<TracingComponentsOption>({"rpc"}));
@@ -233,8 +240,11 @@ TEST_F(GrpcImpersonateServiceAccountIntegrationTest, BlockingCallWithToken) {
 
 TEST_F(GrpcImpersonateServiceAccountIntegrationTest, AsyncCallWithToken) {
   AutomaticallyCreatedBackgroundThreads background;
-  auto config = MakeImpersonateServiceAccountCredentials(
-      MakeGoogleDefaultCredentials(), iam_service_account());
+  auto credentials = MakeImpersonateServiceAccountCredentials(
+      MakeGoogleDefaultCredentials(), iam_service_account(), Options{});
+  auto* config =
+      dynamic_cast<ImpersonateServiceAccountConfig*>(credentials.get());
+  ASSERT_THAT(config, Not(IsNull()));
   auto under_test = GrpcImpersonateServiceAccount::Create(
       background.cq(), *config,
       Options{}.set<TracingComponentsOption>({"rpc"}));

--- a/google/cloud/storage/internal/impersonate_service_account_credentials_test.cc
+++ b/google/cloud/storage/internal/impersonate_service_account_credentials_test.cc
@@ -25,7 +25,7 @@ namespace internal {
 namespace {
 
 using ::google::cloud::internal::AccessToken;
-using ::google::cloud::internal::LifetimeOption;
+using ::google::cloud::internal::AccessTokenLifetimeOption;
 using ::google::cloud::testing_util::IsOk;
 using ::std::chrono::minutes;
 using ::testing::EndsWith;
@@ -49,12 +49,11 @@ TEST(ImpersonateServiceAccountCredentialsTest, Basic) {
       .WillOnce(
           Return(make_status_or(AccessToken{"token2", now + minutes(30)})));
 
-  auto config =
-      google::cloud::internal::MakeImpersonateServiceAccountCredentials(
-          google::cloud::internal::MakeGoogleDefaultCredentials(),
-          "test-only-invalid@test.invalid",
-          Options{}.set<LifetimeOption>(std::chrono::minutes(15)));
-  ImpersonateServiceAccountCredentials under_test(*config, mock);
+  auto config = google::cloud::internal::ImpersonateServiceAccountConfig(
+      google::cloud::internal::MakeGoogleDefaultCredentials(),
+      "test-only-invalid@test.invalid",
+      Options{}.set<AccessTokenLifetimeOption>(std::chrono::minutes(15)));
+  ImpersonateServiceAccountCredentials under_test(config, mock);
 
   for (auto const i : {1, 5, 9}) {
     SCOPED_TRACE("Testing with i = " + std::to_string(i));


### PR DESCRIPTION
Also documented the public APIs, and fixed the return type for the
service account impersonation case. The APIs are still in `internal::`,
but it will be easier to move them.

This one fixes #6309 for realsies :face_with_head_bandage:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6500)
<!-- Reviewable:end -->
