### PR TITLE
feat: an example using identity tokens with gRPC

### DIFF
--- a/ci/cloudbuild/builds/lib/integration.sh
+++ b/ci/cloudbuild/builds/lib/integration.sh
@@ -182,8 +182,15 @@ function integration::bazel_with_emulators() {
     --region="us-central1" --platform="managed" \
     --format='value(status.url)')"
 
+  hello_world_grpc="$(gcloud run services describe \
+    hello-world-grpc \
+    --project="${GOOGLE_CLOUD_PROJECT}" \
+    --region="us-central1" --platform="managed" \
+    --format='value(status.url)')"
+
   bazel "${verb}" "${args[@]}" \
     "--test_env=GOOGLE_CLOUD_CPP_TEST_HELLO_WORLD_HTTP_URL=${hello_world_http}" \
+    "--test_env=GOOGLE_CLOUD_CPP_TEST_HELLO_WORLD_GRPC_URL=${hello_world_grpc}" \
     "--test_env=GOOGLE_CLOUD_CPP_TEST_HELLO_WORLD_SERVICE_ACCOUNT=${GOOGLE_CLOUD_CPP_TEST_HELLO_WORLD_SERVICE_ACCOUNT}" \
     //google/cloud/examples/...
 }

--- a/google/cloud/examples/BUILD
+++ b/google/cloud/examples/BUILD
@@ -16,6 +16,12 @@ package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # Apache 2.0
 
