### PR TITLE
ci: rename publish docs head version to HEAD

### DIFF
--- a/ci/cloudbuild/builds/publish-docs.sh
+++ b/ci/cloudbuild/builds/publish-docs.sh
@@ -33,7 +33,7 @@ if grep -qP 'v\d+\.\d+\..*' <<<"${BRANCH_NAME}"; then
   patch="$(awk '/GOOGLE_CLOUD_CPP_VERSION_PATCH/{print $3}' "${version_file}")"
   version="${major}.${minor}.${patch}"
 else
-  version="master"
+  version="HEAD"
   doc_args+=("-DGOOGLE_CLOUD_CPP_USE_MASTER_FOR_REFDOC_LINKS=ON")
 fi
 


### PR DESCRIPTION
Uses a less offensive term, and a clearer term since the docs are indeed
for the newest unreleased version.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6515)
<!-- Reviewable:end -->
