### PR TITLE
ci(doc): fix some doxygen errors

### DIFF
--- a/ci/cloudbuild/builds/publish-docs.sh
+++ b/ci/cloudbuild/builds/publish-docs.sh
@@ -61,7 +61,7 @@ cmake --build cmake-out --target install
 cmake --build cmake-out --target doxygen-docs
 
 # Cleans up the installed artifacts, which are no longer needed.
-test -d "${install_dir}" && rm -rf "${install_dir}"
+rm -rf "${install_dir}"
 
 io::log_h2 "Installing the docuploader package $(date)"
 python3 -m pip install --user gcp-docuploader protobuf \

--- a/cmake/GoogleCloudCppCommon.cmake
+++ b/cmake/GoogleCloudCppCommon.cmake
@@ -60,7 +60,8 @@ else ()
         set(DOXYGEN_CLANG_OPTIONS)
         set(DOXYGEN_CLANG_DATABASE_PATH)
         set(DOXYGEN_SEARCH_INCLUDES YES)
-        set(DOXYGEN_INCLUDE_PATH "${PROJECT_SOURCE_DIR}"
+        set(DOXYGEN_INCLUDE_PATH "${CMAKE_INSTALL_PREFIX}/include"
+                                 "${PROJECT_SOURCE_DIR}"
                                  "${PROJECT_BINARY_DIR}")
         set(DOXYGEN_GENERATE_LATEX NO)
         set(DOXYGEN_GRAPHICAL_HIERARCHY NO)

--- a/cmake/GoogleCloudCppCommon.cmake
+++ b/cmake/GoogleCloudCppCommon.cmake
@@ -39,10 +39,11 @@ if (${CMAKE_VERSION} VERSION_LESS "3.12")
 else ()
     find_package(Doxygen)
     if (Doxygen_FOUND)
-        set(DOXYGEN_RECURSIVE NO)
+        set(DOXYGEN_RECURSIVE YES)
         set(DOXYGEN_FILE_PATTERNS *.h *.cc *.proto *.dox)
         set(DOXYGEN_EXAMPLE_RECURSIVE YES)
         set(DOXYGEN_EXCLUDE
+            "${CMAKE_INSTALL_PREFIX}"
             "${PROJECT_SOURCE_DIR}/third_party"
             "${PROJECT_SOURCE_DIR}/build-out"
             "${PROJECT_SOURCE_DIR}/cmake-build-debug"

--- a/cmake/GoogleCloudCppCommon.cmake
+++ b/cmake/GoogleCloudCppCommon.cmake
@@ -40,7 +40,7 @@ else ()
     find_package(Doxygen)
     if (Doxygen_FOUND)
         set(DOXYGEN_RECURSIVE YES)
-        set(DOXYGEN_FILE_PATTERNS *.h *.cc *.proto *.dox)
+        set(DOXYGEN_FILE_PATTERNS *.h *.cc *.dox)
         set(DOXYGEN_EXAMPLE_RECURSIVE YES)
         set(DOXYGEN_EXCLUDE
             "${CMAKE_INSTALL_PREFIX}"
@@ -64,7 +64,7 @@ else ()
         set(DOXYGEN_CLANG_ASSISTED_PARSING YES)
         set(DOXYGEN_CLANG_OPTIONS)
         set(DOXYGEN_CLANG_DATABASE_PATH)
-        set(DOXYGEN_SEARCH_INCLUDES YES)
+        set(DOXYGEN_SEARCH_INCLUDES NO)
         set(DOXYGEN_INCLUDE_PATH
             "${CMAKE_INSTALL_PREFIX}/include" "${PROJECT_SOURCE_DIR}"
             "${PROJECT_BINARY_DIR}")

--- a/cmake/GoogleCloudCppCommon.cmake
+++ b/cmake/GoogleCloudCppCommon.cmake
@@ -39,10 +39,14 @@ if (${CMAKE_VERSION} VERSION_LESS "3.12")
 else ()
     find_package(Doxygen)
     if (Doxygen_FOUND)
-        set(DOXYGEN_RECURSIVE YES)
+        set(DOXYGEN_RECURSIVE NO)
         set(DOXYGEN_FILE_PATTERNS *.h *.cc *.proto *.dox)
         set(DOXYGEN_EXAMPLE_RECURSIVE YES)
-        set(DOXYGEN_EXCLUDE "third_party" "cmake-build-debug" "cmake-out")
+        set(DOXYGEN_EXCLUDE
+            "${PROJECT_SOURCE_DIR}/third_party"
+            "${PROJECT_SOURCE_DIR}/build-out"
+            "${PROJECT_SOURCE_DIR}/cmake-build-debug"
+            "${PROJECT_SOURCE_DIR}/cmake-out")
         set(DOXYGEN_EXCLUDE_SYMLINKS YES)
         set(DOXYGEN_QUIET YES)
         set(DOXYGEN_WARN_AS_ERROR NO)
@@ -60,9 +64,9 @@ else ()
         set(DOXYGEN_CLANG_OPTIONS)
         set(DOXYGEN_CLANG_DATABASE_PATH)
         set(DOXYGEN_SEARCH_INCLUDES YES)
-        set(DOXYGEN_INCLUDE_PATH "${CMAKE_INSTALL_PREFIX}/include"
-                                 "${PROJECT_SOURCE_DIR}"
-                                 "${PROJECT_BINARY_DIR}")
+        set(DOXYGEN_INCLUDE_PATH
+            "${CMAKE_INSTALL_PREFIX}/include" "${PROJECT_SOURCE_DIR}"
+            "${PROJECT_BINARY_DIR}")
         set(DOXYGEN_GENERATE_LATEX NO)
         set(DOXYGEN_GRAPHICAL_HIERARCHY NO)
         set(DOXYGEN_DIRECTORY_GRAPH NO)
@@ -73,7 +77,7 @@ else ()
         set(DOXYGEN_DOT_TRANSPARENT YES)
         set(DOXYGEN_MACRO_EXPANSION YES)
         set(DOXYGEN_EXPAND_ONLY_PREDEF YES)
-        set(DOXYGEN_HTML_TIMESTAMP)
+        set(DOXYGEN_HTML_TIMESTAMP YES)
         set(DOXYGEN_STRIP_FROM_INC_PATH "${PROJECT_SOURCE_DIR}")
         set(DOXYGEN_SHOW_USED_FILES NO)
         set(DOXYGEN_REFERENCES_LINK_SOURCE NO)


### PR DESCRIPTION
Related to: #6543

This fixes two sets of doxygen errors:

1. It fixes the `fatal error: 'stddef.h'` errors by setting the clang
   resource-dir path.
2. After these errors, we got a bunch of errors about unable to find
   includes like `google/proto/status.pb.h`. These are fixed by
   installing our library first, then telling doxygen where to find the
   headers we installed.

In my local tests, the only remaining errors seem to be legit warnings
that we likely need to fix (in subsequent PRs).

**NOTE** The doxygen build is now slower. It was ~5 minutes. Now it's ~10 minutes. 

Example docs: https://staging.googleapis.dev/cpp/google-cloud-storage/HEAD/index.html

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6552)
<!-- Reviewable:end -->
