### PR TITLE
cleanup(spanner): quash Doxygen warning

### DIFF
--- a/google/cloud/spanner/read_partition.h
+++ b/google/cloud/spanner/read_partition.h
@@ -127,7 +127,8 @@ class ReadPartition {
       : proto_(std::move(proto)) {}
   ReadPartition(std::string transaction_id, std::string session_id,
                 std::string partition_token, std::string table_name,
-                KeySet key_set, std::vector<std::string> column_names,
+                google::cloud::spanner::KeySet key_set,
+                std::vector<std::string> column_names,
                 google::cloud::spanner::ReadOptions read_options);
 
   // Accessor methods for use by friends.


### PR DESCRIPTION
Quash "no matching class member found" Doxygen warning for
`google::cloud::spanner::ReadPartition` constructor.

Part of #6543.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6548)
<!-- Reviewable:end -->