+load(
+    "@com_google_googleapis_imports//:imports.bzl",
+    "cc_grpc_library",
+    "cc_proto_library",
+)
+
 # This library defines main(). It's declared as a library so it can be part of
 # a cc_test and cc_binary target.
 cc_library(
@@ -41,15 +47,49 @@ cc_test(
     deps = [":gcs2cbt_lib"],
 )
 
+proto_library(
+    name = "hello_world_protos",
+    srcs = [
+        "hello_world_grpc/hello_world.proto",
+    ],
+    visibility = [
+        "//:__pkg__",
+    ],
+    deps = [],
+)
+
+cc_proto_library(
+    name = "hello_world_cc_proto",
+    visibility = [
+        "//:__pkg__",
+    ],
+    deps = [":hello_world_protos"],
+)
+
+cc_grpc_library(
+    name = "hello_world_cc_grpc",
+    srcs = [":hello_world_protos"],
+    grpc_only = True,
+    visibility = [
+        "//:__pkg__",
+    ],
+    deps = [":hello_world_cc_proto"],
+)
+
 cc_test(
     name = "grpc_credential_types",
     timeout = "long",
     srcs = ["grpc_credential_types.cc"],
+    copts = [
+        "-I$(GENDIR)",
+    ],
     tags = [
         "integration-test",
         "integration-test-production",
     ],
     deps = [
+        ":hello_world_cc_grpc",
+        ":hello_world_cc_proto",
         "//:experimental-iam",
         "//:spanner",
         "//google/cloud:google_cloud_cpp_common",

--- a/google/cloud/examples/BUILD
+++ b/google/cloud/examples/BUILD
@@ -53,7 +53,7 @@ proto_library(
         "hello_world_grpc/hello_world.proto",
     ],
     visibility = [
-        "//:__pkg__",
+        "//visibility:private",
     ],
     deps = [],
 )

--- a/google/cloud/examples/BUILD
+++ b/google/cloud/examples/BUILD
@@ -61,7 +61,7 @@ proto_library(
 cc_proto_library(
     name = "hello_world_cc_proto",
     visibility = [
-        "//:__pkg__",
+        "//visibility:private",
     ],
     deps = [":hello_world_protos"],
 )
@@ -71,7 +71,7 @@ cc_grpc_library(
     srcs = [":hello_world_protos"],
     grpc_only = True,
     visibility = [
-        "//:__pkg__",
+        "//visibility:private",
     ],
     deps = [":hello_world_cc_proto"],
 )

--- a/google/cloud/examples/CMakeLists.txt
+++ b/google/cloud/examples/CMakeLists.txt
@@ -25,12 +25,18 @@ google_cloud_cpp_add_common_options(gcs2cbt)
 if (BUILD_TESTING)
     include(FindGMockWithTargets)
     include(FindCurlWithTargets)
+    include(FindgRPC)
+
+    google_cloud_cpp_grpcpp_library(
+        hello_world_protos "hello_world_grpc/hello_world.proto"
+        PROTO_PATH_DIRECTORIES ${CMAKE_CURRENT_SOURCE_DIR})
 
     add_executable(grpc_credential_types grpc_credential_types.cc)
     target_link_libraries(
         grpc_credential_types
-        PRIVATE google_cloud_cpp_testing google-cloud-cpp::experimental-iam
-                google-cloud-cpp::spanner CURL::libcurl)
+        PRIVATE hello_world_protos google_cloud_cpp_testing
+                google-cloud-cpp::experimental-iam google-cloud-cpp::spanner
+                CURL::libcurl)
     google_cloud_cpp_add_common_options(grpc_credential_types)
 
     foreach (test gcs2cbt grpc_credential_types)

--- a/google/cloud/examples/README.md
+++ b/google/cloud/examples/README.md
@@ -3,6 +3,57 @@
 This directory contains examples that combine two or more Google Cloud C++
 client libraries.
 
+## Configuring a Hello World (gRPC) Service
+
+## Prerequisites
+
+Verify the [docker tool][docker] is functional on your workstation:
+
+```shell
+docker run hello-world
+# Output: Hello from Docker! and then some more informational messages.
+```
+
+### Create the Docker image
+
+We use Docker to create an image with our "Greeter" service:
+
+```shell
+docker build -t "gcr.io/${GOOGLE_CLOUD_PROJECT}/hello-world-grpc:latest" \
+    -f google/cloud/examples/hello_world_grpc/Dockerfile \
+    google/cloud/examples/hello_world_grpc
+```
+
+### Push the Docker image to GCR
+
+```shell
+docker push "gcr.io/${GOOGLE_CLOUD_PROJECT}/hello-world-grpc:latest"
+```
+
+### Deploy to Cloud Run
+
+```shell
+SA="hello-world-run-sa@${GOOGLE_CLOUD_PROJECT}.iam.gserviceaccount.com"
+gcloud run deploy hello-world-grpc \
+    --project="${GOOGLE_CLOUD_PROJECT}" \
+    --image="gcr.io/${GOOGLE_CLOUD_PROJECT}/hello-world-grpc:latest" \
+    --region="us-central1" \
+    --platform="managed" \
+    --service-account="${SA}" \
+    --ingress=all \
+    --no-allow-unauthenticated
+```
+
+### Getting the URL
+
+```shell
+GOOGLE_CLOUD_CPP_TEST_HELLO_WORLD_GRPC_URL="$(gcloud run services describe \
+    hello-world-grpc \
+    --project="${GOOGLE_CLOUD_PROJECT}" \
+    --region="us-central1" --platform="managed" \
+    --format='value(status.url)')"
+```
+
 
 ## Configuring Hello World (HTTP) Service
 

--- a/google/cloud/examples/hello_world_grpc/.dockerignore
+++ b/google/cloud/examples/hello_world_grpc/.dockerignore
@@ -1,0 +1,1 @@
+cmake-out/

--- a/google/cloud/examples/hello_world_grpc/CMakeLists.txt
+++ b/google/cloud/examples/hello_world_grpc/CMakeLists.txt
@@ -1,0 +1,50 @@
+# ~~~
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ~~~
+
+cmake_minimum_required(VERSION 3.18)
+project(hello-world-grpc LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+
+find_package(gRPC REQUIRED)
+
+add_executable(
+    hello_world_grpc
+    "${CMAKE_CURRENT_BINARY_DIR}/hello_world.grpc.pb.cc"
+    "${CMAKE_CURRENT_BINARY_DIR}/hello_world.pb.cc" hello_world_grpc.cc)
+target_include_directories(hello_world_grpc
+                           PRIVATE "${CMAKE_CURRENT_BINARY_DIR}")
+target_link_libraries(hello_world_grpc PRIVATE gRPC::grpc++)
+
+add_custom_command(
+    OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/hello_world.grpc.pb.cc"
+           "${CMAKE_CURRENT_BINARY_DIR}/hello_world.grpc.pb.h"
+           "${CMAKE_CURRENT_BINARY_DIR}/hello_world.pb.cc"
+           "${CMAKE_CURRENT_BINARY_DIR}/hello_world.pb.h"
+    COMMAND
+        $<TARGET_FILE:protobuf::protoc> ARGS
+        --plugin=protoc-gen-grpc=$<TARGET_FILE:gRPC::grpc_cpp_plugin>
+        "--grpc_out=${CMAKE_CURRENT_BINARY_DIR}"
+        "--cpp_out=${CMAKE_CURRENT_BINARY_DIR}"
+        "--proto_path=${CMAKE_SOURCE_DIR}" "hello_world.proto"
+    DEPENDS "hello_world.proto" protobuf::protoc gRPC::grpc_cpp_plugin
+    VERBATIM)
+set_source_files_properties(
+    "${CMAKE_CURRENT_BINARY_DIR}/hello_world.grpc.pb.cc"
+    "${CMAKE_CURRENT_BINARY_DIR}/hello_world.grpc.pb.h"
+    "${CMAKE_CURRENT_BINARY_DIR}/hello_world.pb.cc"
+    "${CMAKE_CURRENT_BINARY_DIR}/hello_world.pb.h"
+    PROPERTIES GENERATED TRUE)

--- a/google/cloud/examples/hello_world_grpc/Dockerfile
+++ b/google/cloud/examples/hello_world_grpc/Dockerfile
@@ -1,0 +1,37 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM alpine:edge AS devtools
+
+RUN apk update && apk add build-base gcc g++
+RUN apk update && apk add libc-dev
+RUN apk update && apk add cmake ninja
+RUN apk update && apk add curl git perl unzip tar zip
+RUN apk update && apk add grpc-dev grpc grpc-cli protoc protobuf-dev
+RUN apk update && apk add c-ares-dev
+
+FROM devtools AS build
+
+WORKDIR /home/build
+COPY . /home/build
+RUN cmake -S . -B .build -GNinja \
+    -DCMAKE_BUILD_TYPE=Release \
+    && cmake --build .build
+
+FROM alpine:edge AS deploy
+RUN apk update && apk add grpc protobuf c-ares
+WORKDIR /r
+COPY --from=build /home/build/.build/hello_world_grpc /r
+
+ENTRYPOINT /r/hello_world_grpc

--- a/google/cloud/examples/hello_world_grpc/hello_world.proto
+++ b/google/cloud/examples/hello_world_grpc/hello_world.proto
@@ -1,0 +1,26 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+service Greet {
+  rpc Hello(HelloRequest) returns (HelloResponse) {}
+}
+
+message HelloRequest {
+};
+
+message HelloResponse {
+  string greeting = 1;
+};

--- a/google/cloud/examples/hello_world_grpc/hello_world_grpc.cc
+++ b/google/cloud/examples/hello_world_grpc/hello_world_grpc.cc
@@ -1,0 +1,44 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <grpcpp/grpcpp.h>
+#include <hello_world.grpc.pb.h>
+#include <iostream>
+
+class GreeterImpl final : public Greet::Service {
+ public:
+  grpc::Status Hello(grpc::ServerContext*, HelloRequest const*,
+                     HelloResponse* response) override {
+    response->set_greeting("Hello World");
+    return grpc::Status::OK;
+  }
+};
+
+int main() {
+  char const* port = std::getenv("PORT");
+  if (port == nullptr) {
+    std::cout
+        << R"""({"severity": "info", "message": "defaulting PORT to 8080"}\n)""";
+    port = "8080";
+  }
+  auto const server_address = std::string{"0.0.0.0:"} + port;
+  GreeterImpl impl;
+  grpc::ServerBuilder builder;
+  builder.AddListeningPort(server_address, grpc::InsecureServerCredentials());
+  builder.RegisterService(&impl);
+  auto server = builder.BuildAndStart();
+  server->Wait();
+
+  return 0;
+}

--- a/google/cloud/examples/hello_world_grpc/vcpkg.json
+++ b/google/cloud/examples/hello_world_grpc/vcpkg.json
@@ -1,0 +1,10 @@
+{
+  "name": "hello-world-grpc",
+  "description": "A gRPC Hello World server to deploy on Cloud Run",
+  "$comment": "Facilitate local development with vcpkg",
+  "version-string": "unversioned",
+  "dependencies": [
+    { "name": "grpc", "host":  true},
+    { "name": "grpc", "host":  false}
+  ]
+}


### PR DESCRIPTION
Application developers may want to deploy gRPC services to Cloud Run, to
authenticate with these services one must use `GenerateIdentityToken()`
in the IAM credentials service, and pass the resulting token to the gRPC
library. This example uses a small "Hello World"-type gRPC service to
demonstrate this use-case.

Fixes #6482

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6583)
<!-- Reviewable:end -->
