### PR TITLE
feature(spanner): low-cost instances

### DIFF
--- a/bazel/google_cloud_cpp_deps.bzl
+++ b/bazel/google_cloud_cpp_deps.bzl
@@ -87,7 +87,7 @@ def google_cloud_cpp_deps():
             # committed to the main branch.
             patch_tool = "patch",
             patch_args = ["-p1"],
-            patches = [],
+            patches = ["googleapis.patch"],
         )
 
     # Load protobuf.

--- a/external/googleapis.patch
+++ b/external/googleapis.patch
@@ -1,0 +1,16 @@
+diff --git a/google/spanner/admin/instance/v1/spanner_instance_admin.proto b/google/spanner/admin/instance/v1/spanner_instance_admin.proto
+index 69043c1b..5630d653 100644
+--- a/google/spanner/admin/instance/v1/spanner_instance_admin.proto
++++ b/google/spanner/admin/instance/v1/spanner_instance_admin.proto
+@@ -368,6 +368,11 @@ message Instance {
+   // for more information about nodes.
+   int32 node_count = 5;
+
++  // The number of processing units allocated to this instance. At most one of
++  // processing_units or node_count should be present in the message. This may
++  // be zero in API responses for instances that are not yet in state `READY`.
++  int32 processing_units = 9;
++
+   // Output only. The current instance state. For
+   // [CreateInstance][google.spanner.admin.instance.v1.InstanceAdmin.CreateInstance], the state must be
+   // either omitted or set to `CREATING`. For

--- a/external/googleapis/CMakeLists.txt
+++ b/external/googleapis/CMakeLists.txt
@@ -167,7 +167,9 @@ ExternalProject_Add(
     URL ${GOOGLE_CLOUD_CPP_GOOGLEAPIS_URL}
     URL_HASH SHA256=${GOOGLE_CLOUD_CPP_GOOGLEAPIS_SHA256}
     PATCH_COMMAND
-        ""
+        patch
+        -p1
+        --input=/workspace/external/googleapis.patch
         # ~~~
         # Scaffolding for patching googleapis after download. For example:
         #   PATCH_COMMAND

--- a/google/cloud/spanner/create_instance_request_builder.h
+++ b/google/cloud/spanner/create_instance_request_builder.h
@@ -47,15 +47,14 @@ class CreateInstanceRequestBuilder {
       default;
 
   /**
-   * Constructor requires Instance and Cloud Spanner instance config name. It
-   * sets node_count = 1, and display_name = instance_id as the default values.
+   * Constructor requires Instance and Cloud Spanner instance config name.
+   * The display_name is set to a default value of in.instance_id().
    */
   CreateInstanceRequestBuilder(Instance const& in, std::string config) {
     request_.set_parent("projects/" + in.project_id());
     request_.set_instance_id(in.instance_id());
     request_.mutable_instance()->set_name(in.FullName());
     request_.mutable_instance()->set_display_name(in.instance_id());
-    request_.mutable_instance()->set_node_count(1);
     request_.mutable_instance()->set_config(std::move(config));
   }
 
@@ -79,6 +78,16 @@ class CreateInstanceRequestBuilder {
     return std::move(*this);
   }
 
+  CreateInstanceRequestBuilder& SetProcessingUnits(int processing_units) & {
+    request_.mutable_instance()->set_processing_units(processing_units);
+    return *this;
+  }
+
+  CreateInstanceRequestBuilder&& SetProcessingUnits(int processing_units) && {
+    request_.mutable_instance()->set_processing_units(processing_units);
+    return std::move(*this);
+  }
+
   CreateInstanceRequestBuilder& SetLabels(
       std::map<std::string, std::string> const& labels) & {
     for (auto const& pair : labels) {
@@ -98,9 +107,21 @@ class CreateInstanceRequestBuilder {
   }
 
   google::spanner::admin::instance::v1::CreateInstanceRequest& Build() & {
+    // Preserve original behavior of defaulting node_count to 1.
+    if (request_.instance().processing_units() == 0) {
+      if (request_.instance().node_count() == 0) {
+        request_.mutable_instance()->set_node_count(1);
+      }
+    }
     return request_;
   }
   google::spanner::admin::instance::v1::CreateInstanceRequest&& Build() && {
+    // Preserve original behavior of defaulting node_count to 1.
+    if (request_.instance().processing_units() == 0) {
+      if (request_.instance().node_count() == 0) {
+        request_.mutable_instance()->set_node_count(1);
+      }
+    }
     return std::move(request_);
   }
 

--- a/google/cloud/spanner/create_instance_request_builder_test.cc
+++ b/google/cloud/spanner/create_instance_request_builder_test.cc
@@ -70,14 +70,14 @@ TEST(CreateInstanceRequestBuilder, Lvalue) {
 
   auto builder = CreateInstanceRequestBuilder(in, expected_config);
   auto req = builder.SetDisplayName(expected_display_name)
-                 .SetNodeCount(1)
+                 .SetProcessingUnits(500)
                  .SetLabels({{"key", "value"}})
                  .Build();
   EXPECT_EQ("projects/test-project", req.parent());
   EXPECT_EQ("test-instance", req.instance_id());
   EXPECT_EQ(expected_name, req.instance().name());
   EXPECT_EQ(expected_config, req.instance().config());
-  EXPECT_EQ(1, req.instance().node_count());
+  EXPECT_EQ(500, req.instance().processing_units());
   EXPECT_EQ(1, req.instance().labels_size());
   EXPECT_EQ("value", req.instance().labels().at("key"));
   EXPECT_EQ(expected_display_name, req.instance().display_name());

--- a/google/cloud/spanner/samples/samples.cc
+++ b/google/cloud/spanner/samples/samples.cc
@@ -86,19 +86,56 @@ void CreateInstance(google::cloud::spanner::InstanceAdminClient client,
                   .Build())
           .get();
   if (!instance) throw std::runtime_error(instance.status().message());
-  std::cout << "Created instance [" << in << "]\n";
+  std::cout << "Created instance [" << in << "]:\n" << instance->DebugString();
 }
 //! [END spanner_create_instance] [create-instance]
 
+// [START spanner_create_instance_with_processing_units]
+void CreateInstanceWithProcessingUnits(
+    google::cloud::spanner::InstanceAdminClient client,
+    std::string const& project_id, std::string const& instance_id,
+    std::string const& display_name, std::string const& config) {
+  namespace spanner = google::cloud::spanner;
+  spanner::Instance in(project_id, instance_id);
+
+  std::string instance_config =
+      "projects/" + project_id + "/instanceConfigs/" + config;
+  auto instance =
+      client
+          .CreateInstance(
+              spanner::CreateInstanceRequestBuilder(in, instance_config)
+                  .SetDisplayName(display_name)
+                  .SetProcessingUnits(500)
+                  .SetLabels({{"cloud_spanner_samples", "true"}})
+                  .Build())
+          .get();
+  if (!instance) throw std::runtime_error(instance.status().message());
+  std::cout << "Created instance [" << in << "]:\n" << instance->DebugString();
+
+  instance = client.GetInstance(in);
+  if (!instance) throw std::runtime_error(instance.status().message());
+  std::cout << "Instance " << in << " has " << instance->processing_units()
+            << " processing units.\n";
+}
+// [END spanner_create_instance_with_processing_units]
+
 void CreateInstanceCommand(std::vector<std::string> argv) {
+  bool low_cost = !argv.empty() && argv.front() == "--low-cost";
+  if (low_cost) argv.erase(argv.begin());
   if (argv.size() != 3 && argv.size() != 4) {
     throw std::runtime_error(
-        "create-instance <project-id> <instance-id> <display_name> [config]");
+        "create-instance [--low-cost] <project-id> <instance-id>"
+        " <display_name> [config]");
   }
   google::cloud::spanner::InstanceAdminClient client(
       google::cloud::spanner::MakeInstanceAdminConnection());
   std::string config = argv.size() == 4 ? argv[3] : "regional-us-central1";
-  CreateInstance(std::move(client), argv[0], argv[1], argv[2], config);
+  if (low_cost) {
+    CreateInstanceWithProcessingUnits(std::move(client), argv[0], argv[1],
+                                      argv[2], config);
+  } else {
+    CreateInstance(std::move(client), argv[0], argv[1], argv[2], config);
+  }
 }
 
 //! [update-instance]
@@ -3414,6 +3451,18 @@ void RunAllSlowInstanceTests(
 
   std::cout << "\nRunning delete-instance sample" << std::endl;
   DeleteInstance(instance_admin_client, project_id, crud_instance_id);
+
+  if (!emulator) {
+    std::cout
+        << "\nRunning spanner_create_instance_with_processing_units sample"
+        << std::endl;
+    CreateInstanceWithProcessingUnits(
+        instance_admin_client, project_id, crud_instance_id,
+        "Test Low-Cost Instance", "regional-us-central1");
+
+    std::cout << "\nRunning delete-instance sample" << std::endl;
+    DeleteInstance(instance_admin_client, project_id, crud_instance_id);
+  }
 }
 
 void RunAll(bool emulator) {

--- a/google/cloud/spanner/update_instance_request_builder.h
+++ b/google/cloud/spanner/update_instance_request_builder.h
@@ -93,6 +93,14 @@ class UpdateInstanceRequestBuilder {
     SetNodeCountImpl(node_count);
     return std::move(*this);
   }
+  UpdateInstanceRequestBuilder& SetProcessingUnits(int processing_units) & {
+    SetProcessingUnitsImpl(processing_units);
+    return *this;
+  }
+  UpdateInstanceRequestBuilder&& SetProcessingUnits(int processing_units) && {
+    SetProcessingUnitsImpl(processing_units);
+    return std::move(*this);
+  }
   UpdateInstanceRequestBuilder& AddLabels(
       std::map<std::string, std::string> const& labels) & {
     AddLabelsImpl(labels);
@@ -137,6 +145,13 @@ class UpdateInstanceRequestBuilder {
       request_.mutable_field_mask()->add_paths("node_count");
     }
     request_.mutable_instance()->set_node_count(node_count);
+  }
+  void SetProcessingUnitsImpl(int processing_units) {
+    if (!google::protobuf::util::FieldMaskUtil::IsPathInFieldMask(
+            "processing_units", request_.field_mask())) {
+      request_.mutable_field_mask()->add_paths("processing_units");
+    }
+    request_.mutable_instance()->set_processing_units(processing_units);
   }
   void AddLabelsImpl(std::map<std::string, std::string> const& labels) {
     if (!google::protobuf::util::FieldMaskUtil::IsPathInFieldMask(

--- a/google/cloud/spanner/update_instance_request_builder_test.cc
+++ b/google/cloud/spanner/update_instance_request_builder_test.cc
@@ -106,19 +106,19 @@ TEST(UpdateInstanceRequestBuilder, SetLabels) {
   instance.set_node_count(1);
   instance.mutable_labels()->insert({"key", "value"});
   auto builder = UpdateInstanceRequestBuilder(instance);
-  auto req = builder.SetNodeCount(2)
+  auto req = builder.SetProcessingUnits(500)
                  .SetDisplayName(expected_display_name)
                  .SetLabels({{"newkey", "newvalue"}})
                  .Build();
   EXPECT_EQ(expected_name, req.instance().name());
   EXPECT_EQ(expected_display_name, req.instance().display_name());
-  EXPECT_EQ(2, req.instance().node_count());
+  EXPECT_EQ(500, req.instance().processing_units());
   EXPECT_EQ(1, req.instance().labels_size());
   EXPECT_EQ("newvalue", req.instance().labels().at("newkey"));
   EXPECT_TRUE(google::protobuf::util::FieldMaskUtil::IsPathInFieldMask(
       "display_name", req.field_mask()));
   EXPECT_TRUE(google::protobuf::util::FieldMaskUtil::IsPathInFieldMask(
-      "node_count", req.field_mask()));
+      "processing_units", req.field_mask()));
   EXPECT_TRUE(google::protobuf::util::FieldMaskUtil::IsPathInFieldMask(
       "labels", req.field_mask()));
 }
@@ -133,19 +133,19 @@ TEST(UpdateInstanceRequestBuilder, SetLabelsRvalueReference) {
   instance.set_node_count(1);
   instance.mutable_labels()->insert({"key", "value"});
   auto req = UpdateInstanceRequestBuilder(instance)
-                 .SetNodeCount(2)
+                 .SetProcessingUnits(500)
                  .SetDisplayName(expected_display_name)
                  .SetLabels({{"newkey", "newvalue"}})
                  .Build();
   EXPECT_EQ(expected_name, req.instance().name());
   EXPECT_EQ(expected_display_name, req.instance().display_name());
-  EXPECT_EQ(2, req.instance().node_count());
+  EXPECT_EQ(500, req.instance().processing_units());
   EXPECT_EQ(1, req.instance().labels_size());
   EXPECT_EQ("newvalue", req.instance().labels().at("newkey"));
   EXPECT_TRUE(google::protobuf::util::FieldMaskUtil::IsPathInFieldMask(
       "display_name", req.field_mask()));
   EXPECT_TRUE(google::protobuf::util::FieldMaskUtil::IsPathInFieldMask(
-      "node_count", req.field_mask()));
+      "processing_units", req.field_mask()));
   EXPECT_TRUE(google::protobuf::util::FieldMaskUtil::IsPathInFieldMask(
       "labels", req.field_mask()));
 }


### PR DESCRIPTION
Support the provisioning of Spanner instances using `processing_units`
as an alternative to `node_count`. 1 node == 1,000 processing units.

Note: This commit is for a preview release. DO NOT MERGE AS IS.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6553)
<!-- Reviewable:end -->
