### PR TITLE
feat: make benchmarks and samples optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -223,6 +223,14 @@ endif ()
 # also includes the BUILD_TESTING option, which is on by default.
 include(CTest)
 
+# The examples use exception handling to simplify the code. Therefore they
+# cannot be compiled when exceptions are disabled, and applications cannot force
+# the flag.
+cmake_dependent_option(
+    GOOGLE_CLOUD_CPP_ENABLE_EXAMPLES "Compile the google-cloud-cpp examples."
+    ON "GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS;BUILD_TESTING" OFF)
+mark_as_advanced(GOOGLE_CLOUD_CPP_ENABLE_EXAMPLES)
+
 # Each subproject adds dependencies to this target to have their docs generated.
 add_custom_target(doxygen-docs)
 
@@ -237,7 +245,7 @@ endforeach ()
 
 # The examples are more readable if we use exceptions for error handling. We had
 # to tradeoff readability vs. "making them compile everywhere".
-if (GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS
+if (GOOGLE_CLOUD_CPP_ENABLE_CXX_EXAMPLES
     AND bigtable IN_LIST GOOGLE_CLOUD_CPP_ENABLE
     AND storage IN_LIST GOOGLE_CLOUD_CPP_ENABLE)
     add_subdirectory(google/cloud/examples)

--- a/ci/cloudbuild/builds/cmake-install.sh
+++ b/ci/cloudbuild/builds/cmake-install.sh
@@ -30,6 +30,7 @@ readonly INSTALL_PREFIX
 # Compiles and installs all libraries and headers.
 cmake -GNinja \
   -DBUILD_TESTING=OFF \
+  -DGOOGLE_CLOUD_CPP_ENABLE_EXAMPLES=OFF \
   -DCMAKE_INSTALL_PREFIX="${INSTALL_PREFIX}" \
   -S . -B cmake-out
 cmake --build cmake-out

--- a/ci/cloudbuild/builds/demo-install.sh
+++ b/ci/cloudbuild/builds/demo-install.sh
@@ -31,7 +31,10 @@ source module ci/lib/io.sh
 ## [BEGIN packaging.md]
 # Pick a location to install the artifacts, e.g., `/usr/local` or `/opt`
 PREFIX="${HOME}/google-cloud-cpp-installed"
-cmake -DBUILD_TESTING=OFF -DCMAKE_INSTALL_PREFIX="${PREFIX}" -H. -Bcmake-out
+cmake -H. -Bcmake-out \
+  -DBUILD_TESTING=OFF \
+  -DGOOGLE_CLOUD_CPP_ENABLE_EXAMPLES=OFF \
+  -DCMAKE_INSTALL_PREFIX="${PREFIX}"
 cmake --build cmake-out -- -j "$(nproc)"
 cmake --build cmake-out --target install
 ## [DONE packaging.md]

--- a/ci/generate-markdown/generate-packaging.sh
+++ b/ci/generate-markdown/generate-packaging.sh
@@ -80,7 +80,7 @@ CMake support files, then compiling and installing the libraries
 requires two commands:
 
 ```bash
-cmake -DBUILD_TESTING=OFF -H. -Bcmake-out
+cmake -H. -Bcmake-out -DBUILD_TESTING=OFF -DGOOGLE_CLOUD_CPP_ENABLE_EXAMPLES=OFF
 cmake --build cmake-out --target install
 ```
 

--- a/doc/packaging.md
+++ b/doc/packaging.md
@@ -59,7 +59,7 @@ CMake support files, then compiling and installing the libraries
 requires two commands:
 
 ```bash
-cmake -DBUILD_TESTING=OFF -H. -Bcmake-out
+cmake -H. -Bcmake-out -DBUILD_TESTING=OFF -DGOOGLE_CLOUD_CPP_ENABLE_EXAMPLES=OFF
 cmake --build cmake-out --target install
 ```
 
@@ -300,7 +300,10 @@ We can now compile and install `google-cloud-cpp`
 ```bash
 # Pick a location to install the artifacts, e.g., `/usr/local` or `/opt`
 PREFIX="${HOME}/google-cloud-cpp-installed"
-cmake -DBUILD_TESTING=OFF -DCMAKE_INSTALL_PREFIX="${PREFIX}" -H. -Bcmake-out
+cmake -H. -Bcmake-out \
+  -DBUILD_TESTING=OFF \
+  -DGOOGLE_CLOUD_CPP_ENABLE_EXAMPLES=OFF \
+  -DCMAKE_INSTALL_PREFIX="${PREFIX}"
 cmake --build cmake-out -- -j "$(nproc)"
 cmake --build cmake-out --target install
 ```
@@ -460,7 +463,10 @@ We can now compile and install `google-cloud-cpp`
 ```bash
 # Pick a location to install the artifacts, e.g., `/usr/local` or `/opt`
 PREFIX="${HOME}/google-cloud-cpp-installed"
-cmake -DBUILD_TESTING=OFF -DCMAKE_INSTALL_PREFIX="${PREFIX}" -H. -Bcmake-out
+cmake -H. -Bcmake-out \
+  -DBUILD_TESTING=OFF \
+  -DGOOGLE_CLOUD_CPP_ENABLE_EXAMPLES=OFF \
+  -DCMAKE_INSTALL_PREFIX="${PREFIX}"
 cmake --build cmake-out -- -j "$(nproc)"
 cmake --build cmake-out --target install
 ```
@@ -594,7 +600,10 @@ We can now compile and install `google-cloud-cpp`
 ```bash
 # Pick a location to install the artifacts, e.g., `/usr/local` or `/opt`
 PREFIX="${HOME}/google-cloud-cpp-installed"
-cmake -DBUILD_TESTING=OFF -DCMAKE_INSTALL_PREFIX="${PREFIX}" -H. -Bcmake-out
+cmake -H. -Bcmake-out \
+  -DBUILD_TESTING=OFF \
+  -DGOOGLE_CLOUD_CPP_ENABLE_EXAMPLES=OFF \
+  -DCMAKE_INSTALL_PREFIX="${PREFIX}"
 cmake --build cmake-out -- -j "$(nproc)"
 cmake --build cmake-out --target install
 ```
@@ -744,7 +753,10 @@ We can now compile and install `google-cloud-cpp`
 ```bash
 # Pick a location to install the artifacts, e.g., `/usr/local` or `/opt`
 PREFIX="${HOME}/google-cloud-cpp-installed"
-cmake -DBUILD_TESTING=OFF -DCMAKE_INSTALL_PREFIX="${PREFIX}" -H. -Bcmake-out
+cmake -H. -Bcmake-out \
+  -DBUILD_TESTING=OFF \
+  -DGOOGLE_CLOUD_CPP_ENABLE_EXAMPLES=OFF \
+  -DCMAKE_INSTALL_PREFIX="${PREFIX}"
 cmake --build cmake-out -- -j "$(nproc)"
 cmake --build cmake-out --target install
 ```
@@ -912,7 +924,10 @@ We can now compile and install `google-cloud-cpp`
 ```bash
 # Pick a location to install the artifacts, e.g., `/usr/local` or `/opt`
 PREFIX="${HOME}/google-cloud-cpp-installed"
-cmake -DBUILD_TESTING=OFF -DCMAKE_INSTALL_PREFIX="${PREFIX}" -H. -Bcmake-out
+cmake -H. -Bcmake-out \
+  -DBUILD_TESTING=OFF \
+  -DGOOGLE_CLOUD_CPP_ENABLE_EXAMPLES=OFF \
+  -DCMAKE_INSTALL_PREFIX="${PREFIX}"
 cmake --build cmake-out -- -j "$(nproc)"
 cmake --build cmake-out --target install
 ```
@@ -1010,7 +1025,10 @@ We can now compile and install `google-cloud-cpp`
 ```bash
 # Pick a location to install the artifacts, e.g., `/usr/local` or `/opt`
 PREFIX="${HOME}/google-cloud-cpp-installed"
-cmake -DBUILD_TESTING=OFF -DCMAKE_INSTALL_PREFIX="${PREFIX}" -H. -Bcmake-out
+cmake -H. -Bcmake-out \
+  -DBUILD_TESTING=OFF \
+  -DGOOGLE_CLOUD_CPP_ENABLE_EXAMPLES=OFF \
+  -DCMAKE_INSTALL_PREFIX="${PREFIX}"
 cmake --build cmake-out -- -j "$(nproc)"
 cmake --build cmake-out --target install
 ```
@@ -1185,7 +1203,10 @@ We can now compile and install `google-cloud-cpp`
 ```bash
 # Pick a location to install the artifacts, e.g., `/usr/local` or `/opt`
 PREFIX="${HOME}/google-cloud-cpp-installed"
-cmake -DBUILD_TESTING=OFF -DCMAKE_INSTALL_PREFIX="${PREFIX}" -H. -Bcmake-out
+cmake -H. -Bcmake-out \
+  -DBUILD_TESTING=OFF \
+  -DGOOGLE_CLOUD_CPP_ENABLE_EXAMPLES=OFF \
+  -DCMAKE_INSTALL_PREFIX="${PREFIX}"
 cmake --build cmake-out -- -j "$(nproc)"
 cmake --build cmake-out --target install
 ```
@@ -1331,7 +1352,10 @@ We can now compile and install `google-cloud-cpp`
 ```bash
 # Pick a location to install the artifacts, e.g., `/usr/local` or `/opt`
 PREFIX="${HOME}/google-cloud-cpp-installed"
-cmake -DBUILD_TESTING=OFF -DCMAKE_INSTALL_PREFIX="${PREFIX}" -H. -Bcmake-out
+cmake -H. -Bcmake-out \
+  -DBUILD_TESTING=OFF \
+  -DGOOGLE_CLOUD_CPP_ENABLE_EXAMPLES=OFF \
+  -DCMAKE_INSTALL_PREFIX="${PREFIX}"
 cmake --build cmake-out -- -j "$(nproc)"
 cmake --build cmake-out --target install
 ```
@@ -1503,7 +1527,10 @@ We can now compile and install `google-cloud-cpp`
 ```bash
 # Pick a location to install the artifacts, e.g., `/usr/local` or `/opt`
 PREFIX="${HOME}/google-cloud-cpp-installed"
-cmake -DBUILD_TESTING=OFF -DCMAKE_INSTALL_PREFIX="${PREFIX}" -H. -Bcmake-out
+cmake -H. -Bcmake-out \
+  -DBUILD_TESTING=OFF \
+  -DGOOGLE_CLOUD_CPP_ENABLE_EXAMPLES=OFF \
+  -DCMAKE_INSTALL_PREFIX="${PREFIX}"
 cmake --build cmake-out -- -j "$(nproc)"
 cmake --build cmake-out --target install
 ```

--- a/generator/CMakeLists.txt
+++ b/generator/CMakeLists.txt
@@ -170,11 +170,10 @@ function (google_cloud_cpp_generator_define_tests)
     endforeach ()
 endfunction ()
 
-add_subdirectory(integration_tests)
-
 # Only define the tests if testing is enabled. Package maintainers may not want
 # to build all the tests everytime they create a new package or when the package
 # is installed from source.
 if (BUILD_TESTING)
+    add_subdirectory(integration_tests)
     google_cloud_cpp_generator_define_tests()
 endif (BUILD_TESTING)

--- a/generator/integration_tests/CMakeLists.txt
+++ b/generator/integration_tests/CMakeLists.txt
@@ -102,11 +102,10 @@ function (google_cloud_cpp_generator_define_integration_tests)
     endif ()
 endfunction ()
 
-add_subdirectory(golden)
-
 # Only define the tests if testing is enabled. Package maintainers may not want
 # to build all the tests everytime they create a new package or when the package
 # is installed from source.
 if (BUILD_TESTING)
+    add_subdirectory(golden)
     google_cloud_cpp_generator_define_integration_tests()
 endif (BUILD_TESTING)

--- a/google/cloud/bigtable/CMakeLists.txt
+++ b/google/cloud/bigtable/CMakeLists.txt
@@ -323,17 +323,17 @@ if (GOOGLE_CLOUD_CPP_FORCE_STATIC_ANALYZER_ERRORS)
         PRIVATE -DBIGTABLE_CLIENT_FORCE_STATIC_ANALYZER_ERRORS)
 endif ()
 
