### PR TITLE
fix: GOOGLE_CLOUD_CPP_ENABLE_EXAMPLES depends condition

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -227,6 +227,10 @@ endif ()
 # also includes the BUILD_TESTING option, which is on by default.
 include(CTest)
 
+# Ensure that GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS is initialized since it's
+# used in the depends condition of the next option.
+include(EnableCxxExceptions)
+
 # The examples use exception handling to simplify the code. Therefore they
 # cannot be compiled when exceptions are disabled, and applications cannot force
 # the flag.


### PR DESCRIPTION
`GOOGLE_CLOUD_CPP_ENABLE_EXAMPLES` is dependent on
`GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS`, but that was unset prior to
its first use, so `GOOGLE_CLOUD_CPP_ENABLE_EXAMPLES` was never getting
enabled.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6571)
<!-- Reviewable:end -->
