### PR TITLE
cleanup: move gRPC example protos to a package

### DIFF
--- a/ci/cloudbuild/builds/lib/integration.sh
+++ b/ci/cloudbuild/builds/lib/integration.sh
@@ -183,7 +183,7 @@ function integration::bazel_with_emulators() {
     --format='value(status.url)')"
 
   hello_world_grpc="$(gcloud run services describe \
-    hello-world-grpc \
+    hello-world-grpc-r2 \
     --project="${GOOGLE_CLOUD_PROJECT}" \
     --region="us-central1" --platform="managed" \
     --format='value(status.url)')"

--- a/google/cloud/examples/BUILD
+++ b/google/cloud/examples/BUILD
@@ -81,7 +81,7 @@ cc_test(
     timeout = "long",
     srcs = ["grpc_credential_types.cc"],
     copts = [
-        "-I$(GENDIR)",
+        "-I$(GENDIR)/google/cloud/examples",
     ],
     tags = [
         "integration-test",

--- a/google/cloud/examples/CMakeLists.txt
+++ b/google/cloud/examples/CMakeLists.txt
@@ -30,6 +30,8 @@ if (BUILD_TESTING)
     google_cloud_cpp_grpcpp_library(
         hello_world_protos "hello_world_grpc/hello_world.proto"
         PROTO_PATH_DIRECTORIES ${CMAKE_CURRENT_SOURCE_DIR})
+    target_include_directories(hello_world_protos
+                               PUBLIC "${CMAKE_CURRENT_BINARY_DIR}")
 
     add_executable(grpc_credential_types grpc_credential_types.cc)
     target_link_libraries(

--- a/google/cloud/examples/README.md
+++ b/google/cloud/examples/README.md
@@ -19,7 +19,7 @@ docker run hello-world
 We use Docker to create an image with our "Greeter" service:
 
 ```shell
-docker build -t "gcr.io/${GOOGLE_CLOUD_PROJECT}/hello-world-grpc:latest" \
+docker build -t "gcr.io/${GOOGLE_CLOUD_PROJECT}/hello-world-grpc-r2:latest" \
     -f google/cloud/examples/hello_world_grpc/Dockerfile \
     google/cloud/examples/hello_world_grpc
 ```
@@ -27,14 +27,14 @@ docker build -t "gcr.io/${GOOGLE_CLOUD_PROJECT}/hello-world-grpc:latest" \
 ### Push the Docker image to GCR
 
 ```shell
-docker push "gcr.io/${GOOGLE_CLOUD_PROJECT}/hello-world-grpc:latest"
+docker push "gcr.io/${GOOGLE_CLOUD_PROJECT}/hello-world-grpc-r2:latest"
 ```
 
 ### Deploy to Cloud Run
 
 ```shell
 SA="hello-world-run-sa@${GOOGLE_CLOUD_PROJECT}.iam.gserviceaccount.com"
-gcloud run deploy hello-world-grpc \
+gcloud run deploy hello-world-grpc-r2 \
     --project="${GOOGLE_CLOUD_PROJECT}" \
     --image="gcr.io/${GOOGLE_CLOUD_PROJECT}/hello-world-grpc:latest" \
     --region="us-central1" \
@@ -48,7 +48,7 @@ gcloud run deploy hello-world-grpc \
 
 ```shell
 GOOGLE_CLOUD_CPP_TEST_HELLO_WORLD_GRPC_URL="$(gcloud run services describe \
-    hello-world-grpc \
+    hello-world-grpc-r2 \
     --project="${GOOGLE_CLOUD_PROJECT}" \
     --region="us-central1" --platform="managed" \
     --format='value(status.url)')"

--- a/google/cloud/examples/README.md
+++ b/google/cloud/examples/README.md
@@ -36,7 +36,7 @@ docker push "gcr.io/${GOOGLE_CLOUD_PROJECT}/hello-world-grpc-r2:latest"
 SA="hello-world-run-sa@${GOOGLE_CLOUD_PROJECT}.iam.gserviceaccount.com"
 gcloud run deploy hello-world-grpc-r2 \
     --project="${GOOGLE_CLOUD_PROJECT}" \
-    --image="gcr.io/${GOOGLE_CLOUD_PROJECT}/hello-world-grpc:latest" \
+    --image="gcr.io/${GOOGLE_CLOUD_PROJECT}/hello-world-grpc-r2:latest" \
     --region="us-central1" \
     --platform="managed" \
     --service-account="${SA}" \

--- a/google/cloud/examples/grpc_credential_types.cc
+++ b/google/cloud/examples/grpc_credential_types.cc
@@ -19,8 +19,8 @@
 #include "google/cloud/testing_util/example_driver.h"
 #include "absl/strings/str_split.h"
 #include "absl/time/time.h"  // NOLINT(modernize-deprecated-headers)
-#include <google/cloud/examples/hello_world_grpc/hello_world.grpc.pb.h>
 #include <curl/curl.h>
+#include <hello_world_grpc/hello_world.grpc.pb.h>
 #include <chrono>
 #include <stdexcept>
 #include <thread>
@@ -210,12 +210,12 @@ void UseIdTokenGrpc(google::cloud::iam::IAMCredentialsClient client,
         grpc::SslCredentials(grpc::SslCredentialsOptions{}),
         grpc::AccessTokenCredentials(token->token()));
     auto channel = grpc::CreateChannel(endpoint, credentials);
-    auto stub = Greet::NewStub(channel);
-    auto request = HelloRequest{};
+    auto stub = google::cloud::examples::Greet::NewStub(channel);
+    auto request = google::cloud::examples::HelloRequest{};
     auto backoff = std::chrono::milliseconds(250);
     for (int i = 0; i != 3; ++i) {
       grpc::ClientContext context;
-      HelloResponse response;
+      google::cloud::examples::HelloResponse response;
       auto status = stub->Hello(&context, request, &response);
       if (status.ok()) {
         std::cout << "Servers says: " << response.greeting() << "\n";

--- a/google/cloud/examples/hello_world_grpc/hello_world.proto
+++ b/google/cloud/examples/hello_world_grpc/hello_world.proto
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 syntax = "proto3";
+package google.cloud.examples;
 
 service Greet {
   rpc Hello(HelloRequest) returns (HelloResponse) {}

--- a/google/cloud/examples/hello_world_grpc/hello_world_grpc.cc
+++ b/google/cloud/examples/hello_world_grpc/hello_world_grpc.cc
@@ -16,10 +16,11 @@
 #include <hello_world.grpc.pb.h>
 #include <iostream>
 
-class GreeterImpl final : public Greet::Service {
+class GreeterImpl final : public google::cloud::examples::Greet::Service {
  public:
-  grpc::Status Hello(grpc::ServerContext*, HelloRequest const*,
-                     HelloResponse* response) override {
+  grpc::Status Hello(
+      grpc::ServerContext*, google::cloud::examples::HelloRequest const*,
+      google::cloud::examples::HelloResponse* response) override {
     response->set_greeting("Hello World");
     return grpc::Status::OK;
   }


### PR DESCRIPTION
They cannot be imported into Google's code with the protos in the global
namespace, they conflict with other protos.

I changed the name of the Cloud Run deployment so we can have two
running, once this PR is merged I will send a second one to change
the name back and delete the `*-r2` deployment once that is merged.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6600)
<!-- Reviewable:end -->
