### PR TITLE
feat(common): make unified Credentials public

### DIFF
--- a/google/cloud/CMakeLists.txt
+++ b/google/cloud/CMakeLists.txt
@@ -110,6 +110,8 @@ add_library(
     ${CMAKE_CURRENT_BINARY_DIR}/internal/build_info.cc
     backoff_policy.h
     common_options.h
+    credentials.cc
+    credentials.h
     future.h
     future_generic.h
     future_void.h
@@ -132,8 +134,8 @@ add_library(
     internal/build_info.h
     internal/compiler_info.cc
     internal/compiler_info.h
-    internal/credentials.cc
-    internal/credentials.h
+    internal/credentials_impl.cc
+    internal/credentials_impl.h
     internal/diagnostics_pop.inc
     internal/diagnostics_push.inc
     internal/disable_deprecation_warnings.inc
@@ -260,7 +262,7 @@ if (BUILD_TESTING)
         internal/backoff_policy_test.cc
         internal/big_endian_test.cc
         internal/compiler_info_test.cc
-        internal/credentials_test.cc
+        internal/credentials_impl_test.cc
         internal/env_test.cc
         internal/filesystem_test.cc
         internal/format_time_point_test.cc

--- a/google/cloud/credentials.cc
+++ b/google/cloud/credentials.cc
@@ -12,63 +12,50 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "google/cloud/internal/credentials.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/internal/credentials_impl.h"
 
 namespace google {
 namespace cloud {
 inline namespace GOOGLE_CLOUD_CPP_NS {
-namespace internal {
 
 Credentials::~Credentials() = default;
 
-void CredentialsVisitor::dispatch(Credentials& credentials,
-                                  CredentialsVisitor& visitor) {
-  credentials.dispatch(visitor);
-}
-
 std::shared_ptr<Credentials> MakeInsecureCredentials() {
-  return std::make_shared<InsecureCredentialsConfig>();
+  return std::make_shared<internal::InsecureCredentialsConfig>();
 }
 
 std::shared_ptr<Credentials> MakeGoogleDefaultCredentials() {
-  return std::make_shared<GoogleDefaultCredentialsConfig>();
+  return std::make_shared<internal::GoogleDefaultCredentialsConfig>();
 }
 
 std::shared_ptr<Credentials> MakeAccessTokenCredentials(
     std::string const& access_token,
     std::chrono::system_clock::time_point expiration) {
-  return std::make_shared<AccessTokenConfig>(access_token, expiration);
+  return std::make_shared<internal::AccessTokenConfig>(access_token,
+                                                       expiration);
 }
 
 std::shared_ptr<Credentials> MakeImpersonateServiceAccountCredentials(
     std::shared_ptr<Credentials> base_credentials,
     std::string target_service_account, Options opts) {
-  opts = MergeOptions(
+  opts = internal::MergeOptions(
       std::move(opts),
       Options{}
           .set<ScopesOption>({"https://www.googleapis.com/auth/cloud-platform"})
           .set<AccessTokenLifetimeOption>(
               std::chrono::seconds(std::chrono::hours(1))));
-  return std::make_shared<ImpersonateServiceAccountConfig>(
+  return std::make_shared<internal::ImpersonateServiceAccountConfig>(
       std::move(base_credentials), std::move(target_service_account),
       std::move(opts));
 }
 
 std::shared_ptr<Credentials> MakeServiceAccountCredentials(
     std::string json_object) {
-  return std::make_shared<ServiceAccountConfig>(std::move(json_object));
+  return std::make_shared<internal::ServiceAccountConfig>(
+      std::move(json_object));
 }
 
-ImpersonateServiceAccountConfig::ImpersonateServiceAccountConfig(
-    std::shared_ptr<Credentials> base_credentials,
-    std::string target_service_account, Options opts)
-    : base_credentials_(std::move(base_credentials)),
-      target_service_account_(std::move(target_service_account)),
-      lifetime_(opts.get<AccessTokenLifetimeOption>()),
-      scopes_(std::move(opts.lookup<ScopesOption>())),
-      delegates_(std::move(opts.lookup<DelegatesOption>())) {}
-
-}  // namespace internal
 }  // namespace GOOGLE_CLOUD_CPP_NS
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/credentials.h
+++ b/google/cloud/credentials.h
@@ -12,15 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_CREDENTIALS_H
-#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_CREDENTIALS_H
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CREDENTIALS_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CREDENTIALS_H
 
 #include "google/cloud/options.h"
-#include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
-#include "absl/types/optional.h"
 #include <chrono>
-#include <functional>
 #include <memory>
 #include <string>
 #include <vector>
@@ -32,8 +29,6 @@ namespace internal {
 class CredentialsVisitor;
 }  // namespace internal
 
-// TODO(#6293) - move unified credentials out of internal namespace
-namespace internal {
 /**
  * The public interface for Google's Unified Auth Client (GUAC) library.
  *
@@ -63,8 +58,8 @@ class Credentials {
   virtual ~Credentials() = 0;
 
  private:
-  friend class CredentialsVisitor;
-  virtual void dispatch(CredentialsVisitor& visitor) = 0;
+  friend class internal::CredentialsVisitor;
+  virtual void dispatch(internal::CredentialsVisitor& visitor) = 0;
 };
 
 /**
@@ -208,107 +203,8 @@ struct UnifiedCredentialsOption {
   using Type = std::shared_ptr<Credentials>;
 };
 
-}  // namespace internal
-
-namespace internal {
-
-/// Represents an access token with a known expiration time.
-struct AccessToken {
-  std::string token;
-  std::chrono::system_clock::time_point expiration;
-};
-
-class InsecureCredentialsConfig;
-class GoogleDefaultCredentialsConfig;
-class AccessTokenConfig;
-class ImpersonateServiceAccountConfig;
-class ServiceAccountConfig;
-
-class CredentialsVisitor {
- public:
-  virtual ~CredentialsVisitor() = default;
-  virtual void visit(InsecureCredentialsConfig&) = 0;
-  virtual void visit(GoogleDefaultCredentialsConfig&) = 0;
-  virtual void visit(AccessTokenConfig&) = 0;
-  virtual void visit(ImpersonateServiceAccountConfig&) = 0;
-  virtual void visit(ServiceAccountConfig&) = 0;
-
-  static void dispatch(Credentials& credentials, CredentialsVisitor& visitor);
-};
-
-class InsecureCredentialsConfig : public Credentials {
- public:
-  ~InsecureCredentialsConfig() override = default;
-
- private:
-  void dispatch(CredentialsVisitor& v) override { v.visit(*this); }
-};
-
-class GoogleDefaultCredentialsConfig : public Credentials {
- public:
-  ~GoogleDefaultCredentialsConfig() override = default;
-
- private:
-  void dispatch(CredentialsVisitor& v) override { v.visit(*this); }
-};
-
-class AccessTokenConfig : public Credentials {
- public:
-  AccessTokenConfig(std::string token,
-                    std::chrono::system_clock::time_point expiration)
-      : access_token_(AccessToken{std::move(token), expiration}) {}
-  ~AccessTokenConfig() override = default;
-
-  AccessToken const& access_token() const { return access_token_; }
-
- private:
-  void dispatch(CredentialsVisitor& v) override { v.visit(*this); }
-  AccessToken access_token_;
-};
-
-class ImpersonateServiceAccountConfig : public Credentials {
- public:
-  ImpersonateServiceAccountConfig(std::shared_ptr<Credentials> base_credentials,
-                                  std::string target_service_account,
-                                  Options opts);
-
-  std::shared_ptr<Credentials> base_credentials() const {
-    return base_credentials_;
-  }
-  std::string const& target_service_account() const {
-    return target_service_account_;
-  }
-  std::chrono::seconds lifetime() const { return lifetime_; }
-  std::vector<std::string> const& scopes() const { return scopes_; }
-  std::vector<std::string> const& delegates() const { return delegates_; }
-
- private:
-  void dispatch(CredentialsVisitor& v) override { v.visit(*this); }
-
-  std::shared_ptr<Credentials> base_credentials_;
-  std::string target_service_account_;
-  std::chrono::seconds lifetime_;
-  std::vector<std::string> scopes_;
-  std::vector<std::string> delegates_;
-};
-
-class ServiceAccountConfig : public Credentials {
- public:
-  explicit ServiceAccountConfig(std::string json_object)
-      : json_object_(std::move(json_object)) {}
-
-  std::string const& json_object() const& { return json_object_; }
-  std::string&& json_object() && { return std::move(json_object_); }
-
- private:
-  void dispatch(CredentialsVisitor& v) override { v.visit(*this); }
-
-  std::string json_object_;
-};
-
-}  // namespace internal
 }  // namespace GOOGLE_CLOUD_CPP_NS
 }  // namespace cloud
 }  // namespace google
 
-#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_CREDENTIALS_H
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CREDENTIALS_H

--- a/google/cloud/google_cloud_cpp_common.bzl
+++ b/google/cloud/google_cloud_cpp_common.bzl
@@ -19,6 +19,7 @@
 google_cloud_cpp_common_hdrs = [
     "backoff_policy.h",
     "common_options.h",
+    "credentials.h",
     "future.h",
     "future_generic.h",
     "future_void.h",
@@ -36,7 +37,7 @@ google_cloud_cpp_common_hdrs = [
     "internal/big_endian.h",
     "internal/build_info.h",
     "internal/compiler_info.h",
-    "internal/credentials.h",
+    "internal/credentials_impl.h",
     "internal/diagnostics_pop.inc",
     "internal/diagnostics_push.inc",
     "internal/disable_deprecation_warnings.inc",
@@ -79,12 +80,13 @@ google_cloud_cpp_common_hdrs = [
 ]
 
 google_cloud_cpp_common_srcs = [
+    "credentials.cc",
     "iam_bindings.cc",
     "iam_policy.cc",
     "internal/api_client_header.cc",
     "internal/backoff_policy.cc",
     "internal/compiler_info.cc",
-    "internal/credentials.cc",
+    "internal/credentials_impl.cc",
     "internal/filesystem.cc",
     "internal/format_time_point.cc",
     "internal/future_impl.cc",

--- a/google/cloud/google_cloud_cpp_common_unit_tests.bzl
+++ b/google/cloud/google_cloud_cpp_common_unit_tests.bzl
@@ -28,7 +28,7 @@ google_cloud_cpp_common_unit_tests = [
     "internal/backoff_policy_test.cc",
     "internal/big_endian_test.cc",
     "internal/compiler_info_test.cc",
-    "internal/credentials_test.cc",
+    "internal/credentials_impl_test.cc",
     "internal/env_test.cc",
     "internal/filesystem_test.cc",
     "internal/format_time_point_test.cc",

--- a/google/cloud/internal/credentials_impl.cc
+++ b/google/cloud/internal/credentials_impl.cc
@@ -12,35 +12,28 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_ACCESS_TOKEN_CREDENTIALS_H
-#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_ACCESS_TOKEN_CREDENTIALS_H
-
-#include "google/cloud/storage/oauth2/credentials.h"
-#include "google/cloud/storage/version.h"
 #include "google/cloud/internal/credentials_impl.h"
-#include <string>
 
 namespace google {
 namespace cloud {
-namespace storage {
-inline namespace STORAGE_CLIENT_NS {
+inline namespace GOOGLE_CLOUD_CPP_NS {
 namespace internal {
 
-class AccessTokenCredentials : public oauth2::Credentials {
- public:
-  explicit AccessTokenCredentials(
-      google::cloud::internal::AccessToken const& access_token);
+void CredentialsVisitor::dispatch(Credentials& credentials,
+                                  CredentialsVisitor& visitor) {
+  credentials.dispatch(visitor);
+}
 
-  StatusOr<std::string> AuthorizationHeader() override;
-
- private:
-  std::string header_;
-};
+ImpersonateServiceAccountConfig::ImpersonateServiceAccountConfig(
+    std::shared_ptr<Credentials> base_credentials,
+    std::string target_service_account, Options opts)
+    : base_credentials_(std::move(base_credentials)),
+      target_service_account_(std::move(target_service_account)),
+      lifetime_(opts.get<AccessTokenLifetimeOption>()),
+      scopes_(std::move(opts.lookup<ScopesOption>())),
+      delegates_(std::move(opts.lookup<DelegatesOption>())) {}
 
 }  // namespace internal
-}  // namespace STORAGE_CLIENT_NS
-}  // namespace storage
+}  // namespace GOOGLE_CLOUD_CPP_NS
 }  // namespace cloud
 }  // namespace google
-
-#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_ACCESS_TOKEN_CREDENTIALS_H

--- a/google/cloud/internal/credentials_impl.h
+++ b/google/cloud/internal/credentials_impl.h
@@ -1,0 +1,133 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_CREDENTIALS_IMPL_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_CREDENTIALS_IMPL_H
+
+#include "google/cloud/credentials.h"
+#include "google/cloud/options.h"
+#include "google/cloud/status_or.h"
+#include "google/cloud/version.h"
+#include "absl/types/optional.h"
+#include <chrono>
+#include <functional>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace google {
+namespace cloud {
+inline namespace GOOGLE_CLOUD_CPP_NS {
+namespace internal {
+
+/// Represents an access token with a known expiration time.
+struct AccessToken {
+  std::string token;
+  std::chrono::system_clock::time_point expiration;
+};
+
+class InsecureCredentialsConfig;
+class GoogleDefaultCredentialsConfig;
+class AccessTokenConfig;
+class ImpersonateServiceAccountConfig;
+class ServiceAccountConfig;
+
+class CredentialsVisitor {
+ public:
+  virtual ~CredentialsVisitor() = default;
+  virtual void visit(InsecureCredentialsConfig&) = 0;
+  virtual void visit(GoogleDefaultCredentialsConfig&) = 0;
+  virtual void visit(AccessTokenConfig&) = 0;
+  virtual void visit(ImpersonateServiceAccountConfig&) = 0;
+  virtual void visit(ServiceAccountConfig&) = 0;
+
+  static void dispatch(Credentials& credentials, CredentialsVisitor& visitor);
+};
+
+class InsecureCredentialsConfig : public Credentials {
+ public:
+  ~InsecureCredentialsConfig() override = default;
+
+ private:
+  void dispatch(CredentialsVisitor& v) override { v.visit(*this); }
+};
+
+class GoogleDefaultCredentialsConfig : public Credentials {
+ public:
+  ~GoogleDefaultCredentialsConfig() override = default;
+
+ private:
+  void dispatch(CredentialsVisitor& v) override { v.visit(*this); }
+};
+
+class AccessTokenConfig : public Credentials {
+ public:
+  AccessTokenConfig(std::string token,
+                    std::chrono::system_clock::time_point expiration)
+      : access_token_(AccessToken{std::move(token), expiration}) {}
+  ~AccessTokenConfig() override = default;
+
+  AccessToken const& access_token() const { return access_token_; }
+
+ private:
+  void dispatch(CredentialsVisitor& v) override { v.visit(*this); }
+  AccessToken access_token_;
+};
+
+class ImpersonateServiceAccountConfig : public Credentials {
+ public:
+  ImpersonateServiceAccountConfig(std::shared_ptr<Credentials> base_credentials,
+                                  std::string target_service_account,
+                                  Options opts);
+
+  std::shared_ptr<Credentials> base_credentials() const {
+    return base_credentials_;
+  }
+  std::string const& target_service_account() const {
+    return target_service_account_;
+  }
+  std::chrono::seconds lifetime() const { return lifetime_; }
+  std::vector<std::string> const& scopes() const { return scopes_; }
+  std::vector<std::string> const& delegates() const { return delegates_; }
+
+ private:
+  void dispatch(CredentialsVisitor& v) override { v.visit(*this); }
+
+  std::shared_ptr<Credentials> base_credentials_;
+  std::string target_service_account_;
+  std::chrono::seconds lifetime_;
+  std::vector<std::string> scopes_;
+  std::vector<std::string> delegates_;
+};
+
+class ServiceAccountConfig : public Credentials {
+ public:
+  explicit ServiceAccountConfig(std::string json_object)
+      : json_object_(std::move(json_object)) {}
+
+  std::string const& json_object() const& { return json_object_; }
+  std::string&& json_object() && { return std::move(json_object_); }
+
+ private:
+  void dispatch(CredentialsVisitor& v) override { v.visit(*this); }
+
+  std::string json_object_;
+};
+
+}  // namespace internal
+}  // namespace GOOGLE_CLOUD_CPP_NS
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_CREDENTIALS_IMPL_H

--- a/google/cloud/internal/credentials_impl_test.cc
+++ b/google/cloud/internal/credentials_impl_test.cc
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "google/cloud/internal/credentials.h"
-#include "google/cloud/testing_util/status_matchers.h"
+#include "google/cloud/internal/credentials_impl.h"
 #include <gmock/gmock.h>
 
 namespace google {

--- a/google/cloud/internal/grpc_access_token_authentication.h
+++ b/google/cloud/internal/grpc_access_token_authentication.h
@@ -15,6 +15,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_GRPC_ACCESS_TOKEN_AUTHENTICATION_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_GRPC_ACCESS_TOKEN_AUTHENTICATION_H
 
+#include "google/cloud/internal/credentials_impl.h"
 #include "google/cloud/internal/unified_grpc_credentials.h"
 #include "google/cloud/version.h"
 #include <grpcpp/grpcpp.h>

--- a/google/cloud/internal/grpc_async_access_token_cache.h
+++ b/google/cloud/internal/grpc_async_access_token_cache.h
@@ -16,7 +16,7 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_GRPC_ASYNC_ACCESS_TOKEN_CACHE_H
 
 #include "google/cloud/completion_queue.h"
-#include "google/cloud/internal/credentials.h"
+#include "google/cloud/internal/credentials_impl.h"
 #include "google/cloud/status.h"
 #include "google/cloud/version.h"
 #include <chrono>

--- a/google/cloud/internal/grpc_impersonate_service_account_integration_test.cc
+++ b/google/cloud/internal/grpc_impersonate_service_account_integration_test.cc
@@ -33,9 +33,9 @@ namespace {
 
 using ::google::bigtable::admin::v2::GetTableRequest;
 using ::google::bigtable::admin::v2::Table;
+using ::google::cloud::MakeImpersonateServiceAccountCredentials;
 using ::google::cloud::internal::ImpersonateServiceAccountConfig;
 using ::google::cloud::internal::LogWrapper;
-using ::google::cloud::internal::MakeImpersonateServiceAccountCredentials;
 using ::testing::IsNull;
 using ::testing::Not;
 

--- a/google/cloud/internal/unified_grpc_credentials.h
+++ b/google/cloud/internal/unified_grpc_credentials.h
@@ -16,8 +16,8 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_UNIFIED_GRPC_CREDENTIALS_H
 
 #include "google/cloud/completion_queue.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/future.h"
-#include "google/cloud/internal/credentials.h"
 #include "google/cloud/status.h"
 #include "google/cloud/version.h"
 #include <grpcpp/grpcpp.h>

--- a/google/cloud/storage/internal/grpc_client.cc
+++ b/google/cloud/storage/internal/grpc_client.cc
@@ -112,10 +112,10 @@ std::shared_ptr<grpc::Channel> CreateGrpcChannel(
 
 std::shared_ptr<GrpcAuthenticationStrategy> CreateAuthenticationStrategy(
     CompletionQueue cq, Options const& opts) {
-  if (opts.has<google::cloud::internal::UnifiedCredentialsOption>()) {
+  if (opts.has<google::cloud::UnifiedCredentialsOption>()) {
     return google::cloud::internal::CreateAuthenticationStrategy(
-        opts.get<google::cloud::internal::UnifiedCredentialsOption>(),
-        std::move(cq), opts);
+        opts.get<google::cloud::UnifiedCredentialsOption>(), std::move(cq),
+        opts);
   }
   return google::cloud::internal::CreateAuthenticationStrategy(
       opts.get<google::cloud::GrpcCredentialOption>());

--- a/google/cloud/storage/internal/impersonate_service_account_credentials.h
+++ b/google/cloud/storage/internal/impersonate_service_account_credentials.h
@@ -18,7 +18,7 @@
 #include "google/cloud/storage/internal/minimal_iam_credentials_rest.h"
 #include "google/cloud/storage/oauth2/credentials.h"
 #include "google/cloud/storage/version.h"
-#include "google/cloud/internal/credentials.h"
+#include "google/cloud/credentials.h"
 #include <mutex>
 #include <string>
 

--- a/google/cloud/storage/internal/impersonate_service_account_credentials_test.cc
+++ b/google/cloud/storage/internal/impersonate_service_account_credentials_test.cc
@@ -24,8 +24,8 @@ inline namespace STORAGE_CLIENT_NS {
 namespace internal {
 namespace {
 
+using ::google::cloud::AccessTokenLifetimeOption;
 using ::google::cloud::internal::AccessToken;
-using ::google::cloud::internal::AccessTokenLifetimeOption;
 using ::google::cloud::testing_util::IsOk;
 using ::std::chrono::minutes;
 using ::testing::EndsWith;
@@ -50,7 +50,7 @@ TEST(ImpersonateServiceAccountCredentialsTest, Basic) {
           Return(make_status_or(AccessToken{"token2", now + minutes(30)})));
 
   auto config = google::cloud::internal::ImpersonateServiceAccountConfig(
-      google::cloud::internal::MakeGoogleDefaultCredentials(),
+      google::cloud::MakeGoogleDefaultCredentials(),
       "test-only-invalid@test.invalid",
       Options{}.set<AccessTokenLifetimeOption>(std::chrono::minutes(15)));
   ImpersonateServiceAccountCredentials under_test(config, mock);

--- a/google/cloud/storage/internal/minimal_iam_credentials_rest.h
+++ b/google/cloud/storage/internal/minimal_iam_credentials_rest.h
@@ -17,7 +17,7 @@
 
 #include "google/cloud/storage/oauth2/credentials.h"
 #include "google/cloud/storage/version.h"
-#include "google/cloud/internal/credentials.h"
+#include "google/cloud/internal/credentials_impl.h"
 #include "google/cloud/options.h"
 #include "google/cloud/status_or.h"
 #include <chrono>

--- a/google/cloud/storage/internal/unified_rest_credentials.cc
+++ b/google/cloud/storage/internal/unified_rest_credentials.cc
@@ -33,7 +33,7 @@ using ::google::cloud::internal::InsecureCredentialsConfig;
 using ::google::cloud::internal::ServiceAccountConfig;
 
 std::shared_ptr<oauth2::Credentials> MapCredentials(
-    std::shared_ptr<google::cloud::internal::Credentials> const& credentials) {
+    std::shared_ptr<google::cloud::Credentials> const& credentials) {
   struct Visitor : public CredentialsVisitor {
     std::shared_ptr<oauth2::Credentials> result;
 

--- a/google/cloud/storage/internal/unified_rest_credentials.h
+++ b/google/cloud/storage/internal/unified_rest_credentials.h
@@ -17,7 +17,7 @@
 
 #include "google/cloud/storage/oauth2/credentials.h"
 #include "google/cloud/storage/version.h"
-#include "google/cloud/internal/credentials.h"
+#include "google/cloud/credentials.h"
 #include <memory>
 
 namespace google {
@@ -27,7 +27,7 @@ inline namespace STORAGE_CLIENT_NS {
 namespace internal {
 
 std::shared_ptr<oauth2::Credentials> MapCredentials(
-    std::shared_ptr<google::cloud::internal::Credentials> const& credentials);
+    std::shared_ptr<google::cloud::Credentials> const& credentials);
 
 }  // namespace internal
 }  // namespace STORAGE_CLIENT_NS

--- a/google/cloud/storage/internal/unified_rest_credentials_test.cc
+++ b/google/cloud/storage/internal/unified_rest_credentials_test.cc
@@ -30,9 +30,9 @@ inline namespace STORAGE_CLIENT_NS {
 namespace internal {
 namespace {
 
-using ::google::cloud::internal::MakeAccessTokenCredentials;
-using ::google::cloud::internal::MakeGoogleDefaultCredentials;
-using ::google::cloud::internal::MakeInsecureCredentials;
+using ::google::cloud::MakeAccessTokenCredentials;
+using ::google::cloud::MakeGoogleDefaultCredentials;
+using ::google::cloud::MakeInsecureCredentials;
 using ::google::cloud::testing_util::IsOk;
 using ::google::cloud::testing_util::ScopedEnvironment;
 using ::testing::IsEmpty;

--- a/google/cloud/storage/tests/unified_credentials_integration_test.cc
+++ b/google/cloud/storage/tests/unified_credentials_integration_test.cc
@@ -16,7 +16,7 @@
 #include "google/cloud/storage/grpc_plugin.h"
 #include "google/cloud/storage/internal/unified_rest_credentials.h"
 #include "google/cloud/storage/testing/storage_integration_test.h"
-#include "google/cloud/internal/credentials.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/scoped_environment.h"
 #include "google/cloud/testing_util/status_matchers.h"
@@ -29,11 +29,11 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace {
 
+using ::google::cloud::MakeAccessTokenCredentials;
+using ::google::cloud::MakeGoogleDefaultCredentials;
+using ::google::cloud::MakeServiceAccountCredentials;
+using ::google::cloud::UnifiedCredentialsOption;
 using ::google::cloud::internal::GetEnv;
-using ::google::cloud::internal::MakeAccessTokenCredentials;
-using ::google::cloud::internal::MakeGoogleDefaultCredentials;
-using ::google::cloud::internal::MakeServiceAccountCredentials;
-using ::google::cloud::internal::UnifiedCredentialsOption;
 using ::google::cloud::testing_util::IsOk;
 using ::testing::StartsWith;
 
@@ -59,9 +59,9 @@ class UnifiedCredentialsIntegrationTest
 
   static Client MakeTestClient(Options opts) {
     std::string const client_type = GetParam();
-    // TODO(#...) - this should happen in CreateClient
+    // TODO(#6612) - this should happen in CreateClient
     auto credentials = internal::MapCredentials(
-        opts.get<google::cloud::internal::UnifiedCredentialsOption>());
+        opts.get<google::cloud::UnifiedCredentialsOption>());
     opts.set<internal::Oauth2CredentialsOption>(credentials);
 #if GOOGLE_CLOUD_CPP_STORAGE_HAVE_GRPC
     if (client_type == "grpc") {


### PR DESCRIPTION
Expose the public APIs for `google::cloud::Credentials`. Currently there
are no public APIs to *accept* these credentials in any libraries, that
will come in separate PRs.

Fixes #6293

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6614)
<!-- Reviewable:end -->
