### PR TITLE
fix(storage): compile with GCC 11 in C++17 mode

### DIFF
--- a/google/cloud/storage/internal/curl_handle.h
+++ b/google/cloud/storage/internal/curl_handle.h
@@ -74,6 +74,14 @@ class CurlHandle {
     ThrowSetOptionError(e, option, std::forward<T>(param));
   }
 
+  void SetOption(CURLoption option, std::nullptr_t) {
+    auto e = curl_easy_setopt(handle_.get(), option, nullptr);
+    if (e == CURLE_OK) {
+      return;
+    }
+    ThrowSetOptionError(e, option, static_cast<void*>(nullptr));
+  }
+
   Status EasyPerform() {
     auto e = curl_easy_perform(handle_.get());
     return AsStatus(e, __func__);


### PR DESCRIPTION
I think the compiler caught me doing naughty things with
`std::nullptr_t`, `nullptr`, and C functions consuming varargs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6501)
<!-- Reviewable:end -->
