### PR TITLE
cleanup: avoid the dot-slash idiom when it serves no purpose

### DIFF
--- a/ci/cloudbuild/builds/lib/bazel.sh
+++ b/ci/cloudbuild/builds/lib/bazel.sh
@@ -33,7 +33,7 @@ io::log "Prefetching bazel deps..."
 # build.
 TIMEFORMAT="==> 🕑 prefetching done in %R seconds"
 time {
-  "./ci/retry-command.sh" 3 120 bazel fetch ... \
+  "ci/retry-command.sh" 3 120 bazel fetch ... \
     @local_config_platform//... \
     @local_config_cc_toolchains//... \
     @local_config_sh//... \

--- a/ci/cloudbuild/builds/lib/integration.sh
+++ b/ci/cloudbuild/builds/lib/integration.sh
@@ -145,11 +145,11 @@ function integration::bazel_with_emulators() {
     google/cloud/iam/...
 
   io::log_h2 "Running Pub/Sub integration tests (with emulator)"
-  "./google/cloud/pubsub/ci/${EMULATOR_SCRIPT}" \
+  "google/cloud/pubsub/ci/${EMULATOR_SCRIPT}" \
     bazel "${verb}" "${args[@]}"
 
   io::log_h2 "Running Storage integration tests (with emulator)"
-  "./google/cloud/storage/ci/${EMULATOR_SCRIPT}" \
+  "google/cloud/storage/ci/${EMULATOR_SCRIPT}" \
     bazel "${verb}" "${args[@]}"
 
   io::log_h2 "Running Spanner integration tests"
@@ -162,8 +162,8 @@ function integration::bazel_with_emulators() {
     CBT=/usr/local/google-cloud-sdk/bin/cbt \
     CBT_EMULATOR=/usr/local/google-cloud-sdk/platform/bigtable-emulator/cbtemulator \
     GOPATH="${GOPATH:-}" \
-    ./ci/retry-command.sh 3 0 \
-    "./google/cloud/bigtable/ci/${EMULATOR_SCRIPT}" \
+    ci/retry-command.sh 3 0 \
+    "google/cloud/bigtable/ci/${EMULATOR_SCRIPT}" \
     bazel "${verb}" "${args[@]}"
 
   # This test is run separately because the access token changes every time and
@@ -227,7 +227,7 @@ function integration::ctest_with_emulators() {
     ctest -R "^google_cloud_cpp_generator_integration_" "${ctest_args[@]}"
 
   io::log_h2 "Running Pub/Sub integration tests (with emulator)"
-  "./google/cloud/pubsub/ci/${EMULATOR_SCRIPT}" \
+  "google/cloud/pubsub/ci/${EMULATOR_SCRIPT}" \
     "${cmake_out}" "${ctest_args[@]}" -L integration-test-emulator
 
   io::log_h2 "Running Storage integration tests (with emulator)"
@@ -242,7 +242,7 @@ function integration::ctest_with_emulators() {
   env CBT=/usr/local/google-cloud-sdk/bin/cbt \
     CBT_EMULATOR=/usr/local/google-cloud-sdk/platform/bigtable-emulator/cbtemulator \
     GOPATH="${GOPATH:-}" \
-    ./ci/retry-command.sh 3 0 \
-    "./google/cloud/bigtable/ci/${EMULATOR_SCRIPT}" \
+    ci/retry-command.sh 3 0 \
+    "google/cloud/bigtable/ci/${EMULATOR_SCRIPT}" \
     "${cmake_out}" "${ctest_args[@]}" -L integration-test-emulator
 }

--- a/ci/cloudbuild/builds/scan-build.sh
+++ b/ci/cloudbuild/builds/scan-build.sh
@@ -16,7 +16,7 @@
 
 # NOTE: This build does not have a trigger file and is not automatically run by
 # GCB. To manually run this build use:
-#   ./ci/cloudbuild/build.sh --distro fedora scan-build --docker
+#   ci/cloudbuild/build.sh --distro fedora scan-build --docker
 
 set -eu
 

--- a/ci/cloudbuild/cache.sh
+++ b/ci/cloudbuild/cache.sh
@@ -20,7 +20,7 @@
 # called in one step, followed by the actual build of the code, followed by the
 # "save cache" step.
 #
-# Usage: ./cache <save|restore>
+# Usage: cache.sh <save|restore>
 #
 #   Options:
 #     --bucket_url=<url>    URL to the GCS bucket where the cache should be saved

--- a/ci/cloudbuild/trigger.sh
+++ b/ci/cloudbuild/trigger.sh
@@ -20,7 +20,7 @@
 # `triggers/name-pr.yaml`. These files can then be uploaded to GCB to start
 # running with the `--import` flag.
 #
-# Usage: ./trigger.sh [options]
+# Usage: trigger.sh [options]
 #
 #   Options:
 #     --generate=name     Outputs CI and PR YAML configs for the named build

--- a/ci/cspell.json
+++ b/ci/cspell.json
@@ -6,7 +6,7 @@
   "dictionaryDefinitions": [
     {
       "name": "custom-words",
-      "file": "./custom-words.txt",
+      "file": "custom-words.txt",
       "description": "Project Words"
     }
   ],

--- a/google/cloud/storage/emulator/README.md
+++ b/google/cloud/storage/emulator/README.md
@@ -29,7 +29,7 @@ python -m unittest tests/test_*.py
 ```bash
 cd google-cloud-cpp
 # To make sure `Keep-Alive` header works, `--threads` should not be smaller than 2.
-gunicorn --bind "localhost:9000" --worker-class sync --threads 10 --access-logfile - --chdir ./google/cloud/storage/emulator "emulator:run()"
+gunicorn --bind "localhost:9000" --worker-class sync --threads 10 --access-logfile - --chdir google/cloud/storage/emulator "emulator:run()"
 # if you want to use gRPC API, run the following command.
 curl "http://localhost:9000/start_grpc?port=8000"
 # gRPC server will start listening at port 8000.

--- a/release/README.md
+++ b/release/README.md
@@ -27,7 +27,7 @@ any new APIs are, well, released, and we should think carefully about removing
 them.
 
 ```bash
-./ci/cloudbuild/build.sh -t check-api-pr --docker
+ci/cloudbuild/build.sh -t check-api-pr --docker
 ```
 
 The updated ABI dump files will be left in the `ci/abi-dumps` folder.
@@ -95,7 +95,7 @@ to create the release at an specific point in the revision history.
 
 We next need to create the release tag, the release branch, and create the
 release in the GitHub UI. These steps are handled automatically for us by the
-[`./release/release.sh`
+[`release/release.sh`
 script](https://github.com/googleapis/google-cloud-cpp/blob/main/release/release.sh).
 
 *No PR is needed for this step.*
@@ -104,14 +104,14 @@ First run the following command -- which will *NOT* make any changes to any
 repos -- and verify that the output and *version numbers* look correct.
 
 ```bash
-$ ./release/release.sh googleapis/google-cloud-cpp
+$ release/release.sh googleapis/google-cloud-cpp
 ```
 
 If the output from the previous command looks OK, rerun the command with the
 `-f` flag, which will make the changes and push them to the remote repo.
 
 ```bash
-$ ./release/release.sh -f googleapis/google-cloud-cpp
+$ release/release.sh -f googleapis/google-cloud-cpp
 ```
 
 **NOTE:** This script can be run from any directory. It operates only on the


### PR DESCRIPTION
Avoid prefixing paths with `./` except in the cases where we
really want to execute something from the current directory.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6629)
<!-- Reviewable:end -->
