### PR TITLE
ci: upgrade clang-tidy to Fedora:34

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -30,6 +30,13 @@
 #      class in order to document it as part of the public API, that will
 #      trigger a redundant declaration warning from this check.
 #
+#  -readability-function-cognitive-complexity: too many false positives with
+#      clang-tidy-12. We need to disable this check in macros, and that setting
+#      only appears in clang-tidy-13.
+#
+#  -bugprone-narrowing-conversions: too many false positives around
+#      `std::size_t`  vs. `*::difference_type`.
+#
 Checks: >
   -*,
   bugprone-*,
@@ -50,7 +57,9 @@ Checks: >
   -readability-braces-around-statements,
   -readability-magic-numbers,
   -readability-named-parameter,
-  -readability-redundant-declaration
+  -readability-redundant-declaration,
+  -readability-function-cognitive-complexity,
+  -bugprone-narrowing-conversions
 
 # Turn all the warnings from the checks above into errors.
 WarningsAsErrors: "*"

--- a/ci/cloudbuild/triggers/clang-tidy-ci.yaml
+++ b/ci/cloudbuild/triggers/clang-tidy-ci.yaml
@@ -7,7 +7,7 @@ github:
 name: clang-tidy-ci
 substitutions:
   _BUILD_NAME: clang-tidy
-  _DISTRO: fedora-33
+  _DISTRO: fedora-34
   _TRIGGER_TYPE: ci
 tags:
 - ci

--- a/ci/cloudbuild/triggers/clang-tidy-pr.yaml
+++ b/ci/cloudbuild/triggers/clang-tidy-pr.yaml
@@ -8,7 +8,7 @@ github:
 name: clang-tidy-pr
 substitutions:
   _BUILD_NAME: clang-tidy
-  _DISTRO: fedora-33
+  _DISTRO: fedora-34
   _TRIGGER_TYPE: pr
 tags:
 - pr


### PR DESCRIPTION
Part of the work for #6524

Manual [test logs](https://pantheon.corp.google.com/cloud-build/builds;region=global/77f59651-c028-4cba-8418-2ffc1f74ac2d?project=cloud-cpp-testing-resources)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6526)
<!-- Reviewable:end -->
