### PR TITLE
Revert "ci(gcb): move builds to custom worker pool"

### DIFF
--- a/ci/cloudbuild/README.md
+++ b/ci/cloudbuild/README.md
@@ -101,26 +101,3 @@ while achieving high likelihood of the code working for our customers.
 * Sanitizer builds need to run integration tests
 * We want to test our user-facing instructions (i.e., how to install and use)
   as much as possible (this is difficult on macOS and Windows without docker)
-
-## GCB Worker Pool
-
-We use a lot of GCB quota, so our GCB builds are run in a [custom worker
-pool][custom-worker-pool]. You can see our worker pool(s) in the web UI at
-https://console.cloud.google.com/cloud-build/settings/worker-pool?project=cloud-cpp-testing-resources
-See `gcloud beta builds worker-pools --help` for more info about worker pools.
-
-We initially created the pool with the following command:
-
-```
-$ gcloud beta builds worker-pools create \
-  --region=us-east1 \
-  --project=cloud-cpp-testing-resources \
-  --worker-machine-type=e2-standard-32 \
-  --worker-disk-size=100 \
-  google-cloud-cpp-pool
-```
-
-Details of the pool can be changed with the **`update`** (rather than `create`)
-command.
-
-[custom-worker-pool]: https://cloud.google.com/build/docs/custom-workers/run-builds-in-custom-worker-pool

--- a/ci/cloudbuild/cloudbuild.yaml
+++ b/ci/cloudbuild/cloudbuild.yaml
@@ -13,7 +13,8 @@
 # limitations under the License.
 
 options:
-  workerPool: 'projects/${PROJECT_ID}/locations/${_REGION}/workerPools/google-cloud-cpp-pool'
+  machineType: 'N1_HIGHCPU_32'
+  diskSizeGb: '512'
   dynamic_substitutions: true
   env: [
     'HOME=/h',
@@ -25,7 +26,7 @@ options:
     'COMMIT_SHA=${COMMIT_SHA}',
     'PR_NUMBER=${_PR_NUMBER}',
     'TRIGGER_TYPE=${_TRIGGER_TYPE}',
-    'CONSOLE_LOG_URL=https://console.cloud.google.com/cloud-build/builds;region=${_REGION}/${BUILD_ID};tab=detail?project=${PROJECT_ID}',
+    'CONSOLE_LOG_URL=https://console.cloud.google.com/cloud-build/builds;region=global/${BUILD_ID};tab=detail?project=${PROJECT_ID}',
     'RAW_LOG_URL=https://storage.googleapis.com/${_LOGS_BUCKET}/logs/google-cloud-cpp/${_TRIGGER_SOURCE}/${COMMIT_SHA}/${_DISTRO}-${_BUILD_NAME}/log-${BUILD_ID}.txt'
   ]
   volumes:
@@ -42,7 +43,6 @@ substitutions:
   _TRIGGER_SOURCE: '${_PR_NUMBER:-main}'
   _TRIGGER_TYPE: 'manual'
   _LOGS_BUCKET: 'cloud-cpp-community-publiclogs'
-  _REGION: 'us-east1'
 
 timeout: 3600s
 tags: [
@@ -159,14 +159,14 @@ steps:
     - |
       set -xe
       test -z "${_PR_NUMBER}" && exit 0
-      ctime="$(gcloud builds describe --region '${_REGION}' --format 'value(create_time)' '${BUILD_ID}')"
+      ctime="$(gcloud builds describe --format 'value(create_time)' '${BUILD_ID}')"
       query="tags=pr"
       query+=" AND tags=${_PR_NUMBER}"
       query+=" AND tags=${_BUILD_NAME}"
       query+=" AND substitutions.COMMIT_SHA != ${COMMIT_SHA}"
       query+=" AND create_time > ${ctime}"
-      gcloud builds list --region '${_REGION}' --limit 1 --format='value(id)' --filter "${query}" | \
-        grep . && gcloud builds cancel --region '${_REGION}' '${BUILD_ID}' || exit 0
+      gcloud builds list --limit 1 --format='value(id)' --filter "${query}" | \
+        grep . && gcloud builds cancel '${BUILD_ID}' || exit 0
 
   # Cancels in-progress builds for previous commits in the current PR so we can
   # free up resources to start running the builds for the new commit.
@@ -178,10 +178,10 @@ steps:
     - |
       set -xe
       test -z "${_PR_NUMBER}" && exit 0
-      ctime="$(gcloud builds describe --region '${_REGION}' --format 'value(create_time)' '${BUILD_ID}')"
+      ctime="$(gcloud builds describe --format 'value(create_time)' '${BUILD_ID}')"
       query="tags=pr"
       query+=" AND tags=${_PR_NUMBER}"
       query+=" AND substitutions.COMMIT_SHA != ${COMMIT_SHA}"
       query+=" AND create_time < ${ctime}"
-      gcloud builds list --region '${_REGION}' --ongoing --format='value(id)' --filter "${query}" | \
-        xargs -r -t gcloud builds cancel --region '${_REGION}'
+      gcloud builds list --ongoing --format='value(id)' --filter "${query}" | \
+        xargs -r -t gcloud builds cancel


### PR DESCRIPTION
Reverts googleapis/google-cloud-cpp#6598

This doesn't seem to work for me today. I'm going to revert while I debug so that others aren't impacted.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6601)
<!-- Reviewable:end -->
