### PR TITLE
feat(storage): round-robin stub for GCS+gRPC

### DIFF
--- a/google/cloud/storage/CMakeLists.txt
+++ b/google/cloud/storage/CMakeLists.txt
@@ -329,6 +329,8 @@ if (GOOGLE_CLOUD_CPP_STORAGE_ENABLE_GRPC)
         internal/hybrid_client.h
         internal/storage_auth.cc
         internal/storage_auth.h
+        internal/storage_round_robin.cc
+        internal/storage_round_robin.h
         internal/storage_stub.cc
         internal/storage_stub.h)
     target_link_libraries(
@@ -588,7 +590,8 @@ if (GOOGLE_CLOUD_CPP_STORAGE_ENABLE_GRPC)
             internal/grpc_object_read_source_test.cc
             internal/grpc_resumable_upload_session_test.cc
             internal/grpc_resumable_upload_session_url_test.cc
-            internal/storage_auth_test.cc)
+            internal/storage_auth_test.cc
+            internal/storage_round_robin_test.cc)
 
         foreach (fname ${storage_client_grpc_unit_tests})
             google_cloud_cpp_add_executable(target "storage" "${fname}")

--- a/google/cloud/storage/google_cloud_cpp_storage_grpc.bzl
+++ b/google/cloud/storage/google_cloud_cpp_storage_grpc.bzl
@@ -24,6 +24,7 @@ google_cloud_cpp_storage_grpc_hdrs = [
     "internal/grpc_resumable_upload_session_url.h",
     "internal/hybrid_client.h",
     "internal/storage_auth.h",
+    "internal/storage_round_robin.h",
     "internal/storage_stub.h",
 ]
 
@@ -35,5 +36,6 @@ google_cloud_cpp_storage_grpc_srcs = [
     "internal/grpc_resumable_upload_session_url.cc",
     "internal/hybrid_client.cc",
     "internal/storage_auth.cc",
+    "internal/storage_round_robin.cc",
     "internal/storage_stub.cc",
 ]

