### PR TITLE
feat(storage): add Retry Test API to emulator

### DIFF
--- a/google/cloud/storage/emulator/README.md
+++ b/google/cloud/storage/emulator/README.md
@@ -84,3 +84,40 @@ For N==1 and N==2 behave like `return-305-after-256K`, for `N>=3` ignore the
 failure instruction and return successfully. This is used to test failures during
 retry, the client cooperates by sending the retry counter in the failure
 instructions.
+
+
+## Retry Test API
+
+### Creating a new Retry Test
+
+```bash
+    curl -X POST "http://localhost:9000/retry_test" -H 'Content-Type: application/json' \
+         -d '{"instructions":{"storage.buckets.list": ["return-503"]}}'
+```
+
+### Get a Retry Test resource
+
+```bash
+    curl -X GET "http://localhost:9000/retry_test/1d05c20627844214a9ff7cbcf696317d"
+```
+
+### Delete a Retry Test resource
+
+```bash
+    curl -X DELETE "http://localhost:9000/retry_test/1d05c20627844214a9ff7cbcf696317d"
+```
+
+### Causing a failure using x-retry-test-id header
+
+```bash
+    curl -H "x-retry-test-id: 1d05c20627844214a9ff7cbcf696317d" "http://localhost:9100/storage/v1/b?project=test"
+```
+
+### Forced Failures Supported
+
+| Failure Id              | Description
+| ----------------------- | ---
+| return-X                | Emulator will fail with HTTP code provided for `X`, e.g. return-503 returns a 503
+| return-X-after-YK       | Not Supported. Return X after YKiB of uploaded data
+| return-broken-stream    | Emulator will fail after sending 10 bytes
+| return-reset-connection | Emulator will fail with a reset connection

--- a/google/cloud/storage/emulator/tests/test_utils.py
+++ b/google/cloud/storage/emulator/tests/test_utils.py
@@ -21,6 +21,7 @@ import unittest
 import urllib
 import gzip
 import utils
+import json
 
 from werkzeug.test import create_environ
 from werkzeug.wrappers import Request
@@ -472,6 +473,151 @@ class TestError(unittest.TestCase):
         self.assertIn("Traceback (most recent call last):", body)
         self.assertIn("TypeError", body)
         self.assertIn("custom message", body)
