### PR TITLE
feat: example using identity tokens

### DIFF
--- a/ci/cloudbuild/builds/lib/integration.sh
+++ b/ci/cloudbuild/builds/lib/integration.sh
@@ -172,6 +172,20 @@ function integration::bazel_with_emulators() {
   bazel "${verb}" "${args[@]}" \
     "--test_env=GOOGLE_CLOUD_CPP_BIGTABLE_TEST_ACCESS_TOKEN=${access_token}" \
     //google/cloud/bigtable/examples:bigtable_grpc_credentials
+
+  # This test is run separately because the URL may change and that would mess
+  # up Bazel's test cache for all the other tests.
+  io::log_h2 "Running combined examples using multiple services"
+  hello_world_http="$(gcloud run services describe \
+    hello-world-http \
+    --project="${GOOGLE_CLOUD_PROJECT}" \
+    --region="us-central1" --platform="managed" \
+    --format='value(status.url)')"
+
+  bazel "${verb}" "${args[@]}" \
+    "--test_env=GOOGLE_CLOUD_CPP_TEST_HELLO_WORLD_HTTP_URL=${hello_world_http}" \
+    "--test_env=GOOGLE_CLOUD_CPP_TEST_HELLO_WORLD_SERVICE_ACCOUNT=${GOOGLE_CLOUD_CPP_TEST_HELLO_WORLD_SERVICE_ACCOUNT}" \
+    //google/cloud/examples/...
 }
 
 # Runs integration tests with CTest using emulators. This function requires a

--- a/ci/cloudbuild/notifiers/logs/README.md
+++ b/ci/cloudbuild/notifiers/logs/README.md
@@ -53,7 +53,7 @@ gsutil iam ch \
 
 ## Create the Docker image
 
-We use buildspacks to compile the code in the `function/` directory into a
+We use buildpack to compile the code in the `function/` directory into a
 Docker image. At the end of this build the docker image will reside in your
 workstation. We will then push the image to GCR (Google Container Registry)
 and use it from Cloud Run.

--- a/ci/etc/integration-tests-config.ps1
+++ b/ci/etc/integration-tests-config.ps1
@@ -47,3 +47,9 @@ $env:GOOGLE_CLOUD_CPP_BIGQUERY_TEST_QUICKSTART_TABLE="projects/bigquery-public-d
 # Cloud IAM configuration parameters
 $env:GOOGLE_CLOUD_CPP_IAM_TEST_SERVICE_ACCOUNT="iam-test-sa@${env:GOOGLE_CLOUD_PROJECT}.iam.gserviceaccount.com"
 $env:GOOGLE_CLOUD_CPP_IAM_INVALID_TEST_SERVICE_ACCOUNT="invalid-test-account@cloud-cpp-testing-resources.iam.gserviceaccount.com"
+
+# Cloud IAM credential samples configuration parameters
+# An account able to invoke the Hello World service(s)
+$env:GOOGLE_CLOUD_CPP_TEST_HELLO_WORLD_SERVICE_ACCOUNT="hello-world-caller@${GOOGLE_CLOUD_PROJECT}.iam.gserviceaccount.com"
+# The URL for the HTTP Hello World service, typically set by the CI scripts
+$envGOOGLE_CLOUD_CPP_TEST_HELLO_WORLD_HTTP_URL=""

--- a/ci/etc/integration-tests-config.ps1
+++ b/ci/etc/integration-tests-config.ps1
@@ -47,9 +47,3 @@ $env:GOOGLE_CLOUD_CPP_BIGQUERY_TEST_QUICKSTART_TABLE="projects/bigquery-public-d
 # Cloud IAM configuration parameters
 $env:GOOGLE_CLOUD_CPP_IAM_TEST_SERVICE_ACCOUNT="iam-test-sa@${env:GOOGLE_CLOUD_PROJECT}.iam.gserviceaccount.com"
 $env:GOOGLE_CLOUD_CPP_IAM_INVALID_TEST_SERVICE_ACCOUNT="invalid-test-account@cloud-cpp-testing-resources.iam.gserviceaccount.com"
