### PR TITLE
refactor(bigtable): pull out tests for SampleRows, AsyncSampleRows into their own test fixture

### DIFF
--- a/google/cloud/bigtable/tests/CMakeLists.txt
+++ b/google/cloud/bigtable/tests/CMakeLists.txt
@@ -28,7 +28,8 @@ set(bigtable_client_integration_tests
     filters_integration_test.cc
     instance_admin_async_future_integration_test.cc
     instance_admin_integration_test.cc
-    mutations_integration_test.cc)
+    mutations_integration_test.cc
+    table_sample_rows_integration_test.cc)
 
 include(CreateBazelConfig)
 export_list_to_bazel("bigtable_client_integration_tests.bzl"

--- a/google/cloud/bigtable/tests/bigtable_client_integration_tests.bzl
+++ b/google/cloud/bigtable/tests/bigtable_client_integration_tests.bzl
@@ -28,4 +28,5 @@ bigtable_client_integration_tests = [
     "instance_admin_async_future_integration_test.cc",
     "instance_admin_integration_test.cc",
     "mutations_integration_test.cc",
+    "table_sample_rows_integration_test.cc",
 ]

--- a/google/cloud/bigtable/tests/data_async_future_integration_test.cc
+++ b/google/cloud/bigtable/tests/data_async_future_integration_test.cc
@@ -278,68 +278,6 @@ TEST_F(DataAsyncFutureIntegrationTest, TableReadRowTest) {
   CheckEqualUnordered(expected, actual);
 }
 
-TEST_F(DataAsyncFutureIntegrationTest, TableSampleRowsTest) {
-  auto table = GetTable();
-
-  // Create kBatchSize * kBatchCount rows. Use a special client with tracing
-  // disabled because it simply generates too much data.
-  auto bulk_table =
-      bigtable::Table(bigtable::CreateDefaultDataClient(
-                          testing::TableTestEnvironment::project_id(),
-                          testing::TableTestEnvironment::instance_id(),
-                          ClientOptions().disable_tracing("rpc")),
-                      testing::TableTestEnvironment::table_id());
-  int constexpr kBatchCount = 10;
-  int constexpr kBatchSize = 5000;
-  int constexpr kColumnCount = 10;
-  int rowid = 0;
-  for (int batch = 0; batch != kBatchCount; ++batch) {
-    BulkMutation bulk;
-    for (int row = 0; row != kBatchSize; ++row) {
-      std::ostringstream os;
-      os << "row:" << std::setw(9) << std::setfill('0') << rowid;
-
-      // Build a mutation that creates 10 columns.
-      SingleRowMutation mutation(os.str());
-      for (int col = 0; col != kColumnCount; ++col) {
-        std::string colid = "c" + std::to_string(col);
-        std::string value = colid + "#" + os.str();
-        mutation.emplace_back(SetCell(kFamily, std::move(colid),
-                                      std::chrono::milliseconds(0),
-                                      std::move(value)));
-      }
-      bulk.emplace_back(std::move(mutation));
-      ++rowid;
-    }
-    auto failures = bulk_table.BulkApply(std::move(bulk));
-    ASSERT_THAT(failures, ::testing::IsEmpty());
-  }
-
-  auto fut = table.AsyncSampleRows();
-
-  // Block until the asynchronous operation completes. This is not what one
-  // would do in a real application (the synchronous API is better in that
-  // case), but we need to wait before checking the results.
-  auto samples = fut.get();
-  ASSERT_STATUS_OK(samples);
-
-  // It is somewhat hard to verify that the values returned here are correct.
-  // We cannot check the specific values, not even the format, of the row keys
-  // because Cloud Bigtable might return an empty row key (for "end of table"),
-  // and it might return row keys that have never been written to.
-  // All we can check is that this is not empty, and that the offsets are in
-  // ascending order.
-  EXPECT_FALSE(samples->empty());
-  std::int64_t previous = 0;
-  for (auto const& s : *samples) {
-    EXPECT_LE(previous, s.offset_bytes);
-    previous = s.offset_bytes;
-  }
-  // At least one of the samples should have non-zero offset:
-  auto last = samples->back();
-  EXPECT_LT(0, last.offset_bytes);
-}
-
 }  // namespace
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable

