### PR TITLE
ci: fix several doxygen errors

### DIFF
--- a/cmake/GoogleCloudCppCommon.cmake
+++ b/cmake/GoogleCloudCppCommon.cmake
@@ -40,7 +40,7 @@ else ()
     find_package(Doxygen)
     if (Doxygen_FOUND)
         set(DOXYGEN_RECURSIVE YES)
-        set(DOXYGEN_FILE_PATTERNS *.h *.cc *.proto *.dox)
+        set(DOXYGEN_FILE_PATTERNS *.h *.cc *.dox)
         set(DOXYGEN_EXAMPLE_RECURSIVE YES)
         set(DOXYGEN_EXCLUDE "third_party" "cmake-build-debug" "cmake-out")
         set(DOXYGEN_EXCLUDE_SYMLINKS YES)
@@ -72,6 +72,21 @@ else ()
         set(DOXYGEN_DOT_TRANSPARENT YES)
         set(DOXYGEN_MACRO_EXPANSION YES)
         set(DOXYGEN_EXPAND_ONLY_PREDEF YES)
+        # Macros confuse Doxygen. We don't use too many, so we predefine them
+        # here to be noops or have simple values.
+        set(DOXYGEN_PREDEFINED
+            "GOOGLE_CLOUD_CPP_DEPRECATED(x)="
+            "GOOGLE_CLOUD_CPP_IAM_DEPRECATED(x)="
+            "GOOGLE_CLOUD_CPP_BIGTABLE_ADMIN_ASYNC_DEPRECATED(x)="
+            "GOOGLE_CLOUD_CPP_BIGTABLE_IAM_DEPRECATED(x)="
+            "GOOGLE_CLOUD_CPP_BIGTABLE_ASYNC_CQ_PARAM_DEPRECATED(x)="
+            "GOOGLE_CLOUD_CPP_BIGTABLE_ASYNC_CQ_PARAM_DEPRECATED(x)="
+            "GOOGLE_CLOUD_CPP_GENERATED_NS=v${PROJECT_VERSION_MAJOR}"
+            "GOOGLE_CLOUD_CPP_NS=v${PROJECT_VERSION_MAJOR}"
+            "GOOGLE_CLOUD_CPP_PUBSUB_NS=v${PROJECT_VERSION_MAJOR}"
+            "BIGTABLE_CLIENT_NS=v${PROJECT_VERSION_MAJOR}"
+            "SPANNER_CLIENT_NS=v${PROJECT_VERSION_MAJOR}"
+            "STORAGE_CLIENT_NS=v${PROJECT_VERSION_MAJOR}")
         set(DOXYGEN_HTML_TIMESTAMP YES)
         set(DOXYGEN_STRIP_FROM_INC_PATH "${PROJECT_SOURCE_DIR}")
         set(DOXYGEN_SHOW_USED_FILES NO)