-
-# Cloud IAM credential samples configuration parameters
-# An account able to invoke the Hello World service(s)
-$env:GOOGLE_CLOUD_CPP_TEST_HELLO_WORLD_SERVICE_ACCOUNT="hello-world-caller@${GOOGLE_CLOUD_PROJECT}.iam.gserviceaccount.com"
-# The URL for the HTTP Hello World service, typically set by the CI scripts
-$envGOOGLE_CLOUD_CPP_TEST_HELLO_WORLD_HTTP_URL=""

--- a/ci/etc/integration-tests-config.sh
+++ b/ci/etc/integration-tests-config.sh
@@ -59,3 +59,9 @@ export GOOGLE_CLOUD_CPP_BIGQUERY_TEST_QUICKSTART_TABLE="projects/bigquery-public
 # Cloud IAM configuration parameters
 export GOOGLE_CLOUD_CPP_IAM_TEST_SERVICE_ACCOUNT="iam-test-sa@${GOOGLE_CLOUD_PROJECT}.iam.gserviceaccount.com"
 export GOOGLE_CLOUD_CPP_IAM_INVALID_TEST_SERVICE_ACCOUNT="invalid-test-account@cloud-cpp-testing-resources.iam.gserviceaccount.com"
+
+# Cloud IAM credential samples configuration parameters
+# An account able to invoke the Hello World service(s)
+export GOOGLE_CLOUD_CPP_TEST_HELLO_WORLD_SERVICE_ACCOUNT="hello-world-caller@${GOOGLE_CLOUD_PROJECT}.iam.gserviceaccount.com"
+# The URL for the HTTP Hello World service, typically set by the CI scripts
+export GOOGLE_CLOUD_CPP_TEST_HELLO_WORLD_HTTP_URL=""

--- a/ci/kokoro/macos/build-bazel.sh
+++ b/ci/kokoro/macos/build-bazel.sh
@@ -162,6 +162,7 @@ if should_run_integration_tests; then
     "-//google/cloud/bigtable/examples:bigtable_grpc_credentials"
     "-//google/cloud/storage/examples:storage_service_account_samples"
     "-//google/cloud/storage/tests:service_account_integration_test"
+    "-//google/cloud/examples:grpc_credential_types"
 
     # TODO(#6062) - enable gRPC integration tests again
     "-//google/cloud/storage/examples:storage_grpc_samples"

--- a/ci/kokoro/macos/build-cmake.sh
+++ b/ci/kokoro/macos/build-cmake.sh
@@ -109,7 +109,7 @@ if should_run_integration_tests; then
     # TODO(6062) - restore the GCS+gRPC tests (i.e. remove storage_grpc_ from the -E option)
     ctest \
       -L 'integration-test-production' \
-      -E '(bigtable_grpc_credentials|storage_service_account_samples|service_account_integration_test|storage_grpc_)' \
+      -E '(bigtable_grpc_credentials|grpc_credential_types|storage_service_account_samples|service_account_integration_test|storage_grpc_)' \
       --output-on-failure -j "${NCPU}"
   )
 fi

