### PR TITLE
ci: reintroduce logging of important build commands

### DIFF
--- a/ci/cloudbuild/build.sh
+++ b/ci/cloudbuild/build.sh
@@ -236,7 +236,8 @@ if [[ "${DOCKER_FLAG}" = "true" ]]; then
   mkdir -p "${out_cmake}" "${out_home}/.config/gcloud"
   image="gcb-${DISTRO_FLAG}:latest"
   io::log_h2 "Building docker image: ${image}"
-  docker build -t "${image}" "--build-arg=NCPU=$(nproc)" \
+  io::log_and_run \
+    docker build -t "${image}" "--build-arg=NCPU=$(nproc)" \
     -f "ci/cloudbuild/dockerfiles/${DISTRO_FLAG}.Dockerfile" ci
   io::log_h2 "Starting docker container: ${image}"
   run_flags=(
@@ -277,7 +278,7 @@ if [[ "${DOCKER_FLAG}" = "true" ]]; then
     printf "\n\n"
     cmd=("bash")
   fi
-  docker run "${run_flags[@]}" "${image}" "${cmd[@]}"
+  io::log_and_run docker run "${run_flags[@]}" "${image}" "${cmd[@]}"
   exit
 fi
 
@@ -321,4 +322,4 @@ args=(
   "--substitutions=$(printf "%s," "${subs[@]}")"
   "--project=${project}"
 )
-gcloud builds submit "${args[@]}" .
+io::log_and_run gcloud builds submit "${args[@]}" .

--- a/ci/cloudbuild/build.sh
+++ b/ci/cloudbuild/build.sh
@@ -236,7 +236,7 @@ if [[ "${DOCKER_FLAG}" = "true" ]]; then
   mkdir -p "${out_cmake}" "${out_home}/.config/gcloud"
   image="gcb-${DISTRO_FLAG}:latest"
   io::log_h2 "Building docker image: ${image}"
-  io::log_and_run \
+  io::run \
     docker build -t "${image}" "--build-arg=NCPU=$(nproc)" \
     -f "ci/cloudbuild/dockerfiles/${DISTRO_FLAG}.Dockerfile" ci
   io::log_h2 "Starting docker container: ${image}"
@@ -278,7 +278,7 @@ if [[ "${DOCKER_FLAG}" = "true" ]]; then
     printf "\n\n"
     cmd=("bash")
   fi
-  io::log_and_run docker run "${run_flags[@]}" "${image}" "${cmd[@]}"
+  io::run docker run "${run_flags[@]}" "${image}" "${cmd[@]}"
   exit
 fi
 
@@ -322,4 +322,4 @@ args=(
   "--substitutions=$(printf "%s," "${subs[@]}")"
   "--project=${project}"
 )
-io::log_and_run gcloud builds submit "${args[@]}" .
+io::run gcloud builds submit "${args[@]}" .

--- a/ci/lib/io.sh
+++ b/ci/lib/io.sh
@@ -75,10 +75,18 @@ function io::log_red() {
   io::internal::log_impl "${IO_COLOR_RED}" "$@"
 }
 
-# Logs the arguments, in bold with a timestamp, like they were a command
-# executed under "set -x" in the shell (i.e., with a ${PS4} prefix).
-function io::log_cmdline() {
-  io::internal::log_impl "${IO_BOLD}" "${PS4}$*"
+# Logs the given message in bold with a timestamp.
+function io::log_bold() {
+  io::internal::log_impl "${IO_BOLD}" "$@"
+}
+
+# Logs the arguments, in bold with a timestamp, and then executes them.
+# This is like executing a command under "set -x" in the shell (including
+# the ${PS4} prefix).
+function io::log_and_run() {
+  local cmd="$(printf ' %q' "$@")"
+  io::log_bold "${PS4}${cmd# }"
+  "$@"
 }
 
 # Logs an "H1" heading. This looks like a blank line, followed by the message

--- a/ci/lib/io.sh
+++ b/ci/lib/io.sh
@@ -83,7 +83,7 @@ function io::log_bold() {
 # Logs the arguments, in bold with a timestamp, and then executes them.
 # This is like executing a command under "set -x" in the shell (including
 # the ${PS4} prefix).
-function io::log_and_run() {
+function io::run() {
   local cmd
   cmd="$(printf ' %q' "$@")"
   io::log_bold "${PS4}${cmd# }"

--- a/ci/lib/io.sh
+++ b/ci/lib/io.sh
@@ -84,7 +84,8 @@ function io::log_bold() {
 # This is like executing a command under "set -x" in the shell (including
 # the ${PS4} prefix).
 function io::log_and_run() {
-  local cmd="$(printf ' %q' "$@")"
+  local cmd
+  cmd="$(printf ' %q' "$@")"
   io::log_bold "${PS4}${cmd# }"
   "$@"
 }


### PR DESCRIPTION
Rebrand `io::log_cmdline` as `io::log_and_run`, which, as the
name suggests, now also executes the command so as to eliminate
duplication at the call site.  This version also adds quoting.

Introduce `io::log_and_run` into the `ci/cloudbuild/build.sh`
script. Additions to any of the `ci/cloudbuild/builds/*.sh`
scripts can be made as the need arises.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6609)
<!-- Reviewable:end -->
