### PR TITLE
feat(storage): support multiple channels in GCS+gRPC

### DIFF
--- a/google/cloud/storage/benchmarks/storage_throughput_vs_cpu_benchmark.cc
+++ b/google/cloud/storage/benchmarks/storage_throughput_vs_cpu_benchmark.cc
@@ -246,8 +246,7 @@ TestResults RunThread(ThroughputOptions const& options,
 
   gcs::Client rest_client(*client_options);
 
-  auto uploaders =
-      gcs_bm::CreateUploadExperiments(options, *client_options, thread_id);
+  auto uploaders = gcs_bm::CreateUploadExperiments(options, *client_options);
   if (uploaders.empty()) {
     // This is possible if only gRPC is requested but the benchmark was compiled
     // without gRPC support.

--- a/google/cloud/storage/benchmarks/throughput_experiment.cc
+++ b/google/cloud/storage/benchmarks/throughput_experiment.cc
@@ -326,8 +326,7 @@ class DownloadObjectRawGrpc : public ThroughputExperiment {
 
 std::vector<std::unique_ptr<ThroughputExperiment>> CreateUploadExperiments(
     ThroughputOptions const& options,
-    google::cloud::storage::ClientOptions const& client_options,
-    int thread_id) {
+    google::cloud::storage::ClientOptions const& client_options) {
   auto generator = google::cloud::internal::DefaultPRNG(std::random_device{}());
   auto contents = MakeRandomData(generator, options.maximum_write_size);
   gcs::Client rest_client(client_options);
@@ -340,7 +339,6 @@ std::vector<std::unique_ptr<ThroughputExperiment>> CreateUploadExperiments(
       case ApiName::kApiRawGrpc: {
         gcs::Client grpc_client =
             google::cloud::storage_experimental::DefaultGrpcClient(
-                thread_id,
                 google::cloud::storage::internal::MakeOptions(client_options))
                 .value();
         result.push_back(
@@ -384,7 +382,6 @@ std::vector<std::unique_ptr<ThroughputExperiment>> CreateDownloadExperiments(
       case ApiName::kApiGrpc:
         result.push_back(absl::make_unique<DownloadObject>(
             google::cloud::storage_experimental::DefaultGrpcClient(
-                thread_id,
                 google::cloud::storage::internal::MakeOptions(client_options))
                 .value(),
             a));

--- a/google/cloud/storage/benchmarks/throughput_experiment.cc
+++ b/google/cloud/storage/benchmarks/throughput_experiment.cc
@@ -352,7 +352,6 @@ std::vector<std::unique_ptr<ThroughputExperiment>> CreateUploadExperiments(
 #else
       case ApiName::kApiGrpc:
       case ApiName::kApiRawGrpc:
-        (void)thread_id;
         break;
 #endif  // GOOGLE_CLOUD_CPP_STORAGE_HAVE_GRPC
       case ApiName::kApiXml:

--- a/google/cloud/storage/benchmarks/throughput_experiment.h
+++ b/google/cloud/storage/benchmarks/throughput_experiment.h
@@ -56,7 +56,7 @@ class ThroughputExperiment {
  */
 std::vector<std::unique_ptr<ThroughputExperiment>> CreateUploadExperiments(
     ThroughputOptions const& options,
-    google::cloud::storage::ClientOptions const& client_options, int thread_id);
+    google::cloud::storage::ClientOptions const& client_options);
 
 /**
  * Create the list of download experiments based on the @p options.

--- a/google/cloud/storage/benchmarks/throughput_experiment_test.cc
+++ b/google/cloud/storage/benchmarks/throughput_experiment_test.cc
@@ -54,8 +54,7 @@ TEST_P(ThroughputExperimentIntegrationTest, Upload) {
   auto const& client_options =
       google::cloud::storage::internal::ClientImplDetails::GetRawClient(*client)
           ->client_options();
-  auto experiments =
-      CreateUploadExperiments(options, client_options, /*thread_id=*/0);
+  auto experiments = CreateUploadExperiments(options, client_options);
   for (auto& e : experiments) {
     auto object_name = MakeRandomObjectName();
     ThroughputExperimentConfig config{OpType::kOpInsert,

--- a/google/cloud/storage/grpc_plugin.cc
+++ b/google/cloud/storage/grpc_plugin.cc
@@ -32,15 +32,10 @@ bool UseGrpcForMetadata() {
 }  // namespace
 
 StatusOr<google::cloud::storage::Client> DefaultGrpcClient(Options opts) {
-  return DefaultGrpcClient(0, std::move(opts));
-}
-
-StatusOr<google::cloud::storage::Client> DefaultGrpcClient(int channel_id,
-                                                           Options opts) {
   opts = google::cloud::storage::internal::DefaultOptionsGrpc(std::move(opts));
   if (UseGrpcForMetadata()) {
     return storage::internal::ClientImplDetails::CreateClient(
-        storage::internal::GrpcClient::Create(opts, channel_id));
+        storage::internal::GrpcClient::Create(opts));
   }
   // The hybrid client might need the OAuth2 credentials
   if (!opts.has<storage::internal::Oauth2CredentialsOption>()) {
@@ -54,7 +49,7 @@ StatusOr<google::cloud::storage::Client> DefaultGrpcClient(int channel_id,
         *std::move(credentials));
   }
   return storage::internal::ClientImplDetails::CreateClient(
-      storage::internal::HybridClient::Create(opts, channel_id));
+      storage::internal::HybridClient::Create(opts));
 }
 
 }  // namespace STORAGE_CLIENT_NS

--- a/google/cloud/storage/grpc_plugin.h
+++ b/google/cloud/storage/grpc_plugin.h
@@ -36,25 +36,10 @@ inline namespace STORAGE_CLIENT_NS {
  * @note the Credentials parameter in the configuration is ignored. The gRPC
  *     client only supports Google Default Credentials.
  *
- * @param channel_id set the `grpc.channel_id` attribute in the underlying
- *   gRPC channel, this can be used to segregate the gRPC channels for different
- *   clients.
  * @param opts the configuration parameters for the Client.
  *
  * @warning this is an experimental feature, and subject to change without
  *     notice.
- */
-StatusOr<google::cloud::storage::Client> DefaultGrpcClient(int channel_id,
-                                                           Options opts = {});
-
-/**
- * Create a `google::cloud::storage::Client` object configured to use gRPC.
- *
- * @warning this is an experimental feature, and subject to change without
- *     notice.
- *
- * @par Example
- * @snippet storage_grpc_samples.cc grpc-default-client
  */
 StatusOr<google::cloud::storage::Client> DefaultGrpcClient(Options opts = {});
 

--- a/google/cloud/storage/internal/grpc_client.h
+++ b/google/cloud/storage/internal/grpc_client.h
@@ -40,8 +40,6 @@ class GrpcClient : public RawClient,
                    public std::enable_shared_from_this<GrpcClient> {
  public:
   static std::shared_ptr<GrpcClient> Create(Options const& opts);
-  static std::shared_ptr<GrpcClient> Create(Options const& opts,
-                                            int channel_id);
   ~GrpcClient() override = default;
 
   //@{
@@ -322,7 +320,7 @@ class GrpcClient : public RawClient,
   static std::string MD5ToProto(std::string const&);
 
  protected:
-  explicit GrpcClient(Options const& opts, int channel_id);
+  explicit GrpcClient(Options const& opts);
 
  private:
   ClientOptions backwards_compatibility_options_;

--- a/google/cloud/storage/internal/grpc_resumable_upload_session_test.cc
+++ b/google/cloud/storage/internal/grpc_resumable_upload_session_test.cc
@@ -50,8 +50,7 @@ class MockGrpcClient : public GrpcClient {
 
   MockGrpcClient()
       : GrpcClient(DefaultOptionsGrpc(Options{}.set<GrpcCredentialOption>(
-                       grpc::InsecureChannelCredentials())),
-                   /*channel_id=*/0) {}
+            grpc::InsecureChannelCredentials()))) {}
 
   MOCK_METHOD(std::unique_ptr<GrpcClient::InsertStream>, CreateUploadWriter,
               (std::unique_ptr<grpc::ClientContext>), (override));

--- a/google/cloud/storage/internal/hybrid_client.cc
+++ b/google/cloud/storage/internal/hybrid_client.cc
@@ -21,14 +21,12 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace internal {
 
-std::shared_ptr<RawClient> HybridClient::Create(Options const& options,
-                                                int channel_id) {
-  return std::shared_ptr<RawClient>(new HybridClient(options, channel_id));
+std::shared_ptr<RawClient> HybridClient::Create(Options const& options) {
+  return std::shared_ptr<RawClient>(new HybridClient(options));
 }
 
-HybridClient::HybridClient(Options const& options, int channel_id)
-    : grpc_(GrpcClient::Create(options, channel_id)),
-      curl_(CurlClient::Create(options)) {}
+HybridClient::HybridClient(Options const& options)
+    : grpc_(GrpcClient::Create(options)), curl_(CurlClient::Create(options)) {}
 
 ClientOptions const& HybridClient::client_options() const {
   return curl_->client_options();

--- a/google/cloud/storage/internal/hybrid_client.h
+++ b/google/cloud/storage/internal/hybrid_client.h
@@ -29,11 +29,7 @@ namespace internal {
 
 class HybridClient : public RawClient {
  public:
-  static std::shared_ptr<RawClient> Create(Options const& options) {
-    return Create(std::move(options), /*channel_id=*/0);
-  }
-  static std::shared_ptr<RawClient> Create(Options const& options,
-                                           int channel_id);
+  static std::shared_ptr<RawClient> Create(Options const& options);
   ~HybridClient() override = default;
 
   ClientOptions const& client_options() const override;
@@ -149,7 +145,7 @@ class HybridClient : public RawClient {
       DeleteNotificationRequest const&) override;
 
  private:
-  explicit HybridClient(Options const& options, int channel_id);
+  explicit HybridClient(Options const& options);
 
   std::shared_ptr<GrpcClient> grpc_;
   std::shared_ptr<CurlClient> curl_;


### PR DESCRIPTION
Like our other gRPC-based libraries we need to support multiple channels
behind the same client to get good throughput. This implements the
"round robin" layer for that case.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6593)
<!-- Reviewable:end -->