--- a/ci/kokoro/windows/build-bazel.ps1
+++ b/ci/kokoro/windows/build-bazel.ps1
@@ -212,6 +212,7 @@ if (Integration-Tests-Enabled) {
         "-//google/cloud/bigtable/examples:bigtable_grpc_credentials",
         "-//google/cloud/storage/examples:storage_service_account_samples",
         "-//google/cloud/storage/tests:service_account_integration_test",
+        "-//google/cloud/examples:grpc_credential_types",
 
         # TODO(#6062) - enable gRPC integration tests again
         "-//google/cloud/storage/examples:storage_grpc_samples",

--- a/ci/kokoro/windows/build-cmake.ps1
+++ b/ci/kokoro/windows/build-cmake.ps1
@@ -144,7 +144,7 @@ if (Integration-Tests-Enabled) {
     # TODO(6062) - restore the GCS+gRPC tests (i.e. remove storage_grpc_ from the -E option)
     ctest $ctest_flags `
         -L 'integration-test-production' `
-        -E '(bigtable_grpc_credentials|storage_service_account_samples|service_account_integration_test|storage_grpc_)'
+        -E '(bigtable_grpc_credentials|grpc_credential_types|storage_service_account_samples|service_account_integration_test|storage_grpc_)'
     if ($LastExitCode) {
         Write-Host -ForegroundColor Red "Integration tests failed with exit code ${LastExitCode}."
         Exit ${LastExitCode}

--- a/google/cloud/examples/BUILD
+++ b/google/cloud/examples/BUILD
@@ -47,6 +47,7 @@ cc_test(
     srcs = ["grpc_credential_types.cc"],
     tags = [
         "integration-test",
+        "integration-test-production",
     ],
     deps = [
         "//:experimental-iam",
@@ -54,6 +55,6 @@ cc_test(
         "//google/cloud:google_cloud_cpp_common",
         "//google/cloud/testing_util:google_cloud_cpp_testing",
         "//google/cloud/testing_util:google_cloud_cpp_testing_grpc",
-        "@com_google_googletest//:gtest_main",
+        "@com_github_curl_curl//:curl",
     ],
 )

--- a/google/cloud/examples/CMakeLists.txt
+++ b/google/cloud/examples/CMakeLists.txt
@@ -24,13 +24,13 @@ google_cloud_cpp_add_common_options(gcs2cbt)
 
 if (BUILD_TESTING)
     include(FindGMockWithTargets)
+    include(FindCurlWithTargets)
 
     add_executable(grpc_credential_types grpc_credential_types.cc)
     target_link_libraries(
         grpc_credential_types
         PRIVATE google_cloud_cpp_testing google-cloud-cpp::experimental-iam
-                google-cloud-cpp::spanner GTest::gmock_main GTest::gmock
-                GTest::gtest)
+                google-cloud-cpp::spanner CURL::libcurl)
     google_cloud_cpp_add_common_options(grpc_credential_types)
 
     foreach (test gcs2cbt grpc_credential_types)

--- a/google/cloud/examples/README.md
+++ b/google/cloud/examples/README.md
@@ -1,4 +1,121 @@
-# Google Cloud C++ Client Examples.
+# Google Cloud C++ Client Examples
 
 This directory contains examples that combine two or more Google Cloud C++
 client libraries.
+
+
+## Configuring Hello World (HTTP) Service
+
+The `grpc_credential_types` example uses IAM to obtain an *Identity Token*, and
+then uses this token to authenticate a request. Identity Tokens are used by
+**user** applications deployed to certain GCP environments, including Cloud Run
+and Cloud Functions.
+
+To run integration tests and to demonstrate how these tokens are used we deploy
+a simple "Hello World" application to Cloud Run. The code for this application
+is found
+
+### Prerequisites
+
+Verify the [docker tool][docker] is functional on your workstation:
+
+```shell
+docker run hello-world
+# Output: Hello from Docker! and then some more informational messages.
+```
+
+Verify the [pack tool][pack-install] is functional on our workstation. These
+instructions were tested with `v0.17.0`, although they should work with newer
+versions. Some commands may not work with older versions.
+
+```shell
+pack version
+# Output: a version number, e.g., 0.17.0+git-d9cb4e7.build-2045
+```
+
+### Create the Docker image
+
+We use buildpack to compile the code in the `hello_world_http/` subdirectory
+into a Docker image. At the end of this build the docker image will reside in
+your workstation. We will then push the image to GCR (Google Container Registry)
+and use it from Cloud Run.
+
+```shell
+pack build  --builder gcr.io/buildpacks/builder:latest \
+     --env "GOOGLE_FUNCTION_SIGNATURE_TYPE=http" \
+     --env "GOOGLE_FUNCTION_TARGET=HelloWorldHttp" \
+     --path "google/cloud/examples/hello_world_http/" \
+     "gcr.io/${GOOGLE_CLOUD_PROJECT}/hello-world-http"
+```
+
+### Push the Docker image to GCR
+
+```shell
+docker push "gcr.io/${GOOGLE_CLOUD_PROJECT}/hello-world-http:latest"
+```
+
+### Deploy to Cloud Run
+
+```shell
+SA="hello-world-run-sa@${GOOGLE_CLOUD_PROJECT}.iam.gserviceaccount.com"
+gcloud run deploy hello-world-http \
+    --project="${GOOGLE_CLOUD_PROJECT}" \
+    --image="gcr.io/${GOOGLE_CLOUD_PROJECT}/hello-world-http:latest" \
+    --region="us-central1" \
+    --platform="managed" \
+    --service-account="${SA}" \
+    --ingress=all \
+    --no-allow-unauthenticated
+```
+
+### Getting the URL
+
+```shell
+GOOGLE_CLOUD_CPP_TEST_HELLO_WORLD_HTTP_URL="$(gcloud run services describe \
+    hello-world-http \
+    --project="${GOOGLE_CLOUD_PROJECT}" \
+    --region="us-central1" --platform="managed" \
+    --format='value(status.url)')"
+```
+
+### One Time: Create Service Account and set Permissions
+
+```shell
+# The account in the Hello World service, has not permissions
+gcloud iam service-accounts create hello-world-run-sa \
+    --project="${GOOGLE_CLOUD_PROJECT}" \
+    --display-name="Service account used by Cloud Run 'Hello World' Deployments"
+
+# The account that calls the Hello World service, only has that permission
+gcloud iam service-accounts create hello-world-caller \
+    --project="${GOOGLE_CLOUD_PROJECT}" \
+    --display-name="Service account used to *invoke* Hello World"
+gcloud projects add-iam-policy-binding "${GOOGLE_CLOUD_PROJECT}" \
+    --member="serviceAccount:hello-world-caller@${GOOGLE_CLOUD_PROJECT}.iam.gserviceaccount.com" \
+    --role="roles/run.invoker"
+
+# Grant the account used in the CI builds permissions to impersonate this new
+# account and to fetch the URL for the Hello World service. For more background
+# see go/cloud-cxx:gcb-roles for details
+PROJECT_NUMBER=$(gcloud projects list \
+    --filter="project_id=${GOOGLE_CLOUD_PROJECT}" \
+    --format="value(project_number)" \
+    --limit=1)
+gcloud iam service-accounts add-iam-policy-binding \
+    "hello-world-caller@${GOOGLE_CLOUD_PROJECT}.iam.gserviceaccount.com" \
+    --project="${GOOGLE_CLOUD_PROJECT}" \
+    --member="serviceAccount:kokoro-run@${GOOGLE_CLOUD_PROJECT}.iam.gserviceaccount.com" \
+    --role="roles/iam.serviceAccountTokenCreator"
+gcloud iam service-accounts add-iam-policy-binding \
+    "hello-world-caller@${GOOGLE_CLOUD_PROJECT}.iam.gserviceaccount.com" \
+    --project="${GOOGLE_CLOUD_PROJECT}" \
+    --member="serviceAccount:${PROJECT_NUMBER}@cloudbuild.gserviceaccount.com" \
+    --role="roles/iam.serviceAccountTokenCreator"
+
+gcloud projects add-iam-policy-binding "${GOOGLE_CLOUD_PROJECT}" \
+    --member="serviceAccount:kokoro-run@${GOOGLE_CLOUD_PROJECT}.iam.gserviceaccount.com" \
+    --role="roles/run.viewer"
+gcloud projects add-iam-policy-binding "${GOOGLE_CLOUD_PROJECT}" \
+    --member="serviceAccount:${PROJECT_NUMBER}@cloudbuild.gserviceaccount.com" \
+    --role="roles/run.viewer"
+```

--- a/google/cloud/examples/README.md
+++ b/google/cloud/examples/README.md
@@ -13,7 +13,7 @@ and Cloud Functions.
 
 To run integration tests and to demonstrate how these tokens are used we deploy
 a simple "Hello World" application to Cloud Run. The code for this application
-is found
+is found in the `hello_world_http/` subdirectory.
 
 ### Prerequisites
 
@@ -24,7 +24,7 @@ docker run hello-world
 # Output: Hello from Docker! and then some more informational messages.
 ```
 
-Verify the [pack tool][pack-install] is functional on our workstation. These
+Verify the [pack tool][pack-install] is functional on your workstation. These
 instructions were tested with `v0.17.0`, although they should work with newer
 versions. Some commands may not work with older versions.
 
@@ -36,7 +36,7 @@ pack version
 ### Create the Docker image
 
 We use buildpack to compile the code in the `hello_world_http/` subdirectory
-into a Docker image. At the end of this build the docker image will reside in
+into a Docker image. At the end of this build the docker image will reside on
 your workstation. We will then push the image to GCR (Google Container Registry)
 and use it from Cloud Run.
 
@@ -81,7 +81,7 @@ GOOGLE_CLOUD_CPP_TEST_HELLO_WORLD_HTTP_URL="$(gcloud run services describe \
 ### One Time: Create Service Account and set Permissions
 
 ```shell
-# The account in the Hello World service, has not permissions
+# The account in the Hello World service, has no permissions
 gcloud iam service-accounts create hello-world-run-sa \
     --project="${GOOGLE_CLOUD_PROJECT}" \
     --display-name="Service account used by Cloud Run 'Hello World' Deployments"

--- a/google/cloud/examples/grpc_credential_types.cc
+++ b/google/cloud/examples/grpc_credential_types.cc
@@ -19,6 +19,7 @@
 #include "google/cloud/testing_util/example_driver.h"
 #include "absl/strings/str_split.h"
 #include "absl/time/time.h"  // NOLINT(modernize-deprecated-headers)
+#include <curl/curl.h>
 #include <chrono>
 #include <stdexcept>
 #include <thread>
@@ -26,6 +27,53 @@
 namespace {
 
 auto constexpr kTokenValidationPeriod = std::chrono::seconds(30);
+
+extern "C" size_t CurlOnWriteData(char* ptr, size_t size, size_t nmemb,
+                                  void* userdata) {
+  auto* buffer = reinterpret_cast<std::string*>(userdata);
+  buffer->append(ptr, size * nmemb);
+  return size * nmemb;
+}
+
+google::cloud::StatusOr<std::string> HttpGet(std::string const& url,
+                                             std::string const& token) {
+  static auto const kCurlInit = [] {
+    return curl_global_init(CURL_GLOBAL_ALL);
+  }();
+  (void)kCurlInit;
+  auto const authorization = "Authorization: Bearer " + token;
+  using Headers = std::unique_ptr<curl_slist, decltype(&curl_slist_free_all)>;
+  auto const headers = Headers{
+      curl_slist_append(nullptr, authorization.c_str()), curl_slist_free_all};
+  using CurlHandle = std::unique_ptr<CURL, decltype(&curl_easy_cleanup)>;
+  auto curl = CurlHandle(curl_easy_init(), curl_easy_cleanup);
+  if (!curl) throw std::runtime_error("Failed to create CurlHandle");
+  std::string buffer;
+  curl_easy_setopt(curl.get(), CURLOPT_URL, url.c_str());
+  curl_easy_setopt(curl.get(), CURLOPT_HTTPHEADER, headers.get());
+  curl_easy_setopt(curl.get(), CURLOPT_WRITEFUNCTION, &CurlOnWriteData);
+  curl_easy_setopt(curl.get(), CURLOPT_WRITEDATA, &buffer);
+
+  CURLcode code = curl_easy_perform(curl.get());
+  if (code != CURLE_OK) throw std::runtime_error(curl_easy_strerror(code));
+  long status;  // NOLINT(google-runtime-int)
+  code = curl_easy_getinfo(curl.get(), CURLINFO_RESPONSE_CODE, &status);
+  if (code != CURLE_OK) throw std::runtime_error(curl_easy_strerror(code));
+
+  // Handle common errors as Status, this is not exhaustive.
+  using ::google::cloud::Status;
+  using ::google::cloud::StatusCode;
+  if (status == 400) return Status(StatusCode::kInvalidArgument, buffer);
+  if (status == 401) return Status(StatusCode::kUnauthenticated, buffer);
+  if (status == 403) return Status(StatusCode::kPermissionDenied, buffer);
+  if (status >= 500) return Status(StatusCode::kInternal, buffer);
+  if (status < 200 || status >= 300) {
+    std::ostringstream os;
+    os << "HTTP error [" << status << "]: " << buffer;
+    return Status(StatusCode::kUnknown, buffer);
+  }
+  return buffer;
+}
 
 // TODO(#6185) - this should be done by the generated code
 std::set<std::string> DefaultTracingComponents() {
@@ -116,6 +164,23 @@ void UseAccessTokenUntilExpired(google::cloud::iam::IAMCredentialsClient client,
   }
 }
 
+void UseIdToken(google::cloud::iam::IAMCredentialsClient client,
+                std::vector<std::string> const& argv) {
+  namespace iam = google::cloud::iam;
+  [](iam::IAMCredentialsClient client, std::string const& service_account,
+     std::string const& hello_world_url) {
+    auto token = client.GenerateIdToken(
+        "projects/-/serviceAccounts/" + service_account, /*delegates=*/{},
+        /*audience=*/{hello_world_url},
+        /*include_email=*/true);
+    if (!token) throw std::runtime_error(token.status().message());
+
+    auto text = HttpGet(hello_world_url, token->token());
+    if (!text) throw std::runtime_error(token.status().message());
+    std::cout << "Server says: " << *text << "\n";
+  }(std::move(client), argv.at(0), argv.at(1));
+}
+
 void AutoRun(std::vector<std::string> const& argv) {
   namespace examples = ::google::cloud::testing_util;
   using google::cloud::internal::GetEnv;
@@ -124,10 +189,16 @@ void AutoRun(std::vector<std::string> const& argv) {
   examples::CheckEnvironmentVariablesAreSet({
       "GOOGLE_CLOUD_PROJECT",
       "GOOGLE_CLOUD_CPP_IAM_TEST_SERVICE_ACCOUNT",
+      "GOOGLE_CLOUD_CPP_TEST_HELLO_WORLD_SERVICE_ACCOUNT",
+      "GOOGLE_CLOUD_CPP_TEST_HELLO_WORLD_HTTP_URL",
   });
   auto project_id = GetEnv("GOOGLE_CLOUD_PROJECT").value();
   auto const test_iam_service_account =
       GetEnv("GOOGLE_CLOUD_CPP_IAM_TEST_SERVICE_ACCOUNT").value_or("");
+  auto const hello_world_service_account =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_HELLO_WORLD_SERVICE_ACCOUNT").value_or("");
+  auto const hello_world_url =
+      GetEnv("GOOGLE_CLOUD_CPP_TEST_HELLO_WORLD_HTTP_URL").value_or("");
 
   auto client = google::cloud::iam::IAMCredentialsClient(
       google::cloud::iam::MakeIAMCredentialsConnection(
@@ -139,6 +210,9 @@ void AutoRun(std::vector<std::string> const& argv) {
 
   std::cout << "\nRunning UseAccessTokenUntilExpired() example" << std::endl;
   UseAccessTokenUntilExpired(client, {test_iam_service_account, project_id});
+
+  std::cout << "\nRunning UseIdToken() example" << std::endl;
+  UseIdToken(client, {hello_world_service_account, hello_world_url});
 }
 
 }  // namespace
@@ -175,6 +249,8 @@ int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
                  UseAccessToken),
       make_entry("use-access-token-until-expired",
                  {"service-account", "project-id"}, UseAccessTokenUntilExpired),
+      make_entry("use-id-token", {"service-account", "hello-world-http-url"},
+                 UseIdToken),
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);

--- a/google/cloud/examples/hello_world_http/CMakeLists.txt
+++ b/google/cloud/examples/hello_world_http/CMakeLists.txt
@@ -1,0 +1,26 @@
+# ~~~
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ~~~
+
+cmake_minimum_required(VERSION 3.18)
+project(hello-world-http LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+
+find_package(functions_framework_cpp REQUIRED)
+
+add_library(functions_framework_cpp_function hello_world_http.cc)
+target_link_libraries(functions_framework_cpp_function
+                      functions-framework-cpp::framework)

--- a/google/cloud/examples/hello_world_http/hello_world_http.cc
+++ b/google/cloud/examples/hello_world_http/hello_world_http.cc
@@ -1,0 +1,24 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <google/cloud/functions/http_request.h>
+#include <google/cloud/functions/http_response.h>
+
+namespace gcf = ::google::cloud::functions;
+
+gcf::HttpResponse HelloWorldHttp(gcf::HttpRequest) {  // NOLINT
+  return gcf::HttpResponse{}
+      .set_header("Content-Type", "text/plain")
+      .set_payload("Hello World");
+}

--- a/google/cloud/examples/hello_world_http/vcpkg.json
+++ b/google/cloud/examples/hello_world_http/vcpkg.json
@@ -1,0 +1,7 @@
+{
+  "name": "hello-world-http",
+  "version-string": "unversioned",
+  "dependencies": [
+    "functions-framework-cpp"
+  ]
+}


### PR DESCRIPTION
Use the `GenerateIdToken()` method in
`google::cloud::iam::IAMCredentialsClient`, and shows how to use the
returned value to make a HTTP request to a service in Cloud Run.

Fixes #6481 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6569)
<!-- Reviewable:end -->
