### PR TITLE
ci: make Fedora version configurable

### DIFF
--- a/ci/cloudbuild/build.sh
+++ b/ci/cloudbuild/build.sh
@@ -18,6 +18,7 @@
 #
 #   Options:
 #     --distro=<name>      The distro name to use
+#     --distro-version=<v> The distro version to use
 #     -t|--trigger         The trigger file to extract the build name and distro
 #     -l|--local           Run the build in the local environment
 #     -d|--docker          Run the build in a local docker
@@ -67,6 +68,9 @@
 #   Runs the asan/integration tests in the cloud-cpp-testing-resources project
 #   $ build.sh -t asan-pr --project cloud-cpp-testing-resources
 #
+#   Runs a build with a non-standard version of the distro
+#   $ build.sh --distro fedora --distro-version 35 asan
+#
 #   Runs the checkers in your local docker
 #   NOTE: This is a good way to format your code and check for style issues.
 #   $ build.sh -t checkers-pr --docker
@@ -85,12 +89,13 @@ function print_usage() {
 # Use getopt to parse and normalize all the args.
 PARSED="$(getopt -a \
   --options="p:t:ldsh" \
-  --longoptions="distro:,project:,trigger:,local,docker,docker-shell,help" \
+  --longoptions="distro:,distro-version:,project:,trigger:,local,docker,docker-shell,help" \
   --name="${PROGRAM_NAME}" \
   -- "$@")"
 eval set -- "${PARSED}"
 
 DISTRO_FLAG=""
+DISTRO_VERSION_FLAG=""
 PROJECT_FLAG=""
 TRIGGER_FLAG=""
 LOCAL_FLAG="false"
@@ -100,6 +105,10 @@ while true; do
   case "$1" in
   --distro)
     DISTRO_FLAG="$2"
+    shift 2
+    ;;
+  --distro-version)
+    DISTRO_VERSION_FLAG="$2"
     shift 2
     ;;
   -p | --project)
@@ -144,10 +153,12 @@ if [[ -n "${TRIGGER_FLAG}" ]]; then
     io::log_red "Cannot open ${trigger_file}"
     exit 1
   fi
-  build="$(grep _BUILD_NAME "${trigger_file}" | awk '{print $2}')"
-  distro="$(grep _DISTRO "${trigger_file}" | awk '{print $2}')"
+  build="$(grep _BUILD_NAME: "${trigger_file}" | awk '{print $2}')"
+  distro="$(grep _DISTRO: "${trigger_file}" | awk '{print $2}')"
+  distro_version="$(grep _DISTRO_VERSION: "${trigger_file}" | awk '{print $2}')"
   test -z "${BUILD_NAME}" && BUILD_NAME="${build}"
   test -z "${DISTRO_FLAG}" && DISTRO_FLAG="${distro}"
+  test -z "${DISTRO_VERSION_FLAG}" && DISTRO_VERSION_FLAG="${distro_version}"
 fi
 readonly BUILD_NAME
 readonly DISTRO_FLAG
@@ -235,8 +246,18 @@ if [[ "${DOCKER_FLAG}" = "true" ]]; then
   # will be created by the docker daemon as root-owned directories.
   mkdir -p "${out_cmake}" "${out_home}/.config/gcloud"
   image="gcb-${DISTRO_FLAG}:latest"
+  if [[ -n "${DISTRO_VERSION_FLAG}" ]]; then
+    image="gcb-${DISTRO_FLAG}-${DISTRO_VERSION_FLAG}:latest"
+  fi
   io::log_h2 "Building docker image: ${image}"