--- a/google/cloud/bigtable/tests/data_integration_test.cc
+++ b/google/cloud/bigtable/tests/data_integration_test.cc
@@ -456,62 +456,6 @@ TEST_F(DataIntegrationTest, TableCellValueInt64Test) {
   CheckEqualUnordered(expected_ignore_timestamp, actual_ignore_timestamp);
 }
 
-TEST_F(DataIntegrationTest, TableSampleRowKeysTest) {
-  auto table = GetTable();
-
-  // Create kBatchSize * kBatchCount rows. Use a special client with tracing
-  // disabled because it simply generates too much data.
-  auto bulk_table =
-      bigtable::Table(bigtable::CreateDefaultDataClient(
-                          testing::TableTestEnvironment::project_id(),
-                          testing::TableTestEnvironment::instance_id(),
-                          ClientOptions().disable_tracing("rpc")),
-                      testing::TableTestEnvironment::table_id());
-  int constexpr kBatchCount = 10;
-  int constexpr kBatchSize = 5000;
-  int constexpr kColumnCount = 10;
-  int rowid = 0;
-  for (int batch = 0; batch != kBatchCount; ++batch) {
-    BulkMutation bulk;
-    for (int row = 0; row != kBatchSize; ++row) {
-      std::ostringstream os;
-      os << "row:" << std::setw(9) << std::setfill('0') << rowid;
-
-      // Build a mutation that creates 10 columns.
-      SingleRowMutation mutation(os.str());
-      for (int col = 0; col != kColumnCount; ++col) {
-        std::string colid = "c" + std::to_string(col);
-        std::string value = colid + "#" + os.str();
-        mutation.emplace_back(SetCell(kFamily1, std::move(colid),
-                                      std::chrono::milliseconds(0),
-                                      std::move(value)));
-      }
-      bulk.emplace_back(std::move(mutation));
-      ++rowid;
-    }
-    auto failures = bulk_table.BulkApply(std::move(bulk));
-    ASSERT_THAT(failures, ::testing::IsEmpty());
-  }
-  auto samples = table.SampleRows();
-  ASSERT_STATUS_OK(samples);
-
-  // It is somewhat hard to verify that the values returned here are correct.
-  // We cannot check the specific values, not even the format, of the row keys
-  // because Cloud Bigtable might return an empty row key (for "end of table"),
-  // and it might return row keys that have never been written to.
-  // All we can check is that this is not empty, and that the offsets are in
-  // ascending order.
-  EXPECT_FALSE(samples->empty());
-  std::int64_t previous = 0;
-  for (auto const& s : *samples) {
-    EXPECT_LE(previous, s.offset_bytes);
-    previous = s.offset_bytes;
-  }
-  // At least one of the samples should have non-zero offset:
-  auto last = samples->back();
-  EXPECT_LT(0, last.offset_bytes);
-}
-
 TEST_F(DataIntegrationTest, TableReadMultipleCellsBigValue) {
   if (UsingCloudBigtableEmulator()) {
     // TODO(#151) - remove workarounds for emulator bug(s).

--- a/google/cloud/bigtable/tests/table_sample_rows_integration_test.cc
+++ b/google/cloud/bigtable/tests/table_sample_rows_integration_test.cc
@@ -1,0 +1,136 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/bigtable/client_options.h"
+#include "google/cloud/bigtable/data_client.h"
+#include "google/cloud/bigtable/mutations.h"
+#include "google/cloud/bigtable/row_key_sample.h"
+#include "google/cloud/bigtable/table.h"
+#include "google/cloud/bigtable/testing/table_integration_test.h"
+#include "google/cloud/testing_util/integration_test.h"
+#include "google/cloud/testing_util/status_matchers.h"
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <chrono>
+#include <memory>
+#include <ostream>
+#include <string>
+#include <vector>
+
+namespace google {
+namespace cloud {
+namespace bigtable {
+inline namespace BIGTABLE_CLIENT_NS {
+namespace {
+
+void VerifySamples(StatusOr<std::vector<RowKeySample>> samples) {
+  ASSERT_STATUS_OK(samples);
+
+  // It is somewhat hard to verify that the values returned here are correct.
+  // We cannot check the specific values, not even the format, of the row keys
+  // because Cloud Bigtable might return an empty row key (for "end of table"),
+  // and it might return row keys that have never been written to.
+  // All we can check is that this is not empty, and that the offsets are in
+  // ascending order.
+  EXPECT_FALSE(samples->empty());
+  std::int64_t previous = 0;
+  for (auto const& s : *samples) {
+    EXPECT_LE(previous, s.offset_bytes);
+    previous = s.offset_bytes;
+  }
+  // At least one of the samples should have non-zero offset:
+  auto last = samples->back();
+  EXPECT_LT(0, last.offset_bytes);
+}
+
+using testing::TableTestEnvironment;
+
+class SampleRowsIntegrationTest
+    : public ::google::cloud::testing_util::IntegrationTest {
+ public:
+  static void SetUpTestSuite() {
+    table_ = absl::make_unique<Table>(
+        bigtable::Table(bigtable::CreateDefaultDataClient(
+                            TableTestEnvironment::project_id(),
+                            TableTestEnvironment::instance_id(),
+                            ClientOptions().disable_tracing("rpc")),
+                        TableTestEnvironment::table_id()));
+
+    int constexpr kBatchCount = 10;
+    int constexpr kBatchSize = 5000;
+    int constexpr kColumnCount = 10;
+    std::string const family = "family1";
+    int rowid = 0;
+
+    for (int batch = 0; batch != kBatchCount; ++batch) {
+      BulkMutation bulk;
+      for (int row = 0; row != kBatchSize; ++row) {
+        std::ostringstream os;
+        os << "row:" << std::setw(9) << std::setfill('0') << rowid;
+
+        // Build a mutation that creates 10 columns.
+        SingleRowMutation mutation(os.str());
+        for (int col = 0; col != kColumnCount; ++col) {
+          std::string column_id = "c" + std::to_string(col);
+          std::string value = column_id + "#" + os.str();
+          mutation.emplace_back(SetCell(family, std::move(column_id),
+                                        std::chrono::milliseconds(0),
+                                        std::move(value)));
+        }
+        bulk.emplace_back(std::move(mutation));
+        ++rowid;
+      }
+      auto failures = table_->BulkApply(std::move(bulk));
+      for (auto const& failure : failures) {
+        std::cout << failure.original_index() << ": " << failure.status()
+                  << "\n";
+      }
+      ASSERT_THAT(failures, ::testing::IsEmpty());
+    }
+  }
+
+  static void TearDownTestSuite() { table_ = nullptr; }
+
+ protected:
+  static std::unique_ptr<Table> table_;
+};
+
+std::unique_ptr<Table> SampleRowsIntegrationTest::table_;
+
+TEST_F(SampleRowsIntegrationTest, Synchronous) {
+  VerifySamples(table_->SampleRows());
+};
+
+TEST_F(SampleRowsIntegrationTest, Asynchronous) {
+  auto fut = table_->AsyncSampleRows();
+
+  // Block until the asynchronous operation completes. This is not what one
+  // would do in a real application (the synchronous API is better in that
+  // case), but we need to wait before checking the results.
+  VerifySamples(fut.get());
+};
+
+}  // namespace
+}  // namespace BIGTABLE_CLIENT_NS
+}  // namespace bigtable
+}  // namespace cloud
+}  // namespace google
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleMock(&argc, argv);
+  (void)::testing::AddGlobalTestEnvironment(
+      new google::cloud::bigtable::testing::TableTestEnvironment);
+
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Pros:
* could save test time (since the async test was added)
* could have implications for #441, as we are no longer calling `SampleRowKeys` and `DropRowRange` on the same table in the emulator

Cons:
* increases `CreateTable` calls from 7 to 8 per build. We still should be fine on the GCB quota though.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6599)
<!-- Reviewable:end -->
