### PR TITLE
ci: fix doxygen errors from generated code

### DIFF
--- a/generator/integration_tests/golden/golden_kitchen_sink_client.cc
+++ b/generator/integration_tests/golden/golden_kitchen_sink_client.cc
@@ -27,9 +27,9 @@ inline namespace GOOGLE_CLOUD_CPP_GENERATED_NS {
 GoldenKitchenSinkClient::GoldenKitchenSinkClient(std::shared_ptr<GoldenKitchenSinkConnection> connection) : connection_(std::move(connection)) {}
 GoldenKitchenSinkClient::~GoldenKitchenSinkClient() = default;
 
-StatusOr<::google::test::admin::database::v1::GenerateAccessTokenResponse>
-GoldenKitchenSinkClient::GenerateAccessToken(std::string const& name, std::vector<std::string> const& delegates, std::vector<std::string> const& scope, ::google::protobuf::Duration const& lifetime) {
-  ::google::test::admin::database::v1::GenerateAccessTokenRequest request;
+StatusOr<google::test::admin::database::v1::GenerateAccessTokenResponse>
+GoldenKitchenSinkClient::GenerateAccessToken(std::string const& name, std::vector<std::string> const& delegates, std::vector<std::string> const& scope, google::protobuf::Duration const& lifetime) {
+  google::test::admin::database::v1::GenerateAccessTokenRequest request;
   request.set_name(name);
   *request.mutable_delegates() = {delegates.begin(), delegates.end()};
   *request.mutable_scope() = {scope.begin(), scope.end()};
@@ -37,9 +37,9 @@ GoldenKitchenSinkClient::GenerateAccessToken(std::string const& name, std::vecto
   return connection_->GenerateAccessToken(request);
 }
 
-StatusOr<::google::test::admin::database::v1::GenerateIdTokenResponse>
+StatusOr<google::test::admin::database::v1::GenerateIdTokenResponse>
 GoldenKitchenSinkClient::GenerateIdToken(std::string const& name, std::vector<std::string> const& delegates, std::string const& audience, bool include_email) {
-  ::google::test::admin::database::v1::GenerateIdTokenRequest request;
+  google::test::admin::database::v1::GenerateIdTokenRequest request;
   request.set_name(name);
   *request.mutable_delegates() = {delegates.begin(), delegates.end()};
   request.set_audience(audience);
@@ -47,9 +47,9 @@ GoldenKitchenSinkClient::GenerateIdToken(std::string const& name, std::vector<st
   return connection_->GenerateIdToken(request);
 }
 
-StatusOr<::google::test::admin::database::v1::WriteLogEntriesResponse>
+StatusOr<google::test::admin::database::v1::WriteLogEntriesResponse>
 GoldenKitchenSinkClient::WriteLogEntries(std::string const& log_name, std::map<std::string, std::string> const& labels) {
-  ::google::test::admin::database::v1::WriteLogEntriesRequest request;
+  google::test::admin::database::v1::WriteLogEntriesRequest request;
   request.set_log_name(log_name);
   *request.mutable_labels() = {labels.begin(), labels.end()};
   return connection_->WriteLogEntries(request);
@@ -57,53 +57,53 @@ GoldenKitchenSinkClient::WriteLogEntries(std::string const& log_name, std::map<s
 
 StreamRange<std::string>
 GoldenKitchenSinkClient::ListLogs(std::string const& parent) {
-  ::google::test::admin::database::v1::ListLogsRequest request;
+  google::test::admin::database::v1::ListLogsRequest request;
   request.set_parent(parent);
   return connection_->ListLogs(request);
 }
 
-StreamRange<::google::test::admin::database::v1::TailLogEntriesResponse>
+StreamRange<google::test::admin::database::v1::TailLogEntriesResponse>
 GoldenKitchenSinkClient::TailLogEntries(std::vector<std::string> const& resource_names) {
-  ::google::test::admin::database::v1::TailLogEntriesRequest request;
+  google::test::admin::database::v1::TailLogEntriesRequest request;
   *request.mutable_resource_names() = {resource_names.begin(), resource_names.end()};
   return connection_->TailLogEntries(request);
 }
 
-StatusOr<::google::test::admin::database::v1::ListServiceAccountKeysResponse>
-GoldenKitchenSinkClient::ListServiceAccountKeys(std::string const& name, std::vector<::google::test::admin::database::v1::ListServiceAccountKeysRequest::KeyType> const& key_types) {
-  ::google::test::admin::database::v1::ListServiceAccountKeysRequest request;
+StatusOr<google::test::admin::database::v1::ListServiceAccountKeysResponse>
+GoldenKitchenSinkClient::ListServiceAccountKeys(std::string const& name, std::vector<google::test::admin::database::v1::ListServiceAccountKeysRequest::KeyType> const& key_types) {
+  google::test::admin::database::v1::ListServiceAccountKeysRequest request;
   request.set_name(name);
   *request.mutable_key_types() = {key_types.begin(), key_types.end()};
   return connection_->ListServiceAccountKeys(request);
 }
 
-StatusOr<::google::test::admin::database::v1::GenerateAccessTokenResponse>
-GoldenKitchenSinkClient::GenerateAccessToken(::google::test::admin::database::v1::GenerateAccessTokenRequest const& request) {
+StatusOr<google::test::admin::database::v1::GenerateAccessTokenResponse>
+GoldenKitchenSinkClient::GenerateAccessToken(google::test::admin::database::v1::GenerateAccessTokenRequest const& request) {
   return connection_->GenerateAccessToken(request);
 }
 
-StatusOr<::google::test::admin::database::v1::GenerateIdTokenResponse>
-GoldenKitchenSinkClient::GenerateIdToken(::google::test::admin::database::v1::GenerateIdTokenRequest const& request) {
+StatusOr<google::test::admin::database::v1::GenerateIdTokenResponse>
+GoldenKitchenSinkClient::GenerateIdToken(google::test::admin::database::v1::GenerateIdTokenRequest const& request) {
   return connection_->GenerateIdToken(request);
 }
 
-StatusOr<::google::test::admin::database::v1::WriteLogEntriesResponse>
-GoldenKitchenSinkClient::WriteLogEntries(::google::test::admin::database::v1::WriteLogEntriesRequest const& request) {
+StatusOr<google::test::admin::database::v1::WriteLogEntriesResponse>
+GoldenKitchenSinkClient::WriteLogEntries(google::test::admin::database::v1::WriteLogEntriesRequest const& request) {
   return connection_->WriteLogEntries(request);
 }
 
 StreamRange<std::string>
-GoldenKitchenSinkClient::ListLogs(::google::test::admin::database::v1::ListLogsRequest request) {
+GoldenKitchenSinkClient::ListLogs(google::test::admin::database::v1::ListLogsRequest request) {
   return connection_->ListLogs(std::move(request));
 }
 
-StreamRange<::google::test::admin::database::v1::TailLogEntriesResponse>
-GoldenKitchenSinkClient::TailLogEntries(::google::test::admin::database::v1::TailLogEntriesRequest const& request) {
+StreamRange<google::test::admin::database::v1::TailLogEntriesResponse>
+GoldenKitchenSinkClient::TailLogEntries(google::test::admin::database::v1::TailLogEntriesRequest const& request) {
   return connection_->TailLogEntries(request);
 }
 
-StatusOr<::google::test::admin::database::v1::ListServiceAccountKeysResponse>
-GoldenKitchenSinkClient::ListServiceAccountKeys(::google::test::admin::database::v1::ListServiceAccountKeysRequest const& request) {
+StatusOr<google::test::admin::database::v1::ListServiceAccountKeysResponse>
+GoldenKitchenSinkClient::ListServiceAccountKeys(google::test::admin::database::v1::ListServiceAccountKeysRequest const& request) {
   return connection_->ListServiceAccountKeys(request);
 }
 

--- a/generator/integration_tests/golden/golden_kitchen_sink_client.h
+++ b/generator/integration_tests/golden/golden_kitchen_sink_client.h
@@ -89,10 +89,10 @@ class GoldenKitchenSinkClient {
    *  Must be set to a value less than or equal to 3600 (1 hour). If a value is
    *  not specified, the token's lifetime will be set to a default value of one
    *  hour.
-   * @return [::google::test::admin::database::v1::GenerateAccessTokenResponse](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L872)
+   * @return [google::test::admin::database::v1::GenerateAccessTokenResponse](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L872)
    */
-  StatusOr<::google::test::admin::database::v1::GenerateAccessTokenResponse>
-  GenerateAccessToken(std::string const& name, std::vector<std::string> const& delegates, std::vector<std::string> const& scope, ::google::protobuf::Duration const& lifetime);
+  StatusOr<google::test::admin::database::v1::GenerateAccessTokenResponse>
+  GenerateAccessToken(std::string const& name, std::vector<std::string> const& delegates, std::vector<std::string> const& scope, google::protobuf::Duration const& lifetime);
 
   /**
    * Generates an OpenID Connect ID token for a service account.
@@ -114,9 +114,9 @@ class GoldenKitchenSinkClient {
    *  grants access to.
    * @param include_email  Include the service account email in the token. If set to `true`, the
    *  token will contain `email` and `email_verified` claims.
-   * @return [::google::test::admin::database::v1::GenerateIdTokenResponse](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L914)
+   * @return [google::test::admin::database::v1::GenerateIdTokenResponse](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L914)
    */
-  StatusOr<::google::test::admin::database::v1::GenerateIdTokenResponse>
+  StatusOr<google::test::admin::database::v1::GenerateIdTokenResponse>
   GenerateIdToken(std::string const& name, std::vector<std::string> const& delegates, std::string const& audience, bool include_email);
 
   /**
@@ -145,9 +145,9 @@ class GoldenKitchenSinkClient {
    *  entries in `entries`. If a log entry already has a label with the same key
    *  as a label in this parameter, then the log entry's label is not changed.
    *  See [LogEntry][google.logging.v2.LogEntry]. Test delimiter$
-   * @return [::google::test::admin::database::v1::WriteLogEntriesResponse](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L953)
+   * @return [google::test::admin::database::v1::WriteLogEntriesResponse](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L953)
    */
-  StatusOr<::google::test::admin::database::v1::WriteLogEntriesResponse>
+  StatusOr<google::test::admin::database::v1::WriteLogEntriesResponse>
   WriteLogEntries(std::string const& log_name, std::map<std::string, std::string> const& labels);
 
   /**
@@ -177,9 +177,9 @@ class GoldenKitchenSinkClient {
    *      "organization/[ORGANIZATION_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]"
    *      "billingAccounts/[BILLING_ACCOUNT_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]"
    *      "folders/[FOLDER_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]"
-   * @return [::google::test::admin::database::v1::TailLogEntriesResponse](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L1214)
+   * @return [google::test::admin::database::v1::TailLogEntriesResponse](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L1214)
    */
-  StreamRange<::google::test::admin::database::v1::TailLogEntriesResponse>
+  StreamRange<google::test::admin::database::v1::TailLogEntriesResponse>
   TailLogEntries(std::vector<std::string> const& resource_names);
 
   /**
@@ -193,28 +193,28 @@ class GoldenKitchenSinkClient {
    * @param key_types  Filters the types of keys the user wants to include in the list
    *  response. Duplicate key types are not allowed. If no key type
    *  is provided, all keys are returned.
-   * @return [::google::test::admin::database::v1::ListServiceAccountKeysResponse](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L1286)
+   * @return [google::test::admin::database::v1::ListServiceAccountKeysResponse](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L1286)
    */
-  StatusOr<::google::test::admin::database::v1::ListServiceAccountKeysResponse>
-  ListServiceAccountKeys(std::string const& name, std::vector<::google::test::admin::database::v1::ListServiceAccountKeysRequest::KeyType> const& key_types);
+  StatusOr<google::test::admin::database::v1::ListServiceAccountKeysResponse>
+  ListServiceAccountKeys(std::string const& name, std::vector<google::test::admin::database::v1::ListServiceAccountKeysRequest::KeyType> const& key_types);
 
   /**
    * Generates an OAuth 2.0 access token for a service account.
    *
-   * @param request [::google::test::admin::database::v1::GenerateAccessTokenRequest](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L835)
-   * @return [::google::test::admin::database::v1::GenerateAccessTokenResponse](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L872)
+   * @param request [google::test::admin::database::v1::GenerateAccessTokenRequest](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L835)
+   * @return [google::test::admin::database::v1::GenerateAccessTokenResponse](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L872)
    */
-  StatusOr<::google::test::admin::database::v1::GenerateAccessTokenResponse>
-  GenerateAccessToken(::google::test::admin::database::v1::GenerateAccessTokenRequest const& request);
+  StatusOr<google::test::admin::database::v1::GenerateAccessTokenResponse>
+  GenerateAccessToken(google::test::admin::database::v1::GenerateAccessTokenRequest const& request);
 
   /**
    * Generates an OpenID Connect ID token for a service account.
    *
-   * @param request [::google::test::admin::database::v1::GenerateIdTokenRequest](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L881)
-   * @return [::google::test::admin::database::v1::GenerateIdTokenResponse](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L914)
+   * @param request [google::test::admin::database::v1::GenerateIdTokenRequest](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L881)
+   * @return [google::test::admin::database::v1::GenerateIdTokenResponse](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L914)
    */
-  StatusOr<::google::test::admin::database::v1::GenerateIdTokenResponse>
-  GenerateIdToken(::google::test::admin::database::v1::GenerateIdTokenRequest const& request);
+  StatusOr<google::test::admin::database::v1::GenerateIdTokenResponse>
+  GenerateIdToken(google::test::admin::database::v1::GenerateIdTokenRequest const& request);
 
   /**
    * Writes log entries to Logging. This API method is the
@@ -225,39 +225,39 @@ class GoldenKitchenSinkClient {
    * different resources (projects, organizations, billing accounts or
    * folders)
    *
-   * @param request [::google::test::admin::database::v1::WriteLogEntriesRequest](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L920)
-   * @return [::google::test::admin::database::v1::WriteLogEntriesResponse](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L953)
+   * @param request [google::test::admin::database::v1::WriteLogEntriesRequest](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L920)
+   * @return [google::test::admin::database::v1::WriteLogEntriesResponse](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L953)
    */
-  StatusOr<::google::test::admin::database::v1::WriteLogEntriesResponse>
-  WriteLogEntries(::google::test::admin::database::v1::WriteLogEntriesRequest const& request);
+  StatusOr<google::test::admin::database::v1::WriteLogEntriesResponse>
+  WriteLogEntries(google::test::admin::database::v1::WriteLogEntriesRequest const& request);
 
   /**
    * Lists the logs in projects, organizations, folders, or billing accounts.
    * Only logs that have entries are listed.
    *
-   * @param request [::google::test::admin::database::v1::ListLogsRequest](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L956)
+   * @param request [google::test::admin::database::v1::ListLogsRequest](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L956)
    */
   StreamRange<std::string>
-  ListLogs(::google::test::admin::database::v1::ListLogsRequest request);
+  ListLogs(google::test::admin::database::v1::ListLogsRequest request);
 
   /**
    * Streaming read of log entries as they are ingested. Until the stream is
    * terminated, it will continue reading logs.
    *
-   * @param request [::google::test::admin::database::v1::TailLogEntriesRequest](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L1182)
-   * @return [::google::test::admin::database::v1::TailLogEntriesResponse](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L1214)
+   * @param request [google::test::admin::database::v1::TailLogEntriesRequest](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L1182)
+   * @return [google::test::admin::database::v1::TailLogEntriesResponse](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L1214)
    */
-  StreamRange<::google::test::admin::database::v1::TailLogEntriesResponse>
-  TailLogEntries(::google::test::admin::database::v1::TailLogEntriesRequest const& request);
+  StreamRange<google::test::admin::database::v1::TailLogEntriesResponse>
+  TailLogEntries(google::test::admin::database::v1::TailLogEntriesRequest const& request);
 
   /**
    * Lists every [ServiceAccountKey][google.iam.admin.v1.ServiceAccountKey] for a service account.
    *
-   * @param request [::google::test::admin::database::v1::ListServiceAccountKeysRequest](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L1254)
-   * @return [::google::test::admin::database::v1::ListServiceAccountKeysResponse](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L1286)
+   * @param request [google::test::admin::database::v1::ListServiceAccountKeysRequest](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L1254)
+   * @return [google::test::admin::database::v1::ListServiceAccountKeysResponse](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L1286)
    */
-  StatusOr<::google::test::admin::database::v1::ListServiceAccountKeysResponse>
-  ListServiceAccountKeys(::google::test::admin::database::v1::ListServiceAccountKeysRequest const& request);
+  StatusOr<google::test::admin::database::v1::ListServiceAccountKeysResponse>
+  ListServiceAccountKeys(google::test::admin::database::v1::ListServiceAccountKeysRequest const& request);
 
  private:
   std::shared_ptr<GoldenKitchenSinkConnection> connection_;

--- a/generator/integration_tests/golden/golden_kitchen_sink_connection.cc
+++ b/generator/integration_tests/golden/golden_kitchen_sink_connection.cc
@@ -33,50 +33,50 @@ inline namespace GOOGLE_CLOUD_CPP_GENERATED_NS {
 
 GoldenKitchenSinkConnection::~GoldenKitchenSinkConnection() = default;
 
-StatusOr<::google::test::admin::database::v1::GenerateAccessTokenResponse>
+StatusOr<google::test::admin::database::v1::GenerateAccessTokenResponse>
 GoldenKitchenSinkConnection::GenerateAccessToken(
-    ::google::test::admin::database::v1::GenerateAccessTokenRequest const&) {
+    google::test::admin::database::v1::GenerateAccessTokenRequest const&) {
   return Status(StatusCode::kUnimplemented, "not implemented");
 }
 
-StatusOr<::google::test::admin::database::v1::GenerateIdTokenResponse>
+StatusOr<google::test::admin::database::v1::GenerateIdTokenResponse>
 GoldenKitchenSinkConnection::GenerateIdToken(
-    ::google::test::admin::database::v1::GenerateIdTokenRequest const&) {
+    google::test::admin::database::v1::GenerateIdTokenRequest const&) {
   return Status(StatusCode::kUnimplemented, "not implemented");
 }
 
-StatusOr<::google::test::admin::database::v1::WriteLogEntriesResponse>
+StatusOr<google::test::admin::database::v1::WriteLogEntriesResponse>
 GoldenKitchenSinkConnection::WriteLogEntries(
-    ::google::test::admin::database::v1::WriteLogEntriesRequest const&) {
+    google::test::admin::database::v1::WriteLogEntriesRequest const&) {
   return Status(StatusCode::kUnimplemented, "not implemented");
 }
 
 StreamRange<std::string> GoldenKitchenSinkConnection::ListLogs(
-    ::google::test::admin::database::v1::ListLogsRequest request) {
+    google::test::admin::database::v1::ListLogsRequest request) {
   return google::cloud::internal::MakePaginationRange<StreamRange<
     std::string>>(
     std::move(request),
-    [](::google::test::admin::database::v1::ListLogsRequest const&) {
-      return StatusOr<::google::test::admin::database::v1::ListLogsResponse>{};
+    [](google::test::admin::database::v1::ListLogsRequest const&) {
+      return StatusOr<google::test::admin::database::v1::ListLogsResponse>{};
     },
-    [](::google::test::admin::database::v1::ListLogsResponse const&) {
+    [](google::test::admin::database::v1::ListLogsResponse const&) {
       return std::vector<std::string>();
     });
 }
 
-StreamRange<::google::test::admin::database::v1::TailLogEntriesResponse> GoldenKitchenSinkConnection::TailLogEntries(
-    ::google::test::admin::database::v1::TailLogEntriesRequest const&) {
+StreamRange<google::test::admin::database::v1::TailLogEntriesResponse> GoldenKitchenSinkConnection::TailLogEntries(
+    google::test::admin::database::v1::TailLogEntriesRequest const&) {
   return google::cloud::internal::MakeStreamRange<
-      ::google::test::admin::database::v1::TailLogEntriesResponse>(
+      google::test::admin::database::v1::TailLogEntriesResponse>(
       []() -> absl::variant<Status,
-      ::google::test::admin::database::v1::TailLogEntriesResponse>{
+      google::test::admin::database::v1::TailLogEntriesResponse>{
         return Status(StatusCode::kUnimplemented, "not implemented");}
       );
 }
 
-StatusOr<::google::test::admin::database::v1::ListServiceAccountKeysResponse>
+StatusOr<google::test::admin::database::v1::ListServiceAccountKeysResponse>
 GoldenKitchenSinkConnection::ListServiceAccountKeys(
-    ::google::test::admin::database::v1::ListServiceAccountKeysRequest const&) {
+    google::test::admin::database::v1::ListServiceAccountKeysRequest const&) {
   return Status(StatusCode::kUnimplemented, "not implemented");
 }
 
@@ -93,47 +93,47 @@ class GoldenKitchenSinkConnectionImpl : public GoldenKitchenSinkConnection {
 
   ~GoldenKitchenSinkConnectionImpl() override = default;
 
-  StatusOr<::google::test::admin::database::v1::GenerateAccessTokenResponse>
+  StatusOr<google::test::admin::database::v1::GenerateAccessTokenResponse>
   GenerateAccessToken(
-      ::google::test::admin::database::v1::GenerateAccessTokenRequest const& request) override {
+      google::test::admin::database::v1::GenerateAccessTokenRequest const& request) override {
     return google::cloud::internal::RetryLoop(
         retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
         idempotency_policy_->GenerateAccessToken(request),
         [this](grpc::ClientContext& context,
-            ::google::test::admin::database::v1::GenerateAccessTokenRequest const& request) {
+            google::test::admin::database::v1::GenerateAccessTokenRequest const& request) {
           return stub_->GenerateAccessToken(context, request);
         },
         request, __func__);
 }
 
-  StatusOr<::google::test::admin::database::v1::GenerateIdTokenResponse>
+  StatusOr<google::test::admin::database::v1::GenerateIdTokenResponse>
   GenerateIdToken(
-      ::google::test::admin::database::v1::GenerateIdTokenRequest const& request) override {
+      google::test::admin::database::v1::GenerateIdTokenRequest const& request) override {
     return google::cloud::internal::RetryLoop(
         retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
         idempotency_policy_->GenerateIdToken(request),
         [this](grpc::ClientContext& context,
-            ::google::test::admin::database::v1::GenerateIdTokenRequest const& request) {
+            google::test::admin::database::v1::GenerateIdTokenRequest const& request) {
           return stub_->GenerateIdToken(context, request);
         },
         request, __func__);
 }
 
-  StatusOr<::google::test::admin::database::v1::WriteLogEntriesResponse>
+  StatusOr<google::test::admin::database::v1::WriteLogEntriesResponse>
   WriteLogEntries(
-      ::google::test::admin::database::v1::WriteLogEntriesRequest const& request) override {
+      google::test::admin::database::v1::WriteLogEntriesRequest const& request) override {
     return google::cloud::internal::RetryLoop(
         retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
         idempotency_policy_->WriteLogEntries(request),
         [this](grpc::ClientContext& context,
-            ::google::test::admin::database::v1::WriteLogEntriesRequest const& request) {
+            google::test::admin::database::v1::WriteLogEntriesRequest const& request) {
           return stub_->WriteLogEntries(context, request);
         },
         request, __func__);
 }
 
   StreamRange<std::string> ListLogs(
-      ::google::test::admin::database::v1::ListLogsRequest request) override {
+      google::test::admin::database::v1::ListLogsRequest request) override {
     request.clear_page_token();
     auto stub = stub_;
     auto retry =
@@ -146,16 +146,16 @@ class GoldenKitchenSinkConnectionImpl : public GoldenKitchenSinkConnection {
         std::string>>(
         std::move(request),
         [stub, retry, backoff, idempotency, function_name]
-          (::google::test::admin::database::v1::ListLogsRequest const& r) {
+          (google::test::admin::database::v1::ListLogsRequest const& r) {
           return google::cloud::internal::RetryLoop(
               retry->clone(), backoff->clone(), idempotency,
               [stub](grpc::ClientContext& context,
-                     ::google::test::admin::database::v1::ListLogsRequest const& request) {
+                     google::test::admin::database::v1::ListLogsRequest const& request) {
                 return stub->ListLogs(context, request);
               },
               r, function_name);
         },
-        [](::google::test::admin::database::v1::ListLogsResponse r) {
+        [](google::test::admin::database::v1::ListLogsResponse r) {
           std::vector<std::string> result(r.log_names().size());
           auto& messages = *r.mutable_log_names();
           std::move(messages.begin(), messages.end(), result.begin());
@@ -163,8 +163,8 @@ class GoldenKitchenSinkConnectionImpl : public GoldenKitchenSinkConnection {
         });
   }
 
-  StreamRange<::google::test::admin::database::v1::TailLogEntriesResponse> TailLogEntries(
-      ::google::test::admin::database::v1::TailLogEntriesRequest const& request) override {
+  StreamRange<google::test::admin::database::v1::TailLogEntriesResponse> TailLogEntries(
+      google::test::admin::database::v1::TailLogEntriesRequest const& request) override {
     auto stub = stub_;
     auto retry_policy =
         std::shared_ptr<GoldenKitchenSinkRetryPolicy const>(
@@ -173,33 +173,33 @@ class GoldenKitchenSinkConnectionImpl : public GoldenKitchenSinkConnection {
         backoff_policy_prototype_->clone());
 
     auto factory = [stub](
-        ::google::test::admin::database::v1::TailLogEntriesRequest const& request) {
+        google::test::admin::database::v1::TailLogEntriesRequest const& request) {
       return stub->TailLogEntries(absl::make_unique<grpc::ClientContext>(),
           request);
     };
 
     auto resumable =
         internal::MakeResumableStreamingReadRpc<
-            ::google::test::admin::database::v1::TailLogEntriesResponse,
-            ::google::test::admin::database::v1::TailLogEntriesRequest>(
+            google::test::admin::database::v1::TailLogEntriesResponse,
+            google::test::admin::database::v1::TailLogEntriesRequest>(
                 retry_policy->clone(), backoff_policy->clone(),
                 [](std::chrono::milliseconds) {}, factory,
                 GoldenKitchenSinkTailLogEntriesStreamingUpdater,
                 request);
 
     return internal::MakeStreamRange(internal::StreamReader<
-        ::google::test::admin::database::v1::TailLogEntriesResponse>(
+        google::test::admin::database::v1::TailLogEntriesResponse>(
         [resumable]{return resumable->Read();}));
   }
 
-  StatusOr<::google::test::admin::database::v1::ListServiceAccountKeysResponse>
+  StatusOr<google::test::admin::database::v1::ListServiceAccountKeysResponse>
   ListServiceAccountKeys(
-      ::google::test::admin::database::v1::ListServiceAccountKeysRequest const& request) override {
+      google::test::admin::database::v1::ListServiceAccountKeysRequest const& request) override {
     return google::cloud::internal::RetryLoop(
         retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
         idempotency_policy_->ListServiceAccountKeys(request),
         [this](grpc::ClientContext& context,
-            ::google::test::admin::database::v1::ListServiceAccountKeysRequest const& request) {
+            google::test::admin::database::v1::ListServiceAccountKeysRequest const& request) {
           return stub_->ListServiceAccountKeys(context, request);
         },
         request, __func__);

--- a/generator/integration_tests/golden/golden_kitchen_sink_connection.h
+++ b/generator/integration_tests/golden/golden_kitchen_sink_connection.h
@@ -44,30 +44,30 @@ using GoldenKitchenSinkLimitedErrorCountRetryPolicy =
         golden_internal::GoldenKitchenSinkRetryTraits>;
 
 void GoldenKitchenSinkTailLogEntriesStreamingUpdater(
-    ::google::test::admin::database::v1::TailLogEntriesResponse const& response,
-    ::google::test::admin::database::v1::TailLogEntriesRequest& request);
+    google::test::admin::database::v1::TailLogEntriesResponse const& response,
+    google::test::admin::database::v1::TailLogEntriesRequest& request);
 
 class GoldenKitchenSinkConnection {
  public:
   virtual ~GoldenKitchenSinkConnection() = 0;
 
-  virtual StatusOr<::google::test::admin::database::v1::GenerateAccessTokenResponse>
-  GenerateAccessToken(::google::test::admin::database::v1::GenerateAccessTokenRequest const& request);
+  virtual StatusOr<google::test::admin::database::v1::GenerateAccessTokenResponse>
+  GenerateAccessToken(google::test::admin::database::v1::GenerateAccessTokenRequest const& request);
 
-  virtual StatusOr<::google::test::admin::database::v1::GenerateIdTokenResponse>
-  GenerateIdToken(::google::test::admin::database::v1::GenerateIdTokenRequest const& request);
+  virtual StatusOr<google::test::admin::database::v1::GenerateIdTokenResponse>
+  GenerateIdToken(google::test::admin::database::v1::GenerateIdTokenRequest const& request);
 
-  virtual StatusOr<::google::test::admin::database::v1::WriteLogEntriesResponse>
-  WriteLogEntries(::google::test::admin::database::v1::WriteLogEntriesRequest const& request);
+  virtual StatusOr<google::test::admin::database::v1::WriteLogEntriesResponse>
+  WriteLogEntries(google::test::admin::database::v1::WriteLogEntriesRequest const& request);
 
   virtual StreamRange<std::string>
-  ListLogs(::google::test::admin::database::v1::ListLogsRequest request);
+  ListLogs(google::test::admin::database::v1::ListLogsRequest request);
 
-  virtual StreamRange<::google::test::admin::database::v1::TailLogEntriesResponse>
-  TailLogEntries(::google::test::admin::database::v1::TailLogEntriesRequest const& request);
+  virtual StreamRange<google::test::admin::database::v1::TailLogEntriesResponse>
+  TailLogEntries(google::test::admin::database::v1::TailLogEntriesRequest const& request);
 
-  virtual StatusOr<::google::test::admin::database::v1::ListServiceAccountKeysResponse>
-  ListServiceAccountKeys(::google::test::admin::database::v1::ListServiceAccountKeysRequest const& request);
+  virtual StatusOr<google::test::admin::database::v1::ListServiceAccountKeysResponse>
+  ListServiceAccountKeys(google::test::admin::database::v1::ListServiceAccountKeysRequest const& request);
 
 };
 

--- a/generator/integration_tests/golden/golden_kitchen_sink_connection_idempotency_policy.cc
+++ b/generator/integration_tests/golden/golden_kitchen_sink_connection_idempotency_policy.cc
@@ -39,27 +39,27 @@ class DefaultGoldenKitchenSinkConnectionIdempotencyPolicy : public GoldenKitchen
   }
 
   Idempotency
-  GenerateAccessToken(::google::test::admin::database::v1::GenerateAccessTokenRequest const&) override {
+  GenerateAccessToken(google::test::admin::database::v1::GenerateAccessTokenRequest const&) override {
     return Idempotency::kNonIdempotent;
   }
 
   Idempotency
-  GenerateIdToken(::google::test::admin::database::v1::GenerateIdTokenRequest const&) override {
+  GenerateIdToken(google::test::admin::database::v1::GenerateIdTokenRequest const&) override {
     return Idempotency::kNonIdempotent;
   }
 
   Idempotency
-  WriteLogEntries(::google::test::admin::database::v1::WriteLogEntriesRequest const&) override {
+  WriteLogEntries(google::test::admin::database::v1::WriteLogEntriesRequest const&) override {
     return Idempotency::kNonIdempotent;
   }
 
   Idempotency
-  ListLogs(::google::test::admin::database::v1::ListLogsRequest) override {
+  ListLogs(google::test::admin::database::v1::ListLogsRequest) override {
     return Idempotency::kIdempotent;
   }
 
   Idempotency
-  ListServiceAccountKeys(::google::test::admin::database::v1::ListServiceAccountKeysRequest const&) override {
+  ListServiceAccountKeys(google::test::admin::database::v1::ListServiceAccountKeysRequest const&) override {
     return Idempotency::kIdempotent;
   }
 

--- a/generator/integration_tests/golden/golden_kitchen_sink_connection_idempotency_policy.h
+++ b/generator/integration_tests/golden/golden_kitchen_sink_connection_idempotency_policy.h
@@ -37,19 +37,19 @@ class GoldenKitchenSinkConnectionIdempotencyPolicy {
   virtual std::unique_ptr<GoldenKitchenSinkConnectionIdempotencyPolicy> clone() const = 0;
 
   virtual google::cloud::internal::Idempotency
-  GenerateAccessToken(::google::test::admin::database::v1::GenerateAccessTokenRequest const& request) = 0;
+  GenerateAccessToken(google::test::admin::database::v1::GenerateAccessTokenRequest const& request) = 0;
 
   virtual google::cloud::internal::Idempotency
-  GenerateIdToken(::google::test::admin::database::v1::GenerateIdTokenRequest const& request) = 0;
+  GenerateIdToken(google::test::admin::database::v1::GenerateIdTokenRequest const& request) = 0;
 
   virtual google::cloud::internal::Idempotency
-  WriteLogEntries(::google::test::admin::database::v1::WriteLogEntriesRequest const& request) = 0;
+  WriteLogEntries(google::test::admin::database::v1::WriteLogEntriesRequest const& request) = 0;
 
   virtual google::cloud::internal::Idempotency
-  ListLogs(::google::test::admin::database::v1::ListLogsRequest request) = 0;
+  ListLogs(google::test::admin::database::v1::ListLogsRequest request) = 0;
 
   virtual google::cloud::internal::Idempotency
-  ListServiceAccountKeys(::google::test::admin::database::v1::ListServiceAccountKeysRequest const& request) = 0;
+  ListServiceAccountKeys(google::test::admin::database::v1::ListServiceAccountKeysRequest const& request) = 0;
 
 };
 

--- a/generator/integration_tests/golden/golden_thing_admin_client.cc
+++ b/generator/integration_tests/golden/golden_thing_admin_client.cc
@@ -27,31 +27,31 @@ inline namespace GOOGLE_CLOUD_CPP_GENERATED_NS {
 GoldenThingAdminClient::GoldenThingAdminClient(std::shared_ptr<GoldenThingAdminConnection> connection) : connection_(std::move(connection)) {}
 GoldenThingAdminClient::~GoldenThingAdminClient() = default;
 
-StreamRange<::google::test::admin::database::v1::Database>
+StreamRange<google::test::admin::database::v1::Database>
 GoldenThingAdminClient::ListDatabases(std::string const& parent) {
-  ::google::test::admin::database::v1::ListDatabasesRequest request;
+  google::test::admin::database::v1::ListDatabasesRequest request;
   request.set_parent(parent);
   return connection_->ListDatabases(request);
 }
 
-future<StatusOr<::google::test::admin::database::v1::Database>>
+future<StatusOr<google::test::admin::database::v1::Database>>
 GoldenThingAdminClient::CreateDatabase(std::string const& parent, std::string const& create_statement) {
-  ::google::test::admin::database::v1::CreateDatabaseRequest request;
+  google::test::admin::database::v1::CreateDatabaseRequest request;
   request.set_parent(parent);
   request.set_create_statement(create_statement);
   return connection_->CreateDatabase(request);
 }
 
-StatusOr<::google::test::admin::database::v1::Database>
+StatusOr<google::test::admin::database::v1::Database>
 GoldenThingAdminClient::GetDatabase(std::string const& name) {
-  ::google::test::admin::database::v1::GetDatabaseRequest request;
+  google::test::admin::database::v1::GetDatabaseRequest request;
   request.set_name(name);
   return connection_->GetDatabase(request);
 }
 
-future<StatusOr<::google::test::admin::database::v1::UpdateDatabaseDdlMetadata>>
+future<StatusOr<google::test::admin::database::v1::UpdateDatabaseDdlMetadata>>
 GoldenThingAdminClient::UpdateDatabaseDdl(std::string const& database, std::vector<std::string> const& statements) {
-  ::google::test::admin::database::v1::UpdateDatabaseDdlRequest request;
+  google::test::admin::database::v1::UpdateDatabaseDdlRequest request;
   request.set_database(database);
   *request.mutable_statements() = {statements.begin(), statements.end()};
   return connection_->UpdateDatabaseDdl(request);
@@ -59,60 +59,60 @@ GoldenThingAdminClient::UpdateDatabaseDdl(std::string const& database, std::vect
 
 Status
 GoldenThingAdminClient::DropDatabase(std::string const& database) {
-  ::google::test::admin::database::v1::DropDatabaseRequest request;
+  google::test::admin::database::v1::DropDatabaseRequest request;
   request.set_database(database);
   return connection_->DropDatabase(request);
 }
 
-StatusOr<::google::test::admin::database::v1::GetDatabaseDdlResponse>
+StatusOr<google::test::admin::database::v1::GetDatabaseDdlResponse>
 GoldenThingAdminClient::GetDatabaseDdl(std::string const& database) {
-  ::google::test::admin::database::v1::GetDatabaseDdlRequest request;
+  google::test::admin::database::v1::GetDatabaseDdlRequest request;
   request.set_database(database);
   return connection_->GetDatabaseDdl(request);
 }
 
-StatusOr<::google::iam::v1::Policy>
-GoldenThingAdminClient::SetIamPolicy(std::string const& resource, ::google::iam::v1::Policy const& policy) {
-  ::google::iam::v1::SetIamPolicyRequest request;
+StatusOr<google::iam::v1::Policy>
+GoldenThingAdminClient::SetIamPolicy(std::string const& resource, google::iam::v1::Policy const& policy) {
+  google::iam::v1::SetIamPolicyRequest request;
   request.set_resource(resource);
   *request.mutable_policy() = policy;
   return connection_->SetIamPolicy(request);
 }
 
-StatusOr<::google::iam::v1::Policy>
+StatusOr<google::iam::v1::Policy>
 GoldenThingAdminClient::GetIamPolicy(std::string const& resource) {
-  ::google::iam::v1::GetIamPolicyRequest request;
+  google::iam::v1::GetIamPolicyRequest request;
   request.set_resource(resource);
   return connection_->GetIamPolicy(request);
 }
 
-StatusOr<::google::iam::v1::TestIamPermissionsResponse>
+StatusOr<google::iam::v1::TestIamPermissionsResponse>
 GoldenThingAdminClient::TestIamPermissions(std::string const& resource, std::vector<std::string> const& permissions) {
-  ::google::iam::v1::TestIamPermissionsRequest request;
+  google::iam::v1::TestIamPermissionsRequest request;
   request.set_resource(resource);
   *request.mutable_permissions() = {permissions.begin(), permissions.end()};
   return connection_->TestIamPermissions(request);
 }
 
-future<StatusOr<::google::test::admin::database::v1::Backup>>
-GoldenThingAdminClient::CreateBackup(std::string const& parent, ::google::test::admin::database::v1::Backup const& backup, std::string const& backup_id) {
-  ::google::test::admin::database::v1::CreateBackupRequest request;
+future<StatusOr<google::test::admin::database::v1::Backup>>
+GoldenThingAdminClient::CreateBackup(std::string const& parent, google::test::admin::database::v1::Backup const& backup, std::string const& backup_id) {
+  google::test::admin::database::v1::CreateBackupRequest request;
   request.set_parent(parent);
   *request.mutable_backup() = backup;
   request.set_backup_id(backup_id);
   return connection_->CreateBackup(request);
 }
 
-StatusOr<::google::test::admin::database::v1::Backup>
+StatusOr<google::test::admin::database::v1::Backup>
 GoldenThingAdminClient::GetBackup(std::string const& name) {
-  ::google::test::admin::database::v1::GetBackupRequest request;
+  google::test::admin::database::v1::GetBackupRequest request;
   request.set_name(name);
   return connection_->GetBackup(request);
 }
 
-StatusOr<::google::test::admin::database::v1::Backup>
-GoldenThingAdminClient::UpdateBackup(::google::test::admin::database::v1::Backup const& backup, ::google::protobuf::FieldMask const& update_mask) {
-  ::google::test::admin::database::v1::UpdateBackupRequest request;
+StatusOr<google::test::admin::database::v1::Backup>
+GoldenThingAdminClient::UpdateBackup(google::test::admin::database::v1::Backup const& backup, google::protobuf::FieldMask const& update_mask) {
+  google::test::admin::database::v1::UpdateBackupRequest request;
   *request.mutable_backup() = backup;
   *request.mutable_update_mask() = update_mask;
   return connection_->UpdateBackup(request);
@@ -120,123 +120,123 @@ GoldenThingAdminClient::UpdateBackup(::google::test::admin::database::v1::Backup
 
 Status
 GoldenThingAdminClient::DeleteBackup(std::string const& name) {
-  ::google::test::admin::database::v1::DeleteBackupRequest request;
+  google::test::admin::database::v1::DeleteBackupRequest request;
   request.set_name(name);
   return connection_->DeleteBackup(request);
 }
 
-StreamRange<::google::test::admin::database::v1::Backup>
+StreamRange<google::test::admin::database::v1::Backup>
 GoldenThingAdminClient::ListBackups(std::string const& parent) {
-  ::google::test::admin::database::v1::ListBackupsRequest request;
+  google::test::admin::database::v1::ListBackupsRequest request;
   request.set_parent(parent);
   return connection_->ListBackups(request);
 }
 
-future<StatusOr<::google::test::admin::database::v1::Database>>
+future<StatusOr<google::test::admin::database::v1::Database>>
 GoldenThingAdminClient::RestoreDatabase(std::string const& parent, std::string const& database_id, std::string const& backup) {
-  ::google::test::admin::database::v1::RestoreDatabaseRequest request;
+  google::test::admin::database::v1::RestoreDatabaseRequest request;
   request.set_parent(parent);
   request.set_database_id(database_id);
   request.set_backup(backup);
   return connection_->RestoreDatabase(request);
 }
 
-StreamRange<::google::longrunning::Operation>
+StreamRange<google::longrunning::Operation>
 GoldenThingAdminClient::ListDatabaseOperations(std::string const& parent) {
-  ::google::test::admin::database::v1::ListDatabaseOperationsRequest request;
+  google::test::admin::database::v1::ListDatabaseOperationsRequest request;
   request.set_parent(parent);
   return connection_->ListDatabaseOperations(request);
 }
 
-StreamRange<::google::longrunning::Operation>
+StreamRange<google::longrunning::Operation>
 GoldenThingAdminClient::ListBackupOperations(std::string const& parent) {
-  ::google::test::admin::database::v1::ListBackupOperationsRequest request;
+  google::test::admin::database::v1::ListBackupOperationsRequest request;
   request.set_parent(parent);
   return connection_->ListBackupOperations(request);
 }
 
-StreamRange<::google::test::admin::database::v1::Database>
-GoldenThingAdminClient::ListDatabases(::google::test::admin::database::v1::ListDatabasesRequest request) {
+StreamRange<google::test::admin::database::v1::Database>
+GoldenThingAdminClient::ListDatabases(google::test::admin::database::v1::ListDatabasesRequest request) {
   return connection_->ListDatabases(std::move(request));
 }
 
-future<StatusOr<::google::test::admin::database::v1::Database>>
-GoldenThingAdminClient::CreateDatabase(::google::test::admin::database::v1::CreateDatabaseRequest const& request) {
+future<StatusOr<google::test::admin::database::v1::Database>>
+GoldenThingAdminClient::CreateDatabase(google::test::admin::database::v1::CreateDatabaseRequest const& request) {
   return connection_->CreateDatabase(request);
 }
 
-StatusOr<::google::test::admin::database::v1::Database>
-GoldenThingAdminClient::GetDatabase(::google::test::admin::database::v1::GetDatabaseRequest const& request) {
+StatusOr<google::test::admin::database::v1::Database>
+GoldenThingAdminClient::GetDatabase(google::test::admin::database::v1::GetDatabaseRequest const& request) {
   return connection_->GetDatabase(request);
 }
 
-future<StatusOr<::google::test::admin::database::v1::UpdateDatabaseDdlMetadata>>
-GoldenThingAdminClient::UpdateDatabaseDdl(::google::test::admin::database::v1::UpdateDatabaseDdlRequest const& request) {
+future<StatusOr<google::test::admin::database::v1::UpdateDatabaseDdlMetadata>>
+GoldenThingAdminClient::UpdateDatabaseDdl(google::test::admin::database::v1::UpdateDatabaseDdlRequest const& request) {
   return connection_->UpdateDatabaseDdl(request);
 }
 
 Status
-GoldenThingAdminClient::DropDatabase(::google::test::admin::database::v1::DropDatabaseRequest const& request) {
+GoldenThingAdminClient::DropDatabase(google::test::admin::database::v1::DropDatabaseRequest const& request) {
   return connection_->DropDatabase(request);
 }
 
-StatusOr<::google::test::admin::database::v1::GetDatabaseDdlResponse>
-GoldenThingAdminClient::GetDatabaseDdl(::google::test::admin::database::v1::GetDatabaseDdlRequest const& request) {
+StatusOr<google::test::admin::database::v1::GetDatabaseDdlResponse>
+GoldenThingAdminClient::GetDatabaseDdl(google::test::admin::database::v1::GetDatabaseDdlRequest const& request) {
   return connection_->GetDatabaseDdl(request);
 }
 
-StatusOr<::google::iam::v1::Policy>
-GoldenThingAdminClient::SetIamPolicy(::google::iam::v1::SetIamPolicyRequest const& request) {
+StatusOr<google::iam::v1::Policy>
+GoldenThingAdminClient::SetIamPolicy(google::iam::v1::SetIamPolicyRequest const& request) {
   return connection_->SetIamPolicy(request);
 }
 
-StatusOr<::google::iam::v1::Policy>
-GoldenThingAdminClient::GetIamPolicy(::google::iam::v1::GetIamPolicyRequest const& request) {
+StatusOr<google::iam::v1::Policy>
+GoldenThingAdminClient::GetIamPolicy(google::iam::v1::GetIamPolicyRequest const& request) {
   return connection_->GetIamPolicy(request);
 }
 
-StatusOr<::google::iam::v1::TestIamPermissionsResponse>
-GoldenThingAdminClient::TestIamPermissions(::google::iam::v1::TestIamPermissionsRequest const& request) {
+StatusOr<google::iam::v1::TestIamPermissionsResponse>
+GoldenThingAdminClient::TestIamPermissions(google::iam::v1::TestIamPermissionsRequest const& request) {
   return connection_->TestIamPermissions(request);
 }
 
-future<StatusOr<::google::test::admin::database::v1::Backup>>
-GoldenThingAdminClient::CreateBackup(::google::test::admin::database::v1::CreateBackupRequest const& request) {
+future<StatusOr<google::test::admin::database::v1::Backup>>
+GoldenThingAdminClient::CreateBackup(google::test::admin::database::v1::CreateBackupRequest const& request) {
   return connection_->CreateBackup(request);
 }
 
-StatusOr<::google::test::admin::database::v1::Backup>
-GoldenThingAdminClient::GetBackup(::google::test::admin::database::v1::GetBackupRequest const& request) {
+StatusOr<google::test::admin::database::v1::Backup>
+GoldenThingAdminClient::GetBackup(google::test::admin::database::v1::GetBackupRequest const& request) {
   return connection_->GetBackup(request);
 }
 
-StatusOr<::google::test::admin::database::v1::Backup>
-GoldenThingAdminClient::UpdateBackup(::google::test::admin::database::v1::UpdateBackupRequest const& request) {
+StatusOr<google::test::admin::database::v1::Backup>
+GoldenThingAdminClient::UpdateBackup(google::test::admin::database::v1::UpdateBackupRequest const& request) {
   return connection_->UpdateBackup(request);
 }
 
 Status
-GoldenThingAdminClient::DeleteBackup(::google::test::admin::database::v1::DeleteBackupRequest const& request) {
+GoldenThingAdminClient::DeleteBackup(google::test::admin::database::v1::DeleteBackupRequest const& request) {
   return connection_->DeleteBackup(request);
 }
 
-StreamRange<::google::test::admin::database::v1::Backup>
-GoldenThingAdminClient::ListBackups(::google::test::admin::database::v1::ListBackupsRequest request) {
+StreamRange<google::test::admin::database::v1::Backup>
+GoldenThingAdminClient::ListBackups(google::test::admin::database::v1::ListBackupsRequest request) {
   return connection_->ListBackups(std::move(request));
 }
 
-future<StatusOr<::google::test::admin::database::v1::Database>>
-GoldenThingAdminClient::RestoreDatabase(::google::test::admin::database::v1::RestoreDatabaseRequest const& request) {
+future<StatusOr<google::test::admin::database::v1::Database>>
+GoldenThingAdminClient::RestoreDatabase(google::test::admin::database::v1::RestoreDatabaseRequest const& request) {
   return connection_->RestoreDatabase(request);
 }
 
-StreamRange<::google::longrunning::Operation>
-GoldenThingAdminClient::ListDatabaseOperations(::google::test::admin::database::v1::ListDatabaseOperationsRequest request) {
+StreamRange<google::longrunning::Operation>
+GoldenThingAdminClient::ListDatabaseOperations(google::test::admin::database::v1::ListDatabaseOperationsRequest request) {
   return connection_->ListDatabaseOperations(std::move(request));
 }
 
-StreamRange<::google::longrunning::Operation>
-GoldenThingAdminClient::ListBackupOperations(::google::test::admin::database::v1::ListBackupOperationsRequest request) {
+StreamRange<google::longrunning::Operation>
+GoldenThingAdminClient::ListBackupOperations(google::test::admin::database::v1::ListBackupOperationsRequest request) {
   return connection_->ListBackupOperations(std::move(request));
 }
 

--- a/generator/integration_tests/golden/golden_thing_admin_client.h
+++ b/generator/integration_tests/golden/golden_thing_admin_client.h
@@ -68,7 +68,7 @@ class GoldenThingAdminClient {
    * @param parent  Required. The instance whose databases should be listed.
    *  Values are of the form `projects/<project>/instances/<instance>`.
    */
-  StreamRange<::google::test::admin::database::v1::Database>
+  StreamRange<google::test::admin::database::v1::Database>
   ListDatabases(std::string const& parent);
 
   /**
@@ -88,9 +88,9 @@ class GoldenThingAdminClient {
    *  `[a-z][a-z0-9_\-]*[a-z0-9]` and be between 2 and 30 characters in length.
    *  If the database ID is a reserved word or if it contains a hyphen, the
    *  database ID must be enclosed in backticks (`` ` ``).
-   * @return [::google::test::admin::database::v1::Database](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L329)
+   * @return [google::test::admin::database::v1::Database](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L329)
    */
-  future<StatusOr<::google::test::admin::database::v1::Database>>
+  future<StatusOr<google::test::admin::database::v1::Database>>
   CreateDatabase(std::string const& parent, std::string const& create_statement);
 
   /**
@@ -98,9 +98,9 @@ class GoldenThingAdminClient {
    *
    * @param name  Required. The name of the requested database. Values are of the form
    *  `projects/<project>/instances/<instance>/databases/<database>`.
-   * @return [::google::test::admin::database::v1::Database](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L329)
+   * @return [google::test::admin::database::v1::Database](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L329)
    */
-  StatusOr<::google::test::admin::database::v1::Database>
+  StatusOr<google::test::admin::database::v1::Database>
   GetDatabase(std::string const& name);
 
   /**
@@ -114,9 +114,9 @@ class GoldenThingAdminClient {
    *
    * @param database  Required. The database to update.
    * @param statements  Required. DDL statements to be applied to the database.
-   * @return [::google::test::admin::database::v1::UpdateDatabaseDdlMetadata](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L506)
+   * @return [google::test::admin::database::v1::UpdateDatabaseDdlMetadata](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L506)
    */
-  future<StatusOr<::google::test::admin::database::v1::UpdateDatabaseDdlMetadata>>
+  future<StatusOr<google::test::admin::database::v1::UpdateDatabaseDdlMetadata>>
   UpdateDatabaseDdl(std::string const& database, std::vector<std::string> const& statements);
 
   /**
@@ -135,9 +135,9 @@ class GoldenThingAdminClient {
    * be queried using the [Operations][google.longrunning.Operations] API.
    *
    * @param database  Required. The database whose schema we wish to get.
-   * @return [::google::test::admin::database::v1::GetDatabaseDdlResponse](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L545)
+   * @return [google::test::admin::database::v1::GetDatabaseDdlResponse](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L545)
    */
-  StatusOr<::google::test::admin::database::v1::GetDatabaseDdlResponse>
+  StatusOr<google::test::admin::database::v1::GetDatabaseDdlResponse>
   GetDatabaseDdl(std::string const& database);
 
   /**
@@ -155,10 +155,10 @@ class GoldenThingAdminClient {
    *  the policy is limited to a few 10s of KB. An empty policy is a
    *  valid policy but certain Cloud Platform services (such as Projects)
    *  might reject them.
-   * @return [::google::iam::v1::Policy](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/google/iam/v1/policy.proto#L88)
+   * @return [google::iam::v1::Policy](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/google/iam/v1/policy.proto#L88)
    */
-  StatusOr<::google::iam::v1::Policy>
-  SetIamPolicy(std::string const& resource, ::google::iam::v1::Policy const& policy);
+  StatusOr<google::iam::v1::Policy>
+  SetIamPolicy(std::string const& resource, google::iam::v1::Policy const& policy);
 
   /**
    * Gets the access control policy for a database or backup resource.
@@ -172,9 +172,9 @@ class GoldenThingAdminClient {
    *
    * @param resource  REQUIRED: The resource for which the policy is being requested.
    *  See the operation documentation for the appropriate value for this field.
-   * @return [::google::iam::v1::Policy](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/google/iam/v1/policy.proto#L88)
+   * @return [google::iam::v1::Policy](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/google/iam/v1/policy.proto#L88)
    */
-  StatusOr<::google::iam::v1::Policy>
+  StatusOr<google::iam::v1::Policy>
   GetIamPolicy(std::string const& resource);
 
   /**
@@ -195,9 +195,9 @@ class GoldenThingAdminClient {
    *  wildcards (such as '*' or 'storage.*') are not allowed. For more
    *  information see
    *  [IAM Overview](https://cloud.google.com/iam/docs/overview#permissions).
-   * @return [::google::iam::v1::TestIamPermissionsResponse](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/google/iam/v1/iam_policy.proto#L141)
+   * @return [google::iam::v1::TestIamPermissionsResponse](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/google/iam/v1/iam_policy.proto#L141)
    */
-  StatusOr<::google::iam::v1::TestIamPermissionsResponse>
+  StatusOr<google::iam::v1::TestIamPermissionsResponse>
   TestIamPermissions(std::string const& resource, std::vector<std::string> const& permissions);
 
   /**
@@ -224,10 +224,10 @@ class GoldenThingAdminClient {
    * @param backup_id  Required. The id of the backup to be created. The `backup_id` appended to
    *  `parent` forms the full backup name of the form
    *  `projects/<project>/instances/<instance>/backups/<backup_id>`.
-   * @return [::google::test::admin::database::v1::Backup](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/backup.proto#L36)
+   * @return [google::test::admin::database::v1::Backup](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/backup.proto#L36)
    */
-  future<StatusOr<::google::test::admin::database::v1::Backup>>
-  CreateBackup(std::string const& parent, ::google::test::admin::database::v1::Backup const& backup, std::string const& backup_id);
+  future<StatusOr<google::test::admin::database::v1::Backup>>
+  CreateBackup(std::string const& parent, google::test::admin::database::v1::Backup const& backup, std::string const& backup_id);
 
   /**
    * Gets metadata on a pending or completed [Backup][google.test.admin.database.v1.Backup].
@@ -235,9 +235,9 @@ class GoldenThingAdminClient {
    * @param name  Required. Name of the backup.
    *  Values are of the form
    *  `projects/<project>/instances/<instance>/backups/<backup>`.
-   * @return [::google::test::admin::database::v1::Backup](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/backup.proto#L36)
+   * @return [google::test::admin::database::v1::Backup](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/backup.proto#L36)
    */
-  StatusOr<::google::test::admin::database::v1::Backup>
+  StatusOr<google::test::admin::database::v1::Backup>
   GetBackup(std::string const& name);
 
   /**
@@ -252,10 +252,10 @@ class GoldenThingAdminClient {
    *  resource, not to the request message. The field mask must always be
    *  specified; this prevents any future fields from being erased accidentally
    *  by clients that do not know about them.
-   * @return [::google::test::admin::database::v1::Backup](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/backup.proto#L36)
+   * @return [google::test::admin::database::v1::Backup](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/backup.proto#L36)
    */
-  StatusOr<::google::test::admin::database::v1::Backup>
-  UpdateBackup(::google::test::admin::database::v1::Backup const& backup, ::google::protobuf::FieldMask const& update_mask);
+  StatusOr<google::test::admin::database::v1::Backup>
+  UpdateBackup(google::test::admin::database::v1::Backup const& backup, google::protobuf::FieldMask const& update_mask);
 
   /**
    * Deletes a pending or completed [Backup][google.test.admin.database.v1.Backup].
@@ -275,7 +275,7 @@ class GoldenThingAdminClient {
    * @param parent  Required. The instance to list backups from.  Values are of the
    *  form `projects/<project>/instances/<instance>`.
    */
-  StreamRange<::google::test::admin::database::v1::Backup>
+  StreamRange<google::test::admin::database::v1::Backup>
   ListBackups(std::string const& parent);
 
   /**
@@ -308,9 +308,9 @@ class GoldenThingAdminClient {
    *  `projects/<project>/instances/<instance>/databases/<database_id>`.
    * @param backup  Name of the backup from which to restore.  Values are of the form
    *  `projects/<project>/instances/<instance>/backups/<backup>`.
-   * @return [::google::test::admin::database::v1::Database](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L329)
+   * @return [google::test::admin::database::v1::Database](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L329)
    */
-  future<StatusOr<::google::test::admin::database::v1::Database>>
+  future<StatusOr<google::test::admin::database::v1::Database>>
   RestoreDatabase(std::string const& parent, std::string const& database_id, std::string const& backup);
 
   /**
@@ -326,7 +326,7 @@ class GoldenThingAdminClient {
    * @param parent  Required. The instance of the database operations.
    *  Values are of the form `projects/<project>/instances/<instance>`.
    */
-  StreamRange<::google::longrunning::Operation>
+  StreamRange<google::longrunning::Operation>
   ListDatabaseOperations(std::string const& parent);
 
   /**
@@ -344,16 +344,16 @@ class GoldenThingAdminClient {
    * @param parent  Required. The instance of the backup operations. Values are of
    *  the form `projects/<project>/instances/<instance>`.
    */
-  StreamRange<::google::longrunning::Operation>
+  StreamRange<google::longrunning::Operation>
   ListBackupOperations(std::string const& parent);
 
   /**
    * Lists Cloud Test databases.
    *
-   * @param request [::google::test::admin::database::v1::ListDatabasesRequest](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L377)
+   * @param request [google::test::admin::database::v1::ListDatabasesRequest](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L377)
    */
-  StreamRange<::google::test::admin::database::v1::Database>
-  ListDatabases(::google::test::admin::database::v1::ListDatabasesRequest request);
+  StreamRange<google::test::admin::database::v1::Database>
+  ListDatabases(google::test::admin::database::v1::ListDatabasesRequest request);
 
   /**
    * Creates a new Cloud Test database and starts to prepare it for serving.
@@ -365,20 +365,20 @@ class GoldenThingAdminClient {
    * [response][google.longrunning.Operation.response] field type is
    * [Database][google.test.admin.database.v1.Database], if successful.
    *
-   * @param request [::google::test::admin::database::v1::CreateDatabaseRequest](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L409)
-   * @return [::google::test::admin::database::v1::Database](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L329)
+   * @param request [google::test::admin::database::v1::CreateDatabaseRequest](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L409)
+   * @return [google::test::admin::database::v1::Database](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L329)
    */
-  future<StatusOr<::google::test::admin::database::v1::Database>>
-  CreateDatabase(::google::test::admin::database::v1::CreateDatabaseRequest const& request);
+  future<StatusOr<google::test::admin::database::v1::Database>>
+  CreateDatabase(google::test::admin::database::v1::CreateDatabaseRequest const& request);
 
   /**
    * Gets the state of a Cloud Test database.
    *
-   * @param request [::google::test::admin::database::v1::GetDatabaseRequest](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L443)
-   * @return [::google::test::admin::database::v1::Database](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L329)
+   * @param request [google::test::admin::database::v1::GetDatabaseRequest](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L443)
+   * @return [google::test::admin::database::v1::Database](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L329)
    */
-  StatusOr<::google::test::admin::database::v1::Database>
-  GetDatabase(::google::test::admin::database::v1::GetDatabaseRequest const& request);
+  StatusOr<google::test::admin::database::v1::Database>
+  GetDatabase(google::test::admin::database::v1::GetDatabaseRequest const& request);
 
   /**
    * Updates the schema of a Cloud Test database by
@@ -389,32 +389,32 @@ class GoldenThingAdminClient {
    * [metadata][google.longrunning.Operation.metadata] field type is
    * [UpdateDatabaseDdlMetadata][google.test.admin.database.v1.UpdateDatabaseDdlMetadata].  The operation has no response.
    *
-   * @param request [::google::test::admin::database::v1::UpdateDatabaseDdlRequest](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L470)
-   * @return [::google::test::admin::database::v1::UpdateDatabaseDdlMetadata](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L506)
+   * @param request [google::test::admin::database::v1::UpdateDatabaseDdlRequest](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L470)
+   * @return [google::test::admin::database::v1::UpdateDatabaseDdlMetadata](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L506)
    */
-  future<StatusOr<::google::test::admin::database::v1::UpdateDatabaseDdlMetadata>>
-  UpdateDatabaseDdl(::google::test::admin::database::v1::UpdateDatabaseDdlRequest const& request);
+  future<StatusOr<google::test::admin::database::v1::UpdateDatabaseDdlMetadata>>
+  UpdateDatabaseDdl(google::test::admin::database::v1::UpdateDatabaseDdlRequest const& request);
 
   /**
    * Drops (aka deletes) a Cloud Test database.
    * Completed backups for the database will be retained according to their
    * `expire_time`.
    *
-   * @param request [::google::test::admin::database::v1::DropDatabaseRequest](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L523)
+   * @param request [google::test::admin::database::v1::DropDatabaseRequest](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L523)
    */
   Status
-  DropDatabase(::google::test::admin::database::v1::DropDatabaseRequest const& request);
+  DropDatabase(google::test::admin::database::v1::DropDatabaseRequest const& request);
 
   /**
    * Returns the schema of a Cloud Test database as a list of formatted
    * DDL statements. This method does not show pending schema updates, those may
    * be queried using the [Operations][google.longrunning.Operations] API.
    *
-   * @param request [::google::test::admin::database::v1::GetDatabaseDdlRequest](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L534)
-   * @return [::google::test::admin::database::v1::GetDatabaseDdlResponse](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L545)
+   * @param request [google::test::admin::database::v1::GetDatabaseDdlRequest](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L534)
+   * @return [google::test::admin::database::v1::GetDatabaseDdlResponse](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L545)
    */
-  StatusOr<::google::test::admin::database::v1::GetDatabaseDdlResponse>
-  GetDatabaseDdl(::google::test::admin::database::v1::GetDatabaseDdlRequest const& request);
+  StatusOr<google::test::admin::database::v1::GetDatabaseDdlResponse>
+  GetDatabaseDdl(google::test::admin::database::v1::GetDatabaseDdlRequest const& request);
 
   /**
    * Sets the access control policy on a database or backup resource.
@@ -425,11 +425,11 @@ class GoldenThingAdminClient {
    * For backups, authorization requires `test.backups.setIamPolicy`
    * permission on [resource][google.iam.v1.SetIamPolicyRequest.resource].
    *
-   * @param request [::google::iam::v1::SetIamPolicyRequest](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/google/iam/v1/iam_policy.proto#L98)
-   * @return [::google::iam::v1::Policy](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/google/iam/v1/policy.proto#L88)
+   * @param request [google::iam::v1::SetIamPolicyRequest](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/google/iam/v1/iam_policy.proto#L98)
+   * @return [google::iam::v1::Policy](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/google/iam/v1/policy.proto#L88)
    */
-  StatusOr<::google::iam::v1::Policy>
-  SetIamPolicy(::google::iam::v1::SetIamPolicyRequest const& request);
+  StatusOr<google::iam::v1::Policy>
+  SetIamPolicy(google::iam::v1::SetIamPolicyRequest const& request);
 
   /**
    * Gets the access control policy for a database or backup resource.
@@ -441,11 +441,11 @@ class GoldenThingAdminClient {
    * For backups, authorization requires `test.backups.getIamPolicy`
    * permission on [resource][google.iam.v1.GetIamPolicyRequest.resource].
    *
-   * @param request [::google::iam::v1::GetIamPolicyRequest](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/google/iam/v1/iam_policy.proto#L113)
-   * @return [::google::iam::v1::Policy](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/google/iam/v1/policy.proto#L88)
+   * @param request [google::iam::v1::GetIamPolicyRequest](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/google/iam/v1/iam_policy.proto#L113)
+   * @return [google::iam::v1::Policy](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/google/iam/v1/policy.proto#L88)
    */
-  StatusOr<::google::iam::v1::Policy>
-  GetIamPolicy(::google::iam::v1::GetIamPolicyRequest const& request);
+  StatusOr<google::iam::v1::Policy>
+  GetIamPolicy(google::iam::v1::GetIamPolicyRequest const& request);
 
   /**
    * Returns permissions that the caller has on the specified database or backup
@@ -459,11 +459,11 @@ class GoldenThingAdminClient {
    * result in a NOT_FOUND error if the user has
    * `test.backups.list` permission on the containing instance.
    *
-   * @param request [::google::iam::v1::TestIamPermissionsRequest](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/google/iam/v1/iam_policy.proto#L126)
-   * @return [::google::iam::v1::TestIamPermissionsResponse](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/google/iam/v1/iam_policy.proto#L141)
+   * @param request [google::iam::v1::TestIamPermissionsRequest](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/google/iam/v1/iam_policy.proto#L126)
+   * @return [google::iam::v1::TestIamPermissionsResponse](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/google/iam/v1/iam_policy.proto#L141)
    */
-  StatusOr<::google::iam::v1::TestIamPermissionsResponse>
-  TestIamPermissions(::google::iam::v1::TestIamPermissionsRequest const& request);
+  StatusOr<google::iam::v1::TestIamPermissionsResponse>
+  TestIamPermissions(google::iam::v1::TestIamPermissionsRequest const& request);
 
   /**
    * Starts creating a new Cloud Test Backup.
@@ -479,47 +479,47 @@ class GoldenThingAdminClient {
    * There can be only one pending backup creation per database. Backup creation
    * of different databases can run concurrently.
    *
-   * @param request [::google::test::admin::database::v1::CreateBackupRequest](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/backup.proto#L110)
-   * @return [::google::test::admin::database::v1::Backup](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/backup.proto#L36)
+   * @param request [google::test::admin::database::v1::CreateBackupRequest](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/backup.proto#L110)
+   * @return [google::test::admin::database::v1::Backup](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/backup.proto#L36)
    */
-  future<StatusOr<::google::test::admin::database::v1::Backup>>
-  CreateBackup(::google::test::admin::database::v1::CreateBackupRequest const& request);
+  future<StatusOr<google::test::admin::database::v1::Backup>>
+  CreateBackup(google::test::admin::database::v1::CreateBackupRequest const& request);
 
   /**
    * Gets metadata on a pending or completed [Backup][google.test.admin.database.v1.Backup].
    *
-   * @param request [::google::test::admin::database::v1::GetBackupRequest](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/backup.proto#L177)
-   * @return [::google::test::admin::database::v1::Backup](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/backup.proto#L36)
+   * @param request [google::test::admin::database::v1::GetBackupRequest](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/backup.proto#L177)
+   * @return [google::test::admin::database::v1::Backup](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/backup.proto#L36)
    */
-  StatusOr<::google::test::admin::database::v1::Backup>
-  GetBackup(::google::test::admin::database::v1::GetBackupRequest const& request);
+  StatusOr<google::test::admin::database::v1::Backup>
+  GetBackup(google::test::admin::database::v1::GetBackupRequest const& request);
 
   /**
    * Updates a pending or completed [Backup][google.test.admin.database.v1.Backup].
    *
-   * @param request [::google::test::admin::database::v1::UpdateBackupRequest](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/backup.proto#L161)
-   * @return [::google::test::admin::database::v1::Backup](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/backup.proto#L36)
+   * @param request [google::test::admin::database::v1::UpdateBackupRequest](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/backup.proto#L161)
+   * @return [google::test::admin::database::v1::Backup](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/backup.proto#L36)
    */
-  StatusOr<::google::test::admin::database::v1::Backup>
-  UpdateBackup(::google::test::admin::database::v1::UpdateBackupRequest const& request);
+  StatusOr<google::test::admin::database::v1::Backup>
+  UpdateBackup(google::test::admin::database::v1::UpdateBackupRequest const& request);
 
   /**
    * Deletes a pending or completed [Backup][google.test.admin.database.v1.Backup].
    *
-   * @param request [::google::test::admin::database::v1::DeleteBackupRequest](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/backup.proto#L190)
+   * @param request [google::test::admin::database::v1::DeleteBackupRequest](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/backup.proto#L190)
    */
   Status
-  DeleteBackup(::google::test::admin::database::v1::DeleteBackupRequest const& request);
+  DeleteBackup(google::test::admin::database::v1::DeleteBackupRequest const& request);
 
   /**
    * Lists completed and pending backups.
    * Backups returned are ordered by `create_time` in descending order,
    * starting from the most recent `create_time`.
    *
-   * @param request [::google::test::admin::database::v1::ListBackupsRequest](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/backup.proto#L203)
+   * @param request [google::test::admin::database::v1::ListBackupsRequest](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/backup.proto#L203)
    */
-  StreamRange<::google::test::admin::database::v1::Backup>
-  ListBackups(::google::test::admin::database::v1::ListBackupsRequest request);
+  StreamRange<google::test::admin::database::v1::Backup>
+  ListBackups(google::test::admin::database::v1::ListBackupsRequest request);
 
   /**
    * Create a new database by restoring from a completed backup. The new
@@ -540,11 +540,11 @@ class GoldenThingAdminClient {
    * initiated, without waiting for the optimize operation associated with the
    * first restore to complete.
    *
-   * @param request [::google::test::admin::database::v1::RestoreDatabaseRequest](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L634)
-   * @return [::google::test::admin::database::v1::Database](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L329)
+   * @param request [google::test::admin::database::v1::RestoreDatabaseRequest](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L634)
+   * @return [google::test::admin::database::v1::Database](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L329)
    */
-  future<StatusOr<::google::test::admin::database::v1::Database>>
-  RestoreDatabase(::google::test::admin::database::v1::RestoreDatabaseRequest const& request);
+  future<StatusOr<google::test::admin::database::v1::Database>>
+  RestoreDatabase(google::test::admin::database::v1::RestoreDatabaseRequest const& request);
 
   /**
    * Lists database [longrunning-operations][google.longrunning.Operation].
@@ -556,10 +556,10 @@ class GoldenThingAdminClient {
    * include those that have completed/failed/canceled within the last 7 days,
    * and pending operations.
    *
-   * @param request [::google::test::admin::database::v1::ListDatabaseOperationsRequest](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L553)
+   * @param request [google::test::admin::database::v1::ListDatabaseOperationsRequest](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L553)
    */
-  StreamRange<::google::longrunning::Operation>
-  ListDatabaseOperations(::google::test::admin::database::v1::ListDatabaseOperationsRequest request);
+  StreamRange<google::longrunning::Operation>
+  ListDatabaseOperations(google::test::admin::database::v1::ListDatabaseOperationsRequest request);
 
   /**
    * Lists the backup [long-running operations][google.longrunning.Operation] in
@@ -573,10 +573,10 @@ class GoldenThingAdminClient {
    * `operation.metadata.value.progress.start_time` in descending order starting
    * from the most recently started operation.
    *
-   * @param request [::google::test::admin::database::v1::ListBackupOperationsRequest](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/backup.proto#L274)
+   * @param request [google::test::admin::database::v1::ListBackupOperationsRequest](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/backup.proto#L274)
    */
-  StreamRange<::google::longrunning::Operation>
-  ListBackupOperations(::google::test::admin::database::v1::ListBackupOperationsRequest request);
+  StreamRange<google::longrunning::Operation>
+  ListBackupOperations(google::test::admin::database::v1::ListBackupOperationsRequest request);
 
  private:
   std::shared_ptr<GoldenThingAdminConnection> connection_;

--- a/generator/integration_tests/golden/golden_thing_admin_connection.cc
+++ b/generator/integration_tests/golden/golden_thing_admin_connection.cc
@@ -32,141 +32,141 @@ inline namespace GOOGLE_CLOUD_CPP_GENERATED_NS {
 
 GoldenThingAdminConnection::~GoldenThingAdminConnection() = default;
 
-StreamRange<::google::test::admin::database::v1::Database> GoldenThingAdminConnection::ListDatabases(
-    ::google::test::admin::database::v1::ListDatabasesRequest request) {
+StreamRange<google::test::admin::database::v1::Database> GoldenThingAdminConnection::ListDatabases(
+    google::test::admin::database::v1::ListDatabasesRequest request) {
   return google::cloud::internal::MakePaginationRange<StreamRange<
-    ::google::test::admin::database::v1::Database>>(
+    google::test::admin::database::v1::Database>>(
     std::move(request),
-    [](::google::test::admin::database::v1::ListDatabasesRequest const&) {
-      return StatusOr<::google::test::admin::database::v1::ListDatabasesResponse>{};
+    [](google::test::admin::database::v1::ListDatabasesRequest const&) {
+      return StatusOr<google::test::admin::database::v1::ListDatabasesResponse>{};
     },
-    [](::google::test::admin::database::v1::ListDatabasesResponse const&) {
-      return std::vector<::google::test::admin::database::v1::Database>();
+    [](google::test::admin::database::v1::ListDatabasesResponse const&) {
+      return std::vector<google::test::admin::database::v1::Database>();
     });
 }
 
-future<StatusOr<::google::test::admin::database::v1::Database>>
+future<StatusOr<google::test::admin::database::v1::Database>>
 GoldenThingAdminConnection::CreateDatabase(
-    ::google::test::admin::database::v1::CreateDatabaseRequest const&) {
+    google::test::admin::database::v1::CreateDatabaseRequest const&) {
   return google::cloud::make_ready_future<
-    StatusOr<::google::test::admin::database::v1::Database>>(
+    StatusOr<google::test::admin::database::v1::Database>>(
     Status(StatusCode::kUnimplemented, "not implemented"));
 }
 
-StatusOr<::google::test::admin::database::v1::Database>
+StatusOr<google::test::admin::database::v1::Database>
 GoldenThingAdminConnection::GetDatabase(
-    ::google::test::admin::database::v1::GetDatabaseRequest const&) {
+    google::test::admin::database::v1::GetDatabaseRequest const&) {
   return Status(StatusCode::kUnimplemented, "not implemented");
 }
 
-future<StatusOr<::google::test::admin::database::v1::UpdateDatabaseDdlMetadata>>
+future<StatusOr<google::test::admin::database::v1::UpdateDatabaseDdlMetadata>>
 GoldenThingAdminConnection::UpdateDatabaseDdl(
-    ::google::test::admin::database::v1::UpdateDatabaseDdlRequest const&) {
+    google::test::admin::database::v1::UpdateDatabaseDdlRequest const&) {
   return google::cloud::make_ready_future<
-    StatusOr<::google::test::admin::database::v1::UpdateDatabaseDdlMetadata>>(
+    StatusOr<google::test::admin::database::v1::UpdateDatabaseDdlMetadata>>(
     Status(StatusCode::kUnimplemented, "not implemented"));
 }
 
 Status
 GoldenThingAdminConnection::DropDatabase(
-    ::google::test::admin::database::v1::DropDatabaseRequest const&) {
+    google::test::admin::database::v1::DropDatabaseRequest const&) {
   return Status(StatusCode::kUnimplemented, "not implemented");
 }
 
-StatusOr<::google::test::admin::database::v1::GetDatabaseDdlResponse>
+StatusOr<google::test::admin::database::v1::GetDatabaseDdlResponse>
 GoldenThingAdminConnection::GetDatabaseDdl(
-    ::google::test::admin::database::v1::GetDatabaseDdlRequest const&) {
+    google::test::admin::database::v1::GetDatabaseDdlRequest const&) {
   return Status(StatusCode::kUnimplemented, "not implemented");
 }
 
-StatusOr<::google::iam::v1::Policy>
+StatusOr<google::iam::v1::Policy>
 GoldenThingAdminConnection::SetIamPolicy(
-    ::google::iam::v1::SetIamPolicyRequest const&) {
+    google::iam::v1::SetIamPolicyRequest const&) {
   return Status(StatusCode::kUnimplemented, "not implemented");
 }
 
-StatusOr<::google::iam::v1::Policy>
+StatusOr<google::iam::v1::Policy>
 GoldenThingAdminConnection::GetIamPolicy(
-    ::google::iam::v1::GetIamPolicyRequest const&) {
+    google::iam::v1::GetIamPolicyRequest const&) {
   return Status(StatusCode::kUnimplemented, "not implemented");
 }
 
-StatusOr<::google::iam::v1::TestIamPermissionsResponse>
+StatusOr<google::iam::v1::TestIamPermissionsResponse>
 GoldenThingAdminConnection::TestIamPermissions(
-    ::google::iam::v1::TestIamPermissionsRequest const&) {
+    google::iam::v1::TestIamPermissionsRequest const&) {
   return Status(StatusCode::kUnimplemented, "not implemented");
 }
 
-future<StatusOr<::google::test::admin::database::v1::Backup>>
+future<StatusOr<google::test::admin::database::v1::Backup>>
 GoldenThingAdminConnection::CreateBackup(
-    ::google::test::admin::database::v1::CreateBackupRequest const&) {
+    google::test::admin::database::v1::CreateBackupRequest const&) {
   return google::cloud::make_ready_future<
-    StatusOr<::google::test::admin::database::v1::Backup>>(
+    StatusOr<google::test::admin::database::v1::Backup>>(
     Status(StatusCode::kUnimplemented, "not implemented"));
 }
 
-StatusOr<::google::test::admin::database::v1::Backup>
+StatusOr<google::test::admin::database::v1::Backup>
 GoldenThingAdminConnection::GetBackup(
-    ::google::test::admin::database::v1::GetBackupRequest const&) {
+    google::test::admin::database::v1::GetBackupRequest const&) {
   return Status(StatusCode::kUnimplemented, "not implemented");
 }
 
-StatusOr<::google::test::admin::database::v1::Backup>
+StatusOr<google::test::admin::database::v1::Backup>
 GoldenThingAdminConnection::UpdateBackup(
-    ::google::test::admin::database::v1::UpdateBackupRequest const&) {
+    google::test::admin::database::v1::UpdateBackupRequest const&) {
   return Status(StatusCode::kUnimplemented, "not implemented");
 }
 
 Status
 GoldenThingAdminConnection::DeleteBackup(
-    ::google::test::admin::database::v1::DeleteBackupRequest const&) {
+    google::test::admin::database::v1::DeleteBackupRequest const&) {
   return Status(StatusCode::kUnimplemented, "not implemented");
 }
 
-StreamRange<::google::test::admin::database::v1::Backup> GoldenThingAdminConnection::ListBackups(
-    ::google::test::admin::database::v1::ListBackupsRequest request) {
+StreamRange<google::test::admin::database::v1::Backup> GoldenThingAdminConnection::ListBackups(
+    google::test::admin::database::v1::ListBackupsRequest request) {
   return google::cloud::internal::MakePaginationRange<StreamRange<
-    ::google::test::admin::database::v1::Backup>>(
+    google::test::admin::database::v1::Backup>>(
     std::move(request),
-    [](::google::test::admin::database::v1::ListBackupsRequest const&) {
-      return StatusOr<::google::test::admin::database::v1::ListBackupsResponse>{};
+    [](google::test::admin::database::v1::ListBackupsRequest const&) {
+      return StatusOr<google::test::admin::database::v1::ListBackupsResponse>{};
     },
-    [](::google::test::admin::database::v1::ListBackupsResponse const&) {
-      return std::vector<::google::test::admin::database::v1::Backup>();
+    [](google::test::admin::database::v1::ListBackupsResponse const&) {
+      return std::vector<google::test::admin::database::v1::Backup>();
     });
 }
 
-future<StatusOr<::google::test::admin::database::v1::Database>>
+future<StatusOr<google::test::admin::database::v1::Database>>
 GoldenThingAdminConnection::RestoreDatabase(
-    ::google::test::admin::database::v1::RestoreDatabaseRequest const&) {
+    google::test::admin::database::v1::RestoreDatabaseRequest const&) {
   return google::cloud::make_ready_future<
-    StatusOr<::google::test::admin::database::v1::Database>>(
+    StatusOr<google::test::admin::database::v1::Database>>(
     Status(StatusCode::kUnimplemented, "not implemented"));
 }
 
-StreamRange<::google::longrunning::Operation> GoldenThingAdminConnection::ListDatabaseOperations(
-    ::google::test::admin::database::v1::ListDatabaseOperationsRequest request) {
+StreamRange<google::longrunning::Operation> GoldenThingAdminConnection::ListDatabaseOperations(
+    google::test::admin::database::v1::ListDatabaseOperationsRequest request) {
   return google::cloud::internal::MakePaginationRange<StreamRange<
-    ::google::longrunning::Operation>>(
+    google::longrunning::Operation>>(
     std::move(request),
-    [](::google::test::admin::database::v1::ListDatabaseOperationsRequest const&) {
-      return StatusOr<::google::test::admin::database::v1::ListDatabaseOperationsResponse>{};
+    [](google::test::admin::database::v1::ListDatabaseOperationsRequest const&) {
+      return StatusOr<google::test::admin::database::v1::ListDatabaseOperationsResponse>{};
     },
-    [](::google::test::admin::database::v1::ListDatabaseOperationsResponse const&) {
-      return std::vector<::google::longrunning::Operation>();
+    [](google::test::admin::database::v1::ListDatabaseOperationsResponse const&) {
+      return std::vector<google::longrunning::Operation>();
     });
 }
 
-StreamRange<::google::longrunning::Operation> GoldenThingAdminConnection::ListBackupOperations(
-    ::google::test::admin::database::v1::ListBackupOperationsRequest request) {
+StreamRange<google::longrunning::Operation> GoldenThingAdminConnection::ListBackupOperations(
+    google::test::admin::database::v1::ListBackupOperationsRequest request) {
   return google::cloud::internal::MakePaginationRange<StreamRange<
-    ::google::longrunning::Operation>>(
+    google::longrunning::Operation>>(
     std::move(request),
-    [](::google::test::admin::database::v1::ListBackupOperationsRequest const&) {
-      return StatusOr<::google::test::admin::database::v1::ListBackupOperationsResponse>{};
+    [](google::test::admin::database::v1::ListBackupOperationsRequest const&) {
+      return StatusOr<google::test::admin::database::v1::ListBackupOperationsResponse>{};
     },
-    [](::google::test::admin::database::v1::ListBackupOperationsResponse const&) {
-      return std::vector<::google::longrunning::Operation>();
+    [](google::test::admin::database::v1::ListBackupOperationsResponse const&) {
+      return std::vector<google::longrunning::Operation>();
     });
 }
 
@@ -184,8 +184,8 @@ class GoldenThingAdminConnectionImpl : public GoldenThingAdminConnection {
 
   ~GoldenThingAdminConnectionImpl() override = default;
 
-  StreamRange<::google::test::admin::database::v1::Database> ListDatabases(
-      ::google::test::admin::database::v1::ListDatabasesRequest request) override {
+  StreamRange<google::test::admin::database::v1::Database> ListDatabases(
+      google::test::admin::database::v1::ListDatabasesRequest request) override {
     request.clear_page_token();
     auto stub = stub_;
     auto retry =
@@ -195,72 +195,72 @@ class GoldenThingAdminConnectionImpl : public GoldenThingAdminConnection {
     auto idempotency = idempotency_policy_->ListDatabases(request);
     char const* function_name = __func__;
     return google::cloud::internal::MakePaginationRange<StreamRange<
-        ::google::test::admin::database::v1::Database>>(
+        google::test::admin::database::v1::Database>>(
         std::move(request),
         [stub, retry, backoff, idempotency, function_name]
-          (::google::test::admin::database::v1::ListDatabasesRequest const& r) {
+          (google::test::admin::database::v1::ListDatabasesRequest const& r) {
           return google::cloud::internal::RetryLoop(
               retry->clone(), backoff->clone(), idempotency,
               [stub](grpc::ClientContext& context,
-                     ::google::test::admin::database::v1::ListDatabasesRequest const& request) {
+                     google::test::admin::database::v1::ListDatabasesRequest const& request) {
                 return stub->ListDatabases(context, request);
               },
               r, function_name);
         },
-        [](::google::test::admin::database::v1::ListDatabasesResponse r) {
-          std::vector<::google::test::admin::database::v1::Database> result(r.databases().size());
+        [](google::test::admin::database::v1::ListDatabasesResponse r) {
+          std::vector<google::test::admin::database::v1::Database> result(r.databases().size());
           auto& messages = *r.mutable_databases();
           std::move(messages.begin(), messages.end(), result.begin());
           return result;
         });
   }
 
-  future<StatusOr<::google::test::admin::database::v1::Database>>
+  future<StatusOr<google::test::admin::database::v1::Database>>
   CreateDatabase(
-      ::google::test::admin::database::v1::CreateDatabaseRequest const& request) override {
+      google::test::admin::database::v1::CreateDatabaseRequest const& request) override {
     auto operation = google::cloud::internal::RetryLoop(
         retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
         idempotency_policy_->CreateDatabase(request),
         [this](grpc::ClientContext& context,
-               ::google::test::admin::database::v1::CreateDatabaseRequest const& request) {
+               google::test::admin::database::v1::CreateDatabaseRequest const& request) {
           return stub_->CreateDatabase(context, request);
         },
         request, __func__);
     if (!operation) {
       return google::cloud::make_ready_future(
-          StatusOr<::google::test::admin::database::v1::Database>(operation.status()));
+          StatusOr<google::test::admin::database::v1::Database>(operation.status()));
     }
 
     return AwaitCreateDatabase(*std::move(operation));
 }
 
-  StatusOr<::google::test::admin::database::v1::Database>
+  StatusOr<google::test::admin::database::v1::Database>
   GetDatabase(
-      ::google::test::admin::database::v1::GetDatabaseRequest const& request) override {
+      google::test::admin::database::v1::GetDatabaseRequest const& request) override {
     return google::cloud::internal::RetryLoop(
         retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
         idempotency_policy_->GetDatabase(request),
         [this](grpc::ClientContext& context,
-            ::google::test::admin::database::v1::GetDatabaseRequest const& request) {
+            google::test::admin::database::v1::GetDatabaseRequest const& request) {
           return stub_->GetDatabase(context, request);
         },
         request, __func__);
 }
 
-  future<StatusOr<::google::test::admin::database::v1::UpdateDatabaseDdlMetadata>>
+  future<StatusOr<google::test::admin::database::v1::UpdateDatabaseDdlMetadata>>
   UpdateDatabaseDdl(
-      ::google::test::admin::database::v1::UpdateDatabaseDdlRequest const& request) override {
+      google::test::admin::database::v1::UpdateDatabaseDdlRequest const& request) override {
     auto operation = google::cloud::internal::RetryLoop(
         retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
         idempotency_policy_->UpdateDatabaseDdl(request),
         [this](grpc::ClientContext& context,
-               ::google::test::admin::database::v1::UpdateDatabaseDdlRequest const& request) {
+               google::test::admin::database::v1::UpdateDatabaseDdlRequest const& request) {
           return stub_->UpdateDatabaseDdl(context, request);
         },
         request, __func__);
     if (!operation) {
       return google::cloud::make_ready_future(
-          StatusOr<::google::test::admin::database::v1::UpdateDatabaseDdlMetadata>(operation.status()));
+          StatusOr<google::test::admin::database::v1::UpdateDatabaseDdlMetadata>(operation.status()));
     }
 
     return AwaitUpdateDatabaseDdl(*std::move(operation));
@@ -268,109 +268,109 @@ class GoldenThingAdminConnectionImpl : public GoldenThingAdminConnection {
 
   Status
   DropDatabase(
-      ::google::test::admin::database::v1::DropDatabaseRequest const& request) override {
+      google::test::admin::database::v1::DropDatabaseRequest const& request) override {
     return google::cloud::internal::RetryLoop(
         retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
         idempotency_policy_->DropDatabase(request),
         [this](grpc::ClientContext& context,
-            ::google::test::admin::database::v1::DropDatabaseRequest const& request) {
+            google::test::admin::database::v1::DropDatabaseRequest const& request) {
           return stub_->DropDatabase(context, request);
         },
         request, __func__);
 }
 
-  StatusOr<::google::test::admin::database::v1::GetDatabaseDdlResponse>
+  StatusOr<google::test::admin::database::v1::GetDatabaseDdlResponse>
   GetDatabaseDdl(
-      ::google::test::admin::database::v1::GetDatabaseDdlRequest const& request) override {
+      google::test::admin::database::v1::GetDatabaseDdlRequest const& request) override {
     return google::cloud::internal::RetryLoop(
         retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
         idempotency_policy_->GetDatabaseDdl(request),
         [this](grpc::ClientContext& context,
-            ::google::test::admin::database::v1::GetDatabaseDdlRequest const& request) {
+            google::test::admin::database::v1::GetDatabaseDdlRequest const& request) {
           return stub_->GetDatabaseDdl(context, request);
         },
         request, __func__);
 }
 
-  StatusOr<::google::iam::v1::Policy>
+  StatusOr<google::iam::v1::Policy>
   SetIamPolicy(
-      ::google::iam::v1::SetIamPolicyRequest const& request) override {
+      google::iam::v1::SetIamPolicyRequest const& request) override {
     return google::cloud::internal::RetryLoop(
         retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
         idempotency_policy_->SetIamPolicy(request),
         [this](grpc::ClientContext& context,
-            ::google::iam::v1::SetIamPolicyRequest const& request) {
+            google::iam::v1::SetIamPolicyRequest const& request) {
           return stub_->SetIamPolicy(context, request);
         },
         request, __func__);
 }
 
-  StatusOr<::google::iam::v1::Policy>
+  StatusOr<google::iam::v1::Policy>
   GetIamPolicy(
-      ::google::iam::v1::GetIamPolicyRequest const& request) override {
+      google::iam::v1::GetIamPolicyRequest const& request) override {
     return google::cloud::internal::RetryLoop(
         retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
         idempotency_policy_->GetIamPolicy(request),
         [this](grpc::ClientContext& context,
-            ::google::iam::v1::GetIamPolicyRequest const& request) {
+            google::iam::v1::GetIamPolicyRequest const& request) {
           return stub_->GetIamPolicy(context, request);
         },
         request, __func__);
 }
 
-  StatusOr<::google::iam::v1::TestIamPermissionsResponse>
+  StatusOr<google::iam::v1::TestIamPermissionsResponse>
   TestIamPermissions(
-      ::google::iam::v1::TestIamPermissionsRequest const& request) override {
+      google::iam::v1::TestIamPermissionsRequest const& request) override {
     return google::cloud::internal::RetryLoop(
         retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
         idempotency_policy_->TestIamPermissions(request),
         [this](grpc::ClientContext& context,
-            ::google::iam::v1::TestIamPermissionsRequest const& request) {
+            google::iam::v1::TestIamPermissionsRequest const& request) {
           return stub_->TestIamPermissions(context, request);
         },
         request, __func__);
 }
 
-  future<StatusOr<::google::test::admin::database::v1::Backup>>
+  future<StatusOr<google::test::admin::database::v1::Backup>>
   CreateBackup(
-      ::google::test::admin::database::v1::CreateBackupRequest const& request) override {
+      google::test::admin::database::v1::CreateBackupRequest const& request) override {
     auto operation = google::cloud::internal::RetryLoop(
         retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
         idempotency_policy_->CreateBackup(request),
         [this](grpc::ClientContext& context,
-               ::google::test::admin::database::v1::CreateBackupRequest const& request) {
+               google::test::admin::database::v1::CreateBackupRequest const& request) {
           return stub_->CreateBackup(context, request);
         },
         request, __func__);
     if (!operation) {
       return google::cloud::make_ready_future(
-          StatusOr<::google::test::admin::database::v1::Backup>(operation.status()));
+          StatusOr<google::test::admin::database::v1::Backup>(operation.status()));
     }
 
     return AwaitCreateBackup(*std::move(operation));
 }
 
-  StatusOr<::google::test::admin::database::v1::Backup>
+  StatusOr<google::test::admin::database::v1::Backup>
   GetBackup(
-      ::google::test::admin::database::v1::GetBackupRequest const& request) override {
+      google::test::admin::database::v1::GetBackupRequest const& request) override {
     return google::cloud::internal::RetryLoop(
         retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
         idempotency_policy_->GetBackup(request),
         [this](grpc::ClientContext& context,
-            ::google::test::admin::database::v1::GetBackupRequest const& request) {
+            google::test::admin::database::v1::GetBackupRequest const& request) {
           return stub_->GetBackup(context, request);
         },
         request, __func__);
 }
 
-  StatusOr<::google::test::admin::database::v1::Backup>
+  StatusOr<google::test::admin::database::v1::Backup>
   UpdateBackup(
-      ::google::test::admin::database::v1::UpdateBackupRequest const& request) override {
+      google::test::admin::database::v1::UpdateBackupRequest const& request) override {
     return google::cloud::internal::RetryLoop(
         retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
         idempotency_policy_->UpdateBackup(request),
         [this](grpc::ClientContext& context,
-            ::google::test::admin::database::v1::UpdateBackupRequest const& request) {
+            google::test::admin::database::v1::UpdateBackupRequest const& request) {
           return stub_->UpdateBackup(context, request);
         },
         request, __func__);
@@ -378,19 +378,19 @@ class GoldenThingAdminConnectionImpl : public GoldenThingAdminConnection {
 
   Status
   DeleteBackup(
-      ::google::test::admin::database::v1::DeleteBackupRequest const& request) override {
+      google::test::admin::database::v1::DeleteBackupRequest const& request) override {
     return google::cloud::internal::RetryLoop(
         retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
         idempotency_policy_->DeleteBackup(request),
         [this](grpc::ClientContext& context,
-            ::google::test::admin::database::v1::DeleteBackupRequest const& request) {
+            google::test::admin::database::v1::DeleteBackupRequest const& request) {
           return stub_->DeleteBackup(context, request);
         },
         request, __func__);
 }
 
-  StreamRange<::google::test::admin::database::v1::Backup> ListBackups(
-      ::google::test::admin::database::v1::ListBackupsRequest request) override {
+  StreamRange<google::test::admin::database::v1::Backup> ListBackups(
+      google::test::admin::database::v1::ListBackupsRequest request) override {
     request.clear_page_token();
     auto stub = stub_;
     auto retry =
@@ -400,47 +400,47 @@ class GoldenThingAdminConnectionImpl : public GoldenThingAdminConnection {
     auto idempotency = idempotency_policy_->ListBackups(request);
     char const* function_name = __func__;
     return google::cloud::internal::MakePaginationRange<StreamRange<
-        ::google::test::admin::database::v1::Backup>>(
+        google::test::admin::database::v1::Backup>>(
         std::move(request),
         [stub, retry, backoff, idempotency, function_name]
-          (::google::test::admin::database::v1::ListBackupsRequest const& r) {
+          (google::test::admin::database::v1::ListBackupsRequest const& r) {
           return google::cloud::internal::RetryLoop(
               retry->clone(), backoff->clone(), idempotency,
               [stub](grpc::ClientContext& context,
-                     ::google::test::admin::database::v1::ListBackupsRequest const& request) {
+                     google::test::admin::database::v1::ListBackupsRequest const& request) {
                 return stub->ListBackups(context, request);
               },
               r, function_name);
         },
-        [](::google::test::admin::database::v1::ListBackupsResponse r) {
-          std::vector<::google::test::admin::database::v1::Backup> result(r.backups().size());
+        [](google::test::admin::database::v1::ListBackupsResponse r) {
+          std::vector<google::test::admin::database::v1::Backup> result(r.backups().size());
           auto& messages = *r.mutable_backups();
           std::move(messages.begin(), messages.end(), result.begin());
           return result;
         });
   }
 
-  future<StatusOr<::google::test::admin::database::v1::Database>>
+  future<StatusOr<google::test::admin::database::v1::Database>>
   RestoreDatabase(
-      ::google::test::admin::database::v1::RestoreDatabaseRequest const& request) override {
+      google::test::admin::database::v1::RestoreDatabaseRequest const& request) override {
     auto operation = google::cloud::internal::RetryLoop(
         retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
         idempotency_policy_->RestoreDatabase(request),
         [this](grpc::ClientContext& context,
-               ::google::test::admin::database::v1::RestoreDatabaseRequest const& request) {
+               google::test::admin::database::v1::RestoreDatabaseRequest const& request) {
           return stub_->RestoreDatabase(context, request);
         },
         request, __func__);
     if (!operation) {
       return google::cloud::make_ready_future(
-          StatusOr<::google::test::admin::database::v1::Database>(operation.status()));
+          StatusOr<google::test::admin::database::v1::Database>(operation.status()));
     }
 
     return AwaitRestoreDatabase(*std::move(operation));
 }
 
-  StreamRange<::google::longrunning::Operation> ListDatabaseOperations(
-      ::google::test::admin::database::v1::ListDatabaseOperationsRequest request) override {
+  StreamRange<google::longrunning::Operation> ListDatabaseOperations(
+      google::test::admin::database::v1::ListDatabaseOperationsRequest request) override {
     request.clear_page_token();
     auto stub = stub_;
     auto retry =
@@ -450,28 +450,28 @@ class GoldenThingAdminConnectionImpl : public GoldenThingAdminConnection {
     auto idempotency = idempotency_policy_->ListDatabaseOperations(request);
     char const* function_name = __func__;
     return google::cloud::internal::MakePaginationRange<StreamRange<
-        ::google::longrunning::Operation>>(
+        google::longrunning::Operation>>(
         std::move(request),
         [stub, retry, backoff, idempotency, function_name]
-          (::google::test::admin::database::v1::ListDatabaseOperationsRequest const& r) {
+          (google::test::admin::database::v1::ListDatabaseOperationsRequest const& r) {
           return google::cloud::internal::RetryLoop(
               retry->clone(), backoff->clone(), idempotency,
               [stub](grpc::ClientContext& context,
-                     ::google::test::admin::database::v1::ListDatabaseOperationsRequest const& request) {
+                     google::test::admin::database::v1::ListDatabaseOperationsRequest const& request) {
                 return stub->ListDatabaseOperations(context, request);
               },
               r, function_name);
         },
-        [](::google::test::admin::database::v1::ListDatabaseOperationsResponse r) {
-          std::vector<::google::longrunning::Operation> result(r.operations().size());
+        [](google::test::admin::database::v1::ListDatabaseOperationsResponse r) {
+          std::vector<google::longrunning::Operation> result(r.operations().size());
           auto& messages = *r.mutable_operations();
           std::move(messages.begin(), messages.end(), result.begin());
           return result;
         });
   }
 
-  StreamRange<::google::longrunning::Operation> ListBackupOperations(
-      ::google::test::admin::database::v1::ListBackupOperationsRequest request) override {
+  StreamRange<google::longrunning::Operation> ListBackupOperations(
+      google::test::admin::database::v1::ListBackupOperationsRequest request) override {
     request.clear_page_token();
     auto stub = stub_;
     auto retry =
@@ -481,20 +481,20 @@ class GoldenThingAdminConnectionImpl : public GoldenThingAdminConnection {
     auto idempotency = idempotency_policy_->ListBackupOperations(request);
     char const* function_name = __func__;
     return google::cloud::internal::MakePaginationRange<StreamRange<
-        ::google::longrunning::Operation>>(
+        google::longrunning::Operation>>(
         std::move(request),
         [stub, retry, backoff, idempotency, function_name]
-          (::google::test::admin::database::v1::ListBackupOperationsRequest const& r) {
+          (google::test::admin::database::v1::ListBackupOperationsRequest const& r) {
           return google::cloud::internal::RetryLoop(
               retry->clone(), backoff->clone(), idempotency,
               [stub](grpc::ClientContext& context,
-                     ::google::test::admin::database::v1::ListBackupOperationsRequest const& request) {
+                     google::test::admin::database::v1::ListBackupOperationsRequest const& request) {
                 return stub->ListBackupOperations(context, request);
               },
               r, function_name);
         },
-        [](::google::test::admin::database::v1::ListBackupOperationsResponse r) {
-          std::vector<::google::longrunning::Operation> result(r.operations().size());
+        [](google::test::admin::database::v1::ListBackupOperationsResponse r) {
+          std::vector<google::longrunning::Operation> result(r.operations().size());
           auto& messages = *r.mutable_operations();
           std::move(messages.begin(), messages.end(), result.begin());
           return result;
@@ -542,38 +542,38 @@ class GoldenThingAdminConnectionImpl : public GoldenThingAdminConnection {
     return f;
   }
 
-  future<StatusOr<::google::test::admin::database::v1::Database>>
+  future<StatusOr<google::test::admin::database::v1::Database>>
   AwaitCreateDatabase(
       google::longrunning::Operation operation) {
     return AwaitLongrunningOperation<
-        ::google::test::admin::database::v1::Database,
+        google::test::admin::database::v1::Database,
         google::cloud::internal::PollingLoopResponseExtractor,
         golden_internal::GoldenThingAdminStub>(std::move(operation));
   }
 
-  future<StatusOr<::google::test::admin::database::v1::UpdateDatabaseDdlMetadata>>
+  future<StatusOr<google::test::admin::database::v1::UpdateDatabaseDdlMetadata>>
   AwaitUpdateDatabaseDdl(
       google::longrunning::Operation operation) {
     return AwaitLongrunningOperation<
-        ::google::test::admin::database::v1::UpdateDatabaseDdlMetadata,
+        google::test::admin::database::v1::UpdateDatabaseDdlMetadata,
         google::cloud::internal::PollingLoopMetadataExtractor,
         golden_internal::GoldenThingAdminStub>(std::move(operation));
   }
 
-  future<StatusOr<::google::test::admin::database::v1::Backup>>
+  future<StatusOr<google::test::admin::database::v1::Backup>>
   AwaitCreateBackup(
       google::longrunning::Operation operation) {
     return AwaitLongrunningOperation<
-        ::google::test::admin::database::v1::Backup,
+        google::test::admin::database::v1::Backup,
         google::cloud::internal::PollingLoopResponseExtractor,
         golden_internal::GoldenThingAdminStub>(std::move(operation));
   }
 
-  future<StatusOr<::google::test::admin::database::v1::Database>>
+  future<StatusOr<google::test::admin::database::v1::Database>>
   AwaitRestoreDatabase(
       google::longrunning::Operation operation) {
     return AwaitLongrunningOperation<
-        ::google::test::admin::database::v1::Database,
+        google::test::admin::database::v1::Database,
         google::cloud::internal::PollingLoopResponseExtractor,
         golden_internal::GoldenThingAdminStub>(std::move(operation));
   }

--- a/generator/integration_tests/golden/golden_thing_admin_connection.h
+++ b/generator/integration_tests/golden/golden_thing_admin_connection.h
@@ -50,56 +50,56 @@ class GoldenThingAdminConnection {
  public:
   virtual ~GoldenThingAdminConnection() = 0;
 
-  virtual StreamRange<::google::test::admin::database::v1::Database>
-  ListDatabases(::google::test::admin::database::v1::ListDatabasesRequest request);
+  virtual StreamRange<google::test::admin::database::v1::Database>
+  ListDatabases(google::test::admin::database::v1::ListDatabasesRequest request);
 
-  virtual future<StatusOr<::google::test::admin::database::v1::Database>>
-  CreateDatabase(::google::test::admin::database::v1::CreateDatabaseRequest const& request);
+  virtual future<StatusOr<google::test::admin::database::v1::Database>>
+  CreateDatabase(google::test::admin::database::v1::CreateDatabaseRequest const& request);
 
-  virtual StatusOr<::google::test::admin::database::v1::Database>
-  GetDatabase(::google::test::admin::database::v1::GetDatabaseRequest const& request);
+  virtual StatusOr<google::test::admin::database::v1::Database>
+  GetDatabase(google::test::admin::database::v1::GetDatabaseRequest const& request);
 
-  virtual future<StatusOr<::google::test::admin::database::v1::UpdateDatabaseDdlMetadata>>
-  UpdateDatabaseDdl(::google::test::admin::database::v1::UpdateDatabaseDdlRequest const& request);
-
-  virtual Status
-  DropDatabase(::google::test::admin::database::v1::DropDatabaseRequest const& request);
-
-  virtual StatusOr<::google::test::admin::database::v1::GetDatabaseDdlResponse>
-  GetDatabaseDdl(::google::test::admin::database::v1::GetDatabaseDdlRequest const& request);
-
-  virtual StatusOr<::google::iam::v1::Policy>
-  SetIamPolicy(::google::iam::v1::SetIamPolicyRequest const& request);
-
-  virtual StatusOr<::google::iam::v1::Policy>
-  GetIamPolicy(::google::iam::v1::GetIamPolicyRequest const& request);
-
-  virtual StatusOr<::google::iam::v1::TestIamPermissionsResponse>
-  TestIamPermissions(::google::iam::v1::TestIamPermissionsRequest const& request);
-
-  virtual future<StatusOr<::google::test::admin::database::v1::Backup>>
-  CreateBackup(::google::test::admin::database::v1::CreateBackupRequest const& request);
-
-  virtual StatusOr<::google::test::admin::database::v1::Backup>
-  GetBackup(::google::test::admin::database::v1::GetBackupRequest const& request);
-
-  virtual StatusOr<::google::test::admin::database::v1::Backup>
-  UpdateBackup(::google::test::admin::database::v1::UpdateBackupRequest const& request);
+  virtual future<StatusOr<google::test::admin::database::v1::UpdateDatabaseDdlMetadata>>
+  UpdateDatabaseDdl(google::test::admin::database::v1::UpdateDatabaseDdlRequest const& request);
 
   virtual Status
-  DeleteBackup(::google::test::admin::database::v1::DeleteBackupRequest const& request);
+  DropDatabase(google::test::admin::database::v1::DropDatabaseRequest const& request);
 
-  virtual StreamRange<::google::test::admin::database::v1::Backup>
-  ListBackups(::google::test::admin::database::v1::ListBackupsRequest request);
+  virtual StatusOr<google::test::admin::database::v1::GetDatabaseDdlResponse>
+  GetDatabaseDdl(google::test::admin::database::v1::GetDatabaseDdlRequest const& request);
 
-  virtual future<StatusOr<::google::test::admin::database::v1::Database>>
-  RestoreDatabase(::google::test::admin::database::v1::RestoreDatabaseRequest const& request);
+  virtual StatusOr<google::iam::v1::Policy>
+  SetIamPolicy(google::iam::v1::SetIamPolicyRequest const& request);
 
-  virtual StreamRange<::google::longrunning::Operation>
-  ListDatabaseOperations(::google::test::admin::database::v1::ListDatabaseOperationsRequest request);
+  virtual StatusOr<google::iam::v1::Policy>
+  GetIamPolicy(google::iam::v1::GetIamPolicyRequest const& request);
 
-  virtual StreamRange<::google::longrunning::Operation>
-  ListBackupOperations(::google::test::admin::database::v1::ListBackupOperationsRequest request);
+  virtual StatusOr<google::iam::v1::TestIamPermissionsResponse>
+  TestIamPermissions(google::iam::v1::TestIamPermissionsRequest const& request);
+
+  virtual future<StatusOr<google::test::admin::database::v1::Backup>>
+  CreateBackup(google::test::admin::database::v1::CreateBackupRequest const& request);
+
+  virtual StatusOr<google::test::admin::database::v1::Backup>
+  GetBackup(google::test::admin::database::v1::GetBackupRequest const& request);
+
+  virtual StatusOr<google::test::admin::database::v1::Backup>
+  UpdateBackup(google::test::admin::database::v1::UpdateBackupRequest const& request);
+
+  virtual Status
+  DeleteBackup(google::test::admin::database::v1::DeleteBackupRequest const& request);
+
+  virtual StreamRange<google::test::admin::database::v1::Backup>
+  ListBackups(google::test::admin::database::v1::ListBackupsRequest request);
+
+  virtual future<StatusOr<google::test::admin::database::v1::Database>>
+  RestoreDatabase(google::test::admin::database::v1::RestoreDatabaseRequest const& request);
+
+  virtual StreamRange<google::longrunning::Operation>
+  ListDatabaseOperations(google::test::admin::database::v1::ListDatabaseOperationsRequest request);
+
+  virtual StreamRange<google::longrunning::Operation>
+  ListBackupOperations(google::test::admin::database::v1::ListBackupOperationsRequest request);
 
 };
 

--- a/generator/integration_tests/golden/golden_thing_admin_connection_idempotency_policy.cc
+++ b/generator/integration_tests/golden/golden_thing_admin_connection_idempotency_policy.cc
@@ -39,87 +39,87 @@ class DefaultGoldenThingAdminConnectionIdempotencyPolicy : public GoldenThingAdm
   }
 
   Idempotency
-  ListDatabases(::google::test::admin::database::v1::ListDatabasesRequest) override {
+  ListDatabases(google::test::admin::database::v1::ListDatabasesRequest) override {
     return Idempotency::kIdempotent;
   }
 
   Idempotency
-  CreateDatabase(::google::test::admin::database::v1::CreateDatabaseRequest const&) override {
+  CreateDatabase(google::test::admin::database::v1::CreateDatabaseRequest const&) override {
     return Idempotency::kNonIdempotent;
   }
 
   Idempotency
-  GetDatabase(::google::test::admin::database::v1::GetDatabaseRequest const&) override {
+  GetDatabase(google::test::admin::database::v1::GetDatabaseRequest const&) override {
     return Idempotency::kIdempotent;
   }
 
   Idempotency
-  UpdateDatabaseDdl(::google::test::admin::database::v1::UpdateDatabaseDdlRequest const&) override {
+  UpdateDatabaseDdl(google::test::admin::database::v1::UpdateDatabaseDdlRequest const&) override {
     return Idempotency::kNonIdempotent;
   }
 
   Idempotency
-  DropDatabase(::google::test::admin::database::v1::DropDatabaseRequest const&) override {
+  DropDatabase(google::test::admin::database::v1::DropDatabaseRequest const&) override {
     return Idempotency::kNonIdempotent;
   }
 
   Idempotency
-  GetDatabaseDdl(::google::test::admin::database::v1::GetDatabaseDdlRequest const&) override {
+  GetDatabaseDdl(google::test::admin::database::v1::GetDatabaseDdlRequest const&) override {
     return Idempotency::kIdempotent;
   }
 
   Idempotency
-  SetIamPolicy(::google::iam::v1::SetIamPolicyRequest const&) override {
+  SetIamPolicy(google::iam::v1::SetIamPolicyRequest const&) override {
     return Idempotency::kNonIdempotent;
   }
 
   Idempotency
-  GetIamPolicy(::google::iam::v1::GetIamPolicyRequest const&) override {
+  GetIamPolicy(google::iam::v1::GetIamPolicyRequest const&) override {
     return Idempotency::kNonIdempotent;
   }
 
   Idempotency
-  TestIamPermissions(::google::iam::v1::TestIamPermissionsRequest const&) override {
+  TestIamPermissions(google::iam::v1::TestIamPermissionsRequest const&) override {
     return Idempotency::kNonIdempotent;
   }
 
   Idempotency
-  CreateBackup(::google::test::admin::database::v1::CreateBackupRequest const&) override {
+  CreateBackup(google::test::admin::database::v1::CreateBackupRequest const&) override {
     return Idempotency::kNonIdempotent;
   }
 
   Idempotency
-  GetBackup(::google::test::admin::database::v1::GetBackupRequest const&) override {
+  GetBackup(google::test::admin::database::v1::GetBackupRequest const&) override {
     return Idempotency::kIdempotent;
   }
 
   Idempotency
-  UpdateBackup(::google::test::admin::database::v1::UpdateBackupRequest const&) override {
+  UpdateBackup(google::test::admin::database::v1::UpdateBackupRequest const&) override {
     return Idempotency::kNonIdempotent;
   }
 
   Idempotency
-  DeleteBackup(::google::test::admin::database::v1::DeleteBackupRequest const&) override {
+  DeleteBackup(google::test::admin::database::v1::DeleteBackupRequest const&) override {
     return Idempotency::kNonIdempotent;
   }
 
   Idempotency
-  ListBackups(::google::test::admin::database::v1::ListBackupsRequest) override {
+  ListBackups(google::test::admin::database::v1::ListBackupsRequest) override {
     return Idempotency::kIdempotent;
   }
 
   Idempotency
-  RestoreDatabase(::google::test::admin::database::v1::RestoreDatabaseRequest const&) override {
+  RestoreDatabase(google::test::admin::database::v1::RestoreDatabaseRequest const&) override {
     return Idempotency::kNonIdempotent;
   }
 
   Idempotency
-  ListDatabaseOperations(::google::test::admin::database::v1::ListDatabaseOperationsRequest) override {
+  ListDatabaseOperations(google::test::admin::database::v1::ListDatabaseOperationsRequest) override {
     return Idempotency::kIdempotent;
   }
 
   Idempotency
-  ListBackupOperations(::google::test::admin::database::v1::ListBackupOperationsRequest) override {
+  ListBackupOperations(google::test::admin::database::v1::ListBackupOperationsRequest) override {
     return Idempotency::kIdempotent;
   }
 

--- a/generator/integration_tests/golden/golden_thing_admin_connection_idempotency_policy.h
+++ b/generator/integration_tests/golden/golden_thing_admin_connection_idempotency_policy.h
@@ -38,55 +38,55 @@ class GoldenThingAdminConnectionIdempotencyPolicy {
   virtual std::unique_ptr<GoldenThingAdminConnectionIdempotencyPolicy> clone() const = 0;
 
   virtual google::cloud::internal::Idempotency
-  ListDatabases(::google::test::admin::database::v1::ListDatabasesRequest request) = 0;
+  ListDatabases(google::test::admin::database::v1::ListDatabasesRequest request) = 0;
 
   virtual google::cloud::internal::Idempotency
-  CreateDatabase(::google::test::admin::database::v1::CreateDatabaseRequest const& request) = 0;
+  CreateDatabase(google::test::admin::database::v1::CreateDatabaseRequest const& request) = 0;
 
   virtual google::cloud::internal::Idempotency
-  GetDatabase(::google::test::admin::database::v1::GetDatabaseRequest const& request) = 0;
+  GetDatabase(google::test::admin::database::v1::GetDatabaseRequest const& request) = 0;
 
   virtual google::cloud::internal::Idempotency
-  UpdateDatabaseDdl(::google::test::admin::database::v1::UpdateDatabaseDdlRequest const& request) = 0;
+  UpdateDatabaseDdl(google::test::admin::database::v1::UpdateDatabaseDdlRequest const& request) = 0;
 
   virtual google::cloud::internal::Idempotency
-  DropDatabase(::google::test::admin::database::v1::DropDatabaseRequest const& request) = 0;
+  DropDatabase(google::test::admin::database::v1::DropDatabaseRequest const& request) = 0;
 
   virtual google::cloud::internal::Idempotency
-  GetDatabaseDdl(::google::test::admin::database::v1::GetDatabaseDdlRequest const& request) = 0;
+  GetDatabaseDdl(google::test::admin::database::v1::GetDatabaseDdlRequest const& request) = 0;
 
   virtual google::cloud::internal::Idempotency
-  SetIamPolicy(::google::iam::v1::SetIamPolicyRequest const& request) = 0;
+  SetIamPolicy(google::iam::v1::SetIamPolicyRequest const& request) = 0;
 
   virtual google::cloud::internal::Idempotency
-  GetIamPolicy(::google::iam::v1::GetIamPolicyRequest const& request) = 0;
+  GetIamPolicy(google::iam::v1::GetIamPolicyRequest const& request) = 0;
 
   virtual google::cloud::internal::Idempotency
-  TestIamPermissions(::google::iam::v1::TestIamPermissionsRequest const& request) = 0;
+  TestIamPermissions(google::iam::v1::TestIamPermissionsRequest const& request) = 0;
 
   virtual google::cloud::internal::Idempotency
-  CreateBackup(::google::test::admin::database::v1::CreateBackupRequest const& request) = 0;
+  CreateBackup(google::test::admin::database::v1::CreateBackupRequest const& request) = 0;
 
   virtual google::cloud::internal::Idempotency
-  GetBackup(::google::test::admin::database::v1::GetBackupRequest const& request) = 0;
+  GetBackup(google::test::admin::database::v1::GetBackupRequest const& request) = 0;
 
   virtual google::cloud::internal::Idempotency
-  UpdateBackup(::google::test::admin::database::v1::UpdateBackupRequest const& request) = 0;
+  UpdateBackup(google::test::admin::database::v1::UpdateBackupRequest const& request) = 0;
 
   virtual google::cloud::internal::Idempotency
-  DeleteBackup(::google::test::admin::database::v1::DeleteBackupRequest const& request) = 0;
+  DeleteBackup(google::test::admin::database::v1::DeleteBackupRequest const& request) = 0;
 
   virtual google::cloud::internal::Idempotency
-  ListBackups(::google::test::admin::database::v1::ListBackupsRequest request) = 0;
+  ListBackups(google::test::admin::database::v1::ListBackupsRequest request) = 0;
 
   virtual google::cloud::internal::Idempotency
-  RestoreDatabase(::google::test::admin::database::v1::RestoreDatabaseRequest const& request) = 0;
+  RestoreDatabase(google::test::admin::database::v1::RestoreDatabaseRequest const& request) = 0;
 
   virtual google::cloud::internal::Idempotency
-  ListDatabaseOperations(::google::test::admin::database::v1::ListDatabaseOperationsRequest request) = 0;
+  ListDatabaseOperations(google::test::admin::database::v1::ListDatabaseOperationsRequest request) = 0;
 
   virtual google::cloud::internal::Idempotency
-  ListBackupOperations(::google::test::admin::database::v1::ListBackupOperationsRequest request) = 0;
+  ListBackupOperations(google::test::admin::database::v1::ListBackupOperationsRequest request) = 0;
 
 };
 

--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_logging_decorator.cc
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_logging_decorator.cc
@@ -34,67 +34,67 @@ GoldenKitchenSinkLogging::GoldenKitchenSinkLogging(
     : child_(std::move(child)), tracing_options_(std::move(tracing_options)),
       components_(std::move(components)) {}
 
-StatusOr<::google::test::admin::database::v1::GenerateAccessTokenResponse>
+StatusOr<google::test::admin::database::v1::GenerateAccessTokenResponse>
 GoldenKitchenSinkLogging::GenerateAccessToken(
     grpc::ClientContext& context,
-    ::google::test::admin::database::v1::GenerateAccessTokenRequest const& request) {
+    google::test::admin::database::v1::GenerateAccessTokenRequest const& request) {
   return google::cloud::internal::LogWrapper(
       [this](grpc::ClientContext& context,
-             ::google::test::admin::database::v1::GenerateAccessTokenRequest const& request) {
+             google::test::admin::database::v1::GenerateAccessTokenRequest const& request) {
         return child_->GenerateAccessToken(context, request);
       },
       context, request, __func__, tracing_options_);
 }
 
-StatusOr<::google::test::admin::database::v1::GenerateIdTokenResponse>
+StatusOr<google::test::admin::database::v1::GenerateIdTokenResponse>
 GoldenKitchenSinkLogging::GenerateIdToken(
     grpc::ClientContext& context,
-    ::google::test::admin::database::v1::GenerateIdTokenRequest const& request) {
+    google::test::admin::database::v1::GenerateIdTokenRequest const& request) {
   return google::cloud::internal::LogWrapper(
       [this](grpc::ClientContext& context,
-             ::google::test::admin::database::v1::GenerateIdTokenRequest const& request) {
+             google::test::admin::database::v1::GenerateIdTokenRequest const& request) {
         return child_->GenerateIdToken(context, request);
       },
       context, request, __func__, tracing_options_);
 }
 
-StatusOr<::google::test::admin::database::v1::WriteLogEntriesResponse>
+StatusOr<google::test::admin::database::v1::WriteLogEntriesResponse>
 GoldenKitchenSinkLogging::WriteLogEntries(
     grpc::ClientContext& context,
-    ::google::test::admin::database::v1::WriteLogEntriesRequest const& request) {
+    google::test::admin::database::v1::WriteLogEntriesRequest const& request) {
   return google::cloud::internal::LogWrapper(
       [this](grpc::ClientContext& context,
-             ::google::test::admin::database::v1::WriteLogEntriesRequest const& request) {
+             google::test::admin::database::v1::WriteLogEntriesRequest const& request) {
         return child_->WriteLogEntries(context, request);
       },
       context, request, __func__, tracing_options_);
 }
 
-StatusOr<::google::test::admin::database::v1::ListLogsResponse>
+StatusOr<google::test::admin::database::v1::ListLogsResponse>
 GoldenKitchenSinkLogging::ListLogs(
     grpc::ClientContext& context,
-    ::google::test::admin::database::v1::ListLogsRequest const& request) {
+    google::test::admin::database::v1::ListLogsRequest const& request) {
   return google::cloud::internal::LogWrapper(
       [this](grpc::ClientContext& context,
-             ::google::test::admin::database::v1::ListLogsRequest const& request) {
+             google::test::admin::database::v1::ListLogsRequest const& request) {
         return child_->ListLogs(context, request);
       },
       context, request, __func__, tracing_options_);
 }
 
-std::unique_ptr<internal::StreamingReadRpc<::google::test::admin::database::v1::TailLogEntriesResponse>>
+std::unique_ptr<internal::StreamingReadRpc<google::test::admin::database::v1::TailLogEntriesResponse>>
 GoldenKitchenSinkLogging::TailLogEntries(
     std::unique_ptr<grpc::ClientContext> context,
-    ::google::test::admin::database::v1::TailLogEntriesRequest const& request) {
+    google::test::admin::database::v1::TailLogEntriesRequest const& request) {
   return google::cloud::internal::LogWrapper(
       [this](std::unique_ptr<grpc::ClientContext> context,
-             ::google::test::admin::database::v1::TailLogEntriesRequest const& request) ->
+             google::test::admin::database::v1::TailLogEntriesRequest const& request) ->
       std::unique_ptr<internal::StreamingReadRpc<
-          ::google::test::admin::database::v1::TailLogEntriesResponse>> {
+          google::test::admin::database::v1::TailLogEntriesResponse>> {
         auto stream = child_->TailLogEntries(std::move(context), request);
         if (components_.count("rpc-streams") > 0) {
           stream = absl::make_unique<internal::StreamingReadRpcLogging<
-             ::google::test::admin::database::v1::TailLogEntriesResponse>>(
+             google::test::admin::database::v1::TailLogEntriesResponse>>(
                std::move(stream), tracing_options_,
                internal::RequestIdForLogging());
         }
@@ -103,13 +103,13 @@ GoldenKitchenSinkLogging::TailLogEntries(
       std::move(context), request, __func__, tracing_options_);
 }
 
-StatusOr<::google::test::admin::database::v1::ListServiceAccountKeysResponse>
+StatusOr<google::test::admin::database::v1::ListServiceAccountKeysResponse>
 GoldenKitchenSinkLogging::ListServiceAccountKeys(
     grpc::ClientContext& context,
-    ::google::test::admin::database::v1::ListServiceAccountKeysRequest const& request) {
+    google::test::admin::database::v1::ListServiceAccountKeysRequest const& request) {
   return google::cloud::internal::LogWrapper(
       [this](grpc::ClientContext& context,
-             ::google::test::admin::database::v1::ListServiceAccountKeysRequest const& request) {
+             google::test::admin::database::v1::ListServiceAccountKeysRequest const& request) {
         return child_->ListServiceAccountKeys(context, request);
       },
       context, request, __func__, tracing_options_);

--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_logging_decorator.h
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_logging_decorator.h
@@ -37,30 +37,30 @@ class GoldenKitchenSinkLogging : public GoldenKitchenSinkStub {
                        TracingOptions tracing_options,
                        std::set<std::string> components);
 
-  StatusOr<::google::test::admin::database::v1::GenerateAccessTokenResponse> GenerateAccessToken(
+  StatusOr<google::test::admin::database::v1::GenerateAccessTokenResponse> GenerateAccessToken(
     grpc::ClientContext& context,
-    ::google::test::admin::database::v1::GenerateAccessTokenRequest const& request) override;
+    google::test::admin::database::v1::GenerateAccessTokenRequest const& request) override;
 
-  StatusOr<::google::test::admin::database::v1::GenerateIdTokenResponse> GenerateIdToken(
+  StatusOr<google::test::admin::database::v1::GenerateIdTokenResponse> GenerateIdToken(
     grpc::ClientContext& context,
-    ::google::test::admin::database::v1::GenerateIdTokenRequest const& request) override;
+    google::test::admin::database::v1::GenerateIdTokenRequest const& request) override;
 
-  StatusOr<::google::test::admin::database::v1::WriteLogEntriesResponse> WriteLogEntries(
+  StatusOr<google::test::admin::database::v1::WriteLogEntriesResponse> WriteLogEntries(
     grpc::ClientContext& context,
-    ::google::test::admin::database::v1::WriteLogEntriesRequest const& request) override;
+    google::test::admin::database::v1::WriteLogEntriesRequest const& request) override;
 
-  StatusOr<::google::test::admin::database::v1::ListLogsResponse> ListLogs(
+  StatusOr<google::test::admin::database::v1::ListLogsResponse> ListLogs(
     grpc::ClientContext& context,
-    ::google::test::admin::database::v1::ListLogsRequest const& request) override;
+    google::test::admin::database::v1::ListLogsRequest const& request) override;
 
-  std::unique_ptr<internal::StreamingReadRpc<::google::test::admin::database::v1::TailLogEntriesResponse>>
+  std::unique_ptr<internal::StreamingReadRpc<google::test::admin::database::v1::TailLogEntriesResponse>>
   TailLogEntries(
     std::unique_ptr<grpc::ClientContext> context,
-    ::google::test::admin::database::v1::TailLogEntriesRequest const& request) override;
+    google::test::admin::database::v1::TailLogEntriesRequest const& request) override;
 
-  StatusOr<::google::test::admin::database::v1::ListServiceAccountKeysResponse> ListServiceAccountKeys(
+  StatusOr<google::test::admin::database::v1::ListServiceAccountKeysResponse> ListServiceAccountKeys(
     grpc::ClientContext& context,
-    ::google::test::admin::database::v1::ListServiceAccountKeysRequest const& request) override;
+    google::test::admin::database::v1::ListServiceAccountKeysRequest const& request) override;
 
  private:
   std::shared_ptr<GoldenKitchenSinkStub> child_;

--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_metadata_decorator.cc
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_metadata_decorator.cc
@@ -31,50 +31,50 @@ GoldenKitchenSinkMetadata::GoldenKitchenSinkMetadata(
     : child_(std::move(child)),
       api_client_header_(google::cloud::internal::ApiClientHeader()) {}
 
-StatusOr<::google::test::admin::database::v1::GenerateAccessTokenResponse>
+StatusOr<google::test::admin::database::v1::GenerateAccessTokenResponse>
 GoldenKitchenSinkMetadata::GenerateAccessToken(
     grpc::ClientContext& context,
-    ::google::test::admin::database::v1::GenerateAccessTokenRequest const& request) {
+    google::test::admin::database::v1::GenerateAccessTokenRequest const& request) {
   SetMetadata(context, "name=" + request.name());
   return child_->GenerateAccessToken(context, request);
 }
 
-StatusOr<::google::test::admin::database::v1::GenerateIdTokenResponse>
+StatusOr<google::test::admin::database::v1::GenerateIdTokenResponse>
 GoldenKitchenSinkMetadata::GenerateIdToken(
     grpc::ClientContext& context,
-    ::google::test::admin::database::v1::GenerateIdTokenRequest const& request) {
+    google::test::admin::database::v1::GenerateIdTokenRequest const& request) {
   SetMetadata(context, {});
   return child_->GenerateIdToken(context, request);
 }
 
-StatusOr<::google::test::admin::database::v1::WriteLogEntriesResponse>
+StatusOr<google::test::admin::database::v1::WriteLogEntriesResponse>
 GoldenKitchenSinkMetadata::WriteLogEntries(
     grpc::ClientContext& context,
-    ::google::test::admin::database::v1::WriteLogEntriesRequest const& request) {
+    google::test::admin::database::v1::WriteLogEntriesRequest const& request) {
   SetMetadata(context, {});
   return child_->WriteLogEntries(context, request);
 }
 
-StatusOr<::google::test::admin::database::v1::ListLogsResponse>
+StatusOr<google::test::admin::database::v1::ListLogsResponse>
 GoldenKitchenSinkMetadata::ListLogs(
     grpc::ClientContext& context,
-    ::google::test::admin::database::v1::ListLogsRequest const& request) {
+    google::test::admin::database::v1::ListLogsRequest const& request) {
   SetMetadata(context, "parent=" + request.parent());
   return child_->ListLogs(context, request);
 }
 
-std::unique_ptr<internal::StreamingReadRpc<::google::test::admin::database::v1::TailLogEntriesResponse>>
+std::unique_ptr<internal::StreamingReadRpc<google::test::admin::database::v1::TailLogEntriesResponse>>
 GoldenKitchenSinkMetadata::TailLogEntries(
     std::unique_ptr<grpc::ClientContext> context,
-    ::google::test::admin::database::v1::TailLogEntriesRequest const& request) {
+    google::test::admin::database::v1::TailLogEntriesRequest const& request) {
   SetMetadata(*context, {});
   return child_->TailLogEntries(std::move(context), request);
 }
 
-StatusOr<::google::test::admin::database::v1::ListServiceAccountKeysResponse>
+StatusOr<google::test::admin::database::v1::ListServiceAccountKeysResponse>
 GoldenKitchenSinkMetadata::ListServiceAccountKeys(
     grpc::ClientContext& context,
-    ::google::test::admin::database::v1::ListServiceAccountKeysRequest const& request) {
+    google::test::admin::database::v1::ListServiceAccountKeysRequest const& request) {
   SetMetadata(context, "name=" + request.name());
   return child_->ListServiceAccountKeys(context, request);
 }

--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_metadata_decorator.h
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_metadata_decorator.h
@@ -33,30 +33,30 @@ class GoldenKitchenSinkMetadata : public GoldenKitchenSinkStub {
   ~GoldenKitchenSinkMetadata() override = default;
   explicit GoldenKitchenSinkMetadata(std::shared_ptr<GoldenKitchenSinkStub> child);
 
-  StatusOr<::google::test::admin::database::v1::GenerateAccessTokenResponse> GenerateAccessToken(
+  StatusOr<google::test::admin::database::v1::GenerateAccessTokenResponse> GenerateAccessToken(
     grpc::ClientContext& context,
-    ::google::test::admin::database::v1::GenerateAccessTokenRequest const& request) override;
+    google::test::admin::database::v1::GenerateAccessTokenRequest const& request) override;
 
-  StatusOr<::google::test::admin::database::v1::GenerateIdTokenResponse> GenerateIdToken(
+  StatusOr<google::test::admin::database::v1::GenerateIdTokenResponse> GenerateIdToken(
     grpc::ClientContext& context,
-    ::google::test::admin::database::v1::GenerateIdTokenRequest const& request) override;
+    google::test::admin::database::v1::GenerateIdTokenRequest const& request) override;
 
-  StatusOr<::google::test::admin::database::v1::WriteLogEntriesResponse> WriteLogEntries(
+  StatusOr<google::test::admin::database::v1::WriteLogEntriesResponse> WriteLogEntries(
     grpc::ClientContext& context,
-    ::google::test::admin::database::v1::WriteLogEntriesRequest const& request) override;
+    google::test::admin::database::v1::WriteLogEntriesRequest const& request) override;
 
-  StatusOr<::google::test::admin::database::v1::ListLogsResponse> ListLogs(
+  StatusOr<google::test::admin::database::v1::ListLogsResponse> ListLogs(
     grpc::ClientContext& context,
-    ::google::test::admin::database::v1::ListLogsRequest const& request) override;
+    google::test::admin::database::v1::ListLogsRequest const& request) override;
 
-  std::unique_ptr<internal::StreamingReadRpc<::google::test::admin::database::v1::TailLogEntriesResponse>>
+  std::unique_ptr<internal::StreamingReadRpc<google::test::admin::database::v1::TailLogEntriesResponse>>
     TailLogEntries(
     std::unique_ptr<grpc::ClientContext> context,
-    ::google::test::admin::database::v1::TailLogEntriesRequest const& request) override;
+    google::test::admin::database::v1::TailLogEntriesRequest const& request) override;
 
-  StatusOr<::google::test::admin::database::v1::ListServiceAccountKeysResponse> ListServiceAccountKeys(
+  StatusOr<google::test::admin::database::v1::ListServiceAccountKeysResponse> ListServiceAccountKeys(
     grpc::ClientContext& context,
-    ::google::test::admin::database::v1::ListServiceAccountKeysRequest const& request) override;
+    google::test::admin::database::v1::ListServiceAccountKeysRequest const& request) override;
 
  private:
   void SetMetadata(grpc::ClientContext& context,

--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_stub.cc
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_stub.cc
@@ -30,11 +30,11 @@ inline namespace GOOGLE_CLOUD_CPP_GENERATED_NS {
 
 GoldenKitchenSinkStub::~GoldenKitchenSinkStub() = default;
 
-StatusOr<::google::test::admin::database::v1::GenerateAccessTokenResponse>
+StatusOr<google::test::admin::database::v1::GenerateAccessTokenResponse>
 DefaultGoldenKitchenSinkStub::GenerateAccessToken(
   grpc::ClientContext& client_context,
-  ::google::test::admin::database::v1::GenerateAccessTokenRequest const& request) {
-    ::google::test::admin::database::v1::GenerateAccessTokenResponse response;
+  google::test::admin::database::v1::GenerateAccessTokenRequest const& request) {
+    google::test::admin::database::v1::GenerateAccessTokenResponse response;
     auto status =
         grpc_stub_->GenerateAccessToken(&client_context, request, &response);
     if (!status.ok()) {
@@ -43,11 +43,11 @@ DefaultGoldenKitchenSinkStub::GenerateAccessToken(
     return response;
 }
 
-StatusOr<::google::test::admin::database::v1::GenerateIdTokenResponse>
+StatusOr<google::test::admin::database::v1::GenerateIdTokenResponse>
 DefaultGoldenKitchenSinkStub::GenerateIdToken(
   grpc::ClientContext& client_context,
-  ::google::test::admin::database::v1::GenerateIdTokenRequest const& request) {
-    ::google::test::admin::database::v1::GenerateIdTokenResponse response;
+  google::test::admin::database::v1::GenerateIdTokenRequest const& request) {
+    google::test::admin::database::v1::GenerateIdTokenResponse response;
     auto status =
         grpc_stub_->GenerateIdToken(&client_context, request, &response);
     if (!status.ok()) {
@@ -56,11 +56,11 @@ DefaultGoldenKitchenSinkStub::GenerateIdToken(
     return response;
 }
 
-StatusOr<::google::test::admin::database::v1::WriteLogEntriesResponse>
+StatusOr<google::test::admin::database::v1::WriteLogEntriesResponse>
 DefaultGoldenKitchenSinkStub::WriteLogEntries(
   grpc::ClientContext& client_context,
-  ::google::test::admin::database::v1::WriteLogEntriesRequest const& request) {
-    ::google::test::admin::database::v1::WriteLogEntriesResponse response;
+  google::test::admin::database::v1::WriteLogEntriesRequest const& request) {
+    google::test::admin::database::v1::WriteLogEntriesResponse response;
     auto status =
         grpc_stub_->WriteLogEntries(&client_context, request, &response);
     if (!status.ok()) {
@@ -69,11 +69,11 @@ DefaultGoldenKitchenSinkStub::WriteLogEntries(
     return response;
 }
 
-StatusOr<::google::test::admin::database::v1::ListLogsResponse>
+StatusOr<google::test::admin::database::v1::ListLogsResponse>
 DefaultGoldenKitchenSinkStub::ListLogs(
   grpc::ClientContext& client_context,
-  ::google::test::admin::database::v1::ListLogsRequest const& request) {
-    ::google::test::admin::database::v1::ListLogsResponse response;
+  google::test::admin::database::v1::ListLogsRequest const& request) {
+    google::test::admin::database::v1::ListLogsResponse response;
     auto status =
         grpc_stub_->ListLogs(&client_context, request, &response);
     if (!status.ok()) {
@@ -82,21 +82,21 @@ DefaultGoldenKitchenSinkStub::ListLogs(
     return response;
 }
 
-std::unique_ptr<internal::StreamingReadRpc<::google::test::admin::database::v1::TailLogEntriesResponse>>
+std::unique_ptr<internal::StreamingReadRpc<google::test::admin::database::v1::TailLogEntriesResponse>>
 DefaultGoldenKitchenSinkStub::TailLogEntries(
     std::unique_ptr<grpc::ClientContext> client_context,
-    ::google::test::admin::database::v1::TailLogEntriesRequest const& request) {
+    google::test::admin::database::v1::TailLogEntriesRequest const& request) {
   auto stream = grpc_stub_->TailLogEntries(client_context.get(), request);
   return absl::make_unique<internal::StreamingReadRpcImpl<
-      ::google::test::admin::database::v1::TailLogEntriesResponse>>(
+      google::test::admin::database::v1::TailLogEntriesResponse>>(
       std::move(client_context), std::move(stream));
 }
 
-StatusOr<::google::test::admin::database::v1::ListServiceAccountKeysResponse>
+StatusOr<google::test::admin::database::v1::ListServiceAccountKeysResponse>
 DefaultGoldenKitchenSinkStub::ListServiceAccountKeys(
   grpc::ClientContext& client_context,
-  ::google::test::admin::database::v1::ListServiceAccountKeysRequest const& request) {
-    ::google::test::admin::database::v1::ListServiceAccountKeysResponse response;
+  google::test::admin::database::v1::ListServiceAccountKeysRequest const& request) {
+    google::test::admin::database::v1::ListServiceAccountKeysResponse response;
     auto status =
         grpc_stub_->ListServiceAccountKeys(&client_context, request, &response);
     if (!status.ok()) {

--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_stub.h
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_stub.h
@@ -33,71 +33,71 @@ class GoldenKitchenSinkStub {
  public:
   virtual ~GoldenKitchenSinkStub() = 0;
 
-  virtual StatusOr<::google::test::admin::database::v1::GenerateAccessTokenResponse> GenerateAccessToken(
+  virtual StatusOr<google::test::admin::database::v1::GenerateAccessTokenResponse> GenerateAccessToken(
     grpc::ClientContext& context,
-    ::google::test::admin::database::v1::GenerateAccessTokenRequest const& request) = 0;
+    google::test::admin::database::v1::GenerateAccessTokenRequest const& request) = 0;
 
-  virtual StatusOr<::google::test::admin::database::v1::GenerateIdTokenResponse> GenerateIdToken(
+  virtual StatusOr<google::test::admin::database::v1::GenerateIdTokenResponse> GenerateIdToken(
     grpc::ClientContext& context,
-    ::google::test::admin::database::v1::GenerateIdTokenRequest const& request) = 0;
+    google::test::admin::database::v1::GenerateIdTokenRequest const& request) = 0;
 
-  virtual StatusOr<::google::test::admin::database::v1::WriteLogEntriesResponse> WriteLogEntries(
+  virtual StatusOr<google::test::admin::database::v1::WriteLogEntriesResponse> WriteLogEntries(
     grpc::ClientContext& context,
-    ::google::test::admin::database::v1::WriteLogEntriesRequest const& request) = 0;
+    google::test::admin::database::v1::WriteLogEntriesRequest const& request) = 0;
 
-  virtual StatusOr<::google::test::admin::database::v1::ListLogsResponse> ListLogs(
+  virtual StatusOr<google::test::admin::database::v1::ListLogsResponse> ListLogs(
     grpc::ClientContext& context,
-    ::google::test::admin::database::v1::ListLogsRequest const& request) = 0;
+    google::test::admin::database::v1::ListLogsRequest const& request) = 0;
 
-  virtual std::unique_ptr<internal::StreamingReadRpc<::google::test::admin::database::v1::TailLogEntriesResponse>>
+  virtual std::unique_ptr<internal::StreamingReadRpc<google::test::admin::database::v1::TailLogEntriesResponse>>
   TailLogEntries(
     std::unique_ptr<grpc::ClientContext> context,
-    ::google::test::admin::database::v1::TailLogEntriesRequest const& request) = 0;
+    google::test::admin::database::v1::TailLogEntriesRequest const& request) = 0;
 
-  virtual StatusOr<::google::test::admin::database::v1::ListServiceAccountKeysResponse> ListServiceAccountKeys(
+  virtual StatusOr<google::test::admin::database::v1::ListServiceAccountKeysResponse> ListServiceAccountKeys(
     grpc::ClientContext& context,
-    ::google::test::admin::database::v1::ListServiceAccountKeysRequest const& request) = 0;
+    google::test::admin::database::v1::ListServiceAccountKeysRequest const& request) = 0;
 
 };
 
 class DefaultGoldenKitchenSinkStub : public GoldenKitchenSinkStub {
  public:
   explicit DefaultGoldenKitchenSinkStub(
-      std::unique_ptr<::google::test::admin::database::v1::GoldenKitchenSink::StubInterface> grpc_stub)
+      std::unique_ptr<google::test::admin::database::v1::GoldenKitchenSink::StubInterface> grpc_stub)
       : grpc_stub_(std::move(grpc_stub)) {}
 
-  StatusOr<::google::test::admin::database::v1::GenerateAccessTokenResponse>
+  StatusOr<google::test::admin::database::v1::GenerateAccessTokenResponse>
   GenerateAccessToken(
     grpc::ClientContext& client_context,
-    ::google::test::admin::database::v1::GenerateAccessTokenRequest const& request) override;
+    google::test::admin::database::v1::GenerateAccessTokenRequest const& request) override;
 
-  StatusOr<::google::test::admin::database::v1::GenerateIdTokenResponse>
+  StatusOr<google::test::admin::database::v1::GenerateIdTokenResponse>
   GenerateIdToken(
     grpc::ClientContext& client_context,
-    ::google::test::admin::database::v1::GenerateIdTokenRequest const& request) override;
+    google::test::admin::database::v1::GenerateIdTokenRequest const& request) override;
 
-  StatusOr<::google::test::admin::database::v1::WriteLogEntriesResponse>
+  StatusOr<google::test::admin::database::v1::WriteLogEntriesResponse>
   WriteLogEntries(
     grpc::ClientContext& client_context,
-    ::google::test::admin::database::v1::WriteLogEntriesRequest const& request) override;
+    google::test::admin::database::v1::WriteLogEntriesRequest const& request) override;
 
-  StatusOr<::google::test::admin::database::v1::ListLogsResponse>
+  StatusOr<google::test::admin::database::v1::ListLogsResponse>
   ListLogs(
     grpc::ClientContext& client_context,
-    ::google::test::admin::database::v1::ListLogsRequest const& request) override;
+    google::test::admin::database::v1::ListLogsRequest const& request) override;
 
-  std::unique_ptr<internal::StreamingReadRpc<::google::test::admin::database::v1::TailLogEntriesResponse>>
+  std::unique_ptr<internal::StreamingReadRpc<google::test::admin::database::v1::TailLogEntriesResponse>>
   TailLogEntries(
     std::unique_ptr<grpc::ClientContext> client_context,
-    ::google::test::admin::database::v1::TailLogEntriesRequest const& request) override;
+    google::test::admin::database::v1::TailLogEntriesRequest const& request) override;
 
-  StatusOr<::google::test::admin::database::v1::ListServiceAccountKeysResponse>
+  StatusOr<google::test::admin::database::v1::ListServiceAccountKeysResponse>
   ListServiceAccountKeys(
     grpc::ClientContext& client_context,
-    ::google::test::admin::database::v1::ListServiceAccountKeysRequest const& request) override;
+    google::test::admin::database::v1::ListServiceAccountKeysRequest const& request) override;
 
  private:
-  std::unique_ptr<::google::test::admin::database::v1::GoldenKitchenSink::StubInterface> grpc_stub_;
+  std::unique_ptr<google::test::admin::database::v1::GoldenKitchenSink::StubInterface> grpc_stub_;
 };
 
 }  // namespace GOOGLE_CLOUD_CPP_GENERATED_NS

--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_stub_factory.cc
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_stub_factory.cc
@@ -39,7 +39,7 @@ CreateDefaultGoldenKitchenSinkStub(Options const& options) {
       options.get<GrpcCredentialOption>(),
       internal::MakeChannelArguments(options));
   auto service_grpc_stub =
-      ::google::test::admin::database::v1::GoldenKitchenSink::NewStub(channel);
+      google::test::admin::database::v1::GoldenKitchenSink::NewStub(channel);
   std::shared_ptr<GoldenKitchenSinkStub> stub =
       std::make_shared<DefaultGoldenKitchenSinkStub>(
           std::move(service_grpc_stub));

--- a/generator/integration_tests/golden/internal/golden_thing_admin_logging_decorator.cc
+++ b/generator/integration_tests/golden/internal/golden_thing_admin_logging_decorator.cc
@@ -33,49 +33,49 @@ GoldenThingAdminLogging::GoldenThingAdminLogging(
     : child_(std::move(child)), tracing_options_(std::move(tracing_options)),
       components_(std::move(components)) {}
 
-StatusOr<::google::test::admin::database::v1::ListDatabasesResponse>
+StatusOr<google::test::admin::database::v1::ListDatabasesResponse>
 GoldenThingAdminLogging::ListDatabases(
     grpc::ClientContext& context,
-    ::google::test::admin::database::v1::ListDatabasesRequest const& request) {
+    google::test::admin::database::v1::ListDatabasesRequest const& request) {
   return google::cloud::internal::LogWrapper(
       [this](grpc::ClientContext& context,
-             ::google::test::admin::database::v1::ListDatabasesRequest const& request) {
+             google::test::admin::database::v1::ListDatabasesRequest const& request) {
         return child_->ListDatabases(context, request);
       },
       context, request, __func__, tracing_options_);
 }
 
-StatusOr<::google::longrunning::Operation>
+StatusOr<google::longrunning::Operation>
 GoldenThingAdminLogging::CreateDatabase(
     grpc::ClientContext& context,
-    ::google::test::admin::database::v1::CreateDatabaseRequest const& request) {
+    google::test::admin::database::v1::CreateDatabaseRequest const& request) {
   return google::cloud::internal::LogWrapper(
       [this](grpc::ClientContext& context,
-             ::google::test::admin::database::v1::CreateDatabaseRequest const& request) {
+             google::test::admin::database::v1::CreateDatabaseRequest const& request) {
         return child_->CreateDatabase(context, request);
       },
       context, request, __func__, tracing_options_);
 }
 
-StatusOr<::google::test::admin::database::v1::Database>
+StatusOr<google::test::admin::database::v1::Database>
 GoldenThingAdminLogging::GetDatabase(
     grpc::ClientContext& context,
-    ::google::test::admin::database::v1::GetDatabaseRequest const& request) {
+    google::test::admin::database::v1::GetDatabaseRequest const& request) {
   return google::cloud::internal::LogWrapper(
       [this](grpc::ClientContext& context,
-             ::google::test::admin::database::v1::GetDatabaseRequest const& request) {
+             google::test::admin::database::v1::GetDatabaseRequest const& request) {
         return child_->GetDatabase(context, request);
       },
       context, request, __func__, tracing_options_);
 }
 
-StatusOr<::google::longrunning::Operation>
+StatusOr<google::longrunning::Operation>
 GoldenThingAdminLogging::UpdateDatabaseDdl(
     grpc::ClientContext& context,
-    ::google::test::admin::database::v1::UpdateDatabaseDdlRequest const& request) {
+    google::test::admin::database::v1::UpdateDatabaseDdlRequest const& request) {
   return google::cloud::internal::LogWrapper(
       [this](grpc::ClientContext& context,
-             ::google::test::admin::database::v1::UpdateDatabaseDdlRequest const& request) {
+             google::test::admin::database::v1::UpdateDatabaseDdlRequest const& request) {
         return child_->UpdateDatabaseDdl(context, request);
       },
       context, request, __func__, tracing_options_);
@@ -84,94 +84,94 @@ GoldenThingAdminLogging::UpdateDatabaseDdl(
 Status
 GoldenThingAdminLogging::DropDatabase(
     grpc::ClientContext& context,
-    ::google::test::admin::database::v1::DropDatabaseRequest const& request) {
+    google::test::admin::database::v1::DropDatabaseRequest const& request) {
   return google::cloud::internal::LogWrapper(
       [this](grpc::ClientContext& context,
-             ::google::test::admin::database::v1::DropDatabaseRequest const& request) {
+             google::test::admin::database::v1::DropDatabaseRequest const& request) {
         return child_->DropDatabase(context, request);
       },
       context, request, __func__, tracing_options_);
 }
 
-StatusOr<::google::test::admin::database::v1::GetDatabaseDdlResponse>
+StatusOr<google::test::admin::database::v1::GetDatabaseDdlResponse>
 GoldenThingAdminLogging::GetDatabaseDdl(
     grpc::ClientContext& context,
-    ::google::test::admin::database::v1::GetDatabaseDdlRequest const& request) {
+    google::test::admin::database::v1::GetDatabaseDdlRequest const& request) {
   return google::cloud::internal::LogWrapper(
       [this](grpc::ClientContext& context,
-             ::google::test::admin::database::v1::GetDatabaseDdlRequest const& request) {
+             google::test::admin::database::v1::GetDatabaseDdlRequest const& request) {
         return child_->GetDatabaseDdl(context, request);
       },
       context, request, __func__, tracing_options_);
 }
 
-StatusOr<::google::iam::v1::Policy>
+StatusOr<google::iam::v1::Policy>
 GoldenThingAdminLogging::SetIamPolicy(
     grpc::ClientContext& context,
-    ::google::iam::v1::SetIamPolicyRequest const& request) {
+    google::iam::v1::SetIamPolicyRequest const& request) {
   return google::cloud::internal::LogWrapper(
       [this](grpc::ClientContext& context,
-             ::google::iam::v1::SetIamPolicyRequest const& request) {
+             google::iam::v1::SetIamPolicyRequest const& request) {
         return child_->SetIamPolicy(context, request);
       },
       context, request, __func__, tracing_options_);
 }
 
-StatusOr<::google::iam::v1::Policy>
+StatusOr<google::iam::v1::Policy>
 GoldenThingAdminLogging::GetIamPolicy(
     grpc::ClientContext& context,
-    ::google::iam::v1::GetIamPolicyRequest const& request) {
+    google::iam::v1::GetIamPolicyRequest const& request) {
   return google::cloud::internal::LogWrapper(
       [this](grpc::ClientContext& context,
-             ::google::iam::v1::GetIamPolicyRequest const& request) {
+             google::iam::v1::GetIamPolicyRequest const& request) {
         return child_->GetIamPolicy(context, request);
       },
       context, request, __func__, tracing_options_);
 }
 
-StatusOr<::google::iam::v1::TestIamPermissionsResponse>
+StatusOr<google::iam::v1::TestIamPermissionsResponse>
 GoldenThingAdminLogging::TestIamPermissions(
     grpc::ClientContext& context,
-    ::google::iam::v1::TestIamPermissionsRequest const& request) {
+    google::iam::v1::TestIamPermissionsRequest const& request) {
   return google::cloud::internal::LogWrapper(
       [this](grpc::ClientContext& context,
-             ::google::iam::v1::TestIamPermissionsRequest const& request) {
+             google::iam::v1::TestIamPermissionsRequest const& request) {
         return child_->TestIamPermissions(context, request);
       },
       context, request, __func__, tracing_options_);
 }
 
-StatusOr<::google::longrunning::Operation>
+StatusOr<google::longrunning::Operation>
 GoldenThingAdminLogging::CreateBackup(
     grpc::ClientContext& context,
-    ::google::test::admin::database::v1::CreateBackupRequest const& request) {
+    google::test::admin::database::v1::CreateBackupRequest const& request) {
   return google::cloud::internal::LogWrapper(
       [this](grpc::ClientContext& context,
-             ::google::test::admin::database::v1::CreateBackupRequest const& request) {
+             google::test::admin::database::v1::CreateBackupRequest const& request) {
         return child_->CreateBackup(context, request);
       },
       context, request, __func__, tracing_options_);
 }
 
-StatusOr<::google::test::admin::database::v1::Backup>
+StatusOr<google::test::admin::database::v1::Backup>
 GoldenThingAdminLogging::GetBackup(
     grpc::ClientContext& context,
-    ::google::test::admin::database::v1::GetBackupRequest const& request) {
+    google::test::admin::database::v1::GetBackupRequest const& request) {
   return google::cloud::internal::LogWrapper(
       [this](grpc::ClientContext& context,
-             ::google::test::admin::database::v1::GetBackupRequest const& request) {
+             google::test::admin::database::v1::GetBackupRequest const& request) {
         return child_->GetBackup(context, request);
       },
       context, request, __func__, tracing_options_);
 }
 
-StatusOr<::google::test::admin::database::v1::Backup>
+StatusOr<google::test::admin::database::v1::Backup>
 GoldenThingAdminLogging::UpdateBackup(
     grpc::ClientContext& context,
-    ::google::test::admin::database::v1::UpdateBackupRequest const& request) {
+    google::test::admin::database::v1::UpdateBackupRequest const& request) {
   return google::cloud::internal::LogWrapper(
       [this](grpc::ClientContext& context,
-             ::google::test::admin::database::v1::UpdateBackupRequest const& request) {
+             google::test::admin::database::v1::UpdateBackupRequest const& request) {
         return child_->UpdateBackup(context, request);
       },
       context, request, __func__, tracing_options_);
@@ -180,58 +180,58 @@ GoldenThingAdminLogging::UpdateBackup(
 Status
 GoldenThingAdminLogging::DeleteBackup(
     grpc::ClientContext& context,
-    ::google::test::admin::database::v1::DeleteBackupRequest const& request) {
+    google::test::admin::database::v1::DeleteBackupRequest const& request) {
   return google::cloud::internal::LogWrapper(
       [this](grpc::ClientContext& context,
-             ::google::test::admin::database::v1::DeleteBackupRequest const& request) {
+             google::test::admin::database::v1::DeleteBackupRequest const& request) {
         return child_->DeleteBackup(context, request);
       },
       context, request, __func__, tracing_options_);
 }
 
-StatusOr<::google::test::admin::database::v1::ListBackupsResponse>
+StatusOr<google::test::admin::database::v1::ListBackupsResponse>
 GoldenThingAdminLogging::ListBackups(
     grpc::ClientContext& context,
-    ::google::test::admin::database::v1::ListBackupsRequest const& request) {
+    google::test::admin::database::v1::ListBackupsRequest const& request) {
   return google::cloud::internal::LogWrapper(
       [this](grpc::ClientContext& context,
-             ::google::test::admin::database::v1::ListBackupsRequest const& request) {
+             google::test::admin::database::v1::ListBackupsRequest const& request) {
         return child_->ListBackups(context, request);
       },
       context, request, __func__, tracing_options_);
 }
 
-StatusOr<::google::longrunning::Operation>
+StatusOr<google::longrunning::Operation>
 GoldenThingAdminLogging::RestoreDatabase(
     grpc::ClientContext& context,
-    ::google::test::admin::database::v1::RestoreDatabaseRequest const& request) {
+    google::test::admin::database::v1::RestoreDatabaseRequest const& request) {
   return google::cloud::internal::LogWrapper(
       [this](grpc::ClientContext& context,
-             ::google::test::admin::database::v1::RestoreDatabaseRequest const& request) {
+             google::test::admin::database::v1::RestoreDatabaseRequest const& request) {
         return child_->RestoreDatabase(context, request);
       },
       context, request, __func__, tracing_options_);
 }
 
-StatusOr<::google::test::admin::database::v1::ListDatabaseOperationsResponse>
+StatusOr<google::test::admin::database::v1::ListDatabaseOperationsResponse>
 GoldenThingAdminLogging::ListDatabaseOperations(
     grpc::ClientContext& context,
-    ::google::test::admin::database::v1::ListDatabaseOperationsRequest const& request) {
+    google::test::admin::database::v1::ListDatabaseOperationsRequest const& request) {
   return google::cloud::internal::LogWrapper(
       [this](grpc::ClientContext& context,
-             ::google::test::admin::database::v1::ListDatabaseOperationsRequest const& request) {
+             google::test::admin::database::v1::ListDatabaseOperationsRequest const& request) {
         return child_->ListDatabaseOperations(context, request);
       },
       context, request, __func__, tracing_options_);
 }
 
-StatusOr<::google::test::admin::database::v1::ListBackupOperationsResponse>
+StatusOr<google::test::admin::database::v1::ListBackupOperationsResponse>
 GoldenThingAdminLogging::ListBackupOperations(
     grpc::ClientContext& context,
-    ::google::test::admin::database::v1::ListBackupOperationsRequest const& request) {
+    google::test::admin::database::v1::ListBackupOperationsRequest const& request) {
   return google::cloud::internal::LogWrapper(
       [this](grpc::ClientContext& context,
-             ::google::test::admin::database::v1::ListBackupOperationsRequest const& request) {
+             google::test::admin::database::v1::ListBackupOperationsRequest const& request) {
         return child_->ListBackupOperations(context, request);
       },
       context, request, __func__, tracing_options_);

--- a/generator/integration_tests/golden/internal/golden_thing_admin_logging_decorator.h
+++ b/generator/integration_tests/golden/internal/golden_thing_admin_logging_decorator.h
@@ -38,73 +38,73 @@ class GoldenThingAdminLogging : public GoldenThingAdminStub {
                        TracingOptions tracing_options,
                        std::set<std::string> components);
 
-  StatusOr<::google::test::admin::database::v1::ListDatabasesResponse> ListDatabases(
+  StatusOr<google::test::admin::database::v1::ListDatabasesResponse> ListDatabases(
     grpc::ClientContext& context,
-    ::google::test::admin::database::v1::ListDatabasesRequest const& request) override;
+    google::test::admin::database::v1::ListDatabasesRequest const& request) override;
 
-  StatusOr<::google::longrunning::Operation> CreateDatabase(
+  StatusOr<google::longrunning::Operation> CreateDatabase(
     grpc::ClientContext& context,
-    ::google::test::admin::database::v1::CreateDatabaseRequest const& request) override;
+    google::test::admin::database::v1::CreateDatabaseRequest const& request) override;
 
-  StatusOr<::google::test::admin::database::v1::Database> GetDatabase(
+  StatusOr<google::test::admin::database::v1::Database> GetDatabase(
     grpc::ClientContext& context,
-    ::google::test::admin::database::v1::GetDatabaseRequest const& request) override;
+    google::test::admin::database::v1::GetDatabaseRequest const& request) override;
 
-  StatusOr<::google::longrunning::Operation> UpdateDatabaseDdl(
+  StatusOr<google::longrunning::Operation> UpdateDatabaseDdl(
     grpc::ClientContext& context,
-    ::google::test::admin::database::v1::UpdateDatabaseDdlRequest const& request) override;
+    google::test::admin::database::v1::UpdateDatabaseDdlRequest const& request) override;
 
   Status DropDatabase(
     grpc::ClientContext& context,
-    ::google::test::admin::database::v1::DropDatabaseRequest const& request) override;
+    google::test::admin::database::v1::DropDatabaseRequest const& request) override;
 
-  StatusOr<::google::test::admin::database::v1::GetDatabaseDdlResponse> GetDatabaseDdl(
+  StatusOr<google::test::admin::database::v1::GetDatabaseDdlResponse> GetDatabaseDdl(
     grpc::ClientContext& context,
-    ::google::test::admin::database::v1::GetDatabaseDdlRequest const& request) override;
+    google::test::admin::database::v1::GetDatabaseDdlRequest const& request) override;
 
-  StatusOr<::google::iam::v1::Policy> SetIamPolicy(
+  StatusOr<google::iam::v1::Policy> SetIamPolicy(
     grpc::ClientContext& context,
-    ::google::iam::v1::SetIamPolicyRequest const& request) override;
+    google::iam::v1::SetIamPolicyRequest const& request) override;
 
-  StatusOr<::google::iam::v1::Policy> GetIamPolicy(
+  StatusOr<google::iam::v1::Policy> GetIamPolicy(
     grpc::ClientContext& context,
-    ::google::iam::v1::GetIamPolicyRequest const& request) override;
+    google::iam::v1::GetIamPolicyRequest const& request) override;
 
-  StatusOr<::google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
+  StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
     grpc::ClientContext& context,
-    ::google::iam::v1::TestIamPermissionsRequest const& request) override;
+    google::iam::v1::TestIamPermissionsRequest const& request) override;
 
-  StatusOr<::google::longrunning::Operation> CreateBackup(
+  StatusOr<google::longrunning::Operation> CreateBackup(
     grpc::ClientContext& context,
-    ::google::test::admin::database::v1::CreateBackupRequest const& request) override;
+    google::test::admin::database::v1::CreateBackupRequest const& request) override;
 
-  StatusOr<::google::test::admin::database::v1::Backup> GetBackup(
+  StatusOr<google::test::admin::database::v1::Backup> GetBackup(
     grpc::ClientContext& context,
-    ::google::test::admin::database::v1::GetBackupRequest const& request) override;
+    google::test::admin::database::v1::GetBackupRequest const& request) override;
 
-  StatusOr<::google::test::admin::database::v1::Backup> UpdateBackup(
+  StatusOr<google::test::admin::database::v1::Backup> UpdateBackup(
     grpc::ClientContext& context,
-    ::google::test::admin::database::v1::UpdateBackupRequest const& request) override;
+    google::test::admin::database::v1::UpdateBackupRequest const& request) override;
 
   Status DeleteBackup(
     grpc::ClientContext& context,
-    ::google::test::admin::database::v1::DeleteBackupRequest const& request) override;
+    google::test::admin::database::v1::DeleteBackupRequest const& request) override;
 
-  StatusOr<::google::test::admin::database::v1::ListBackupsResponse> ListBackups(
+  StatusOr<google::test::admin::database::v1::ListBackupsResponse> ListBackups(
     grpc::ClientContext& context,
-    ::google::test::admin::database::v1::ListBackupsRequest const& request) override;
+    google::test::admin::database::v1::ListBackupsRequest const& request) override;
 
-  StatusOr<::google::longrunning::Operation> RestoreDatabase(
+  StatusOr<google::longrunning::Operation> RestoreDatabase(
     grpc::ClientContext& context,
-    ::google::test::admin::database::v1::RestoreDatabaseRequest const& request) override;
+    google::test::admin::database::v1::RestoreDatabaseRequest const& request) override;
 
-  StatusOr<::google::test::admin::database::v1::ListDatabaseOperationsResponse> ListDatabaseOperations(
+  StatusOr<google::test::admin::database::v1::ListDatabaseOperationsResponse> ListDatabaseOperations(
     grpc::ClientContext& context,
-    ::google::test::admin::database::v1::ListDatabaseOperationsRequest const& request) override;
+    google::test::admin::database::v1::ListDatabaseOperationsRequest const& request) override;
 
-  StatusOr<::google::test::admin::database::v1::ListBackupOperationsResponse> ListBackupOperations(
+  StatusOr<google::test::admin::database::v1::ListBackupOperationsResponse> ListBackupOperations(
     grpc::ClientContext& context,
-    ::google::test::admin::database::v1::ListBackupOperationsRequest const& request) override;
+    google::test::admin::database::v1::ListBackupOperationsRequest const& request) override;
 
   /// Poll a long-running operation.
   StatusOr<google::longrunning::Operation> GetOperation(

--- a/generator/integration_tests/golden/internal/golden_thing_admin_metadata_decorator.cc
+++ b/generator/integration_tests/golden/internal/golden_thing_admin_metadata_decorator.cc
@@ -31,34 +31,34 @@ GoldenThingAdminMetadata::GoldenThingAdminMetadata(
     : child_(std::move(child)),
       api_client_header_(google::cloud::internal::ApiClientHeader()) {}
 
-StatusOr<::google::test::admin::database::v1::ListDatabasesResponse>
+StatusOr<google::test::admin::database::v1::ListDatabasesResponse>
 GoldenThingAdminMetadata::ListDatabases(
     grpc::ClientContext& context,
-    ::google::test::admin::database::v1::ListDatabasesRequest const& request) {
+    google::test::admin::database::v1::ListDatabasesRequest const& request) {
   SetMetadata(context, "parent=" + request.parent());
   return child_->ListDatabases(context, request);
 }
 
-StatusOr<::google::longrunning::Operation>
+StatusOr<google::longrunning::Operation>
 GoldenThingAdminMetadata::CreateDatabase(
     grpc::ClientContext& context,
-    ::google::test::admin::database::v1::CreateDatabaseRequest const& request) {
+    google::test::admin::database::v1::CreateDatabaseRequest const& request) {
   SetMetadata(context, "parent=" + request.parent());
   return child_->CreateDatabase(context, request);
 }
 
-StatusOr<::google::test::admin::database::v1::Database>
+StatusOr<google::test::admin::database::v1::Database>
 GoldenThingAdminMetadata::GetDatabase(
     grpc::ClientContext& context,
-    ::google::test::admin::database::v1::GetDatabaseRequest const& request) {
+    google::test::admin::database::v1::GetDatabaseRequest const& request) {
   SetMetadata(context, "name=" + request.name());
   return child_->GetDatabase(context, request);
 }
 
-StatusOr<::google::longrunning::Operation>
+StatusOr<google::longrunning::Operation>
 GoldenThingAdminMetadata::UpdateDatabaseDdl(
     grpc::ClientContext& context,
-    ::google::test::admin::database::v1::UpdateDatabaseDdlRequest const& request) {
+    google::test::admin::database::v1::UpdateDatabaseDdlRequest const& request) {
   SetMetadata(context, "database=" + request.database());
   return child_->UpdateDatabaseDdl(context, request);
 }
@@ -66,63 +66,63 @@ GoldenThingAdminMetadata::UpdateDatabaseDdl(
 Status
 GoldenThingAdminMetadata::DropDatabase(
     grpc::ClientContext& context,
-    ::google::test::admin::database::v1::DropDatabaseRequest const& request) {
+    google::test::admin::database::v1::DropDatabaseRequest const& request) {
   SetMetadata(context, "database=" + request.database());
   return child_->DropDatabase(context, request);
 }
 
-StatusOr<::google::test::admin::database::v1::GetDatabaseDdlResponse>
+StatusOr<google::test::admin::database::v1::GetDatabaseDdlResponse>
 GoldenThingAdminMetadata::GetDatabaseDdl(
     grpc::ClientContext& context,
-    ::google::test::admin::database::v1::GetDatabaseDdlRequest const& request) {
+    google::test::admin::database::v1::GetDatabaseDdlRequest const& request) {
   SetMetadata(context, "database=" + request.database());
   return child_->GetDatabaseDdl(context, request);
 }
 
-StatusOr<::google::iam::v1::Policy>
+StatusOr<google::iam::v1::Policy>
 GoldenThingAdminMetadata::SetIamPolicy(
     grpc::ClientContext& context,
-    ::google::iam::v1::SetIamPolicyRequest const& request) {
+    google::iam::v1::SetIamPolicyRequest const& request) {
   SetMetadata(context, "resource=" + request.resource());
   return child_->SetIamPolicy(context, request);
 }
 
-StatusOr<::google::iam::v1::Policy>
+StatusOr<google::iam::v1::Policy>
 GoldenThingAdminMetadata::GetIamPolicy(
     grpc::ClientContext& context,
-    ::google::iam::v1::GetIamPolicyRequest const& request) {
+    google::iam::v1::GetIamPolicyRequest const& request) {
   SetMetadata(context, "resource=" + request.resource());
   return child_->GetIamPolicy(context, request);
 }
 
-StatusOr<::google::iam::v1::TestIamPermissionsResponse>
+StatusOr<google::iam::v1::TestIamPermissionsResponse>
 GoldenThingAdminMetadata::TestIamPermissions(
     grpc::ClientContext& context,
-    ::google::iam::v1::TestIamPermissionsRequest const& request) {
+    google::iam::v1::TestIamPermissionsRequest const& request) {
   SetMetadata(context, "resource=" + request.resource());
   return child_->TestIamPermissions(context, request);
 }
 
-StatusOr<::google::longrunning::Operation>
+StatusOr<google::longrunning::Operation>
 GoldenThingAdminMetadata::CreateBackup(
     grpc::ClientContext& context,
-    ::google::test::admin::database::v1::CreateBackupRequest const& request) {
+    google::test::admin::database::v1::CreateBackupRequest const& request) {
   SetMetadata(context, "parent=" + request.parent());
   return child_->CreateBackup(context, request);
 }
 
-StatusOr<::google::test::admin::database::v1::Backup>
+StatusOr<google::test::admin::database::v1::Backup>
 GoldenThingAdminMetadata::GetBackup(
     grpc::ClientContext& context,
-    ::google::test::admin::database::v1::GetBackupRequest const& request) {
+    google::test::admin::database::v1::GetBackupRequest const& request) {
   SetMetadata(context, "name=" + request.name());
   return child_->GetBackup(context, request);
 }
 
-StatusOr<::google::test::admin::database::v1::Backup>
+StatusOr<google::test::admin::database::v1::Backup>
 GoldenThingAdminMetadata::UpdateBackup(
     grpc::ClientContext& context,
-    ::google::test::admin::database::v1::UpdateBackupRequest const& request) {
+    google::test::admin::database::v1::UpdateBackupRequest const& request) {
   SetMetadata(context, "backup.name=" + request.backup().name());
   return child_->UpdateBackup(context, request);
 }
@@ -130,39 +130,39 @@ GoldenThingAdminMetadata::UpdateBackup(
 Status
 GoldenThingAdminMetadata::DeleteBackup(
     grpc::ClientContext& context,
-    ::google::test::admin::database::v1::DeleteBackupRequest const& request) {
+    google::test::admin::database::v1::DeleteBackupRequest const& request) {
   SetMetadata(context, "name=" + request.name());
   return child_->DeleteBackup(context, request);
 }
 
-StatusOr<::google::test::admin::database::v1::ListBackupsResponse>
+StatusOr<google::test::admin::database::v1::ListBackupsResponse>
 GoldenThingAdminMetadata::ListBackups(
     grpc::ClientContext& context,
-    ::google::test::admin::database::v1::ListBackupsRequest const& request) {
+    google::test::admin::database::v1::ListBackupsRequest const& request) {
   SetMetadata(context, "parent=" + request.parent());
   return child_->ListBackups(context, request);
 }
 
-StatusOr<::google::longrunning::Operation>
+StatusOr<google::longrunning::Operation>
 GoldenThingAdminMetadata::RestoreDatabase(
     grpc::ClientContext& context,
-    ::google::test::admin::database::v1::RestoreDatabaseRequest const& request) {
+    google::test::admin::database::v1::RestoreDatabaseRequest const& request) {
   SetMetadata(context, "parent=" + request.parent());
   return child_->RestoreDatabase(context, request);
 }
 
-StatusOr<::google::test::admin::database::v1::ListDatabaseOperationsResponse>
+StatusOr<google::test::admin::database::v1::ListDatabaseOperationsResponse>
 GoldenThingAdminMetadata::ListDatabaseOperations(
     grpc::ClientContext& context,
-    ::google::test::admin::database::v1::ListDatabaseOperationsRequest const& request) {
+    google::test::admin::database::v1::ListDatabaseOperationsRequest const& request) {
   SetMetadata(context, "parent=" + request.parent());
   return child_->ListDatabaseOperations(context, request);
 }
 
-StatusOr<::google::test::admin::database::v1::ListBackupOperationsResponse>
+StatusOr<google::test::admin::database::v1::ListBackupOperationsResponse>
 GoldenThingAdminMetadata::ListBackupOperations(
     grpc::ClientContext& context,
-    ::google::test::admin::database::v1::ListBackupOperationsRequest const& request) {
+    google::test::admin::database::v1::ListBackupOperationsRequest const& request) {
   SetMetadata(context, "parent=" + request.parent());
   return child_->ListBackupOperations(context, request);
 }

--- a/generator/integration_tests/golden/internal/golden_thing_admin_metadata_decorator.h
+++ b/generator/integration_tests/golden/internal/golden_thing_admin_metadata_decorator.h
@@ -34,73 +34,73 @@ class GoldenThingAdminMetadata : public GoldenThingAdminStub {
   ~GoldenThingAdminMetadata() override = default;
   explicit GoldenThingAdminMetadata(std::shared_ptr<GoldenThingAdminStub> child);
 
-  StatusOr<::google::test::admin::database::v1::ListDatabasesResponse> ListDatabases(
+  StatusOr<google::test::admin::database::v1::ListDatabasesResponse> ListDatabases(
     grpc::ClientContext& context,
-    ::google::test::admin::database::v1::ListDatabasesRequest const& request) override;
+    google::test::admin::database::v1::ListDatabasesRequest const& request) override;
 
-  StatusOr<::google::longrunning::Operation> CreateDatabase(
+  StatusOr<google::longrunning::Operation> CreateDatabase(
     grpc::ClientContext& context,
-    ::google::test::admin::database::v1::CreateDatabaseRequest const& request) override;
+    google::test::admin::database::v1::CreateDatabaseRequest const& request) override;
 
-  StatusOr<::google::test::admin::database::v1::Database> GetDatabase(
+  StatusOr<google::test::admin::database::v1::Database> GetDatabase(
     grpc::ClientContext& context,
-    ::google::test::admin::database::v1::GetDatabaseRequest const& request) override;
+    google::test::admin::database::v1::GetDatabaseRequest const& request) override;
 
-  StatusOr<::google::longrunning::Operation> UpdateDatabaseDdl(
+  StatusOr<google::longrunning::Operation> UpdateDatabaseDdl(
     grpc::ClientContext& context,
-    ::google::test::admin::database::v1::UpdateDatabaseDdlRequest const& request) override;
+    google::test::admin::database::v1::UpdateDatabaseDdlRequest const& request) override;
 
   Status DropDatabase(
     grpc::ClientContext& context,
-    ::google::test::admin::database::v1::DropDatabaseRequest const& request) override;
+    google::test::admin::database::v1::DropDatabaseRequest const& request) override;
 
-  StatusOr<::google::test::admin::database::v1::GetDatabaseDdlResponse> GetDatabaseDdl(
+  StatusOr<google::test::admin::database::v1::GetDatabaseDdlResponse> GetDatabaseDdl(
     grpc::ClientContext& context,
-    ::google::test::admin::database::v1::GetDatabaseDdlRequest const& request) override;
+    google::test::admin::database::v1::GetDatabaseDdlRequest const& request) override;
 
-  StatusOr<::google::iam::v1::Policy> SetIamPolicy(
+  StatusOr<google::iam::v1::Policy> SetIamPolicy(
     grpc::ClientContext& context,
-    ::google::iam::v1::SetIamPolicyRequest const& request) override;
+    google::iam::v1::SetIamPolicyRequest const& request) override;
 
-  StatusOr<::google::iam::v1::Policy> GetIamPolicy(
+  StatusOr<google::iam::v1::Policy> GetIamPolicy(
     grpc::ClientContext& context,
-    ::google::iam::v1::GetIamPolicyRequest const& request) override;
+    google::iam::v1::GetIamPolicyRequest const& request) override;
 
-  StatusOr<::google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
+  StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
     grpc::ClientContext& context,
-    ::google::iam::v1::TestIamPermissionsRequest const& request) override;
+    google::iam::v1::TestIamPermissionsRequest const& request) override;
 
-  StatusOr<::google::longrunning::Operation> CreateBackup(
+  StatusOr<google::longrunning::Operation> CreateBackup(
     grpc::ClientContext& context,
-    ::google::test::admin::database::v1::CreateBackupRequest const& request) override;
+    google::test::admin::database::v1::CreateBackupRequest const& request) override;
 
-  StatusOr<::google::test::admin::database::v1::Backup> GetBackup(
+  StatusOr<google::test::admin::database::v1::Backup> GetBackup(
     grpc::ClientContext& context,
-    ::google::test::admin::database::v1::GetBackupRequest const& request) override;
+    google::test::admin::database::v1::GetBackupRequest const& request) override;
 
-  StatusOr<::google::test::admin::database::v1::Backup> UpdateBackup(
+  StatusOr<google::test::admin::database::v1::Backup> UpdateBackup(
     grpc::ClientContext& context,
-    ::google::test::admin::database::v1::UpdateBackupRequest const& request) override;
+    google::test::admin::database::v1::UpdateBackupRequest const& request) override;
 
   Status DeleteBackup(
     grpc::ClientContext& context,
-    ::google::test::admin::database::v1::DeleteBackupRequest const& request) override;
+    google::test::admin::database::v1::DeleteBackupRequest const& request) override;
 
-  StatusOr<::google::test::admin::database::v1::ListBackupsResponse> ListBackups(
+  StatusOr<google::test::admin::database::v1::ListBackupsResponse> ListBackups(
     grpc::ClientContext& context,
-    ::google::test::admin::database::v1::ListBackupsRequest const& request) override;
+    google::test::admin::database::v1::ListBackupsRequest const& request) override;
 
-  StatusOr<::google::longrunning::Operation> RestoreDatabase(
+  StatusOr<google::longrunning::Operation> RestoreDatabase(
     grpc::ClientContext& context,
-    ::google::test::admin::database::v1::RestoreDatabaseRequest const& request) override;
+    google::test::admin::database::v1::RestoreDatabaseRequest const& request) override;
 
-  StatusOr<::google::test::admin::database::v1::ListDatabaseOperationsResponse> ListDatabaseOperations(
+  StatusOr<google::test::admin::database::v1::ListDatabaseOperationsResponse> ListDatabaseOperations(
     grpc::ClientContext& context,
-    ::google::test::admin::database::v1::ListDatabaseOperationsRequest const& request) override;
+    google::test::admin::database::v1::ListDatabaseOperationsRequest const& request) override;
 
-  StatusOr<::google::test::admin::database::v1::ListBackupOperationsResponse> ListBackupOperations(
+  StatusOr<google::test::admin::database::v1::ListBackupOperationsResponse> ListBackupOperations(
     grpc::ClientContext& context,
-    ::google::test::admin::database::v1::ListBackupOperationsRequest const& request) override;
+    google::test::admin::database::v1::ListBackupOperationsRequest const& request) override;
 
   /// Poll a long-running operation.
   StatusOr<google::longrunning::Operation> GetOperation(

--- a/generator/integration_tests/golden/internal/golden_thing_admin_stub.cc
+++ b/generator/integration_tests/golden/internal/golden_thing_admin_stub.cc
@@ -30,11 +30,11 @@ inline namespace GOOGLE_CLOUD_CPP_GENERATED_NS {
 
 GoldenThingAdminStub::~GoldenThingAdminStub() = default;
 
-StatusOr<::google::test::admin::database::v1::ListDatabasesResponse>
+StatusOr<google::test::admin::database::v1::ListDatabasesResponse>
 DefaultGoldenThingAdminStub::ListDatabases(
   grpc::ClientContext& client_context,
-  ::google::test::admin::database::v1::ListDatabasesRequest const& request) {
-    ::google::test::admin::database::v1::ListDatabasesResponse response;
+  google::test::admin::database::v1::ListDatabasesRequest const& request) {
+    google::test::admin::database::v1::ListDatabasesResponse response;
     auto status =
         grpc_stub_->ListDatabases(&client_context, request, &response);
     if (!status.ok()) {
@@ -43,11 +43,11 @@ DefaultGoldenThingAdminStub::ListDatabases(
     return response;
 }
 
-StatusOr<::google::longrunning::Operation>
+StatusOr<google::longrunning::Operation>
 DefaultGoldenThingAdminStub::CreateDatabase(
   grpc::ClientContext& client_context,
-  ::google::test::admin::database::v1::CreateDatabaseRequest const& request) {
-    ::google::longrunning::Operation response;
+  google::test::admin::database::v1::CreateDatabaseRequest const& request) {
+    google::longrunning::Operation response;
     auto status =
         grpc_stub_->CreateDatabase(&client_context, request, &response);
     if (!status.ok()) {
@@ -56,11 +56,11 @@ DefaultGoldenThingAdminStub::CreateDatabase(
     return response;
 }
 
-StatusOr<::google::test::admin::database::v1::Database>
+StatusOr<google::test::admin::database::v1::Database>
 DefaultGoldenThingAdminStub::GetDatabase(
   grpc::ClientContext& client_context,
-  ::google::test::admin::database::v1::GetDatabaseRequest const& request) {
-    ::google::test::admin::database::v1::Database response;
+  google::test::admin::database::v1::GetDatabaseRequest const& request) {
+    google::test::admin::database::v1::Database response;
     auto status =
         grpc_stub_->GetDatabase(&client_context, request, &response);
     if (!status.ok()) {
@@ -69,11 +69,11 @@ DefaultGoldenThingAdminStub::GetDatabase(
     return response;
 }
 
-StatusOr<::google::longrunning::Operation>
+StatusOr<google::longrunning::Operation>
 DefaultGoldenThingAdminStub::UpdateDatabaseDdl(
   grpc::ClientContext& client_context,
-  ::google::test::admin::database::v1::UpdateDatabaseDdlRequest const& request) {
-    ::google::longrunning::Operation response;
+  google::test::admin::database::v1::UpdateDatabaseDdlRequest const& request) {
+    google::longrunning::Operation response;
     auto status =
         grpc_stub_->UpdateDatabaseDdl(&client_context, request, &response);
     if (!status.ok()) {
@@ -85,8 +85,8 @@ DefaultGoldenThingAdminStub::UpdateDatabaseDdl(
 Status
 DefaultGoldenThingAdminStub::DropDatabase(
   grpc::ClientContext& client_context,
-  ::google::test::admin::database::v1::DropDatabaseRequest const& request) {
-    ::google::protobuf::Empty response;
+  google::test::admin::database::v1::DropDatabaseRequest const& request) {
+    google::protobuf::Empty response;
     auto status =
         grpc_stub_->DropDatabase(&client_context, request, &response);
     if (!status.ok()) {
@@ -95,11 +95,11 @@ DefaultGoldenThingAdminStub::DropDatabase(
     return google::cloud::Status();
 }
 
-StatusOr<::google::test::admin::database::v1::GetDatabaseDdlResponse>
+StatusOr<google::test::admin::database::v1::GetDatabaseDdlResponse>
 DefaultGoldenThingAdminStub::GetDatabaseDdl(
   grpc::ClientContext& client_context,
-  ::google::test::admin::database::v1::GetDatabaseDdlRequest const& request) {
-    ::google::test::admin::database::v1::GetDatabaseDdlResponse response;
+  google::test::admin::database::v1::GetDatabaseDdlRequest const& request) {
+    google::test::admin::database::v1::GetDatabaseDdlResponse response;
     auto status =
         grpc_stub_->GetDatabaseDdl(&client_context, request, &response);
     if (!status.ok()) {
@@ -108,11 +108,11 @@ DefaultGoldenThingAdminStub::GetDatabaseDdl(
     return response;
 }
 
-StatusOr<::google::iam::v1::Policy>
+StatusOr<google::iam::v1::Policy>
 DefaultGoldenThingAdminStub::SetIamPolicy(
   grpc::ClientContext& client_context,
-  ::google::iam::v1::SetIamPolicyRequest const& request) {
-    ::google::iam::v1::Policy response;
+  google::iam::v1::SetIamPolicyRequest const& request) {
+    google::iam::v1::Policy response;
     auto status =
         grpc_stub_->SetIamPolicy(&client_context, request, &response);
     if (!status.ok()) {
@@ -121,11 +121,11 @@ DefaultGoldenThingAdminStub::SetIamPolicy(
     return response;
 }
 
-StatusOr<::google::iam::v1::Policy>
+StatusOr<google::iam::v1::Policy>
 DefaultGoldenThingAdminStub::GetIamPolicy(
   grpc::ClientContext& client_context,
-  ::google::iam::v1::GetIamPolicyRequest const& request) {
-    ::google::iam::v1::Policy response;
+  google::iam::v1::GetIamPolicyRequest const& request) {
+    google::iam::v1::Policy response;
     auto status =
         grpc_stub_->GetIamPolicy(&client_context, request, &response);
     if (!status.ok()) {
@@ -134,11 +134,11 @@ DefaultGoldenThingAdminStub::GetIamPolicy(
     return response;
 }
 
-StatusOr<::google::iam::v1::TestIamPermissionsResponse>
+StatusOr<google::iam::v1::TestIamPermissionsResponse>
 DefaultGoldenThingAdminStub::TestIamPermissions(
   grpc::ClientContext& client_context,
-  ::google::iam::v1::TestIamPermissionsRequest const& request) {
-    ::google::iam::v1::TestIamPermissionsResponse response;
+  google::iam::v1::TestIamPermissionsRequest const& request) {
+    google::iam::v1::TestIamPermissionsResponse response;
     auto status =
         grpc_stub_->TestIamPermissions(&client_context, request, &response);
     if (!status.ok()) {
@@ -147,11 +147,11 @@ DefaultGoldenThingAdminStub::TestIamPermissions(
     return response;
 }
 
-StatusOr<::google::longrunning::Operation>
+StatusOr<google::longrunning::Operation>
 DefaultGoldenThingAdminStub::CreateBackup(
   grpc::ClientContext& client_context,
-  ::google::test::admin::database::v1::CreateBackupRequest const& request) {
-    ::google::longrunning::Operation response;
+  google::test::admin::database::v1::CreateBackupRequest const& request) {
+    google::longrunning::Operation response;
     auto status =
         grpc_stub_->CreateBackup(&client_context, request, &response);
     if (!status.ok()) {
@@ -160,11 +160,11 @@ DefaultGoldenThingAdminStub::CreateBackup(
     return response;
 }
 
-StatusOr<::google::test::admin::database::v1::Backup>
+StatusOr<google::test::admin::database::v1::Backup>
 DefaultGoldenThingAdminStub::GetBackup(
   grpc::ClientContext& client_context,
-  ::google::test::admin::database::v1::GetBackupRequest const& request) {
-    ::google::test::admin::database::v1::Backup response;
+  google::test::admin::database::v1::GetBackupRequest const& request) {
+    google::test::admin::database::v1::Backup response;
     auto status =
         grpc_stub_->GetBackup(&client_context, request, &response);
     if (!status.ok()) {
@@ -173,11 +173,11 @@ DefaultGoldenThingAdminStub::GetBackup(
     return response;
 }
 
-StatusOr<::google::test::admin::database::v1::Backup>
+StatusOr<google::test::admin::database::v1::Backup>
 DefaultGoldenThingAdminStub::UpdateBackup(
   grpc::ClientContext& client_context,
-  ::google::test::admin::database::v1::UpdateBackupRequest const& request) {
-    ::google::test::admin::database::v1::Backup response;
+  google::test::admin::database::v1::UpdateBackupRequest const& request) {
+    google::test::admin::database::v1::Backup response;
     auto status =
         grpc_stub_->UpdateBackup(&client_context, request, &response);
     if (!status.ok()) {
@@ -189,8 +189,8 @@ DefaultGoldenThingAdminStub::UpdateBackup(
 Status
 DefaultGoldenThingAdminStub::DeleteBackup(
   grpc::ClientContext& client_context,
-  ::google::test::admin::database::v1::DeleteBackupRequest const& request) {
-    ::google::protobuf::Empty response;
+  google::test::admin::database::v1::DeleteBackupRequest const& request) {
+    google::protobuf::Empty response;
     auto status =
         grpc_stub_->DeleteBackup(&client_context, request, &response);
     if (!status.ok()) {
@@ -199,11 +199,11 @@ DefaultGoldenThingAdminStub::DeleteBackup(
     return google::cloud::Status();
 }
 
-StatusOr<::google::test::admin::database::v1::ListBackupsResponse>
+StatusOr<google::test::admin::database::v1::ListBackupsResponse>
 DefaultGoldenThingAdminStub::ListBackups(
   grpc::ClientContext& client_context,
-  ::google::test::admin::database::v1::ListBackupsRequest const& request) {
-    ::google::test::admin::database::v1::ListBackupsResponse response;
+  google::test::admin::database::v1::ListBackupsRequest const& request) {
+    google::test::admin::database::v1::ListBackupsResponse response;
     auto status =
         grpc_stub_->ListBackups(&client_context, request, &response);
     if (!status.ok()) {
@@ -212,11 +212,11 @@ DefaultGoldenThingAdminStub::ListBackups(
     return response;
 }
 
-StatusOr<::google::longrunning::Operation>
+StatusOr<google::longrunning::Operation>
 DefaultGoldenThingAdminStub::RestoreDatabase(
   grpc::ClientContext& client_context,
-  ::google::test::admin::database::v1::RestoreDatabaseRequest const& request) {
-    ::google::longrunning::Operation response;
+  google::test::admin::database::v1::RestoreDatabaseRequest const& request) {
+    google::longrunning::Operation response;
     auto status =
         grpc_stub_->RestoreDatabase(&client_context, request, &response);
     if (!status.ok()) {
@@ -225,11 +225,11 @@ DefaultGoldenThingAdminStub::RestoreDatabase(
     return response;
 }
 
-StatusOr<::google::test::admin::database::v1::ListDatabaseOperationsResponse>
+StatusOr<google::test::admin::database::v1::ListDatabaseOperationsResponse>
 DefaultGoldenThingAdminStub::ListDatabaseOperations(
   grpc::ClientContext& client_context,
-  ::google::test::admin::database::v1::ListDatabaseOperationsRequest const& request) {
-    ::google::test::admin::database::v1::ListDatabaseOperationsResponse response;
+  google::test::admin::database::v1::ListDatabaseOperationsRequest const& request) {
+    google::test::admin::database::v1::ListDatabaseOperationsResponse response;
     auto status =
         grpc_stub_->ListDatabaseOperations(&client_context, request, &response);
     if (!status.ok()) {
@@ -238,11 +238,11 @@ DefaultGoldenThingAdminStub::ListDatabaseOperations(
     return response;
 }
 
-StatusOr<::google::test::admin::database::v1::ListBackupOperationsResponse>
+StatusOr<google::test::admin::database::v1::ListBackupOperationsResponse>
 DefaultGoldenThingAdminStub::ListBackupOperations(
   grpc::ClientContext& client_context,
-  ::google::test::admin::database::v1::ListBackupOperationsRequest const& request) {
-    ::google::test::admin::database::v1::ListBackupOperationsResponse response;
+  google::test::admin::database::v1::ListBackupOperationsRequest const& request) {
+    google::test::admin::database::v1::ListBackupOperationsResponse response;
     auto status =
         grpc_stub_->ListBackupOperations(&client_context, request, &response);
     if (!status.ok()) {

--- a/generator/integration_tests/golden/internal/golden_thing_admin_stub.h
+++ b/generator/integration_tests/golden/internal/golden_thing_admin_stub.h
@@ -33,73 +33,73 @@ class GoldenThingAdminStub {
  public:
   virtual ~GoldenThingAdminStub() = 0;
 
-  virtual StatusOr<::google::test::admin::database::v1::ListDatabasesResponse> ListDatabases(
+  virtual StatusOr<google::test::admin::database::v1::ListDatabasesResponse> ListDatabases(
     grpc::ClientContext& context,
-    ::google::test::admin::database::v1::ListDatabasesRequest const& request) = 0;
+    google::test::admin::database::v1::ListDatabasesRequest const& request) = 0;
 
-  virtual StatusOr<::google::longrunning::Operation> CreateDatabase(
+  virtual StatusOr<google::longrunning::Operation> CreateDatabase(
     grpc::ClientContext& context,
-    ::google::test::admin::database::v1::CreateDatabaseRequest const& request) = 0;
+    google::test::admin::database::v1::CreateDatabaseRequest const& request) = 0;
 
-  virtual StatusOr<::google::test::admin::database::v1::Database> GetDatabase(
+  virtual StatusOr<google::test::admin::database::v1::Database> GetDatabase(
     grpc::ClientContext& context,
-    ::google::test::admin::database::v1::GetDatabaseRequest const& request) = 0;
+    google::test::admin::database::v1::GetDatabaseRequest const& request) = 0;
 
-  virtual StatusOr<::google::longrunning::Operation> UpdateDatabaseDdl(
+  virtual StatusOr<google::longrunning::Operation> UpdateDatabaseDdl(
     grpc::ClientContext& context,
-    ::google::test::admin::database::v1::UpdateDatabaseDdlRequest const& request) = 0;
+    google::test::admin::database::v1::UpdateDatabaseDdlRequest const& request) = 0;
 
   virtual Status DropDatabase(
     grpc::ClientContext& context,
-    ::google::test::admin::database::v1::DropDatabaseRequest const& request) = 0;
+    google::test::admin::database::v1::DropDatabaseRequest const& request) = 0;
 
-  virtual StatusOr<::google::test::admin::database::v1::GetDatabaseDdlResponse> GetDatabaseDdl(
+  virtual StatusOr<google::test::admin::database::v1::GetDatabaseDdlResponse> GetDatabaseDdl(
     grpc::ClientContext& context,
-    ::google::test::admin::database::v1::GetDatabaseDdlRequest const& request) = 0;
+    google::test::admin::database::v1::GetDatabaseDdlRequest const& request) = 0;
 
-  virtual StatusOr<::google::iam::v1::Policy> SetIamPolicy(
+  virtual StatusOr<google::iam::v1::Policy> SetIamPolicy(
     grpc::ClientContext& context,
-    ::google::iam::v1::SetIamPolicyRequest const& request) = 0;
+    google::iam::v1::SetIamPolicyRequest const& request) = 0;
 
-  virtual StatusOr<::google::iam::v1::Policy> GetIamPolicy(
+  virtual StatusOr<google::iam::v1::Policy> GetIamPolicy(
     grpc::ClientContext& context,
-    ::google::iam::v1::GetIamPolicyRequest const& request) = 0;
+    google::iam::v1::GetIamPolicyRequest const& request) = 0;
 
-  virtual StatusOr<::google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
+  virtual StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
     grpc::ClientContext& context,
-    ::google::iam::v1::TestIamPermissionsRequest const& request) = 0;
+    google::iam::v1::TestIamPermissionsRequest const& request) = 0;
 
-  virtual StatusOr<::google::longrunning::Operation> CreateBackup(
+  virtual StatusOr<google::longrunning::Operation> CreateBackup(
     grpc::ClientContext& context,
-    ::google::test::admin::database::v1::CreateBackupRequest const& request) = 0;
+    google::test::admin::database::v1::CreateBackupRequest const& request) = 0;
 
-  virtual StatusOr<::google::test::admin::database::v1::Backup> GetBackup(
+  virtual StatusOr<google::test::admin::database::v1::Backup> GetBackup(
     grpc::ClientContext& context,
-    ::google::test::admin::database::v1::GetBackupRequest const& request) = 0;
+    google::test::admin::database::v1::GetBackupRequest const& request) = 0;
 
-  virtual StatusOr<::google::test::admin::database::v1::Backup> UpdateBackup(
+  virtual StatusOr<google::test::admin::database::v1::Backup> UpdateBackup(
     grpc::ClientContext& context,
-    ::google::test::admin::database::v1::UpdateBackupRequest const& request) = 0;
+    google::test::admin::database::v1::UpdateBackupRequest const& request) = 0;
 
   virtual Status DeleteBackup(
     grpc::ClientContext& context,
-    ::google::test::admin::database::v1::DeleteBackupRequest const& request) = 0;
+    google::test::admin::database::v1::DeleteBackupRequest const& request) = 0;
 
-  virtual StatusOr<::google::test::admin::database::v1::ListBackupsResponse> ListBackups(
+  virtual StatusOr<google::test::admin::database::v1::ListBackupsResponse> ListBackups(
     grpc::ClientContext& context,
-    ::google::test::admin::database::v1::ListBackupsRequest const& request) = 0;
+    google::test::admin::database::v1::ListBackupsRequest const& request) = 0;
 
-  virtual StatusOr<::google::longrunning::Operation> RestoreDatabase(
+  virtual StatusOr<google::longrunning::Operation> RestoreDatabase(
     grpc::ClientContext& context,
-    ::google::test::admin::database::v1::RestoreDatabaseRequest const& request) = 0;
+    google::test::admin::database::v1::RestoreDatabaseRequest const& request) = 0;
 
-  virtual StatusOr<::google::test::admin::database::v1::ListDatabaseOperationsResponse> ListDatabaseOperations(
+  virtual StatusOr<google::test::admin::database::v1::ListDatabaseOperationsResponse> ListDatabaseOperations(
     grpc::ClientContext& context,
-    ::google::test::admin::database::v1::ListDatabaseOperationsRequest const& request) = 0;
+    google::test::admin::database::v1::ListDatabaseOperationsRequest const& request) = 0;
 
-  virtual StatusOr<::google::test::admin::database::v1::ListBackupOperationsResponse> ListBackupOperations(
+  virtual StatusOr<google::test::admin::database::v1::ListBackupOperationsResponse> ListBackupOperations(
     grpc::ClientContext& context,
-    ::google::test::admin::database::v1::ListBackupOperationsRequest const& request) = 0;
+    google::test::admin::database::v1::ListBackupOperationsRequest const& request) = 0;
 
   /// Poll a long-running operation.
   virtual StatusOr<google::longrunning::Operation> GetOperation(
@@ -116,95 +116,95 @@ class GoldenThingAdminStub {
 class DefaultGoldenThingAdminStub : public GoldenThingAdminStub {
  public:
   DefaultGoldenThingAdminStub(
-      std::unique_ptr<::google::test::admin::database::v1::GoldenThingAdmin::StubInterface> grpc_stub,
+      std::unique_ptr<google::test::admin::database::v1::GoldenThingAdmin::StubInterface> grpc_stub,
       std::unique_ptr<google::longrunning::Operations::StubInterface> operations)
       : grpc_stub_(std::move(grpc_stub)),
         operations_(std::move(operations)) {}
 
-  StatusOr<::google::test::admin::database::v1::ListDatabasesResponse>
+  StatusOr<google::test::admin::database::v1::ListDatabasesResponse>
   ListDatabases(
     grpc::ClientContext& client_context,
-    ::google::test::admin::database::v1::ListDatabasesRequest const& request) override;
+    google::test::admin::database::v1::ListDatabasesRequest const& request) override;
 
-  StatusOr<::google::longrunning::Operation>
+  StatusOr<google::longrunning::Operation>
   CreateDatabase(
     grpc::ClientContext& client_context,
-    ::google::test::admin::database::v1::CreateDatabaseRequest const& request) override;
+    google::test::admin::database::v1::CreateDatabaseRequest const& request) override;
 
-  StatusOr<::google::test::admin::database::v1::Database>
+  StatusOr<google::test::admin::database::v1::Database>
   GetDatabase(
     grpc::ClientContext& client_context,
-    ::google::test::admin::database::v1::GetDatabaseRequest const& request) override;
+    google::test::admin::database::v1::GetDatabaseRequest const& request) override;
 
-  StatusOr<::google::longrunning::Operation>
+  StatusOr<google::longrunning::Operation>
   UpdateDatabaseDdl(
     grpc::ClientContext& client_context,
-    ::google::test::admin::database::v1::UpdateDatabaseDdlRequest const& request) override;
+    google::test::admin::database::v1::UpdateDatabaseDdlRequest const& request) override;
 
   Status
   DropDatabase(
     grpc::ClientContext& client_context,
-    ::google::test::admin::database::v1::DropDatabaseRequest const& request) override;
+    google::test::admin::database::v1::DropDatabaseRequest const& request) override;
 
-  StatusOr<::google::test::admin::database::v1::GetDatabaseDdlResponse>
+  StatusOr<google::test::admin::database::v1::GetDatabaseDdlResponse>
   GetDatabaseDdl(
     grpc::ClientContext& client_context,
-    ::google::test::admin::database::v1::GetDatabaseDdlRequest const& request) override;
+    google::test::admin::database::v1::GetDatabaseDdlRequest const& request) override;
 
-  StatusOr<::google::iam::v1::Policy>
+  StatusOr<google::iam::v1::Policy>
   SetIamPolicy(
     grpc::ClientContext& client_context,
-    ::google::iam::v1::SetIamPolicyRequest const& request) override;
+    google::iam::v1::SetIamPolicyRequest const& request) override;
 
-  StatusOr<::google::iam::v1::Policy>
+  StatusOr<google::iam::v1::Policy>
   GetIamPolicy(
     grpc::ClientContext& client_context,
-    ::google::iam::v1::GetIamPolicyRequest const& request) override;
+    google::iam::v1::GetIamPolicyRequest const& request) override;
 
-  StatusOr<::google::iam::v1::TestIamPermissionsResponse>
+  StatusOr<google::iam::v1::TestIamPermissionsResponse>
   TestIamPermissions(
     grpc::ClientContext& client_context,
-    ::google::iam::v1::TestIamPermissionsRequest const& request) override;
+    google::iam::v1::TestIamPermissionsRequest const& request) override;
 
-  StatusOr<::google::longrunning::Operation>
+  StatusOr<google::longrunning::Operation>
   CreateBackup(
     grpc::ClientContext& client_context,
-    ::google::test::admin::database::v1::CreateBackupRequest const& request) override;
+    google::test::admin::database::v1::CreateBackupRequest const& request) override;
 
-  StatusOr<::google::test::admin::database::v1::Backup>
+  StatusOr<google::test::admin::database::v1::Backup>
   GetBackup(
     grpc::ClientContext& client_context,
-    ::google::test::admin::database::v1::GetBackupRequest const& request) override;
+    google::test::admin::database::v1::GetBackupRequest const& request) override;
 
-  StatusOr<::google::test::admin::database::v1::Backup>
+  StatusOr<google::test::admin::database::v1::Backup>
   UpdateBackup(
     grpc::ClientContext& client_context,
-    ::google::test::admin::database::v1::UpdateBackupRequest const& request) override;
+    google::test::admin::database::v1::UpdateBackupRequest const& request) override;
 
   Status
   DeleteBackup(
     grpc::ClientContext& client_context,
-    ::google::test::admin::database::v1::DeleteBackupRequest const& request) override;
+    google::test::admin::database::v1::DeleteBackupRequest const& request) override;
 
-  StatusOr<::google::test::admin::database::v1::ListBackupsResponse>
+  StatusOr<google::test::admin::database::v1::ListBackupsResponse>
   ListBackups(
     grpc::ClientContext& client_context,
-    ::google::test::admin::database::v1::ListBackupsRequest const& request) override;
+    google::test::admin::database::v1::ListBackupsRequest const& request) override;
 
-  StatusOr<::google::longrunning::Operation>
+  StatusOr<google::longrunning::Operation>
   RestoreDatabase(
     grpc::ClientContext& client_context,
-    ::google::test::admin::database::v1::RestoreDatabaseRequest const& request) override;
+    google::test::admin::database::v1::RestoreDatabaseRequest const& request) override;
 
-  StatusOr<::google::test::admin::database::v1::ListDatabaseOperationsResponse>
+  StatusOr<google::test::admin::database::v1::ListDatabaseOperationsResponse>
   ListDatabaseOperations(
     grpc::ClientContext& client_context,
-    ::google::test::admin::database::v1::ListDatabaseOperationsRequest const& request) override;
+    google::test::admin::database::v1::ListDatabaseOperationsRequest const& request) override;
 
-  StatusOr<::google::test::admin::database::v1::ListBackupOperationsResponse>
+  StatusOr<google::test::admin::database::v1::ListBackupOperationsResponse>
   ListBackupOperations(
     grpc::ClientContext& client_context,
-    ::google::test::admin::database::v1::ListBackupOperationsRequest const& request) override;
+    google::test::admin::database::v1::ListBackupOperationsRequest const& request) override;
 
   /// Poll a long-running operation.
   StatusOr<google::longrunning::Operation> GetOperation(
@@ -217,7 +217,7 @@ class DefaultGoldenThingAdminStub : public GoldenThingAdminStub {
       google::longrunning::CancelOperationRequest const& request) override;
 
  private:
-  std::unique_ptr<::google::test::admin::database::v1::GoldenThingAdmin::StubInterface> grpc_stub_;
+  std::unique_ptr<google::test::admin::database::v1::GoldenThingAdmin::StubInterface> grpc_stub_;
   std::unique_ptr<google::longrunning::Operations::StubInterface> operations_;
 };
 

--- a/generator/integration_tests/golden/internal/golden_thing_admin_stub_factory.cc
+++ b/generator/integration_tests/golden/internal/golden_thing_admin_stub_factory.cc
@@ -39,7 +39,7 @@ CreateDefaultGoldenThingAdminStub(Options const& options) {
       options.get<GrpcCredentialOption>(),
       internal::MakeChannelArguments(options));
   auto service_grpc_stub =
-      ::google::test::admin::database::v1::GoldenThingAdmin::NewStub(channel);
+      google::test::admin::database::v1::GoldenThingAdmin::NewStub(channel);
   auto longrunning_grpc_stub =
       google::longrunning::Operations::NewStub(channel);
 

--- a/generator/integration_tests/golden/mocks/mock_golden_kitchen_sink_connection.h
+++ b/generator/integration_tests/golden/mocks/mock_golden_kitchen_sink_connection.h
@@ -28,29 +28,29 @@ inline namespace GOOGLE_CLOUD_CPP_GENERATED_NS {
 
 class MockGoldenKitchenSinkConnection : public golden::GoldenKitchenSinkConnection {
  public:
-  MOCK_METHOD(StatusOr<::google::test::admin::database::v1::GenerateAccessTokenResponse>,
+  MOCK_METHOD(StatusOr<google::test::admin::database::v1::GenerateAccessTokenResponse>,
   GenerateAccessToken,
-  (::google::test::admin::database::v1::GenerateAccessTokenRequest const& request), (override));
+  (google::test::admin::database::v1::GenerateAccessTokenRequest const& request), (override));
 
-  MOCK_METHOD(StatusOr<::google::test::admin::database::v1::GenerateIdTokenResponse>,
+  MOCK_METHOD(StatusOr<google::test::admin::database::v1::GenerateIdTokenResponse>,
   GenerateIdToken,
-  (::google::test::admin::database::v1::GenerateIdTokenRequest const& request), (override));
+  (google::test::admin::database::v1::GenerateIdTokenRequest const& request), (override));
 
-  MOCK_METHOD(StatusOr<::google::test::admin::database::v1::WriteLogEntriesResponse>,
+  MOCK_METHOD(StatusOr<google::test::admin::database::v1::WriteLogEntriesResponse>,
   WriteLogEntries,
-  (::google::test::admin::database::v1::WriteLogEntriesRequest const& request), (override));
+  (google::test::admin::database::v1::WriteLogEntriesRequest const& request), (override));
 
   MOCK_METHOD(StreamRange<std::string>,
   ListLogs,
-  (::google::test::admin::database::v1::ListLogsRequest request), (override));
+  (google::test::admin::database::v1::ListLogsRequest request), (override));
 
-  MOCK_METHOD(StreamRange<::google::test::admin::database::v1::TailLogEntriesResponse>,
+  MOCK_METHOD(StreamRange<google::test::admin::database::v1::TailLogEntriesResponse>,
   TailLogEntries,
-  (::google::test::admin::database::v1::TailLogEntriesRequest const& request), (override));
+  (google::test::admin::database::v1::TailLogEntriesRequest const& request), (override));
 
-  MOCK_METHOD(StatusOr<::google::test::admin::database::v1::ListServiceAccountKeysResponse>,
+  MOCK_METHOD(StatusOr<google::test::admin::database::v1::ListServiceAccountKeysResponse>,
   ListServiceAccountKeys,
-  (::google::test::admin::database::v1::ListServiceAccountKeysRequest const& request), (override));
+  (google::test::admin::database::v1::ListServiceAccountKeysRequest const& request), (override));
 
 };
 

--- a/generator/integration_tests/golden/mocks/mock_golden_thing_admin_connection.h
+++ b/generator/integration_tests/golden/mocks/mock_golden_thing_admin_connection.h
@@ -28,73 +28,73 @@ inline namespace GOOGLE_CLOUD_CPP_GENERATED_NS {
 
 class MockGoldenThingAdminConnection : public golden::GoldenThingAdminConnection {
  public:
-  MOCK_METHOD(StreamRange<::google::test::admin::database::v1::Database>,
+  MOCK_METHOD(StreamRange<google::test::admin::database::v1::Database>,
   ListDatabases,
-  (::google::test::admin::database::v1::ListDatabasesRequest request), (override));
+  (google::test::admin::database::v1::ListDatabasesRequest request), (override));
 
-  MOCK_METHOD(future<StatusOr<::google::test::admin::database::v1::Database>>,
+  MOCK_METHOD(future<StatusOr<google::test::admin::database::v1::Database>>,
   CreateDatabase,
-  (::google::test::admin::database::v1::CreateDatabaseRequest const& request), (override));
+  (google::test::admin::database::v1::CreateDatabaseRequest const& request), (override));
 
-  MOCK_METHOD(StatusOr<::google::test::admin::database::v1::Database>,
+  MOCK_METHOD(StatusOr<google::test::admin::database::v1::Database>,
   GetDatabase,
-  (::google::test::admin::database::v1::GetDatabaseRequest const& request), (override));
+  (google::test::admin::database::v1::GetDatabaseRequest const& request), (override));
 
-  MOCK_METHOD(future<StatusOr<::google::test::admin::database::v1::UpdateDatabaseDdlMetadata>>,
+  MOCK_METHOD(future<StatusOr<google::test::admin::database::v1::UpdateDatabaseDdlMetadata>>,
   UpdateDatabaseDdl,
-  (::google::test::admin::database::v1::UpdateDatabaseDdlRequest const& request), (override));
+  (google::test::admin::database::v1::UpdateDatabaseDdlRequest const& request), (override));
 
   MOCK_METHOD(Status,
   DropDatabase,
-  (::google::test::admin::database::v1::DropDatabaseRequest const& request), (override));
+  (google::test::admin::database::v1::DropDatabaseRequest const& request), (override));
 
-  MOCK_METHOD(StatusOr<::google::test::admin::database::v1::GetDatabaseDdlResponse>,
+  MOCK_METHOD(StatusOr<google::test::admin::database::v1::GetDatabaseDdlResponse>,
   GetDatabaseDdl,
-  (::google::test::admin::database::v1::GetDatabaseDdlRequest const& request), (override));
+  (google::test::admin::database::v1::GetDatabaseDdlRequest const& request), (override));
 
-  MOCK_METHOD(StatusOr<::google::iam::v1::Policy>,
+  MOCK_METHOD(StatusOr<google::iam::v1::Policy>,
   SetIamPolicy,
-  (::google::iam::v1::SetIamPolicyRequest const& request), (override));
+  (google::iam::v1::SetIamPolicyRequest const& request), (override));
 
-  MOCK_METHOD(StatusOr<::google::iam::v1::Policy>,
+  MOCK_METHOD(StatusOr<google::iam::v1::Policy>,
   GetIamPolicy,
-  (::google::iam::v1::GetIamPolicyRequest const& request), (override));
+  (google::iam::v1::GetIamPolicyRequest const& request), (override));
 
-  MOCK_METHOD(StatusOr<::google::iam::v1::TestIamPermissionsResponse>,
+  MOCK_METHOD(StatusOr<google::iam::v1::TestIamPermissionsResponse>,
   TestIamPermissions,
-  (::google::iam::v1::TestIamPermissionsRequest const& request), (override));
+  (google::iam::v1::TestIamPermissionsRequest const& request), (override));
 
-  MOCK_METHOD(future<StatusOr<::google::test::admin::database::v1::Backup>>,
+  MOCK_METHOD(future<StatusOr<google::test::admin::database::v1::Backup>>,
   CreateBackup,
-  (::google::test::admin::database::v1::CreateBackupRequest const& request), (override));
+  (google::test::admin::database::v1::CreateBackupRequest const& request), (override));
 
-  MOCK_METHOD(StatusOr<::google::test::admin::database::v1::Backup>,
+  MOCK_METHOD(StatusOr<google::test::admin::database::v1::Backup>,
   GetBackup,
-  (::google::test::admin::database::v1::GetBackupRequest const& request), (override));
+  (google::test::admin::database::v1::GetBackupRequest const& request), (override));
 
-  MOCK_METHOD(StatusOr<::google::test::admin::database::v1::Backup>,
+  MOCK_METHOD(StatusOr<google::test::admin::database::v1::Backup>,
   UpdateBackup,
-  (::google::test::admin::database::v1::UpdateBackupRequest const& request), (override));
+  (google::test::admin::database::v1::UpdateBackupRequest const& request), (override));
 
   MOCK_METHOD(Status,
   DeleteBackup,
-  (::google::test::admin::database::v1::DeleteBackupRequest const& request), (override));
+  (google::test::admin::database::v1::DeleteBackupRequest const& request), (override));
 
-  MOCK_METHOD(StreamRange<::google::test::admin::database::v1::Backup>,
+  MOCK_METHOD(StreamRange<google::test::admin::database::v1::Backup>,
   ListBackups,
-  (::google::test::admin::database::v1::ListBackupsRequest request), (override));
+  (google::test::admin::database::v1::ListBackupsRequest request), (override));
 
-  MOCK_METHOD(future<StatusOr<::google::test::admin::database::v1::Database>>,
+  MOCK_METHOD(future<StatusOr<google::test::admin::database::v1::Database>>,
   RestoreDatabase,
-  (::google::test::admin::database::v1::RestoreDatabaseRequest const& request), (override));
+  (google::test::admin::database::v1::RestoreDatabaseRequest const& request), (override));
 
-  MOCK_METHOD(StreamRange<::google::longrunning::Operation>,
+  MOCK_METHOD(StreamRange<google::longrunning::Operation>,
   ListDatabaseOperations,
-  (::google::test::admin::database::v1::ListDatabaseOperationsRequest request), (override));
+  (google::test::admin::database::v1::ListDatabaseOperationsRequest request), (override));
 
-  MOCK_METHOD(StreamRange<::google::longrunning::Operation>,
+  MOCK_METHOD(StreamRange<google::longrunning::Operation>,
   ListBackupOperations,
-  (::google::test::admin::database::v1::ListBackupOperationsRequest request), (override));
+  (google::test::admin::database::v1::ListBackupOperationsRequest request), (override));
 
 };
 

--- a/generator/internal/codegen_utils.cc
+++ b/generator/internal/codegen_utils.cc
@@ -164,7 +164,7 @@ std::string ServiceNameToFilePath(absl::string_view service_name) {
 }
 
 std::string ProtoNameToCppName(absl::string_view proto_name) {
-  return "::" + absl::StrReplaceAll(proto_name, {{".", "::"}});
+  return absl::StrReplaceAll(proto_name, {{".", "::"}});
 }
 
 std::vector<std::string> BuildNamespaces(std::string const& product_path,

--- a/generator/internal/codegen_utils_test.cc
+++ b/generator/internal/codegen_utils_test.cc
@@ -85,7 +85,7 @@ TEST(ServiceNameToFilePath, TrailingServiceInIntermediateComponent) {
 }
 
 TEST(ProtoNameToCppName, MessageType) {
-  EXPECT_EQ("::google::spanner::admin::database::v1::Request",
+  EXPECT_EQ("google::spanner::admin::database::v1::Request",
             ProtoNameToCppName("google.spanner.admin.database.v1.Request"));
 }
 

--- a/generator/internal/descriptor_utils_test.cc
+++ b/generator/internal/descriptor_utils_test.cc
@@ -207,7 +207,7 @@ INSTANTIATE_TEST_SUITE_P(
         std::make_pair("connection_options_traits_name",
                        "FrobberServiceConnectionOptionsTraits"),
         std::make_pair("grpc_stub_fqn",
-                       "::google::cloud::frobber::v1::FrobberService"),
+                       "google::cloud::frobber::v1::FrobberService"),
         std::make_pair("idempotency_class_name",
                        "FrobberServiceConnectionIdempotencyPolicy"),
         std::make_pair("idempotency_policy_cc_path",
@@ -498,7 +498,7 @@ TEST_F(CreateMethodVarsTest,
           MethodParameterStyle::kProtobufRequest),
       "  /**\n   * Leading comments about rpc Method0$$.\n   *\n   * @param "
       "request "
-      "[::google::protobuf::Bar](https://github.com/googleapis/googleapis/blob/"
+      "[google::protobuf::Bar](https://github.com/googleapis/googleapis/blob/"
       "$googleapis_commit_hash$/google/foo/v1/service.proto#L14)\n   */\n");
 }
 
@@ -532,16 +532,16 @@ INSTANTIATE_TEST_SUITE_P(
         MethodVarsTestValues("google.protobuf.Service.Method0",
                              "method_name_snake", "method0"),
         MethodVarsTestValues("google.protobuf.Service.Method0", "request_type",
-                             "::google::protobuf::Bar"),
+                             "google::protobuf::Bar"),
         MethodVarsTestValues("google.protobuf.Service.Method0",
                              "response_message_type", "google.protobuf.Empty"),
         MethodVarsTestValues("google.protobuf.Service.Method0", "response_type",
-                             "::google::protobuf::Empty"),
+                             "google::protobuf::Empty"),
         MethodVarsTestValues("google.protobuf.Service.Method0",
                              "default_idempotency", "kNonIdempotent"),
         MethodVarsTestValues(
             "google.protobuf.Service.Method0", "method_return_doxygen_link",
-            "[::google::protobuf::Empty](https://github.com/googleapis/"
+            "[google::protobuf::Empty](https://github.com/googleapis/"
             "googleapis/blob/foo/google/foo/v1/service.proto#L28)"),
         // Method1
         MethodVarsTestValues("google.protobuf.Service.Method1", "method_name",
@@ -549,26 +549,26 @@ INSTANTIATE_TEST_SUITE_P(
         MethodVarsTestValues("google.protobuf.Service.Method1",
                              "method_name_snake", "method1"),
         MethodVarsTestValues("google.protobuf.Service.Method1", "request_type",
-                             "::google::protobuf::Bar"),
+                             "google::protobuf::Bar"),
         MethodVarsTestValues("google.protobuf.Service.Method1", "response_type",
-                             "::google::protobuf::Bar"),
+                             "google::protobuf::Bar"),
         MethodVarsTestValues(
             "google.protobuf.Service.Method1", "method_return_doxygen_link",
-            "[::google::protobuf::Bar](https://github.com/googleapis/"
+            "[google::protobuf::Bar](https://github.com/googleapis/"
             "googleapis/blob/foo/google/foo/v1/service.proto#L14)"),
         // Method2
         MethodVarsTestValues("google.protobuf.Service.Method2",
                              "longrunning_metadata_type",
-                             "::google::protobuf::Method2Metadata"),
+                             "google::protobuf::Method2Metadata"),
         MethodVarsTestValues("google.protobuf.Service.Method2",
                              "longrunning_response_type",
-                             "::google::protobuf::Bar"),
+                             "google::protobuf::Bar"),
         MethodVarsTestValues("google.protobuf.Service.Method2",
                              "longrunning_deduced_response_message_type",
                              "google.protobuf.Bar"),
         MethodVarsTestValues("google.protobuf.Service.Method2",
                              "longrunning_deduced_response_type",
-                             "::google::protobuf::Bar"),
+                             "google::protobuf::Bar"),
         MethodVarsTestValues("google.protobuf.Service.Method2",
                              "method_request_param_key", "parent"),
         MethodVarsTestValues("google.protobuf.Service.Method2",
@@ -584,18 +584,18 @@ INSTANTIATE_TEST_SUITE_P(
         MethodVarsTestValues(
             "google.protobuf.Service.Method2",
             "method_longrunning_deduced_return_doxygen_link",
-            "[::google::protobuf::Bar](https://github.com/googleapis/"
+            "[google::protobuf::Bar](https://github.com/googleapis/"
             "googleapis/blob/foo/google/foo/v1/service.proto#L14)"),
         // Method3
         MethodVarsTestValues("google.protobuf.Service.Method3",
                              "longrunning_metadata_type",
-                             "::google::protobuf::Struct"),
+                             "google::protobuf::Struct"),
         MethodVarsTestValues("google.protobuf.Service.Method3",
                              "longrunning_response_type",
-                             "::google::protobuf::Empty"),
+                             "google::protobuf::Empty"),
         MethodVarsTestValues("google.protobuf.Service.Method3",
                              "longrunning_deduced_response_type",
-                             "::google::protobuf::Struct"),
+                             "google::protobuf::Struct"),
         MethodVarsTestValues("google.protobuf.Service.Method3",
                              "method_request_param_key", "parent"),
         MethodVarsTestValues("google.protobuf.Service.Method3",
@@ -610,12 +610,12 @@ INSTANTIATE_TEST_SUITE_P(
                              "default_idempotency", "kIdempotent"),
         MethodVarsTestValues("google.protobuf.Service.Method3",
                              "method_longrunning_deduced_return_doxygen_link",
-                             "::google::protobuf::Struct"),
+                             "google::protobuf::Struct"),
         // Method4
         MethodVarsTestValues("google.protobuf.Service.Method4",
                              "range_output_field_name", "repeated_field"),
         MethodVarsTestValues("google.protobuf.Service.Method4",
-                             "range_output_type", "::google::protobuf::Bar"),
+                             "range_output_type", "google::protobuf::Bar"),
         MethodVarsTestValues("google.protobuf.Service.Method4",
                              "method_request_param_key", "name"),
         MethodVarsTestValues("google.protobuf.Service.Method4",
@@ -634,7 +634,7 @@ INSTANTIATE_TEST_SUITE_P(
         MethodVarsTestValues("google.protobuf.Service.Method5",
                              "method_signature1",
                              "std::int32_t number, "
-                             "::google::protobuf::Foo const& widget"),
+                             "google::protobuf::Foo const& widget"),
         MethodVarsTestValues("google.protobuf.Service.Method5",
                              "method_signature2", "bool toggle"),
         MethodVarsTestValues("google.protobuf.Service.Method5",
@@ -644,7 +644,7 @@ INSTANTIATE_TEST_SUITE_P(
         MethodVarsTestValues("google.protobuf.Service.Method5",
                              "method_signature4",
                              "std::string const& name, "
-                             "std::vector<::google::protobuf::Bar::SwallowType>"
+                             "std::vector<google::protobuf::Bar::SwallowType>"
                              " const& swallow_types"),
         MethodVarsTestValues("google.protobuf.Service.Method5",
                              "method_request_setters0",
@@ -689,20 +689,20 @@ INSTANTIATE_TEST_SUITE_P(
         // Method7
         MethodVarsTestValues("google.protobuf.Service.Method7",
                              "longrunning_metadata_type",
-                             "::google::protobuf::Method2Metadata"),
+                             "google::protobuf::Method2Metadata"),
         MethodVarsTestValues("google.protobuf.Service.Method7",
                              "longrunning_response_type",
-                             "::google::protobuf::Bar"),
+                             "google::protobuf::Bar"),
         MethodVarsTestValues("google.protobuf.Service.Method7",
                              "longrunning_deduced_response_message_type",
                              "google.protobuf.Bar"),
         MethodVarsTestValues("google.protobuf.Service.Method7",
                              "longrunning_deduced_response_type",
-                             "::google::protobuf::Bar"),
+                             "google::protobuf::Bar"),
         MethodVarsTestValues(
             "google.protobuf.Service.Method7",
             "method_longrunning_deduced_return_doxygen_link",
-            "[::google::protobuf::Bar](https://github.com/googleapis/"
+            "[google::protobuf::Bar](https://github.com/googleapis/"
             "googleapis/blob/foo/google/foo/v1/service.proto#L14)")),
     [](const testing::TestParamInfo<CreateMethodVarsTest::ParamType>& info) {
       std::vector<std::string> pieces = absl::StrSplit(info.param.method, '.');

--- a/google/cloud/bigquery/bigquery_read_client.cc
+++ b/google/cloud/bigquery/bigquery_read_client.cc
@@ -29,43 +29,43 @@ BigQueryReadClient::BigQueryReadClient(
     : connection_(std::move(connection)) {}
 BigQueryReadClient::~BigQueryReadClient() = default;
 
-StatusOr<::google::cloud::bigquery::storage::v1::ReadSession>
+StatusOr<google::cloud::bigquery::storage::v1::ReadSession>
 BigQueryReadClient::CreateReadSession(
     std::string const& parent,
-    ::google::cloud::bigquery::storage::v1::ReadSession const& read_session,
+    google::cloud::bigquery::storage::v1::ReadSession const& read_session,
     std::int32_t max_stream_count) {
-  ::google::cloud::bigquery::storage::v1::CreateReadSessionRequest request;
+  google::cloud::bigquery::storage::v1::CreateReadSessionRequest request;
   request.set_parent(parent);
   *request.mutable_read_session() = read_session;
   request.set_max_stream_count(max_stream_count);
   return connection_->CreateReadSession(request);
 }
 
-StreamRange<::google::cloud::bigquery::storage::v1::ReadRowsResponse>
+StreamRange<google::cloud::bigquery::storage::v1::ReadRowsResponse>
 BigQueryReadClient::ReadRows(std::string const& read_stream,
                              std::int64_t offset) {
-  ::google::cloud::bigquery::storage::v1::ReadRowsRequest request;
+  google::cloud::bigquery::storage::v1::ReadRowsRequest request;
   request.set_read_stream(read_stream);
   request.set_offset(offset);
   return connection_->ReadRows(request);
 }
 
-StatusOr<::google::cloud::bigquery::storage::v1::ReadSession>
+StatusOr<google::cloud::bigquery::storage::v1::ReadSession>
 BigQueryReadClient::CreateReadSession(
-    ::google::cloud::bigquery::storage::v1::CreateReadSessionRequest const&
+    google::cloud::bigquery::storage::v1::CreateReadSessionRequest const&
         request) {
   return connection_->CreateReadSession(request);
 }
 
-StreamRange<::google::cloud::bigquery::storage::v1::ReadRowsResponse>
+StreamRange<google::cloud::bigquery::storage::v1::ReadRowsResponse>
 BigQueryReadClient::ReadRows(
-    ::google::cloud::bigquery::storage::v1::ReadRowsRequest const& request) {
+    google::cloud::bigquery::storage::v1::ReadRowsRequest const& request) {
   return connection_->ReadRows(request);
 }
 
-StatusOr<::google::cloud::bigquery::storage::v1::SplitReadStreamResponse>
+StatusOr<google::cloud::bigquery::storage::v1::SplitReadStreamResponse>
 BigQueryReadClient::SplitReadStream(
-    ::google::cloud::bigquery::storage::v1::SplitReadStreamRequest const&
+    google::cloud::bigquery::storage::v1::SplitReadStreamRequest const&
         request) {
   return connection_->SplitReadStream(request);
 }

--- a/google/cloud/bigquery/bigquery_read_client.h
+++ b/google/cloud/bigquery/bigquery_read_client.h
@@ -93,12 +93,11 @@ class BigQueryReadClient {
    * greater than the current system max limit of 1,000. Streams must be read
    * starting from offset 0.
    * @return
-   * [::google::cloud::bigquery::storage::v1::ReadSession](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/cloud/bigquery/storage/v1/stream.proto#L47)
+   * [google::cloud::bigquery::storage::v1::ReadSession](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/cloud/bigquery/storage/v1/stream.proto#L47)
    */
-  StatusOr<::google::cloud::bigquery::storage::v1::ReadSession>
-  CreateReadSession(
+  StatusOr<google::cloud::bigquery::storage::v1::ReadSession> CreateReadSession(
       std::string const& parent,
-      ::google::cloud::bigquery::storage::v1::ReadSession const& read_session,
+      google::cloud::bigquery::storage::v1::ReadSession const& read_session,
       std::int32_t max_stream_count);
 
   /**
@@ -115,10 +114,10 @@ class BigQueryReadClient {
    * from Read. Requesting a larger offset is undefined. If not specified, start
    * reading from offset zero.
    * @return
-   * [::google::cloud::bigquery::storage::v1::ReadRowsResponse](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/cloud/bigquery/storage/v1/storage.proto#L185)
+   * [google::cloud::bigquery::storage::v1::ReadRowsResponse](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/cloud/bigquery/storage/v1/storage.proto#L185)
    */
-  StreamRange<::google::cloud::bigquery::storage::v1::ReadRowsResponse>
-  ReadRows(std::string const& read_stream, std::int64_t offset);
+  StreamRange<google::cloud::bigquery::storage::v1::ReadRowsResponse> ReadRows(
+      std::string const& read_stream, std::int64_t offset);
 
   /**
    * Creates a new read session. A read session divides the contents of a
@@ -142,13 +141,12 @@ class BigQueryReadClient {
    * not require manual clean-up by the caller.
    *
    * @param request
-   * [::google::cloud::bigquery::storage::v1::CreateReadSessionRequest](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/cloud/bigquery/storage/v1/storage.proto#L110)
+   * [google::cloud::bigquery::storage::v1::CreateReadSessionRequest](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/cloud/bigquery/storage/v1/storage.proto#L110)
    * @return
-   * [::google::cloud::bigquery::storage::v1::ReadSession](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/cloud/bigquery/storage/v1/stream.proto#L47)
+   * [google::cloud::bigquery::storage::v1::ReadSession](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/cloud/bigquery/storage/v1/stream.proto#L47)
    */
-  StatusOr<::google::cloud::bigquery::storage::v1::ReadSession>
-  CreateReadSession(
-      ::google::cloud::bigquery::storage::v1::CreateReadSessionRequest const&
+  StatusOr<google::cloud::bigquery::storage::v1::ReadSession> CreateReadSession(
+      google::cloud::bigquery::storage::v1::CreateReadSessionRequest const&
           request);
 
   /**
@@ -161,13 +159,12 @@ class BigQueryReadClient {
    * state of the stream.
    *
    * @param request
-   * [::google::cloud::bigquery::storage::v1::ReadRowsRequest](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/cloud/bigquery/storage/v1/storage.proto#L135)
+   * [google::cloud::bigquery::storage::v1::ReadRowsRequest](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/cloud/bigquery/storage/v1/storage.proto#L135)
    * @return
-   * [::google::cloud::bigquery::storage::v1::ReadRowsResponse](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/cloud/bigquery/storage/v1/storage.proto#L185)
+   * [google::cloud::bigquery::storage::v1::ReadRowsResponse](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/cloud/bigquery/storage/v1/storage.proto#L185)
    */
-  StreamRange<::google::cloud::bigquery::storage::v1::ReadRowsResponse>
-  ReadRows(
-      ::google::cloud::bigquery::storage::v1::ReadRowsRequest const& request);
+  StreamRange<google::cloud::bigquery::storage::v1::ReadRowsResponse> ReadRows(
+      google::cloud::bigquery::storage::v1::ReadRowsRequest const& request);
 
   /**
    * Splits a given `ReadStream` into two `ReadStream` objects. These
@@ -184,13 +181,13 @@ class BigQueryReadClient {
    * completion.
    *
    * @param request
-   * [::google::cloud::bigquery::storage::v1::SplitReadStreamRequest](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/cloud/bigquery/storage/v1/storage.proto#L207)
+   * [google::cloud::bigquery::storage::v1::SplitReadStreamRequest](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/cloud/bigquery/storage/v1/storage.proto#L207)
    * @return
-   * [::google::cloud::bigquery::storage::v1::SplitReadStreamResponse](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/cloud/bigquery/storage/v1/storage.proto#L227)
+   * [google::cloud::bigquery::storage::v1::SplitReadStreamResponse](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/cloud/bigquery/storage/v1/storage.proto#L227)
    */
-  StatusOr<::google::cloud::bigquery::storage::v1::SplitReadStreamResponse>
+  StatusOr<google::cloud::bigquery::storage::v1::SplitReadStreamResponse>
   SplitReadStream(
-      ::google::cloud::bigquery::storage::v1::SplitReadStreamRequest const&
+      google::cloud::bigquery::storage::v1::SplitReadStreamRequest const&
           request);
 
  private:

--- a/google/cloud/bigquery/bigquery_read_connection.cc
+++ b/google/cloud/bigquery/bigquery_read_connection.cc
@@ -32,27 +32,26 @@ inline namespace GOOGLE_CLOUD_CPP_GENERATED_NS {
 
 BigQueryReadConnection::~BigQueryReadConnection() = default;
 
-StatusOr<::google::cloud::bigquery::storage::v1::ReadSession>
+StatusOr<google::cloud::bigquery::storage::v1::ReadSession>
 BigQueryReadConnection::CreateReadSession(
-    ::google::cloud::bigquery::storage::v1::CreateReadSessionRequest const&) {
+    google::cloud::bigquery::storage::v1::CreateReadSessionRequest const&) {
   return Status(StatusCode::kUnimplemented, "not implemented");
 }
 
-StreamRange<::google::cloud::bigquery::storage::v1::ReadRowsResponse>
+StreamRange<google::cloud::bigquery::storage::v1::ReadRowsResponse>
 BigQueryReadConnection::ReadRows(
-    ::google::cloud::bigquery::storage::v1::ReadRowsRequest const&) {
+    google::cloud::bigquery::storage::v1::ReadRowsRequest const&) {
   return google::cloud::internal::MakeStreamRange<
-      ::google::cloud::bigquery::storage::v1::ReadRowsResponse>(
+      google::cloud::bigquery::storage::v1::ReadRowsResponse>(
       []() -> absl::variant<
-               Status,
-               ::google::cloud::bigquery::storage::v1::ReadRowsResponse> {
+               Status, google::cloud::bigquery::storage::v1::ReadRowsResponse> {
         return Status(StatusCode::kUnimplemented, "not implemented");
       });
 }
 
-StatusOr<::google::cloud::bigquery::storage::v1::SplitReadStreamResponse>
+StatusOr<google::cloud::bigquery::storage::v1::SplitReadStreamResponse>
 BigQueryReadConnection::SplitReadStream(
-    ::google::cloud::bigquery::storage::v1::SplitReadStreamRequest const&) {
+    google::cloud::bigquery::storage::v1::SplitReadStreamRequest const&) {
   return Status(StatusCode::kUnimplemented, "not implemented");
 }
 
@@ -73,24 +72,23 @@ class BigQueryReadConnectionImpl : public BigQueryReadConnection {
 
   ~BigQueryReadConnectionImpl() override = default;
 
-  StatusOr<::google::cloud::bigquery::storage::v1::ReadSession>
-  CreateReadSession(
-      ::google::cloud::bigquery::storage::v1::CreateReadSessionRequest const&
+  StatusOr<google::cloud::bigquery::storage::v1::ReadSession> CreateReadSession(
+      google::cloud::bigquery::storage::v1::CreateReadSessionRequest const&
           request) override {
     return google::cloud::internal::RetryLoop(
         retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
         idempotency_policy_->CreateReadSession(request),
         [this](grpc::ClientContext& context,
-               ::google::cloud::bigquery::storage::v1::
+               google::cloud::bigquery::storage::v1::
                    CreateReadSessionRequest const& request) {
           return stub_->CreateReadSession(context, request);
         },
         request, __func__);
   }
 
-  StreamRange<::google::cloud::bigquery::storage::v1::ReadRowsResponse>
-  ReadRows(::google::cloud::bigquery::storage::v1::ReadRowsRequest const&
-               request) override {
+  StreamRange<google::cloud::bigquery::storage::v1::ReadRowsResponse> ReadRows(
+      google::cloud::bigquery::storage::v1::ReadRowsRequest const& request)
+      override {
     auto stub = stub_;
     auto retry_policy = std::shared_ptr<BigQueryReadRetryPolicy const>(
         retry_policy_prototype_->clone());
@@ -98,37 +96,36 @@ class BigQueryReadConnectionImpl : public BigQueryReadConnection {
         backoff_policy_prototype_->clone());
 
     auto factory =
-        [stub](::google::cloud::bigquery::storage::v1::ReadRowsRequest const&
+        [stub](google::cloud::bigquery::storage::v1::ReadRowsRequest const&
                    request) {
           return stub->ReadRows(absl::make_unique<grpc::ClientContext>(),
                                 request);
         };
 
     auto resumable = internal::MakeResumableStreamingReadRpc<
-        ::google::cloud::bigquery::storage::v1::ReadRowsResponse,
-        ::google::cloud::bigquery::storage::v1::ReadRowsRequest>(
+        google::cloud::bigquery::storage::v1::ReadRowsResponse,
+        google::cloud::bigquery::storage::v1::ReadRowsRequest>(
         retry_policy->clone(), backoff_policy->clone(),
         [](std::chrono::milliseconds) {}, factory,
         BigQueryReadReadRowsStreamingUpdater, request);
 
     return internal::MakeStreamRange(
         internal::StreamReader<
-            ::google::cloud::bigquery::storage::v1::ReadRowsResponse>(
+            google::cloud::bigquery::storage::v1::ReadRowsResponse>(
             [resumable] { return resumable->Read(); }));
   }
 
-  StatusOr<::google::cloud::bigquery::storage::v1::SplitReadStreamResponse>
+  StatusOr<google::cloud::bigquery::storage::v1::SplitReadStreamResponse>
   SplitReadStream(
-      ::google::cloud::bigquery::storage::v1::SplitReadStreamRequest const&
+      google::cloud::bigquery::storage::v1::SplitReadStreamRequest const&
           request) override {
     return google::cloud::internal::RetryLoop(
         retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
         idempotency_policy_->SplitReadStream(request),
-        [this](grpc::ClientContext& context,
-               ::google::cloud::bigquery::storage::v1::
-                   SplitReadStreamRequest const& request) {
-          return stub_->SplitReadStream(context, request);
-        },
+        [this](
+            grpc::ClientContext& context,
+            google::cloud::bigquery::storage::v1::SplitReadStreamRequest const&
+                request) { return stub_->SplitReadStream(context, request); },
         request, __func__);
   }
 

--- a/google/cloud/bigquery/bigquery_read_connection.h
+++ b/google/cloud/bigquery/bigquery_read_connection.h
@@ -45,26 +45,26 @@ using BigQueryReadLimitedErrorCountRetryPolicy =
         bigquery_internal::BigQueryReadRetryTraits>;
 
 void BigQueryReadReadRowsStreamingUpdater(
-    ::google::cloud::bigquery::storage::v1::ReadRowsResponse const& response,
-    ::google::cloud::bigquery::storage::v1::ReadRowsRequest& request);
+    google::cloud::bigquery::storage::v1::ReadRowsResponse const& response,
+    google::cloud::bigquery::storage::v1::ReadRowsRequest& request);
 
 class BigQueryReadConnection {
  public:
   virtual ~BigQueryReadConnection() = 0;
 
-  virtual StatusOr<::google::cloud::bigquery::storage::v1::ReadSession>
+  virtual StatusOr<google::cloud::bigquery::storage::v1::ReadSession>
   CreateReadSession(
-      ::google::cloud::bigquery::storage::v1::CreateReadSessionRequest const&
+      google::cloud::bigquery::storage::v1::CreateReadSessionRequest const&
           request);
 
-  virtual StreamRange<::google::cloud::bigquery::storage::v1::ReadRowsResponse>
+  virtual StreamRange<google::cloud::bigquery::storage::v1::ReadRowsResponse>
   ReadRows(
-      ::google::cloud::bigquery::storage::v1::ReadRowsRequest const& request);
+      google::cloud::bigquery::storage::v1::ReadRowsRequest const& request);
 
   virtual StatusOr<
-      ::google::cloud::bigquery::storage::v1::SplitReadStreamResponse>
+      google::cloud::bigquery::storage::v1::SplitReadStreamResponse>
   SplitReadStream(
-      ::google::cloud::bigquery::storage::v1::SplitReadStreamRequest const&
+      google::cloud::bigquery::storage::v1::SplitReadStreamRequest const&
           request);
 };
 

--- a/google/cloud/bigquery/bigquery_read_connection_idempotency_policy.cc
+++ b/google/cloud/bigquery/bigquery_read_connection_idempotency_policy.cc
@@ -43,13 +43,13 @@ class DefaultBigQueryReadConnectionIdempotencyPolicy
   }
 
   Idempotency CreateReadSession(
-      ::google::cloud::bigquery::storage::v1::CreateReadSessionRequest const&)
+      google::cloud::bigquery::storage::v1::CreateReadSessionRequest const&)
       override {
     return Idempotency::kNonIdempotent;
   }
 
   Idempotency SplitReadStream(
-      ::google::cloud::bigquery::storage::v1::SplitReadStreamRequest const&)
+      google::cloud::bigquery::storage::v1::SplitReadStreamRequest const&)
       override {
     return Idempotency::kIdempotent;
   }

--- a/google/cloud/bigquery/bigquery_read_connection_idempotency_policy.h
+++ b/google/cloud/bigquery/bigquery_read_connection_idempotency_policy.h
@@ -38,11 +38,11 @@ class BigQueryReadConnectionIdempotencyPolicy {
       const = 0;
 
   virtual google::cloud::internal::Idempotency CreateReadSession(
-      ::google::cloud::bigquery::storage::v1::CreateReadSessionRequest const&
+      google::cloud::bigquery::storage::v1::CreateReadSessionRequest const&
           request) = 0;
 
   virtual google::cloud::internal::Idempotency SplitReadStream(
-      ::google::cloud::bigquery::storage::v1::SplitReadStreamRequest const&
+      google::cloud::bigquery::storage::v1::SplitReadStreamRequest const&
           request) = 0;
 };
 

--- a/google/cloud/bigquery/internal/bigquery_read_logging_decorator.cc
+++ b/google/cloud/bigquery/internal/bigquery_read_logging_decorator.cc
@@ -34,35 +34,34 @@ BigQueryReadLogging::BigQueryReadLogging(
       tracing_options_(std::move(tracing_options)),
       components_(std::move(components)) {}
 
-StatusOr<::google::cloud::bigquery::storage::v1::ReadSession>
+StatusOr<google::cloud::bigquery::storage::v1::ReadSession>
 BigQueryReadLogging::CreateReadSession(
     grpc::ClientContext& context,
-    ::google::cloud::bigquery::storage::v1::CreateReadSessionRequest const&
+    google::cloud::bigquery::storage::v1::CreateReadSessionRequest const&
         request) {
   return google::cloud::internal::LogWrapper(
-      [this](grpc::ClientContext& context,
-             ::google::cloud::bigquery::storage::v1::
-                 CreateReadSessionRequest const& request) {
-        return child_->CreateReadSession(context, request);
-      },
+      [this](
+          grpc::ClientContext& context,
+          google::cloud::bigquery::storage::v1::CreateReadSessionRequest const&
+              request) { return child_->CreateReadSession(context, request); },
       context, request, __func__, tracing_options_);
 }
 
 std::unique_ptr<internal::StreamingReadRpc<
-    ::google::cloud::bigquery::storage::v1::ReadRowsResponse>>
+    google::cloud::bigquery::storage::v1::ReadRowsResponse>>
 BigQueryReadLogging::ReadRows(
     std::unique_ptr<grpc::ClientContext> context,
-    ::google::cloud::bigquery::storage::v1::ReadRowsRequest const& request) {
+    google::cloud::bigquery::storage::v1::ReadRowsRequest const& request) {
   return google::cloud::internal::LogWrapper(
-      [this](std::unique_ptr<grpc::ClientContext> context,
-             ::google::cloud::bigquery::storage::v1::ReadRowsRequest const&
-                 request)
+      [this](
+          std::unique_ptr<grpc::ClientContext> context,
+          google::cloud::bigquery::storage::v1::ReadRowsRequest const& request)
           -> std::unique_ptr<internal::StreamingReadRpc<
-              ::google::cloud::bigquery::storage::v1::ReadRowsResponse>> {
+              google::cloud::bigquery::storage::v1::ReadRowsResponse>> {
         auto stream = child_->ReadRows(std::move(context), request);
         if (components_.count("rpc-streams") > 0) {
           stream = absl::make_unique<internal::StreamingReadRpcLogging<
-              ::google::cloud::bigquery::storage::v1::ReadRowsResponse>>(
+              google::cloud::bigquery::storage::v1::ReadRowsResponse>>(
               std::move(stream), tracing_options_,
               internal::RequestIdForLogging());
         }
@@ -71,16 +70,15 @@ BigQueryReadLogging::ReadRows(
       std::move(context), request, __func__, tracing_options_);
 }
 
-StatusOr<::google::cloud::bigquery::storage::v1::SplitReadStreamResponse>
+StatusOr<google::cloud::bigquery::storage::v1::SplitReadStreamResponse>
 BigQueryReadLogging::SplitReadStream(
     grpc::ClientContext& context,
-    ::google::cloud::bigquery::storage::v1::SplitReadStreamRequest const&
+    google::cloud::bigquery::storage::v1::SplitReadStreamRequest const&
         request) {
   return google::cloud::internal::LogWrapper(
-      [this](
-          grpc::ClientContext& context,
-          ::google::cloud::bigquery::storage::v1::SplitReadStreamRequest const&
-              request) { return child_->SplitReadStream(context, request); },
+      [this](grpc::ClientContext& context,
+             google::cloud::bigquery::storage::v1::SplitReadStreamRequest const&
+                 request) { return child_->SplitReadStream(context, request); },
       context, request, __func__, tracing_options_);
 }
 

--- a/google/cloud/bigquery/internal/bigquery_read_logging_decorator.h
+++ b/google/cloud/bigquery/internal/bigquery_read_logging_decorator.h
@@ -37,22 +37,21 @@ class BigQueryReadLogging : public BigQueryReadStub {
                       TracingOptions tracing_options,
                       std::set<std::string> components);
 
-  StatusOr<::google::cloud::bigquery::storage::v1::ReadSession>
-  CreateReadSession(
+  StatusOr<google::cloud::bigquery::storage::v1::ReadSession> CreateReadSession(
       grpc::ClientContext& context,
-      ::google::cloud::bigquery::storage::v1::CreateReadSessionRequest const&
+      google::cloud::bigquery::storage::v1::CreateReadSessionRequest const&
           request) override;
 
   std::unique_ptr<internal::StreamingReadRpc<
-      ::google::cloud::bigquery::storage::v1::ReadRowsResponse>>
+      google::cloud::bigquery::storage::v1::ReadRowsResponse>>
   ReadRows(std::unique_ptr<grpc::ClientContext> context,
-           ::google::cloud::bigquery::storage::v1::ReadRowsRequest const&
-               request) override;
+           google::cloud::bigquery::storage::v1::ReadRowsRequest const& request)
+      override;
 
-  StatusOr<::google::cloud::bigquery::storage::v1::SplitReadStreamResponse>
+  StatusOr<google::cloud::bigquery::storage::v1::SplitReadStreamResponse>
   SplitReadStream(
       grpc::ClientContext& context,
-      ::google::cloud::bigquery::storage::v1::SplitReadStreamRequest const&
+      google::cloud::bigquery::storage::v1::SplitReadStreamRequest const&
           request) override;
 
  private:

--- a/google/cloud/bigquery/internal/bigquery_read_metadata_decorator.cc
+++ b/google/cloud/bigquery/internal/bigquery_read_metadata_decorator.cc
@@ -31,28 +31,28 @@ BigQueryReadMetadata::BigQueryReadMetadata(
     : child_(std::move(child)),
       api_client_header_(google::cloud::internal::ApiClientHeader()) {}
 
-StatusOr<::google::cloud::bigquery::storage::v1::ReadSession>
+StatusOr<google::cloud::bigquery::storage::v1::ReadSession>
 BigQueryReadMetadata::CreateReadSession(
     grpc::ClientContext& context,
-    ::google::cloud::bigquery::storage::v1::CreateReadSessionRequest const&
+    google::cloud::bigquery::storage::v1::CreateReadSessionRequest const&
         request) {
   SetMetadata(context, "read_session.table=" + request.read_session().table());
   return child_->CreateReadSession(context, request);
 }
 
 std::unique_ptr<internal::StreamingReadRpc<
-    ::google::cloud::bigquery::storage::v1::ReadRowsResponse>>
+    google::cloud::bigquery::storage::v1::ReadRowsResponse>>
 BigQueryReadMetadata::ReadRows(
     std::unique_ptr<grpc::ClientContext> context,
-    ::google::cloud::bigquery::storage::v1::ReadRowsRequest const& request) {
+    google::cloud::bigquery::storage::v1::ReadRowsRequest const& request) {
   SetMetadata(*context, "read_stream=" + request.read_stream());
   return child_->ReadRows(std::move(context), request);
 }
 
-StatusOr<::google::cloud::bigquery::storage::v1::SplitReadStreamResponse>
+StatusOr<google::cloud::bigquery::storage::v1::SplitReadStreamResponse>
 BigQueryReadMetadata::SplitReadStream(
     grpc::ClientContext& context,
-    ::google::cloud::bigquery::storage::v1::SplitReadStreamRequest const&
+    google::cloud::bigquery::storage::v1::SplitReadStreamRequest const&
         request) {
   SetMetadata(context, "name=" + request.name());
   return child_->SplitReadStream(context, request);

--- a/google/cloud/bigquery/internal/bigquery_read_metadata_decorator.h
+++ b/google/cloud/bigquery/internal/bigquery_read_metadata_decorator.h
@@ -33,22 +33,21 @@ class BigQueryReadMetadata : public BigQueryReadStub {
   ~BigQueryReadMetadata() override = default;
   explicit BigQueryReadMetadata(std::shared_ptr<BigQueryReadStub> child);
 
-  StatusOr<::google::cloud::bigquery::storage::v1::ReadSession>
-  CreateReadSession(
+  StatusOr<google::cloud::bigquery::storage::v1::ReadSession> CreateReadSession(
       grpc::ClientContext& context,
-      ::google::cloud::bigquery::storage::v1::CreateReadSessionRequest const&
+      google::cloud::bigquery::storage::v1::CreateReadSessionRequest const&
           request) override;
 
   std::unique_ptr<internal::StreamingReadRpc<
-      ::google::cloud::bigquery::storage::v1::ReadRowsResponse>>
+      google::cloud::bigquery::storage::v1::ReadRowsResponse>>
   ReadRows(std::unique_ptr<grpc::ClientContext> context,
-           ::google::cloud::bigquery::storage::v1::ReadRowsRequest const&
-               request) override;
+           google::cloud::bigquery::storage::v1::ReadRowsRequest const& request)
+      override;
 
-  StatusOr<::google::cloud::bigquery::storage::v1::SplitReadStreamResponse>
+  StatusOr<google::cloud::bigquery::storage::v1::SplitReadStreamResponse>
   SplitReadStream(
       grpc::ClientContext& context,
-      ::google::cloud::bigquery::storage::v1::SplitReadStreamRequest const&
+      google::cloud::bigquery::storage::v1::SplitReadStreamRequest const&
           request) override;
 
  private:

--- a/google/cloud/bigquery/internal/bigquery_read_stub.cc
+++ b/google/cloud/bigquery/internal/bigquery_read_stub.cc
@@ -30,12 +30,12 @@ inline namespace GOOGLE_CLOUD_CPP_GENERATED_NS {
 
 BigQueryReadStub::~BigQueryReadStub() = default;
 
-StatusOr<::google::cloud::bigquery::storage::v1::ReadSession>
+StatusOr<google::cloud::bigquery::storage::v1::ReadSession>
 DefaultBigQueryReadStub::CreateReadSession(
     grpc::ClientContext& client_context,
-    ::google::cloud::bigquery::storage::v1::CreateReadSessionRequest const&
+    google::cloud::bigquery::storage::v1::CreateReadSessionRequest const&
         request) {
-  ::google::cloud::bigquery::storage::v1::ReadSession response;
+  google::cloud::bigquery::storage::v1::ReadSession response;
   auto status =
       grpc_stub_->CreateReadSession(&client_context, request, &response);
   if (!status.ok()) {
@@ -45,22 +45,22 @@ DefaultBigQueryReadStub::CreateReadSession(
 }
 
 std::unique_ptr<internal::StreamingReadRpc<
-    ::google::cloud::bigquery::storage::v1::ReadRowsResponse>>
+    google::cloud::bigquery::storage::v1::ReadRowsResponse>>
 DefaultBigQueryReadStub::ReadRows(
     std::unique_ptr<grpc::ClientContext> client_context,
-    ::google::cloud::bigquery::storage::v1::ReadRowsRequest const& request) {
+    google::cloud::bigquery::storage::v1::ReadRowsRequest const& request) {
   auto stream = grpc_stub_->ReadRows(client_context.get(), request);
   return absl::make_unique<internal::StreamingReadRpcImpl<
-      ::google::cloud::bigquery::storage::v1::ReadRowsResponse>>(
+      google::cloud::bigquery::storage::v1::ReadRowsResponse>>(
       std::move(client_context), std::move(stream));
 }
 
-StatusOr<::google::cloud::bigquery::storage::v1::SplitReadStreamResponse>
+StatusOr<google::cloud::bigquery::storage::v1::SplitReadStreamResponse>
 DefaultBigQueryReadStub::SplitReadStream(
     grpc::ClientContext& client_context,
-    ::google::cloud::bigquery::storage::v1::SplitReadStreamRequest const&
+    google::cloud::bigquery::storage::v1::SplitReadStreamRequest const&
         request) {
-  ::google::cloud::bigquery::storage::v1::SplitReadStreamResponse response;
+  google::cloud::bigquery::storage::v1::SplitReadStreamResponse response;
   auto status =
       grpc_stub_->SplitReadStream(&client_context, request, &response);
   if (!status.ok()) {

--- a/google/cloud/bigquery/internal/bigquery_read_stub.h
+++ b/google/cloud/bigquery/internal/bigquery_read_stub.h
@@ -33,23 +33,23 @@ class BigQueryReadStub {
  public:
   virtual ~BigQueryReadStub() = 0;
 
-  virtual StatusOr<::google::cloud::bigquery::storage::v1::ReadSession>
+  virtual StatusOr<google::cloud::bigquery::storage::v1::ReadSession>
   CreateReadSession(
       grpc::ClientContext& context,
-      ::google::cloud::bigquery::storage::v1::CreateReadSessionRequest const&
+      google::cloud::bigquery::storage::v1::CreateReadSessionRequest const&
           request) = 0;
 
   virtual std::unique_ptr<internal::StreamingReadRpc<
-      ::google::cloud::bigquery::storage::v1::ReadRowsResponse>>
-  ReadRows(std::unique_ptr<grpc::ClientContext> context,
-           ::google::cloud::bigquery::storage::v1::ReadRowsRequest const&
-               request) = 0;
+      google::cloud::bigquery::storage::v1::ReadRowsResponse>>
+  ReadRows(
+      std::unique_ptr<grpc::ClientContext> context,
+      google::cloud::bigquery::storage::v1::ReadRowsRequest const& request) = 0;
 
   virtual StatusOr<
-      ::google::cloud::bigquery::storage::v1::SplitReadStreamResponse>
+      google::cloud::bigquery::storage::v1::SplitReadStreamResponse>
   SplitReadStream(
       grpc::ClientContext& context,
-      ::google::cloud::bigquery::storage::v1::SplitReadStreamRequest const&
+      google::cloud::bigquery::storage::v1::SplitReadStreamRequest const&
           request) = 0;
 };
 
@@ -57,31 +57,30 @@ class DefaultBigQueryReadStub : public BigQueryReadStub {
  public:
   explicit DefaultBigQueryReadStub(
       std::unique_ptr<
-          ::google::cloud::bigquery::storage::v1::BigQueryRead::StubInterface>
+          google::cloud::bigquery::storage::v1::BigQueryRead::StubInterface>
           grpc_stub)
       : grpc_stub_(std::move(grpc_stub)) {}
 
-  StatusOr<::google::cloud::bigquery::storage::v1::ReadSession>
-  CreateReadSession(
+  StatusOr<google::cloud::bigquery::storage::v1::ReadSession> CreateReadSession(
       grpc::ClientContext& client_context,
-      ::google::cloud::bigquery::storage::v1::CreateReadSessionRequest const&
+      google::cloud::bigquery::storage::v1::CreateReadSessionRequest const&
           request) override;
 
   std::unique_ptr<internal::StreamingReadRpc<
-      ::google::cloud::bigquery::storage::v1::ReadRowsResponse>>
+      google::cloud::bigquery::storage::v1::ReadRowsResponse>>
   ReadRows(std::unique_ptr<grpc::ClientContext> client_context,
-           ::google::cloud::bigquery::storage::v1::ReadRowsRequest const&
-               request) override;
+           google::cloud::bigquery::storage::v1::ReadRowsRequest const& request)
+      override;
 
-  StatusOr<::google::cloud::bigquery::storage::v1::SplitReadStreamResponse>
+  StatusOr<google::cloud::bigquery::storage::v1::SplitReadStreamResponse>
   SplitReadStream(
       grpc::ClientContext& client_context,
-      ::google::cloud::bigquery::storage::v1::SplitReadStreamRequest const&
+      google::cloud::bigquery::storage::v1::SplitReadStreamRequest const&
           request) override;
 
  private:
   std::unique_ptr<
-      ::google::cloud::bigquery::storage::v1::BigQueryRead::StubInterface>
+      google::cloud::bigquery::storage::v1::BigQueryRead::StubInterface>
       grpc_stub_;
 };
 

--- a/google/cloud/bigquery/internal/bigquery_read_stub_factory.cc
+++ b/google/cloud/bigquery/internal/bigquery_read_stub_factory.cc
@@ -38,7 +38,7 @@ std::shared_ptr<BigQueryReadStub> CreateDefaultBigQueryReadStub(
       options.get<EndpointOption>(), options.get<GrpcCredentialOption>(),
       internal::MakeChannelArguments(options));
   auto service_grpc_stub =
-      ::google::cloud::bigquery::storage::v1::BigQueryRead::NewStub(channel);
+      google::cloud::bigquery::storage::v1::BigQueryRead::NewStub(channel);
   std::shared_ptr<BigQueryReadStub> stub =
       std::make_shared<DefaultBigQueryReadStub>(std::move(service_grpc_stub));
 

--- a/google/cloud/bigquery/mocks/mock_bigquery_read_connection.h
+++ b/google/cloud/bigquery/mocks/mock_bigquery_read_connection.h
@@ -29,22 +29,22 @@ inline namespace GOOGLE_CLOUD_CPP_GENERATED_NS {
 class MockBigQueryReadConnection : public bigquery::BigQueryReadConnection {
  public:
   MOCK_METHOD(
-      StatusOr<::google::cloud::bigquery::storage::v1::ReadSession>,
+      StatusOr<google::cloud::bigquery::storage::v1::ReadSession>,
       CreateReadSession,
-      (::google::cloud::bigquery::storage::v1::CreateReadSessionRequest const&
+      (google::cloud::bigquery::storage::v1::CreateReadSessionRequest const&
            request),
       (override));
 
   MOCK_METHOD(
-      StreamRange<::google::cloud::bigquery::storage::v1::ReadRowsResponse>,
+      StreamRange<google::cloud::bigquery::storage::v1::ReadRowsResponse>,
       ReadRows,
-      (::google::cloud::bigquery::storage::v1::ReadRowsRequest const& request),
+      (google::cloud::bigquery::storage::v1::ReadRowsRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<::google::cloud::bigquery::storage::v1::SplitReadStreamResponse>,
+      StatusOr<google::cloud::bigquery::storage::v1::SplitReadStreamResponse>,
       SplitReadStream,
-      (::google::cloud::bigquery::storage::v1::SplitReadStreamRequest const&
+      (google::cloud::bigquery::storage::v1::SplitReadStreamRequest const&
            request),
       (override));
 };

--- a/google/cloud/iam/iam_client.cc
+++ b/google/cloud/iam/iam_client.cc
@@ -28,25 +28,25 @@ IAMClient::IAMClient(std::shared_ptr<IAMConnection> connection)
     : connection_(std::move(connection)) {}
 IAMClient::~IAMClient() = default;
 
-StreamRange<::google::iam::admin::v1::ServiceAccount>
+StreamRange<google::iam::admin::v1::ServiceAccount>
 IAMClient::ListServiceAccounts(std::string const& name) {
-  ::google::iam::admin::v1::ListServiceAccountsRequest request;
+  google::iam::admin::v1::ListServiceAccountsRequest request;
   request.set_name(name);
   return connection_->ListServiceAccounts(request);
 }
 
-StatusOr<::google::iam::admin::v1::ServiceAccount> IAMClient::GetServiceAccount(
+StatusOr<google::iam::admin::v1::ServiceAccount> IAMClient::GetServiceAccount(
     std::string const& name) {
-  ::google::iam::admin::v1::GetServiceAccountRequest request;
+  google::iam::admin::v1::GetServiceAccountRequest request;
   request.set_name(name);
   return connection_->GetServiceAccount(request);
 }
 
-StatusOr<::google::iam::admin::v1::ServiceAccount>
+StatusOr<google::iam::admin::v1::ServiceAccount>
 IAMClient::CreateServiceAccount(
     std::string const& name, std::string const& account_id,
-    ::google::iam::admin::v1::ServiceAccount const& service_account) {
-  ::google::iam::admin::v1::CreateServiceAccountRequest request;
+    google::iam::admin::v1::ServiceAccount const& service_account) {
+  google::iam::admin::v1::CreateServiceAccountRequest request;
   request.set_name(name);
   request.set_account_id(account_id);
   *request.mutable_service_account() = service_account;
@@ -54,39 +54,39 @@ IAMClient::CreateServiceAccount(
 }
 
 Status IAMClient::DeleteServiceAccount(std::string const& name) {
-  ::google::iam::admin::v1::DeleteServiceAccountRequest request;
+  google::iam::admin::v1::DeleteServiceAccountRequest request;
   request.set_name(name);
   return connection_->DeleteServiceAccount(request);
 }
 
-StatusOr<::google::iam::admin::v1::ListServiceAccountKeysResponse>
+StatusOr<google::iam::admin::v1::ListServiceAccountKeysResponse>
 IAMClient::ListServiceAccountKeys(
     std::string const& name,
     std::vector<
-        ::google::iam::admin::v1::ListServiceAccountKeysRequest::KeyType> const&
+        google::iam::admin::v1::ListServiceAccountKeysRequest::KeyType> const&
         key_types) {
-  ::google::iam::admin::v1::ListServiceAccountKeysRequest request;
+  google::iam::admin::v1::ListServiceAccountKeysRequest request;
   request.set_name(name);
   *request.mutable_key_types() = {key_types.begin(), key_types.end()};
   return connection_->ListServiceAccountKeys(request);
 }
 
-StatusOr<::google::iam::admin::v1::ServiceAccountKey>
+StatusOr<google::iam::admin::v1::ServiceAccountKey>
 IAMClient::GetServiceAccountKey(
     std::string const& name,
-    ::google::iam::admin::v1::ServiceAccountPublicKeyType public_key_type) {
-  ::google::iam::admin::v1::GetServiceAccountKeyRequest request;
+    google::iam::admin::v1::ServiceAccountPublicKeyType public_key_type) {
+  google::iam::admin::v1::GetServiceAccountKeyRequest request;
   request.set_name(name);
   request.set_public_key_type(public_key_type);
   return connection_->GetServiceAccountKey(request);
 }
 
-StatusOr<::google::iam::admin::v1::ServiceAccountKey>
+StatusOr<google::iam::admin::v1::ServiceAccountKey>
 IAMClient::CreateServiceAccountKey(
     std::string const& name,
-    ::google::iam::admin::v1::ServiceAccountPrivateKeyType private_key_type,
-    ::google::iam::admin::v1::ServiceAccountKeyAlgorithm key_algorithm) {
-  ::google::iam::admin::v1::CreateServiceAccountKeyRequest request;
+    google::iam::admin::v1::ServiceAccountPrivateKeyType private_key_type,
+    google::iam::admin::v1::ServiceAccountKeyAlgorithm key_algorithm) {
+  google::iam::admin::v1::CreateServiceAccountKeyRequest request;
   request.set_name(name);
   request.set_private_key_type(private_key_type);
   request.set_key_algorithm(key_algorithm);
@@ -94,180 +94,179 @@ IAMClient::CreateServiceAccountKey(
 }
 
 Status IAMClient::DeleteServiceAccountKey(std::string const& name) {
-  ::google::iam::admin::v1::DeleteServiceAccountKeyRequest request;
+  google::iam::admin::v1::DeleteServiceAccountKeyRequest request;
   request.set_name(name);
   return connection_->DeleteServiceAccountKey(request);
 }
 
-StatusOr<::google::iam::v1::Policy> IAMClient::GetIamPolicy(
+StatusOr<google::iam::v1::Policy> IAMClient::GetIamPolicy(
     std::string const& resource) {
-  ::google::iam::v1::GetIamPolicyRequest request;
+  google::iam::v1::GetIamPolicyRequest request;
   request.set_resource(resource);
   return connection_->GetIamPolicy(request);
 }
 
-StatusOr<::google::iam::v1::Policy> IAMClient::SetIamPolicy(
-    std::string const& resource, ::google::iam::v1::Policy const& policy) {
-  ::google::iam::v1::SetIamPolicyRequest request;
+StatusOr<google::iam::v1::Policy> IAMClient::SetIamPolicy(
+    std::string const& resource, google::iam::v1::Policy const& policy) {
+  google::iam::v1::SetIamPolicyRequest request;
   request.set_resource(resource);
   *request.mutable_policy() = policy;
   return connection_->SetIamPolicy(request);
 }
 
-StatusOr<::google::iam::v1::TestIamPermissionsResponse>
+StatusOr<google::iam::v1::TestIamPermissionsResponse>
 IAMClient::TestIamPermissions(std::string const& resource,
                               std::vector<std::string> const& permissions) {
-  ::google::iam::v1::TestIamPermissionsRequest request;
+  google::iam::v1::TestIamPermissionsRequest request;
   request.set_resource(resource);
   *request.mutable_permissions() = {permissions.begin(), permissions.end()};
   return connection_->TestIamPermissions(request);
 }
 
-StreamRange<::google::iam::admin::v1::Role> IAMClient::QueryGrantableRoles(
+StreamRange<google::iam::admin::v1::Role> IAMClient::QueryGrantableRoles(
     std::string const& full_resource_name) {
-  ::google::iam::admin::v1::QueryGrantableRolesRequest request;
+  google::iam::admin::v1::QueryGrantableRolesRequest request;
   request.set_full_resource_name(full_resource_name);
   return connection_->QueryGrantableRoles(request);
 }
 
-StreamRange<::google::iam::admin::v1::ServiceAccount>
+StreamRange<google::iam::admin::v1::ServiceAccount>
 IAMClient::ListServiceAccounts(
-    ::google::iam::admin::v1::ListServiceAccountsRequest request) {
+    google::iam::admin::v1::ListServiceAccountsRequest request) {
   return connection_->ListServiceAccounts(std::move(request));
 }
 
-StatusOr<::google::iam::admin::v1::ServiceAccount> IAMClient::GetServiceAccount(
-    ::google::iam::admin::v1::GetServiceAccountRequest const& request) {
+StatusOr<google::iam::admin::v1::ServiceAccount> IAMClient::GetServiceAccount(
+    google::iam::admin::v1::GetServiceAccountRequest const& request) {
   return connection_->GetServiceAccount(request);
 }
 
-StatusOr<::google::iam::admin::v1::ServiceAccount>
+StatusOr<google::iam::admin::v1::ServiceAccount>
 IAMClient::CreateServiceAccount(
-    ::google::iam::admin::v1::CreateServiceAccountRequest const& request) {
+    google::iam::admin::v1::CreateServiceAccountRequest const& request) {
   return connection_->CreateServiceAccount(request);
 }
 
-StatusOr<::google::iam::admin::v1::ServiceAccount>
-IAMClient::PatchServiceAccount(
-    ::google::iam::admin::v1::PatchServiceAccountRequest const& request) {
+StatusOr<google::iam::admin::v1::ServiceAccount> IAMClient::PatchServiceAccount(
+    google::iam::admin::v1::PatchServiceAccountRequest const& request) {
   return connection_->PatchServiceAccount(request);
 }
 
 Status IAMClient::DeleteServiceAccount(
-    ::google::iam::admin::v1::DeleteServiceAccountRequest const& request) {
+    google::iam::admin::v1::DeleteServiceAccountRequest const& request) {
   return connection_->DeleteServiceAccount(request);
 }
 
-StatusOr<::google::iam::admin::v1::UndeleteServiceAccountResponse>
+StatusOr<google::iam::admin::v1::UndeleteServiceAccountResponse>
 IAMClient::UndeleteServiceAccount(
-    ::google::iam::admin::v1::UndeleteServiceAccountRequest const& request) {
+    google::iam::admin::v1::UndeleteServiceAccountRequest const& request) {
   return connection_->UndeleteServiceAccount(request);
 }
 
 Status IAMClient::EnableServiceAccount(
-    ::google::iam::admin::v1::EnableServiceAccountRequest const& request) {
+    google::iam::admin::v1::EnableServiceAccountRequest const& request) {
   return connection_->EnableServiceAccount(request);
 }
 
 Status IAMClient::DisableServiceAccount(
-    ::google::iam::admin::v1::DisableServiceAccountRequest const& request) {
+    google::iam::admin::v1::DisableServiceAccountRequest const& request) {
   return connection_->DisableServiceAccount(request);
 }
 
-StatusOr<::google::iam::admin::v1::ListServiceAccountKeysResponse>
+StatusOr<google::iam::admin::v1::ListServiceAccountKeysResponse>
 IAMClient::ListServiceAccountKeys(
-    ::google::iam::admin::v1::ListServiceAccountKeysRequest const& request) {
+    google::iam::admin::v1::ListServiceAccountKeysRequest const& request) {
   return connection_->ListServiceAccountKeys(request);
 }
 
-StatusOr<::google::iam::admin::v1::ServiceAccountKey>
+StatusOr<google::iam::admin::v1::ServiceAccountKey>
 IAMClient::GetServiceAccountKey(
-    ::google::iam::admin::v1::GetServiceAccountKeyRequest const& request) {
+    google::iam::admin::v1::GetServiceAccountKeyRequest const& request) {
   return connection_->GetServiceAccountKey(request);
 }
 
-StatusOr<::google::iam::admin::v1::ServiceAccountKey>
+StatusOr<google::iam::admin::v1::ServiceAccountKey>
 IAMClient::CreateServiceAccountKey(
-    ::google::iam::admin::v1::CreateServiceAccountKeyRequest const& request) {
+    google::iam::admin::v1::CreateServiceAccountKeyRequest const& request) {
   return connection_->CreateServiceAccountKey(request);
 }
 
-StatusOr<::google::iam::admin::v1::ServiceAccountKey>
+StatusOr<google::iam::admin::v1::ServiceAccountKey>
 IAMClient::UploadServiceAccountKey(
-    ::google::iam::admin::v1::UploadServiceAccountKeyRequest const& request) {
+    google::iam::admin::v1::UploadServiceAccountKeyRequest const& request) {
   return connection_->UploadServiceAccountKey(request);
 }
 
 Status IAMClient::DeleteServiceAccountKey(
-    ::google::iam::admin::v1::DeleteServiceAccountKeyRequest const& request) {
+    google::iam::admin::v1::DeleteServiceAccountKeyRequest const& request) {
   return connection_->DeleteServiceAccountKey(request);
 }
 
-StatusOr<::google::iam::v1::Policy> IAMClient::GetIamPolicy(
-    ::google::iam::v1::GetIamPolicyRequest const& request) {
+StatusOr<google::iam::v1::Policy> IAMClient::GetIamPolicy(
+    google::iam::v1::GetIamPolicyRequest const& request) {
   return connection_->GetIamPolicy(request);
 }
 
-StatusOr<::google::iam::v1::Policy> IAMClient::SetIamPolicy(
-    ::google::iam::v1::SetIamPolicyRequest const& request) {
+StatusOr<google::iam::v1::Policy> IAMClient::SetIamPolicy(
+    google::iam::v1::SetIamPolicyRequest const& request) {
   return connection_->SetIamPolicy(request);
 }
 
-StatusOr<::google::iam::v1::TestIamPermissionsResponse>
+StatusOr<google::iam::v1::TestIamPermissionsResponse>
 IAMClient::TestIamPermissions(
-    ::google::iam::v1::TestIamPermissionsRequest const& request) {
+    google::iam::v1::TestIamPermissionsRequest const& request) {
   return connection_->TestIamPermissions(request);
 }
 
-StreamRange<::google::iam::admin::v1::Role> IAMClient::QueryGrantableRoles(
-    ::google::iam::admin::v1::QueryGrantableRolesRequest request) {
+StreamRange<google::iam::admin::v1::Role> IAMClient::QueryGrantableRoles(
+    google::iam::admin::v1::QueryGrantableRolesRequest request) {
   return connection_->QueryGrantableRoles(std::move(request));
 }
 
-StreamRange<::google::iam::admin::v1::Role> IAMClient::ListRoles(
-    ::google::iam::admin::v1::ListRolesRequest request) {
+StreamRange<google::iam::admin::v1::Role> IAMClient::ListRoles(
+    google::iam::admin::v1::ListRolesRequest request) {
   return connection_->ListRoles(std::move(request));
 }
 
-StatusOr<::google::iam::admin::v1::Role> IAMClient::GetRole(
-    ::google::iam::admin::v1::GetRoleRequest const& request) {
+StatusOr<google::iam::admin::v1::Role> IAMClient::GetRole(
+    google::iam::admin::v1::GetRoleRequest const& request) {
   return connection_->GetRole(request);
 }
 
-StatusOr<::google::iam::admin::v1::Role> IAMClient::CreateRole(
-    ::google::iam::admin::v1::CreateRoleRequest const& request) {
+StatusOr<google::iam::admin::v1::Role> IAMClient::CreateRole(
+    google::iam::admin::v1::CreateRoleRequest const& request) {
   return connection_->CreateRole(request);
 }
 
-StatusOr<::google::iam::admin::v1::Role> IAMClient::UpdateRole(
-    ::google::iam::admin::v1::UpdateRoleRequest const& request) {
+StatusOr<google::iam::admin::v1::Role> IAMClient::UpdateRole(
+    google::iam::admin::v1::UpdateRoleRequest const& request) {
   return connection_->UpdateRole(request);
 }
 
-StatusOr<::google::iam::admin::v1::Role> IAMClient::DeleteRole(
-    ::google::iam::admin::v1::DeleteRoleRequest const& request) {
+StatusOr<google::iam::admin::v1::Role> IAMClient::DeleteRole(
+    google::iam::admin::v1::DeleteRoleRequest const& request) {
   return connection_->DeleteRole(request);
 }
 
-StatusOr<::google::iam::admin::v1::Role> IAMClient::UndeleteRole(
-    ::google::iam::admin::v1::UndeleteRoleRequest const& request) {
+StatusOr<google::iam::admin::v1::Role> IAMClient::UndeleteRole(
+    google::iam::admin::v1::UndeleteRoleRequest const& request) {
   return connection_->UndeleteRole(request);
 }
 
-StreamRange<::google::iam::admin::v1::Permission>
+StreamRange<google::iam::admin::v1::Permission>
 IAMClient::QueryTestablePermissions(
-    ::google::iam::admin::v1::QueryTestablePermissionsRequest request) {
+    google::iam::admin::v1::QueryTestablePermissionsRequest request) {
   return connection_->QueryTestablePermissions(std::move(request));
 }
 
-StatusOr<::google::iam::admin::v1::QueryAuditableServicesResponse>
+StatusOr<google::iam::admin::v1::QueryAuditableServicesResponse>
 IAMClient::QueryAuditableServices(
-    ::google::iam::admin::v1::QueryAuditableServicesRequest const& request) {
+    google::iam::admin::v1::QueryAuditableServicesRequest const& request) {
   return connection_->QueryAuditableServices(request);
 }
 
-StatusOr<::google::iam::admin::v1::LintPolicyResponse> IAMClient::LintPolicy(
-    ::google::iam::admin::v1::LintPolicyRequest const& request) {
+StatusOr<google::iam::admin::v1::LintPolicyResponse> IAMClient::LintPolicy(
+    google::iam::admin::v1::LintPolicyRequest const& request) {
   return connection_->LintPolicy(request);
 }
 

--- a/google/cloud/iam/iam_client.h
+++ b/google/cloud/iam/iam_client.h
@@ -81,7 +81,7 @@ class IAMClient {
    * @param name  Required. The resource name of the project associated with the
    * service accounts, such as `projects/my-project-123`.
    */
-  StreamRange<::google::iam::admin::v1::ServiceAccount> ListServiceAccounts(
+  StreamRange<google::iam::admin::v1::ServiceAccount> ListServiceAccounts(
       std::string const& name);
 
   /**
@@ -93,9 +93,9 @@ class IAMClient {
    * account. The `ACCOUNT` value can be the `email` address or the `unique_id`
    * of the service account.
    * @return
-   * [::google::iam::admin::v1::ServiceAccount](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/admin/v1/iam.proto#L457)
+   * [google::iam::admin::v1::ServiceAccount](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/admin/v1/iam.proto#L457)
    */
-  StatusOr<::google::iam::admin::v1::ServiceAccount> GetServiceAccount(
+  StatusOr<google::iam::admin::v1::ServiceAccount> GetServiceAccount(
       std::string const& name);
 
   /**
@@ -112,11 +112,11 @@ class IAMClient {
    * Currently, only the following values are user assignable: `display_name`
    * and `description`.
    * @return
-   * [::google::iam::admin::v1::ServiceAccount](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/admin/v1/iam.proto#L457)
+   * [google::iam::admin::v1::ServiceAccount](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/admin/v1/iam.proto#L457)
    */
-  StatusOr<::google::iam::admin::v1::ServiceAccount> CreateServiceAccount(
+  StatusOr<google::iam::admin::v1::ServiceAccount> CreateServiceAccount(
       std::string const& name, std::string const& account_id,
-      ::google::iam::admin::v1::ServiceAccount const& service_account);
+      google::iam::admin::v1::ServiceAccount const& service_account);
 
   /**
    * Deletes a [ServiceAccount][google.iam.admin.v1.ServiceAccount].
@@ -159,13 +159,14 @@ class IAMClient {
    * the list response. Duplicate key types are not allowed. If no key type is
    * provided, all keys are returned.
    * @return
-   * [::google::iam::admin::v1::ListServiceAccountKeysResponse](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/admin/v1/iam.proto#L688)
+   * [google::iam::admin::v1::ListServiceAccountKeysResponse](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/admin/v1/iam.proto#L688)
    */
-  StatusOr<::google::iam::admin::v1::ListServiceAccountKeysResponse>
+  StatusOr<google::iam::admin::v1::ListServiceAccountKeysResponse>
   ListServiceAccountKeys(
       std::string const& name,
-      std::vector<::google::iam::admin::v1::ListServiceAccountKeysRequest::
-                      KeyType> const& key_types);
+      std::vector<
+          google::iam::admin::v1::ListServiceAccountKeysRequest::KeyType> const&
+          key_types);
 
   /**
    * Gets a [ServiceAccountKey][google.iam.admin.v1.ServiceAccountKey].
@@ -179,11 +180,11 @@ class IAMClient {
    * @param public_key_type  The output format of the public key requested.
    *  X509_PEM is the default output format.
    * @return
-   * [::google::iam::admin::v1::ServiceAccountKey](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/admin/v1/iam.proto#L737)
+   * [google::iam::admin::v1::ServiceAccountKey](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/admin/v1/iam.proto#L737)
    */
-  StatusOr<::google::iam::admin::v1::ServiceAccountKey> GetServiceAccountKey(
+  StatusOr<google::iam::admin::v1::ServiceAccountKey> GetServiceAccountKey(
       std::string const& name,
-      ::google::iam::admin::v1::ServiceAccountPublicKeyType public_key_type);
+      google::iam::admin::v1::ServiceAccountPublicKeyType public_key_type);
 
   /**
    * Creates a [ServiceAccountKey][google.iam.admin.v1.ServiceAccountKey].
@@ -200,12 +201,12 @@ class IAMClient {
    *  The default is currently a 2K RSA key.  However this may change in the
    *  future.
    * @return
-   * [::google::iam::admin::v1::ServiceAccountKey](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/admin/v1/iam.proto#L737)
+   * [google::iam::admin::v1::ServiceAccountKey](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/admin/v1/iam.proto#L737)
    */
-  StatusOr<::google::iam::admin::v1::ServiceAccountKey> CreateServiceAccountKey(
+  StatusOr<google::iam::admin::v1::ServiceAccountKey> CreateServiceAccountKey(
       std::string const& name,
-      ::google::iam::admin::v1::ServiceAccountPrivateKeyType private_key_type,
-      ::google::iam::admin::v1::ServiceAccountKeyAlgorithm key_algorithm);
+      google::iam::admin::v1::ServiceAccountPrivateKeyType private_key_type,
+      google::iam::admin::v1::ServiceAccountKeyAlgorithm key_algorithm);
 
   /**
    * Deletes a [ServiceAccountKey][google.iam.admin.v1.ServiceAccountKey].
@@ -238,9 +239,9 @@ class IAMClient {
    * requested. See the operation documentation for the appropriate value for
    * this field.
    * @return
-   * [::google::iam::v1::Policy](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/v1/policy.proto#L88)
+   * [google::iam::v1::Policy](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/v1/policy.proto#L88)
    */
-  StatusOr<::google::iam::v1::Policy> GetIamPolicy(std::string const& resource);
+  StatusOr<google::iam::v1::Policy> GetIamPolicy(std::string const& resource);
 
   /**
    * Sets the IAM policy that is attached to a
@@ -270,10 +271,10 @@ class IAMClient {
    * policy is a valid policy but certain Cloud Platform services (such as
    * Projects) might reject them.
    * @return
-   * [::google::iam::v1::Policy](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/v1/policy.proto#L88)
+   * [google::iam::v1::Policy](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/v1/policy.proto#L88)
    */
-  StatusOr<::google::iam::v1::Policy> SetIamPolicy(
-      std::string const& resource, ::google::iam::v1::Policy const& policy);
+  StatusOr<google::iam::v1::Policy> SetIamPolicy(
+      std::string const& resource, google::iam::v1::Policy const& policy);
 
   /**
    * Tests whether the caller has the specified permissions on a
@@ -287,9 +288,9 @@ class IAMClient {
    * For more information see [IAM
    * Overview](https://cloud.google.com/iam/docs/overview#permissions).
    * @return
-   * [::google::iam::v1::TestIamPermissionsResponse](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/v1/iam_policy.proto#L141)
+   * [google::iam::v1::TestIamPermissionsResponse](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/v1/iam_policy.proto#L141)
    */
-  StatusOr<::google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
+  StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
       std::string const& resource, std::vector<std::string> const& permissions);
 
   /**
@@ -303,7 +304,7 @@ class IAMClient {
    * will be named
    *  `//cloudresourcemanager.googleapis.com/projects/my-project`.
    */
-  StreamRange<::google::iam::admin::v1::Role> QueryGrantableRoles(
+  StreamRange<google::iam::admin::v1::Role> QueryGrantableRoles(
       std::string const& full_resource_name);
 
   /**
@@ -311,43 +312,43 @@ class IAMClient {
    * belongs to a specific project.
    *
    * @param request
-   * [::google::iam::admin::v1::ListServiceAccountsRequest](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/admin/v1/iam.proto#L540)
+   * [google::iam::admin::v1::ListServiceAccountsRequest](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/admin/v1/iam.proto#L540)
    */
-  StreamRange<::google::iam::admin::v1::ServiceAccount> ListServiceAccounts(
-      ::google::iam::admin::v1::ListServiceAccountsRequest request);
+  StreamRange<google::iam::admin::v1::ServiceAccount> ListServiceAccounts(
+      google::iam::admin::v1::ListServiceAccountsRequest request);
 
   /**
    * Gets a [ServiceAccount][google.iam.admin.v1.ServiceAccount].
    *
    * @param request
-   * [::google::iam::admin::v1::GetServiceAccountRequest](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/admin/v1/iam.proto#L575)
+   * [google::iam::admin::v1::GetServiceAccountRequest](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/admin/v1/iam.proto#L575)
    * @return
-   * [::google::iam::admin::v1::ServiceAccount](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/admin/v1/iam.proto#L457)
+   * [google::iam::admin::v1::ServiceAccount](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/admin/v1/iam.proto#L457)
    */
-  StatusOr<::google::iam::admin::v1::ServiceAccount> GetServiceAccount(
-      ::google::iam::admin::v1::GetServiceAccountRequest const& request);
+  StatusOr<google::iam::admin::v1::ServiceAccount> GetServiceAccount(
+      google::iam::admin::v1::GetServiceAccountRequest const& request);
 
   /**
    * Creates a [ServiceAccount][google.iam.admin.v1.ServiceAccount].
    *
    * @param request
-   * [::google::iam::admin::v1::CreateServiceAccountRequest](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/admin/v1/iam.proto#L517)
+   * [google::iam::admin::v1::CreateServiceAccountRequest](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/admin/v1/iam.proto#L517)
    * @return
-   * [::google::iam::admin::v1::ServiceAccount](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/admin/v1/iam.proto#L457)
+   * [google::iam::admin::v1::ServiceAccount](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/admin/v1/iam.proto#L457)
    */
-  StatusOr<::google::iam::admin::v1::ServiceAccount> CreateServiceAccount(
-      ::google::iam::admin::v1::CreateServiceAccountRequest const& request);
+  StatusOr<google::iam::admin::v1::ServiceAccount> CreateServiceAccount(
+      google::iam::admin::v1::CreateServiceAccountRequest const& request);
 
   /**
    * Patches a [ServiceAccount][google.iam.admin.v1.ServiceAccount].
    *
    * @param request
-   * [::google::iam::admin::v1::PatchServiceAccountRequest](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/admin/v1/iam.proto#L612)
+   * [google::iam::admin::v1::PatchServiceAccountRequest](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/admin/v1/iam.proto#L612)
    * @return
-   * [::google::iam::admin::v1::ServiceAccount](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/admin/v1/iam.proto#L457)
+   * [google::iam::admin::v1::ServiceAccount](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/admin/v1/iam.proto#L457)
    */
-  StatusOr<::google::iam::admin::v1::ServiceAccount> PatchServiceAccount(
-      ::google::iam::admin::v1::PatchServiceAccountRequest const& request);
+  StatusOr<google::iam::admin::v1::ServiceAccount> PatchServiceAccount(
+      google::iam::admin::v1::PatchServiceAccountRequest const& request);
 
   /**
    * Deletes a [ServiceAccount][google.iam.admin.v1.ServiceAccount].
@@ -370,10 +371,10 @@ class IAMClient {
    * delete the service account.
    *
    * @param request
-   * [::google::iam::admin::v1::DeleteServiceAccountRequest](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/admin/v1/iam.proto#L590)
+   * [google::iam::admin::v1::DeleteServiceAccountRequest](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/admin/v1/iam.proto#L590)
    */
   Status DeleteServiceAccount(
-      ::google::iam::admin::v1::DeleteServiceAccountRequest const& request);
+      google::iam::admin::v1::DeleteServiceAccountRequest const& request);
 
   /**
    * Restores a deleted [ServiceAccount][google.iam.admin.v1.ServiceAccount].
@@ -386,13 +387,13 @@ class IAMClient {
    * that has been permanently removed.
    *
    * @param request
-   * [::google::iam::admin::v1::UndeleteServiceAccountRequest](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/admin/v1/iam.proto#L619)
+   * [google::iam::admin::v1::UndeleteServiceAccountRequest](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/admin/v1/iam.proto#L619)
    * @return
-   * [::google::iam::admin::v1::UndeleteServiceAccountResponse](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/admin/v1/iam.proto#L627)
+   * [google::iam::admin::v1::UndeleteServiceAccountResponse](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/admin/v1/iam.proto#L627)
    */
-  StatusOr<::google::iam::admin::v1::UndeleteServiceAccountResponse>
+  StatusOr<google::iam::admin::v1::UndeleteServiceAccountResponse>
   UndeleteServiceAccount(
-      ::google::iam::admin::v1::UndeleteServiceAccountRequest const& request);
+      google::iam::admin::v1::UndeleteServiceAccountRequest const& request);
 
   /**
    * Enables a [ServiceAccount][google.iam.admin.v1.ServiceAccount] that was
@@ -406,10 +407,10 @@ class IAMClient {
    * method to enable the service account.
    *
    * @param request
-   * [::google::iam::admin::v1::EnableServiceAccountRequest](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/admin/v1/iam.proto#L633)
+   * [google::iam::admin::v1::EnableServiceAccountRequest](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/admin/v1/iam.proto#L633)
    */
   Status EnableServiceAccount(
-      ::google::iam::admin::v1::EnableServiceAccountRequest const& request);
+      google::iam::admin::v1::EnableServiceAccountRequest const& request);
 
   /**
    * Disables a [ServiceAccount][google.iam.admin.v1.ServiceAccount]
@@ -432,57 +433,57 @@ class IAMClient {
    * with [DeleteServiceAccount][google.iam.admin.v1.IAM.DeleteServiceAccount].
    *
    * @param request
-   * [::google::iam::admin::v1::DisableServiceAccountRequest](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/admin/v1/iam.proto#L643)
+   * [google::iam::admin::v1::DisableServiceAccountRequest](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/admin/v1/iam.proto#L643)
    */
   Status DisableServiceAccount(
-      ::google::iam::admin::v1::DisableServiceAccountRequest const& request);
+      google::iam::admin::v1::DisableServiceAccountRequest const& request);
 
   /**
    * Lists every [ServiceAccountKey][google.iam.admin.v1.ServiceAccountKey] for
    * a service account.
    *
    * @param request
-   * [::google::iam::admin::v1::ListServiceAccountKeysRequest](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/admin/v1/iam.proto#L653)
+   * [google::iam::admin::v1::ListServiceAccountKeysRequest](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/admin/v1/iam.proto#L653)
    * @return
-   * [::google::iam::admin::v1::ListServiceAccountKeysResponse](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/admin/v1/iam.proto#L688)
+   * [google::iam::admin::v1::ListServiceAccountKeysResponse](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/admin/v1/iam.proto#L688)
    */
-  StatusOr<::google::iam::admin::v1::ListServiceAccountKeysResponse>
+  StatusOr<google::iam::admin::v1::ListServiceAccountKeysResponse>
   ListServiceAccountKeys(
-      ::google::iam::admin::v1::ListServiceAccountKeysRequest const& request);
+      google::iam::admin::v1::ListServiceAccountKeysRequest const& request);
 
   /**
    * Gets a [ServiceAccountKey][google.iam.admin.v1.ServiceAccountKey].
    *
    * @param request
-   * [::google::iam::admin::v1::GetServiceAccountKeyRequest](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/admin/v1/iam.proto#L694)
+   * [google::iam::admin::v1::GetServiceAccountKeyRequest](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/admin/v1/iam.proto#L694)
    * @return
-   * [::google::iam::admin::v1::ServiceAccountKey](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/admin/v1/iam.proto#L737)
+   * [google::iam::admin::v1::ServiceAccountKey](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/admin/v1/iam.proto#L737)
    */
-  StatusOr<::google::iam::admin::v1::ServiceAccountKey> GetServiceAccountKey(
-      ::google::iam::admin::v1::GetServiceAccountKeyRequest const& request);
+  StatusOr<google::iam::admin::v1::ServiceAccountKey> GetServiceAccountKey(
+      google::iam::admin::v1::GetServiceAccountKeyRequest const& request);
 
   /**
    * Creates a [ServiceAccountKey][google.iam.admin.v1.ServiceAccountKey].
    *
    * @param request
-   * [::google::iam::admin::v1::CreateServiceAccountKeyRequest](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/admin/v1/iam.proto#L787)
+   * [google::iam::admin::v1::CreateServiceAccountKeyRequest](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/admin/v1/iam.proto#L787)
    * @return
-   * [::google::iam::admin::v1::ServiceAccountKey](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/admin/v1/iam.proto#L737)
+   * [google::iam::admin::v1::ServiceAccountKey](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/admin/v1/iam.proto#L737)
    */
-  StatusOr<::google::iam::admin::v1::ServiceAccountKey> CreateServiceAccountKey(
-      ::google::iam::admin::v1::CreateServiceAccountKeyRequest const& request);
+  StatusOr<google::iam::admin::v1::ServiceAccountKey> CreateServiceAccountKey(
+      google::iam::admin::v1::CreateServiceAccountKeyRequest const& request);
 
   /**
    * Creates a [ServiceAccountKey][google.iam.admin.v1.ServiceAccountKey], using
    * a public key that you provide.
    *
    * @param request
-   * [::google::iam::admin::v1::UploadServiceAccountKeyRequest](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/admin/v1/iam.proto#L812)
+   * [google::iam::admin::v1::UploadServiceAccountKeyRequest](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/admin/v1/iam.proto#L812)
    * @return
-   * [::google::iam::admin::v1::ServiceAccountKey](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/admin/v1/iam.proto#L737)
+   * [google::iam::admin::v1::ServiceAccountKey](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/admin/v1/iam.proto#L737)
    */
-  StatusOr<::google::iam::admin::v1::ServiceAccountKey> UploadServiceAccountKey(
-      ::google::iam::admin::v1::UploadServiceAccountKeyRequest const& request);
+  StatusOr<google::iam::admin::v1::ServiceAccountKey> UploadServiceAccountKey(
+      google::iam::admin::v1::UploadServiceAccountKeyRequest const& request);
 
   /**
    * Deletes a [ServiceAccountKey][google.iam.admin.v1.ServiceAccountKey].
@@ -490,10 +491,10 @@ class IAMClient {
    * have been issued based on the service account key.
    *
    * @param request
-   * [::google::iam::admin::v1::DeleteServiceAccountKeyRequest](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/admin/v1/iam.proto#L828)
+   * [google::iam::admin::v1::DeleteServiceAccountKeyRequest](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/admin/v1/iam.proto#L828)
    */
   Status DeleteServiceAccountKey(
-      ::google::iam::admin::v1::DeleteServiceAccountKeyRequest const& request);
+      google::iam::admin::v1::DeleteServiceAccountKeyRequest const& request);
 
   /**
    * Gets the IAM policy that is attached to a
@@ -509,12 +510,12 @@ class IAMClient {
    * method.
    *
    * @param request
-   * [::google::iam::v1::GetIamPolicyRequest](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/v1/iam_policy.proto#L113)
+   * [google::iam::v1::GetIamPolicyRequest](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/v1/iam_policy.proto#L113)
    * @return
-   * [::google::iam::v1::Policy](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/v1/policy.proto#L88)
+   * [google::iam::v1::Policy](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/v1/policy.proto#L88)
    */
-  StatusOr<::google::iam::v1::Policy> GetIamPolicy(
-      ::google::iam::v1::GetIamPolicyRequest const& request);
+  StatusOr<google::iam::v1::Policy> GetIamPolicy(
+      google::iam::v1::GetIamPolicyRequest const& request);
 
   /**
    * Sets the IAM policy that is attached to a
@@ -537,24 +538,24 @@ class IAMClient {
    * resources](https://cloud.google.com/iam/help/service-accounts/granting-access-to-service-accounts).
    *
    * @param request
-   * [::google::iam::v1::SetIamPolicyRequest](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/v1/iam_policy.proto#L98)
+   * [google::iam::v1::SetIamPolicyRequest](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/v1/iam_policy.proto#L98)
    * @return
-   * [::google::iam::v1::Policy](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/v1/policy.proto#L88)
+   * [google::iam::v1::Policy](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/v1/policy.proto#L88)
    */
-  StatusOr<::google::iam::v1::Policy> SetIamPolicy(
-      ::google::iam::v1::SetIamPolicyRequest const& request);
+  StatusOr<google::iam::v1::Policy> SetIamPolicy(
+      google::iam::v1::SetIamPolicyRequest const& request);
 
   /**
    * Tests whether the caller has the specified permissions on a
    * [ServiceAccount][google.iam.admin.v1.ServiceAccount].
    *
    * @param request
-   * [::google::iam::v1::TestIamPermissionsRequest](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/v1/iam_policy.proto#L126)
+   * [google::iam::v1::TestIamPermissionsRequest](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/v1/iam_policy.proto#L126)
    * @return
-   * [::google::iam::v1::TestIamPermissionsResponse](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/v1/iam_policy.proto#L141)
+   * [google::iam::v1::TestIamPermissionsResponse](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/v1/iam_policy.proto#L141)
    */
-  StatusOr<::google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
-      ::google::iam::v1::TestIamPermissionsRequest const& request);
+  StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
+      google::iam::v1::TestIamPermissionsRequest const& request);
 
   /**
    * Lists roles that can be granted on a Google Cloud resource. A role is
@@ -562,53 +563,53 @@ class IAMClient {
    * role.
    *
    * @param request
-   * [::google::iam::admin::v1::QueryGrantableRolesRequest](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/admin/v1/iam.proto#L1058)
+   * [google::iam::admin::v1::QueryGrantableRolesRequest](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/admin/v1/iam.proto#L1058)
    */
-  StreamRange<::google::iam::admin::v1::Role> QueryGrantableRoles(
-      ::google::iam::admin::v1::QueryGrantableRolesRequest request);
+  StreamRange<google::iam::admin::v1::Role> QueryGrantableRoles(
+      google::iam::admin::v1::QueryGrantableRolesRequest request);
 
   /**
    * Lists every predefined [Role][google.iam.admin.v1.Role] that IAM supports,
    * or every custom role that is defined for an organization or project.
    *
    * @param request
-   * [::google::iam::admin::v1::ListRolesRequest](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/admin/v1/iam.proto#L1089)
+   * [google::iam::admin::v1::ListRolesRequest](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/admin/v1/iam.proto#L1089)
    */
-  StreamRange<::google::iam::admin::v1::Role> ListRoles(
-      ::google::iam::admin::v1::ListRolesRequest request);
+  StreamRange<google::iam::admin::v1::Role> ListRoles(
+      google::iam::admin::v1::ListRolesRequest request);
 
   /**
    * Gets the definition of a [Role][google.iam.admin.v1.Role].
    *
    * @param request
-   * [::google::iam::admin::v1::GetRoleRequest](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/admin/v1/iam.proto#L1148)
+   * [google::iam::admin::v1::GetRoleRequest](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/admin/v1/iam.proto#L1148)
    * @return
-   * [::google::iam::admin::v1::Role](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/admin/v1/iam.proto#L1000)
+   * [google::iam::admin::v1::Role](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/admin/v1/iam.proto#L1000)
    */
-  StatusOr<::google::iam::admin::v1::Role> GetRole(
-      ::google::iam::admin::v1::GetRoleRequest const& request);
+  StatusOr<google::iam::admin::v1::Role> GetRole(
+      google::iam::admin::v1::GetRoleRequest const& request);
 
   /**
    * Creates a new custom [Role][google.iam.admin.v1.Role].
    *
    * @param request
-   * [::google::iam::admin::v1::CreateRoleRequest](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/admin/v1/iam.proto#L1180)
+   * [google::iam::admin::v1::CreateRoleRequest](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/admin/v1/iam.proto#L1180)
    * @return
-   * [::google::iam::admin::v1::Role](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/admin/v1/iam.proto#L1000)
+   * [google::iam::admin::v1::Role](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/admin/v1/iam.proto#L1000)
    */
-  StatusOr<::google::iam::admin::v1::Role> CreateRole(
-      ::google::iam::admin::v1::CreateRoleRequest const& request);
+  StatusOr<google::iam::admin::v1::Role> CreateRole(
+      google::iam::admin::v1::CreateRoleRequest const& request);
 
   /**
    * Updates the definition of a custom [Role][google.iam.admin.v1.Role].
    *
    * @param request
-   * [::google::iam::admin::v1::UpdateRoleRequest](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/admin/v1/iam.proto#L1215)
+   * [google::iam::admin::v1::UpdateRoleRequest](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/admin/v1/iam.proto#L1215)
    * @return
-   * [::google::iam::admin::v1::Role](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/admin/v1/iam.proto#L1000)
+   * [google::iam::admin::v1::Role](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/admin/v1/iam.proto#L1000)
    */
-  StatusOr<::google::iam::admin::v1::Role> UpdateRole(
-      ::google::iam::admin::v1::UpdateRoleRequest const& request);
+  StatusOr<google::iam::admin::v1::Role> UpdateRole(
+      google::iam::admin::v1::UpdateRoleRequest const& request);
 
   /**
    * Deletes a custom [Role][google.iam.admin.v1.Role].
@@ -631,23 +632,23 @@ class IAMClient {
    * permanently removed.
    *
    * @param request
-   * [::google::iam::admin::v1::DeleteRoleRequest](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/admin/v1/iam.proto#L1246)
+   * [google::iam::admin::v1::DeleteRoleRequest](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/admin/v1/iam.proto#L1246)
    * @return
-   * [::google::iam::admin::v1::Role](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/admin/v1/iam.proto#L1000)
+   * [google::iam::admin::v1::Role](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/admin/v1/iam.proto#L1000)
    */
-  StatusOr<::google::iam::admin::v1::Role> DeleteRole(
-      ::google::iam::admin::v1::DeleteRoleRequest const& request);
+  StatusOr<google::iam::admin::v1::Role> DeleteRole(
+      google::iam::admin::v1::DeleteRoleRequest const& request);
 
   /**
    * Undeletes a custom [Role][google.iam.admin.v1.Role].
    *
    * @param request
-   * [::google::iam::admin::v1::UndeleteRoleRequest](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/admin/v1/iam.proto#L1274)
+   * [google::iam::admin::v1::UndeleteRoleRequest](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/admin/v1/iam.proto#L1274)
    * @return
-   * [::google::iam::admin::v1::Role](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/admin/v1/iam.proto#L1000)
+   * [google::iam::admin::v1::Role](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/admin/v1/iam.proto#L1000)
    */
-  StatusOr<::google::iam::admin::v1::Role> UndeleteRole(
-      ::google::iam::admin::v1::UndeleteRoleRequest const& request);
+  StatusOr<google::iam::admin::v1::Role> UndeleteRole(
+      google::iam::admin::v1::UndeleteRoleRequest const& request);
 
   /**
    * Lists every permission that you can test on a resource. A permission is
@@ -655,10 +656,10 @@ class IAMClient {
    * resource.
    *
    * @param request
-   * [::google::iam::admin::v1::QueryTestablePermissionsRequest](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/admin/v1/iam.proto#L1357)
+   * [google::iam::admin::v1::QueryTestablePermissionsRequest](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/admin/v1/iam.proto#L1357)
    */
-  StreamRange<::google::iam::admin::v1::Permission> QueryTestablePermissions(
-      ::google::iam::admin::v1::QueryTestablePermissionsRequest request);
+  StreamRange<google::iam::admin::v1::Permission> QueryTestablePermissions(
+      google::iam::admin::v1::QueryTestablePermissionsRequest request);
 
   /**
    * Returns a list of services that allow you to opt into audit logs that are
@@ -668,13 +669,13 @@ class IAMClient {
    * documentation](https://cloud.google.com/logging/docs/audit).
    *
    * @param request
-   * [::google::iam::admin::v1::QueryAuditableServicesRequest](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/admin/v1/iam.proto#L1387)
+   * [google::iam::admin::v1::QueryAuditableServicesRequest](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/admin/v1/iam.proto#L1387)
    * @return
-   * [::google::iam::admin::v1::QueryAuditableServicesResponse](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/admin/v1/iam.proto#L1398)
+   * [google::iam::admin::v1::QueryAuditableServicesResponse](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/admin/v1/iam.proto#L1398)
    */
-  StatusOr<::google::iam::admin::v1::QueryAuditableServicesResponse>
+  StatusOr<google::iam::admin::v1::QueryAuditableServicesResponse>
   QueryAuditableServices(
-      ::google::iam::admin::v1::QueryAuditableServicesRequest const& request);
+      google::iam::admin::v1::QueryAuditableServicesRequest const& request);
 
   /**
    * Lints, or validates, an IAM policy. Currently checks the
@@ -685,12 +686,12 @@ class IAMClient {
    * even if the linter detects an issue in the IAM policy.
    *
    * @param request
-   * [::google::iam::admin::v1::LintPolicyRequest](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/admin/v1/iam.proto#L1411)
+   * [google::iam::admin::v1::LintPolicyRequest](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/admin/v1/iam.proto#L1411)
    * @return
-   * [::google::iam::admin::v1::LintPolicyResponse](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/admin/v1/iam.proto#L1509)
+   * [google::iam::admin::v1::LintPolicyResponse](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/admin/v1/iam.proto#L1509)
    */
-  StatusOr<::google::iam::admin::v1::LintPolicyResponse> LintPolicy(
-      ::google::iam::admin::v1::LintPolicyRequest const& request);
+  StatusOr<google::iam::admin::v1::LintPolicyResponse> LintPolicy(
+      google::iam::admin::v1::LintPolicyRequest const& request);
 
  private:
   std::shared_ptr<IAMConnection> connection_;

--- a/google/cloud/iam/iam_connection.cc
+++ b/google/cloud/iam/iam_connection.cc
@@ -31,180 +31,178 @@ inline namespace GOOGLE_CLOUD_CPP_GENERATED_NS {
 
 IAMConnection::~IAMConnection() = default;
 
-StreamRange<::google::iam::admin::v1::ServiceAccount>
+StreamRange<google::iam::admin::v1::ServiceAccount>
 IAMConnection::ListServiceAccounts(
-    ::google::iam::admin::v1::ListServiceAccountsRequest request) {
+    google::iam::admin::v1::ListServiceAccountsRequest request) {
   return google::cloud::internal::MakePaginationRange<
-      StreamRange<::google::iam::admin::v1::ServiceAccount>>(
+      StreamRange<google::iam::admin::v1::ServiceAccount>>(
       std::move(request),
-      [](::google::iam::admin::v1::ListServiceAccountsRequest const&) {
-        return StatusOr<
-            ::google::iam::admin::v1::ListServiceAccountsResponse>{};
+      [](google::iam::admin::v1::ListServiceAccountsRequest const&) {
+        return StatusOr<google::iam::admin::v1::ListServiceAccountsResponse>{};
       },
-      [](::google::iam::admin::v1::ListServiceAccountsResponse const&) {
-        return std::vector<::google::iam::admin::v1::ServiceAccount>();
+      [](google::iam::admin::v1::ListServiceAccountsResponse const&) {
+        return std::vector<google::iam::admin::v1::ServiceAccount>();
       });
 }
 
-StatusOr<::google::iam::admin::v1::ServiceAccount>
+StatusOr<google::iam::admin::v1::ServiceAccount>
 IAMConnection::GetServiceAccount(
-    ::google::iam::admin::v1::GetServiceAccountRequest const&) {
+    google::iam::admin::v1::GetServiceAccountRequest const&) {
   return Status(StatusCode::kUnimplemented, "not implemented");
 }
 
-StatusOr<::google::iam::admin::v1::ServiceAccount>
+StatusOr<google::iam::admin::v1::ServiceAccount>
 IAMConnection::CreateServiceAccount(
-    ::google::iam::admin::v1::CreateServiceAccountRequest const&) {
+    google::iam::admin::v1::CreateServiceAccountRequest const&) {
   return Status(StatusCode::kUnimplemented, "not implemented");
 }
 
-StatusOr<::google::iam::admin::v1::ServiceAccount>
+StatusOr<google::iam::admin::v1::ServiceAccount>
 IAMConnection::PatchServiceAccount(
-    ::google::iam::admin::v1::PatchServiceAccountRequest const&) {
+    google::iam::admin::v1::PatchServiceAccountRequest const&) {
   return Status(StatusCode::kUnimplemented, "not implemented");
 }
 
 Status IAMConnection::DeleteServiceAccount(
-    ::google::iam::admin::v1::DeleteServiceAccountRequest const&) {
+    google::iam::admin::v1::DeleteServiceAccountRequest const&) {
   return Status(StatusCode::kUnimplemented, "not implemented");
 }
 
-StatusOr<::google::iam::admin::v1::UndeleteServiceAccountResponse>
+StatusOr<google::iam::admin::v1::UndeleteServiceAccountResponse>
 IAMConnection::UndeleteServiceAccount(
-    ::google::iam::admin::v1::UndeleteServiceAccountRequest const&) {
+    google::iam::admin::v1::UndeleteServiceAccountRequest const&) {
   return Status(StatusCode::kUnimplemented, "not implemented");
 }
 
 Status IAMConnection::EnableServiceAccount(
-    ::google::iam::admin::v1::EnableServiceAccountRequest const&) {
+    google::iam::admin::v1::EnableServiceAccountRequest const&) {
   return Status(StatusCode::kUnimplemented, "not implemented");
 }
 
 Status IAMConnection::DisableServiceAccount(
-    ::google::iam::admin::v1::DisableServiceAccountRequest const&) {
+    google::iam::admin::v1::DisableServiceAccountRequest const&) {
   return Status(StatusCode::kUnimplemented, "not implemented");
 }
 
-StatusOr<::google::iam::admin::v1::ListServiceAccountKeysResponse>
+StatusOr<google::iam::admin::v1::ListServiceAccountKeysResponse>
 IAMConnection::ListServiceAccountKeys(
-    ::google::iam::admin::v1::ListServiceAccountKeysRequest const&) {
+    google::iam::admin::v1::ListServiceAccountKeysRequest const&) {
   return Status(StatusCode::kUnimplemented, "not implemented");
 }
 
-StatusOr<::google::iam::admin::v1::ServiceAccountKey>
+StatusOr<google::iam::admin::v1::ServiceAccountKey>
 IAMConnection::GetServiceAccountKey(
-    ::google::iam::admin::v1::GetServiceAccountKeyRequest const&) {
+    google::iam::admin::v1::GetServiceAccountKeyRequest const&) {
   return Status(StatusCode::kUnimplemented, "not implemented");
 }
 
-StatusOr<::google::iam::admin::v1::ServiceAccountKey>
+StatusOr<google::iam::admin::v1::ServiceAccountKey>
 IAMConnection::CreateServiceAccountKey(
-    ::google::iam::admin::v1::CreateServiceAccountKeyRequest const&) {
+    google::iam::admin::v1::CreateServiceAccountKeyRequest const&) {
   return Status(StatusCode::kUnimplemented, "not implemented");
 }
 
-StatusOr<::google::iam::admin::v1::ServiceAccountKey>
+StatusOr<google::iam::admin::v1::ServiceAccountKey>
 IAMConnection::UploadServiceAccountKey(
-    ::google::iam::admin::v1::UploadServiceAccountKeyRequest const&) {
+    google::iam::admin::v1::UploadServiceAccountKeyRequest const&) {
   return Status(StatusCode::kUnimplemented, "not implemented");
 }
 
 Status IAMConnection::DeleteServiceAccountKey(
-    ::google::iam::admin::v1::DeleteServiceAccountKeyRequest const&) {
+    google::iam::admin::v1::DeleteServiceAccountKeyRequest const&) {
   return Status(StatusCode::kUnimplemented, "not implemented");
 }
 
-StatusOr<::google::iam::v1::Policy> IAMConnection::GetIamPolicy(
-    ::google::iam::v1::GetIamPolicyRequest const&) {
+StatusOr<google::iam::v1::Policy> IAMConnection::GetIamPolicy(
+    google::iam::v1::GetIamPolicyRequest const&) {
   return Status(StatusCode::kUnimplemented, "not implemented");
 }
 
-StatusOr<::google::iam::v1::Policy> IAMConnection::SetIamPolicy(
-    ::google::iam::v1::SetIamPolicyRequest const&) {
+StatusOr<google::iam::v1::Policy> IAMConnection::SetIamPolicy(
+    google::iam::v1::SetIamPolicyRequest const&) {
   return Status(StatusCode::kUnimplemented, "not implemented");
 }
 
-StatusOr<::google::iam::v1::TestIamPermissionsResponse>
+StatusOr<google::iam::v1::TestIamPermissionsResponse>
 IAMConnection::TestIamPermissions(
-    ::google::iam::v1::TestIamPermissionsRequest const&) {
+    google::iam::v1::TestIamPermissionsRequest const&) {
   return Status(StatusCode::kUnimplemented, "not implemented");
 }
 
-StreamRange<::google::iam::admin::v1::Role> IAMConnection::QueryGrantableRoles(
-    ::google::iam::admin::v1::QueryGrantableRolesRequest request) {
+StreamRange<google::iam::admin::v1::Role> IAMConnection::QueryGrantableRoles(
+    google::iam::admin::v1::QueryGrantableRolesRequest request) {
   return google::cloud::internal::MakePaginationRange<
-      StreamRange<::google::iam::admin::v1::Role>>(
+      StreamRange<google::iam::admin::v1::Role>>(
       std::move(request),
-      [](::google::iam::admin::v1::QueryGrantableRolesRequest const&) {
-        return StatusOr<
-            ::google::iam::admin::v1::QueryGrantableRolesResponse>{};
+      [](google::iam::admin::v1::QueryGrantableRolesRequest const&) {
+        return StatusOr<google::iam::admin::v1::QueryGrantableRolesResponse>{};
       },
-      [](::google::iam::admin::v1::QueryGrantableRolesResponse const&) {
-        return std::vector<::google::iam::admin::v1::Role>();
+      [](google::iam::admin::v1::QueryGrantableRolesResponse const&) {
+        return std::vector<google::iam::admin::v1::Role>();
       });
 }
 
-StreamRange<::google::iam::admin::v1::Role> IAMConnection::ListRoles(
-    ::google::iam::admin::v1::ListRolesRequest request) {
+StreamRange<google::iam::admin::v1::Role> IAMConnection::ListRoles(
+    google::iam::admin::v1::ListRolesRequest request) {
   return google::cloud::internal::MakePaginationRange<
-      StreamRange<::google::iam::admin::v1::Role>>(
+      StreamRange<google::iam::admin::v1::Role>>(
       std::move(request),
-      [](::google::iam::admin::v1::ListRolesRequest const&) {
-        return StatusOr<::google::iam::admin::v1::ListRolesResponse>{};
+      [](google::iam::admin::v1::ListRolesRequest const&) {
+        return StatusOr<google::iam::admin::v1::ListRolesResponse>{};
       },
-      [](::google::iam::admin::v1::ListRolesResponse const&) {
-        return std::vector<::google::iam::admin::v1::Role>();
+      [](google::iam::admin::v1::ListRolesResponse const&) {
+        return std::vector<google::iam::admin::v1::Role>();
       });
 }
 
-StatusOr<::google::iam::admin::v1::Role> IAMConnection::GetRole(
-    ::google::iam::admin::v1::GetRoleRequest const&) {
+StatusOr<google::iam::admin::v1::Role> IAMConnection::GetRole(
+    google::iam::admin::v1::GetRoleRequest const&) {
   return Status(StatusCode::kUnimplemented, "not implemented");
 }
 
-StatusOr<::google::iam::admin::v1::Role> IAMConnection::CreateRole(
-    ::google::iam::admin::v1::CreateRoleRequest const&) {
+StatusOr<google::iam::admin::v1::Role> IAMConnection::CreateRole(
+    google::iam::admin::v1::CreateRoleRequest const&) {
   return Status(StatusCode::kUnimplemented, "not implemented");
 }
 
-StatusOr<::google::iam::admin::v1::Role> IAMConnection::UpdateRole(
-    ::google::iam::admin::v1::UpdateRoleRequest const&) {
+StatusOr<google::iam::admin::v1::Role> IAMConnection::UpdateRole(
+    google::iam::admin::v1::UpdateRoleRequest const&) {
   return Status(StatusCode::kUnimplemented, "not implemented");
 }
 
-StatusOr<::google::iam::admin::v1::Role> IAMConnection::DeleteRole(
-    ::google::iam::admin::v1::DeleteRoleRequest const&) {
+StatusOr<google::iam::admin::v1::Role> IAMConnection::DeleteRole(
+    google::iam::admin::v1::DeleteRoleRequest const&) {
   return Status(StatusCode::kUnimplemented, "not implemented");
 }
 
-StatusOr<::google::iam::admin::v1::Role> IAMConnection::UndeleteRole(
-    ::google::iam::admin::v1::UndeleteRoleRequest const&) {
+StatusOr<google::iam::admin::v1::Role> IAMConnection::UndeleteRole(
+    google::iam::admin::v1::UndeleteRoleRequest const&) {
   return Status(StatusCode::kUnimplemented, "not implemented");
 }
 
-StreamRange<::google::iam::admin::v1::Permission>
+StreamRange<google::iam::admin::v1::Permission>
 IAMConnection::QueryTestablePermissions(
-    ::google::iam::admin::v1::QueryTestablePermissionsRequest request) {
+    google::iam::admin::v1::QueryTestablePermissionsRequest request) {
   return google::cloud::internal::MakePaginationRange<
-      StreamRange<::google::iam::admin::v1::Permission>>(
+      StreamRange<google::iam::admin::v1::Permission>>(
       std::move(request),
-      [](::google::iam::admin::v1::QueryTestablePermissionsRequest const&) {
+      [](google::iam::admin::v1::QueryTestablePermissionsRequest const&) {
         return StatusOr<
-            ::google::iam::admin::v1::QueryTestablePermissionsResponse>{};
+            google::iam::admin::v1::QueryTestablePermissionsResponse>{};
       },
-      [](::google::iam::admin::v1::QueryTestablePermissionsResponse const&) {
-        return std::vector<::google::iam::admin::v1::Permission>();
+      [](google::iam::admin::v1::QueryTestablePermissionsResponse const&) {
+        return std::vector<google::iam::admin::v1::Permission>();
       });
 }
 
-StatusOr<::google::iam::admin::v1::QueryAuditableServicesResponse>
+StatusOr<google::iam::admin::v1::QueryAuditableServicesResponse>
 IAMConnection::QueryAuditableServices(
-    ::google::iam::admin::v1::QueryAuditableServicesRequest const&) {
+    google::iam::admin::v1::QueryAuditableServicesRequest const&) {
   return Status(StatusCode::kUnimplemented, "not implemented");
 }
 
-StatusOr<::google::iam::admin::v1::LintPolicyResponse>
-IAMConnection::LintPolicy(::google::iam::admin::v1::LintPolicyRequest const&) {
+StatusOr<google::iam::admin::v1::LintPolicyResponse> IAMConnection::LintPolicy(
+    google::iam::admin::v1::LintPolicyRequest const&) {
   return Status(StatusCode::kUnimplemented, "not implemented");
 }
 
@@ -222,8 +220,8 @@ class IAMConnectionImpl : public IAMConnection {
 
   ~IAMConnectionImpl() override = default;
 
-  StreamRange<::google::iam::admin::v1::ServiceAccount> ListServiceAccounts(
-      ::google::iam::admin::v1::ListServiceAccountsRequest request) override {
+  StreamRange<google::iam::admin::v1::ServiceAccount> ListServiceAccounts(
+      google::iam::admin::v1::ListServiceAccountsRequest request) override {
     request.clear_page_token();
     auto stub = stub_;
     auto retry =
@@ -233,21 +231,21 @@ class IAMConnectionImpl : public IAMConnection {
     auto idempotency = idempotency_policy_->ListServiceAccounts(request);
     char const* function_name = __func__;
     return google::cloud::internal::MakePaginationRange<
-        StreamRange<::google::iam::admin::v1::ServiceAccount>>(
+        StreamRange<google::iam::admin::v1::ServiceAccount>>(
         std::move(request),
         [stub, retry, backoff, idempotency, function_name](
-            ::google::iam::admin::v1::ListServiceAccountsRequest const& r) {
+            google::iam::admin::v1::ListServiceAccountsRequest const& r) {
           return google::cloud::internal::RetryLoop(
               retry->clone(), backoff->clone(), idempotency,
               [stub](grpc::ClientContext& context,
-                     ::google::iam::admin::v1::ListServiceAccountsRequest const&
+                     google::iam::admin::v1::ListServiceAccountsRequest const&
                          request) {
                 return stub->ListServiceAccounts(context, request);
               },
               r, function_name);
         },
-        [](::google::iam::admin::v1::ListServiceAccountsResponse r) {
-          std::vector<::google::iam::admin::v1::ServiceAccount> result(
+        [](google::iam::admin::v1::ListServiceAccountsResponse r) {
+          std::vector<google::iam::admin::v1::ServiceAccount> result(
               r.accounts().size());
           auto& messages = *r.mutable_accounts();
           std::move(messages.begin(), messages.end(), result.begin());
@@ -255,71 +253,71 @@ class IAMConnectionImpl : public IAMConnection {
         });
   }
 
-  StatusOr<::google::iam::admin::v1::ServiceAccount> GetServiceAccount(
-      ::google::iam::admin::v1::GetServiceAccountRequest const& request)
+  StatusOr<google::iam::admin::v1::ServiceAccount> GetServiceAccount(
+      google::iam::admin::v1::GetServiceAccountRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
         retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
         idempotency_policy_->GetServiceAccount(request),
         [this](
             grpc::ClientContext& context,
-            ::google::iam::admin::v1::GetServiceAccountRequest const& request) {
+            google::iam::admin::v1::GetServiceAccountRequest const& request) {
           return stub_->GetServiceAccount(context, request);
         },
         request, __func__);
   }
 
-  StatusOr<::google::iam::admin::v1::ServiceAccount> CreateServiceAccount(
-      ::google::iam::admin::v1::CreateServiceAccountRequest const& request)
+  StatusOr<google::iam::admin::v1::ServiceAccount> CreateServiceAccount(
+      google::iam::admin::v1::CreateServiceAccountRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
         retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
         idempotency_policy_->CreateServiceAccount(request),
         [this](grpc::ClientContext& context,
-               ::google::iam::admin::v1::CreateServiceAccountRequest const&
+               google::iam::admin::v1::CreateServiceAccountRequest const&
                    request) {
           return stub_->CreateServiceAccount(context, request);
         },
         request, __func__);
   }
 
-  StatusOr<::google::iam::admin::v1::ServiceAccount> PatchServiceAccount(
-      ::google::iam::admin::v1::PatchServiceAccountRequest const& request)
+  StatusOr<google::iam::admin::v1::ServiceAccount> PatchServiceAccount(
+      google::iam::admin::v1::PatchServiceAccountRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
         retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
         idempotency_policy_->PatchServiceAccount(request),
-        [this](grpc::ClientContext& context,
-               ::google::iam::admin::v1::PatchServiceAccountRequest const&
-                   request) {
+        [this](
+            grpc::ClientContext& context,
+            google::iam::admin::v1::PatchServiceAccountRequest const& request) {
           return stub_->PatchServiceAccount(context, request);
         },
         request, __func__);
   }
 
   Status DeleteServiceAccount(
-      ::google::iam::admin::v1::DeleteServiceAccountRequest const& request)
+      google::iam::admin::v1::DeleteServiceAccountRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
         retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
         idempotency_policy_->DeleteServiceAccount(request),
         [this](grpc::ClientContext& context,
-               ::google::iam::admin::v1::DeleteServiceAccountRequest const&
+               google::iam::admin::v1::DeleteServiceAccountRequest const&
                    request) {
           return stub_->DeleteServiceAccount(context, request);
         },
         request, __func__);
   }
 
-  StatusOr<::google::iam::admin::v1::UndeleteServiceAccountResponse>
+  StatusOr<google::iam::admin::v1::UndeleteServiceAccountResponse>
   UndeleteServiceAccount(
-      ::google::iam::admin::v1::UndeleteServiceAccountRequest const& request)
+      google::iam::admin::v1::UndeleteServiceAccountRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
         retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
         idempotency_policy_->UndeleteServiceAccount(request),
         [this](grpc::ClientContext& context,
-               ::google::iam::admin::v1::UndeleteServiceAccountRequest const&
+               google::iam::admin::v1::UndeleteServiceAccountRequest const&
                    request) {
           return stub_->UndeleteServiceAccount(context, request);
         },
@@ -327,13 +325,13 @@ class IAMConnectionImpl : public IAMConnection {
   }
 
   Status EnableServiceAccount(
-      ::google::iam::admin::v1::EnableServiceAccountRequest const& request)
+      google::iam::admin::v1::EnableServiceAccountRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
         retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
         idempotency_policy_->EnableServiceAccount(request),
         [this](grpc::ClientContext& context,
-               ::google::iam::admin::v1::EnableServiceAccountRequest const&
+               google::iam::admin::v1::EnableServiceAccountRequest const&
                    request) {
           return stub_->EnableServiceAccount(context, request);
         },
@@ -341,70 +339,70 @@ class IAMConnectionImpl : public IAMConnection {
   }
 
   Status DisableServiceAccount(
-      ::google::iam::admin::v1::DisableServiceAccountRequest const& request)
+      google::iam::admin::v1::DisableServiceAccountRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
         retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
         idempotency_policy_->DisableServiceAccount(request),
         [this](grpc::ClientContext& context,
-               ::google::iam::admin::v1::DisableServiceAccountRequest const&
+               google::iam::admin::v1::DisableServiceAccountRequest const&
                    request) {
           return stub_->DisableServiceAccount(context, request);
         },
         request, __func__);
   }
 
-  StatusOr<::google::iam::admin::v1::ListServiceAccountKeysResponse>
+  StatusOr<google::iam::admin::v1::ListServiceAccountKeysResponse>
   ListServiceAccountKeys(
-      ::google::iam::admin::v1::ListServiceAccountKeysRequest const& request)
+      google::iam::admin::v1::ListServiceAccountKeysRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
         retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
         idempotency_policy_->ListServiceAccountKeys(request),
         [this](grpc::ClientContext& context,
-               ::google::iam::admin::v1::ListServiceAccountKeysRequest const&
+               google::iam::admin::v1::ListServiceAccountKeysRequest const&
                    request) {
           return stub_->ListServiceAccountKeys(context, request);
         },
         request, __func__);
   }
 
-  StatusOr<::google::iam::admin::v1::ServiceAccountKey> GetServiceAccountKey(
-      ::google::iam::admin::v1::GetServiceAccountKeyRequest const& request)
+  StatusOr<google::iam::admin::v1::ServiceAccountKey> GetServiceAccountKey(
+      google::iam::admin::v1::GetServiceAccountKeyRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
         retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
         idempotency_policy_->GetServiceAccountKey(request),
         [this](grpc::ClientContext& context,
-               ::google::iam::admin::v1::GetServiceAccountKeyRequest const&
+               google::iam::admin::v1::GetServiceAccountKeyRequest const&
                    request) {
           return stub_->GetServiceAccountKey(context, request);
         },
         request, __func__);
   }
 
-  StatusOr<::google::iam::admin::v1::ServiceAccountKey> CreateServiceAccountKey(
-      ::google::iam::admin::v1::CreateServiceAccountKeyRequest const& request)
+  StatusOr<google::iam::admin::v1::ServiceAccountKey> CreateServiceAccountKey(
+      google::iam::admin::v1::CreateServiceAccountKeyRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
         retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
         idempotency_policy_->CreateServiceAccountKey(request),
         [this](grpc::ClientContext& context,
-               ::google::iam::admin::v1::CreateServiceAccountKeyRequest const&
+               google::iam::admin::v1::CreateServiceAccountKeyRequest const&
                    request) {
           return stub_->CreateServiceAccountKey(context, request);
         },
         request, __func__);
   }
 
-  StatusOr<::google::iam::admin::v1::ServiceAccountKey> UploadServiceAccountKey(
-      ::google::iam::admin::v1::UploadServiceAccountKeyRequest const& request)
+  StatusOr<google::iam::admin::v1::ServiceAccountKey> UploadServiceAccountKey(
+      google::iam::admin::v1::UploadServiceAccountKeyRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
         retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
         idempotency_policy_->UploadServiceAccountKey(request),
         [this](grpc::ClientContext& context,
-               ::google::iam::admin::v1::UploadServiceAccountKeyRequest const&
+               google::iam::admin::v1::UploadServiceAccountKeyRequest const&
                    request) {
           return stub_->UploadServiceAccountKey(context, request);
         },
@@ -412,57 +410,57 @@ class IAMConnectionImpl : public IAMConnection {
   }
 
   Status DeleteServiceAccountKey(
-      ::google::iam::admin::v1::DeleteServiceAccountKeyRequest const& request)
+      google::iam::admin::v1::DeleteServiceAccountKeyRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
         retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
         idempotency_policy_->DeleteServiceAccountKey(request),
         [this](grpc::ClientContext& context,
-               ::google::iam::admin::v1::DeleteServiceAccountKeyRequest const&
+               google::iam::admin::v1::DeleteServiceAccountKeyRequest const&
                    request) {
           return stub_->DeleteServiceAccountKey(context, request);
         },
         request, __func__);
   }
 
-  StatusOr<::google::iam::v1::Policy> GetIamPolicy(
-      ::google::iam::v1::GetIamPolicyRequest const& request) override {
+  StatusOr<google::iam::v1::Policy> GetIamPolicy(
+      google::iam::v1::GetIamPolicyRequest const& request) override {
     return google::cloud::internal::RetryLoop(
         retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
         idempotency_policy_->GetIamPolicy(request),
         [this](grpc::ClientContext& context,
-               ::google::iam::v1::GetIamPolicyRequest const& request) {
+               google::iam::v1::GetIamPolicyRequest const& request) {
           return stub_->GetIamPolicy(context, request);
         },
         request, __func__);
   }
 
-  StatusOr<::google::iam::v1::Policy> SetIamPolicy(
-      ::google::iam::v1::SetIamPolicyRequest const& request) override {
+  StatusOr<google::iam::v1::Policy> SetIamPolicy(
+      google::iam::v1::SetIamPolicyRequest const& request) override {
     return google::cloud::internal::RetryLoop(
         retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
         idempotency_policy_->SetIamPolicy(request),
         [this](grpc::ClientContext& context,
-               ::google::iam::v1::SetIamPolicyRequest const& request) {
+               google::iam::v1::SetIamPolicyRequest const& request) {
           return stub_->SetIamPolicy(context, request);
         },
         request, __func__);
   }
 
-  StatusOr<::google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
-      ::google::iam::v1::TestIamPermissionsRequest const& request) override {
+  StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
+      google::iam::v1::TestIamPermissionsRequest const& request) override {
     return google::cloud::internal::RetryLoop(
         retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
         idempotency_policy_->TestIamPermissions(request),
         [this](grpc::ClientContext& context,
-               ::google::iam::v1::TestIamPermissionsRequest const& request) {
+               google::iam::v1::TestIamPermissionsRequest const& request) {
           return stub_->TestIamPermissions(context, request);
         },
         request, __func__);
   }
 
-  StreamRange<::google::iam::admin::v1::Role> QueryGrantableRoles(
-      ::google::iam::admin::v1::QueryGrantableRolesRequest request) override {
+  StreamRange<google::iam::admin::v1::Role> QueryGrantableRoles(
+      google::iam::admin::v1::QueryGrantableRolesRequest request) override {
     request.clear_page_token();
     auto stub = stub_;
     auto retry =
@@ -472,29 +470,29 @@ class IAMConnectionImpl : public IAMConnection {
     auto idempotency = idempotency_policy_->QueryGrantableRoles(request);
     char const* function_name = __func__;
     return google::cloud::internal::MakePaginationRange<
-        StreamRange<::google::iam::admin::v1::Role>>(
+        StreamRange<google::iam::admin::v1::Role>>(
         std::move(request),
         [stub, retry, backoff, idempotency, function_name](
-            ::google::iam::admin::v1::QueryGrantableRolesRequest const& r) {
+            google::iam::admin::v1::QueryGrantableRolesRequest const& r) {
           return google::cloud::internal::RetryLoop(
               retry->clone(), backoff->clone(), idempotency,
               [stub](grpc::ClientContext& context,
-                     ::google::iam::admin::v1::QueryGrantableRolesRequest const&
+                     google::iam::admin::v1::QueryGrantableRolesRequest const&
                          request) {
                 return stub->QueryGrantableRoles(context, request);
               },
               r, function_name);
         },
-        [](::google::iam::admin::v1::QueryGrantableRolesResponse r) {
-          std::vector<::google::iam::admin::v1::Role> result(r.roles().size());
+        [](google::iam::admin::v1::QueryGrantableRolesResponse r) {
+          std::vector<google::iam::admin::v1::Role> result(r.roles().size());
           auto& messages = *r.mutable_roles();
           std::move(messages.begin(), messages.end(), result.begin());
           return result;
         });
   }
 
-  StreamRange<::google::iam::admin::v1::Role> ListRoles(
-      ::google::iam::admin::v1::ListRolesRequest request) override {
+  StreamRange<google::iam::admin::v1::Role> ListRoles(
+      google::iam::admin::v1::ListRolesRequest request) override {
     request.clear_page_token();
     auto stub = stub_;
     auto retry =
@@ -504,89 +502,88 @@ class IAMConnectionImpl : public IAMConnection {
     auto idempotency = idempotency_policy_->ListRoles(request);
     char const* function_name = __func__;
     return google::cloud::internal::MakePaginationRange<
-        StreamRange<::google::iam::admin::v1::Role>>(
+        StreamRange<google::iam::admin::v1::Role>>(
         std::move(request),
         [stub, retry, backoff, idempotency,
-         function_name](::google::iam::admin::v1::ListRolesRequest const& r) {
+         function_name](google::iam::admin::v1::ListRolesRequest const& r) {
           return google::cloud::internal::RetryLoop(
               retry->clone(), backoff->clone(), idempotency,
-              [stub](
-                  grpc::ClientContext& context,
-                  ::google::iam::admin::v1::ListRolesRequest const& request) {
+              [stub](grpc::ClientContext& context,
+                     google::iam::admin::v1::ListRolesRequest const& request) {
                 return stub->ListRoles(context, request);
               },
               r, function_name);
         },
-        [](::google::iam::admin::v1::ListRolesResponse r) {
-          std::vector<::google::iam::admin::v1::Role> result(r.roles().size());
+        [](google::iam::admin::v1::ListRolesResponse r) {
+          std::vector<google::iam::admin::v1::Role> result(r.roles().size());
           auto& messages = *r.mutable_roles();
           std::move(messages.begin(), messages.end(), result.begin());
           return result;
         });
   }
 
-  StatusOr<::google::iam::admin::v1::Role> GetRole(
-      ::google::iam::admin::v1::GetRoleRequest const& request) override {
+  StatusOr<google::iam::admin::v1::Role> GetRole(
+      google::iam::admin::v1::GetRoleRequest const& request) override {
     return google::cloud::internal::RetryLoop(
         retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
         idempotency_policy_->GetRole(request),
         [this](grpc::ClientContext& context,
-               ::google::iam::admin::v1::GetRoleRequest const& request) {
+               google::iam::admin::v1::GetRoleRequest const& request) {
           return stub_->GetRole(context, request);
         },
         request, __func__);
   }
 
-  StatusOr<::google::iam::admin::v1::Role> CreateRole(
-      ::google::iam::admin::v1::CreateRoleRequest const& request) override {
+  StatusOr<google::iam::admin::v1::Role> CreateRole(
+      google::iam::admin::v1::CreateRoleRequest const& request) override {
     return google::cloud::internal::RetryLoop(
         retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
         idempotency_policy_->CreateRole(request),
         [this](grpc::ClientContext& context,
-               ::google::iam::admin::v1::CreateRoleRequest const& request) {
+               google::iam::admin::v1::CreateRoleRequest const& request) {
           return stub_->CreateRole(context, request);
         },
         request, __func__);
   }
 
-  StatusOr<::google::iam::admin::v1::Role> UpdateRole(
-      ::google::iam::admin::v1::UpdateRoleRequest const& request) override {
+  StatusOr<google::iam::admin::v1::Role> UpdateRole(
+      google::iam::admin::v1::UpdateRoleRequest const& request) override {
     return google::cloud::internal::RetryLoop(
         retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
         idempotency_policy_->UpdateRole(request),
         [this](grpc::ClientContext& context,
-               ::google::iam::admin::v1::UpdateRoleRequest const& request) {
+               google::iam::admin::v1::UpdateRoleRequest const& request) {
           return stub_->UpdateRole(context, request);
         },
         request, __func__);
   }
 
-  StatusOr<::google::iam::admin::v1::Role> DeleteRole(
-      ::google::iam::admin::v1::DeleteRoleRequest const& request) override {
+  StatusOr<google::iam::admin::v1::Role> DeleteRole(
+      google::iam::admin::v1::DeleteRoleRequest const& request) override {
     return google::cloud::internal::RetryLoop(
         retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
         idempotency_policy_->DeleteRole(request),
         [this](grpc::ClientContext& context,
-               ::google::iam::admin::v1::DeleteRoleRequest const& request) {
+               google::iam::admin::v1::DeleteRoleRequest const& request) {
           return stub_->DeleteRole(context, request);
         },
         request, __func__);
   }
 
-  StatusOr<::google::iam::admin::v1::Role> UndeleteRole(
-      ::google::iam::admin::v1::UndeleteRoleRequest const& request) override {
+  StatusOr<google::iam::admin::v1::Role> UndeleteRole(
+      google::iam::admin::v1::UndeleteRoleRequest const& request) override {
     return google::cloud::internal::RetryLoop(
         retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
         idempotency_policy_->UndeleteRole(request),
         [this](grpc::ClientContext& context,
-               ::google::iam::admin::v1::UndeleteRoleRequest const& request) {
+               google::iam::admin::v1::UndeleteRoleRequest const& request) {
           return stub_->UndeleteRole(context, request);
         },
         request, __func__);
   }
 
-  StreamRange<::google::iam::admin::v1::Permission> QueryTestablePermissions(
-      ::google::iam::admin::v1::QueryTestablePermissionsRequest request)
+  StreamRange<google::iam::admin::v1::Permission> QueryTestablePermissions(
+      google::iam::admin::v1::QueryTestablePermissionsRequest request)
       override {
     request.clear_page_token();
     auto stub = stub_;
@@ -597,22 +594,22 @@ class IAMConnectionImpl : public IAMConnection {
     auto idempotency = idempotency_policy_->QueryTestablePermissions(request);
     char const* function_name = __func__;
     return google::cloud::internal::MakePaginationRange<
-        StreamRange<::google::iam::admin::v1::Permission>>(
+        StreamRange<google::iam::admin::v1::Permission>>(
         std::move(request),
         [stub, retry, backoff, idempotency, function_name](
-            ::google::iam::admin::v1::QueryTestablePermissionsRequest const&
-                r) {
+            google::iam::admin::v1::QueryTestablePermissionsRequest const& r) {
           return google::cloud::internal::RetryLoop(
               retry->clone(), backoff->clone(), idempotency,
-              [stub](grpc::ClientContext& context,
-                     ::google::iam::admin::v1::
-                         QueryTestablePermissionsRequest const& request) {
+              [stub](
+                  grpc::ClientContext& context,
+                  google::iam::admin::v1::QueryTestablePermissionsRequest const&
+                      request) {
                 return stub->QueryTestablePermissions(context, request);
               },
               r, function_name);
         },
-        [](::google::iam::admin::v1::QueryTestablePermissionsResponse r) {
-          std::vector<::google::iam::admin::v1::Permission> result(
+        [](google::iam::admin::v1::QueryTestablePermissionsResponse r) {
+          std::vector<google::iam::admin::v1::Permission> result(
               r.permissions().size());
           auto& messages = *r.mutable_permissions();
           std::move(messages.begin(), messages.end(), result.begin());
@@ -620,28 +617,28 @@ class IAMConnectionImpl : public IAMConnection {
         });
   }
 
-  StatusOr<::google::iam::admin::v1::QueryAuditableServicesResponse>
+  StatusOr<google::iam::admin::v1::QueryAuditableServicesResponse>
   QueryAuditableServices(
-      ::google::iam::admin::v1::QueryAuditableServicesRequest const& request)
+      google::iam::admin::v1::QueryAuditableServicesRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
         retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
         idempotency_policy_->QueryAuditableServices(request),
         [this](grpc::ClientContext& context,
-               ::google::iam::admin::v1::QueryAuditableServicesRequest const&
+               google::iam::admin::v1::QueryAuditableServicesRequest const&
                    request) {
           return stub_->QueryAuditableServices(context, request);
         },
         request, __func__);
   }
 
-  StatusOr<::google::iam::admin::v1::LintPolicyResponse> LintPolicy(
-      ::google::iam::admin::v1::LintPolicyRequest const& request) override {
+  StatusOr<google::iam::admin::v1::LintPolicyResponse> LintPolicy(
+      google::iam::admin::v1::LintPolicyRequest const& request) override {
     return google::cloud::internal::RetryLoop(
         retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
         idempotency_policy_->LintPolicy(request),
         [this](grpc::ClientContext& context,
-               ::google::iam::admin::v1::LintPolicyRequest const& request) {
+               google::iam::admin::v1::LintPolicyRequest const& request) {
           return stub_->LintPolicy(context, request);
         },
         request, __func__);

--- a/google/cloud/iam/iam_connection.h
+++ b/google/cloud/iam/iam_connection.h
@@ -48,94 +48,91 @@ class IAMConnection {
  public:
   virtual ~IAMConnection() = 0;
 
-  virtual StreamRange<::google::iam::admin::v1::ServiceAccount>
+  virtual StreamRange<google::iam::admin::v1::ServiceAccount>
   ListServiceAccounts(
-      ::google::iam::admin::v1::ListServiceAccountsRequest request);
+      google::iam::admin::v1::ListServiceAccountsRequest request);
 
-  virtual StatusOr<::google::iam::admin::v1::ServiceAccount> GetServiceAccount(
-      ::google::iam::admin::v1::GetServiceAccountRequest const& request);
+  virtual StatusOr<google::iam::admin::v1::ServiceAccount> GetServiceAccount(
+      google::iam::admin::v1::GetServiceAccountRequest const& request);
 
-  virtual StatusOr<::google::iam::admin::v1::ServiceAccount>
-  CreateServiceAccount(
-      ::google::iam::admin::v1::CreateServiceAccountRequest const& request);
+  virtual StatusOr<google::iam::admin::v1::ServiceAccount> CreateServiceAccount(
+      google::iam::admin::v1::CreateServiceAccountRequest const& request);
 
-  virtual StatusOr<::google::iam::admin::v1::ServiceAccount>
-  PatchServiceAccount(
-      ::google::iam::admin::v1::PatchServiceAccountRequest const& request);
+  virtual StatusOr<google::iam::admin::v1::ServiceAccount> PatchServiceAccount(
+      google::iam::admin::v1::PatchServiceAccountRequest const& request);
 
   virtual Status DeleteServiceAccount(
-      ::google::iam::admin::v1::DeleteServiceAccountRequest const& request);
+      google::iam::admin::v1::DeleteServiceAccountRequest const& request);
 
-  virtual StatusOr<::google::iam::admin::v1::UndeleteServiceAccountResponse>
+  virtual StatusOr<google::iam::admin::v1::UndeleteServiceAccountResponse>
   UndeleteServiceAccount(
-      ::google::iam::admin::v1::UndeleteServiceAccountRequest const& request);
+      google::iam::admin::v1::UndeleteServiceAccountRequest const& request);
 
   virtual Status EnableServiceAccount(
-      ::google::iam::admin::v1::EnableServiceAccountRequest const& request);
+      google::iam::admin::v1::EnableServiceAccountRequest const& request);
 
   virtual Status DisableServiceAccount(
-      ::google::iam::admin::v1::DisableServiceAccountRequest const& request);
+      google::iam::admin::v1::DisableServiceAccountRequest const& request);
 
-  virtual StatusOr<::google::iam::admin::v1::ListServiceAccountKeysResponse>
+  virtual StatusOr<google::iam::admin::v1::ListServiceAccountKeysResponse>
   ListServiceAccountKeys(
-      ::google::iam::admin::v1::ListServiceAccountKeysRequest const& request);
+      google::iam::admin::v1::ListServiceAccountKeysRequest const& request);
 
-  virtual StatusOr<::google::iam::admin::v1::ServiceAccountKey>
+  virtual StatusOr<google::iam::admin::v1::ServiceAccountKey>
   GetServiceAccountKey(
-      ::google::iam::admin::v1::GetServiceAccountKeyRequest const& request);
+      google::iam::admin::v1::GetServiceAccountKeyRequest const& request);
 
-  virtual StatusOr<::google::iam::admin::v1::ServiceAccountKey>
+  virtual StatusOr<google::iam::admin::v1::ServiceAccountKey>
   CreateServiceAccountKey(
-      ::google::iam::admin::v1::CreateServiceAccountKeyRequest const& request);
+      google::iam::admin::v1::CreateServiceAccountKeyRequest const& request);
 
-  virtual StatusOr<::google::iam::admin::v1::ServiceAccountKey>
+  virtual StatusOr<google::iam::admin::v1::ServiceAccountKey>
   UploadServiceAccountKey(
-      ::google::iam::admin::v1::UploadServiceAccountKeyRequest const& request);
+      google::iam::admin::v1::UploadServiceAccountKeyRequest const& request);
 
   virtual Status DeleteServiceAccountKey(
-      ::google::iam::admin::v1::DeleteServiceAccountKeyRequest const& request);
+      google::iam::admin::v1::DeleteServiceAccountKeyRequest const& request);
 
-  virtual StatusOr<::google::iam::v1::Policy> GetIamPolicy(
-      ::google::iam::v1::GetIamPolicyRequest const& request);
+  virtual StatusOr<google::iam::v1::Policy> GetIamPolicy(
+      google::iam::v1::GetIamPolicyRequest const& request);
 
-  virtual StatusOr<::google::iam::v1::Policy> SetIamPolicy(
-      ::google::iam::v1::SetIamPolicyRequest const& request);
+  virtual StatusOr<google::iam::v1::Policy> SetIamPolicy(
+      google::iam::v1::SetIamPolicyRequest const& request);
 
-  virtual StatusOr<::google::iam::v1::TestIamPermissionsResponse>
-  TestIamPermissions(
-      ::google::iam::v1::TestIamPermissionsRequest const& request);
+  virtual StatusOr<google::iam::v1::TestIamPermissionsResponse>
+  TestIamPermissions(google::iam::v1::TestIamPermissionsRequest const& request);
 
-  virtual StreamRange<::google::iam::admin::v1::Role> QueryGrantableRoles(
-      ::google::iam::admin::v1::QueryGrantableRolesRequest request);
+  virtual StreamRange<google::iam::admin::v1::Role> QueryGrantableRoles(
+      google::iam::admin::v1::QueryGrantableRolesRequest request);
 
-  virtual StreamRange<::google::iam::admin::v1::Role> ListRoles(
-      ::google::iam::admin::v1::ListRolesRequest request);
+  virtual StreamRange<google::iam::admin::v1::Role> ListRoles(
+      google::iam::admin::v1::ListRolesRequest request);
 
-  virtual StatusOr<::google::iam::admin::v1::Role> GetRole(
-      ::google::iam::admin::v1::GetRoleRequest const& request);
+  virtual StatusOr<google::iam::admin::v1::Role> GetRole(
+      google::iam::admin::v1::GetRoleRequest const& request);
 
-  virtual StatusOr<::google::iam::admin::v1::Role> CreateRole(
-      ::google::iam::admin::v1::CreateRoleRequest const& request);
+  virtual StatusOr<google::iam::admin::v1::Role> CreateRole(
+      google::iam::admin::v1::CreateRoleRequest const& request);
 
-  virtual StatusOr<::google::iam::admin::v1::Role> UpdateRole(
-      ::google::iam::admin::v1::UpdateRoleRequest const& request);
+  virtual StatusOr<google::iam::admin::v1::Role> UpdateRole(
+      google::iam::admin::v1::UpdateRoleRequest const& request);
 
-  virtual StatusOr<::google::iam::admin::v1::Role> DeleteRole(
-      ::google::iam::admin::v1::DeleteRoleRequest const& request);
+  virtual StatusOr<google::iam::admin::v1::Role> DeleteRole(
+      google::iam::admin::v1::DeleteRoleRequest const& request);
 
-  virtual StatusOr<::google::iam::admin::v1::Role> UndeleteRole(
-      ::google::iam::admin::v1::UndeleteRoleRequest const& request);
+  virtual StatusOr<google::iam::admin::v1::Role> UndeleteRole(
+      google::iam::admin::v1::UndeleteRoleRequest const& request);
 
-  virtual StreamRange<::google::iam::admin::v1::Permission>
+  virtual StreamRange<google::iam::admin::v1::Permission>
   QueryTestablePermissions(
-      ::google::iam::admin::v1::QueryTestablePermissionsRequest request);
+      google::iam::admin::v1::QueryTestablePermissionsRequest request);
 
-  virtual StatusOr<::google::iam::admin::v1::QueryAuditableServicesResponse>
+  virtual StatusOr<google::iam::admin::v1::QueryAuditableServicesResponse>
   QueryAuditableServices(
-      ::google::iam::admin::v1::QueryAuditableServicesRequest const& request);
+      google::iam::admin::v1::QueryAuditableServicesRequest const& request);
 
-  virtual StatusOr<::google::iam::admin::v1::LintPolicyResponse> LintPolicy(
-      ::google::iam::admin::v1::LintPolicyRequest const& request);
+  virtual StatusOr<google::iam::admin::v1::LintPolicyResponse> LintPolicy(
+      google::iam::admin::v1::LintPolicyRequest const& request);
 };
 
 std::shared_ptr<IAMConnection> MakeIAMConnection(Options options = {});

--- a/google/cloud/iam/iam_connection_idempotency_policy.cc
+++ b/google/cloud/iam/iam_connection_idempotency_policy.cc
@@ -40,134 +40,130 @@ class DefaultIAMConnectionIdempotencyPolicy
   }
 
   Idempotency ListServiceAccounts(
-      ::google::iam::admin::v1::ListServiceAccountsRequest) override {
+      google::iam::admin::v1::ListServiceAccountsRequest) override {
     return Idempotency::kIdempotent;
   }
 
   Idempotency GetServiceAccount(
-      ::google::iam::admin::v1::GetServiceAccountRequest const&) override {
+      google::iam::admin::v1::GetServiceAccountRequest const&) override {
     return Idempotency::kIdempotent;
   }
 
   Idempotency CreateServiceAccount(
-      ::google::iam::admin::v1::CreateServiceAccountRequest const&) override {
+      google::iam::admin::v1::CreateServiceAccountRequest const&) override {
     return Idempotency::kNonIdempotent;
   }
 
   Idempotency PatchServiceAccount(
-      ::google::iam::admin::v1::PatchServiceAccountRequest const&) override {
+      google::iam::admin::v1::PatchServiceAccountRequest const&) override {
     return Idempotency::kNonIdempotent;
   }
 
   Idempotency DeleteServiceAccount(
-      ::google::iam::admin::v1::DeleteServiceAccountRequest const&) override {
+      google::iam::admin::v1::DeleteServiceAccountRequest const&) override {
     return Idempotency::kNonIdempotent;
   }
 
   Idempotency UndeleteServiceAccount(
-      ::google::iam::admin::v1::UndeleteServiceAccountRequest const&) override {
+      google::iam::admin::v1::UndeleteServiceAccountRequest const&) override {
     return Idempotency::kNonIdempotent;
   }
 
   Idempotency EnableServiceAccount(
-      ::google::iam::admin::v1::EnableServiceAccountRequest const&) override {
+      google::iam::admin::v1::EnableServiceAccountRequest const&) override {
     return Idempotency::kNonIdempotent;
   }
 
   Idempotency DisableServiceAccount(
-      ::google::iam::admin::v1::DisableServiceAccountRequest const&) override {
+      google::iam::admin::v1::DisableServiceAccountRequest const&) override {
     return Idempotency::kNonIdempotent;
   }
 
   Idempotency ListServiceAccountKeys(
-      ::google::iam::admin::v1::ListServiceAccountKeysRequest const&) override {
+      google::iam::admin::v1::ListServiceAccountKeysRequest const&) override {
     return Idempotency::kIdempotent;
   }
 
   Idempotency GetServiceAccountKey(
-      ::google::iam::admin::v1::GetServiceAccountKeyRequest const&) override {
+      google::iam::admin::v1::GetServiceAccountKeyRequest const&) override {
     return Idempotency::kIdempotent;
   }
 
   Idempotency CreateServiceAccountKey(
-      ::google::iam::admin::v1::CreateServiceAccountKeyRequest const&)
-      override {
+      google::iam::admin::v1::CreateServiceAccountKeyRequest const&) override {
     return Idempotency::kNonIdempotent;
   }
 
   Idempotency UploadServiceAccountKey(
-      ::google::iam::admin::v1::UploadServiceAccountKeyRequest const&)
-      override {
+      google::iam::admin::v1::UploadServiceAccountKeyRequest const&) override {
     return Idempotency::kNonIdempotent;
   }
 
   Idempotency DeleteServiceAccountKey(
-      ::google::iam::admin::v1::DeleteServiceAccountKeyRequest const&)
-      override {
+      google::iam::admin::v1::DeleteServiceAccountKeyRequest const&) override {
     return Idempotency::kNonIdempotent;
   }
 
   Idempotency GetIamPolicy(
-      ::google::iam::v1::GetIamPolicyRequest const&) override {
+      google::iam::v1::GetIamPolicyRequest const&) override {
     return Idempotency::kNonIdempotent;
   }
 
   Idempotency SetIamPolicy(
-      ::google::iam::v1::SetIamPolicyRequest const&) override {
+      google::iam::v1::SetIamPolicyRequest const&) override {
     return Idempotency::kNonIdempotent;
   }
 
   Idempotency TestIamPermissions(
-      ::google::iam::v1::TestIamPermissionsRequest const&) override {
+      google::iam::v1::TestIamPermissionsRequest const&) override {
     return Idempotency::kNonIdempotent;
   }
 
   Idempotency QueryGrantableRoles(
-      ::google::iam::admin::v1::QueryGrantableRolesRequest) override {
+      google::iam::admin::v1::QueryGrantableRolesRequest) override {
     return Idempotency::kNonIdempotent;
   }
 
-  Idempotency ListRoles(::google::iam::admin::v1::ListRolesRequest) override {
+  Idempotency ListRoles(google::iam::admin::v1::ListRolesRequest) override {
     return Idempotency::kIdempotent;
   }
 
-  Idempotency GetRole(
-      ::google::iam::admin::v1::GetRoleRequest const&) override {
+  Idempotency GetRole(google::iam::admin::v1::GetRoleRequest const&) override {
     return Idempotency::kIdempotent;
   }
 
   Idempotency CreateRole(
-      ::google::iam::admin::v1::CreateRoleRequest const&) override {
+      google::iam::admin::v1::CreateRoleRequest const&) override {
     return Idempotency::kNonIdempotent;
   }
 
   Idempotency UpdateRole(
-      ::google::iam::admin::v1::UpdateRoleRequest const&) override {
+      google::iam::admin::v1::UpdateRoleRequest const&) override {
     return Idempotency::kNonIdempotent;
   }
 
   Idempotency DeleteRole(
-      ::google::iam::admin::v1::DeleteRoleRequest const&) override {
+      google::iam::admin::v1::DeleteRoleRequest const&) override {
     return Idempotency::kNonIdempotent;
   }
 
   Idempotency UndeleteRole(
-      ::google::iam::admin::v1::UndeleteRoleRequest const&) override {
+      google::iam::admin::v1::UndeleteRoleRequest const&) override {
     return Idempotency::kNonIdempotent;
   }
 
   Idempotency QueryTestablePermissions(
-      ::google::iam::admin::v1::QueryTestablePermissionsRequest) override {
+      google::iam::admin::v1::QueryTestablePermissionsRequest) override {
     return Idempotency::kNonIdempotent;
   }
 
   Idempotency QueryAuditableServices(
-      ::google::iam::admin::v1::QueryAuditableServicesRequest const&) override {
+      google::iam::admin::v1::QueryAuditableServicesRequest const&) override {
     return Idempotency::kNonIdempotent;
   }
 
   Idempotency LintPolicy(
-      ::google::iam::admin::v1::LintPolicyRequest const&) override {
+      google::iam::admin::v1::LintPolicyRequest const&) override {
     return Idempotency::kNonIdempotent;
   }
 };

--- a/google/cloud/iam/iam_connection_idempotency_policy.h
+++ b/google/cloud/iam/iam_connection_idempotency_policy.h
@@ -37,89 +37,85 @@ class IAMConnectionIdempotencyPolicy {
   virtual std::unique_ptr<IAMConnectionIdempotencyPolicy> clone() const = 0;
 
   virtual google::cloud::internal::Idempotency ListServiceAccounts(
-      ::google::iam::admin::v1::ListServiceAccountsRequest request) = 0;
+      google::iam::admin::v1::ListServiceAccountsRequest request) = 0;
 
   virtual google::cloud::internal::Idempotency GetServiceAccount(
-      ::google::iam::admin::v1::GetServiceAccountRequest const& request) = 0;
+      google::iam::admin::v1::GetServiceAccountRequest const& request) = 0;
 
   virtual google::cloud::internal::Idempotency CreateServiceAccount(
-      ::google::iam::admin::v1::CreateServiceAccountRequest const& request) = 0;
+      google::iam::admin::v1::CreateServiceAccountRequest const& request) = 0;
 
   virtual google::cloud::internal::Idempotency PatchServiceAccount(
-      ::google::iam::admin::v1::PatchServiceAccountRequest const& request) = 0;
+      google::iam::admin::v1::PatchServiceAccountRequest const& request) = 0;
 
   virtual google::cloud::internal::Idempotency DeleteServiceAccount(
-      ::google::iam::admin::v1::DeleteServiceAccountRequest const& request) = 0;
+      google::iam::admin::v1::DeleteServiceAccountRequest const& request) = 0;
 
   virtual google::cloud::internal::Idempotency UndeleteServiceAccount(
-      ::google::iam::admin::v1::UndeleteServiceAccountRequest const&
-          request) = 0;
+      google::iam::admin::v1::UndeleteServiceAccountRequest const& request) = 0;
 
   virtual google::cloud::internal::Idempotency EnableServiceAccount(
-      ::google::iam::admin::v1::EnableServiceAccountRequest const& request) = 0;
+      google::iam::admin::v1::EnableServiceAccountRequest const& request) = 0;
 
   virtual google::cloud::internal::Idempotency DisableServiceAccount(
-      ::google::iam::admin::v1::DisableServiceAccountRequest const&
-          request) = 0;
+      google::iam::admin::v1::DisableServiceAccountRequest const& request) = 0;
 
   virtual google::cloud::internal::Idempotency ListServiceAccountKeys(
-      ::google::iam::admin::v1::ListServiceAccountKeysRequest const&
-          request) = 0;
+      google::iam::admin::v1::ListServiceAccountKeysRequest const& request) = 0;
 
   virtual google::cloud::internal::Idempotency GetServiceAccountKey(
-      ::google::iam::admin::v1::GetServiceAccountKeyRequest const& request) = 0;
+      google::iam::admin::v1::GetServiceAccountKeyRequest const& request) = 0;
 
   virtual google::cloud::internal::Idempotency CreateServiceAccountKey(
-      ::google::iam::admin::v1::CreateServiceAccountKeyRequest const&
+      google::iam::admin::v1::CreateServiceAccountKeyRequest const&
           request) = 0;
 
   virtual google::cloud::internal::Idempotency UploadServiceAccountKey(
-      ::google::iam::admin::v1::UploadServiceAccountKeyRequest const&
+      google::iam::admin::v1::UploadServiceAccountKeyRequest const&
           request) = 0;
 
   virtual google::cloud::internal::Idempotency DeleteServiceAccountKey(
-      ::google::iam::admin::v1::DeleteServiceAccountKeyRequest const&
+      google::iam::admin::v1::DeleteServiceAccountKeyRequest const&
           request) = 0;
 
   virtual google::cloud::internal::Idempotency GetIamPolicy(
-      ::google::iam::v1::GetIamPolicyRequest const& request) = 0;
+      google::iam::v1::GetIamPolicyRequest const& request) = 0;
 
   virtual google::cloud::internal::Idempotency SetIamPolicy(
-      ::google::iam::v1::SetIamPolicyRequest const& request) = 0;
+      google::iam::v1::SetIamPolicyRequest const& request) = 0;
 
   virtual google::cloud::internal::Idempotency TestIamPermissions(
-      ::google::iam::v1::TestIamPermissionsRequest const& request) = 0;
+      google::iam::v1::TestIamPermissionsRequest const& request) = 0;
 
   virtual google::cloud::internal::Idempotency QueryGrantableRoles(
-      ::google::iam::admin::v1::QueryGrantableRolesRequest request) = 0;
+      google::iam::admin::v1::QueryGrantableRolesRequest request) = 0;
 
   virtual google::cloud::internal::Idempotency ListRoles(
-      ::google::iam::admin::v1::ListRolesRequest request) = 0;
+      google::iam::admin::v1::ListRolesRequest request) = 0;
 
   virtual google::cloud::internal::Idempotency GetRole(
-      ::google::iam::admin::v1::GetRoleRequest const& request) = 0;
+      google::iam::admin::v1::GetRoleRequest const& request) = 0;
 
   virtual google::cloud::internal::Idempotency CreateRole(
-      ::google::iam::admin::v1::CreateRoleRequest const& request) = 0;
+      google::iam::admin::v1::CreateRoleRequest const& request) = 0;
 
   virtual google::cloud::internal::Idempotency UpdateRole(
-      ::google::iam::admin::v1::UpdateRoleRequest const& request) = 0;
+      google::iam::admin::v1::UpdateRoleRequest const& request) = 0;
 
   virtual google::cloud::internal::Idempotency DeleteRole(
-      ::google::iam::admin::v1::DeleteRoleRequest const& request) = 0;
+      google::iam::admin::v1::DeleteRoleRequest const& request) = 0;
 
   virtual google::cloud::internal::Idempotency UndeleteRole(
-      ::google::iam::admin::v1::UndeleteRoleRequest const& request) = 0;
+      google::iam::admin::v1::UndeleteRoleRequest const& request) = 0;
 
   virtual google::cloud::internal::Idempotency QueryTestablePermissions(
-      ::google::iam::admin::v1::QueryTestablePermissionsRequest request) = 0;
+      google::iam::admin::v1::QueryTestablePermissionsRequest request) = 0;
 
   virtual google::cloud::internal::Idempotency QueryAuditableServices(
-      ::google::iam::admin::v1::QueryAuditableServicesRequest const&
-          request) = 0;
+      google::iam::admin::v1::QueryAuditableServicesRequest const& request) = 0;
 
   virtual google::cloud::internal::Idempotency LintPolicy(
-      ::google::iam::admin::v1::LintPolicyRequest const& request) = 0;
+      google::iam::admin::v1::LintPolicyRequest const& request) = 0;
 };
 
 std::unique_ptr<IAMConnectionIdempotencyPolicy>

--- a/google/cloud/iam/iam_credentials_client.cc
+++ b/google/cloud/iam/iam_credentials_client.cc
@@ -29,12 +29,12 @@ IAMCredentialsClient::IAMCredentialsClient(
     : connection_(std::move(connection)) {}
 IAMCredentialsClient::~IAMCredentialsClient() = default;
 
-StatusOr<::google::iam::credentials::v1::GenerateAccessTokenResponse>
+StatusOr<google::iam::credentials::v1::GenerateAccessTokenResponse>
 IAMCredentialsClient::GenerateAccessToken(
     std::string const& name, std::vector<std::string> const& delegates,
     std::vector<std::string> const& scope,
-    ::google::protobuf::Duration const& lifetime) {
-  ::google::iam::credentials::v1::GenerateAccessTokenRequest request;
+    google::protobuf::Duration const& lifetime) {
+  google::iam::credentials::v1::GenerateAccessTokenRequest request;
   request.set_name(name);
   *request.mutable_delegates() = {delegates.begin(), delegates.end()};
   *request.mutable_scope() = {scope.begin(), scope.end()};
@@ -42,12 +42,12 @@ IAMCredentialsClient::GenerateAccessToken(
   return connection_->GenerateAccessToken(request);
 }
 
-StatusOr<::google::iam::credentials::v1::GenerateIdTokenResponse>
+StatusOr<google::iam::credentials::v1::GenerateIdTokenResponse>
 IAMCredentialsClient::GenerateIdToken(std::string const& name,
                                       std::vector<std::string> const& delegates,
                                       std::string const& audience,
                                       bool include_email) {
-  ::google::iam::credentials::v1::GenerateIdTokenRequest request;
+  google::iam::credentials::v1::GenerateIdTokenRequest request;
   request.set_name(name);
   *request.mutable_delegates() = {delegates.begin(), delegates.end()};
   request.set_audience(audience);
@@ -55,49 +55,49 @@ IAMCredentialsClient::GenerateIdToken(std::string const& name,
   return connection_->GenerateIdToken(request);
 }
 
-StatusOr<::google::iam::credentials::v1::SignBlobResponse>
+StatusOr<google::iam::credentials::v1::SignBlobResponse>
 IAMCredentialsClient::SignBlob(std::string const& name,
                                std::vector<std::string> const& delegates,
                                std::string const& payload) {
-  ::google::iam::credentials::v1::SignBlobRequest request;
+  google::iam::credentials::v1::SignBlobRequest request;
   request.set_name(name);
   *request.mutable_delegates() = {delegates.begin(), delegates.end()};
   request.set_payload(payload);
   return connection_->SignBlob(request);
 }
 
-StatusOr<::google::iam::credentials::v1::SignJwtResponse>
+StatusOr<google::iam::credentials::v1::SignJwtResponse>
 IAMCredentialsClient::SignJwt(std::string const& name,
                               std::vector<std::string> const& delegates,
                               std::string const& payload) {
-  ::google::iam::credentials::v1::SignJwtRequest request;
+  google::iam::credentials::v1::SignJwtRequest request;
   request.set_name(name);
   *request.mutable_delegates() = {delegates.begin(), delegates.end()};
   request.set_payload(payload);
   return connection_->SignJwt(request);
 }
 
-StatusOr<::google::iam::credentials::v1::GenerateAccessTokenResponse>
+StatusOr<google::iam::credentials::v1::GenerateAccessTokenResponse>
 IAMCredentialsClient::GenerateAccessToken(
-    ::google::iam::credentials::v1::GenerateAccessTokenRequest const& request) {
+    google::iam::credentials::v1::GenerateAccessTokenRequest const& request) {
   return connection_->GenerateAccessToken(request);
 }
 
-StatusOr<::google::iam::credentials::v1::GenerateIdTokenResponse>
+StatusOr<google::iam::credentials::v1::GenerateIdTokenResponse>
 IAMCredentialsClient::GenerateIdToken(
-    ::google::iam::credentials::v1::GenerateIdTokenRequest const& request) {
+    google::iam::credentials::v1::GenerateIdTokenRequest const& request) {
   return connection_->GenerateIdToken(request);
 }
 
-StatusOr<::google::iam::credentials::v1::SignBlobResponse>
+StatusOr<google::iam::credentials::v1::SignBlobResponse>
 IAMCredentialsClient::SignBlob(
-    ::google::iam::credentials::v1::SignBlobRequest const& request) {
+    google::iam::credentials::v1::SignBlobRequest const& request) {
   return connection_->SignBlob(request);
 }
 
-StatusOr<::google::iam::credentials::v1::SignJwtResponse>
+StatusOr<google::iam::credentials::v1::SignJwtResponse>
 IAMCredentialsClient::SignJwt(
-    ::google::iam::credentials::v1::SignJwtRequest const& request) {
+    google::iam::credentials::v1::SignJwtRequest const& request) {
   return connection_->SignJwt(request);
 }
 

--- a/google/cloud/iam/iam_credentials_client.h
+++ b/google/cloud/iam/iam_credentials_client.h
@@ -93,13 +93,13 @@ class IAMCredentialsClient {
    * value is not specified, the token's lifetime will be set to a default value
    * of one hour.
    * @return
-   * [::google::iam::credentials::v1::GenerateAccessTokenResponse](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/credentials/v1/common.proto#L72)
+   * [google::iam::credentials::v1::GenerateAccessTokenResponse](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/credentials/v1/common.proto#L72)
    */
-  StatusOr<::google::iam::credentials::v1::GenerateAccessTokenResponse>
+  StatusOr<google::iam::credentials::v1::GenerateAccessTokenResponse>
   GenerateAccessToken(std::string const& name,
                       std::vector<std::string> const& delegates,
                       std::vector<std::string> const& scope,
-                      ::google::protobuf::Duration const& lifetime);
+                      google::protobuf::Duration const& lifetime);
 
   /**
    * Generates an OpenID Connect ID token for a service account.
@@ -122,9 +122,9 @@ class IAMCredentialsClient {
    * @param include_email  Include the service account email in the token. If
    * set to `true`, the token will contain `email` and `email_verified` claims.
    * @return
-   * [::google::iam::credentials::v1::GenerateIdTokenResponse](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/credentials/v1/common.proto#L186)
+   * [google::iam::credentials::v1::GenerateIdTokenResponse](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/credentials/v1/common.proto#L186)
    */
-  StatusOr<::google::iam::credentials::v1::GenerateIdTokenResponse>
+  StatusOr<google::iam::credentials::v1::GenerateIdTokenResponse>
   GenerateIdToken(std::string const& name,
                   std::vector<std::string> const& delegates,
                   std::string const& audience, bool include_email);
@@ -147,9 +147,9 @@ class IAMCredentialsClient {
    * invalid.
    * @param payload  Required. The bytes to sign.
    * @return
-   * [::google::iam::credentials::v1::SignBlobResponse](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/credentials/v1/common.proto#L109)
+   * [google::iam::credentials::v1::SignBlobResponse](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/credentials/v1/common.proto#L109)
    */
-  StatusOr<::google::iam::credentials::v1::SignBlobResponse> SignBlob(
+  StatusOr<google::iam::credentials::v1::SignBlobResponse> SignBlob(
       std::string const& name, std::vector<std::string> const& delegates,
       std::string const& payload);
 
@@ -172,9 +172,9 @@ class IAMCredentialsClient {
    * @param payload  Required. The JWT payload to sign: a JSON object that
    * contains a JWT Claims Set.
    * @return
-   * [::google::iam::credentials::v1::SignJwtResponse](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/credentials/v1/common.proto#L145)
+   * [google::iam::credentials::v1::SignJwtResponse](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/credentials/v1/common.proto#L145)
    */
-  StatusOr<::google::iam::credentials::v1::SignJwtResponse> SignJwt(
+  StatusOr<google::iam::credentials::v1::SignJwtResponse> SignJwt(
       std::string const& name, std::vector<std::string> const& delegates,
       std::string const& payload);
 
@@ -182,48 +182,47 @@ class IAMCredentialsClient {
    * Generates an OAuth 2.0 access token for a service account.
    *
    * @param request
-   * [::google::iam::credentials::v1::GenerateAccessTokenRequest](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/credentials/v1/common.proto#L35)
+   * [google::iam::credentials::v1::GenerateAccessTokenRequest](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/credentials/v1/common.proto#L35)
    * @return
-   * [::google::iam::credentials::v1::GenerateAccessTokenResponse](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/credentials/v1/common.proto#L72)
+   * [google::iam::credentials::v1::GenerateAccessTokenResponse](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/credentials/v1/common.proto#L72)
    */
-  StatusOr<::google::iam::credentials::v1::GenerateAccessTokenResponse>
+  StatusOr<google::iam::credentials::v1::GenerateAccessTokenResponse>
   GenerateAccessToken(
-      ::google::iam::credentials::v1::GenerateAccessTokenRequest const&
-          request);
+      google::iam::credentials::v1::GenerateAccessTokenRequest const& request);
 
   /**
    * Generates an OpenID Connect ID token for a service account.
    *
    * @param request
-   * [::google::iam::credentials::v1::GenerateIdTokenRequest](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/credentials/v1/common.proto#L153)
+   * [google::iam::credentials::v1::GenerateIdTokenRequest](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/credentials/v1/common.proto#L153)
    * @return
-   * [::google::iam::credentials::v1::GenerateIdTokenResponse](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/credentials/v1/common.proto#L186)
+   * [google::iam::credentials::v1::GenerateIdTokenResponse](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/credentials/v1/common.proto#L186)
    */
-  StatusOr<::google::iam::credentials::v1::GenerateIdTokenResponse>
+  StatusOr<google::iam::credentials::v1::GenerateIdTokenResponse>
   GenerateIdToken(
-      ::google::iam::credentials::v1::GenerateIdTokenRequest const& request);
+      google::iam::credentials::v1::GenerateIdTokenRequest const& request);
 
   /**
    * Signs a blob using a service account's system-managed private key.
    *
    * @param request
-   * [::google::iam::credentials::v1::SignBlobRequest](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/credentials/v1/common.proto#L81)
+   * [google::iam::credentials::v1::SignBlobRequest](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/credentials/v1/common.proto#L81)
    * @return
-   * [::google::iam::credentials::v1::SignBlobResponse](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/credentials/v1/common.proto#L109)
+   * [google::iam::credentials::v1::SignBlobResponse](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/credentials/v1/common.proto#L109)
    */
-  StatusOr<::google::iam::credentials::v1::SignBlobResponse> SignBlob(
-      ::google::iam::credentials::v1::SignBlobRequest const& request);
+  StatusOr<google::iam::credentials::v1::SignBlobResponse> SignBlob(
+      google::iam::credentials::v1::SignBlobRequest const& request);
 
   /**
    * Signs a JWT using a service account's system-managed private key.
    *
    * @param request
-   * [::google::iam::credentials::v1::SignJwtRequest](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/credentials/v1/common.proto#L117)
+   * [google::iam::credentials::v1::SignJwtRequest](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/credentials/v1/common.proto#L117)
    * @return
-   * [::google::iam::credentials::v1::SignJwtResponse](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/credentials/v1/common.proto#L145)
+   * [google::iam::credentials::v1::SignJwtResponse](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/iam/credentials/v1/common.proto#L145)
    */
-  StatusOr<::google::iam::credentials::v1::SignJwtResponse> SignJwt(
-      ::google::iam::credentials::v1::SignJwtRequest const& request);
+  StatusOr<google::iam::credentials::v1::SignJwtResponse> SignJwt(
+      google::iam::credentials::v1::SignJwtRequest const& request);
 
  private:
   std::shared_ptr<IAMCredentialsConnection> connection_;

--- a/google/cloud/iam/iam_credentials_connection.cc
+++ b/google/cloud/iam/iam_credentials_connection.cc
@@ -30,27 +30,27 @@ inline namespace GOOGLE_CLOUD_CPP_GENERATED_NS {
 
 IAMCredentialsConnection::~IAMCredentialsConnection() = default;
 
-StatusOr<::google::iam::credentials::v1::GenerateAccessTokenResponse>
+StatusOr<google::iam::credentials::v1::GenerateAccessTokenResponse>
 IAMCredentialsConnection::GenerateAccessToken(
-    ::google::iam::credentials::v1::GenerateAccessTokenRequest const&) {
+    google::iam::credentials::v1::GenerateAccessTokenRequest const&) {
   return Status(StatusCode::kUnimplemented, "not implemented");
 }
 
-StatusOr<::google::iam::credentials::v1::GenerateIdTokenResponse>
+StatusOr<google::iam::credentials::v1::GenerateIdTokenResponse>
 IAMCredentialsConnection::GenerateIdToken(
-    ::google::iam::credentials::v1::GenerateIdTokenRequest const&) {
+    google::iam::credentials::v1::GenerateIdTokenRequest const&) {
   return Status(StatusCode::kUnimplemented, "not implemented");
 }
 
-StatusOr<::google::iam::credentials::v1::SignBlobResponse>
+StatusOr<google::iam::credentials::v1::SignBlobResponse>
 IAMCredentialsConnection::SignBlob(
-    ::google::iam::credentials::v1::SignBlobRequest const&) {
+    google::iam::credentials::v1::SignBlobRequest const&) {
   return Status(StatusCode::kUnimplemented, "not implemented");
 }
 
-StatusOr<::google::iam::credentials::v1::SignJwtResponse>
+StatusOr<google::iam::credentials::v1::SignJwtResponse>
 IAMCredentialsConnection::SignJwt(
-    ::google::iam::credentials::v1::SignJwtRequest const&) {
+    google::iam::credentials::v1::SignJwtRequest const&) {
   return Status(StatusCode::kUnimplemented, "not implemented");
 }
 
@@ -71,54 +71,54 @@ class IAMCredentialsConnectionImpl : public IAMCredentialsConnection {
 
   ~IAMCredentialsConnectionImpl() override = default;
 
-  StatusOr<::google::iam::credentials::v1::GenerateAccessTokenResponse>
+  StatusOr<google::iam::credentials::v1::GenerateAccessTokenResponse>
   GenerateAccessToken(
-      ::google::iam::credentials::v1::GenerateAccessTokenRequest const& request)
+      google::iam::credentials::v1::GenerateAccessTokenRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
         retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
         idempotency_policy_->GenerateAccessToken(request),
         [this](grpc::ClientContext& context,
-               ::google::iam::credentials::v1::GenerateAccessTokenRequest const&
+               google::iam::credentials::v1::GenerateAccessTokenRequest const&
                    request) {
           return stub_->GenerateAccessToken(context, request);
         },
         request, __func__);
   }
 
-  StatusOr<::google::iam::credentials::v1::GenerateIdTokenResponse>
-  GenerateIdToken(::google::iam::credentials::v1::GenerateIdTokenRequest const&
+  StatusOr<google::iam::credentials::v1::GenerateIdTokenResponse>
+  GenerateIdToken(google::iam::credentials::v1::GenerateIdTokenRequest const&
                       request) override {
     return google::cloud::internal::RetryLoop(
         retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
         idempotency_policy_->GenerateIdToken(request),
         [this](grpc::ClientContext& context,
-               ::google::iam::credentials::v1::GenerateIdTokenRequest const&
+               google::iam::credentials::v1::GenerateIdTokenRequest const&
                    request) {
           return stub_->GenerateIdToken(context, request);
         },
         request, __func__);
   }
 
-  StatusOr<::google::iam::credentials::v1::SignBlobResponse> SignBlob(
-      ::google::iam::credentials::v1::SignBlobRequest const& request) override {
+  StatusOr<google::iam::credentials::v1::SignBlobResponse> SignBlob(
+      google::iam::credentials::v1::SignBlobRequest const& request) override {
     return google::cloud::internal::RetryLoop(
         retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
         idempotency_policy_->SignBlob(request),
         [this](grpc::ClientContext& context,
-               ::google::iam::credentials::v1::SignBlobRequest const& request) {
+               google::iam::credentials::v1::SignBlobRequest const& request) {
           return stub_->SignBlob(context, request);
         },
         request, __func__);
   }
 
-  StatusOr<::google::iam::credentials::v1::SignJwtResponse> SignJwt(
-      ::google::iam::credentials::v1::SignJwtRequest const& request) override {
+  StatusOr<google::iam::credentials::v1::SignJwtResponse> SignJwt(
+      google::iam::credentials::v1::SignJwtRequest const& request) override {
     return google::cloud::internal::RetryLoop(
         retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
         idempotency_policy_->SignJwt(request),
         [this](grpc::ClientContext& context,
-               ::google::iam::credentials::v1::SignJwtRequest const& request) {
+               google::iam::credentials::v1::SignJwtRequest const& request) {
           return stub_->SignJwt(context, request);
         },
         request, __func__);

--- a/google/cloud/iam/iam_credentials_connection.h
+++ b/google/cloud/iam/iam_credentials_connection.h
@@ -48,20 +48,19 @@ class IAMCredentialsConnection {
  public:
   virtual ~IAMCredentialsConnection() = 0;
 
-  virtual StatusOr<::google::iam::credentials::v1::GenerateAccessTokenResponse>
+  virtual StatusOr<google::iam::credentials::v1::GenerateAccessTokenResponse>
   GenerateAccessToken(
-      ::google::iam::credentials::v1::GenerateAccessTokenRequest const&
-          request);
+      google::iam::credentials::v1::GenerateAccessTokenRequest const& request);
 
-  virtual StatusOr<::google::iam::credentials::v1::GenerateIdTokenResponse>
+  virtual StatusOr<google::iam::credentials::v1::GenerateIdTokenResponse>
   GenerateIdToken(
-      ::google::iam::credentials::v1::GenerateIdTokenRequest const& request);
+      google::iam::credentials::v1::GenerateIdTokenRequest const& request);
 
-  virtual StatusOr<::google::iam::credentials::v1::SignBlobResponse> SignBlob(
-      ::google::iam::credentials::v1::SignBlobRequest const& request);
+  virtual StatusOr<google::iam::credentials::v1::SignBlobResponse> SignBlob(
+      google::iam::credentials::v1::SignBlobRequest const& request);
 
-  virtual StatusOr<::google::iam::credentials::v1::SignJwtResponse> SignJwt(
-      ::google::iam::credentials::v1::SignJwtRequest const& request);
+  virtual StatusOr<google::iam::credentials::v1::SignJwtResponse> SignJwt(
+      google::iam::credentials::v1::SignJwtRequest const& request);
 };
 
 std::shared_ptr<IAMCredentialsConnection> MakeIAMCredentialsConnection(

--- a/google/cloud/iam/iam_credentials_connection_idempotency_policy.cc
+++ b/google/cloud/iam/iam_credentials_connection_idempotency_policy.cc
@@ -43,23 +43,23 @@ class DefaultIAMCredentialsConnectionIdempotencyPolicy
   }
 
   Idempotency GenerateAccessToken(
-      ::google::iam::credentials::v1::GenerateAccessTokenRequest const&)
+      google::iam::credentials::v1::GenerateAccessTokenRequest const&)
       override {
     return Idempotency::kNonIdempotent;
   }
 
   Idempotency GenerateIdToken(
-      ::google::iam::credentials::v1::GenerateIdTokenRequest const&) override {
+      google::iam::credentials::v1::GenerateIdTokenRequest const&) override {
     return Idempotency::kNonIdempotent;
   }
 
   Idempotency SignBlob(
-      ::google::iam::credentials::v1::SignBlobRequest const&) override {
+      google::iam::credentials::v1::SignBlobRequest const&) override {
     return Idempotency::kNonIdempotent;
   }
 
   Idempotency SignJwt(
-      ::google::iam::credentials::v1::SignJwtRequest const&) override {
+      google::iam::credentials::v1::SignJwtRequest const&) override {
     return Idempotency::kNonIdempotent;
   }
 };

--- a/google/cloud/iam/iam_credentials_connection_idempotency_policy.h
+++ b/google/cloud/iam/iam_credentials_connection_idempotency_policy.h
@@ -38,18 +38,17 @@ class IAMCredentialsConnectionIdempotencyPolicy {
       const = 0;
 
   virtual google::cloud::internal::Idempotency GenerateAccessToken(
-      ::google::iam::credentials::v1::GenerateAccessTokenRequest const&
+      google::iam::credentials::v1::GenerateAccessTokenRequest const&
           request) = 0;
 
   virtual google::cloud::internal::Idempotency GenerateIdToken(
-      ::google::iam::credentials::v1::GenerateIdTokenRequest const&
-          request) = 0;
+      google::iam::credentials::v1::GenerateIdTokenRequest const& request) = 0;
 
   virtual google::cloud::internal::Idempotency SignBlob(
-      ::google::iam::credentials::v1::SignBlobRequest const& request) = 0;
+      google::iam::credentials::v1::SignBlobRequest const& request) = 0;
 
   virtual google::cloud::internal::Idempotency SignJwt(
-      ::google::iam::credentials::v1::SignJwtRequest const& request) = 0;
+      google::iam::credentials::v1::SignJwtRequest const& request) = 0;
 };
 
 std::unique_ptr<IAMCredentialsConnectionIdempotencyPolicy>

--- a/google/cloud/iam/internal/iam_credentials_logging_decorator.cc
+++ b/google/cloud/iam/internal/iam_credentials_logging_decorator.cc
@@ -33,49 +33,51 @@ IAMCredentialsLogging::IAMCredentialsLogging(
       tracing_options_(std::move(tracing_options)),
       components_(std::move(components)) {}
 
-StatusOr<::google::iam::credentials::v1::GenerateAccessTokenResponse>
+StatusOr<google::iam::credentials::v1::GenerateAccessTokenResponse>
 IAMCredentialsLogging::GenerateAccessToken(
     grpc::ClientContext& context,
-    ::google::iam::credentials::v1::GenerateAccessTokenRequest const& request) {
+    google::iam::credentials::v1::GenerateAccessTokenRequest const& request) {
   return google::cloud::internal::LogWrapper(
       [this](grpc::ClientContext& context,
-             ::google::iam::credentials::v1::GenerateAccessTokenRequest const&
+             google::iam::credentials::v1::GenerateAccessTokenRequest const&
                  request) {
         return child_->GenerateAccessToken(context, request);
       },
       context, request, __func__, tracing_options_);
 }
 
-StatusOr<::google::iam::credentials::v1::GenerateIdTokenResponse>
+StatusOr<google::iam::credentials::v1::GenerateIdTokenResponse>
 IAMCredentialsLogging::GenerateIdToken(
     grpc::ClientContext& context,
-    ::google::iam::credentials::v1::GenerateIdTokenRequest const& request) {
+    google::iam::credentials::v1::GenerateIdTokenRequest const& request) {
   return google::cloud::internal::LogWrapper(
-      [this](grpc::ClientContext& context,
-             ::google::iam::credentials::v1::GenerateIdTokenRequest const&
-                 request) { return child_->GenerateIdToken(context, request); },
+      [this](
+          grpc::ClientContext& context,
+          google::iam::credentials::v1::GenerateIdTokenRequest const& request) {
+        return child_->GenerateIdToken(context, request);
+      },
       context, request, __func__, tracing_options_);
 }
 
-StatusOr<::google::iam::credentials::v1::SignBlobResponse>
+StatusOr<google::iam::credentials::v1::SignBlobResponse>
 IAMCredentialsLogging::SignBlob(
     grpc::ClientContext& context,
-    ::google::iam::credentials::v1::SignBlobRequest const& request) {
+    google::iam::credentials::v1::SignBlobRequest const& request) {
   return google::cloud::internal::LogWrapper(
       [this](grpc::ClientContext& context,
-             ::google::iam::credentials::v1::SignBlobRequest const& request) {
+             google::iam::credentials::v1::SignBlobRequest const& request) {
         return child_->SignBlob(context, request);
       },
       context, request, __func__, tracing_options_);
 }
 
-StatusOr<::google::iam::credentials::v1::SignJwtResponse>
+StatusOr<google::iam::credentials::v1::SignJwtResponse>
 IAMCredentialsLogging::SignJwt(
     grpc::ClientContext& context,
-    ::google::iam::credentials::v1::SignJwtRequest const& request) {
+    google::iam::credentials::v1::SignJwtRequest const& request) {
   return google::cloud::internal::LogWrapper(
       [this](grpc::ClientContext& context,
-             ::google::iam::credentials::v1::SignJwtRequest const& request) {
+             google::iam::credentials::v1::SignJwtRequest const& request) {
         return child_->SignJwt(context, request);
       },
       context, request, __func__, tracing_options_);

--- a/google/cloud/iam/internal/iam_credentials_logging_decorator.h
+++ b/google/cloud/iam/internal/iam_credentials_logging_decorator.h
@@ -37,24 +37,24 @@ class IAMCredentialsLogging : public IAMCredentialsStub {
                         TracingOptions tracing_options,
                         std::set<std::string> components);
 
-  StatusOr<::google::iam::credentials::v1::GenerateAccessTokenResponse>
+  StatusOr<google::iam::credentials::v1::GenerateAccessTokenResponse>
   GenerateAccessToken(
       grpc::ClientContext& context,
-      ::google::iam::credentials::v1::GenerateAccessTokenRequest const& request)
+      google::iam::credentials::v1::GenerateAccessTokenRequest const& request)
       override;
 
-  StatusOr<::google::iam::credentials::v1::GenerateIdTokenResponse>
+  StatusOr<google::iam::credentials::v1::GenerateIdTokenResponse>
   GenerateIdToken(grpc::ClientContext& context,
-                  ::google::iam::credentials::v1::GenerateIdTokenRequest const&
+                  google::iam::credentials::v1::GenerateIdTokenRequest const&
                       request) override;
 
-  StatusOr<::google::iam::credentials::v1::SignBlobResponse> SignBlob(
+  StatusOr<google::iam::credentials::v1::SignBlobResponse> SignBlob(
       grpc::ClientContext& context,
-      ::google::iam::credentials::v1::SignBlobRequest const& request) override;
+      google::iam::credentials::v1::SignBlobRequest const& request) override;
 
-  StatusOr<::google::iam::credentials::v1::SignJwtResponse> SignJwt(
+  StatusOr<google::iam::credentials::v1::SignJwtResponse> SignJwt(
       grpc::ClientContext& context,
-      ::google::iam::credentials::v1::SignJwtRequest const& request) override;
+      google::iam::credentials::v1::SignJwtRequest const& request) override;
 
  private:
   std::shared_ptr<IAMCredentialsStub> child_;

--- a/google/cloud/iam/internal/iam_credentials_metadata_decorator.cc
+++ b/google/cloud/iam/internal/iam_credentials_metadata_decorator.cc
@@ -31,34 +31,34 @@ IAMCredentialsMetadata::IAMCredentialsMetadata(
     : child_(std::move(child)),
       api_client_header_(google::cloud::internal::ApiClientHeader()) {}
 
-StatusOr<::google::iam::credentials::v1::GenerateAccessTokenResponse>
+StatusOr<google::iam::credentials::v1::GenerateAccessTokenResponse>
 IAMCredentialsMetadata::GenerateAccessToken(
     grpc::ClientContext& context,
-    ::google::iam::credentials::v1::GenerateAccessTokenRequest const& request) {
+    google::iam::credentials::v1::GenerateAccessTokenRequest const& request) {
   SetMetadata(context, "name=" + request.name());
   return child_->GenerateAccessToken(context, request);
 }
 
-StatusOr<::google::iam::credentials::v1::GenerateIdTokenResponse>
+StatusOr<google::iam::credentials::v1::GenerateIdTokenResponse>
 IAMCredentialsMetadata::GenerateIdToken(
     grpc::ClientContext& context,
-    ::google::iam::credentials::v1::GenerateIdTokenRequest const& request) {
+    google::iam::credentials::v1::GenerateIdTokenRequest const& request) {
   SetMetadata(context, "name=" + request.name());
   return child_->GenerateIdToken(context, request);
 }
 
-StatusOr<::google::iam::credentials::v1::SignBlobResponse>
+StatusOr<google::iam::credentials::v1::SignBlobResponse>
 IAMCredentialsMetadata::SignBlob(
     grpc::ClientContext& context,
-    ::google::iam::credentials::v1::SignBlobRequest const& request) {
+    google::iam::credentials::v1::SignBlobRequest const& request) {
   SetMetadata(context, "name=" + request.name());
   return child_->SignBlob(context, request);
 }
 
-StatusOr<::google::iam::credentials::v1::SignJwtResponse>
+StatusOr<google::iam::credentials::v1::SignJwtResponse>
 IAMCredentialsMetadata::SignJwt(
     grpc::ClientContext& context,
-    ::google::iam::credentials::v1::SignJwtRequest const& request) {
+    google::iam::credentials::v1::SignJwtRequest const& request) {
   SetMetadata(context, "name=" + request.name());
   return child_->SignJwt(context, request);
 }

--- a/google/cloud/iam/internal/iam_credentials_metadata_decorator.h
+++ b/google/cloud/iam/internal/iam_credentials_metadata_decorator.h
@@ -33,24 +33,24 @@ class IAMCredentialsMetadata : public IAMCredentialsStub {
   ~IAMCredentialsMetadata() override = default;
   explicit IAMCredentialsMetadata(std::shared_ptr<IAMCredentialsStub> child);
 
-  StatusOr<::google::iam::credentials::v1::GenerateAccessTokenResponse>
+  StatusOr<google::iam::credentials::v1::GenerateAccessTokenResponse>
   GenerateAccessToken(
       grpc::ClientContext& context,
-      ::google::iam::credentials::v1::GenerateAccessTokenRequest const& request)
+      google::iam::credentials::v1::GenerateAccessTokenRequest const& request)
       override;
 
-  StatusOr<::google::iam::credentials::v1::GenerateIdTokenResponse>
+  StatusOr<google::iam::credentials::v1::GenerateIdTokenResponse>
   GenerateIdToken(grpc::ClientContext& context,
-                  ::google::iam::credentials::v1::GenerateIdTokenRequest const&
+                  google::iam::credentials::v1::GenerateIdTokenRequest const&
                       request) override;
 
-  StatusOr<::google::iam::credentials::v1::SignBlobResponse> SignBlob(
+  StatusOr<google::iam::credentials::v1::SignBlobResponse> SignBlob(
       grpc::ClientContext& context,
-      ::google::iam::credentials::v1::SignBlobRequest const& request) override;
+      google::iam::credentials::v1::SignBlobRequest const& request) override;
 
-  StatusOr<::google::iam::credentials::v1::SignJwtResponse> SignJwt(
+  StatusOr<google::iam::credentials::v1::SignJwtResponse> SignJwt(
       grpc::ClientContext& context,
-      ::google::iam::credentials::v1::SignJwtRequest const& request) override;
+      google::iam::credentials::v1::SignJwtRequest const& request) override;
 
  private:
   void SetMetadata(grpc::ClientContext& context,

--- a/google/cloud/iam/internal/iam_credentials_stub.cc
+++ b/google/cloud/iam/internal/iam_credentials_stub.cc
@@ -29,11 +29,11 @@ inline namespace GOOGLE_CLOUD_CPP_GENERATED_NS {
 
 IAMCredentialsStub::~IAMCredentialsStub() = default;
 
-StatusOr<::google::iam::credentials::v1::GenerateAccessTokenResponse>
+StatusOr<google::iam::credentials::v1::GenerateAccessTokenResponse>
 DefaultIAMCredentialsStub::GenerateAccessToken(
     grpc::ClientContext& client_context,
-    ::google::iam::credentials::v1::GenerateAccessTokenRequest const& request) {
-  ::google::iam::credentials::v1::GenerateAccessTokenResponse response;
+    google::iam::credentials::v1::GenerateAccessTokenRequest const& request) {
+  google::iam::credentials::v1::GenerateAccessTokenResponse response;
   auto status =
       grpc_stub_->GenerateAccessToken(&client_context, request, &response);
   if (!status.ok()) {
@@ -42,11 +42,11 @@ DefaultIAMCredentialsStub::GenerateAccessToken(
   return response;
 }
 
-StatusOr<::google::iam::credentials::v1::GenerateIdTokenResponse>
+StatusOr<google::iam::credentials::v1::GenerateIdTokenResponse>
 DefaultIAMCredentialsStub::GenerateIdToken(
     grpc::ClientContext& client_context,
-    ::google::iam::credentials::v1::GenerateIdTokenRequest const& request) {
-  ::google::iam::credentials::v1::GenerateIdTokenResponse response;
+    google::iam::credentials::v1::GenerateIdTokenRequest const& request) {
+  google::iam::credentials::v1::GenerateIdTokenResponse response;
   auto status =
       grpc_stub_->GenerateIdToken(&client_context, request, &response);
   if (!status.ok()) {
@@ -55,11 +55,11 @@ DefaultIAMCredentialsStub::GenerateIdToken(
   return response;
 }
 
-StatusOr<::google::iam::credentials::v1::SignBlobResponse>
+StatusOr<google::iam::credentials::v1::SignBlobResponse>
 DefaultIAMCredentialsStub::SignBlob(
     grpc::ClientContext& client_context,
-    ::google::iam::credentials::v1::SignBlobRequest const& request) {
-  ::google::iam::credentials::v1::SignBlobResponse response;
+    google::iam::credentials::v1::SignBlobRequest const& request) {
+  google::iam::credentials::v1::SignBlobResponse response;
   auto status = grpc_stub_->SignBlob(&client_context, request, &response);
   if (!status.ok()) {
     return google::cloud::MakeStatusFromRpcError(status);
@@ -67,11 +67,11 @@ DefaultIAMCredentialsStub::SignBlob(
   return response;
 }
 
-StatusOr<::google::iam::credentials::v1::SignJwtResponse>
+StatusOr<google::iam::credentials::v1::SignJwtResponse>
 DefaultIAMCredentialsStub::SignJwt(
     grpc::ClientContext& client_context,
-    ::google::iam::credentials::v1::SignJwtRequest const& request) {
-  ::google::iam::credentials::v1::SignJwtResponse response;
+    google::iam::credentials::v1::SignJwtRequest const& request) {
+  google::iam::credentials::v1::SignJwtResponse response;
   auto status = grpc_stub_->SignJwt(&client_context, request, &response);
   if (!status.ok()) {
     return google::cloud::MakeStatusFromRpcError(status);

--- a/google/cloud/iam/internal/iam_credentials_stub.h
+++ b/google/cloud/iam/internal/iam_credentials_stub.h
@@ -32,55 +32,55 @@ class IAMCredentialsStub {
  public:
   virtual ~IAMCredentialsStub() = 0;
 
-  virtual StatusOr<::google::iam::credentials::v1::GenerateAccessTokenResponse>
+  virtual StatusOr<google::iam::credentials::v1::GenerateAccessTokenResponse>
   GenerateAccessToken(
       grpc::ClientContext& context,
-      ::google::iam::credentials::v1::GenerateAccessTokenRequest const&
+      google::iam::credentials::v1::GenerateAccessTokenRequest const&
           request) = 0;
 
-  virtual StatusOr<::google::iam::credentials::v1::GenerateIdTokenResponse>
-  GenerateIdToken(grpc::ClientContext& context,
-                  ::google::iam::credentials::v1::GenerateIdTokenRequest const&
-                      request) = 0;
-
-  virtual StatusOr<::google::iam::credentials::v1::SignBlobResponse> SignBlob(
+  virtual StatusOr<google::iam::credentials::v1::GenerateIdTokenResponse>
+  GenerateIdToken(
       grpc::ClientContext& context,
-      ::google::iam::credentials::v1::SignBlobRequest const& request) = 0;
+      google::iam::credentials::v1::GenerateIdTokenRequest const& request) = 0;
 
-  virtual StatusOr<::google::iam::credentials::v1::SignJwtResponse> SignJwt(
+  virtual StatusOr<google::iam::credentials::v1::SignBlobResponse> SignBlob(
       grpc::ClientContext& context,
-      ::google::iam::credentials::v1::SignJwtRequest const& request) = 0;
+      google::iam::credentials::v1::SignBlobRequest const& request) = 0;
+
+  virtual StatusOr<google::iam::credentials::v1::SignJwtResponse> SignJwt(
+      grpc::ClientContext& context,
+      google::iam::credentials::v1::SignJwtRequest const& request) = 0;
 };
 
 class DefaultIAMCredentialsStub : public IAMCredentialsStub {
  public:
   explicit DefaultIAMCredentialsStub(
       std::unique_ptr<
-          ::google::iam::credentials::v1::IAMCredentials::StubInterface>
+          google::iam::credentials::v1::IAMCredentials::StubInterface>
           grpc_stub)
       : grpc_stub_(std::move(grpc_stub)) {}
 
-  StatusOr<::google::iam::credentials::v1::GenerateAccessTokenResponse>
+  StatusOr<google::iam::credentials::v1::GenerateAccessTokenResponse>
   GenerateAccessToken(
       grpc::ClientContext& client_context,
-      ::google::iam::credentials::v1::GenerateAccessTokenRequest const& request)
+      google::iam::credentials::v1::GenerateAccessTokenRequest const& request)
       override;
 
-  StatusOr<::google::iam::credentials::v1::GenerateIdTokenResponse>
+  StatusOr<google::iam::credentials::v1::GenerateIdTokenResponse>
   GenerateIdToken(grpc::ClientContext& client_context,
-                  ::google::iam::credentials::v1::GenerateIdTokenRequest const&
+                  google::iam::credentials::v1::GenerateIdTokenRequest const&
                       request) override;
 
-  StatusOr<::google::iam::credentials::v1::SignBlobResponse> SignBlob(
+  StatusOr<google::iam::credentials::v1::SignBlobResponse> SignBlob(
       grpc::ClientContext& client_context,
-      ::google::iam::credentials::v1::SignBlobRequest const& request) override;
+      google::iam::credentials::v1::SignBlobRequest const& request) override;
 
-  StatusOr<::google::iam::credentials::v1::SignJwtResponse> SignJwt(
+  StatusOr<google::iam::credentials::v1::SignJwtResponse> SignJwt(
       grpc::ClientContext& client_context,
-      ::google::iam::credentials::v1::SignJwtRequest const& request) override;
+      google::iam::credentials::v1::SignJwtRequest const& request) override;
 
  private:
-  std::unique_ptr<::google::iam::credentials::v1::IAMCredentials::StubInterface>
+  std::unique_ptr<google::iam::credentials::v1::IAMCredentials::StubInterface>
       grpc_stub_;
 };
 

--- a/google/cloud/iam/internal/iam_credentials_stub_factory.cc
+++ b/google/cloud/iam/internal/iam_credentials_stub_factory.cc
@@ -38,7 +38,7 @@ std::shared_ptr<IAMCredentialsStub> CreateDefaultIAMCredentialsStub(
       options.get<EndpointOption>(), options.get<GrpcCredentialOption>(),
       internal::MakeChannelArguments(options));
   auto service_grpc_stub =
-      ::google::iam::credentials::v1::IAMCredentials::NewStub(channel);
+      google::iam::credentials::v1::IAMCredentials::NewStub(channel);
   std::shared_ptr<IAMCredentialsStub> stub =
       std::make_shared<DefaultIAMCredentialsStub>(std::move(service_grpc_stub));
 

--- a/google/cloud/iam/internal/iam_logging_decorator.cc
+++ b/google/cloud/iam/internal/iam_logging_decorator.cc
@@ -33,53 +33,51 @@ IAMLogging::IAMLogging(std::shared_ptr<IAMStub> child,
       tracing_options_(std::move(tracing_options)),
       components_(std::move(components)) {}
 
-StatusOr<::google::iam::admin::v1::ListServiceAccountsResponse>
+StatusOr<google::iam::admin::v1::ListServiceAccountsResponse>
 IAMLogging::ListServiceAccounts(
     grpc::ClientContext& context,
-    ::google::iam::admin::v1::ListServiceAccountsRequest const& request) {
+    google::iam::admin::v1::ListServiceAccountsRequest const& request) {
   return google::cloud::internal::LogWrapper(
       [this](
           grpc::ClientContext& context,
-          ::google::iam::admin::v1::ListServiceAccountsRequest const& request) {
+          google::iam::admin::v1::ListServiceAccountsRequest const& request) {
         return child_->ListServiceAccounts(context, request);
       },
       context, request, __func__, tracing_options_);
 }
 
-StatusOr<::google::iam::admin::v1::ServiceAccount>
-IAMLogging::GetServiceAccount(
+StatusOr<google::iam::admin::v1::ServiceAccount> IAMLogging::GetServiceAccount(
     grpc::ClientContext& context,
-    ::google::iam::admin::v1::GetServiceAccountRequest const& request) {
+    google::iam::admin::v1::GetServiceAccountRequest const& request) {
   return google::cloud::internal::LogWrapper(
-      [this](
-          grpc::ClientContext& context,
-          ::google::iam::admin::v1::GetServiceAccountRequest const& request) {
+      [this](grpc::ClientContext& context,
+             google::iam::admin::v1::GetServiceAccountRequest const& request) {
         return child_->GetServiceAccount(context, request);
       },
       context, request, __func__, tracing_options_);
 }
 
-StatusOr<::google::iam::admin::v1::ServiceAccount>
+StatusOr<google::iam::admin::v1::ServiceAccount>
 IAMLogging::CreateServiceAccount(
     grpc::ClientContext& context,
-    ::google::iam::admin::v1::CreateServiceAccountRequest const& request) {
+    google::iam::admin::v1::CreateServiceAccountRequest const& request) {
   return google::cloud::internal::LogWrapper(
-      [this](grpc::ClientContext& context,
-             ::google::iam::admin::v1::CreateServiceAccountRequest const&
-                 request) {
+      [this](
+          grpc::ClientContext& context,
+          google::iam::admin::v1::CreateServiceAccountRequest const& request) {
         return child_->CreateServiceAccount(context, request);
       },
       context, request, __func__, tracing_options_);
 }
 
-StatusOr<::google::iam::admin::v1::ServiceAccount>
+StatusOr<google::iam::admin::v1::ServiceAccount>
 IAMLogging::PatchServiceAccount(
     grpc::ClientContext& context,
-    ::google::iam::admin::v1::PatchServiceAccountRequest const& request) {
+    google::iam::admin::v1::PatchServiceAccountRequest const& request) {
   return google::cloud::internal::LogWrapper(
       [this](
           grpc::ClientContext& context,
-          ::google::iam::admin::v1::PatchServiceAccountRequest const& request) {
+          google::iam::admin::v1::PatchServiceAccountRequest const& request) {
         return child_->PatchServiceAccount(context, request);
       },
       context, request, __func__, tracing_options_);
@@ -87,23 +85,23 @@ IAMLogging::PatchServiceAccount(
 
 Status IAMLogging::DeleteServiceAccount(
     grpc::ClientContext& context,
-    ::google::iam::admin::v1::DeleteServiceAccountRequest const& request) {
+    google::iam::admin::v1::DeleteServiceAccountRequest const& request) {
   return google::cloud::internal::LogWrapper(
-      [this](grpc::ClientContext& context,
-             ::google::iam::admin::v1::DeleteServiceAccountRequest const&
-                 request) {
+      [this](
+          grpc::ClientContext& context,
+          google::iam::admin::v1::DeleteServiceAccountRequest const& request) {
         return child_->DeleteServiceAccount(context, request);
       },
       context, request, __func__, tracing_options_);
 }
 
-StatusOr<::google::iam::admin::v1::UndeleteServiceAccountResponse>
+StatusOr<google::iam::admin::v1::UndeleteServiceAccountResponse>
 IAMLogging::UndeleteServiceAccount(
     grpc::ClientContext& context,
-    ::google::iam::admin::v1::UndeleteServiceAccountRequest const& request) {
+    google::iam::admin::v1::UndeleteServiceAccountRequest const& request) {
   return google::cloud::internal::LogWrapper(
       [this](grpc::ClientContext& context,
-             ::google::iam::admin::v1::UndeleteServiceAccountRequest const&
+             google::iam::admin::v1::UndeleteServiceAccountRequest const&
                  request) {
         return child_->UndeleteServiceAccount(context, request);
       },
@@ -112,11 +110,11 @@ IAMLogging::UndeleteServiceAccount(
 
 Status IAMLogging::EnableServiceAccount(
     grpc::ClientContext& context,
-    ::google::iam::admin::v1::EnableServiceAccountRequest const& request) {
+    google::iam::admin::v1::EnableServiceAccountRequest const& request) {
   return google::cloud::internal::LogWrapper(
-      [this](grpc::ClientContext& context,
-             ::google::iam::admin::v1::EnableServiceAccountRequest const&
-                 request) {
+      [this](
+          grpc::ClientContext& context,
+          google::iam::admin::v1::EnableServiceAccountRequest const& request) {
         return child_->EnableServiceAccount(context, request);
       },
       context, request, __func__, tracing_options_);
@@ -124,62 +122,62 @@ Status IAMLogging::EnableServiceAccount(
 
 Status IAMLogging::DisableServiceAccount(
     grpc::ClientContext& context,
-    ::google::iam::admin::v1::DisableServiceAccountRequest const& request) {
+    google::iam::admin::v1::DisableServiceAccountRequest const& request) {
   return google::cloud::internal::LogWrapper(
-      [this](grpc::ClientContext& context,
-             ::google::iam::admin::v1::DisableServiceAccountRequest const&
-                 request) {
+      [this](
+          grpc::ClientContext& context,
+          google::iam::admin::v1::DisableServiceAccountRequest const& request) {
         return child_->DisableServiceAccount(context, request);
       },
       context, request, __func__, tracing_options_);
 }
 
-StatusOr<::google::iam::admin::v1::ListServiceAccountKeysResponse>
+StatusOr<google::iam::admin::v1::ListServiceAccountKeysResponse>
 IAMLogging::ListServiceAccountKeys(
     grpc::ClientContext& context,
-    ::google::iam::admin::v1::ListServiceAccountKeysRequest const& request) {
+    google::iam::admin::v1::ListServiceAccountKeysRequest const& request) {
   return google::cloud::internal::LogWrapper(
       [this](grpc::ClientContext& context,
-             ::google::iam::admin::v1::ListServiceAccountKeysRequest const&
+             google::iam::admin::v1::ListServiceAccountKeysRequest const&
                  request) {
         return child_->ListServiceAccountKeys(context, request);
       },
       context, request, __func__, tracing_options_);
 }
 
-StatusOr<::google::iam::admin::v1::ServiceAccountKey>
+StatusOr<google::iam::admin::v1::ServiceAccountKey>
 IAMLogging::GetServiceAccountKey(
     grpc::ClientContext& context,
-    ::google::iam::admin::v1::GetServiceAccountKeyRequest const& request) {
+    google::iam::admin::v1::GetServiceAccountKeyRequest const& request) {
   return google::cloud::internal::LogWrapper(
-      [this](grpc::ClientContext& context,
-             ::google::iam::admin::v1::GetServiceAccountKeyRequest const&
-                 request) {
+      [this](
+          grpc::ClientContext& context,
+          google::iam::admin::v1::GetServiceAccountKeyRequest const& request) {
         return child_->GetServiceAccountKey(context, request);
       },
       context, request, __func__, tracing_options_);
 }
 
-StatusOr<::google::iam::admin::v1::ServiceAccountKey>
+StatusOr<google::iam::admin::v1::ServiceAccountKey>
 IAMLogging::CreateServiceAccountKey(
     grpc::ClientContext& context,
-    ::google::iam::admin::v1::CreateServiceAccountKeyRequest const& request) {
+    google::iam::admin::v1::CreateServiceAccountKeyRequest const& request) {
   return google::cloud::internal::LogWrapper(
       [this](grpc::ClientContext& context,
-             ::google::iam::admin::v1::CreateServiceAccountKeyRequest const&
+             google::iam::admin::v1::CreateServiceAccountKeyRequest const&
                  request) {
         return child_->CreateServiceAccountKey(context, request);
       },
       context, request, __func__, tracing_options_);
 }
 
-StatusOr<::google::iam::admin::v1::ServiceAccountKey>
+StatusOr<google::iam::admin::v1::ServiceAccountKey>
 IAMLogging::UploadServiceAccountKey(
     grpc::ClientContext& context,
-    ::google::iam::admin::v1::UploadServiceAccountKeyRequest const& request) {
+    google::iam::admin::v1::UploadServiceAccountKeyRequest const& request) {
   return google::cloud::internal::LogWrapper(
       [this](grpc::ClientContext& context,
-             ::google::iam::admin::v1::UploadServiceAccountKeyRequest const&
+             google::iam::admin::v1::UploadServiceAccountKeyRequest const&
                  request) {
         return child_->UploadServiceAccountKey(context, request);
       },
@@ -188,161 +186,161 @@ IAMLogging::UploadServiceAccountKey(
 
 Status IAMLogging::DeleteServiceAccountKey(
     grpc::ClientContext& context,
-    ::google::iam::admin::v1::DeleteServiceAccountKeyRequest const& request) {
+    google::iam::admin::v1::DeleteServiceAccountKeyRequest const& request) {
   return google::cloud::internal::LogWrapper(
       [this](grpc::ClientContext& context,
-             ::google::iam::admin::v1::DeleteServiceAccountKeyRequest const&
+             google::iam::admin::v1::DeleteServiceAccountKeyRequest const&
                  request) {
         return child_->DeleteServiceAccountKey(context, request);
       },
       context, request, __func__, tracing_options_);
 }
 
-StatusOr<::google::iam::v1::Policy> IAMLogging::GetIamPolicy(
+StatusOr<google::iam::v1::Policy> IAMLogging::GetIamPolicy(
     grpc::ClientContext& context,
-    ::google::iam::v1::GetIamPolicyRequest const& request) {
+    google::iam::v1::GetIamPolicyRequest const& request) {
   return google::cloud::internal::LogWrapper(
       [this](grpc::ClientContext& context,
-             ::google::iam::v1::GetIamPolicyRequest const& request) {
+             google::iam::v1::GetIamPolicyRequest const& request) {
         return child_->GetIamPolicy(context, request);
       },
       context, request, __func__, tracing_options_);
 }
 
-StatusOr<::google::iam::v1::Policy> IAMLogging::SetIamPolicy(
+StatusOr<google::iam::v1::Policy> IAMLogging::SetIamPolicy(
     grpc::ClientContext& context,
-    ::google::iam::v1::SetIamPolicyRequest const& request) {
+    google::iam::v1::SetIamPolicyRequest const& request) {
   return google::cloud::internal::LogWrapper(
       [this](grpc::ClientContext& context,
-             ::google::iam::v1::SetIamPolicyRequest const& request) {
+             google::iam::v1::SetIamPolicyRequest const& request) {
         return child_->SetIamPolicy(context, request);
       },
       context, request, __func__, tracing_options_);
 }
 
-StatusOr<::google::iam::v1::TestIamPermissionsResponse>
+StatusOr<google::iam::v1::TestIamPermissionsResponse>
 IAMLogging::TestIamPermissions(
     grpc::ClientContext& context,
-    ::google::iam::v1::TestIamPermissionsRequest const& request) {
+    google::iam::v1::TestIamPermissionsRequest const& request) {
   return google::cloud::internal::LogWrapper(
       [this](grpc::ClientContext& context,
-             ::google::iam::v1::TestIamPermissionsRequest const& request) {
+             google::iam::v1::TestIamPermissionsRequest const& request) {
         return child_->TestIamPermissions(context, request);
       },
       context, request, __func__, tracing_options_);
 }
 
-StatusOr<::google::iam::admin::v1::QueryGrantableRolesResponse>
+StatusOr<google::iam::admin::v1::QueryGrantableRolesResponse>
 IAMLogging::QueryGrantableRoles(
     grpc::ClientContext& context,
-    ::google::iam::admin::v1::QueryGrantableRolesRequest const& request) {
+    google::iam::admin::v1::QueryGrantableRolesRequest const& request) {
   return google::cloud::internal::LogWrapper(
       [this](
           grpc::ClientContext& context,
-          ::google::iam::admin::v1::QueryGrantableRolesRequest const& request) {
+          google::iam::admin::v1::QueryGrantableRolesRequest const& request) {
         return child_->QueryGrantableRoles(context, request);
       },
       context, request, __func__, tracing_options_);
 }
 
-StatusOr<::google::iam::admin::v1::ListRolesResponse> IAMLogging::ListRoles(
+StatusOr<google::iam::admin::v1::ListRolesResponse> IAMLogging::ListRoles(
     grpc::ClientContext& context,
-    ::google::iam::admin::v1::ListRolesRequest const& request) {
+    google::iam::admin::v1::ListRolesRequest const& request) {
   return google::cloud::internal::LogWrapper(
       [this](grpc::ClientContext& context,
-             ::google::iam::admin::v1::ListRolesRequest const& request) {
+             google::iam::admin::v1::ListRolesRequest const& request) {
         return child_->ListRoles(context, request);
       },
       context, request, __func__, tracing_options_);
 }
 
-StatusOr<::google::iam::admin::v1::Role> IAMLogging::GetRole(
+StatusOr<google::iam::admin::v1::Role> IAMLogging::GetRole(
     grpc::ClientContext& context,
-    ::google::iam::admin::v1::GetRoleRequest const& request) {
+    google::iam::admin::v1::GetRoleRequest const& request) {
   return google::cloud::internal::LogWrapper(
       [this](grpc::ClientContext& context,
-             ::google::iam::admin::v1::GetRoleRequest const& request) {
+             google::iam::admin::v1::GetRoleRequest const& request) {
         return child_->GetRole(context, request);
       },
       context, request, __func__, tracing_options_);
 }
 
-StatusOr<::google::iam::admin::v1::Role> IAMLogging::CreateRole(
+StatusOr<google::iam::admin::v1::Role> IAMLogging::CreateRole(
     grpc::ClientContext& context,
-    ::google::iam::admin::v1::CreateRoleRequest const& request) {
+    google::iam::admin::v1::CreateRoleRequest const& request) {
   return google::cloud::internal::LogWrapper(
       [this](grpc::ClientContext& context,
-             ::google::iam::admin::v1::CreateRoleRequest const& request) {
+             google::iam::admin::v1::CreateRoleRequest const& request) {
         return child_->CreateRole(context, request);
       },
       context, request, __func__, tracing_options_);
 }
 
-StatusOr<::google::iam::admin::v1::Role> IAMLogging::UpdateRole(
+StatusOr<google::iam::admin::v1::Role> IAMLogging::UpdateRole(
     grpc::ClientContext& context,
-    ::google::iam::admin::v1::UpdateRoleRequest const& request) {
+    google::iam::admin::v1::UpdateRoleRequest const& request) {
   return google::cloud::internal::LogWrapper(
       [this](grpc::ClientContext& context,
-             ::google::iam::admin::v1::UpdateRoleRequest const& request) {
+             google::iam::admin::v1::UpdateRoleRequest const& request) {
         return child_->UpdateRole(context, request);
       },
       context, request, __func__, tracing_options_);
 }
 
-StatusOr<::google::iam::admin::v1::Role> IAMLogging::DeleteRole(
+StatusOr<google::iam::admin::v1::Role> IAMLogging::DeleteRole(
     grpc::ClientContext& context,
-    ::google::iam::admin::v1::DeleteRoleRequest const& request) {
+    google::iam::admin::v1::DeleteRoleRequest const& request) {
   return google::cloud::internal::LogWrapper(
       [this](grpc::ClientContext& context,
-             ::google::iam::admin::v1::DeleteRoleRequest const& request) {
+             google::iam::admin::v1::DeleteRoleRequest const& request) {
         return child_->DeleteRole(context, request);
       },
       context, request, __func__, tracing_options_);
 }
 
-StatusOr<::google::iam::admin::v1::Role> IAMLogging::UndeleteRole(
+StatusOr<google::iam::admin::v1::Role> IAMLogging::UndeleteRole(
     grpc::ClientContext& context,
-    ::google::iam::admin::v1::UndeleteRoleRequest const& request) {
+    google::iam::admin::v1::UndeleteRoleRequest const& request) {
   return google::cloud::internal::LogWrapper(
       [this](grpc::ClientContext& context,
-             ::google::iam::admin::v1::UndeleteRoleRequest const& request) {
+             google::iam::admin::v1::UndeleteRoleRequest const& request) {
         return child_->UndeleteRole(context, request);
       },
       context, request, __func__, tracing_options_);
 }
 
-StatusOr<::google::iam::admin::v1::QueryTestablePermissionsResponse>
+StatusOr<google::iam::admin::v1::QueryTestablePermissionsResponse>
 IAMLogging::QueryTestablePermissions(
     grpc::ClientContext& context,
-    ::google::iam::admin::v1::QueryTestablePermissionsRequest const& request) {
+    google::iam::admin::v1::QueryTestablePermissionsRequest const& request) {
   return google::cloud::internal::LogWrapper(
       [this](grpc::ClientContext& context,
-             ::google::iam::admin::v1::QueryTestablePermissionsRequest const&
+             google::iam::admin::v1::QueryTestablePermissionsRequest const&
                  request) {
         return child_->QueryTestablePermissions(context, request);
       },
       context, request, __func__, tracing_options_);
 }
 
-StatusOr<::google::iam::admin::v1::QueryAuditableServicesResponse>
+StatusOr<google::iam::admin::v1::QueryAuditableServicesResponse>
 IAMLogging::QueryAuditableServices(
     grpc::ClientContext& context,
-    ::google::iam::admin::v1::QueryAuditableServicesRequest const& request) {
+    google::iam::admin::v1::QueryAuditableServicesRequest const& request) {
   return google::cloud::internal::LogWrapper(
       [this](grpc::ClientContext& context,
-             ::google::iam::admin::v1::QueryAuditableServicesRequest const&
+             google::iam::admin::v1::QueryAuditableServicesRequest const&
                  request) {
         return child_->QueryAuditableServices(context, request);
       },
       context, request, __func__, tracing_options_);
 }
 
-StatusOr<::google::iam::admin::v1::LintPolicyResponse> IAMLogging::LintPolicy(
+StatusOr<google::iam::admin::v1::LintPolicyResponse> IAMLogging::LintPolicy(
     grpc::ClientContext& context,
-    ::google::iam::admin::v1::LintPolicyRequest const& request) {
+    google::iam::admin::v1::LintPolicyRequest const& request) {
   return google::cloud::internal::LogWrapper(
       [this](grpc::ClientContext& context,
-             ::google::iam::admin::v1::LintPolicyRequest const& request) {
+             google::iam::admin::v1::LintPolicyRequest const& request) {
         return child_->LintPolicy(context, request);
       },
       context, request, __func__, tracing_options_);

--- a/google/cloud/iam/internal/iam_logging_decorator.h
+++ b/google/cloud/iam/internal/iam_logging_decorator.h
@@ -36,131 +36,128 @@ class IAMLogging : public IAMStub {
   IAMLogging(std::shared_ptr<IAMStub> child, TracingOptions tracing_options,
              std::set<std::string> components);
 
-  StatusOr<::google::iam::admin::v1::ListServiceAccountsResponse>
-  ListServiceAccounts(
+  StatusOr<google::iam::admin::v1::ListServiceAccountsResponse>
+  ListServiceAccounts(grpc::ClientContext& context,
+                      google::iam::admin::v1::ListServiceAccountsRequest const&
+                          request) override;
+
+  StatusOr<google::iam::admin::v1::ServiceAccount> GetServiceAccount(
       grpc::ClientContext& context,
-      ::google::iam::admin::v1::ListServiceAccountsRequest const& request)
+      google::iam::admin::v1::GetServiceAccountRequest const& request) override;
+
+  StatusOr<google::iam::admin::v1::ServiceAccount> CreateServiceAccount(
+      grpc::ClientContext& context,
+      google::iam::admin::v1::CreateServiceAccountRequest const& request)
       override;
 
-  StatusOr<::google::iam::admin::v1::ServiceAccount> GetServiceAccount(
+  StatusOr<google::iam::admin::v1::ServiceAccount> PatchServiceAccount(
       grpc::ClientContext& context,
-      ::google::iam::admin::v1::GetServiceAccountRequest const& request)
-      override;
-
-  StatusOr<::google::iam::admin::v1::ServiceAccount> CreateServiceAccount(
-      grpc::ClientContext& context,
-      ::google::iam::admin::v1::CreateServiceAccountRequest const& request)
-      override;
-
-  StatusOr<::google::iam::admin::v1::ServiceAccount> PatchServiceAccount(
-      grpc::ClientContext& context,
-      ::google::iam::admin::v1::PatchServiceAccountRequest const& request)
+      google::iam::admin::v1::PatchServiceAccountRequest const& request)
       override;
 
   Status DeleteServiceAccount(
       grpc::ClientContext& context,
-      ::google::iam::admin::v1::DeleteServiceAccountRequest const& request)
+      google::iam::admin::v1::DeleteServiceAccountRequest const& request)
       override;
 
-  StatusOr<::google::iam::admin::v1::UndeleteServiceAccountResponse>
+  StatusOr<google::iam::admin::v1::UndeleteServiceAccountResponse>
   UndeleteServiceAccount(
       grpc::ClientContext& context,
-      ::google::iam::admin::v1::UndeleteServiceAccountRequest const& request)
+      google::iam::admin::v1::UndeleteServiceAccountRequest const& request)
       override;
 
   Status EnableServiceAccount(
       grpc::ClientContext& context,
-      ::google::iam::admin::v1::EnableServiceAccountRequest const& request)
+      google::iam::admin::v1::EnableServiceAccountRequest const& request)
       override;
 
   Status DisableServiceAccount(
       grpc::ClientContext& context,
-      ::google::iam::admin::v1::DisableServiceAccountRequest const& request)
+      google::iam::admin::v1::DisableServiceAccountRequest const& request)
       override;
 
-  StatusOr<::google::iam::admin::v1::ListServiceAccountKeysResponse>
+  StatusOr<google::iam::admin::v1::ListServiceAccountKeysResponse>
   ListServiceAccountKeys(
       grpc::ClientContext& context,
-      ::google::iam::admin::v1::ListServiceAccountKeysRequest const& request)
+      google::iam::admin::v1::ListServiceAccountKeysRequest const& request)
       override;
 
-  StatusOr<::google::iam::admin::v1::ServiceAccountKey> GetServiceAccountKey(
+  StatusOr<google::iam::admin::v1::ServiceAccountKey> GetServiceAccountKey(
       grpc::ClientContext& context,
-      ::google::iam::admin::v1::GetServiceAccountKeyRequest const& request)
+      google::iam::admin::v1::GetServiceAccountKeyRequest const& request)
       override;
 
-  StatusOr<::google::iam::admin::v1::ServiceAccountKey> CreateServiceAccountKey(
+  StatusOr<google::iam::admin::v1::ServiceAccountKey> CreateServiceAccountKey(
       grpc::ClientContext& context,
-      ::google::iam::admin::v1::CreateServiceAccountKeyRequest const& request)
+      google::iam::admin::v1::CreateServiceAccountKeyRequest const& request)
       override;
 
-  StatusOr<::google::iam::admin::v1::ServiceAccountKey> UploadServiceAccountKey(
+  StatusOr<google::iam::admin::v1::ServiceAccountKey> UploadServiceAccountKey(
       grpc::ClientContext& context,
-      ::google::iam::admin::v1::UploadServiceAccountKeyRequest const& request)
+      google::iam::admin::v1::UploadServiceAccountKeyRequest const& request)
       override;
 
   Status DeleteServiceAccountKey(
       grpc::ClientContext& context,
-      ::google::iam::admin::v1::DeleteServiceAccountKeyRequest const& request)
+      google::iam::admin::v1::DeleteServiceAccountKeyRequest const& request)
       override;
 
-  StatusOr<::google::iam::v1::Policy> GetIamPolicy(
+  StatusOr<google::iam::v1::Policy> GetIamPolicy(
       grpc::ClientContext& context,
-      ::google::iam::v1::GetIamPolicyRequest const& request) override;
+      google::iam::v1::GetIamPolicyRequest const& request) override;
 
-  StatusOr<::google::iam::v1::Policy> SetIamPolicy(
+  StatusOr<google::iam::v1::Policy> SetIamPolicy(
       grpc::ClientContext& context,
-      ::google::iam::v1::SetIamPolicyRequest const& request) override;
+      google::iam::v1::SetIamPolicyRequest const& request) override;
 
-  StatusOr<::google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
+  StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
       grpc::ClientContext& context,
-      ::google::iam::v1::TestIamPermissionsRequest const& request) override;
+      google::iam::v1::TestIamPermissionsRequest const& request) override;
 
-  StatusOr<::google::iam::admin::v1::QueryGrantableRolesResponse>
-  QueryGrantableRoles(
+  StatusOr<google::iam::admin::v1::QueryGrantableRolesResponse>
+  QueryGrantableRoles(grpc::ClientContext& context,
+                      google::iam::admin::v1::QueryGrantableRolesRequest const&
+                          request) override;
+
+  StatusOr<google::iam::admin::v1::ListRolesResponse> ListRoles(
       grpc::ClientContext& context,
-      ::google::iam::admin::v1::QueryGrantableRolesRequest const& request)
-      override;
+      google::iam::admin::v1::ListRolesRequest const& request) override;
 
-  StatusOr<::google::iam::admin::v1::ListRolesResponse> ListRoles(
+  StatusOr<google::iam::admin::v1::Role> GetRole(
       grpc::ClientContext& context,
-      ::google::iam::admin::v1::ListRolesRequest const& request) override;
+      google::iam::admin::v1::GetRoleRequest const& request) override;
 
-  StatusOr<::google::iam::admin::v1::Role> GetRole(
+  StatusOr<google::iam::admin::v1::Role> CreateRole(
       grpc::ClientContext& context,
-      ::google::iam::admin::v1::GetRoleRequest const& request) override;
+      google::iam::admin::v1::CreateRoleRequest const& request) override;
 
-  StatusOr<::google::iam::admin::v1::Role> CreateRole(
+  StatusOr<google::iam::admin::v1::Role> UpdateRole(
       grpc::ClientContext& context,
-      ::google::iam::admin::v1::CreateRoleRequest const& request) override;
+      google::iam::admin::v1::UpdateRoleRequest const& request) override;
 
-  StatusOr<::google::iam::admin::v1::Role> UpdateRole(
+  StatusOr<google::iam::admin::v1::Role> DeleteRole(
       grpc::ClientContext& context,
-      ::google::iam::admin::v1::UpdateRoleRequest const& request) override;
+      google::iam::admin::v1::DeleteRoleRequest const& request) override;
 
-  StatusOr<::google::iam::admin::v1::Role> DeleteRole(
+  StatusOr<google::iam::admin::v1::Role> UndeleteRole(
       grpc::ClientContext& context,
-      ::google::iam::admin::v1::DeleteRoleRequest const& request) override;
+      google::iam::admin::v1::UndeleteRoleRequest const& request) override;
 
-  StatusOr<::google::iam::admin::v1::Role> UndeleteRole(
-      grpc::ClientContext& context,
-      ::google::iam::admin::v1::UndeleteRoleRequest const& request) override;
-
-  StatusOr<::google::iam::admin::v1::QueryTestablePermissionsResponse>
+  StatusOr<google::iam::admin::v1::QueryTestablePermissionsResponse>
   QueryTestablePermissions(
       grpc::ClientContext& context,
-      ::google::iam::admin::v1::QueryTestablePermissionsRequest const& request)
+      google::iam::admin::v1::QueryTestablePermissionsRequest const& request)
       override;
 
-  StatusOr<::google::iam::admin::v1::QueryAuditableServicesResponse>
+  StatusOr<google::iam::admin::v1::QueryAuditableServicesResponse>
   QueryAuditableServices(
       grpc::ClientContext& context,
-      ::google::iam::admin::v1::QueryAuditableServicesRequest const& request)
+      google::iam::admin::v1::QueryAuditableServicesRequest const& request)
       override;
 
-  StatusOr<::google::iam::admin::v1::LintPolicyResponse> LintPolicy(
+  StatusOr<google::iam::admin::v1::LintPolicyResponse> LintPolicy(
       grpc::ClientContext& context,
-      ::google::iam::admin::v1::LintPolicyRequest const& request) override;
+      google::iam::admin::v1::LintPolicyRequest const& request) override;
 
  private:
   std::shared_ptr<IAMStub> child_;

--- a/google/cloud/iam/internal/iam_metadata_decorator.cc
+++ b/google/cloud/iam/internal/iam_metadata_decorator.cc
@@ -30,34 +30,33 @@ IAMMetadata::IAMMetadata(std::shared_ptr<IAMStub> child)
     : child_(std::move(child)),
       api_client_header_(google::cloud::internal::ApiClientHeader()) {}
 
-StatusOr<::google::iam::admin::v1::ListServiceAccountsResponse>
+StatusOr<google::iam::admin::v1::ListServiceAccountsResponse>
 IAMMetadata::ListServiceAccounts(
     grpc::ClientContext& context,
-    ::google::iam::admin::v1::ListServiceAccountsRequest const& request) {
+    google::iam::admin::v1::ListServiceAccountsRequest const& request) {
   SetMetadata(context, "name=" + request.name());
   return child_->ListServiceAccounts(context, request);
 }
 
-StatusOr<::google::iam::admin::v1::ServiceAccount>
-IAMMetadata::GetServiceAccount(
+StatusOr<google::iam::admin::v1::ServiceAccount> IAMMetadata::GetServiceAccount(
     grpc::ClientContext& context,
-    ::google::iam::admin::v1::GetServiceAccountRequest const& request) {
+    google::iam::admin::v1::GetServiceAccountRequest const& request) {
   SetMetadata(context, "name=" + request.name());
   return child_->GetServiceAccount(context, request);
 }
 
-StatusOr<::google::iam::admin::v1::ServiceAccount>
+StatusOr<google::iam::admin::v1::ServiceAccount>
 IAMMetadata::CreateServiceAccount(
     grpc::ClientContext& context,
-    ::google::iam::admin::v1::CreateServiceAccountRequest const& request) {
+    google::iam::admin::v1::CreateServiceAccountRequest const& request) {
   SetMetadata(context, "name=" + request.name());
   return child_->CreateServiceAccount(context, request);
 }
 
-StatusOr<::google::iam::admin::v1::ServiceAccount>
+StatusOr<google::iam::admin::v1::ServiceAccount>
 IAMMetadata::PatchServiceAccount(
     grpc::ClientContext& context,
-    ::google::iam::admin::v1::PatchServiceAccountRequest const& request) {
+    google::iam::admin::v1::PatchServiceAccountRequest const& request) {
   SetMetadata(context,
               "service_account.name=" + request.service_account().name());
   return child_->PatchServiceAccount(context, request);
@@ -65,163 +64,163 @@ IAMMetadata::PatchServiceAccount(
 
 Status IAMMetadata::DeleteServiceAccount(
     grpc::ClientContext& context,
-    ::google::iam::admin::v1::DeleteServiceAccountRequest const& request) {
+    google::iam::admin::v1::DeleteServiceAccountRequest const& request) {
   SetMetadata(context, "name=" + request.name());
   return child_->DeleteServiceAccount(context, request);
 }
 
-StatusOr<::google::iam::admin::v1::UndeleteServiceAccountResponse>
+StatusOr<google::iam::admin::v1::UndeleteServiceAccountResponse>
 IAMMetadata::UndeleteServiceAccount(
     grpc::ClientContext& context,
-    ::google::iam::admin::v1::UndeleteServiceAccountRequest const& request) {
+    google::iam::admin::v1::UndeleteServiceAccountRequest const& request) {
   SetMetadata(context, "name=" + request.name());
   return child_->UndeleteServiceAccount(context, request);
 }
 
 Status IAMMetadata::EnableServiceAccount(
     grpc::ClientContext& context,
-    ::google::iam::admin::v1::EnableServiceAccountRequest const& request) {
+    google::iam::admin::v1::EnableServiceAccountRequest const& request) {
   SetMetadata(context, "name=" + request.name());
   return child_->EnableServiceAccount(context, request);
 }
 
 Status IAMMetadata::DisableServiceAccount(
     grpc::ClientContext& context,
-    ::google::iam::admin::v1::DisableServiceAccountRequest const& request) {
+    google::iam::admin::v1::DisableServiceAccountRequest const& request) {
   SetMetadata(context, "name=" + request.name());
   return child_->DisableServiceAccount(context, request);
 }
 
-StatusOr<::google::iam::admin::v1::ListServiceAccountKeysResponse>
+StatusOr<google::iam::admin::v1::ListServiceAccountKeysResponse>
 IAMMetadata::ListServiceAccountKeys(
     grpc::ClientContext& context,
-    ::google::iam::admin::v1::ListServiceAccountKeysRequest const& request) {
+    google::iam::admin::v1::ListServiceAccountKeysRequest const& request) {
   SetMetadata(context, "name=" + request.name());
   return child_->ListServiceAccountKeys(context, request);
 }
 
-StatusOr<::google::iam::admin::v1::ServiceAccountKey>
+StatusOr<google::iam::admin::v1::ServiceAccountKey>
 IAMMetadata::GetServiceAccountKey(
     grpc::ClientContext& context,
-    ::google::iam::admin::v1::GetServiceAccountKeyRequest const& request) {
+    google::iam::admin::v1::GetServiceAccountKeyRequest const& request) {
   SetMetadata(context, "name=" + request.name());
   return child_->GetServiceAccountKey(context, request);
 }
 
-StatusOr<::google::iam::admin::v1::ServiceAccountKey>
+StatusOr<google::iam::admin::v1::ServiceAccountKey>
 IAMMetadata::CreateServiceAccountKey(
     grpc::ClientContext& context,
-    ::google::iam::admin::v1::CreateServiceAccountKeyRequest const& request) {
+    google::iam::admin::v1::CreateServiceAccountKeyRequest const& request) {
   SetMetadata(context, "name=" + request.name());
   return child_->CreateServiceAccountKey(context, request);
 }
 
-StatusOr<::google::iam::admin::v1::ServiceAccountKey>
+StatusOr<google::iam::admin::v1::ServiceAccountKey>
 IAMMetadata::UploadServiceAccountKey(
     grpc::ClientContext& context,
-    ::google::iam::admin::v1::UploadServiceAccountKeyRequest const& request) {
+    google::iam::admin::v1::UploadServiceAccountKeyRequest const& request) {
   SetMetadata(context, "name=" + request.name());
   return child_->UploadServiceAccountKey(context, request);
 }
 
 Status IAMMetadata::DeleteServiceAccountKey(
     grpc::ClientContext& context,
-    ::google::iam::admin::v1::DeleteServiceAccountKeyRequest const& request) {
+    google::iam::admin::v1::DeleteServiceAccountKeyRequest const& request) {
   SetMetadata(context, "name=" + request.name());
   return child_->DeleteServiceAccountKey(context, request);
 }
 
-StatusOr<::google::iam::v1::Policy> IAMMetadata::GetIamPolicy(
+StatusOr<google::iam::v1::Policy> IAMMetadata::GetIamPolicy(
     grpc::ClientContext& context,
-    ::google::iam::v1::GetIamPolicyRequest const& request) {
+    google::iam::v1::GetIamPolicyRequest const& request) {
   SetMetadata(context, "resource=" + request.resource());
   return child_->GetIamPolicy(context, request);
 }
 
-StatusOr<::google::iam::v1::Policy> IAMMetadata::SetIamPolicy(
+StatusOr<google::iam::v1::Policy> IAMMetadata::SetIamPolicy(
     grpc::ClientContext& context,
-    ::google::iam::v1::SetIamPolicyRequest const& request) {
+    google::iam::v1::SetIamPolicyRequest const& request) {
   SetMetadata(context, "resource=" + request.resource());
   return child_->SetIamPolicy(context, request);
 }
 
-StatusOr<::google::iam::v1::TestIamPermissionsResponse>
+StatusOr<google::iam::v1::TestIamPermissionsResponse>
 IAMMetadata::TestIamPermissions(
     grpc::ClientContext& context,
-    ::google::iam::v1::TestIamPermissionsRequest const& request) {
+    google::iam::v1::TestIamPermissionsRequest const& request) {
   SetMetadata(context, "resource=" + request.resource());
   return child_->TestIamPermissions(context, request);
 }
 
-StatusOr<::google::iam::admin::v1::QueryGrantableRolesResponse>
+StatusOr<google::iam::admin::v1::QueryGrantableRolesResponse>
 IAMMetadata::QueryGrantableRoles(
     grpc::ClientContext& context,
-    ::google::iam::admin::v1::QueryGrantableRolesRequest const& request) {
+    google::iam::admin::v1::QueryGrantableRolesRequest const& request) {
   SetMetadata(context, {});
   return child_->QueryGrantableRoles(context, request);
 }
 
-StatusOr<::google::iam::admin::v1::ListRolesResponse> IAMMetadata::ListRoles(
+StatusOr<google::iam::admin::v1::ListRolesResponse> IAMMetadata::ListRoles(
     grpc::ClientContext& context,
-    ::google::iam::admin::v1::ListRolesRequest const& request) {
+    google::iam::admin::v1::ListRolesRequest const& request) {
   SetMetadata(context, {});
   return child_->ListRoles(context, request);
 }
 
-StatusOr<::google::iam::admin::v1::Role> IAMMetadata::GetRole(
+StatusOr<google::iam::admin::v1::Role> IAMMetadata::GetRole(
     grpc::ClientContext& context,
-    ::google::iam::admin::v1::GetRoleRequest const& request) {
+    google::iam::admin::v1::GetRoleRequest const& request) {
   SetMetadata(context, "name=" + request.name());
   return child_->GetRole(context, request);
 }
 
-StatusOr<::google::iam::admin::v1::Role> IAMMetadata::CreateRole(
+StatusOr<google::iam::admin::v1::Role> IAMMetadata::CreateRole(
     grpc::ClientContext& context,
-    ::google::iam::admin::v1::CreateRoleRequest const& request) {
+    google::iam::admin::v1::CreateRoleRequest const& request) {
   SetMetadata(context, "parent=" + request.parent());
   return child_->CreateRole(context, request);
 }
 
-StatusOr<::google::iam::admin::v1::Role> IAMMetadata::UpdateRole(
+StatusOr<google::iam::admin::v1::Role> IAMMetadata::UpdateRole(
     grpc::ClientContext& context,
-    ::google::iam::admin::v1::UpdateRoleRequest const& request) {
+    google::iam::admin::v1::UpdateRoleRequest const& request) {
   SetMetadata(context, "name=" + request.name());
   return child_->UpdateRole(context, request);
 }
 
-StatusOr<::google::iam::admin::v1::Role> IAMMetadata::DeleteRole(
+StatusOr<google::iam::admin::v1::Role> IAMMetadata::DeleteRole(
     grpc::ClientContext& context,
-    ::google::iam::admin::v1::DeleteRoleRequest const& request) {
+    google::iam::admin::v1::DeleteRoleRequest const& request) {
   SetMetadata(context, "name=" + request.name());
   return child_->DeleteRole(context, request);
 }
 
-StatusOr<::google::iam::admin::v1::Role> IAMMetadata::UndeleteRole(
+StatusOr<google::iam::admin::v1::Role> IAMMetadata::UndeleteRole(
     grpc::ClientContext& context,
-    ::google::iam::admin::v1::UndeleteRoleRequest const& request) {
+    google::iam::admin::v1::UndeleteRoleRequest const& request) {
   SetMetadata(context, "name=" + request.name());
   return child_->UndeleteRole(context, request);
 }
 
-StatusOr<::google::iam::admin::v1::QueryTestablePermissionsResponse>
+StatusOr<google::iam::admin::v1::QueryTestablePermissionsResponse>
 IAMMetadata::QueryTestablePermissions(
     grpc::ClientContext& context,
-    ::google::iam::admin::v1::QueryTestablePermissionsRequest const& request) {
+    google::iam::admin::v1::QueryTestablePermissionsRequest const& request) {
   SetMetadata(context, {});
   return child_->QueryTestablePermissions(context, request);
 }
 
-StatusOr<::google::iam::admin::v1::QueryAuditableServicesResponse>
+StatusOr<google::iam::admin::v1::QueryAuditableServicesResponse>
 IAMMetadata::QueryAuditableServices(
     grpc::ClientContext& context,
-    ::google::iam::admin::v1::QueryAuditableServicesRequest const& request) {
+    google::iam::admin::v1::QueryAuditableServicesRequest const& request) {
   SetMetadata(context, {});
   return child_->QueryAuditableServices(context, request);
 }
 
-StatusOr<::google::iam::admin::v1::LintPolicyResponse> IAMMetadata::LintPolicy(
+StatusOr<google::iam::admin::v1::LintPolicyResponse> IAMMetadata::LintPolicy(
     grpc::ClientContext& context,
-    ::google::iam::admin::v1::LintPolicyRequest const& request) {
+    google::iam::admin::v1::LintPolicyRequest const& request) {
   SetMetadata(context, {});
   return child_->LintPolicy(context, request);
 }

--- a/google/cloud/iam/internal/iam_metadata_decorator.h
+++ b/google/cloud/iam/internal/iam_metadata_decorator.h
@@ -33,131 +33,128 @@ class IAMMetadata : public IAMStub {
   ~IAMMetadata() override = default;
   explicit IAMMetadata(std::shared_ptr<IAMStub> child);
 
-  StatusOr<::google::iam::admin::v1::ListServiceAccountsResponse>
-  ListServiceAccounts(
+  StatusOr<google::iam::admin::v1::ListServiceAccountsResponse>
+  ListServiceAccounts(grpc::ClientContext& context,
+                      google::iam::admin::v1::ListServiceAccountsRequest const&
+                          request) override;
+
+  StatusOr<google::iam::admin::v1::ServiceAccount> GetServiceAccount(
       grpc::ClientContext& context,
-      ::google::iam::admin::v1::ListServiceAccountsRequest const& request)
+      google::iam::admin::v1::GetServiceAccountRequest const& request) override;
+
+  StatusOr<google::iam::admin::v1::ServiceAccount> CreateServiceAccount(
+      grpc::ClientContext& context,
+      google::iam::admin::v1::CreateServiceAccountRequest const& request)
       override;
 
-  StatusOr<::google::iam::admin::v1::ServiceAccount> GetServiceAccount(
+  StatusOr<google::iam::admin::v1::ServiceAccount> PatchServiceAccount(
       grpc::ClientContext& context,
-      ::google::iam::admin::v1::GetServiceAccountRequest const& request)
-      override;
-
-  StatusOr<::google::iam::admin::v1::ServiceAccount> CreateServiceAccount(
-      grpc::ClientContext& context,
-      ::google::iam::admin::v1::CreateServiceAccountRequest const& request)
-      override;
-
-  StatusOr<::google::iam::admin::v1::ServiceAccount> PatchServiceAccount(
-      grpc::ClientContext& context,
-      ::google::iam::admin::v1::PatchServiceAccountRequest const& request)
+      google::iam::admin::v1::PatchServiceAccountRequest const& request)
       override;
 
   Status DeleteServiceAccount(
       grpc::ClientContext& context,
-      ::google::iam::admin::v1::DeleteServiceAccountRequest const& request)
+      google::iam::admin::v1::DeleteServiceAccountRequest const& request)
       override;
 
-  StatusOr<::google::iam::admin::v1::UndeleteServiceAccountResponse>
+  StatusOr<google::iam::admin::v1::UndeleteServiceAccountResponse>
   UndeleteServiceAccount(
       grpc::ClientContext& context,
-      ::google::iam::admin::v1::UndeleteServiceAccountRequest const& request)
+      google::iam::admin::v1::UndeleteServiceAccountRequest const& request)
       override;
 
   Status EnableServiceAccount(
       grpc::ClientContext& context,
-      ::google::iam::admin::v1::EnableServiceAccountRequest const& request)
+      google::iam::admin::v1::EnableServiceAccountRequest const& request)
       override;
 
   Status DisableServiceAccount(
       grpc::ClientContext& context,
-      ::google::iam::admin::v1::DisableServiceAccountRequest const& request)
+      google::iam::admin::v1::DisableServiceAccountRequest const& request)
       override;
 
-  StatusOr<::google::iam::admin::v1::ListServiceAccountKeysResponse>
+  StatusOr<google::iam::admin::v1::ListServiceAccountKeysResponse>
   ListServiceAccountKeys(
       grpc::ClientContext& context,
-      ::google::iam::admin::v1::ListServiceAccountKeysRequest const& request)
+      google::iam::admin::v1::ListServiceAccountKeysRequest const& request)
       override;
 
-  StatusOr<::google::iam::admin::v1::ServiceAccountKey> GetServiceAccountKey(
+  StatusOr<google::iam::admin::v1::ServiceAccountKey> GetServiceAccountKey(
       grpc::ClientContext& context,
-      ::google::iam::admin::v1::GetServiceAccountKeyRequest const& request)
+      google::iam::admin::v1::GetServiceAccountKeyRequest const& request)
       override;
 
-  StatusOr<::google::iam::admin::v1::ServiceAccountKey> CreateServiceAccountKey(
+  StatusOr<google::iam::admin::v1::ServiceAccountKey> CreateServiceAccountKey(
       grpc::ClientContext& context,
-      ::google::iam::admin::v1::CreateServiceAccountKeyRequest const& request)
+      google::iam::admin::v1::CreateServiceAccountKeyRequest const& request)
       override;
 
-  StatusOr<::google::iam::admin::v1::ServiceAccountKey> UploadServiceAccountKey(
+  StatusOr<google::iam::admin::v1::ServiceAccountKey> UploadServiceAccountKey(
       grpc::ClientContext& context,
-      ::google::iam::admin::v1::UploadServiceAccountKeyRequest const& request)
+      google::iam::admin::v1::UploadServiceAccountKeyRequest const& request)
       override;
 
   Status DeleteServiceAccountKey(
       grpc::ClientContext& context,
-      ::google::iam::admin::v1::DeleteServiceAccountKeyRequest const& request)
+      google::iam::admin::v1::DeleteServiceAccountKeyRequest const& request)
       override;
 
-  StatusOr<::google::iam::v1::Policy> GetIamPolicy(
+  StatusOr<google::iam::v1::Policy> GetIamPolicy(
       grpc::ClientContext& context,
-      ::google::iam::v1::GetIamPolicyRequest const& request) override;
+      google::iam::v1::GetIamPolicyRequest const& request) override;
 
-  StatusOr<::google::iam::v1::Policy> SetIamPolicy(
+  StatusOr<google::iam::v1::Policy> SetIamPolicy(
       grpc::ClientContext& context,
-      ::google::iam::v1::SetIamPolicyRequest const& request) override;
+      google::iam::v1::SetIamPolicyRequest const& request) override;
 
-  StatusOr<::google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
+  StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
       grpc::ClientContext& context,
-      ::google::iam::v1::TestIamPermissionsRequest const& request) override;
+      google::iam::v1::TestIamPermissionsRequest const& request) override;
 
-  StatusOr<::google::iam::admin::v1::QueryGrantableRolesResponse>
-  QueryGrantableRoles(
+  StatusOr<google::iam::admin::v1::QueryGrantableRolesResponse>
+  QueryGrantableRoles(grpc::ClientContext& context,
+                      google::iam::admin::v1::QueryGrantableRolesRequest const&
+                          request) override;
+
+  StatusOr<google::iam::admin::v1::ListRolesResponse> ListRoles(
       grpc::ClientContext& context,
-      ::google::iam::admin::v1::QueryGrantableRolesRequest const& request)
-      override;
+      google::iam::admin::v1::ListRolesRequest const& request) override;
 
-  StatusOr<::google::iam::admin::v1::ListRolesResponse> ListRoles(
+  StatusOr<google::iam::admin::v1::Role> GetRole(
       grpc::ClientContext& context,
-      ::google::iam::admin::v1::ListRolesRequest const& request) override;
+      google::iam::admin::v1::GetRoleRequest const& request) override;
 
-  StatusOr<::google::iam::admin::v1::Role> GetRole(
+  StatusOr<google::iam::admin::v1::Role> CreateRole(
       grpc::ClientContext& context,
-      ::google::iam::admin::v1::GetRoleRequest const& request) override;
+      google::iam::admin::v1::CreateRoleRequest const& request) override;
 
-  StatusOr<::google::iam::admin::v1::Role> CreateRole(
+  StatusOr<google::iam::admin::v1::Role> UpdateRole(
       grpc::ClientContext& context,
-      ::google::iam::admin::v1::CreateRoleRequest const& request) override;
+      google::iam::admin::v1::UpdateRoleRequest const& request) override;
 
-  StatusOr<::google::iam::admin::v1::Role> UpdateRole(
+  StatusOr<google::iam::admin::v1::Role> DeleteRole(
       grpc::ClientContext& context,
-      ::google::iam::admin::v1::UpdateRoleRequest const& request) override;
+      google::iam::admin::v1::DeleteRoleRequest const& request) override;
 
-  StatusOr<::google::iam::admin::v1::Role> DeleteRole(
+  StatusOr<google::iam::admin::v1::Role> UndeleteRole(
       grpc::ClientContext& context,
-      ::google::iam::admin::v1::DeleteRoleRequest const& request) override;
+      google::iam::admin::v1::UndeleteRoleRequest const& request) override;
 
-  StatusOr<::google::iam::admin::v1::Role> UndeleteRole(
-      grpc::ClientContext& context,
-      ::google::iam::admin::v1::UndeleteRoleRequest const& request) override;
-
-  StatusOr<::google::iam::admin::v1::QueryTestablePermissionsResponse>
+  StatusOr<google::iam::admin::v1::QueryTestablePermissionsResponse>
   QueryTestablePermissions(
       grpc::ClientContext& context,
-      ::google::iam::admin::v1::QueryTestablePermissionsRequest const& request)
+      google::iam::admin::v1::QueryTestablePermissionsRequest const& request)
       override;
 
-  StatusOr<::google::iam::admin::v1::QueryAuditableServicesResponse>
+  StatusOr<google::iam::admin::v1::QueryAuditableServicesResponse>
   QueryAuditableServices(
       grpc::ClientContext& context,
-      ::google::iam::admin::v1::QueryAuditableServicesRequest const& request)
+      google::iam::admin::v1::QueryAuditableServicesRequest const& request)
       override;
 
-  StatusOr<::google::iam::admin::v1::LintPolicyResponse> LintPolicy(
+  StatusOr<google::iam::admin::v1::LintPolicyResponse> LintPolicy(
       grpc::ClientContext& context,
-      ::google::iam::admin::v1::LintPolicyRequest const& request) override;
+      google::iam::admin::v1::LintPolicyRequest const& request) override;
 
  private:
   void SetMetadata(grpc::ClientContext& context,

--- a/google/cloud/iam/internal/iam_stub.cc
+++ b/google/cloud/iam/internal/iam_stub.cc
@@ -29,11 +29,11 @@ inline namespace GOOGLE_CLOUD_CPP_GENERATED_NS {
 
 IAMStub::~IAMStub() = default;
 
-StatusOr<::google::iam::admin::v1::ListServiceAccountsResponse>
+StatusOr<google::iam::admin::v1::ListServiceAccountsResponse>
 DefaultIAMStub::ListServiceAccounts(
     grpc::ClientContext& client_context,
-    ::google::iam::admin::v1::ListServiceAccountsRequest const& request) {
-  ::google::iam::admin::v1::ListServiceAccountsResponse response;
+    google::iam::admin::v1::ListServiceAccountsRequest const& request) {
+  google::iam::admin::v1::ListServiceAccountsResponse response;
   auto status =
       grpc_stub_->ListServiceAccounts(&client_context, request, &response);
   if (!status.ok()) {
@@ -42,11 +42,11 @@ DefaultIAMStub::ListServiceAccounts(
   return response;
 }
 
-StatusOr<::google::iam::admin::v1::ServiceAccount>
+StatusOr<google::iam::admin::v1::ServiceAccount>
 DefaultIAMStub::GetServiceAccount(
     grpc::ClientContext& client_context,
-    ::google::iam::admin::v1::GetServiceAccountRequest const& request) {
-  ::google::iam::admin::v1::ServiceAccount response;
+    google::iam::admin::v1::GetServiceAccountRequest const& request) {
+  google::iam::admin::v1::ServiceAccount response;
   auto status =
       grpc_stub_->GetServiceAccount(&client_context, request, &response);
   if (!status.ok()) {
@@ -55,11 +55,11 @@ DefaultIAMStub::GetServiceAccount(
   return response;
 }
 
-StatusOr<::google::iam::admin::v1::ServiceAccount>
+StatusOr<google::iam::admin::v1::ServiceAccount>
 DefaultIAMStub::CreateServiceAccount(
     grpc::ClientContext& client_context,
-    ::google::iam::admin::v1::CreateServiceAccountRequest const& request) {
-  ::google::iam::admin::v1::ServiceAccount response;
+    google::iam::admin::v1::CreateServiceAccountRequest const& request) {
+  google::iam::admin::v1::ServiceAccount response;
   auto status =
       grpc_stub_->CreateServiceAccount(&client_context, request, &response);
   if (!status.ok()) {
@@ -68,11 +68,11 @@ DefaultIAMStub::CreateServiceAccount(
   return response;
 }
 
-StatusOr<::google::iam::admin::v1::ServiceAccount>
+StatusOr<google::iam::admin::v1::ServiceAccount>
 DefaultIAMStub::PatchServiceAccount(
     grpc::ClientContext& client_context,
-    ::google::iam::admin::v1::PatchServiceAccountRequest const& request) {
-  ::google::iam::admin::v1::ServiceAccount response;
+    google::iam::admin::v1::PatchServiceAccountRequest const& request) {
+  google::iam::admin::v1::ServiceAccount response;
   auto status =
       grpc_stub_->PatchServiceAccount(&client_context, request, &response);
   if (!status.ok()) {
@@ -83,8 +83,8 @@ DefaultIAMStub::PatchServiceAccount(
 
 Status DefaultIAMStub::DeleteServiceAccount(
     grpc::ClientContext& client_context,
-    ::google::iam::admin::v1::DeleteServiceAccountRequest const& request) {
-  ::google::protobuf::Empty response;
+    google::iam::admin::v1::DeleteServiceAccountRequest const& request) {
+  google::protobuf::Empty response;
   auto status =
       grpc_stub_->DeleteServiceAccount(&client_context, request, &response);
   if (!status.ok()) {
@@ -93,11 +93,11 @@ Status DefaultIAMStub::DeleteServiceAccount(
   return google::cloud::Status();
 }
 
-StatusOr<::google::iam::admin::v1::UndeleteServiceAccountResponse>
+StatusOr<google::iam::admin::v1::UndeleteServiceAccountResponse>
 DefaultIAMStub::UndeleteServiceAccount(
     grpc::ClientContext& client_context,
-    ::google::iam::admin::v1::UndeleteServiceAccountRequest const& request) {
-  ::google::iam::admin::v1::UndeleteServiceAccountResponse response;
+    google::iam::admin::v1::UndeleteServiceAccountRequest const& request) {
+  google::iam::admin::v1::UndeleteServiceAccountResponse response;
   auto status =
       grpc_stub_->UndeleteServiceAccount(&client_context, request, &response);
   if (!status.ok()) {
@@ -108,8 +108,8 @@ DefaultIAMStub::UndeleteServiceAccount(
 
 Status DefaultIAMStub::EnableServiceAccount(
     grpc::ClientContext& client_context,
-    ::google::iam::admin::v1::EnableServiceAccountRequest const& request) {
-  ::google::protobuf::Empty response;
+    google::iam::admin::v1::EnableServiceAccountRequest const& request) {
+  google::protobuf::Empty response;
   auto status =
       grpc_stub_->EnableServiceAccount(&client_context, request, &response);
   if (!status.ok()) {
@@ -120,8 +120,8 @@ Status DefaultIAMStub::EnableServiceAccount(
 
 Status DefaultIAMStub::DisableServiceAccount(
     grpc::ClientContext& client_context,
-    ::google::iam::admin::v1::DisableServiceAccountRequest const& request) {
-  ::google::protobuf::Empty response;
+    google::iam::admin::v1::DisableServiceAccountRequest const& request) {
+  google::protobuf::Empty response;
   auto status =
       grpc_stub_->DisableServiceAccount(&client_context, request, &response);
   if (!status.ok()) {
@@ -130,11 +130,11 @@ Status DefaultIAMStub::DisableServiceAccount(
   return google::cloud::Status();
 }
 
-StatusOr<::google::iam::admin::v1::ListServiceAccountKeysResponse>
+StatusOr<google::iam::admin::v1::ListServiceAccountKeysResponse>
 DefaultIAMStub::ListServiceAccountKeys(
     grpc::ClientContext& client_context,
-    ::google::iam::admin::v1::ListServiceAccountKeysRequest const& request) {
-  ::google::iam::admin::v1::ListServiceAccountKeysResponse response;
+    google::iam::admin::v1::ListServiceAccountKeysRequest const& request) {
+  google::iam::admin::v1::ListServiceAccountKeysResponse response;
   auto status =
       grpc_stub_->ListServiceAccountKeys(&client_context, request, &response);
   if (!status.ok()) {
@@ -143,11 +143,11 @@ DefaultIAMStub::ListServiceAccountKeys(
   return response;
 }
 
-StatusOr<::google::iam::admin::v1::ServiceAccountKey>
+StatusOr<google::iam::admin::v1::ServiceAccountKey>
 DefaultIAMStub::GetServiceAccountKey(
     grpc::ClientContext& client_context,
-    ::google::iam::admin::v1::GetServiceAccountKeyRequest const& request) {
-  ::google::iam::admin::v1::ServiceAccountKey response;
+    google::iam::admin::v1::GetServiceAccountKeyRequest const& request) {
+  google::iam::admin::v1::ServiceAccountKey response;
   auto status =
       grpc_stub_->GetServiceAccountKey(&client_context, request, &response);
   if (!status.ok()) {
@@ -156,11 +156,11 @@ DefaultIAMStub::GetServiceAccountKey(
   return response;
 }
 
-StatusOr<::google::iam::admin::v1::ServiceAccountKey>
+StatusOr<google::iam::admin::v1::ServiceAccountKey>
 DefaultIAMStub::CreateServiceAccountKey(
     grpc::ClientContext& client_context,
-    ::google::iam::admin::v1::CreateServiceAccountKeyRequest const& request) {
-  ::google::iam::admin::v1::ServiceAccountKey response;
+    google::iam::admin::v1::CreateServiceAccountKeyRequest const& request) {
+  google::iam::admin::v1::ServiceAccountKey response;
   auto status =
       grpc_stub_->CreateServiceAccountKey(&client_context, request, &response);
   if (!status.ok()) {
@@ -169,11 +169,11 @@ DefaultIAMStub::CreateServiceAccountKey(
   return response;
 }
 
-StatusOr<::google::iam::admin::v1::ServiceAccountKey>
+StatusOr<google::iam::admin::v1::ServiceAccountKey>
 DefaultIAMStub::UploadServiceAccountKey(
     grpc::ClientContext& client_context,
-    ::google::iam::admin::v1::UploadServiceAccountKeyRequest const& request) {
-  ::google::iam::admin::v1::ServiceAccountKey response;
+    google::iam::admin::v1::UploadServiceAccountKeyRequest const& request) {
+  google::iam::admin::v1::ServiceAccountKey response;
   auto status =
       grpc_stub_->UploadServiceAccountKey(&client_context, request, &response);
   if (!status.ok()) {
@@ -184,8 +184,8 @@ DefaultIAMStub::UploadServiceAccountKey(
 
 Status DefaultIAMStub::DeleteServiceAccountKey(
     grpc::ClientContext& client_context,
-    ::google::iam::admin::v1::DeleteServiceAccountKeyRequest const& request) {
-  ::google::protobuf::Empty response;
+    google::iam::admin::v1::DeleteServiceAccountKeyRequest const& request) {
+  google::protobuf::Empty response;
   auto status =
       grpc_stub_->DeleteServiceAccountKey(&client_context, request, &response);
   if (!status.ok()) {
@@ -194,10 +194,10 @@ Status DefaultIAMStub::DeleteServiceAccountKey(
   return google::cloud::Status();
 }
 
-StatusOr<::google::iam::v1::Policy> DefaultIAMStub::GetIamPolicy(
+StatusOr<google::iam::v1::Policy> DefaultIAMStub::GetIamPolicy(
     grpc::ClientContext& client_context,
-    ::google::iam::v1::GetIamPolicyRequest const& request) {
-  ::google::iam::v1::Policy response;
+    google::iam::v1::GetIamPolicyRequest const& request) {
+  google::iam::v1::Policy response;
   auto status = grpc_stub_->GetIamPolicy(&client_context, request, &response);
   if (!status.ok()) {
     return google::cloud::MakeStatusFromRpcError(status);
@@ -205,10 +205,10 @@ StatusOr<::google::iam::v1::Policy> DefaultIAMStub::GetIamPolicy(
   return response;
 }
 
-StatusOr<::google::iam::v1::Policy> DefaultIAMStub::SetIamPolicy(
+StatusOr<google::iam::v1::Policy> DefaultIAMStub::SetIamPolicy(
     grpc::ClientContext& client_context,
-    ::google::iam::v1::SetIamPolicyRequest const& request) {
-  ::google::iam::v1::Policy response;
+    google::iam::v1::SetIamPolicyRequest const& request) {
+  google::iam::v1::Policy response;
   auto status = grpc_stub_->SetIamPolicy(&client_context, request, &response);
   if (!status.ok()) {
     return google::cloud::MakeStatusFromRpcError(status);
@@ -216,11 +216,11 @@ StatusOr<::google::iam::v1::Policy> DefaultIAMStub::SetIamPolicy(
   return response;
 }
 
-StatusOr<::google::iam::v1::TestIamPermissionsResponse>
+StatusOr<google::iam::v1::TestIamPermissionsResponse>
 DefaultIAMStub::TestIamPermissions(
     grpc::ClientContext& client_context,
-    ::google::iam::v1::TestIamPermissionsRequest const& request) {
-  ::google::iam::v1::TestIamPermissionsResponse response;
+    google::iam::v1::TestIamPermissionsRequest const& request) {
+  google::iam::v1::TestIamPermissionsResponse response;
   auto status =
       grpc_stub_->TestIamPermissions(&client_context, request, &response);
   if (!status.ok()) {
@@ -229,11 +229,11 @@ DefaultIAMStub::TestIamPermissions(
   return response;
 }
 
-StatusOr<::google::iam::admin::v1::QueryGrantableRolesResponse>
+StatusOr<google::iam::admin::v1::QueryGrantableRolesResponse>
 DefaultIAMStub::QueryGrantableRoles(
     grpc::ClientContext& client_context,
-    ::google::iam::admin::v1::QueryGrantableRolesRequest const& request) {
-  ::google::iam::admin::v1::QueryGrantableRolesResponse response;
+    google::iam::admin::v1::QueryGrantableRolesRequest const& request) {
+  google::iam::admin::v1::QueryGrantableRolesResponse response;
   auto status =
       grpc_stub_->QueryGrantableRoles(&client_context, request, &response);
   if (!status.ok()) {
@@ -242,10 +242,10 @@ DefaultIAMStub::QueryGrantableRoles(
   return response;
 }
 
-StatusOr<::google::iam::admin::v1::ListRolesResponse> DefaultIAMStub::ListRoles(
+StatusOr<google::iam::admin::v1::ListRolesResponse> DefaultIAMStub::ListRoles(
     grpc::ClientContext& client_context,
-    ::google::iam::admin::v1::ListRolesRequest const& request) {
-  ::google::iam::admin::v1::ListRolesResponse response;
+    google::iam::admin::v1::ListRolesRequest const& request) {
+  google::iam::admin::v1::ListRolesResponse response;
   auto status = grpc_stub_->ListRoles(&client_context, request, &response);
   if (!status.ok()) {
     return google::cloud::MakeStatusFromRpcError(status);
@@ -253,10 +253,10 @@ StatusOr<::google::iam::admin::v1::ListRolesResponse> DefaultIAMStub::ListRoles(
   return response;
 }
 
-StatusOr<::google::iam::admin::v1::Role> DefaultIAMStub::GetRole(
+StatusOr<google::iam::admin::v1::Role> DefaultIAMStub::GetRole(
     grpc::ClientContext& client_context,
-    ::google::iam::admin::v1::GetRoleRequest const& request) {
-  ::google::iam::admin::v1::Role response;
+    google::iam::admin::v1::GetRoleRequest const& request) {
+  google::iam::admin::v1::Role response;
   auto status = grpc_stub_->GetRole(&client_context, request, &response);
   if (!status.ok()) {
     return google::cloud::MakeStatusFromRpcError(status);
@@ -264,10 +264,10 @@ StatusOr<::google::iam::admin::v1::Role> DefaultIAMStub::GetRole(
   return response;
 }
 
-StatusOr<::google::iam::admin::v1::Role> DefaultIAMStub::CreateRole(
+StatusOr<google::iam::admin::v1::Role> DefaultIAMStub::CreateRole(
     grpc::ClientContext& client_context,
-    ::google::iam::admin::v1::CreateRoleRequest const& request) {
-  ::google::iam::admin::v1::Role response;
+    google::iam::admin::v1::CreateRoleRequest const& request) {
+  google::iam::admin::v1::Role response;
   auto status = grpc_stub_->CreateRole(&client_context, request, &response);
   if (!status.ok()) {
     return google::cloud::MakeStatusFromRpcError(status);
@@ -275,10 +275,10 @@ StatusOr<::google::iam::admin::v1::Role> DefaultIAMStub::CreateRole(
   return response;
 }
 
-StatusOr<::google::iam::admin::v1::Role> DefaultIAMStub::UpdateRole(
+StatusOr<google::iam::admin::v1::Role> DefaultIAMStub::UpdateRole(
     grpc::ClientContext& client_context,
-    ::google::iam::admin::v1::UpdateRoleRequest const& request) {
-  ::google::iam::admin::v1::Role response;
+    google::iam::admin::v1::UpdateRoleRequest const& request) {
+  google::iam::admin::v1::Role response;
   auto status = grpc_stub_->UpdateRole(&client_context, request, &response);
   if (!status.ok()) {
     return google::cloud::MakeStatusFromRpcError(status);
@@ -286,10 +286,10 @@ StatusOr<::google::iam::admin::v1::Role> DefaultIAMStub::UpdateRole(
   return response;
 }
 
-StatusOr<::google::iam::admin::v1::Role> DefaultIAMStub::DeleteRole(
+StatusOr<google::iam::admin::v1::Role> DefaultIAMStub::DeleteRole(
     grpc::ClientContext& client_context,
-    ::google::iam::admin::v1::DeleteRoleRequest const& request) {
-  ::google::iam::admin::v1::Role response;
+    google::iam::admin::v1::DeleteRoleRequest const& request) {
+  google::iam::admin::v1::Role response;
   auto status = grpc_stub_->DeleteRole(&client_context, request, &response);
   if (!status.ok()) {
     return google::cloud::MakeStatusFromRpcError(status);
@@ -297,10 +297,10 @@ StatusOr<::google::iam::admin::v1::Role> DefaultIAMStub::DeleteRole(
   return response;
 }
 
-StatusOr<::google::iam::admin::v1::Role> DefaultIAMStub::UndeleteRole(
+StatusOr<google::iam::admin::v1::Role> DefaultIAMStub::UndeleteRole(
     grpc::ClientContext& client_context,
-    ::google::iam::admin::v1::UndeleteRoleRequest const& request) {
-  ::google::iam::admin::v1::Role response;
+    google::iam::admin::v1::UndeleteRoleRequest const& request) {
+  google::iam::admin::v1::Role response;
   auto status = grpc_stub_->UndeleteRole(&client_context, request, &response);
   if (!status.ok()) {
     return google::cloud::MakeStatusFromRpcError(status);
@@ -308,11 +308,11 @@ StatusOr<::google::iam::admin::v1::Role> DefaultIAMStub::UndeleteRole(
   return response;
 }
 
-StatusOr<::google::iam::admin::v1::QueryTestablePermissionsResponse>
+StatusOr<google::iam::admin::v1::QueryTestablePermissionsResponse>
 DefaultIAMStub::QueryTestablePermissions(
     grpc::ClientContext& client_context,
-    ::google::iam::admin::v1::QueryTestablePermissionsRequest const& request) {
-  ::google::iam::admin::v1::QueryTestablePermissionsResponse response;
+    google::iam::admin::v1::QueryTestablePermissionsRequest const& request) {
+  google::iam::admin::v1::QueryTestablePermissionsResponse response;
   auto status =
       grpc_stub_->QueryTestablePermissions(&client_context, request, &response);
   if (!status.ok()) {
@@ -321,11 +321,11 @@ DefaultIAMStub::QueryTestablePermissions(
   return response;
 }
 
-StatusOr<::google::iam::admin::v1::QueryAuditableServicesResponse>
+StatusOr<google::iam::admin::v1::QueryAuditableServicesResponse>
 DefaultIAMStub::QueryAuditableServices(
     grpc::ClientContext& client_context,
-    ::google::iam::admin::v1::QueryAuditableServicesRequest const& request) {
-  ::google::iam::admin::v1::QueryAuditableServicesResponse response;
+    google::iam::admin::v1::QueryAuditableServicesRequest const& request) {
+  google::iam::admin::v1::QueryAuditableServicesResponse response;
   auto status =
       grpc_stub_->QueryAuditableServices(&client_context, request, &response);
   if (!status.ok()) {
@@ -334,11 +334,10 @@ DefaultIAMStub::QueryAuditableServices(
   return response;
 }
 
-StatusOr<::google::iam::admin::v1::LintPolicyResponse>
-DefaultIAMStub::LintPolicy(
+StatusOr<google::iam::admin::v1::LintPolicyResponse> DefaultIAMStub::LintPolicy(
     grpc::ClientContext& client_context,
-    ::google::iam::admin::v1::LintPolicyRequest const& request) {
-  ::google::iam::admin::v1::LintPolicyResponse response;
+    google::iam::admin::v1::LintPolicyRequest const& request) {
+  google::iam::admin::v1::LintPolicyResponse response;
   auto status = grpc_stub_->LintPolicy(&client_context, request, &response);
   if (!status.ok()) {
     return google::cloud::MakeStatusFromRpcError(status);

--- a/google/cloud/iam/internal/iam_stub.h
+++ b/google/cloud/iam/internal/iam_stub.h
@@ -32,265 +32,256 @@ class IAMStub {
  public:
   virtual ~IAMStub() = 0;
 
-  virtual StatusOr<::google::iam::admin::v1::ListServiceAccountsResponse>
+  virtual StatusOr<google::iam::admin::v1::ListServiceAccountsResponse>
   ListServiceAccounts(
       grpc::ClientContext& context,
-      ::google::iam::admin::v1::ListServiceAccountsRequest const& request) = 0;
+      google::iam::admin::v1::ListServiceAccountsRequest const& request) = 0;
 
-  virtual StatusOr<::google::iam::admin::v1::ServiceAccount> GetServiceAccount(
+  virtual StatusOr<google::iam::admin::v1::ServiceAccount> GetServiceAccount(
       grpc::ClientContext& context,
-      ::google::iam::admin::v1::GetServiceAccountRequest const& request) = 0;
+      google::iam::admin::v1::GetServiceAccountRequest const& request) = 0;
 
-  virtual StatusOr<::google::iam::admin::v1::ServiceAccount>
-  CreateServiceAccount(
+  virtual StatusOr<google::iam::admin::v1::ServiceAccount> CreateServiceAccount(
       grpc::ClientContext& context,
-      ::google::iam::admin::v1::CreateServiceAccountRequest const& request) = 0;
+      google::iam::admin::v1::CreateServiceAccountRequest const& request) = 0;
 
-  virtual StatusOr<::google::iam::admin::v1::ServiceAccount>
-  PatchServiceAccount(
+  virtual StatusOr<google::iam::admin::v1::ServiceAccount> PatchServiceAccount(
       grpc::ClientContext& context,
-      ::google::iam::admin::v1::PatchServiceAccountRequest const& request) = 0;
+      google::iam::admin::v1::PatchServiceAccountRequest const& request) = 0;
 
   virtual Status DeleteServiceAccount(
       grpc::ClientContext& context,
-      ::google::iam::admin::v1::DeleteServiceAccountRequest const& request) = 0;
+      google::iam::admin::v1::DeleteServiceAccountRequest const& request) = 0;
 
-  virtual StatusOr<::google::iam::admin::v1::UndeleteServiceAccountResponse>
+  virtual StatusOr<google::iam::admin::v1::UndeleteServiceAccountResponse>
   UndeleteServiceAccount(
       grpc::ClientContext& context,
-      ::google::iam::admin::v1::UndeleteServiceAccountRequest const&
-          request) = 0;
+      google::iam::admin::v1::UndeleteServiceAccountRequest const& request) = 0;
 
   virtual Status EnableServiceAccount(
       grpc::ClientContext& context,
-      ::google::iam::admin::v1::EnableServiceAccountRequest const& request) = 0;
+      google::iam::admin::v1::EnableServiceAccountRequest const& request) = 0;
 
   virtual Status DisableServiceAccount(
       grpc::ClientContext& context,
-      ::google::iam::admin::v1::DisableServiceAccountRequest const&
-          request) = 0;
+      google::iam::admin::v1::DisableServiceAccountRequest const& request) = 0;
 
-  virtual StatusOr<::google::iam::admin::v1::ListServiceAccountKeysResponse>
+  virtual StatusOr<google::iam::admin::v1::ListServiceAccountKeysResponse>
   ListServiceAccountKeys(
       grpc::ClientContext& context,
-      ::google::iam::admin::v1::ListServiceAccountKeysRequest const&
-          request) = 0;
+      google::iam::admin::v1::ListServiceAccountKeysRequest const& request) = 0;
 
-  virtual StatusOr<::google::iam::admin::v1::ServiceAccountKey>
+  virtual StatusOr<google::iam::admin::v1::ServiceAccountKey>
   GetServiceAccountKey(
       grpc::ClientContext& context,
-      ::google::iam::admin::v1::GetServiceAccountKeyRequest const& request) = 0;
+      google::iam::admin::v1::GetServiceAccountKeyRequest const& request) = 0;
 
-  virtual StatusOr<::google::iam::admin::v1::ServiceAccountKey>
+  virtual StatusOr<google::iam::admin::v1::ServiceAccountKey>
   CreateServiceAccountKey(
       grpc::ClientContext& context,
-      ::google::iam::admin::v1::CreateServiceAccountKeyRequest const&
+      google::iam::admin::v1::CreateServiceAccountKeyRequest const&
           request) = 0;
 
-  virtual StatusOr<::google::iam::admin::v1::ServiceAccountKey>
+  virtual StatusOr<google::iam::admin::v1::ServiceAccountKey>
   UploadServiceAccountKey(
       grpc::ClientContext& context,
-      ::google::iam::admin::v1::UploadServiceAccountKeyRequest const&
+      google::iam::admin::v1::UploadServiceAccountKeyRequest const&
           request) = 0;
 
   virtual Status DeleteServiceAccountKey(
       grpc::ClientContext& context,
-      ::google::iam::admin::v1::DeleteServiceAccountKeyRequest const&
+      google::iam::admin::v1::DeleteServiceAccountKeyRequest const&
           request) = 0;
 
-  virtual StatusOr<::google::iam::v1::Policy> GetIamPolicy(
+  virtual StatusOr<google::iam::v1::Policy> GetIamPolicy(
       grpc::ClientContext& context,
-      ::google::iam::v1::GetIamPolicyRequest const& request) = 0;
+      google::iam::v1::GetIamPolicyRequest const& request) = 0;
 
-  virtual StatusOr<::google::iam::v1::Policy> SetIamPolicy(
+  virtual StatusOr<google::iam::v1::Policy> SetIamPolicy(
       grpc::ClientContext& context,
-      ::google::iam::v1::SetIamPolicyRequest const& request) = 0;
+      google::iam::v1::SetIamPolicyRequest const& request) = 0;
 
-  virtual StatusOr<::google::iam::v1::TestIamPermissionsResponse>
+  virtual StatusOr<google::iam::v1::TestIamPermissionsResponse>
   TestIamPermissions(
       grpc::ClientContext& context,
-      ::google::iam::v1::TestIamPermissionsRequest const& request) = 0;
+      google::iam::v1::TestIamPermissionsRequest const& request) = 0;
 
-  virtual StatusOr<::google::iam::admin::v1::QueryGrantableRolesResponse>
+  virtual StatusOr<google::iam::admin::v1::QueryGrantableRolesResponse>
   QueryGrantableRoles(
       grpc::ClientContext& context,
-      ::google::iam::admin::v1::QueryGrantableRolesRequest const& request) = 0;
+      google::iam::admin::v1::QueryGrantableRolesRequest const& request) = 0;
 
-  virtual StatusOr<::google::iam::admin::v1::ListRolesResponse> ListRoles(
+  virtual StatusOr<google::iam::admin::v1::ListRolesResponse> ListRoles(
       grpc::ClientContext& context,
-      ::google::iam::admin::v1::ListRolesRequest const& request) = 0;
+      google::iam::admin::v1::ListRolesRequest const& request) = 0;
 
-  virtual StatusOr<::google::iam::admin::v1::Role> GetRole(
+  virtual StatusOr<google::iam::admin::v1::Role> GetRole(
       grpc::ClientContext& context,
-      ::google::iam::admin::v1::GetRoleRequest const& request) = 0;
+      google::iam::admin::v1::GetRoleRequest const& request) = 0;
 
-  virtual StatusOr<::google::iam::admin::v1::Role> CreateRole(
+  virtual StatusOr<google::iam::admin::v1::Role> CreateRole(
       grpc::ClientContext& context,
-      ::google::iam::admin::v1::CreateRoleRequest const& request) = 0;
+      google::iam::admin::v1::CreateRoleRequest const& request) = 0;
 
-  virtual StatusOr<::google::iam::admin::v1::Role> UpdateRole(
+  virtual StatusOr<google::iam::admin::v1::Role> UpdateRole(
       grpc::ClientContext& context,
-      ::google::iam::admin::v1::UpdateRoleRequest const& request) = 0;
+      google::iam::admin::v1::UpdateRoleRequest const& request) = 0;
 
-  virtual StatusOr<::google::iam::admin::v1::Role> DeleteRole(
+  virtual StatusOr<google::iam::admin::v1::Role> DeleteRole(
       grpc::ClientContext& context,
-      ::google::iam::admin::v1::DeleteRoleRequest const& request) = 0;
+      google::iam::admin::v1::DeleteRoleRequest const& request) = 0;
 
-  virtual StatusOr<::google::iam::admin::v1::Role> UndeleteRole(
+  virtual StatusOr<google::iam::admin::v1::Role> UndeleteRole(
       grpc::ClientContext& context,
-      ::google::iam::admin::v1::UndeleteRoleRequest const& request) = 0;
+      google::iam::admin::v1::UndeleteRoleRequest const& request) = 0;
 
-  virtual StatusOr<::google::iam::admin::v1::QueryTestablePermissionsResponse>
+  virtual StatusOr<google::iam::admin::v1::QueryTestablePermissionsResponse>
   QueryTestablePermissions(
       grpc::ClientContext& context,
-      ::google::iam::admin::v1::QueryTestablePermissionsRequest const&
+      google::iam::admin::v1::QueryTestablePermissionsRequest const&
           request) = 0;
 
-  virtual StatusOr<::google::iam::admin::v1::QueryAuditableServicesResponse>
+  virtual StatusOr<google::iam::admin::v1::QueryAuditableServicesResponse>
   QueryAuditableServices(
       grpc::ClientContext& context,
-      ::google::iam::admin::v1::QueryAuditableServicesRequest const&
-          request) = 0;
+      google::iam::admin::v1::QueryAuditableServicesRequest const& request) = 0;
 
-  virtual StatusOr<::google::iam::admin::v1::LintPolicyResponse> LintPolicy(
+  virtual StatusOr<google::iam::admin::v1::LintPolicyResponse> LintPolicy(
       grpc::ClientContext& context,
-      ::google::iam::admin::v1::LintPolicyRequest const& request) = 0;
+      google::iam::admin::v1::LintPolicyRequest const& request) = 0;
 };
 
 class DefaultIAMStub : public IAMStub {
  public:
   explicit DefaultIAMStub(
-      std::unique_ptr<::google::iam::admin::v1::IAM::StubInterface> grpc_stub)
+      std::unique_ptr<google::iam::admin::v1::IAM::StubInterface> grpc_stub)
       : grpc_stub_(std::move(grpc_stub)) {}
 
-  StatusOr<::google::iam::admin::v1::ListServiceAccountsResponse>
-  ListServiceAccounts(
+  StatusOr<google::iam::admin::v1::ListServiceAccountsResponse>
+  ListServiceAccounts(grpc::ClientContext& client_context,
+                      google::iam::admin::v1::ListServiceAccountsRequest const&
+                          request) override;
+
+  StatusOr<google::iam::admin::v1::ServiceAccount> GetServiceAccount(
       grpc::ClientContext& client_context,
-      ::google::iam::admin::v1::ListServiceAccountsRequest const& request)
+      google::iam::admin::v1::GetServiceAccountRequest const& request) override;
+
+  StatusOr<google::iam::admin::v1::ServiceAccount> CreateServiceAccount(
+      grpc::ClientContext& client_context,
+      google::iam::admin::v1::CreateServiceAccountRequest const& request)
       override;
 
-  StatusOr<::google::iam::admin::v1::ServiceAccount> GetServiceAccount(
+  StatusOr<google::iam::admin::v1::ServiceAccount> PatchServiceAccount(
       grpc::ClientContext& client_context,
-      ::google::iam::admin::v1::GetServiceAccountRequest const& request)
-      override;
-
-  StatusOr<::google::iam::admin::v1::ServiceAccount> CreateServiceAccount(
-      grpc::ClientContext& client_context,
-      ::google::iam::admin::v1::CreateServiceAccountRequest const& request)
-      override;
-
-  StatusOr<::google::iam::admin::v1::ServiceAccount> PatchServiceAccount(
-      grpc::ClientContext& client_context,
-      ::google::iam::admin::v1::PatchServiceAccountRequest const& request)
+      google::iam::admin::v1::PatchServiceAccountRequest const& request)
       override;
 
   Status DeleteServiceAccount(
       grpc::ClientContext& client_context,
-      ::google::iam::admin::v1::DeleteServiceAccountRequest const& request)
+      google::iam::admin::v1::DeleteServiceAccountRequest const& request)
       override;
 
-  StatusOr<::google::iam::admin::v1::UndeleteServiceAccountResponse>
+  StatusOr<google::iam::admin::v1::UndeleteServiceAccountResponse>
   UndeleteServiceAccount(
       grpc::ClientContext& client_context,
-      ::google::iam::admin::v1::UndeleteServiceAccountRequest const& request)
+      google::iam::admin::v1::UndeleteServiceAccountRequest const& request)
       override;
 
   Status EnableServiceAccount(
       grpc::ClientContext& client_context,
-      ::google::iam::admin::v1::EnableServiceAccountRequest const& request)
+      google::iam::admin::v1::EnableServiceAccountRequest const& request)
       override;
 
   Status DisableServiceAccount(
       grpc::ClientContext& client_context,
-      ::google::iam::admin::v1::DisableServiceAccountRequest const& request)
+      google::iam::admin::v1::DisableServiceAccountRequest const& request)
       override;
 
-  StatusOr<::google::iam::admin::v1::ListServiceAccountKeysResponse>
+  StatusOr<google::iam::admin::v1::ListServiceAccountKeysResponse>
   ListServiceAccountKeys(
       grpc::ClientContext& client_context,
-      ::google::iam::admin::v1::ListServiceAccountKeysRequest const& request)
+      google::iam::admin::v1::ListServiceAccountKeysRequest const& request)
       override;
 
-  StatusOr<::google::iam::admin::v1::ServiceAccountKey> GetServiceAccountKey(
+  StatusOr<google::iam::admin::v1::ServiceAccountKey> GetServiceAccountKey(
       grpc::ClientContext& client_context,
-      ::google::iam::admin::v1::GetServiceAccountKeyRequest const& request)
+      google::iam::admin::v1::GetServiceAccountKeyRequest const& request)
       override;
 
-  StatusOr<::google::iam::admin::v1::ServiceAccountKey> CreateServiceAccountKey(
+  StatusOr<google::iam::admin::v1::ServiceAccountKey> CreateServiceAccountKey(
       grpc::ClientContext& client_context,
-      ::google::iam::admin::v1::CreateServiceAccountKeyRequest const& request)
+      google::iam::admin::v1::CreateServiceAccountKeyRequest const& request)
       override;
 
-  StatusOr<::google::iam::admin::v1::ServiceAccountKey> UploadServiceAccountKey(
+  StatusOr<google::iam::admin::v1::ServiceAccountKey> UploadServiceAccountKey(
       grpc::ClientContext& client_context,
-      ::google::iam::admin::v1::UploadServiceAccountKeyRequest const& request)
+      google::iam::admin::v1::UploadServiceAccountKeyRequest const& request)
       override;
 
   Status DeleteServiceAccountKey(
       grpc::ClientContext& client_context,
-      ::google::iam::admin::v1::DeleteServiceAccountKeyRequest const& request)
+      google::iam::admin::v1::DeleteServiceAccountKeyRequest const& request)
       override;
 
-  StatusOr<::google::iam::v1::Policy> GetIamPolicy(
+  StatusOr<google::iam::v1::Policy> GetIamPolicy(
       grpc::ClientContext& client_context,
-      ::google::iam::v1::GetIamPolicyRequest const& request) override;
+      google::iam::v1::GetIamPolicyRequest const& request) override;
 
-  StatusOr<::google::iam::v1::Policy> SetIamPolicy(
+  StatusOr<google::iam::v1::Policy> SetIamPolicy(
       grpc::ClientContext& client_context,
-      ::google::iam::v1::SetIamPolicyRequest const& request) override;
+      google::iam::v1::SetIamPolicyRequest const& request) override;
 
-  StatusOr<::google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
+  StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
       grpc::ClientContext& client_context,
-      ::google::iam::v1::TestIamPermissionsRequest const& request) override;
+      google::iam::v1::TestIamPermissionsRequest const& request) override;
 
-  StatusOr<::google::iam::admin::v1::QueryGrantableRolesResponse>
-  QueryGrantableRoles(
+  StatusOr<google::iam::admin::v1::QueryGrantableRolesResponse>
+  QueryGrantableRoles(grpc::ClientContext& client_context,
+                      google::iam::admin::v1::QueryGrantableRolesRequest const&
+                          request) override;
+
+  StatusOr<google::iam::admin::v1::ListRolesResponse> ListRoles(
       grpc::ClientContext& client_context,
-      ::google::iam::admin::v1::QueryGrantableRolesRequest const& request)
-      override;
+      google::iam::admin::v1::ListRolesRequest const& request) override;
 
-  StatusOr<::google::iam::admin::v1::ListRolesResponse> ListRoles(
+  StatusOr<google::iam::admin::v1::Role> GetRole(
       grpc::ClientContext& client_context,
-      ::google::iam::admin::v1::ListRolesRequest const& request) override;
+      google::iam::admin::v1::GetRoleRequest const& request) override;
 
-  StatusOr<::google::iam::admin::v1::Role> GetRole(
+  StatusOr<google::iam::admin::v1::Role> CreateRole(
       grpc::ClientContext& client_context,
-      ::google::iam::admin::v1::GetRoleRequest const& request) override;
+      google::iam::admin::v1::CreateRoleRequest const& request) override;
 
-  StatusOr<::google::iam::admin::v1::Role> CreateRole(
+  StatusOr<google::iam::admin::v1::Role> UpdateRole(
       grpc::ClientContext& client_context,
-      ::google::iam::admin::v1::CreateRoleRequest const& request) override;
+      google::iam::admin::v1::UpdateRoleRequest const& request) override;
 
-  StatusOr<::google::iam::admin::v1::Role> UpdateRole(
+  StatusOr<google::iam::admin::v1::Role> DeleteRole(
       grpc::ClientContext& client_context,
-      ::google::iam::admin::v1::UpdateRoleRequest const& request) override;
+      google::iam::admin::v1::DeleteRoleRequest const& request) override;
 
-  StatusOr<::google::iam::admin::v1::Role> DeleteRole(
+  StatusOr<google::iam::admin::v1::Role> UndeleteRole(
       grpc::ClientContext& client_context,
-      ::google::iam::admin::v1::DeleteRoleRequest const& request) override;
+      google::iam::admin::v1::UndeleteRoleRequest const& request) override;
 
-  StatusOr<::google::iam::admin::v1::Role> UndeleteRole(
-      grpc::ClientContext& client_context,
-      ::google::iam::admin::v1::UndeleteRoleRequest const& request) override;
-
-  StatusOr<::google::iam::admin::v1::QueryTestablePermissionsResponse>
+  StatusOr<google::iam::admin::v1::QueryTestablePermissionsResponse>
   QueryTestablePermissions(
       grpc::ClientContext& client_context,
-      ::google::iam::admin::v1::QueryTestablePermissionsRequest const& request)
+      google::iam::admin::v1::QueryTestablePermissionsRequest const& request)
       override;
 
-  StatusOr<::google::iam::admin::v1::QueryAuditableServicesResponse>
+  StatusOr<google::iam::admin::v1::QueryAuditableServicesResponse>
   QueryAuditableServices(
       grpc::ClientContext& client_context,
-      ::google::iam::admin::v1::QueryAuditableServicesRequest const& request)
+      google::iam::admin::v1::QueryAuditableServicesRequest const& request)
       override;
 
-  StatusOr<::google::iam::admin::v1::LintPolicyResponse> LintPolicy(
+  StatusOr<google::iam::admin::v1::LintPolicyResponse> LintPolicy(
       grpc::ClientContext& client_context,
-      ::google::iam::admin::v1::LintPolicyRequest const& request) override;
+      google::iam::admin::v1::LintPolicyRequest const& request) override;
 
  private:
-  std::unique_ptr<::google::iam::admin::v1::IAM::StubInterface> grpc_stub_;
+  std::unique_ptr<google::iam::admin::v1::IAM::StubInterface> grpc_stub_;
 };
 
 }  // namespace GOOGLE_CLOUD_CPP_GENERATED_NS

--- a/google/cloud/iam/internal/iam_stub_factory.cc
+++ b/google/cloud/iam/internal/iam_stub_factory.cc
@@ -36,7 +36,7 @@ std::shared_ptr<IAMStub> CreateDefaultIAMStub(Options const& options) {
   auto channel = grpc::CreateCustomChannel(
       options.get<EndpointOption>(), options.get<GrpcCredentialOption>(),
       internal::MakeChannelArguments(options));
-  auto service_grpc_stub = ::google::iam::admin::v1::IAM::NewStub(channel);
+  auto service_grpc_stub = google::iam::admin::v1::IAM::NewStub(channel);
   std::shared_ptr<IAMStub> stub =
       std::make_shared<DefaultIAMStub>(std::move(service_grpc_stub));
 

--- a/google/cloud/iam/mocks/mock_iam_connection.h
+++ b/google/cloud/iam/mocks/mock_iam_connection.h
@@ -28,131 +28,128 @@ inline namespace GOOGLE_CLOUD_CPP_GENERATED_NS {
 
 class MockIAMConnection : public iam::IAMConnection {
  public:
-  MOCK_METHOD(StreamRange<::google::iam::admin::v1::ServiceAccount>,
+  MOCK_METHOD(StreamRange<google::iam::admin::v1::ServiceAccount>,
               ListServiceAccounts,
-              (::google::iam::admin::v1::ListServiceAccountsRequest request),
+              (google::iam::admin::v1::ListServiceAccountsRequest request),
+              (override));
+
+  MOCK_METHOD(StatusOr<google::iam::admin::v1::ServiceAccount>,
+              GetServiceAccount,
+              (google::iam::admin::v1::GetServiceAccountRequest const& request),
               (override));
 
   MOCK_METHOD(
-      StatusOr<::google::iam::admin::v1::ServiceAccount>, GetServiceAccount,
-      (::google::iam::admin::v1::GetServiceAccountRequest const& request),
+      StatusOr<google::iam::admin::v1::ServiceAccount>, CreateServiceAccount,
+      (google::iam::admin::v1::CreateServiceAccountRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<::google::iam::admin::v1::ServiceAccount>, CreateServiceAccount,
-      (::google::iam::admin::v1::CreateServiceAccountRequest const& request),
-      (override));
-
-  MOCK_METHOD(
-      StatusOr<::google::iam::admin::v1::ServiceAccount>, PatchServiceAccount,
-      (::google::iam::admin::v1::PatchServiceAccountRequest const& request),
+      StatusOr<google::iam::admin::v1::ServiceAccount>, PatchServiceAccount,
+      (google::iam::admin::v1::PatchServiceAccountRequest const& request),
       (override));
 
   MOCK_METHOD(
       Status, DeleteServiceAccount,
-      (::google::iam::admin::v1::DeleteServiceAccountRequest const& request),
+      (google::iam::admin::v1::DeleteServiceAccountRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<::google::iam::admin::v1::UndeleteServiceAccountResponse>,
+      StatusOr<google::iam::admin::v1::UndeleteServiceAccountResponse>,
       UndeleteServiceAccount,
-      (::google::iam::admin::v1::UndeleteServiceAccountRequest const& request),
+      (google::iam::admin::v1::UndeleteServiceAccountRequest const& request),
       (override));
 
   MOCK_METHOD(
       Status, EnableServiceAccount,
-      (::google::iam::admin::v1::EnableServiceAccountRequest const& request),
+      (google::iam::admin::v1::EnableServiceAccountRequest const& request),
       (override));
 
   MOCK_METHOD(
       Status, DisableServiceAccount,
-      (::google::iam::admin::v1::DisableServiceAccountRequest const& request),
+      (google::iam::admin::v1::DisableServiceAccountRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<::google::iam::admin::v1::ListServiceAccountKeysResponse>,
+      StatusOr<google::iam::admin::v1::ListServiceAccountKeysResponse>,
       ListServiceAccountKeys,
-      (::google::iam::admin::v1::ListServiceAccountKeysRequest const& request),
+      (google::iam::admin::v1::ListServiceAccountKeysRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<::google::iam::admin::v1::ServiceAccountKey>,
-      GetServiceAccountKey,
-      (::google::iam::admin::v1::GetServiceAccountKeyRequest const& request),
+      StatusOr<google::iam::admin::v1::ServiceAccountKey>, GetServiceAccountKey,
+      (google::iam::admin::v1::GetServiceAccountKeyRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<::google::iam::admin::v1::ServiceAccountKey>,
+      StatusOr<google::iam::admin::v1::ServiceAccountKey>,
       CreateServiceAccountKey,
-      (::google::iam::admin::v1::CreateServiceAccountKeyRequest const& request),
+      (google::iam::admin::v1::CreateServiceAccountKeyRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<::google::iam::admin::v1::ServiceAccountKey>,
+      StatusOr<google::iam::admin::v1::ServiceAccountKey>,
       UploadServiceAccountKey,
-      (::google::iam::admin::v1::UploadServiceAccountKeyRequest const& request),
+      (google::iam::admin::v1::UploadServiceAccountKeyRequest const& request),
       (override));
 
   MOCK_METHOD(
       Status, DeleteServiceAccountKey,
-      (::google::iam::admin::v1::DeleteServiceAccountKeyRequest const& request),
+      (google::iam::admin::v1::DeleteServiceAccountKeyRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<::google::iam::v1::Policy>, GetIamPolicy,
-              (::google::iam::v1::GetIamPolicyRequest const& request),
+  MOCK_METHOD(StatusOr<google::iam::v1::Policy>, GetIamPolicy,
+              (google::iam::v1::GetIamPolicyRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<::google::iam::v1::Policy>, SetIamPolicy,
-              (::google::iam::v1::SetIamPolicyRequest const& request),
+  MOCK_METHOD(StatusOr<google::iam::v1::Policy>, SetIamPolicy,
+              (google::iam::v1::SetIamPolicyRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<::google::iam::v1::TestIamPermissionsResponse>,
+  MOCK_METHOD(StatusOr<google::iam::v1::TestIamPermissionsResponse>,
               TestIamPermissions,
-              (::google::iam::v1::TestIamPermissionsRequest const& request),
+              (google::iam::v1::TestIamPermissionsRequest const& request),
               (override));
 
-  MOCK_METHOD(StreamRange<::google::iam::admin::v1::Role>, QueryGrantableRoles,
-              (::google::iam::admin::v1::QueryGrantableRolesRequest request),
+  MOCK_METHOD(StreamRange<google::iam::admin::v1::Role>, QueryGrantableRoles,
+              (google::iam::admin::v1::QueryGrantableRolesRequest request),
               (override));
 
-  MOCK_METHOD(StreamRange<::google::iam::admin::v1::Role>, ListRoles,
-              (::google::iam::admin::v1::ListRolesRequest request), (override));
+  MOCK_METHOD(StreamRange<google::iam::admin::v1::Role>, ListRoles,
+              (google::iam::admin::v1::ListRolesRequest request), (override));
 
-  MOCK_METHOD(StatusOr<::google::iam::admin::v1::Role>, GetRole,
-              (::google::iam::admin::v1::GetRoleRequest const& request),
+  MOCK_METHOD(StatusOr<google::iam::admin::v1::Role>, GetRole,
+              (google::iam::admin::v1::GetRoleRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<::google::iam::admin::v1::Role>, CreateRole,
-              (::google::iam::admin::v1::CreateRoleRequest const& request),
+  MOCK_METHOD(StatusOr<google::iam::admin::v1::Role>, CreateRole,
+              (google::iam::admin::v1::CreateRoleRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<::google::iam::admin::v1::Role>, UpdateRole,
-              (::google::iam::admin::v1::UpdateRoleRequest const& request),
+  MOCK_METHOD(StatusOr<google::iam::admin::v1::Role>, UpdateRole,
+              (google::iam::admin::v1::UpdateRoleRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<::google::iam::admin::v1::Role>, DeleteRole,
-              (::google::iam::admin::v1::DeleteRoleRequest const& request),
+  MOCK_METHOD(StatusOr<google::iam::admin::v1::Role>, DeleteRole,
+              (google::iam::admin::v1::DeleteRoleRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<::google::iam::admin::v1::Role>, UndeleteRole,
-              (::google::iam::admin::v1::UndeleteRoleRequest const& request),
+  MOCK_METHOD(StatusOr<google::iam::admin::v1::Role>, UndeleteRole,
+              (google::iam::admin::v1::UndeleteRoleRequest const& request),
+              (override));
+
+  MOCK_METHOD(StreamRange<google::iam::admin::v1::Permission>,
+              QueryTestablePermissions,
+              (google::iam::admin::v1::QueryTestablePermissionsRequest request),
               (override));
 
   MOCK_METHOD(
-      StreamRange<::google::iam::admin::v1::Permission>,
-      QueryTestablePermissions,
-      (::google::iam::admin::v1::QueryTestablePermissionsRequest request),
-      (override));
-
-  MOCK_METHOD(
-      StatusOr<::google::iam::admin::v1::QueryAuditableServicesResponse>,
+      StatusOr<google::iam::admin::v1::QueryAuditableServicesResponse>,
       QueryAuditableServices,
-      (::google::iam::admin::v1::QueryAuditableServicesRequest const& request),
+      (google::iam::admin::v1::QueryAuditableServicesRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<::google::iam::admin::v1::LintPolicyResponse>,
-              LintPolicy,
-              (::google::iam::admin::v1::LintPolicyRequest const& request),
+  MOCK_METHOD(StatusOr<google::iam::admin::v1::LintPolicyResponse>, LintPolicy,
+              (google::iam::admin::v1::LintPolicyRequest const& request),
               (override));
 };
 

--- a/google/cloud/iam/mocks/mock_iam_credentials_connection.h
+++ b/google/cloud/iam/mocks/mock_iam_credentials_connection.h
@@ -29,26 +29,24 @@ inline namespace GOOGLE_CLOUD_CPP_GENERATED_NS {
 class MockIAMCredentialsConnection : public iam::IAMCredentialsConnection {
  public:
   MOCK_METHOD(
-      StatusOr<::google::iam::credentials::v1::GenerateAccessTokenResponse>,
+      StatusOr<google::iam::credentials::v1::GenerateAccessTokenResponse>,
       GenerateAccessToken,
-      (::google::iam::credentials::v1::GenerateAccessTokenRequest const&
-           request),
+      (google::iam::credentials::v1::GenerateAccessTokenRequest const& request),
       (override));
 
   MOCK_METHOD(
-      StatusOr<::google::iam::credentials::v1::GenerateIdTokenResponse>,
+      StatusOr<google::iam::credentials::v1::GenerateIdTokenResponse>,
       GenerateIdToken,
-      (::google::iam::credentials::v1::GenerateIdTokenRequest const& request),
+      (google::iam::credentials::v1::GenerateIdTokenRequest const& request),
       (override));
 
-  MOCK_METHOD(StatusOr<::google::iam::credentials::v1::SignBlobResponse>,
+  MOCK_METHOD(StatusOr<google::iam::credentials::v1::SignBlobResponse>,
               SignBlob,
-              (::google::iam::credentials::v1::SignBlobRequest const& request),
+              (google::iam::credentials::v1::SignBlobRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<::google::iam::credentials::v1::SignJwtResponse>,
-              SignJwt,
-              (::google::iam::credentials::v1::SignJwtRequest const& request),
+  MOCK_METHOD(StatusOr<google::iam::credentials::v1::SignJwtResponse>, SignJwt,
+              (google::iam::credentials::v1::SignJwtRequest const& request),
               (override));
 };
 

--- a/google/cloud/logging/internal/logging_service_v2_logging_decorator.cc
+++ b/google/cloud/logging/internal/logging_service_v2_logging_decorator.cc
@@ -35,61 +35,60 @@ LoggingServiceV2Logging::LoggingServiceV2Logging(
 
 Status LoggingServiceV2Logging::DeleteLog(
     grpc::ClientContext& context,
-    ::google::logging::v2::DeleteLogRequest const& request) {
+    google::logging::v2::DeleteLogRequest const& request) {
   return google::cloud::internal::LogWrapper(
       [this](grpc::ClientContext& context,
-             ::google::logging::v2::DeleteLogRequest const& request) {
+             google::logging::v2::DeleteLogRequest const& request) {
         return child_->DeleteLog(context, request);
       },
       context, request, __func__, tracing_options_);
 }
 
-StatusOr<::google::logging::v2::WriteLogEntriesResponse>
+StatusOr<google::logging::v2::WriteLogEntriesResponse>
 LoggingServiceV2Logging::WriteLogEntries(
     grpc::ClientContext& context,
-    ::google::logging::v2::WriteLogEntriesRequest const& request) {
+    google::logging::v2::WriteLogEntriesRequest const& request) {
   return google::cloud::internal::LogWrapper(
       [this](grpc::ClientContext& context,
-             ::google::logging::v2::WriteLogEntriesRequest const& request) {
+             google::logging::v2::WriteLogEntriesRequest const& request) {
         return child_->WriteLogEntries(context, request);
       },
       context, request, __func__, tracing_options_);
 }
 
-StatusOr<::google::logging::v2::ListLogEntriesResponse>
+StatusOr<google::logging::v2::ListLogEntriesResponse>
 LoggingServiceV2Logging::ListLogEntries(
     grpc::ClientContext& context,
-    ::google::logging::v2::ListLogEntriesRequest const& request) {
+    google::logging::v2::ListLogEntriesRequest const& request) {
   return google::cloud::internal::LogWrapper(
       [this](grpc::ClientContext& context,
-             ::google::logging::v2::ListLogEntriesRequest const& request) {
+             google::logging::v2::ListLogEntriesRequest const& request) {
         return child_->ListLogEntries(context, request);
       },
       context, request, __func__, tracing_options_);
 }
 
-StatusOr<::google::logging::v2::ListMonitoredResourceDescriptorsResponse>
+StatusOr<google::logging::v2::ListMonitoredResourceDescriptorsResponse>
 LoggingServiceV2Logging::ListMonitoredResourceDescriptors(
     grpc::ClientContext& context,
-    ::google::logging::v2::ListMonitoredResourceDescriptorsRequest const&
+    google::logging::v2::ListMonitoredResourceDescriptorsRequest const&
         request) {
   return google::cloud::internal::LogWrapper(
-      [this](
-          grpc::ClientContext& context,
-          ::google::logging::v2::ListMonitoredResourceDescriptorsRequest const&
-              request) {
+      [this](grpc::ClientContext& context,
+             google::logging::v2::ListMonitoredResourceDescriptorsRequest const&
+                 request) {
         return child_->ListMonitoredResourceDescriptors(context, request);
       },
       context, request, __func__, tracing_options_);
 }
 
-StatusOr<::google::logging::v2::ListLogsResponse>
+StatusOr<google::logging::v2::ListLogsResponse>
 LoggingServiceV2Logging::ListLogs(
     grpc::ClientContext& context,
-    ::google::logging::v2::ListLogsRequest const& request) {
+    google::logging::v2::ListLogsRequest const& request) {
   return google::cloud::internal::LogWrapper(
       [this](grpc::ClientContext& context,
-             ::google::logging::v2::ListLogsRequest const& request) {
+             google::logging::v2::ListLogsRequest const& request) {
         return child_->ListLogs(context, request);
       },
       context, request, __func__, tracing_options_);

--- a/google/cloud/logging/internal/logging_service_v2_logging_decorator.h
+++ b/google/cloud/logging/internal/logging_service_v2_logging_decorator.h
@@ -39,25 +39,25 @@ class LoggingServiceV2Logging : public LoggingServiceV2Stub {
 
   Status DeleteLog(
       grpc::ClientContext& context,
-      ::google::logging::v2::DeleteLogRequest const& request) override;
+      google::logging::v2::DeleteLogRequest const& request) override;
 
-  StatusOr<::google::logging::v2::WriteLogEntriesResponse> WriteLogEntries(
+  StatusOr<google::logging::v2::WriteLogEntriesResponse> WriteLogEntries(
       grpc::ClientContext& context,
-      ::google::logging::v2::WriteLogEntriesRequest const& request) override;
+      google::logging::v2::WriteLogEntriesRequest const& request) override;
 
-  StatusOr<::google::logging::v2::ListLogEntriesResponse> ListLogEntries(
+  StatusOr<google::logging::v2::ListLogEntriesResponse> ListLogEntries(
       grpc::ClientContext& context,
-      ::google::logging::v2::ListLogEntriesRequest const& request) override;
+      google::logging::v2::ListLogEntriesRequest const& request) override;
 
-  StatusOr<::google::logging::v2::ListMonitoredResourceDescriptorsResponse>
+  StatusOr<google::logging::v2::ListMonitoredResourceDescriptorsResponse>
   ListMonitoredResourceDescriptors(
       grpc::ClientContext& context,
-      ::google::logging::v2::ListMonitoredResourceDescriptorsRequest const&
+      google::logging::v2::ListMonitoredResourceDescriptorsRequest const&
           request) override;
 
-  StatusOr<::google::logging::v2::ListLogsResponse> ListLogs(
+  StatusOr<google::logging::v2::ListLogsResponse> ListLogs(
       grpc::ClientContext& context,
-      ::google::logging::v2::ListLogsRequest const& request) override;
+      google::logging::v2::ListLogsRequest const& request) override;
 
  private:
   std::shared_ptr<LoggingServiceV2Stub> child_;

--- a/google/cloud/logging/internal/logging_service_v2_metadata_decorator.cc
+++ b/google/cloud/logging/internal/logging_service_v2_metadata_decorator.cc
@@ -33,40 +33,40 @@ LoggingServiceV2Metadata::LoggingServiceV2Metadata(
 
 Status LoggingServiceV2Metadata::DeleteLog(
     grpc::ClientContext& context,
-    ::google::logging::v2::DeleteLogRequest const& request) {
+    google::logging::v2::DeleteLogRequest const& request) {
   SetMetadata(context, "log_name=" + request.log_name());
   return child_->DeleteLog(context, request);
 }
 
-StatusOr<::google::logging::v2::WriteLogEntriesResponse>
+StatusOr<google::logging::v2::WriteLogEntriesResponse>
 LoggingServiceV2Metadata::WriteLogEntries(
     grpc::ClientContext& context,
-    ::google::logging::v2::WriteLogEntriesRequest const& request) {
+    google::logging::v2::WriteLogEntriesRequest const& request) {
   SetMetadata(context, {});
   return child_->WriteLogEntries(context, request);
 }
 
-StatusOr<::google::logging::v2::ListLogEntriesResponse>
+StatusOr<google::logging::v2::ListLogEntriesResponse>
 LoggingServiceV2Metadata::ListLogEntries(
     grpc::ClientContext& context,
-    ::google::logging::v2::ListLogEntriesRequest const& request) {
+    google::logging::v2::ListLogEntriesRequest const& request) {
   SetMetadata(context, {});
   return child_->ListLogEntries(context, request);
 }
 
-StatusOr<::google::logging::v2::ListMonitoredResourceDescriptorsResponse>
+StatusOr<google::logging::v2::ListMonitoredResourceDescriptorsResponse>
 LoggingServiceV2Metadata::ListMonitoredResourceDescriptors(
     grpc::ClientContext& context,
-    ::google::logging::v2::ListMonitoredResourceDescriptorsRequest const&
+    google::logging::v2::ListMonitoredResourceDescriptorsRequest const&
         request) {
   SetMetadata(context, {});
   return child_->ListMonitoredResourceDescriptors(context, request);
 }
 
-StatusOr<::google::logging::v2::ListLogsResponse>
+StatusOr<google::logging::v2::ListLogsResponse>
 LoggingServiceV2Metadata::ListLogs(
     grpc::ClientContext& context,
-    ::google::logging::v2::ListLogsRequest const& request) {
+    google::logging::v2::ListLogsRequest const& request) {
   SetMetadata(context, "parent=" + request.parent());
   return child_->ListLogs(context, request);
 }

--- a/google/cloud/logging/internal/logging_service_v2_metadata_decorator.h
+++ b/google/cloud/logging/internal/logging_service_v2_metadata_decorator.h
@@ -36,25 +36,25 @@ class LoggingServiceV2Metadata : public LoggingServiceV2Stub {
 
   Status DeleteLog(
       grpc::ClientContext& context,
-      ::google::logging::v2::DeleteLogRequest const& request) override;
+      google::logging::v2::DeleteLogRequest const& request) override;
 
-  StatusOr<::google::logging::v2::WriteLogEntriesResponse> WriteLogEntries(
+  StatusOr<google::logging::v2::WriteLogEntriesResponse> WriteLogEntries(
       grpc::ClientContext& context,
-      ::google::logging::v2::WriteLogEntriesRequest const& request) override;
+      google::logging::v2::WriteLogEntriesRequest const& request) override;
 
-  StatusOr<::google::logging::v2::ListLogEntriesResponse> ListLogEntries(
+  StatusOr<google::logging::v2::ListLogEntriesResponse> ListLogEntries(
       grpc::ClientContext& context,
-      ::google::logging::v2::ListLogEntriesRequest const& request) override;
+      google::logging::v2::ListLogEntriesRequest const& request) override;
 
-  StatusOr<::google::logging::v2::ListMonitoredResourceDescriptorsResponse>
+  StatusOr<google::logging::v2::ListMonitoredResourceDescriptorsResponse>
   ListMonitoredResourceDescriptors(
       grpc::ClientContext& context,
-      ::google::logging::v2::ListMonitoredResourceDescriptorsRequest const&
+      google::logging::v2::ListMonitoredResourceDescriptorsRequest const&
           request) override;
 
-  StatusOr<::google::logging::v2::ListLogsResponse> ListLogs(
+  StatusOr<google::logging::v2::ListLogsResponse> ListLogs(
       grpc::ClientContext& context,
-      ::google::logging::v2::ListLogsRequest const& request) override;
+      google::logging::v2::ListLogsRequest const& request) override;
 
  private:
   void SetMetadata(grpc::ClientContext& context,

--- a/google/cloud/logging/internal/logging_service_v2_stub.cc
+++ b/google/cloud/logging/internal/logging_service_v2_stub.cc
@@ -31,8 +31,8 @@ LoggingServiceV2Stub::~LoggingServiceV2Stub() = default;
 
 Status DefaultLoggingServiceV2Stub::DeleteLog(
     grpc::ClientContext& client_context,
-    ::google::logging::v2::DeleteLogRequest const& request) {
-  ::google::protobuf::Empty response;
+    google::logging::v2::DeleteLogRequest const& request) {
+  google::protobuf::Empty response;
   auto status = grpc_stub_->DeleteLog(&client_context, request, &response);
   if (!status.ok()) {
     return google::cloud::MakeStatusFromRpcError(status);
@@ -40,11 +40,11 @@ Status DefaultLoggingServiceV2Stub::DeleteLog(
   return google::cloud::Status();
 }
 
-StatusOr<::google::logging::v2::WriteLogEntriesResponse>
+StatusOr<google::logging::v2::WriteLogEntriesResponse>
 DefaultLoggingServiceV2Stub::WriteLogEntries(
     grpc::ClientContext& client_context,
-    ::google::logging::v2::WriteLogEntriesRequest const& request) {
-  ::google::logging::v2::WriteLogEntriesResponse response;
+    google::logging::v2::WriteLogEntriesRequest const& request) {
+  google::logging::v2::WriteLogEntriesResponse response;
   auto status =
       grpc_stub_->WriteLogEntries(&client_context, request, &response);
   if (!status.ok()) {
@@ -53,11 +53,11 @@ DefaultLoggingServiceV2Stub::WriteLogEntries(
   return response;
 }
 
-StatusOr<::google::logging::v2::ListLogEntriesResponse>
+StatusOr<google::logging::v2::ListLogEntriesResponse>
 DefaultLoggingServiceV2Stub::ListLogEntries(
     grpc::ClientContext& client_context,
-    ::google::logging::v2::ListLogEntriesRequest const& request) {
-  ::google::logging::v2::ListLogEntriesResponse response;
+    google::logging::v2::ListLogEntriesRequest const& request) {
+  google::logging::v2::ListLogEntriesResponse response;
   auto status = grpc_stub_->ListLogEntries(&client_context, request, &response);
   if (!status.ok()) {
     return google::cloud::MakeStatusFromRpcError(status);
@@ -65,12 +65,12 @@ DefaultLoggingServiceV2Stub::ListLogEntries(
   return response;
 }
 
-StatusOr<::google::logging::v2::ListMonitoredResourceDescriptorsResponse>
+StatusOr<google::logging::v2::ListMonitoredResourceDescriptorsResponse>
 DefaultLoggingServiceV2Stub::ListMonitoredResourceDescriptors(
     grpc::ClientContext& client_context,
-    ::google::logging::v2::ListMonitoredResourceDescriptorsRequest const&
+    google::logging::v2::ListMonitoredResourceDescriptorsRequest const&
         request) {
-  ::google::logging::v2::ListMonitoredResourceDescriptorsResponse response;
+  google::logging::v2::ListMonitoredResourceDescriptorsResponse response;
   auto status = grpc_stub_->ListMonitoredResourceDescriptors(
       &client_context, request, &response);
   if (!status.ok()) {
@@ -79,11 +79,11 @@ DefaultLoggingServiceV2Stub::ListMonitoredResourceDescriptors(
   return response;
 }
 
-StatusOr<::google::logging::v2::ListLogsResponse>
+StatusOr<google::logging::v2::ListLogsResponse>
 DefaultLoggingServiceV2Stub::ListLogs(
     grpc::ClientContext& client_context,
-    ::google::logging::v2::ListLogsRequest const& request) {
-  ::google::logging::v2::ListLogsResponse response;
+    google::logging::v2::ListLogsRequest const& request) {
+  google::logging::v2::ListLogsResponse response;
   auto status = grpc_stub_->ListLogs(&client_context, request, &response);
   if (!status.ok()) {
     return google::cloud::MakeStatusFromRpcError(status);

--- a/google/cloud/logging/internal/logging_service_v2_stub.h
+++ b/google/cloud/logging/internal/logging_service_v2_stub.h
@@ -34,61 +34,60 @@ class LoggingServiceV2Stub {
 
   virtual Status DeleteLog(
       grpc::ClientContext& context,
-      ::google::logging::v2::DeleteLogRequest const& request) = 0;
+      google::logging::v2::DeleteLogRequest const& request) = 0;
 
-  virtual StatusOr<::google::logging::v2::WriteLogEntriesResponse>
+  virtual StatusOr<google::logging::v2::WriteLogEntriesResponse>
   WriteLogEntries(
       grpc::ClientContext& context,
-      ::google::logging::v2::WriteLogEntriesRequest const& request) = 0;
+      google::logging::v2::WriteLogEntriesRequest const& request) = 0;
 
-  virtual StatusOr<::google::logging::v2::ListLogEntriesResponse>
-  ListLogEntries(
+  virtual StatusOr<google::logging::v2::ListLogEntriesResponse> ListLogEntries(
       grpc::ClientContext& context,
-      ::google::logging::v2::ListLogEntriesRequest const& request) = 0;
+      google::logging::v2::ListLogEntriesRequest const& request) = 0;
 
   virtual StatusOr<
-      ::google::logging::v2::ListMonitoredResourceDescriptorsResponse>
+      google::logging::v2::ListMonitoredResourceDescriptorsResponse>
   ListMonitoredResourceDescriptors(
       grpc::ClientContext& context,
-      ::google::logging::v2::ListMonitoredResourceDescriptorsRequest const&
+      google::logging::v2::ListMonitoredResourceDescriptorsRequest const&
           request) = 0;
 
-  virtual StatusOr<::google::logging::v2::ListLogsResponse> ListLogs(
+  virtual StatusOr<google::logging::v2::ListLogsResponse> ListLogs(
       grpc::ClientContext& context,
-      ::google::logging::v2::ListLogsRequest const& request) = 0;
+      google::logging::v2::ListLogsRequest const& request) = 0;
 };
 
 class DefaultLoggingServiceV2Stub : public LoggingServiceV2Stub {
  public:
   explicit DefaultLoggingServiceV2Stub(
-      std::unique_ptr<::google::logging::v2::LoggingServiceV2::StubInterface>
+      std::unique_ptr<google::logging::v2::LoggingServiceV2::StubInterface>
           grpc_stub)
       : grpc_stub_(std::move(grpc_stub)) {}
 
   Status DeleteLog(
       grpc::ClientContext& client_context,
-      ::google::logging::v2::DeleteLogRequest const& request) override;
+      google::logging::v2::DeleteLogRequest const& request) override;
 
-  StatusOr<::google::logging::v2::WriteLogEntriesResponse> WriteLogEntries(
+  StatusOr<google::logging::v2::WriteLogEntriesResponse> WriteLogEntries(
       grpc::ClientContext& client_context,
-      ::google::logging::v2::WriteLogEntriesRequest const& request) override;
+      google::logging::v2::WriteLogEntriesRequest const& request) override;
 
-  StatusOr<::google::logging::v2::ListLogEntriesResponse> ListLogEntries(
+  StatusOr<google::logging::v2::ListLogEntriesResponse> ListLogEntries(
       grpc::ClientContext& client_context,
-      ::google::logging::v2::ListLogEntriesRequest const& request) override;
+      google::logging::v2::ListLogEntriesRequest const& request) override;
 
-  StatusOr<::google::logging::v2::ListMonitoredResourceDescriptorsResponse>
+  StatusOr<google::logging::v2::ListMonitoredResourceDescriptorsResponse>
   ListMonitoredResourceDescriptors(
       grpc::ClientContext& client_context,
-      ::google::logging::v2::ListMonitoredResourceDescriptorsRequest const&
+      google::logging::v2::ListMonitoredResourceDescriptorsRequest const&
           request) override;
 
-  StatusOr<::google::logging::v2::ListLogsResponse> ListLogs(
+  StatusOr<google::logging::v2::ListLogsResponse> ListLogs(
       grpc::ClientContext& client_context,
-      ::google::logging::v2::ListLogsRequest const& request) override;
+      google::logging::v2::ListLogsRequest const& request) override;
 
  private:
-  std::unique_ptr<::google::logging::v2::LoggingServiceV2::StubInterface>
+  std::unique_ptr<google::logging::v2::LoggingServiceV2::StubInterface>
       grpc_stub_;
 };
 

--- a/google/cloud/logging/internal/logging_service_v2_stub_factory.cc
+++ b/google/cloud/logging/internal/logging_service_v2_stub_factory.cc
@@ -38,7 +38,7 @@ std::shared_ptr<LoggingServiceV2Stub> CreateDefaultLoggingServiceV2Stub(
       options.get<EndpointOption>(), options.get<GrpcCredentialOption>(),
       internal::MakeChannelArguments(options));
   auto service_grpc_stub =
-      ::google::logging::v2::LoggingServiceV2::NewStub(channel);
+      google::logging::v2::LoggingServiceV2::NewStub(channel);
   std::shared_ptr<LoggingServiceV2Stub> stub =
       std::make_shared<DefaultLoggingServiceV2Stub>(
           std::move(service_grpc_stub));

--- a/google/cloud/logging/logging_service_v2_client.cc
+++ b/google/cloud/logging/logging_service_v2_client.cc
@@ -30,18 +30,17 @@ LoggingServiceV2Client::LoggingServiceV2Client(
 LoggingServiceV2Client::~LoggingServiceV2Client() = default;
 
 Status LoggingServiceV2Client::DeleteLog(std::string const& log_name) {
-  ::google::logging::v2::DeleteLogRequest request;
+  google::logging::v2::DeleteLogRequest request;
   request.set_log_name(log_name);
   return connection_->DeleteLog(request);
 }
 
-StatusOr<::google::logging::v2::WriteLogEntriesResponse>
+StatusOr<google::logging::v2::WriteLogEntriesResponse>
 LoggingServiceV2Client::WriteLogEntries(
-    std::string const& log_name,
-    ::google::api::MonitoredResource const& resource,
+    std::string const& log_name, google::api::MonitoredResource const& resource,
     std::map<std::string, std::string> const& labels,
-    std::vector<::google::logging::v2::LogEntry> const& entries) {
-  ::google::logging::v2::WriteLogEntriesRequest request;
+    std::vector<google::logging::v2::LogEntry> const& entries) {
+  google::logging::v2::WriteLogEntriesRequest request;
   request.set_log_name(log_name);
   *request.mutable_resource() = resource;
   *request.mutable_labels() = {labels.begin(), labels.end()};
@@ -49,11 +48,11 @@ LoggingServiceV2Client::WriteLogEntries(
   return connection_->WriteLogEntries(request);
 }
 
-StreamRange<::google::logging::v2::LogEntry>
+StreamRange<google::logging::v2::LogEntry>
 LoggingServiceV2Client::ListLogEntries(
     std::vector<std::string> const& resource_names, std::string const& filter,
     std::string const& order_by) {
-  ::google::logging::v2::ListLogEntriesRequest request;
+  google::logging::v2::ListLogEntriesRequest request;
   *request.mutable_resource_names() = {resource_names.begin(),
                                        resource_names.end()};
   request.set_filter(filter);
@@ -63,36 +62,36 @@ LoggingServiceV2Client::ListLogEntries(
 
 StreamRange<std::string> LoggingServiceV2Client::ListLogs(
     std::string const& parent) {
-  ::google::logging::v2::ListLogsRequest request;
+  google::logging::v2::ListLogsRequest request;
   request.set_parent(parent);
   return connection_->ListLogs(request);
 }
 
 Status LoggingServiceV2Client::DeleteLog(
-    ::google::logging::v2::DeleteLogRequest const& request) {
+    google::logging::v2::DeleteLogRequest const& request) {
   return connection_->DeleteLog(request);
 }
 
-StatusOr<::google::logging::v2::WriteLogEntriesResponse>
+StatusOr<google::logging::v2::WriteLogEntriesResponse>
 LoggingServiceV2Client::WriteLogEntries(
-    ::google::logging::v2::WriteLogEntriesRequest const& request) {
+    google::logging::v2::WriteLogEntriesRequest const& request) {
   return connection_->WriteLogEntries(request);
 }
 
-StreamRange<::google::logging::v2::LogEntry>
+StreamRange<google::logging::v2::LogEntry>
 LoggingServiceV2Client::ListLogEntries(
-    ::google::logging::v2::ListLogEntriesRequest request) {
+    google::logging::v2::ListLogEntriesRequest request) {
   return connection_->ListLogEntries(std::move(request));
 }
 
-StreamRange<::google::api::MonitoredResourceDescriptor>
+StreamRange<google::api::MonitoredResourceDescriptor>
 LoggingServiceV2Client::ListMonitoredResourceDescriptors(
-    ::google::logging::v2::ListMonitoredResourceDescriptorsRequest request) {
+    google::logging::v2::ListMonitoredResourceDescriptorsRequest request) {
   return connection_->ListMonitoredResourceDescriptors(std::move(request));
 }
 
 StreamRange<std::string> LoggingServiceV2Client::ListLogs(
-    ::google::logging::v2::ListLogsRequest request) {
+    google::logging::v2::ListLogsRequest request) {
   return connection_->ListLogs(std::move(request));
 }
 

--- a/google/cloud/logging/logging_service_v2_client.h
+++ b/google/cloud/logging/logging_service_v2_client.h
@@ -133,13 +133,13 @@ class LoggingServiceV2Client {
    *  `entries.write`, you should try to include several log entries in this
    *  list, rather than calling this method for each individual log entry.
    * @return
-   * [::google::logging::v2::WriteLogEntriesResponse](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/logging/v2/logging.proto#L243)
+   * [google::logging::v2::WriteLogEntriesResponse](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/logging/v2/logging.proto#L243)
    */
-  StatusOr<::google::logging::v2::WriteLogEntriesResponse> WriteLogEntries(
+  StatusOr<google::logging::v2::WriteLogEntriesResponse> WriteLogEntries(
       std::string const& log_name,
-      ::google::api::MonitoredResource const& resource,
+      google::api::MonitoredResource const& resource,
       std::map<std::string, std::string> const& labels,
-      std::vector<::google::logging::v2::LogEntry> const& entries);
+      std::vector<google::logging::v2::LogEntry> const& entries);
 
   /**
    * Lists log entries.  Use this method to retrieve log entries that originated
@@ -173,7 +173,7 @@ class LoggingServiceV2Client {
    *  in order of decreasing timestamps (newest first).  Entries with equal
    *  timestamps are returned in order of their `insert_id` values.
    */
-  StreamRange<::google::logging::v2::LogEntry> ListLogEntries(
+  StreamRange<google::logging::v2::LogEntry> ListLogEntries(
       std::vector<std::string> const& resource_names, std::string const& filter,
       std::string const& order_by);
 
@@ -196,9 +196,9 @@ class LoggingServiceV2Client {
    * before the operation will be deleted.
    *
    * @param request
-   * [::google::logging::v2::DeleteLogRequest](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/logging/v2/logging.proto#L140)
+   * [google::logging::v2::DeleteLogRequest](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/logging/v2/logging.proto#L140)
    */
-  Status DeleteLog(::google::logging::v2::DeleteLogRequest const& request);
+  Status DeleteLog(google::logging::v2::DeleteLogRequest const& request);
 
   /**
    * Writes log entries to Logging. This API method is the
@@ -210,12 +210,12 @@ class LoggingServiceV2Client {
    * folders)
    *
    * @param request
-   * [::google::logging::v2::WriteLogEntriesRequest](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/logging/v2/logging.proto#L162)
+   * [google::logging::v2::WriteLogEntriesRequest](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/logging/v2/logging.proto#L162)
    * @return
-   * [::google::logging::v2::WriteLogEntriesResponse](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/logging/v2/logging.proto#L243)
+   * [google::logging::v2::WriteLogEntriesResponse](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/logging/v2/logging.proto#L243)
    */
-  StatusOr<::google::logging::v2::WriteLogEntriesResponse> WriteLogEntries(
-      ::google::logging::v2::WriteLogEntriesRequest const& request);
+  StatusOr<google::logging::v2::WriteLogEntriesResponse> WriteLogEntries(
+      google::logging::v2::WriteLogEntriesRequest const& request);
 
   /**
    * Lists log entries.  Use this method to retrieve log entries that originated
@@ -224,30 +224,30 @@ class LoggingServiceV2Client {
    * Logs](https://cloud.google.com/logging/docs/export).
    *
    * @param request
-   * [::google::logging::v2::ListLogEntriesRequest](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/logging/v2/logging.proto#L257)
+   * [google::logging::v2::ListLogEntriesRequest](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/logging/v2/logging.proto#L257)
    */
-  StreamRange<::google::logging::v2::LogEntry> ListLogEntries(
-      ::google::logging::v2::ListLogEntriesRequest request);
+  StreamRange<google::logging::v2::LogEntry> ListLogEntries(
+      google::logging::v2::ListLogEntriesRequest request);
 
   /**
    * Lists the descriptors for monitored resource types used by Logging.
    *
    * @param request
-   * [::google::logging::v2::ListMonitoredResourceDescriptorsRequest](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/logging/v2/logging.proto#L331)
+   * [google::logging::v2::ListMonitoredResourceDescriptorsRequest](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/logging/v2/logging.proto#L331)
    */
-  StreamRange<::google::api::MonitoredResourceDescriptor>
+  StreamRange<google::api::MonitoredResourceDescriptor>
   ListMonitoredResourceDescriptors(
-      ::google::logging::v2::ListMonitoredResourceDescriptorsRequest request);
+      google::logging::v2::ListMonitoredResourceDescriptorsRequest request);
 
   /**
    * Lists the logs in projects, organizations, folders, or billing accounts.
    * Only logs that have entries are listed.
    *
    * @param request
-   * [::google::logging::v2::ListLogsRequest](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/logging/v2/logging.proto#L356)
+   * [google::logging::v2::ListLogsRequest](https://github.com/googleapis/googleapis/blob/6ce40ff8faf68226782f507ca6b2d497a77044de/google/logging/v2/logging.proto#L356)
    */
   StreamRange<std::string> ListLogs(
-      ::google::logging::v2::ListLogsRequest request);
+      google::logging::v2::ListLogsRequest request);
 
  private:
   std::shared_ptr<LoggingServiceV2Connection> connection_;

--- a/google/cloud/logging/logging_service_v2_connection.cc
+++ b/google/cloud/logging/logging_service_v2_connection.cc
@@ -32,55 +32,53 @@ inline namespace GOOGLE_CLOUD_CPP_GENERATED_NS {
 LoggingServiceV2Connection::~LoggingServiceV2Connection() = default;
 
 Status LoggingServiceV2Connection::DeleteLog(
-    ::google::logging::v2::DeleteLogRequest const&) {
+    google::logging::v2::DeleteLogRequest const&) {
   return Status(StatusCode::kUnimplemented, "not implemented");
 }
 
-StatusOr<::google::logging::v2::WriteLogEntriesResponse>
+StatusOr<google::logging::v2::WriteLogEntriesResponse>
 LoggingServiceV2Connection::WriteLogEntries(
-    ::google::logging::v2::WriteLogEntriesRequest const&) {
+    google::logging::v2::WriteLogEntriesRequest const&) {
   return Status(StatusCode::kUnimplemented, "not implemented");
 }
 
-StreamRange<::google::logging::v2::LogEntry>
+StreamRange<google::logging::v2::LogEntry>
 LoggingServiceV2Connection::ListLogEntries(
-    ::google::logging::v2::ListLogEntriesRequest request) {
+    google::logging::v2::ListLogEntriesRequest request) {
   return google::cloud::internal::MakePaginationRange<
-      StreamRange<::google::logging::v2::LogEntry>>(
+      StreamRange<google::logging::v2::LogEntry>>(
       std::move(request),
-      [](::google::logging::v2::ListLogEntriesRequest const&) {
-        return StatusOr<::google::logging::v2::ListLogEntriesResponse>{};
+      [](google::logging::v2::ListLogEntriesRequest const&) {
+        return StatusOr<google::logging::v2::ListLogEntriesResponse>{};
       },
-      [](::google::logging::v2::ListLogEntriesResponse const&) {
-        return std::vector<::google::logging::v2::LogEntry>();
+      [](google::logging::v2::ListLogEntriesResponse const&) {
+        return std::vector<google::logging::v2::LogEntry>();
       });
 }
 
-StreamRange<::google::api::MonitoredResourceDescriptor>
+StreamRange<google::api::MonitoredResourceDescriptor>
 LoggingServiceV2Connection::ListMonitoredResourceDescriptors(
-    ::google::logging::v2::ListMonitoredResourceDescriptorsRequest request) {
+    google::logging::v2::ListMonitoredResourceDescriptorsRequest request) {
   return google::cloud::internal::MakePaginationRange<
-      StreamRange<::google::api::MonitoredResourceDescriptor>>(
+      StreamRange<google::api::MonitoredResourceDescriptor>>(
       std::move(request),
-      [](::google::logging::v2::
-             ListMonitoredResourceDescriptorsRequest const&) {
+      [](google::logging::v2::ListMonitoredResourceDescriptorsRequest const&) {
         return StatusOr<
-            ::google::logging::v2::ListMonitoredResourceDescriptorsResponse>{};
+            google::logging::v2::ListMonitoredResourceDescriptorsResponse>{};
       },
-      [](::google::logging::v2::
-             ListMonitoredResourceDescriptorsResponse const&) {
-        return std::vector<::google::api::MonitoredResourceDescriptor>();
+      [](google::logging::v2::ListMonitoredResourceDescriptorsResponse const&) {
+        return std::vector<google::api::MonitoredResourceDescriptor>();
       });
 }
 
 StreamRange<std::string> LoggingServiceV2Connection::ListLogs(
-    ::google::logging::v2::ListLogsRequest request) {
+    google::logging::v2::ListLogsRequest request) {
   return google::cloud::internal::MakePaginationRange<StreamRange<std::string>>(
       std::move(request),
-      [](::google::logging::v2::ListLogsRequest const&) {
-        return StatusOr<::google::logging::v2::ListLogsResponse>{};
+      [](google::logging::v2::ListLogsRequest const&) {
+        return StatusOr<google::logging::v2::ListLogsResponse>{};
       },
-      [](::google::logging::v2::ListLogsResponse const&) {
+      [](google::logging::v2::ListLogsResponse const&) {
         return std::vector<std::string>();
       });
 }
@@ -103,31 +101,31 @@ class LoggingServiceV2ConnectionImpl : public LoggingServiceV2Connection {
   ~LoggingServiceV2ConnectionImpl() override = default;
 
   Status DeleteLog(
-      ::google::logging::v2::DeleteLogRequest const& request) override {
+      google::logging::v2::DeleteLogRequest const& request) override {
     return google::cloud::internal::RetryLoop(
         retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
         idempotency_policy_->DeleteLog(request),
         [this](grpc::ClientContext& context,
-               ::google::logging::v2::DeleteLogRequest const& request) {
+               google::logging::v2::DeleteLogRequest const& request) {
           return stub_->DeleteLog(context, request);
         },
         request, __func__);
   }
 
-  StatusOr<::google::logging::v2::WriteLogEntriesResponse> WriteLogEntries(
-      ::google::logging::v2::WriteLogEntriesRequest const& request) override {
+  StatusOr<google::logging::v2::WriteLogEntriesResponse> WriteLogEntries(
+      google::logging::v2::WriteLogEntriesRequest const& request) override {
     return google::cloud::internal::RetryLoop(
         retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
         idempotency_policy_->WriteLogEntries(request),
         [this](grpc::ClientContext& context,
-               ::google::logging::v2::WriteLogEntriesRequest const& request) {
+               google::logging::v2::WriteLogEntriesRequest const& request) {
           return stub_->WriteLogEntries(context, request);
         },
         request, __func__);
   }
 
-  StreamRange<::google::logging::v2::LogEntry> ListLogEntries(
-      ::google::logging::v2::ListLogEntriesRequest request) override {
+  StreamRange<google::logging::v2::LogEntry> ListLogEntries(
+      google::logging::v2::ListLogEntriesRequest request) override {
     request.clear_page_token();
     auto stub = stub_;
     auto retry = std::shared_ptr<LoggingServiceV2RetryPolicy const>(
@@ -137,31 +135,30 @@ class LoggingServiceV2ConnectionImpl : public LoggingServiceV2Connection {
     auto idempotency = idempotency_policy_->ListLogEntries(request);
     char const* function_name = __func__;
     return google::cloud::internal::MakePaginationRange<
-        StreamRange<::google::logging::v2::LogEntry>>(
+        StreamRange<google::logging::v2::LogEntry>>(
         std::move(request),
         [stub, retry, backoff, idempotency,
-         function_name](::google::logging::v2::ListLogEntriesRequest const& r) {
+         function_name](google::logging::v2::ListLogEntriesRequest const& r) {
           return google::cloud::internal::RetryLoop(
               retry->clone(), backoff->clone(), idempotency,
               [stub](
                   grpc::ClientContext& context,
-                  ::google::logging::v2::ListLogEntriesRequest const& request) {
+                  google::logging::v2::ListLogEntriesRequest const& request) {
                 return stub->ListLogEntries(context, request);
               },
               r, function_name);
         },
-        [](::google::logging::v2::ListLogEntriesResponse r) {
-          std::vector<::google::logging::v2::LogEntry> result(
-              r.entries().size());
+        [](google::logging::v2::ListLogEntriesResponse r) {
+          std::vector<google::logging::v2::LogEntry> result(r.entries().size());
           auto& messages = *r.mutable_entries();
           std::move(messages.begin(), messages.end(), result.begin());
           return result;
         });
   }
 
-  StreamRange<::google::api::MonitoredResourceDescriptor>
+  StreamRange<google::api::MonitoredResourceDescriptor>
   ListMonitoredResourceDescriptors(
-      ::google::logging::v2::ListMonitoredResourceDescriptorsRequest request)
+      google::logging::v2::ListMonitoredResourceDescriptorsRequest request)
       override {
     request.clear_page_token();
     auto stub = stub_;
@@ -173,23 +170,23 @@ class LoggingServiceV2ConnectionImpl : public LoggingServiceV2Connection {
         idempotency_policy_->ListMonitoredResourceDescriptors(request);
     char const* function_name = __func__;
     return google::cloud::internal::MakePaginationRange<
-        StreamRange<::google::api::MonitoredResourceDescriptor>>(
+        StreamRange<google::api::MonitoredResourceDescriptor>>(
         std::move(request),
-        [stub, retry, backoff, idempotency,
-         function_name](::google::logging::v2::
-                            ListMonitoredResourceDescriptorsRequest const& r) {
+        [stub, retry, backoff, idempotency, function_name](
+            google::logging::v2::ListMonitoredResourceDescriptorsRequest const&
+                r) {
           return google::cloud::internal::RetryLoop(
               retry->clone(), backoff->clone(), idempotency,
               [stub](
                   grpc::ClientContext& context,
-                  ::google::logging::v2::
+                  google::logging::v2::
                       ListMonitoredResourceDescriptorsRequest const& request) {
                 return stub->ListMonitoredResourceDescriptors(context, request);
               },
               r, function_name);
         },
-        [](::google::logging::v2::ListMonitoredResourceDescriptorsResponse r) {
-          std::vector<::google::api::MonitoredResourceDescriptor> result(
+        [](google::logging::v2::ListMonitoredResourceDescriptorsResponse r) {
+          std::vector<google::api::MonitoredResourceDescriptor> result(
               r.resource_descriptors().size());
           auto& messages = *r.mutable_resource_descriptors();
           std::move(messages.begin(), messages.end(), result.begin());
@@ -198,7 +195,7 @@ class LoggingServiceV2ConnectionImpl : public LoggingServiceV2Connection {
   }
 
   StreamRange<std::string> ListLogs(
-      ::google::logging::v2::ListLogsRequest request) override {
+      google::logging::v2::ListLogsRequest request) override {
     request.clear_page_token();
     auto stub = stub_;
     auto retry = std::shared_ptr<LoggingServiceV2RetryPolicy const>(
@@ -211,16 +208,16 @@ class LoggingServiceV2ConnectionImpl : public LoggingServiceV2Connection {
         StreamRange<std::string>>(
         std::move(request),
         [stub, retry, backoff, idempotency,
-         function_name](::google::logging::v2::ListLogsRequest const& r) {
+         function_name](google::logging::v2::ListLogsRequest const& r) {
           return google::cloud::internal::RetryLoop(
               retry->clone(), backoff->clone(), idempotency,
               [stub](grpc::ClientContext& context,
-                     ::google::logging::v2::ListLogsRequest const& request) {
+                     google::logging::v2::ListLogsRequest const& request) {
                 return stub->ListLogs(context, request);
               },
               r, function_name);
         },
-        [](::google::logging::v2::ListLogsResponse r) {
+        [](google::logging::v2::ListLogsResponse r) {
           std::vector<std::string> result(r.log_names().size());
           auto& messages = *r.mutable_log_names();
           std::move(messages.begin(), messages.end(), result.begin());

--- a/google/cloud/logging/logging_service_v2_connection.h
+++ b/google/cloud/logging/logging_service_v2_connection.h
@@ -50,20 +50,20 @@ class LoggingServiceV2Connection {
   virtual ~LoggingServiceV2Connection() = 0;
 
   virtual Status DeleteLog(
-      ::google::logging::v2::DeleteLogRequest const& request);
+      google::logging::v2::DeleteLogRequest const& request);
 
-  virtual StatusOr<::google::logging::v2::WriteLogEntriesResponse>
-  WriteLogEntries(::google::logging::v2::WriteLogEntriesRequest const& request);
+  virtual StatusOr<google::logging::v2::WriteLogEntriesResponse>
+  WriteLogEntries(google::logging::v2::WriteLogEntriesRequest const& request);
 
-  virtual StreamRange<::google::logging::v2::LogEntry> ListLogEntries(
-      ::google::logging::v2::ListLogEntriesRequest request);
+  virtual StreamRange<google::logging::v2::LogEntry> ListLogEntries(
+      google::logging::v2::ListLogEntriesRequest request);
 
-  virtual StreamRange<::google::api::MonitoredResourceDescriptor>
+  virtual StreamRange<google::api::MonitoredResourceDescriptor>
   ListMonitoredResourceDescriptors(
-      ::google::logging::v2::ListMonitoredResourceDescriptorsRequest request);
+      google::logging::v2::ListMonitoredResourceDescriptorsRequest request);
 
   virtual StreamRange<std::string> ListLogs(
-      ::google::logging::v2::ListLogsRequest request);
+      google::logging::v2::ListLogsRequest request);
 };
 
 std::shared_ptr<LoggingServiceV2Connection> MakeLoggingServiceV2Connection(

--- a/google/cloud/logging/logging_service_v2_connection_idempotency_policy.cc
+++ b/google/cloud/logging/logging_service_v2_connection_idempotency_policy.cc
@@ -42,27 +42,26 @@ class DefaultLoggingServiceV2ConnectionIdempotencyPolicy
         DefaultLoggingServiceV2ConnectionIdempotencyPolicy>(*this);
   }
 
-  Idempotency DeleteLog(
-      ::google::logging::v2::DeleteLogRequest const&) override {
+  Idempotency DeleteLog(google::logging::v2::DeleteLogRequest const&) override {
     return Idempotency::kNonIdempotent;
   }
 
   Idempotency WriteLogEntries(
-      ::google::logging::v2::WriteLogEntriesRequest const&) override {
+      google::logging::v2::WriteLogEntriesRequest const&) override {
     return Idempotency::kNonIdempotent;
   }
 
   Idempotency ListLogEntries(
-      ::google::logging::v2::ListLogEntriesRequest) override {
+      google::logging::v2::ListLogEntriesRequest) override {
     return Idempotency::kNonIdempotent;
   }
 
   Idempotency ListMonitoredResourceDescriptors(
-      ::google::logging::v2::ListMonitoredResourceDescriptorsRequest) override {
+      google::logging::v2::ListMonitoredResourceDescriptorsRequest) override {
     return Idempotency::kIdempotent;
   }
 
-  Idempotency ListLogs(::google::logging::v2::ListLogsRequest) override {
+  Idempotency ListLogs(google::logging::v2::ListLogsRequest) override {
     return Idempotency::kIdempotent;
   }
 };

--- a/google/cloud/logging/logging_service_v2_connection_idempotency_policy.h
+++ b/google/cloud/logging/logging_service_v2_connection_idempotency_policy.h
@@ -38,20 +38,19 @@ class LoggingServiceV2ConnectionIdempotencyPolicy {
       const = 0;
 
   virtual google::cloud::internal::Idempotency DeleteLog(
-      ::google::logging::v2::DeleteLogRequest const& request) = 0;
+      google::logging::v2::DeleteLogRequest const& request) = 0;
 
   virtual google::cloud::internal::Idempotency WriteLogEntries(
-      ::google::logging::v2::WriteLogEntriesRequest const& request) = 0;
+      google::logging::v2::WriteLogEntriesRequest const& request) = 0;
 
   virtual google::cloud::internal::Idempotency ListLogEntries(
-      ::google::logging::v2::ListLogEntriesRequest request) = 0;
+      google::logging::v2::ListLogEntriesRequest request) = 0;
 
   virtual google::cloud::internal::Idempotency ListMonitoredResourceDescriptors(
-      ::google::logging::v2::ListMonitoredResourceDescriptorsRequest
-          request) = 0;
+      google::logging::v2::ListMonitoredResourceDescriptorsRequest request) = 0;
 
   virtual google::cloud::internal::Idempotency ListLogs(
-      ::google::logging::v2::ListLogsRequest request) = 0;
+      google::logging::v2::ListLogsRequest request) = 0;
 };
 
 std::unique_ptr<LoggingServiceV2ConnectionIdempotencyPolicy>

--- a/google/cloud/logging/mocks/mock_logging_service_v2_connection.h
+++ b/google/cloud/logging/mocks/mock_logging_service_v2_connection.h
@@ -30,26 +30,25 @@ class MockLoggingServiceV2Connection
     : public logging::LoggingServiceV2Connection {
  public:
   MOCK_METHOD(Status, DeleteLog,
-              (::google::logging::v2::DeleteLogRequest const& request),
+              (google::logging::v2::DeleteLogRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<::google::logging::v2::WriteLogEntriesResponse>,
+  MOCK_METHOD(StatusOr<google::logging::v2::WriteLogEntriesResponse>,
               WriteLogEntries,
-              (::google::logging::v2::WriteLogEntriesRequest const& request),
+              (google::logging::v2::WriteLogEntriesRequest const& request),
               (override));
 
-  MOCK_METHOD(StreamRange<::google::logging::v2::LogEntry>, ListLogEntries,
-              (::google::logging::v2::ListLogEntriesRequest request),
-              (override));
+  MOCK_METHOD(StreamRange<google::logging::v2::LogEntry>, ListLogEntries,
+              (google::logging::v2::ListLogEntriesRequest request), (override));
 
   MOCK_METHOD(
-      StreamRange<::google::api::MonitoredResourceDescriptor>,
+      StreamRange<google::api::MonitoredResourceDescriptor>,
       ListMonitoredResourceDescriptors,
-      (::google::logging::v2::ListMonitoredResourceDescriptorsRequest request),
+      (google::logging::v2::ListMonitoredResourceDescriptorsRequest request),
       (override));
 
   MOCK_METHOD(StreamRange<std::string>, ListLogs,
-              (::google::logging::v2::ListLogsRequest request), (override));
+              (google::logging::v2::ListLogsRequest request), (override));
 };
 
 }  // namespace GOOGLE_CLOUD_CPP_GENERATED_NS


### PR DESCRIPTION
The only actual code change is in `generator/internal/codegen_utils.cc`, where I changed the code to not generate full class names with a leading `::`. This is because links like `[::foo::bar](http://...)` cause errors in with doxygen. We need to get rid of the leading `::`. But this seems fine as that's how we usually write the code anyway (without the leading `::`).

Everything else in this PR was auto generated, either w/ a search-n-replaces to fix the golden file tests, or by running the `generate-libraries-pr` build.

Related to https://github.com/googleapis/google-cloud-cpp/issues/6543
This cleans up the vast majority of the remaining doxygen errors.

An example of the errors fix by this PR are in
GCB: https://console.cloud.google.com/cloud-build/builds;region=global/42f1b158-00d6-4fe0-bc90-7bd90f1b35ce;tab=detail?project=cloud-cpp-testing-resources
Raw: https://storage.googleapis.com/cloud-cpp-community-publiclogs/logs/google-cloud-cpp/main/abddc91b53948c2d097eb3a88aa60682343308c3/fedora-34-publish-docs/log-42f1b158-00d6-4fe0-bc90-7bd90f1b35ce.txt

such as

```
/workspace/google/cloud/iam/iam_client.h:468: warning: explicit link request to 'google::iam::admin::v1::CreateServiceAccountKeyRequest' could not be resolved
/workspace/google/cloud/iam/iam_client.h:470: warning: explicit link request to 'google::iam::admin::v1::ServiceAccountKey' could not be resolved
/workspace/google/cloud/iam/iam_client.h:203: warning: explicit link request to 'google::iam::admin::v1::ServiceAccountKey' could not be resolved
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6564)
<!-- Reviewable:end -->
