### PR TITLE
feat(pubsub): add ability to set the ack deadline extension

### DIFF
--- a/google/cloud/pubsub/internal/subscription_lease_management.cc
+++ b/google/cloud/pubsub/internal/subscription_lease_management.cc
@@ -20,7 +20,6 @@ namespace pubsub_internal {
 inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
 
 std::chrono::seconds constexpr SubscriptionLeaseManagement::kMinimumAckDeadline;
-std::chrono::seconds constexpr SubscriptionLeaseManagement::kMaximumAckDeadline;
 std::chrono::seconds constexpr SubscriptionLeaseManagement::kAckDeadlineSlack;
 
 void SubscriptionLeaseManagement::Start(BatchCallback cb) {
@@ -101,7 +100,7 @@ void SubscriptionLeaseManagement::RefreshMessageLeases(
 
   std::vector<std::string> ack_ids;
   ack_ids.reserve(leases_.size());
-  auto extension = kMaximumAckDeadline;
+  auto extension = max_deadline_extension_;
   auto const now = std::chrono::system_clock::now();
   for (auto const& kv : leases_) {
     // This message lease cannot be extended any further, and we do not want to

--- a/google/cloud/pubsub/internal/subscription_lease_management.h
+++ b/google/cloud/pubsub/internal/subscription_lease_management.h
@@ -36,7 +36,6 @@ class SubscriptionLeaseManagement
  public:
   static auto constexpr kAckDeadlineSlack = std::chrono::seconds(2);
   static auto constexpr kMinimumAckDeadline = std::chrono::seconds(10);
-  static auto constexpr kMaximumAckDeadline = std::chrono::seconds(600);
 
   /**
    * A wrapper to create timers.
@@ -50,7 +49,8 @@ class SubscriptionLeaseManagement
       google::cloud::CompletionQueue cq,
       std::shared_ptr<SessionShutdownManager> shutdown_manager,
       std::shared_ptr<SubscriptionBatchSource> child,
-      std::chrono::seconds max_deadline_time) {
+      std::chrono::seconds max_deadline_time,
+      std::chrono::seconds max_deadline_extension) {
     auto timer_factory =
         [cq](std::chrono::system_clock::time_point tp) mutable {
           return cq.MakeDeadlineTimer(tp).then(
@@ -61,7 +61,8 @@ class SubscriptionLeaseManagement
     return std::shared_ptr<SubscriptionLeaseManagement>(
         new SubscriptionLeaseManagement(
             std::move(cq), std::move(shutdown_manager),
-            std::move(timer_factory), std::move(child), max_deadline_time));
+            std::move(timer_factory), std::move(child), max_deadline_time,
+            max_deadline_extension));
   }
 
   static std::shared_ptr<SubscriptionLeaseManagement> CreateForTesting(
@@ -69,11 +70,13 @@ class SubscriptionLeaseManagement
       std::shared_ptr<SessionShutdownManager> shutdown_manager,
       TimerFactory timer_factory,
       std::shared_ptr<SubscriptionBatchSource> child,
-      std::chrono::seconds max_deadline_time) {
+      std::chrono::seconds max_deadline_time,
+      std::chrono::seconds max_deadline_extension) {
     return std::shared_ptr<SubscriptionLeaseManagement>(
         new SubscriptionLeaseManagement(
             std::move(cq), std::move(shutdown_manager),
-            std::move(timer_factory), std::move(child), max_deadline_time));
+            std::move(timer_factory), std::move(child), max_deadline_time,
+            max_deadline_extension));
   }
 
   void Start(BatchCallback cb) override;
@@ -90,12 +93,14 @@ class SubscriptionLeaseManagement
       std::shared_ptr<SessionShutdownManager> shutdown_manager,
       TimerFactory timer_factory,
       std::shared_ptr<SubscriptionBatchSource> child,
-      std::chrono::seconds max_deadline_time)
+      std::chrono::seconds max_deadline_time,
+      std::chrono::seconds max_deadline_extension)
       : cq_(std::move(cq)),
         timer_factory_(std::move(timer_factory)),
         child_(std::move(child)),
         shutdown_manager_(std::move(shutdown_manager)),
-        max_deadline_time_(max_deadline_time) {}
+        max_deadline_time_(max_deadline_time),
+        max_deadline_extension_(max_deadline_extension) {}
 
   void OnRead(
       StatusOr<google::pubsub::v1::StreamingPullResponse> const& response);
@@ -118,6 +123,7 @@ class SubscriptionLeaseManagement
   std::shared_ptr<SubscriptionBatchSource> const child_;
   std::shared_ptr<SessionShutdownManager> const shutdown_manager_;
   std::chrono::seconds const max_deadline_time_;
+  std::chrono::seconds const max_deadline_extension_;
 
   std::mutex mu_;
 

--- a/google/cloud/pubsub/internal/subscription_session.cc
+++ b/google/cloud/pubsub/internal/subscription_session.cc
@@ -171,8 +171,8 @@ future<Status> CreateSubscriptionSession(
       std::move(client_id), options, std::move(retry_policy),
       std::move(backoff_policy));
   auto lease_management = SubscriptionLeaseManagement::Create(
-      executor, shutdown_manager, std::move(batch),
-      options.max_deadline_time());
+      executor, shutdown_manager, std::move(batch), options.max_deadline_time(),
+      options.max_deadline_extension());
 
   return SubscriptionSessionImpl::Create(
       options, std::move(executor), std::move(shutdown_manager),
@@ -212,7 +212,7 @@ future<Status> CreateTestingSubscriptionSession(
   };
   auto lease_management = SubscriptionLeaseManagement::CreateForTesting(
       executor, shutdown_manager, timer, std::move(batch),
-      options.max_deadline_time());
+      options.max_deadline_time(), options.max_deadline_extension());
 
   return SubscriptionSessionImpl::Create(
       options, std::move(executor), std::move(shutdown_manager),

--- a/google/cloud/pubsub/subscriber_options.cc
+++ b/google/cloud/pubsub/subscriber_options.cc
@@ -20,6 +20,15 @@ namespace cloud {
 namespace pubsub {
 inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
 
+using seconds = std::chrono::seconds;
+
+SubscriberOptions& SubscriberOptions::set_max_deadline_extension(
+    seconds extension) {
+  max_deadline_extension_ =
+      (std::max)((std::min)(extension, seconds(600)), seconds(10));
+  return *this;
+}
+
 SubscriberOptions& SubscriberOptions::set_max_outstanding_messages(
     std::int64_t message_count) {
   max_outstanding_messages_ = (std::max<std::int64_t>)(0, message_count);

--- a/google/cloud/pubsub/subscriber_options.h
+++ b/google/cloud/pubsub/subscriber_options.h
@@ -105,6 +105,26 @@ class SubscriberOptions {
   }
 
   /**
+   * Set the maximum time by which the deadline for each incoming message is
+   * extended.
+   *
+   * The Cloud Pub/Sub C++ client library will extend the deadline by at most
+   * this amount, while waiting for an ack or nack. The default extension is 10
+   * minutes. An application may wish to reduce this extension so that the
+   * Pub/Sub service will resend a message sooner when it does not hear back
+   * from a Subscriber.
+   *
+   * The value is clamped between 10 seconds and 10 minutes.
+   *
+   * @param extension the maximum time that the deadline can be extended by,
+   * measured in seconds.
+   */
+  SubscriberOptions& set_max_deadline_extension(std::chrono::seconds extension);
+  std::chrono::seconds max_deadline_extension() const {
+    return max_deadline_extension_;
+  }
+
+  /**
    * Set the maximum number of outstanding messages per streaming pull.
    *
    * The Cloud Pub/Sub C++ client library uses streaming pull requests to
@@ -191,6 +211,7 @@ class SubscriberOptions {
   }
 
   std::chrono::seconds max_deadline_time_ = std::chrono::seconds(0);
+  std::chrono::seconds max_deadline_extension_ = std::chrono::seconds(600);
   std::int64_t max_outstanding_messages_ = 1000;
   std::int64_t max_outstanding_bytes_ = 100 * 1024 * 1024L;
   std::size_t max_concurrency_ = DefaultMaxConcurrency();

--- a/google/cloud/pubsub/subscriber_options_test.cc
+++ b/google/cloud/pubsub/subscriber_options_test.cc
@@ -14,6 +14,7 @@
 
 #include "google/cloud/pubsub/subscriber_options.h"
 #include <gmock/gmock.h>
+#include <chrono>
 
 namespace google {
 namespace cloud {
@@ -21,11 +22,25 @@ namespace pubsub {
 inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
 namespace {
 
+using seconds = std::chrono::seconds;
+
 TEST(SubscriberOptionsTest, Default) {
   SubscriberOptions const options{};
+  EXPECT_EQ(seconds(600), options.max_deadline_extension());
   EXPECT_LT(0, options.max_outstanding_messages());
   EXPECT_LT(0, options.max_outstanding_bytes());
   EXPECT_LT(0, options.max_concurrency());
+}
+
+TEST(SubscriberOptionsTest, SetDeadlineExtension) {
+  auto options = SubscriberOptions{}.set_max_deadline_extension(seconds(60));
+  EXPECT_EQ(seconds(60), options.max_deadline_extension());
+
+  options.set_max_deadline_extension(seconds(5));
+  EXPECT_EQ(seconds(10), options.max_deadline_extension());
+
+  options.set_max_deadline_extension(seconds(1000));
+  EXPECT_EQ(seconds(600), options.max_deadline_extension());
 }
 
 TEST(SubscriberOptionsTest, SetMessageCount) {


### PR DESCRIPTION
Fixes #6283 

Note that this change gives the users the ability to set their desired deadline extension (in seconds). It does not calculate and use the p99 latency, like the other Pub/Sub libraries do.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6620)
<!-- Reviewable:end -->
