### PR TITLE
chore: add patch tool to more docker images

### DIFF
--- a/ci/cloudbuild/dockerfiles/demo-centos-7.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-centos-7.Dockerfile
@@ -28,8 +28,8 @@ RUN yum install -y centos-release-scl yum-utils
 RUN yum-config-manager --enable rhel-server-rhscl-7-rpms
 RUN yum makecache && \
     yum install -y automake ccache cmake3 curl-devel devtoolset-7 gcc gcc-c++ \
-        git libtool make openssl-devel pkgconfig re2-devel tar wget which \
-        zlib-devel
+        git libtool make openssl-devel patch pkgconfig re2-devel tar wget \
+        which zlib-devel
 RUN ln -sf /usr/bin/cmake3 /usr/bin/cmake && ln -sf /usr/bin/ctest3 /usr/bin/ctest
 # ```
 

--- a/ci/cloudbuild/dockerfiles/demo-centos-8.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-centos-8.Dockerfile
@@ -24,7 +24,7 @@ ARG NCPU=4
 RUN dnf makecache && \
     dnf install -y epel-release && \
     dnf makecache && \
-    dnf install -y ccache cmake gcc-c++ git make openssl-devel pkgconfig \
+    dnf install -y ccache cmake gcc-c++ git make openssl-devel patch pkgconfig \
         re2-devel zlib-devel libcurl-devel c-ares-devel tar wget which
 # ```
 

--- a/ci/cloudbuild/dockerfiles/demo-fedora.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-fedora.Dockerfile
@@ -21,7 +21,7 @@ ARG NCPU=4
 
 # ```bash
 RUN dnf makecache && \
-    dnf install -y ccache cmake gcc-c++ git make openssl-devel pkgconfig \
+    dnf install -y ccache cmake gcc-c++ git make openssl-devel patch pkgconfig \
         zlib-devel
 # ```
 

--- a/ci/cloudbuild/dockerfiles/demo-opensuse-leap.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-opensuse-leap.Dockerfile
@@ -26,7 +26,7 @@ ARG NCPU=4
 RUN zypper refresh && \
     zypper install --allow-downgrade -y automake ccache cmake curl \
         gcc gcc-c++ git gzip libcurl-devel libopenssl-devel \
-        libtool make re2-devel tar wget which zlib zlib-devel-static
+        libtool make patch re2-devel tar wget which zlib zlib-devel-static
 # ```
 
 # The following steps will install libraries and tools in `/usr/local`. openSUSE

--- a/doc/packaging.md
+++ b/doc/packaging.md
@@ -211,7 +211,7 @@ Install the minimal development tools:
 
 ```bash
 sudo dnf makecache && \
-sudo dnf install -y ccache cmake gcc-c++ git make openssl-devel pkgconfig \
+sudo dnf install -y ccache cmake gcc-c++ git make openssl-devel patch pkgconfig \
         zlib-devel
 ```
 
@@ -320,7 +320,7 @@ workstation or build server.
 sudo zypper refresh && \
 sudo zypper install --allow-downgrade -y automake ccache cmake curl \
         gcc gcc-c++ git gzip libcurl-devel libopenssl-devel \
-        libtool make re2-devel tar wget which zlib zlib-devel-static
+        libtool make patch re2-devel tar wget which zlib zlib-devel-static
 ```
 
 The following steps will install libraries and tools in `/usr/local`. openSUSE
@@ -1203,7 +1203,7 @@ library (required by gRPC):
 sudo dnf makecache && \
 sudo dnf install -y epel-release && \
 sudo dnf makecache && \
-sudo dnf install -y ccache cmake gcc-c++ git make openssl-devel pkgconfig \
+sudo dnf install -y ccache cmake gcc-c++ git make openssl-devel patch pkgconfig \
         re2-devel zlib-devel libcurl-devel c-ares-devel tar wget which
 ```
 
@@ -1353,8 +1353,8 @@ sudo yum install -y centos-release-scl yum-utils
 sudo yum-config-manager --enable rhel-server-rhscl-7-rpms
 sudo yum makecache && \
 sudo yum install -y automake ccache cmake3 curl-devel devtoolset-7 gcc gcc-c++ \
-        git libtool make openssl-devel pkgconfig re2-devel tar wget which \
-        zlib-devel
+        git libtool make openssl-devel patch pkgconfig re2-devel tar wget \
+        which zlib-devel
 sudo ln -sf /usr/bin/cmake3 /usr/bin/cmake && sudo ln -sf /usr/bin/ctest3 /usr/bin/ctest
 ```
 


### PR DESCRIPTION
Add the patch tool to additional docker images, for cases where
it might be needed to update downloaded source in a demo build.
This is only intended for use when developing a new feature.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6554)
<!-- Reviewable:end -->
