### PR TITLE
ci: log cache.sh command

### DIFF
--- a/ci/cloudbuild/cache.sh
+++ b/ci/cloudbuild/cache.sh
@@ -39,6 +39,9 @@ function print_usage() {
   sed -n '17,/^$/s/^# \?//p' "${PROGRAM_PATH}"
 }
 
+io::log "Executing command:"
+printf "env -C '%s' %q\n" "$(pwd)" "$@"
+
 # Use getopt to parse and normalize all the args.
 PARSED="$(getopt -a \
   --options="h" \

--- a/ci/cloudbuild/cache.sh
+++ b/ci/cloudbuild/cache.sh
@@ -39,8 +39,10 @@ function print_usage() {
   sed -n '17,/^$/s/^# \?//p' "${PROGRAM_PATH}"
 }
 
-io::log "Executing command:"
-printf "env -C '%s' %q\n" "$(pwd)" "$@"
+io::log "Running:"
+printf "env -C '%s' %s" "$(pwd)" "$0"
+printf " %q" "$@"
+printf "\n"
 
 # Use getopt to parse and normalize all the args.
 PARSED="$(getopt -a \


### PR DESCRIPTION
Sometimes it's useful to use the cached artifacts that were used in a GCB build even when running locally in docker. This may help reproduce build breaks if they're cache related. This prints the command to run locally to pull the production cache

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6597)
<!-- Reviewable:end -->
