### PR TITLE
fix(spanner): do not warn about SessionPoolClockOption

### DIFF
--- a/google/cloud/spanner/client.cc
+++ b/google/cloud/spanner/client.cc
@@ -329,9 +329,10 @@ QueryOptions Client::OverlayQueryOptions(QueryOptions const& preferred) {
 
 std::shared_ptr<spanner::Connection> MakeConnection(spanner::Database const& db,
                                                     Options opts) {
-  internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
-                                 SessionPoolOptionList,
-                                 SpannerPolicyOptionList>(opts, __func__);
+  internal::CheckExpectedOptions<
+      CommonOptionList, GrpcOptionList, SessionPoolOptionList,
+      spanner_internal::SessionPoolClockOption, SpannerPolicyOptionList>(
+      opts, __func__);
   opts = spanner_internal::DefaultOptions(std::move(opts));
   std::vector<std::shared_ptr<spanner_internal::SpannerStub>> stubs;
   int num_channels = opts.get<GrpcNumChannelsOption>();


### PR DESCRIPTION
While the advertised `spanner::SessionPoolOptionList` should
not include `spanner_internal::SessionPoolClockOption`, that
option will be set in the `spanner::SessionPoolOptions` passed
to `spanner::MakeConnection()`, so we should not warn about its
presence.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6619)
<!-- Reviewable:end -->
