### PR TITLE
fix(ci): ci builds don't have a PR number

### DIFF
--- a/ci/cloudbuild/cloudbuild.yaml
+++ b/ci/cloudbuild/cloudbuild.yaml
@@ -160,7 +160,7 @@ steps:
       set -xe
       ctime="$(gcloud builds describe --format 'value(create_time)' '${BUILD_ID}')"
       query="tags=pr"
-      query+=" AND tags=${_PR_NUMBER}"
+      query+=" AND tags=${_PR_NUMBER:-none}"
       query+=" AND tags=${_BUILD_NAME}"
       query+=" AND substitutions.COMMIT_SHA != ${COMMIT_SHA}"
       query+=" AND create_time > ${ctime}"
@@ -178,7 +178,7 @@ steps:
       set -xe
       ctime="$(gcloud builds describe --format 'value(create_time)' '${BUILD_ID}')"
       query="tags=pr"
-      query+=" AND tags=${_PR_NUMBER}"
+      query+=" AND tags=${_PR_NUMBER:-none}"
       query+=" AND substitutions.COMMIT_SHA != ${COMMIT_SHA}"
       query+=" AND create_time < ${ctime}"
       gcloud builds list --ongoing --format='value(id)' --filter "${query}" | \

--- a/ci/cloudbuild/cloudbuild.yaml
+++ b/ci/cloudbuild/cloudbuild.yaml
@@ -158,9 +158,10 @@ steps:
     - '-c'
     - |
       set -xe
+      test -z "${_PR_NUMBER}" && exit 0
       ctime="$(gcloud builds describe --format 'value(create_time)' '${BUILD_ID}')"
       query="tags=pr"
-      query+=" AND tags=${_PR_NUMBER:-none}"
+      query+=" AND tags=${_PR_NUMBER}"
       query+=" AND tags=${_BUILD_NAME}"
       query+=" AND substitutions.COMMIT_SHA != ${COMMIT_SHA}"
       query+=" AND create_time > ${ctime}"
@@ -176,9 +177,10 @@ steps:
     - '-c'
     - |
       set -xe
+      test -z "${_PR_NUMBER}" && exit 0
       ctime="$(gcloud builds describe --format 'value(create_time)' '${BUILD_ID}')"
       query="tags=pr"
-      query+=" AND tags=${_PR_NUMBER:-none}"
+      query+=" AND tags=${_PR_NUMBER}"
       query+=" AND substitutions.COMMIT_SHA != ${COMMIT_SHA}"
       query+=" AND create_time < ${ctime}"
       gcloud builds list --ongoing --format='value(id)' --filter "${query}" | \


### PR DESCRIPTION
On post-submit (ci) builds, we have no `${_PR_NUBMER}`, so we see
non-fatal errors in the logs like:

```
+ gcloud builds list --limit 1 '--format=value(id)' --filter 'tags=pr AND tags= AND tags=publish-docs AND substitutions.COMMIT_SHA != 2f69122b4f2b20c85e2e55c1b2c753c21a85d912 AND create_time > 2021-05-14T16:23:37.115578690Z'
ERROR: (gcloud.builds.list) Logical operator not expected [tags=pr AND tags= *HERE* AND tags=publish-docs AND substitutions.COMMIT_SHA != 2f69122b4f2b20c85e2e55c1b2c753c21a85d912 AND create_time > 2021-05-14T16:23:37.115578690Z].
+ exit 0
```

This PR will avoid those errors.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6572)
<!-- Reviewable:end -->
