### PR TITLE
ci: exclude hello_world_http from doxygen

### DIFF
--- a/google/cloud/CMakeLists.txt
+++ b/google/cloud/CMakeLists.txt
@@ -27,6 +27,7 @@ set(DOXYGEN_EXCLUDE_PATTERNS
     "*/generator/*"
     "*/google/cloud/README.md"
     "*/google/cloud/internal/*"
+    "*/google/cloud/examples/hello_world_http/*"
     "*/google/cloud/testing_util/*"
     "*/google/cloud/bigtable/*"
     "*/google/cloud/bigquery/*"


### PR DESCRIPTION
To include this in doxygen output we'll need to fetch the functions
framework dep, which we could do, but that would be a big-ish change for
doxygen. Maybe we can consider that later, but for now, I think
excluding this from doxygen sounds better.


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6576)
<!-- Reviewable:end -->