--- a/google/cloud/storage/internal/storage_round_robin.cc
+++ b/google/cloud/storage/internal/storage_round_robin.cc
@@ -1,0 +1,214 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/storage/internal/storage_round_robin.h"
+
+namespace google {
+namespace cloud {
+namespace storage {
+inline namespace STORAGE_CLIENT_NS {
+namespace internal {
+
+std::unique_ptr<StorageStub::ObjectMediaStream>
+StorageRoundRobin::GetObjectMedia(
+    std::unique_ptr<grpc::ClientContext> context,
+    google::storage::v1::GetObjectMediaRequest const& request) {
+  return Child()->GetObjectMedia(std::move(context), request);
+}
+
+std::unique_ptr<StorageStub::InsertStream> StorageRoundRobin::InsertObjectMedia(
+    std::unique_ptr<grpc::ClientContext> context) {
+  return Child()->InsertObjectMedia(std::move(context));
+}
+
+Status StorageRoundRobin::DeleteBucketAccessControl(
+    grpc::ClientContext& context,
+    google::storage::v1::DeleteBucketAccessControlRequest const& request) {
+  return Child()->DeleteBucketAccessControl(context, request);
+}
+
+StatusOr<google::storage::v1::BucketAccessControl>
+StorageRoundRobin::GetBucketAccessControl(
+    grpc::ClientContext& context,
+    google::storage::v1::GetBucketAccessControlRequest const& request) {
+  return Child()->GetBucketAccessControl(context, request);
+}
+
+StatusOr<google::storage::v1::BucketAccessControl>
+StorageRoundRobin::InsertBucketAccessControl(
+    grpc::ClientContext& context,
+    google::storage::v1::InsertBucketAccessControlRequest const& request) {
+  return Child()->InsertBucketAccessControl(context, request);
+}
+
+StatusOr<google::storage::v1::ListBucketAccessControlsResponse>
+StorageRoundRobin::ListBucketAccessControls(
+    grpc::ClientContext& context,
+    google::storage::v1::ListBucketAccessControlsRequest const& request) {
+  return Child()->ListBucketAccessControls(context, request);
+}
+
+StatusOr<google::storage::v1::BucketAccessControl>
+StorageRoundRobin::UpdateBucketAccessControl(
+    grpc::ClientContext& context,
+    google::storage::v1::UpdateBucketAccessControlRequest const& request) {
+  return Child()->UpdateBucketAccessControl(context, request);
+}
+
+Status StorageRoundRobin::DeleteBucket(
+    grpc::ClientContext& context,
+    google::storage::v1::DeleteBucketRequest const& request) {
+  return Child()->DeleteBucket(context, request);
+}
+
+StatusOr<google::storage::v1::Bucket> StorageRoundRobin::GetBucket(
+    grpc::ClientContext& context,
+    google::storage::v1::GetBucketRequest const& request) {
+  return Child()->GetBucket(context, request);
+}
+
+StatusOr<google::storage::v1::Bucket> StorageRoundRobin::InsertBucket(
+    grpc::ClientContext& context,
+    google::storage::v1::InsertBucketRequest const& request) {
+  return Child()->InsertBucket(context, request);
+}
+
+StatusOr<google::storage::v1::ListBucketsResponse>
+StorageRoundRobin::ListBuckets(
+    grpc::ClientContext& context,
+    google::storage::v1::ListBucketsRequest const& request) {
+  return Child()->ListBuckets(context, request);
+}
+
+StatusOr<google::iam::v1::Policy> StorageRoundRobin::GetBucketIamPolicy(
+    grpc::ClientContext& context,
+    google::storage::v1::GetIamPolicyRequest const& request) {
+  return Child()->GetBucketIamPolicy(context, request);
+}
+
+StatusOr<google::iam::v1::Policy> StorageRoundRobin::SetBucketIamPolicy(
+    grpc::ClientContext& context,
+    google::storage::v1::SetIamPolicyRequest const& request) {
+  return Child()->SetBucketIamPolicy(context, request);
+}
+
+StatusOr<google::iam::v1::TestIamPermissionsResponse>
+StorageRoundRobin::TestBucketIamPermissions(
+    grpc::ClientContext& context,
+    google::storage::v1::TestIamPermissionsRequest const& request) {
+  return Child()->TestBucketIamPermissions(context, request);
+}
+
+StatusOr<google::storage::v1::Bucket> StorageRoundRobin::UpdateBucket(
+    grpc::ClientContext& context,
+    google::storage::v1::UpdateBucketRequest const& request) {
+  return Child()->UpdateBucket(context, request);
+}
+
+Status StorageRoundRobin::DeleteDefaultObjectAccessControl(
+    grpc::ClientContext& context,
+    google::storage::v1::DeleteDefaultObjectAccessControlRequest const&
+        request) {
+  return Child()->DeleteDefaultObjectAccessControl(context, request);
+}
+
+StatusOr<google::storage::v1::ObjectAccessControl>
+StorageRoundRobin::GetDefaultObjectAccessControl(
+    grpc::ClientContext& context,
+    google::storage::v1::GetDefaultObjectAccessControlRequest const& request) {
+  return Child()->GetDefaultObjectAccessControl(context, request);
+}
+
+StatusOr<google::storage::v1::ObjectAccessControl>
+StorageRoundRobin::InsertDefaultObjectAccessControl(
+    grpc::ClientContext& context,
+    google::storage::v1::InsertDefaultObjectAccessControlRequest const&
+        request) {
+  return Child()->InsertDefaultObjectAccessControl(context, request);
+}
+
+StatusOr<google::storage::v1::ListObjectAccessControlsResponse>
+StorageRoundRobin::ListDefaultObjectAccessControls(
+    grpc::ClientContext& context,
+    google::storage::v1::ListDefaultObjectAccessControlsRequest const&
+        request) {
+  return Child()->ListDefaultObjectAccessControls(context, request);
+}
+
+StatusOr<google::storage::v1::ObjectAccessControl>
+StorageRoundRobin::UpdateDefaultObjectAccessControl(
+    grpc::ClientContext& context,
+    google::storage::v1::UpdateDefaultObjectAccessControlRequest const&
+        request) {
+  return Child()->UpdateDefaultObjectAccessControl(context, request);
+}
+
+Status StorageRoundRobin::DeleteNotification(
+    grpc::ClientContext& context,
+    google::storage::v1::DeleteNotificationRequest const& request) {
+  return Child()->DeleteNotification(context, request);
+}
+
+StatusOr<google::storage::v1::Notification> StorageRoundRobin::GetNotification(
+    grpc::ClientContext& context,
+    google::storage::v1::GetNotificationRequest const& request) {
+  return Child()->GetNotification(context, request);
+}
+
+StatusOr<google::storage::v1::Notification>
+StorageRoundRobin::InsertNotification(
+    grpc::ClientContext& context,
+    google::storage::v1::InsertNotificationRequest const& request) {
+  return Child()->InsertNotification(context, request);
+}
+
+StatusOr<google::storage::v1::ListNotificationsResponse>
+StorageRoundRobin::ListNotifications(
+    grpc::ClientContext& context,
+    google::storage::v1::ListNotificationsRequest const& request) {
+  return Child()->ListNotifications(context, request);
+}
+
+Status StorageRoundRobin::DeleteObject(
+    grpc::ClientContext& context,
+    google::storage::v1::DeleteObjectRequest const& request) {
+  return Child()->DeleteObject(context, request);
+}
+
+StatusOr<google::storage::v1::StartResumableWriteResponse>
+StorageRoundRobin::StartResumableWrite(
+    grpc::ClientContext& context,
+    google::storage::v1::StartResumableWriteRequest const& request) {
+  return Child()->StartResumableWrite(context, request);
+}
+
+StatusOr<google::storage::v1::QueryWriteStatusResponse>
+StorageRoundRobin::QueryWriteStatus(
+    grpc::ClientContext& context,
+    google::storage::v1::QueryWriteStatusRequest const& request) {
+  return Child()->QueryWriteStatus(context, request);
+}
+
+std::shared_ptr<StorageStub> StorageRoundRobin::Child() {
+  std::lock_guard<std::mutex> lk(mu_);
+  auto child = children_[current_];
+  current_ = (current_ + 1) % children_.size();
+  return child;
+}
+
+}  // namespace internal
+}  // namespace STORAGE_CLIENT_NS
+}  // namespace storage
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/storage/internal/storage_round_robin.h
+++ b/google/cloud/storage/internal/storage_round_robin.h
@@ -1,0 +1,149 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_STORAGE_ROUND_ROBIN_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_STORAGE_ROUND_ROBIN_H
+
+#include "google/cloud/storage/internal/storage_stub.h"
+#include "google/cloud/storage/version.h"
+#include <mutex>
+#include <vector>
+
+namespace google {
+namespace cloud {
+namespace storage {
+inline namespace STORAGE_CLIENT_NS {
+namespace internal {
+
+class StorageRoundRobin : public StorageStub {
+ public:
+  explicit StorageRoundRobin(std::vector<std::shared_ptr<StorageStub>> children)
+      : children_(std::move(children)) {}
+  ~StorageRoundRobin() override = default;
+
+  std::unique_ptr<ObjectMediaStream> GetObjectMedia(
+      std::unique_ptr<grpc::ClientContext> context,
+      google::storage::v1::GetObjectMediaRequest const& request) override;
+
+  std::unique_ptr<InsertStream> InsertObjectMedia(
+      std::unique_ptr<grpc::ClientContext> context) override;
+
+  Status DeleteBucketAccessControl(
+      grpc::ClientContext& context,
+      google::storage::v1::DeleteBucketAccessControlRequest const& request)
+      override;
+  StatusOr<google::storage::v1::BucketAccessControl> GetBucketAccessControl(
+      grpc::ClientContext& context,
+      google::storage::v1::GetBucketAccessControlRequest const& request)
+      override;
+  StatusOr<google::storage::v1::BucketAccessControl> InsertBucketAccessControl(
+      grpc::ClientContext& context,
+      google::storage::v1::InsertBucketAccessControlRequest const& request)
+      override;
+  StatusOr<google::storage::v1::ListBucketAccessControlsResponse>
+  ListBucketAccessControls(
+      grpc::ClientContext& context,
+      google::storage::v1::ListBucketAccessControlsRequest const& request)
+      override;
+  StatusOr<google::storage::v1::BucketAccessControl> UpdateBucketAccessControl(
+      grpc::ClientContext& context,
+      google::storage::v1::UpdateBucketAccessControlRequest const& request)
+      override;
+  Status DeleteBucket(
+      grpc::ClientContext& context,
+      google::storage::v1::DeleteBucketRequest const& request) override;
+  StatusOr<google::storage::v1::Bucket> GetBucket(
+      grpc::ClientContext& context,
+      google::storage::v1::GetBucketRequest const& request) override;
+  StatusOr<google::storage::v1::Bucket> InsertBucket(
+      grpc::ClientContext& context,
+      google::storage::v1::InsertBucketRequest const& request) override;
+  StatusOr<google::storage::v1::ListBucketsResponse> ListBuckets(
+      grpc::ClientContext& context,
+      google::storage::v1::ListBucketsRequest const& request) override;
+  StatusOr<google::iam::v1::Policy> GetBucketIamPolicy(
+      grpc::ClientContext& context,
+      google::storage::v1::GetIamPolicyRequest const& request) override;
+  StatusOr<google::iam::v1::Policy> SetBucketIamPolicy(
+      grpc::ClientContext& context,
+      google::storage::v1::SetIamPolicyRequest const& request) override;
+  StatusOr<google::iam::v1::TestIamPermissionsResponse>
+  TestBucketIamPermissions(
+      grpc::ClientContext& context,
+      google::storage::v1::TestIamPermissionsRequest const& request) override;
+  StatusOr<google::storage::v1::Bucket> UpdateBucket(
+      grpc::ClientContext& context,
+      google::storage::v1::UpdateBucketRequest const& request) override;
+  Status DeleteDefaultObjectAccessControl(
+      grpc::ClientContext& context,
+      google::storage::v1::DeleteDefaultObjectAccessControlRequest const&
+          request) override;
+  StatusOr<google::storage::v1::ObjectAccessControl>
+  GetDefaultObjectAccessControl(
+      grpc::ClientContext& context,
+      google::storage::v1::GetDefaultObjectAccessControlRequest const& request)
+      override;
+  StatusOr<google::storage::v1::ObjectAccessControl>
+  InsertDefaultObjectAccessControl(
+      grpc::ClientContext& context,
+      google::storage::v1::InsertDefaultObjectAccessControlRequest const&
+          request) override;
+  StatusOr<google::storage::v1::ListObjectAccessControlsResponse>
+  ListDefaultObjectAccessControls(
+      grpc::ClientContext& context,
+      google::storage::v1::ListDefaultObjectAccessControlsRequest const&
+          request) override;
+  StatusOr<google::storage::v1::ObjectAccessControl>
+  UpdateDefaultObjectAccessControl(
+      grpc::ClientContext& context,
+      google::storage::v1::UpdateDefaultObjectAccessControlRequest const&
+          request) override;
+  Status DeleteNotification(
+      grpc::ClientContext& context,
+      google::storage::v1::DeleteNotificationRequest const& request) override;
+  StatusOr<google::storage::v1::Notification> GetNotification(
+      grpc::ClientContext& context,
+      google::storage::v1::GetNotificationRequest const& request) override;
+  StatusOr<google::storage::v1::Notification> InsertNotification(
+      grpc::ClientContext& context,
+      google::storage::v1::InsertNotificationRequest const& request) override;
+  StatusOr<google::storage::v1::ListNotificationsResponse> ListNotifications(
+      grpc::ClientContext& context,
+      google::storage::v1::ListNotificationsRequest const& request) override;
+  Status DeleteObject(
+      grpc::ClientContext& context,
+      google::storage::v1::DeleteObjectRequest const& request) override;
+  StatusOr<google::storage::v1::StartResumableWriteResponse>
+  StartResumableWrite(
+      grpc::ClientContext& context,
+      google::storage::v1::StartResumableWriteRequest const& request) override;
+  StatusOr<google::storage::v1::QueryWriteStatusResponse> QueryWriteStatus(
+      grpc::ClientContext& context,
+      google::storage::v1::QueryWriteStatusRequest const& request) override;
+
+ private:
+  std::shared_ptr<StorageStub> Child();
+
+  std::vector<std::shared_ptr<StorageStub>> const children_;
+  std::mutex mu_;
+  std::size_t current_ = 0;
+};
+
+}  // namespace internal
+}  // namespace STORAGE_CLIENT_NS
+}  // namespace storage
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_STORAGE_ROUND_ROBIN_H

--- a/google/cloud/storage/internal/storage_round_robin_test.cc
+++ b/google/cloud/storage/internal/storage_round_robin_test.cc
@@ -1,0 +1,588 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/storage/internal/storage_round_robin.h"
+#include "google/cloud/storage/testing/mock_storage_stub.h"
+#include "google/cloud/testing_util/status_matchers.h"
+#include "absl/memory/memory.h"
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+namespace storage {
+inline namespace STORAGE_CLIENT_NS {
+namespace internal {
+namespace {
+
+using ::google::cloud::storage::testing::MockStorageStub;
+using ::google::cloud::testing_util::StatusIs;
+using ::testing::InSequence;
+using ::testing::Return;
+
+// All the tests have nearly identical structure. They create 3 mocks, setup
+// each mock to receive 2 calls of some function, then call the
+// StorageRoundRobin version of that function 6 times.  The mocks are setup to
+// return errors because it is simpler to do so than return the specific
+// "success" type.
+
+auto constexpr kMockCount = 3;
+auto constexpr kRepeats = 2;
+
+std::vector<std::shared_ptr<MockStorageStub>> MakeMocks() {
+  std::vector<std::shared_ptr<MockStorageStub>> mocks(kMockCount);
+  std::generate(mocks.begin(), mocks.end(),
+                [] { return std::make_shared<MockStorageStub>(); });
+  return mocks;
+}
+
+std::vector<std::shared_ptr<StorageStub>> AsPlainStubs(
+    std::vector<std::shared_ptr<MockStorageStub>> mocks) {
+  return std::vector<std::shared_ptr<StorageStub>>(mocks.begin(), mocks.end());
+}
+
+std::unique_ptr<StorageStub::ObjectMediaStream> MakeObjectMediaStream(
+    std::unique_ptr<grpc::ClientContext>,
+    google::storage::v1::GetObjectMediaRequest const&) {
+  using ErrorStream = google::cloud::internal::StreamingReadRpcError<
+      google::storage::v1::GetObjectMediaResponse>;
+  return absl::make_unique<ErrorStream>(
+      Status(StatusCode::kPermissionDenied, "uh-oh"));
+}
+
+std::unique_ptr<StorageStub::InsertStream> MakeInsertStream(
+    std::unique_ptr<grpc::ClientContext>) {
+  using ErrorStream = google::cloud::internal::StreamingWriteRpcError<
+      google::storage::v1::InsertObjectRequest, google::storage::v1::Object>;
+  return absl::make_unique<ErrorStream>(
+      Status(StatusCode::kPermissionDenied, "uh-oh"));
+}
+
+TEST(StorageAuthTest, GetObjectMedia) {
+  auto mocks = MakeMocks();
+  InSequence sequence;
+  for (int i = 0; i != kRepeats; ++i) {
+    for (auto& m : mocks) {
+      EXPECT_CALL(*m, GetObjectMedia).WillOnce(MakeObjectMediaStream);
+    }
+  }
+
+  StorageRoundRobin under_test(AsPlainStubs(mocks));
+  for (size_t i = 0; i != kRepeats * mocks.size(); ++i) {
+    google::storage::v1::GetObjectMediaRequest request;
+    auto response = under_test.GetObjectMedia(
+        absl::make_unique<grpc::ClientContext>(), request);
+    auto v = response->Read();
+    ASSERT_TRUE(absl::holds_alternative<Status>(v));
+    EXPECT_THAT(absl::get<Status>(v), StatusIs(StatusCode::kPermissionDenied));
+  }
+}
+
+TEST(StorageAuthTest, InsertObjectMedia) {
+  auto mocks = MakeMocks();
+  InSequence sequence;
+  for (int i = 0; i != kRepeats; ++i) {
+    for (auto& m : mocks) {
+      EXPECT_CALL(*m, InsertObjectMedia).WillOnce(MakeInsertStream);
+    }
+  }
+
+  StorageRoundRobin under_test(AsPlainStubs(mocks));
+  for (size_t i = 0; i != kRepeats * mocks.size(); ++i) {
+    auto response =
+        under_test.InsertObjectMedia(absl::make_unique<grpc::ClientContext>());
+    EXPECT_THAT(response->Close(), StatusIs(StatusCode::kPermissionDenied));
+  }
+}
+
+TEST(StorageAuthTest, DeleteBucketAccessControl) {
+  auto mocks = MakeMocks();
+  InSequence sequence;
+  for (int i = 0; i != kRepeats; ++i) {
+    for (auto& m : mocks) {
+      EXPECT_CALL(*m, DeleteBucketAccessControl)
+          .WillOnce(Return(Status(StatusCode::kPermissionDenied, "uh-oh")));
+    }
+  }
+
+  StorageRoundRobin under_test(AsPlainStubs(mocks));
+  for (size_t i = 0; i != kRepeats * mocks.size(); ++i) {
+    google::storage::v1::DeleteBucketAccessControlRequest request;
+    grpc::ClientContext ctx;
+    auto response = under_test.DeleteBucketAccessControl(ctx, request);
+    EXPECT_THAT(response, StatusIs(StatusCode::kPermissionDenied));
+  }
+}
+
+TEST(StorageAuthTest, GetBucketAccessControl) {
+  auto mocks = MakeMocks();
+  InSequence sequence;
+  for (int i = 0; i != kRepeats; ++i) {
+    for (auto& m : mocks) {
+      EXPECT_CALL(*m, GetBucketAccessControl)
+          .WillOnce(Return(Status(StatusCode::kPermissionDenied, "uh-oh")));
+    }
+  }
+
+  StorageRoundRobin under_test(AsPlainStubs(mocks));
+  for (size_t i = 0; i != kRepeats * mocks.size(); ++i) {
+    google::storage::v1::GetBucketAccessControlRequest request;
+    grpc::ClientContext ctx;
+    auto response = under_test.GetBucketAccessControl(ctx, request);
+    EXPECT_THAT(response, StatusIs(StatusCode::kPermissionDenied));
+  }
+}
+
+TEST(StorageAuthTest, InsertBucketAccessControl) {
+  auto mocks = MakeMocks();
+  InSequence sequence;
+  for (int i = 0; i != kRepeats; ++i) {
+    for (auto& m : mocks) {
+      EXPECT_CALL(*m, InsertBucketAccessControl)
+          .WillOnce(Return(Status(StatusCode::kPermissionDenied, "uh-oh")));
+    }
+  }
+
+  StorageRoundRobin under_test(AsPlainStubs(mocks));
+  for (size_t i = 0; i != kRepeats * mocks.size(); ++i) {
+    google::storage::v1::InsertBucketAccessControlRequest request;
+    grpc::ClientContext ctx;
+    auto response = under_test.InsertBucketAccessControl(ctx, request);
+    EXPECT_THAT(response, StatusIs(StatusCode::kPermissionDenied));
+  }
+}
+
+TEST(StorageAuthTest, ListBucketAccessControls) {
+  auto mocks = MakeMocks();
+  InSequence sequence;
+  for (int i = 0; i != kRepeats; ++i) {
+    for (auto& m : mocks) {
+      EXPECT_CALL(*m, ListBucketAccessControls)
+          .WillOnce(Return(Status(StatusCode::kPermissionDenied, "uh-oh")));
+    }
+  }
+
+  StorageRoundRobin under_test(AsPlainStubs(mocks));
+  for (size_t i = 0; i != kRepeats * mocks.size(); ++i) {
+    google::storage::v1::ListBucketAccessControlsRequest request;
+    grpc::ClientContext ctx;
+    auto response = under_test.ListBucketAccessControls(ctx, request);
+    EXPECT_THAT(response, StatusIs(StatusCode::kPermissionDenied));
+  }
+}
+
+TEST(StorageAuthTest, UpdateBucketAccessControl) {
+  auto mocks = MakeMocks();
+  InSequence sequence;
+  for (int i = 0; i != kRepeats; ++i) {
+    for (auto& m : mocks) {
+      EXPECT_CALL(*m, UpdateBucketAccessControl)
+          .WillOnce(Return(Status(StatusCode::kPermissionDenied, "uh-oh")));
+    }
+  }
+
+  StorageRoundRobin under_test(AsPlainStubs(mocks));
+  for (size_t i = 0; i != kRepeats * mocks.size(); ++i) {
+    google::storage::v1::UpdateBucketAccessControlRequest request;
+    grpc::ClientContext ctx;
+    auto response = under_test.UpdateBucketAccessControl(ctx, request);
+    EXPECT_THAT(response, StatusIs(StatusCode::kPermissionDenied));
+  }
+}
+
+TEST(StorageAuthTest, DeleteBucket) {
+  auto mocks = MakeMocks();
+  InSequence sequence;
+  for (int i = 0; i != kRepeats; ++i) {
+    for (auto& m : mocks) {
+      EXPECT_CALL(*m, DeleteBucket)
+          .WillOnce(Return(Status(StatusCode::kPermissionDenied, "uh-oh")));
+    }
+  }
+
+  StorageRoundRobin under_test(AsPlainStubs(mocks));
+  for (size_t i = 0; i != kRepeats * mocks.size(); ++i) {
+    google::storage::v1::DeleteBucketRequest request;
+    grpc::ClientContext ctx;
+    auto response = under_test.DeleteBucket(ctx, request);
+    EXPECT_THAT(response, StatusIs(StatusCode::kPermissionDenied));
+  }
+}
+
+TEST(StorageAuthTest, GetBucket) {
+  auto mocks = MakeMocks();
+  InSequence sequence;
+  for (int i = 0; i != kRepeats; ++i) {
+    for (auto& m : mocks) {
+      EXPECT_CALL(*m, GetBucket)
+          .WillOnce(Return(Status(StatusCode::kPermissionDenied, "uh-oh")));
+    }
+  }
+
+  StorageRoundRobin under_test(AsPlainStubs(mocks));
+  for (size_t i = 0; i != kRepeats * mocks.size(); ++i) {
+    google::storage::v1::GetBucketRequest request;
+    grpc::ClientContext ctx;
+    auto response = under_test.GetBucket(ctx, request);
+    EXPECT_THAT(response, StatusIs(StatusCode::kPermissionDenied));
+  }
+}
+
+TEST(StorageAuthTest, InsertBucket) {
+  auto mocks = MakeMocks();
+  InSequence sequence;
+  for (int i = 0; i != kRepeats; ++i) {
+    for (auto& m : mocks) {
+      EXPECT_CALL(*m, InsertBucket)
+          .WillOnce(Return(Status(StatusCode::kPermissionDenied, "uh-oh")));
+    }
+  }
+
+  StorageRoundRobin under_test(AsPlainStubs(mocks));
+  for (size_t i = 0; i != kRepeats * mocks.size(); ++i) {
+    google::storage::v1::InsertBucketRequest request;
+    grpc::ClientContext ctx;
+    auto response = under_test.InsertBucket(ctx, request);
+    EXPECT_THAT(response, StatusIs(StatusCode::kPermissionDenied));
+  }
+}
+
+TEST(StorageAuthTest, ListBuckets) {
+  auto mocks = MakeMocks();
+  InSequence sequence;
+  for (int i = 0; i != kRepeats; ++i) {
+    for (auto& m : mocks) {
+      EXPECT_CALL(*m, ListBuckets)
+          .WillOnce(Return(Status(StatusCode::kPermissionDenied, "uh-oh")));
+    }
+  }
+
+  StorageRoundRobin under_test(AsPlainStubs(mocks));
+  for (size_t i = 0; i != kRepeats * mocks.size(); ++i) {
+    google::storage::v1::ListBucketsRequest request;
+    grpc::ClientContext ctx;
+    auto response = under_test.ListBuckets(ctx, request);
+    EXPECT_THAT(response, StatusIs(StatusCode::kPermissionDenied));
+  }
+}
+
+TEST(StorageAuthTest, GetBucketIamPolicy) {
+  auto mocks = MakeMocks();
+  InSequence sequence;
+  for (int i = 0; i != kRepeats; ++i) {
+    for (auto& m : mocks) {
+      EXPECT_CALL(*m, GetBucketIamPolicy)
+          .WillOnce(Return(Status(StatusCode::kPermissionDenied, "uh-oh")));
+    }
+  }
+
+  StorageRoundRobin under_test(AsPlainStubs(mocks));
+  for (size_t i = 0; i != kRepeats * mocks.size(); ++i) {
+    google::storage::v1::GetIamPolicyRequest request;
+    grpc::ClientContext ctx;
+    auto response = under_test.GetBucketIamPolicy(ctx, request);
+    EXPECT_THAT(response, StatusIs(StatusCode::kPermissionDenied));
+  }
+}
+
+TEST(StorageAuthTest, SetBucketIamPolicy) {
+  auto mocks = MakeMocks();
+  InSequence sequence;
+  for (int i = 0; i != kRepeats; ++i) {
+    for (auto& m : mocks) {
+      EXPECT_CALL(*m, SetBucketIamPolicy)
+          .WillOnce(Return(Status(StatusCode::kPermissionDenied, "uh-oh")));
+    }
+  }
+
+  StorageRoundRobin under_test(AsPlainStubs(mocks));
+  for (size_t i = 0; i != kRepeats * mocks.size(); ++i) {
+    google::storage::v1::SetIamPolicyRequest request;
+    grpc::ClientContext ctx;
+    auto response = under_test.SetBucketIamPolicy(ctx, request);
+    EXPECT_THAT(response, StatusIs(StatusCode::kPermissionDenied));
+  }
+}
+
+TEST(StorageAuthTest, TestBucketIamPermissions) {
+  auto mocks = MakeMocks();
+  InSequence sequence;
+  for (int i = 0; i != kRepeats; ++i) {
+    for (auto& m : mocks) {
+      EXPECT_CALL(*m, TestBucketIamPermissions)
+          .WillOnce(Return(Status(StatusCode::kPermissionDenied, "uh-oh")));
+    }
+  }
+
+  StorageRoundRobin under_test(AsPlainStubs(mocks));
+  for (size_t i = 0; i != kRepeats * mocks.size(); ++i) {
+    google::storage::v1::TestIamPermissionsRequest request;
+    grpc::ClientContext ctx;
+    auto response = under_test.TestBucketIamPermissions(ctx, request);
+    EXPECT_THAT(response, StatusIs(StatusCode::kPermissionDenied));
+  }
+}
+
+TEST(StorageAuthTest, UpdateBucket) {
+  auto mocks = MakeMocks();
+  InSequence sequence;
+  for (int i = 0; i != kRepeats; ++i) {
+    for (auto& m : mocks) {
+      EXPECT_CALL(*m, UpdateBucket)
+          .WillOnce(Return(Status(StatusCode::kPermissionDenied, "uh-oh")));
+    }
+  }
+
+  StorageRoundRobin under_test(AsPlainStubs(mocks));
+  for (size_t i = 0; i != kRepeats * mocks.size(); ++i) {
+    google::storage::v1::UpdateBucketRequest request;
+    grpc::ClientContext ctx;
+    auto response = under_test.UpdateBucket(ctx, request);
+    EXPECT_THAT(response, StatusIs(StatusCode::kPermissionDenied));
+  }
+}
+
+TEST(StorageAuthTest, DeleteDefaultObjectAccessControl) {
+  auto mocks = MakeMocks();
+  InSequence sequence;
+  for (int i = 0; i != kRepeats; ++i) {
+    for (auto& m : mocks) {
+      EXPECT_CALL(*m, DeleteDefaultObjectAccessControl)
+          .WillOnce(Return(Status(StatusCode::kPermissionDenied, "uh-oh")));
+    }
+  }
+
+  StorageRoundRobin under_test(AsPlainStubs(mocks));
+  for (size_t i = 0; i != kRepeats * mocks.size(); ++i) {
+    google::storage::v1::DeleteDefaultObjectAccessControlRequest request;
+    grpc::ClientContext ctx;
+    auto response = under_test.DeleteDefaultObjectAccessControl(ctx, request);
+    EXPECT_THAT(response, StatusIs(StatusCode::kPermissionDenied));
+  }
+}
+
+TEST(StorageAuthTest, GetDefaultObjectAccessControl) {
+  auto mocks = MakeMocks();
+  InSequence sequence;
+  for (int i = 0; i != kRepeats; ++i) {
+    for (auto& m : mocks) {
+      EXPECT_CALL(*m, GetDefaultObjectAccessControl)
+          .WillOnce(Return(Status(StatusCode::kPermissionDenied, "uh-oh")));
+    }
+  }
+
+  StorageRoundRobin under_test(AsPlainStubs(mocks));
+  for (size_t i = 0; i != kRepeats * mocks.size(); ++i) {
+    google::storage::v1::GetDefaultObjectAccessControlRequest request;
+    grpc::ClientContext ctx;
+    auto response = under_test.GetDefaultObjectAccessControl(ctx, request);
+    EXPECT_THAT(response, StatusIs(StatusCode::kPermissionDenied));
+  }
+}
+
+TEST(StorageAuthTest, InsertDefaultObjectAccessControl) {
+  auto mocks = MakeMocks();
+  InSequence sequence;
+  for (int i = 0; i != kRepeats; ++i) {
+    for (auto& m : mocks) {
+      EXPECT_CALL(*m, InsertDefaultObjectAccessControl)
+          .WillOnce(Return(Status(StatusCode::kPermissionDenied, "uh-oh")));
+    }
+  }
+
+  StorageRoundRobin under_test(AsPlainStubs(mocks));
+  for (size_t i = 0; i != kRepeats * mocks.size(); ++i) {
+    google::storage::v1::InsertDefaultObjectAccessControlRequest request;
+    grpc::ClientContext ctx;
+    auto response = under_test.InsertDefaultObjectAccessControl(ctx, request);
+    EXPECT_THAT(response, StatusIs(StatusCode::kPermissionDenied));
+  }
+}
+
+TEST(StorageAuthTest, ListDefaultObjectAccessControls) {
+  auto mocks = MakeMocks();
+  InSequence sequence;
+  for (int i = 0; i != kRepeats; ++i) {
+    for (auto& m : mocks) {
+      EXPECT_CALL(*m, ListDefaultObjectAccessControls)
+          .WillOnce(Return(Status(StatusCode::kPermissionDenied, "uh-oh")));
+    }
+  }
+
+  StorageRoundRobin under_test(AsPlainStubs(mocks));
+  for (size_t i = 0; i != kRepeats * mocks.size(); ++i) {
+    google::storage::v1::ListDefaultObjectAccessControlsRequest request;
+    grpc::ClientContext ctx;
+    auto response = under_test.ListDefaultObjectAccessControls(ctx, request);
+    EXPECT_THAT(response, StatusIs(StatusCode::kPermissionDenied));
+  }
+}
+
+TEST(StorageAuthTest, UpdateDefaultObjectAccessControl) {
+  auto mocks = MakeMocks();
+  InSequence sequence;
+  for (int i = 0; i != kRepeats; ++i) {
+    for (auto& m : mocks) {
+      EXPECT_CALL(*m, UpdateDefaultObjectAccessControl)
+          .WillOnce(Return(Status(StatusCode::kPermissionDenied, "uh-oh")));
+    }
+  }
+
+  StorageRoundRobin under_test(AsPlainStubs(mocks));
+  for (size_t i = 0; i != kRepeats * mocks.size(); ++i) {
+    google::storage::v1::UpdateDefaultObjectAccessControlRequest request;
+    grpc::ClientContext ctx;
+    auto response = under_test.UpdateDefaultObjectAccessControl(ctx, request);
+    EXPECT_THAT(response, StatusIs(StatusCode::kPermissionDenied));
+  }
+}
+
+TEST(StorageAuthTest, DeleteNotification) {
+  auto mocks = MakeMocks();
+  InSequence sequence;
+  for (int i = 0; i != kRepeats; ++i) {
+    for (auto& m : mocks) {
+      EXPECT_CALL(*m, DeleteNotification)
+          .WillOnce(Return(Status(StatusCode::kPermissionDenied, "uh-oh")));
+    }
+  }
+
+  StorageRoundRobin under_test(AsPlainStubs(mocks));
+  for (size_t i = 0; i != kRepeats * mocks.size(); ++i) {
+    google::storage::v1::DeleteNotificationRequest request;
+    grpc::ClientContext ctx;
+    auto response = under_test.DeleteNotification(ctx, request);
+    EXPECT_THAT(response, StatusIs(StatusCode::kPermissionDenied));
+  }
+}
+
+TEST(StorageAuthTest, GetNotification) {
+  auto mocks = MakeMocks();
+  InSequence sequence;
+  for (int i = 0; i != kRepeats; ++i) {
+    for (auto& m : mocks) {
+      EXPECT_CALL(*m, GetNotification)
+          .WillOnce(Return(Status(StatusCode::kPermissionDenied, "uh-oh")));
+    }
+  }
+
+  StorageRoundRobin under_test(AsPlainStubs(mocks));
+  for (size_t i = 0; i != kRepeats * mocks.size(); ++i) {
+    google::storage::v1::GetNotificationRequest request;
+    grpc::ClientContext ctx;
+    auto response = under_test.GetNotification(ctx, request);
+    EXPECT_THAT(response, StatusIs(StatusCode::kPermissionDenied));
+  }
+}
+
+TEST(StorageAuthTest, InsertNotification) {
+  auto mocks = MakeMocks();
+  InSequence sequence;
+  for (int i = 0; i != kRepeats; ++i) {
+    for (auto& m : mocks) {
+      EXPECT_CALL(*m, InsertNotification)
+          .WillOnce(Return(Status(StatusCode::kPermissionDenied, "uh-oh")));
+    }
+  }
+
+  StorageRoundRobin under_test(AsPlainStubs(mocks));
+  for (size_t i = 0; i != kRepeats * mocks.size(); ++i) {
+    google::storage::v1::InsertNotificationRequest request;
+    grpc::ClientContext ctx;
+    auto response = under_test.InsertNotification(ctx, request);
+    EXPECT_THAT(response, StatusIs(StatusCode::kPermissionDenied));
+  }
+}
+
+TEST(StorageAuthTest, ListNotifications) {
+  auto mocks = MakeMocks();
+  InSequence sequence;
+  for (int i = 0; i != kRepeats; ++i) {
+    for (auto& m : mocks) {
+      EXPECT_CALL(*m, ListNotifications)
+          .WillOnce(Return(Status(StatusCode::kPermissionDenied, "uh-oh")));
+    }
+  }
+
+  StorageRoundRobin under_test(AsPlainStubs(mocks));
+  for (size_t i = 0; i != kRepeats * mocks.size(); ++i) {
+    google::storage::v1::ListNotificationsRequest request;
+    grpc::ClientContext ctx;
+    auto response = under_test.ListNotifications(ctx, request);
+    EXPECT_THAT(response, StatusIs(StatusCode::kPermissionDenied));
+  }
+}
+
+TEST(StorageAuthTest, DeleteObject) {
+  auto mocks = MakeMocks();
+  InSequence sequence;
+  for (int i = 0; i != kRepeats; ++i) {
+    for (auto& m : mocks) {
+      EXPECT_CALL(*m, DeleteObject)
+          .WillOnce(Return(Status(StatusCode::kPermissionDenied, "uh-oh")));
+    }
+  }
+
+  StorageRoundRobin under_test(AsPlainStubs(mocks));
+  for (size_t i = 0; i != kRepeats * mocks.size(); ++i) {
+    google::storage::v1::DeleteObjectRequest request;
+    grpc::ClientContext ctx;
+    auto response = under_test.DeleteObject(ctx, request);
+    EXPECT_THAT(response, StatusIs(StatusCode::kPermissionDenied));
+  }
+}
+
+TEST(StorageAuthTest, StartResumableWrite) {
+  auto mocks = MakeMocks();
+  InSequence sequence;
+  for (int i = 0; i != kRepeats; ++i) {
+    for (auto& m : mocks) {
+      EXPECT_CALL(*m, StartResumableWrite)
+          .WillOnce(Return(Status(StatusCode::kPermissionDenied, "uh-oh")));
+    }
+  }
+
+  StorageRoundRobin under_test(AsPlainStubs(mocks));
+  for (size_t i = 0; i != kRepeats * mocks.size(); ++i) {
+    google::storage::v1::StartResumableWriteRequest request;
+    grpc::ClientContext ctx;
+    auto response = under_test.StartResumableWrite(ctx, request);
+    EXPECT_THAT(response, StatusIs(StatusCode::kPermissionDenied));
+  }
+}
+
+TEST(StorageAuthTest, QueryWriteStatus) {
+  auto mocks = MakeMocks();
+  InSequence sequence;
+  for (int i = 0; i != kRepeats; ++i) {
+    for (auto& m : mocks) {
+      EXPECT_CALL(*m, QueryWriteStatus)
+          .WillOnce(Return(Status(StatusCode::kPermissionDenied, "uh-oh")));
+    }
+  }
+
+  StorageRoundRobin under_test(AsPlainStubs(mocks));
+  for (size_t i = 0; i != kRepeats * mocks.size(); ++i) {
+    google::storage::v1::QueryWriteStatusRequest request;
+    grpc::ClientContext ctx;
+    auto response = under_test.QueryWriteStatus(ctx, request);
+    EXPECT_THAT(response, StatusIs(StatusCode::kPermissionDenied));
+  }
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace STORAGE_CLIENT_NS
+}  // namespace storage
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/storage/storage_client_grpc_unit_tests.bzl
+++ b/google/cloud/storage/storage_client_grpc_unit_tests.bzl
@@ -26,4 +26,5 @@ storage_client_grpc_unit_tests = [
     "internal/grpc_resumable_upload_session_test.cc",
     "internal/grpc_resumable_upload_session_url_test.cc",
     "internal/storage_auth_test.cc",
+    "internal/storage_round_robin_test.cc",
 ]


### PR DESCRIPTION
This will make it easier to use the plugin in applications and
benchmarks, so far we have been using ad-hoc functions to create
separate channels in each thread or some similar hack.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6584)
<!-- Reviewable:end -->
