### PR TITLE
feat: implement unified insecure credentials

### DIFF
--- a/google/cloud/internal/credentials.cc
+++ b/google/cloud/internal/credentials.cc
@@ -26,6 +26,10 @@ void CredentialsVisitor::dispatch(Credentials& credentials,
   credentials.dispatch(visitor);
 }
 
+std::shared_ptr<Credentials> MakeInsecureCredentials() {
+  return std::make_shared<InsecureCredentialsConfig>();
+}
+
 std::shared_ptr<Credentials> MakeGoogleDefaultCredentials() {
   return std::make_shared<GoogleDefaultCredentialsConfig>();
 }

--- a/google/cloud/internal/credentials_test.cc
+++ b/google/cloud/internal/credentials_test.cc
@@ -31,6 +31,9 @@ struct Visitor : public CredentialsVisitor {
   AccessToken access_token;
   ImpersonateServiceAccountConfig* impersonate = nullptr;
 
+  void visit(InsecureCredentialsConfig&) override {
+    name = "InsecureCredentialsConfig";
+  }
   void visit(GoogleDefaultCredentialsConfig&) override {
     name = "GoogleDefaultCredentialsConfig";
   }
@@ -43,6 +46,14 @@ struct Visitor : public CredentialsVisitor {
     impersonate = &cfg;
   }
 };
+
+TEST(Credentials, InsecureCredentials) {
+  Visitor visitor;
+
+  auto credentials = MakeInsecureCredentials();
+  CredentialsVisitor::dispatch(*credentials, visitor);
+  EXPECT_EQ("InsecureCredentialsConfig", visitor.name);
+}
 
 TEST(Credentials, GoogleDefaultCredentials) {
   Visitor visitor;

--- a/google/cloud/internal/unified_grpc_credentials.cc
+++ b/google/cloud/internal/unified_grpc_credentials.cc
@@ -36,6 +36,10 @@ std::shared_ptr<GrpcAuthenticationStrategy> CreateAuthenticationStrategy(
     Visitor(CompletionQueue c, Options o)
         : cq(std::move(c)), options(std::move(o)) {}
 
+    void visit(InsecureCredentialsConfig&) override {
+      result = absl::make_unique<GrpcChannelCredentialsAuthentication>(
+          grpc::InsecureChannelCredentials());
+    }
     void visit(GoogleDefaultCredentialsConfig&) override {
       result = absl::make_unique<GrpcChannelCredentialsAuthentication>(
           grpc::GoogleDefaultCredentials());

--- a/google/cloud/internal/unified_grpc_credentials_test.cc
+++ b/google/cloud/internal/unified_grpc_credentials_test.cc
@@ -35,6 +35,16 @@ TEST(UnifiedGrpcCredentialsTest, WithGrpcCredentials) {
   ASSERT_EQ(nullptr, context.credentials());
 }
 
+TEST(UnifiedGrpcCredentialsTest, WithInsecureCredentials) {
+  CompletionQueue cq;
+  auto result = CreateAuthenticationStrategy(MakeInsecureCredentials(), cq);
+  ASSERT_NE(nullptr, result.get());
+  grpc::ClientContext context;
+  auto status = result->ConfigureContext(context);
+  EXPECT_THAT(status, IsOk());
+  ASSERT_EQ(nullptr, context.credentials());
+}
+
 TEST(UnifiedGrpcCredentialsTest, WithDefaultCredentials) {
   // Create a filename for a file that (most likely) does not exist. We just
   // want to initialize the default credentials, the filename won't be used by

--- a/google/cloud/storage/internal/unified_rest_credentials.cc
+++ b/google/cloud/storage/internal/unified_rest_credentials.cc
@@ -28,12 +28,16 @@ using ::google::cloud::internal::AccessTokenConfig;
 using ::google::cloud::internal::CredentialsVisitor;
 using ::google::cloud::internal::GoogleDefaultCredentialsConfig;
 using ::google::cloud::internal::ImpersonateServiceAccountConfig;
+using ::google::cloud::internal::InsecureCredentialsConfig;
 
 std::shared_ptr<oauth2::Credentials> MapCredentials(
     std::shared_ptr<google::cloud::internal::Credentials> const& credentials) {
   struct Visitor : public CredentialsVisitor {
     std::shared_ptr<oauth2::Credentials> result;
 
+    void visit(InsecureCredentialsConfig&) override {
+      result = google::cloud::storage::oauth2::CreateAnonymousCredentials();
+    }
     void visit(GoogleDefaultCredentialsConfig&) override {
       auto credentials =
           google::cloud::storage::oauth2::GoogleDefaultCredentials();

--- a/google/cloud/storage/internal/unified_rest_credentials_test.cc
+++ b/google/cloud/storage/internal/unified_rest_credentials_test.cc
@@ -30,10 +30,12 @@ inline namespace STORAGE_CLIENT_NS {
 namespace internal {
 namespace {
 
-using google::cloud::internal::MakeAccessTokenCredentials;
-using google::cloud::internal::MakeGoogleDefaultCredentials;
-using google::cloud::testing_util::IsOk;
-using google::cloud::testing_util::ScopedEnvironment;
+using ::google::cloud::internal::MakeAccessTokenCredentials;
+using ::google::cloud::internal::MakeGoogleDefaultCredentials;
+using ::google::cloud::internal::MakeInsecureCredentials;
+using ::google::cloud::testing_util::IsOk;
+using ::google::cloud::testing_util::ScopedEnvironment;
+using ::testing::IsEmpty;
 
 class UnifiedRestCredentialsTest : public ::testing::Test {
  public:
@@ -49,6 +51,13 @@ class UnifiedRestCredentialsTest : public ::testing::Test {
  private:
   google::cloud::internal::DefaultPRNG generator_;
 };
+
+TEST_F(UnifiedRestCredentialsTest, Insecure) {
+  auto credentials = MapCredentials(MakeInsecureCredentials());
+  auto header = credentials->AuthorizationHeader();
+  ASSERT_THAT(header, IsOk());
+  EXPECT_THAT(*header, IsEmpty());
+}
 
 TEST_F(UnifiedRestCredentialsTest, AccessToken) {
   auto credentials = MapCredentials(


### PR DESCRIPTION
We use insecure credentials to run integration tests against the
emulators, or to run unit tests that need to initialize a (maybe mocked)
client. This change introduces a common way to require such credentials
for both REST-based and gRPC-based libraries.

Fixes #6462

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6518)
<!-- Reviewable:end -->