+# Only compile integration tests and benchmarks if testing is enabled.
 if (BUILD_TESTING)
     add_subdirectory(tests)
+    add_subdirectory(benchmarks)
 endif ()
 
-add_subdirectory(benchmarks)
-
-if (GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
-    # The examples are more readable if we use exceptions for error handling. We
-    # had to tradeoff readability vs. "making them compile everywhere".
+# Examples are enabled if possible, but package maintainers may want to disable
+# compilation to speed up their builds.
+if (GOOGLE_CLOUD_CPP_ENABLE_EXAMPLES)
     add_subdirectory(examples)
-endif (GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
+endif ()
 
 # Export the CMake targets to make it easy to create configuration files.
 install(

--- a/google/cloud/iam/CMakeLists.txt
+++ b/google/cloud/iam/CMakeLists.txt
@@ -114,9 +114,12 @@ target_compile_options(google_cloud_cpp_iam_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
 add_subdirectory(integration_tests)
-if (GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
+
+# Examples are enabled if possible, but package maintainers may want to disable
+# compilation to speed up their builds.
+if (GOOGLE_CLOUD_CPP_ENABLE_EXAMPLES)
     add_subdirectory(samples)
-endif (GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
+endif ()
 
 # Get the destination directories based on the GNU recommendations.
 include(GNUInstallDirs)

--- a/google/cloud/pubsub/CMakeLists.txt
+++ b/google/cloud/pubsub/CMakeLists.txt
@@ -301,16 +301,15 @@ endfunction ()
 # is installed from source.
 if (BUILD_TESTING)
     google_cloud_cpp_pubsub_client_define_tests()
+    add_subdirectory(benchmarks)
+    add_subdirectory(integration_tests)
 endif (BUILD_TESTING)
 
-add_subdirectory(benchmarks)
-add_subdirectory(integration_tests)
-
-# Only compile the samples if we're building with exceptions enabled. They
-# require exceptions to keep them simple and idiomatic.
-if (GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
+# Examples are enabled if possible, but package maintainers may want to disable
+# compilation to speed up their builds.
+if (GOOGLE_CLOUD_CPP_ENABLE_EXAMPLES)
     add_subdirectory(samples)
-endif (GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
+endif ()
 
 # Get the destination directories based on the GNU recommendations.
 include(GNUInstallDirs)

--- a/google/cloud/spanner/CMakeLists.txt
+++ b/google/cloud/spanner/CMakeLists.txt
@@ -374,16 +374,15 @@ endfunction ()
 if (BUILD_TESTING)
     spanner_client_define_tests()
     spanner_client_define_benchmarks()
+    add_subdirectory(integration_tests)
+    add_subdirectory(benchmarks) # macro benchmarks
 endif (BUILD_TESTING)
 
-add_subdirectory(integration_tests)
-add_subdirectory(benchmarks) # macro benchmarks
-
-# Only compile the samples if we're building with exceptions enabled. They
-# require exceptions to keep them simple and idiomatic.
-if (GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
+# Examples are enabled if possible, but package maintainers may want to disable
+# compilation to speed up their builds.
+if (GOOGLE_CLOUD_CPP_ENABLE_EXAMPLES)
     add_subdirectory(samples)
-endif (GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
+endif ()
 
 # Export the CMake targets to make it easy to create configuration files.
 install(

--- a/google/cloud/storage/CMakeLists.txt
+++ b/google/cloud/storage/CMakeLists.txt
@@ -615,13 +615,16 @@ if (GOOGLE_CLOUD_CPP_STORAGE_ENABLE_GRPC)
     endif ()
 endif (GOOGLE_CLOUD_CPP_STORAGE_ENABLE_GRPC)
 
-add_subdirectory(benchmarks)
+# Skip the macro benchmarks if testing is disabled.
+if (BUILD_TESTING)
+    add_subdirectory(benchmarks)
+endif ()
 
-if (GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
-    # The examples are more readable if we use exceptions for error handling. We
-    # had to tradeoff readability vs. "making them compile everywhere".
+# Examples are enabled if possible, but package maintainers may want to disable
+# compilation to speed up their builds.
+if (GOOGLE_CLOUD_CPP_ENABLE_EXAMPLES)
     add_subdirectory(examples)
-endif (GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
+endif ()
 
 install(
     TARGETS google_cloud_cpp_storage google_cloud_cpp_storage_grpc


### PR DESCRIPTION
Package maintainers may want to disable compilation of benchmarks,
integration tests, samples, etc. They do not install those, so it is
just wasted time for them and the downstreams users for source-based
package systems (e.g. vcpkg).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6559)
<!-- Reviewable:end -->