+        conn.close()
+
+
+class TestRetryTest(unittest.TestCase):
+    def setUp(self):
+        self.emulator = os.getenv("CLOUD_STORAGE_EMULATOR_ENDPOINT")
+        if self.emulator is None:
+            self.skipTest("CLOUD_STORAGE_EMULATOR_ENDPOINT is not set")
+        self.conn = http.client.HTTPConnection(
+            self.emulator[len("http://") :], timeout=10
+        )
+
+    def tearDown(self):
+        self.conn.close()
+
+    def test_retry_test_resource_crud(self):
+        self.conn.request("GET", "/retry_tests")
+        response = self.conn.getresponse()
+        self.assertEqual(response.code, 200)
+        self.conn.close()
+
+        initial_retry_test = {"instructions": {"storage.buckets.list": ["return-503"]}}
+        request_body = json.dumps(initial_retry_test)
+        self.conn.request("POST", "/retry_test", body=request_body)
+        response = self.conn.getresponse()
+        body = response.read().decode("utf-8")
+        retry_test = json.loads(body)
+        retry_test_id = retry_test.get("id", None)
+        self.assertIsNotNone(retry_test_id)
+        self.conn.close()
+
+        self.conn.request("GET", "/retry_test/%s" % (retry_test_id))
+        response = self.conn.getresponse()
+        body = response.read().decode("utf-8")
+        retry_test = json.loads(body)
+        self.assertEqual(retry_test["instructions"], initial_retry_test["instructions"])
+        self.conn.close()
+
+        self.conn.request("DELETE", "/retry_test/%s" % (retry_test_id))
+        response = self.conn.getresponse()
+        body = response.read().decode("utf-8")
+        self.assertIn("Deleted %s" % (retry_test_id), body)
+        self.conn.close()
+
+    def test_retry_test_reset_connection(self):
+
+        initial_retry_test = {
+            "instructions": {"storage.buckets.list": ["return-reset-connection"]}
+        }
+        request_body = json.dumps(initial_retry_test)
+        self.conn.request("POST", "/retry_test", body=request_body)
+        response = self.conn.getresponse()
+        body = response.read().decode("utf-8")
+        retry_test = json.loads(body)
+        retry_test_id = retry_test.get("id", None)
+        self.assertIsNotNone(retry_test_id)
+        self.conn.close()
+
+        self.conn.request(
+            "GET",
+            "/storage/v1/b?project=test",
+            headers={"x-retry-test-id": retry_test_id},
+        )
+        with self.assertRaises(ConnectionResetError):
+            response = self.conn.getresponse()
+
+        self.conn.request("DELETE", "/retry_test/%s" % (retry_test_id))
+        response = self.conn.getresponse()
+        body = response.read().decode("utf-8")
+        self.assertIn("Deleted %s" % (retry_test_id), body)
+        self.conn.close()
+
+    def test_retry_test_broken_stream(self):
+
+        initial_retry_test = {
+            "instructions": {"storage.buckets.list": ["return-broken-stream"]}
+        }
+        request_body = json.dumps(initial_retry_test)
+        self.conn.request("POST", "/retry_test", body=request_body)
+        response = self.conn.getresponse()
+        body = response.read().decode("utf-8")
+        retry_test = json.loads(body)
+        retry_test_id = retry_test.get("id", None)
+        self.assertIsNotNone(retry_test_id)
+        self.conn.close()
+
+        self.conn.request(
+            "GET",
+            "/storage/v1/b?project=test",
+            headers={"x-retry-test-id": retry_test_id},
+        )
+        with self.assertRaises(http.client.IncompleteRead):
+            response = self.conn.getresponse()
+            response.read().decode("utf-8")
+        self.conn.close()
+
+        self.conn.request("DELETE", "/retry_test/%s" % (retry_test_id))
+        response = self.conn.getresponse()
+        body = response.read().decode("utf-8")
+        self.assertIn("Deleted %s" % (retry_test_id), body)
+        self.conn.close()
+
+    def test_retry_test_503(self):
+
+        initial_retry_test = {
+            "instructions": {"storage.buckets.list": ["return-503", "return-503"]}
+        }
+        request_body = json.dumps(initial_retry_test)
+        self.conn.request("POST", "/retry_test", body=request_body)
+        response = self.conn.getresponse()
+        body = response.read().decode("utf-8")
+        retry_test = json.loads(body)
+        retry_test_id = retry_test.get("id", None)
+        self.assertIsNotNone(retry_test_id)
+        self.conn.close()
+
+        self.conn.request(
+            "GET",
+            "/storage/v1/b?project=test",
+            headers={"x-retry-test-id": retry_test_id},
+        )
+        self.assertEqual(self.conn.getresponse().code, 503)
+        self.conn.close()
+
+        self.conn.request(
+            "GET",
+            "/storage/v1/b?project=test",
+            headers={"x-retry-test-id": retry_test_id},
+        )
+        self.assertEqual(self.conn.getresponse().code, 503)
+        self.conn.close()
+
+        self.conn.request(
+            "GET",
+            "/storage/v1/b?project=test",
+            headers={"x-retry-test-id": retry_test_id},
+        )
+        self.assertEqual(self.conn.getresponse().code, 200)
+        self.conn.close()
+
+        self.conn.request("DELETE", "/retry_test/%s" % (retry_test_id))
+        response = self.conn.getresponse()
+        body = response.read().decode("utf-8")
+        self.assertIn("Deleted %s" % (retry_test_id), body)
+        self.conn.close()
 
 
 class TestHandleGzip(unittest.TestCase):

--- a/google/cloud/storage/emulator/tests/test_utils.py
+++ b/google/cloud/storage/emulator/tests/test_utils.py
@@ -20,6 +20,7 @@ import os
 import unittest
 import urllib
 import gzip
+import socket
 import utils
 import json
 

--- a/google/cloud/storage/emulator/utils/common.py
+++ b/google/cloud/storage/emulator/utils/common.py
@@ -388,6 +388,7 @@ def handle_retry_test_instruction(database, request, method):
                 fd.setsockopt(
                     socket.SOL_SOCKET, socket.SO_LINGER, struct.pack("ii", 1, 0)
                 )
+                fd.close()
                 sys.exit(1)
             elif items[0] == "broken-stream":
 

--- a/google/cloud/storage/emulator/utils/common.py
+++ b/google/cloud/storage/emulator/utils/common.py
@@ -399,6 +399,8 @@ def handle_retry_test_instruction(database, request, method):
                         chunk_size = 4
                         for r in range(0, len(d), chunk_size):
                             if r >= 10:
+                                fd = request.environ["gunicorn.socket"]
+                                fd.close()
                                 sys.exit(1)
                             chunk_end = min(r + chunk_size, len(d))
                             yield d[r:chunk_end]


### PR DESCRIPTION
Feature to add Retry Test API into the emulator to support retry strategy conformance testing in Storage libraries.

cc: @tritone

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6610)
<!-- Reviewable:end -->
