### PR TITLE
ci: simplify and document generator formatting trick

### DIFF
--- a/ci/cloudbuild/builds/checkers.sh
+++ b/ci/cloudbuild/builds/checkers.sh
@@ -37,6 +37,10 @@ function replace_original_if_changed() {
   fi
 }
 
+# TODO(#6513): Delete this once we have clang-format version 13 and can use:
+# https://github.com/googleapis/google-cloud-cpp/issues/6513
+cp .clang-format generator/integration_tests/golden/tests
+
 # This controls the output format from bash's `time` command, which we use
 # below to time blocks of the script. A newline is automatically included.
 readonly TIMEFORMAT="... %R seconds"
@@ -93,16 +97,6 @@ time {
       replace_original_if_changed "${file}" "${file}.tmp"
     done
 }
-
-# Currently, we need to exclude golden files from being formatted, but at the
-# same time format the unit tests for those golden files. Due to clang-formats
-# limited exclusion functionality, we must maintain a second copy of the
-# project clang-format config in the unit test directory.
-clang_format_project_file="${PROJECT_ROOT}/.clang-format"
-clang_format_generator_file="${PROJECT_ROOT}/generator/integration_tests/golden/tests/.clang-format"
-if ! cmp -s "${clang_format_project_file}" "${clang_format_generator_file}"; then
-  cp "${clang_format_project_file}" "${clang_format_generator_file}"
-fi
 
 # Apply clang-format(1) to fix whitespace and other formatting rules.
 # The version of clang-format is important, different versions have slightly


### PR DESCRIPTION
The trick we currently use to clang-format most (but not all) of the
generator files has a much better solution in clang-format version 13. I
created an issue so we don't forget about this and I added a TODO in the
code linking this issue. I also simplified the code a bit to just a
single cp.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6514)
<!-- Reviewable:end -->
