### PR TITLE
ci(gcb): update kaniko version and retry pushes

### DIFF
--- a/ci/cloudbuild/cloudbuild.yaml
+++ b/ci/cloudbuild/cloudbuild.yaml
@@ -65,6 +65,7 @@ steps:
 - name: 'gcr.io/kaniko-project/executor:edge'
   args: [
     '--log-format=text',
+    '--push-retry=3',
     '--context=dir:///workspace/ci',
     '--dockerfile=ci/cloudbuild/dockerfiles/${_DISTRO}.Dockerfile',
     '--cache=true',

--- a/ci/cloudbuild/cloudbuild.yaml
+++ b/ci/cloudbuild/cloudbuild.yaml
@@ -62,14 +62,14 @@ logsBucket: 'gs://${_LOGS_BUCKET}/logs/google-cloud-cpp/${_TRIGGER_SOURCE}/${COM
 
 steps:
   # Builds the docker image that will be used by the main build step.
-- name: 'gcr.io/kaniko-project/executor:edge'
+- name: 'gcr.io/kaniko-project/executor:v1.6.0-debug'
   args: [
     '--log-format=text',
-    '--push-retry=3',
     '--context=dir:///workspace/ci',
     '--dockerfile=ci/cloudbuild/dockerfiles/${_DISTRO}.Dockerfile',
     '--cache=true',
     '--destination=gcr.io/${PROJECT_ID}/${_IMAGE}:${BUILD_ID}',
+    '--push-retry=3',
   ]
 
   # Pull the docker image. The step running 'ci/cloud/build.sh' would do this


### PR DESCRIPTION
This change likely fixes #6327. 

As of today, Kaniko `v1.6.0` is the newest released version. Using that version directly results in the crash described in https://github.com/GoogleContainerTools/kaniko/issues/1604. However, using the `v1.6.0-debug` image works, I _think_ because of a different version of the `docker-credentials-gcr` helper as I described in https://github.com/GoogleContainerTools/kaniko/issues/1604#issuecomment-848287852

Updating Kaniko may also help #6336

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6634)
<!-- Reviewable:end -->
