### PR TITLE
ci: move tsan build to Fedora:34

### DIFF
--- a/ci/cloudbuild/builds/tsan.sh
+++ b/ci/cloudbuild/builds/tsan.sh
@@ -20,13 +20,8 @@ source "$(dirname "$0")/../../lib/init.sh"
 source module ci/cloudbuild/builds/lib/bazel.sh
 source module ci/cloudbuild/builds/lib/integration.sh
 
-# Compile with the ThreadSanitizer enabled.
-# We need to use clang-9 for the TSAN build because:
-#   https://github.com/google/sanitizers/issues/1259
-# Using Fedora >= 32 will push us to clang-10, and Fedora < 32 is EOL.
-# Fortunately, Ubuntu:18.04 is a LTS release with clang-9 as an alternative.
-export CC=clang-9
-export CXX=clang++-9
+export CC=clang
+export CXX=clang++
 
 mapfile -t args < <(bazel::common_args)
 args+=("--config=tsan")

--- a/ci/cloudbuild/triggers/tsan-ci.yaml
+++ b/ci/cloudbuild/triggers/tsan-ci.yaml
@@ -7,7 +7,7 @@ github:
 name: tsan-ci
 substitutions:
   _BUILD_NAME: tsan
-  _DISTRO: ubuntu-bionic
+  _DISTRO: fedora-34
   _TRIGGER_TYPE: ci
 tags:
 - ci

--- a/ci/cloudbuild/triggers/tsan-pr.yaml
+++ b/ci/cloudbuild/triggers/tsan-pr.yaml
@@ -8,7 +8,7 @@ github:
 name: tsan-pr
 substitutions:
   _BUILD_NAME: tsan
-  _DISTRO: ubuntu-bionic
+  _DISTRO: fedora-34
   _TRIGGER_TYPE: pr
 tags:
 - pr


### PR DESCRIPTION
Part of the work for #6524

Manual [test log](https://console.cloud.google.com/cloud-build/builds;region=global/b5bf8568-629c-4698-b657-c7bbdb4cedec;tab=detail?project=cloud-cpp-testing-resources)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6525)
<!-- Reviewable:end -->