--- a/google/cloud/CMakeLists.txt
+++ b/google/cloud/CMakeLists.txt
@@ -23,7 +23,6 @@ configure_file(internal/version_info.h.in
 set(DOXYGEN_PROJECT_NAME "Google Cloud C++ Client")
 set(DOXYGEN_PROJECT_BRIEF "C++ Client Library for Google Cloud Platform")
 set(DOXYGEN_PROJECT_NUMBER "${PROJECT_VERSION}")
-set(DOXYGEN_PREDEFINED "GOOGLE_CLOUD_CPP_NS=v${PROJECT_VERSION_MAJOR}")
 set(DOXYGEN_EXCLUDE_PATTERNS
     "*/generator/*"
     "*/google/cloud/README.md"

--- a/google/cloud/bigquery/CMakeLists.txt
+++ b/google/cloud/bigquery/CMakeLists.txt
@@ -17,12 +17,10 @@
 set(DOXYGEN_PROJECT_NAME "Google Cloud BigQuery C++ Client")
 set(DOXYGEN_PROJECT_BRIEF "A C++ Client Library for Google Cloud BigQuery")
 set(DOXYGEN_PROJECT_NUMBER "${PROJECT_VERSION} (Beta)")
-set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/samples
-                         ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
+set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
 set(DOXYGEN_EXCLUDE_PATTERNS "*/*_test.cc")
 set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "bigquery_internal" "bigquery_testing"
                             "examples")
-set(DOXYGEN_PREDEFINED "GOOGLE_CLOUD_CPP_NS=v1")
 
 include(GoogleCloudCppCommon)
 

--- a/google/cloud/bigtable/CMakeLists.txt
+++ b/google/cloud/bigtable/CMakeLists.txt
@@ -21,9 +21,6 @@ set(DOXYGEN_PROJECT_BRIEF "A C++ Client Library for Google Cloud Bigtable")
 set(DOXYGEN_PROJECT_NUMBER "${PROJECT_VERSION}")
 set(DOXYGEN_EXAMPLE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/examples"
                          "${CMAKE_CURRENT_SOURCE_DIR}/quickstart")
-set(DOXYGEN_PREDEFINED "GOOGLE_CLOUD_CPP_NS=v${PROJECT_VERSION_MAJOR}"
-                       "BIGTABLE_CLIENT_NS=v${PROJECT_VERSION_MAJOR}")
-
 set(DOXYGEN_EXCLUDE_PATTERNS
     "*/google/cloud/bigtable/README.md"
     "*/google/cloud/bigtable/benchmarks/*"

--- a/google/cloud/bigtable/instance_admin.h
+++ b/google/cloud/bigtable/instance_admin.h
@@ -1285,7 +1285,7 @@ class InstanceAdmin {
    * and using different copies in each thread.
    *
    * @par Example
-   * Use #SetNativeIamPolicy()
+   * Use #SetIamPolicy()
    */
   GOOGLE_CLOUD_CPP_BIGTABLE_ADMIN_ASYNC_DEPRECATED
   future<StatusOr<google::cloud::IamPolicy>> AsyncSetIamPolicy(

--- a/google/cloud/bigtable/table_admin.h
+++ b/google/cloud/bigtable/table_admin.h
@@ -1516,7 +1516,7 @@ class TableAdmin {
    * and using different copies in each thread.
    *
    * @par Example
-   * Use #GetNativeIamPolicy()
+   * Use #GetIamPolicy()
    */
   GOOGLE_CLOUD_CPP_BIGTABLE_ADMIN_ASYNC_DEPRECATED
   future<StatusOr<google::iam::v1::Policy>> AsyncGetIamPolicy(

--- a/google/cloud/firestore/CMakeLists.txt
+++ b/google/cloud/firestore/CMakeLists.txt
@@ -17,8 +17,6 @@
 set(DOXYGEN_PROJECT_NAME "Google Cloud Firestore C++ Client")
 set(DOXYGEN_PROJECT_BRIEF "A C++ Client Library for Google Cloud Firestore")
 set(DOXYGEN_PROJECT_NUMBER "${PROJECT_VERSION}")
-set(DOXYGEN_PREDEFINED "GOOGLE_CLOUD_CPP_NS=v${PROJECT_VERSION_MAJOR}"
-                       "FIRESTORE_CLIENT_NS=v${PROJECT_VERSION_MAJOR}")
 set(DOXYGEN_EXCLUDE_PATTERNS
     "*/google/cloud/firestore/README.md" "*/google/cloud/firestore/internal/*"
     "*/google/cloud/firestore/*_test.cc")

--- a/google/cloud/iam/CMakeLists.txt
+++ b/google/cloud/iam/CMakeLists.txt
@@ -17,11 +17,9 @@
 set(DOXYGEN_PROJECT_NAME "Google Cloud IAM C++ Client")
 set(DOXYGEN_PROJECT_BRIEF "A C++ Client Library for Google Cloud IAM")
 set(DOXYGEN_PROJECT_NUMBER "${PROJECT_VERSION} (Beta)")
-set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/samples
-                         ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
+set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/samples)
 set(DOXYGEN_EXCLUDE_PATTERNS "*/*_test.cc")
 set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "iam_internal" "iam_testing" "examples")
-set(DOXYGEN_PREDEFINED "GOOGLE_CLOUD_CPP_NS=v1")
 
 include(GoogleCloudCppCommon)
 

--- a/google/cloud/logging/CMakeLists.txt
+++ b/google/cloud/logging/CMakeLists.txt
@@ -17,12 +17,9 @@
 set(DOXYGEN_PROJECT_NAME "Google Cloud Logging C++ Client")
 set(DOXYGEN_PROJECT_BRIEF "A C++ Client Library for Google Cloud Logging")
 set(DOXYGEN_PROJECT_NUMBER "${PROJECT_VERSION} (Beta)")
-set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/samples
-                         ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
 set(DOXYGEN_EXCLUDE_PATTERNS "*/*_test.cc")
 set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "logging_internal" "logging_testing"
                             "examples")
-set(DOXYGEN_PREDEFINED "GOOGLE_CLOUD_CPP_NS=v1")
 
 include(GoogleCloudCppCommon)
 

--- a/google/cloud/pubsub/CMakeLists.txt
+++ b/google/cloud/pubsub/CMakeLists.txt
@@ -22,7 +22,6 @@ set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/samples
 set(DOXYGEN_EXCLUDE_PATTERNS "*/*_test.cc")
 set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "pubsub_internal" "pubsub_testing"
                             "examples")
-set(DOXYGEN_PREDEFINED "GOOGLE_CLOUD_CPP_PUBSUB_NS=v1")
 
 include(GoogleCloudCppCommon)
 

--- a/google/cloud/spanner/CMakeLists.txt
+++ b/google/cloud/spanner/CMakeLists.txt
@@ -22,7 +22,6 @@ set(DOXYGEN_PROJECT_NUMBER "${PROJECT_VERSION}")
 set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/samples
                          ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
 set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "spanner_testing")
-set(DOXYGEN_PREDEFINED "SPANNER_CLIENT_NS=v${PROJECT_VERSION_MAJOR}")
 set(DOXYGEN_EXCLUDE_PATTERNS
     "*/google/cloud/spanner/README.md" "*/google/cloud/spanner/internal/*"
     "*/google/cloud/spanner/benchmarks/*" "*/google/cloud/spanner/testing/*"

--- a/google/cloud/storage/CMakeLists.txt
+++ b/google/cloud/storage/CMakeLists.txt
@@ -25,8 +25,6 @@ set(DOXYGEN_PROJECT_BRIEF "A C++ Client Library for Google Cloud Storage")
 set(DOXYGEN_PROJECT_NUMBER "${PROJECT_VERSION}")
 set(DOXYGEN_EXAMPLE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/examples"
                          "${CMAKE_CURRENT_SOURCE_DIR}/quickstart")
-set(DOXYGEN_PREDEFINED "GOOGLE_CLOUD_CPP_NS=v${PROJECT_VERSION_MAJOR}"
-                       "STORAGE_CLIENT_NS=v${PROJECT_VERSION_MAJOR}")
 set(DOXYGEN_EXCLUDE_PATTERNS
     "*/google/cloud/storage/README.md"
     "*/google/cloud/storage/ci/*"

--- a/google/cloud/storage/grpc_plugin.h
+++ b/google/cloud/storage/grpc_plugin.h
@@ -36,10 +36,10 @@ inline namespace STORAGE_CLIENT_NS {
  * @note the Credentials parameter in the configuration is ignored. The gRPC
  *     client only supports Google Default Credentials.
  *
- * @param options the configuration parameters for the Client.
  * @param channel_id set the `grpc.channel_id` attribute in the underlying
  *   gRPC channel, this can be used to segregate the gRPC channels for different
  *   clients.
+ * @param opts the configuration parameters for the Client.
  *
  * @warning this is an experimental feature, and subject to change without
  *     notice.

--- a/google/cloud/stream_range.h
+++ b/google/cloud/stream_range.h
@@ -98,7 +98,7 @@ class StreamRange {
   /**
    * An input iterator for a `StreamRange<T>` -- DO NOT USE DIRECTLY.
    *
-   * Use `StreamRange<T>::iterator` instead.
+   * Use `StreamRange::iterator` instead.
    */
   template <typename U>
   class IteratorImpl {


### PR DESCRIPTION
The main fix in here is predefining several macros that our code uses
that confuse doxygen. I predefine them to noop value or some sensible
and simple value. This fixes most of the errors.

Part of: https://github.com/googleapis/google-cloud-cpp/issues/6543

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6563)
<!-- Reviewable:end -->