-  docker build -t "${image}" "--build-arg=NCPU=$(nproc)" \
+  build_flags=(
+    "-t" "${image}"
+    "--build-arg=NCPU=$(nproc)"
+  )
+  if [[ -n "${DISTRO_VERSION_FLAG}" ]]; then
+    build_flags+=("--build-arg=DISTRO_VERSION=${DISTRO_VERSION_FLAG}")
+  fi
+  docker build "${build_flags[@]}" \
     -f "ci/cloudbuild/dockerfiles/${DISTRO_FLAG}.Dockerfile" ci
   io::log_h2 "Starting docker container: ${image}"
   run_flags=(

--- a/ci/cloudbuild/cloudbuild.yaml
+++ b/ci/cloudbuild/cloudbuild.yaml
@@ -37,6 +37,7 @@ options:
 # the `--substitutions=_FOO=bar` flag.
 substitutions:
   _DISTRO: 'unknown'
+  _DISTRO_VERSION: 'unknown'
   _BUILD_NAME: 'unknown'
   _CACHE_BUCKET: '${PROJECT_ID}_cloudbuild'
   _IMAGE: 'cloudbuild/${_DISTRO}'
@@ -66,6 +67,8 @@ steps:
 - name: 'gcr.io/kaniko-project/executor:edge'
   args: [
     '--context=dir:///workspace/ci',
+    # TODO(#6502) - add this when the triggers and Dockerfiles are ready
+    #     '--build-arg=DISTRO_VERSION=${_DISTRO_VERSION}',
     '--dockerfile=ci/cloudbuild/dockerfiles/${_DISTRO}.Dockerfile',
     '--cache=true',
     '--destination=gcr.io/${PROJECT_ID}/${_IMAGE}:${BUILD_ID}',

--- a/ci/cloudbuild/dockerfiles/demo-centos-7.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-centos-7.Dockerfile
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG DISTRO_VERSION=7
-FROM centos:${DISTRO_VERSION}
+FROM centos:7
 ARG NCPU=4
 
 ## [BEGIN packaging.md]

--- a/ci/cloudbuild/dockerfiles/demo-centos-8.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-centos-8.Dockerfile
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG DISTRO_VERSION=8
-FROM centos:${DISTRO_VERSION}
+FROM centos:8
 ARG NCPU=4
 
 ## [BEGIN packaging.md]

--- a/ci/cloudbuild/dockerfiles/demo-debian-buster.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-debian-buster.Dockerfile
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG DISTRO_VERSION=buster
-FROM debian:${DISTRO_VERSION}
+FROM debian:buster
 ARG NCPU=4
 
 ## [BEGIN packaging.md]

--- a/ci/cloudbuild/dockerfiles/demo-debian-stretch.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-debian-stretch.Dockerfile
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG DISTRO_VERSION=stretch
-FROM debian:${DISTRO_VERSION}
+FROM debian:stretch
 ARG NCPU=4
 
 ## [BEGIN packaging.md]

--- a/ci/cloudbuild/dockerfiles/demo-opensuse-leap.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-opensuse-leap.Dockerfile
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG DISTRO_VERSION=latest
-FROM opensuse/leap:${DISTRO_VERSION}
+FROM opensuse/leap:latest
 ARG NCPU=4
 
 ## [BEGIN packaging.md]

--- a/ci/cloudbuild/dockerfiles/demo-ubuntu-bionic.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-ubuntu-bionic.Dockerfile
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG DISTRO_VERSION=bionic
-FROM ubuntu:${DISTRO_VERSION}
+FROM ubuntu:bionic
 ARG NCPU=4
 
 ## [BEGIN packaging.md]

--- a/ci/cloudbuild/dockerfiles/demo-ubuntu-focal.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-ubuntu-focal.Dockerfile
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG DISTRO_VERSION=focal
-FROM ubuntu:${DISTRO_VERSION}
+FROM ubuntu:focal
 ARG NCPU=4
 
 ## [BEGIN packaging.md]

--- a/ci/cloudbuild/dockerfiles/demo-ubuntu-xenial.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-ubuntu-xenial.Dockerfile
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG DISTRO_VERSION=xenial
-FROM ubuntu:${DISTRO_VERSION}
+FROM ubuntu:xenial
 ARG NCPU=4
 
 ## [BEGIN packaging.md]

--- a/ci/cloudbuild/dockerfiles/fedora-msan.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/fedora-msan.Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG DISTRO_VERSION=33
+ARG DISTRO_VERSION
 FROM fedora:${DISTRO_VERSION}
 ARG NCPU=4
 

--- a/ci/cloudbuild/dockerfiles/fedora.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/fedora.Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG DISTRO_VERSION=33
+ARG DISTRO_VERSION
 FROM fedora:${DISTRO_VERSION}
 ARG NCPU=4
 

--- a/ci/cloudbuild/dockerfiles/ubuntu-bionic.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/ubuntu-bionic.Dockerfile
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG DISTRO_VERSION=18.04
-FROM ubuntu:${DISTRO_VERSION}
+FROM ubuntu:bionic
 ARG NCPU=4
 
 RUN apt-get update && \

--- a/ci/cloudbuild/dockerfiles/ubuntu-focal.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/ubuntu-focal.Dockerfile
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG DISTRO_VERSION=20.04
-FROM ubuntu:${DISTRO_VERSION}
+FROM ubuntu:focal
 ARG NCPU=4
 
 ENV DEBIAN_FRONTEND=noninteractive

--- a/ci/cloudbuild/triggers/asan-ci.yaml
+++ b/ci/cloudbuild/triggers/asan-ci.yaml
@@ -8,6 +8,7 @@ name: asan-ci
 substitutions:
   _BUILD_NAME: asan
   _DISTRO: fedora
+  _DISTRO_VERSION: 33
   _TRIGGER_TYPE: ci
 tags:
 - ci

--- a/ci/cloudbuild/triggers/asan-pr.yaml
+++ b/ci/cloudbuild/triggers/asan-pr.yaml
@@ -9,6 +9,7 @@ name: asan-pr
 substitutions:
   _BUILD_NAME: asan
   _DISTRO: fedora
+  _DISTRO_VERSION: 33
   _TRIGGER_TYPE: pr
 tags:
 - pr

--- a/ci/cloudbuild/triggers/bazel-targets-ci.yaml
+++ b/ci/cloudbuild/triggers/bazel-targets-ci.yaml
@@ -8,6 +8,7 @@ name: bazel-targets-ci
 substitutions:
   _BUILD_NAME: bazel-targets
   _DISTRO: fedora
+  _DISTRO_VERSION: 33
   _TRIGGER_TYPE: ci
 tags:
 - ci

--- a/ci/cloudbuild/triggers/bazel-targets-pr.yaml
+++ b/ci/cloudbuild/triggers/bazel-targets-pr.yaml
@@ -9,6 +9,7 @@ name: bazel-targets-pr
 substitutions:
   _BUILD_NAME: bazel-targets
   _DISTRO: fedora
+  _DISTRO_VERSION: 33
   _TRIGGER_TYPE: pr
 tags:
 - pr

--- a/ci/cloudbuild/triggers/check-api-ci.yaml
+++ b/ci/cloudbuild/triggers/check-api-ci.yaml
@@ -8,6 +8,7 @@ name: check-api-ci
 substitutions:
   _BUILD_NAME: check-api
   _DISTRO: fedora
+  _DISTRO_VERSION: 33
   _TRIGGER_TYPE: ci
 tags:
 - ci

--- a/ci/cloudbuild/triggers/check-api-pr.yaml
+++ b/ci/cloudbuild/triggers/check-api-pr.yaml
@@ -9,6 +9,7 @@ name: check-api-pr
 substitutions:
   _BUILD_NAME: check-api
   _DISTRO: fedora
+  _DISTRO_VERSION: 33
   _TRIGGER_TYPE: pr
 tags:
 - pr

--- a/ci/cloudbuild/triggers/checkers-ci.yaml
+++ b/ci/cloudbuild/triggers/checkers-ci.yaml
@@ -8,6 +8,7 @@ name: checkers-ci
 substitutions:
   _BUILD_NAME: checkers
   _DISTRO: fedora
+  _DISTRO_VERSION: 33
   _TRIGGER_TYPE: ci
 tags:
 - ci

--- a/ci/cloudbuild/triggers/checkers-pr.yaml
+++ b/ci/cloudbuild/triggers/checkers-pr.yaml
@@ -9,6 +9,7 @@ name: checkers-pr
 substitutions:
   _BUILD_NAME: checkers
   _DISTRO: fedora
+  _DISTRO_VERSION: 33
   _TRIGGER_TYPE: pr
 tags:
 - pr

--- a/ci/cloudbuild/triggers/clang-tidy-ci.yaml
+++ b/ci/cloudbuild/triggers/clang-tidy-ci.yaml
@@ -8,6 +8,7 @@ name: clang-tidy-ci
 substitutions:
   _BUILD_NAME: clang-tidy
   _DISTRO: fedora
+  _DISTRO_VERSION: 33
   _TRIGGER_TYPE: ci
 tags:
 - ci

--- a/ci/cloudbuild/triggers/clang-tidy-pr.yaml
+++ b/ci/cloudbuild/triggers/clang-tidy-pr.yaml
@@ -9,6 +9,7 @@ name: clang-tidy-pr
 substitutions:
   _BUILD_NAME: clang-tidy
   _DISTRO: fedora
+  _DISTRO_VERSION: 33
   _TRIGGER_TYPE: pr
 tags:
 - pr

--- a/ci/cloudbuild/triggers/cmake-install-ci.yaml
+++ b/ci/cloudbuild/triggers/cmake-install-ci.yaml
@@ -8,6 +8,7 @@ name: cmake-install-ci
 substitutions:
   _BUILD_NAME: cmake-install
   _DISTRO: fedora
+  _DISTRO_VERSION: 33
   _TRIGGER_TYPE: ci
 tags:
 - ci

--- a/ci/cloudbuild/triggers/cmake-install-pr.yaml
+++ b/ci/cloudbuild/triggers/cmake-install-pr.yaml
@@ -9,6 +9,7 @@ name: cmake-install-pr
 substitutions:
   _BUILD_NAME: cmake-install
   _DISTRO: fedora
+  _DISTRO_VERSION: 33
   _TRIGGER_TYPE: pr
 tags:
 - pr

--- a/ci/cloudbuild/triggers/coverage-ci.yaml
+++ b/ci/cloudbuild/triggers/coverage-ci.yaml
@@ -8,6 +8,7 @@ name: coverage-ci
 substitutions:
   _BUILD_NAME: coverage
   _DISTRO: fedora
+  _DISTRO_VERSION: 33
   _TRIGGER_TYPE: ci
 tags:
 - ci

--- a/ci/cloudbuild/triggers/coverage-pr.yaml
+++ b/ci/cloudbuild/triggers/coverage-pr.yaml
@@ -9,6 +9,7 @@ name: coverage-pr
 substitutions:
   _BUILD_NAME: coverage
   _DISTRO: fedora
+  _DISTRO_VERSION: 33
   _TRIGGER_TYPE: pr
 tags:
 - pr

--- a/ci/cloudbuild/triggers/cxx17-ci.yaml
+++ b/ci/cloudbuild/triggers/cxx17-ci.yaml
@@ -8,6 +8,7 @@ name: cxx17-ci
 substitutions:
   _BUILD_NAME: cxx17
   _DISTRO: fedora
+  _DISTRO_VERSION: 33
   _TRIGGER_TYPE: ci
 tags:
 - ci

--- a/ci/cloudbuild/triggers/cxx17-pr.yaml
+++ b/ci/cloudbuild/triggers/cxx17-pr.yaml
@@ -9,6 +9,7 @@ name: cxx17-pr
 substitutions:
   _BUILD_NAME: cxx17
   _DISTRO: fedora
+  _DISTRO_VERSION: 33
   _TRIGGER_TYPE: pr
 tags:
 - pr

--- a/ci/cloudbuild/triggers/demo-fedora-ci.yaml
+++ b/ci/cloudbuild/triggers/demo-fedora-ci.yaml
@@ -8,6 +8,7 @@ name: demo-fedora-ci
 substitutions:
   _BUILD_NAME: demo-install
   _DISTRO: demo-fedora
+  _DISTRO_VERSION: 33
   _TRIGGER_TYPE: ci
 tags:
 - ci

--- a/ci/cloudbuild/triggers/demo-fedora-pr.yaml
+++ b/ci/cloudbuild/triggers/demo-fedora-pr.yaml
@@ -9,6 +9,7 @@ name: demo-fedora-pr
 substitutions:
   _BUILD_NAME: demo-install
   _DISTRO: demo-fedora
+  _DISTRO_VERSION: 33
   _TRIGGER_TYPE: pr
 tags:
 - pr

--- a/ci/cloudbuild/triggers/gcs-grpc-ci.yaml
+++ b/ci/cloudbuild/triggers/gcs-grpc-ci.yaml
@@ -8,6 +8,7 @@ name: gcs-grpc-ci
 substitutions:
   _BUILD_NAME: gcs-grpc
   _DISTRO: fedora
+  _DISTRO_VERSION: 33
   _TRIGGER_TYPE: ci
 tags:
 - ci

--- a/ci/cloudbuild/triggers/gcs-grpc-pr.yaml
+++ b/ci/cloudbuild/triggers/gcs-grpc-pr.yaml
@@ -9,6 +9,7 @@ name: gcs-grpc-pr
 substitutions:
   _BUILD_NAME: gcs-grpc
   _DISTRO: fedora
+  _DISTRO_VERSION: 33
   _TRIGGER_TYPE: pr
 tags:
 - pr

--- a/ci/cloudbuild/triggers/generate-libraries-ci.yaml
+++ b/ci/cloudbuild/triggers/generate-libraries-ci.yaml
@@ -8,6 +8,7 @@ name: generate-libraries-ci
 substitutions:
   _BUILD_NAME: generate-libraries
   _DISTRO: fedora
+  _DISTRO_VERSION: 33
   _TRIGGER_TYPE: ci
 tags:
 - ci

--- a/ci/cloudbuild/triggers/generate-libraries-pr.yaml
+++ b/ci/cloudbuild/triggers/generate-libraries-pr.yaml
@@ -9,6 +9,7 @@ name: generate-libraries-pr
 substitutions:
   _BUILD_NAME: generate-libraries
   _DISTRO: fedora
+  _DISTRO_VERSION: 33
   _TRIGGER_TYPE: pr
 tags:
 - pr

--- a/ci/cloudbuild/triggers/libcxx-ci.yaml
+++ b/ci/cloudbuild/triggers/libcxx-ci.yaml
@@ -8,6 +8,7 @@ name: libcxx-ci
 substitutions:
   _BUILD_NAME: libcxx
   _DISTRO: fedora
+  _DISTRO_VERSION: 33
   _TRIGGER_TYPE: ci
 tags:
 - ci

--- a/ci/cloudbuild/triggers/libcxx-pr.yaml
+++ b/ci/cloudbuild/triggers/libcxx-pr.yaml
@@ -9,6 +9,7 @@ name: libcxx-pr
 substitutions:
   _BUILD_NAME: libcxx
   _DISTRO: fedora
+  _DISTRO_VERSION: 33
   _TRIGGER_TYPE: pr
 tags:
 - pr

--- a/ci/cloudbuild/triggers/msan-ci.yaml
+++ b/ci/cloudbuild/triggers/msan-ci.yaml
@@ -8,6 +8,7 @@ name: msan-ci
 substitutions:
   _BUILD_NAME: msan
   _DISTRO: fedora-msan
+  _DISTRO_VERSION: 33
   _TRIGGER_TYPE: ci
 tags:
 - ci

--- a/ci/cloudbuild/triggers/msan-pr.yaml
+++ b/ci/cloudbuild/triggers/msan-pr.yaml
@@ -9,6 +9,7 @@ name: msan-pr
 substitutions:
   _BUILD_NAME: msan
   _DISTRO: fedora-msan
+  _DISTRO_VERSION: 33
   _TRIGGER_TYPE: pr
 tags:
 - pr

--- a/ci/cloudbuild/triggers/noex-ci.yaml
+++ b/ci/cloudbuild/triggers/noex-ci.yaml
@@ -8,6 +8,7 @@ name: noex-ci
 substitutions:
   _BUILD_NAME: noex
   _DISTRO: fedora
+  _DISTRO_VERSION: 33
   _TRIGGER_TYPE: ci
 tags:
 - ci

--- a/ci/cloudbuild/triggers/noex-pr.yaml
+++ b/ci/cloudbuild/triggers/noex-pr.yaml
@@ -9,6 +9,7 @@ name: noex-pr
 substitutions:
   _BUILD_NAME: noex
   _DISTRO: fedora
+  _DISTRO_VERSION: 33
   _TRIGGER_TYPE: pr
 tags:
 - pr

--- a/ci/cloudbuild/triggers/publish-docs-ci.yaml
+++ b/ci/cloudbuild/triggers/publish-docs-ci.yaml
@@ -8,6 +8,7 @@ name: publish-docs-ci
 substitutions:
   _BUILD_NAME: publish-docs
   _DISTRO: fedora
+  _DISTRO_VERSION: 33
   _TRIGGER_TYPE: ci
 tags:
 - ci

--- a/ci/cloudbuild/triggers/publish-docs-pr.yaml
+++ b/ci/cloudbuild/triggers/publish-docs-pr.yaml
@@ -9,6 +9,7 @@ name: publish-docs-pr
 substitutions:
   _BUILD_NAME: publish-docs
   _DISTRO: fedora
+  _DISTRO_VERSION: 33
   _TRIGGER_TYPE: pr
 tags:
 - pr

--- a/ci/cloudbuild/triggers/shared-ci.yaml
+++ b/ci/cloudbuild/triggers/shared-ci.yaml
@@ -8,6 +8,7 @@ name: shared-ci
 substitutions:
   _BUILD_NAME: shared
   _DISTRO: fedora
+  _DISTRO_VERSION: 33
   _TRIGGER_TYPE: ci
 tags:
 - ci

--- a/ci/cloudbuild/triggers/shared-pr.yaml
+++ b/ci/cloudbuild/triggers/shared-pr.yaml
@@ -9,6 +9,7 @@ name: shared-pr
 substitutions:
   _BUILD_NAME: shared
   _DISTRO: fedora
+  _DISTRO_VERSION: 33
   _TRIGGER_TYPE: pr
 tags:
 - pr

--- a/ci/cloudbuild/triggers/ubsan-ci.yaml
+++ b/ci/cloudbuild/triggers/ubsan-ci.yaml
@@ -8,6 +8,7 @@ name: ubsan-ci
 substitutions:
   _BUILD_NAME: ubsan
   _DISTRO: fedora
+  _DISTRO_VERSION: 33
   _TRIGGER_TYPE: ci
 tags:
 - ci

--- a/ci/cloudbuild/triggers/ubsan-pr.yaml
+++ b/ci/cloudbuild/triggers/ubsan-pr.yaml
@@ -9,6 +9,7 @@ name: ubsan-pr
 substitutions:
   _BUILD_NAME: ubsan
   _DISTRO: fedora
+  _DISTRO_VERSION: 33
   _TRIGGER_TYPE: pr
 tags:
 - pr

--- a/ci/cloudbuild/triggers/xsan-ci.yaml
+++ b/ci/cloudbuild/triggers/xsan-ci.yaml
@@ -8,6 +8,7 @@ name: xsan-ci
 substitutions:
   _BUILD_NAME: xsan
   _DISTRO: fedora
+  _DISTRO_VERSION: 33
   _TRIGGER_TYPE: ci
 tags:
 - ci

--- a/ci/cloudbuild/triggers/xsan-pr.yaml
+++ b/ci/cloudbuild/triggers/xsan-pr.yaml
@@ -9,6 +9,7 @@ name: xsan-pr
 substitutions:
   _BUILD_NAME: xsan
   _DISTRO: fedora
+  _DISTRO_VERSION: 33
   _TRIGGER_TYPE: pr
 tags:
 - pr


### PR DESCRIPTION
Change the dockerfiles to make *only* the Fedora version configurable.
The other builds have the version fixed in their name, e.g.,
`ubuntu-bionic.Dockerfile` obviously is intended to be used exclusively
with `ubuntu:bionic` (aka `ubuntu:18.04`).

Change the build.sh script to accept a `--distro-version` flag to set
the `DISTRO_VERSION` build argument in `docker build`. Also changed the
triggers to set `_DISTRO_VERSION` substitution, so this value is picked
up correctly in builds with `-t` flag. The substitution is not used in
the GCB builds yet.

Part of the work for #6502 