### PR TITLE
feat(storage): recommend `g::c::Options`

### DIFF
--- a/google/cloud/examples/gcs2cbt.cc
+++ b/google/cloud/examples/gcs2cbt.cc
@@ -86,13 +86,8 @@ int main(int argc, char* argv[]) try {
   }
   std::cout << " DONE\n";
 
-  google::cloud::StatusOr<gcs::ClientOptions> opts =
-      gcs::ClientOptions::CreateDefaultClientOptions();
-  if (!opts) {
-    std::cerr << "Couldn't create gcs::ClientOptions, status=" << opts.status();
-    return 1;
-  }
-  gcs::Client client(opts->set_project_id(options.project_id));
+  gcs::Client client(
+      google::cloud::Options{}.set<gcs::ProjectIdOption>(options.project_id));
   // The main thread just reads the file one line at a time.
   auto is = client.ReadObject(options.bucket, options.object);
   std::string line;
@@ -274,7 +269,7 @@ Options AutoRun() {
       GetEnv("GOOGLE_CLOUD_CPP_STORAGE_TEST_BUCKET_NAME").value();
   auto constexpr kTableId = "gcs2cbt-auto-run";
   auto constexpr kObjectName = "gcs2cbt-sample-data.csv";
-  auto gcs_client = gcs::Client::CreateDefaultClient().value();
+  auto gcs_client = gcs::Client();
   auto constexpr kTestData = R"""(RowId,Header1,Header2,Header3
 1,v1,v2,v3
 3,v1,v2,v3

--- a/google/cloud/storage/benchmarks/storage_file_transfer_benchmark.cc
+++ b/google/cloud/storage/benchmarks/storage_file_transfer_benchmark.cc
@@ -69,18 +69,11 @@ int main(int argc, char* argv[]) {
     return 1;
   }
 
-  google::cloud::StatusOr<gcs::ClientOptions> client_options =
-      gcs::ClientOptions::CreateDefaultClientOptions();
-  if (!client_options) {
-    std::cerr << "Could not create ClientOptions, status="
-              << client_options.status() << "\n";
-    return 1;
-  }
-  client_options->SetUploadBufferSize(options->upload_buffer_size);
-  client_options->SetDownloadBufferSize(options->download_buffer_size);
-  client_options->set_project_id(options->project_id);
-
-  gcs::Client client(*std::move(client_options));
+  auto client = gcs::Client(
+      google::cloud::Options{}
+          .set<gcs::UploadBufferSizeOption>(options->upload_buffer_size)
+          .set<gcs::DownloadBufferSizeOption>(options->download_buffer_size)
+          .set<gcs::ProjectIdOption>(options->project_id));
 
   std::cout << "# Cleaning up stale benchmark buckets\n";
   google::cloud::storage::testing::RemoveStaleBuckets(

--- a/google/cloud/storage/benchmarks/storage_parallel_uploads_benchmark.cc
+++ b/google/cloud/storage/benchmarks/storage_parallel_uploads_benchmark.cc
@@ -177,18 +177,9 @@ int main(int argc, char* argv[]) {
     return 1;
   }
 
-  google::cloud::StatusOr<gcs::ClientOptions> client_options =
-      gcs::ClientOptions::CreateDefaultClientOptions();
-  if (!client_options) {
-    std::cerr << "Could not create ClientOptions, status="
-              << client_options.status() << "\n";
-    return 1;
-  }
-  if (!options->project_id.empty()) {
-    client_options->set_project_id(options->project_id);
-  }
-  client_options->set_connection_pool_size(0);
-  gcs::Client client(*std::move(client_options));
+  auto client = gcs::Client(google::cloud::Options{}
+                                .set<gcs::ProjectIdOption>(options->project_id)
+                                .set<gcs::ConnectionPoolSizeOption>(0));
 
   google::cloud::internal::DefaultPRNG generator =
       google::cloud::internal::MakeDefaultPRNG();
@@ -236,15 +227,7 @@ int main(int argc, char* argv[]) {
       google::cloud::internal::DefaultPRNG generator =
           google::cloud::internal::MakeDefaultPRNG();
 
-      google::cloud::StatusOr<gcs::ClientOptions> client_options =
-          gcs::ClientOptions::CreateDefaultClientOptions();
-      if (!client_options) {
-        std::lock_guard<std::mutex> lk(cout_mutex);
-        std::cout << "# Could not create ClientOptions, status="
-                  << client_options.status() << "\n";
-        return;
-      }
-      gcs::Client client(*std::move(client_options));
+      auto client = gcs::Client();
 
       std::uniform_int_distribution<std::uint64_t> size_generator(
           options->minimum_object_size, options->maximum_object_size);

--- a/google/cloud/storage/benchmarks/throughput_experiment.cc
+++ b/google/cloud/storage/benchmarks/throughput_experiment.cc
@@ -326,7 +326,7 @@ class DownloadObjectRawGrpc : public ThroughputExperiment {
 
 std::vector<std::unique_ptr<ThroughputExperiment>> CreateUploadExperiments(
     ThroughputOptions const& options,
-    google::cloud::storage::ClientOptions const& client_options) {
+    google::cloud::Options const& client_options) {
   auto generator = google::cloud::internal::DefaultPRNG(std::random_device{}());
   auto contents = MakeRandomData(generator, options.maximum_write_size);
   gcs::Client rest_client(client_options);
@@ -339,7 +339,7 @@ std::vector<std::unique_ptr<ThroughputExperiment>> CreateUploadExperiments(
       case ApiName::kApiRawGrpc: {
         gcs::Client grpc_client =
             google::cloud::storage_experimental::DefaultGrpcClient(
-                google::cloud::storage::internal::MakeOptions(client_options))
+                client_options)
                 .value();
         result.push_back(
             absl::make_unique<UploadObject>(grpc_client, a, contents, false));
@@ -370,8 +370,7 @@ std::vector<std::unique_ptr<ThroughputExperiment>> CreateUploadExperiments(
 
 std::vector<std::unique_ptr<ThroughputExperiment>> CreateDownloadExperiments(
     ThroughputOptions const& options,
-    google::cloud::storage::ClientOptions const& client_options,
-    int thread_id) {
+    google::cloud::Options const& client_options, int thread_id) {
   gcs::Client rest_client(client_options);
 
   std::vector<std::unique_ptr<ThroughputExperiment>> result;
@@ -381,7 +380,7 @@ std::vector<std::unique_ptr<ThroughputExperiment>> CreateDownloadExperiments(
       case ApiName::kApiGrpc:
         result.push_back(absl::make_unique<DownloadObject>(
             google::cloud::storage_experimental::DefaultGrpcClient(
-                google::cloud::storage::internal::MakeOptions(client_options))
+                client_options)
                 .value(),
             a));
         break;

--- a/google/cloud/storage/benchmarks/throughput_experiment.h
+++ b/google/cloud/storage/benchmarks/throughput_experiment.h
@@ -56,7 +56,7 @@ class ThroughputExperiment {
  */
 std::vector<std::unique_ptr<ThroughputExperiment>> CreateUploadExperiments(
     ThroughputOptions const& options,
-    google::cloud::storage::ClientOptions const& client_options);
+    google::cloud::Options const& client_options);
 
 /**
  * Create the list of download experiments based on the @p options.
@@ -66,7 +66,7 @@ std::vector<std::unique_ptr<ThroughputExperiment>> CreateUploadExperiments(
  */
 std::vector<std::unique_ptr<ThroughputExperiment>> CreateDownloadExperiments(
     ThroughputOptions const& options,
-    google::cloud::storage::ClientOptions const& client_options, int thread_id);
+    google::cloud::Options const& client_options, int thread_id);
 
 }  // namespace storage_benchmarks
 }  // namespace cloud

--- a/google/cloud/storage/benchmarks/throughput_experiment_test.cc
+++ b/google/cloud/storage/benchmarks/throughput_experiment_test.cc
@@ -54,7 +54,7 @@ TEST_P(ThroughputExperimentIntegrationTest, Upload) {
   auto const& client_options =
       google::cloud::storage::internal::ClientImplDetails::GetRawClient(*client)
           ->client_options();
-  auto experiments = CreateUploadExperiments(options, client_options);
+  auto experiments = CreateUploadExperiments(options, {});
   for (auto& e : experiments) {
     auto object_name = MakeRandomObjectName();
     ThroughputExperimentConfig config{OpType::kOpInsert,
@@ -85,8 +85,7 @@ TEST_P(ThroughputExperimentIntegrationTest, Download) {
   auto const& client_options =
       google::cloud::storage::internal::ClientImplDetails::GetRawClient(*client)
           ->client_options();
-  auto experiments =
-      CreateDownloadExperiments(options, client_options, /*thread_id=*/0);
+  auto experiments = CreateDownloadExperiments(options, {}, /*thread_id=*/0);
   for (auto& e : experiments) {
     auto object_name = MakeRandomObjectName();
 

--- a/google/cloud/storage/client.cc
+++ b/google/cloud/storage/client.cc
@@ -29,10 +29,16 @@ namespace google {
 namespace cloud {
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
+
 static_assert(std::is_copy_constructible<storage::Client>::value,
               "storage::Client must be constructible");
 static_assert(std::is_copy_assignable<storage::Client>::value,
               "storage::Client must be assignable");
+
+Client::Client(Options opts)
+    : Client(Client::InternalOnlyNoDecorations{},
+             Client::CreateDefaultInternalClient(
+                 internal::DefaultOptionsWithCredentials(std::move(opts)))) {}
 
 std::shared_ptr<internal::RawClient> Client::CreateDefaultInternalClient(
     Options const& opts, std::shared_ptr<internal::RawClient> client) {
@@ -51,13 +57,7 @@ std::shared_ptr<internal::RawClient> Client::CreateDefaultInternalClient(
   return CreateDefaultInternalClient(opts, internal::CurlClient::Create(opts));
 }
 
-StatusOr<Client> Client::CreateDefaultClient() {
-  auto opts = ClientOptions::CreateDefaultClientOptions();
-  if (!opts) {
-    return StatusOr<Client>(opts.status());
-  }
-  return StatusOr<Client>(Client(*opts));
-}
+StatusOr<Client> Client::CreateDefaultClient() { return Client(Options{}); }
 
 ObjectReadStream Client::ReadObjectImpl(
     internal::ReadObjectRangeRequest const& request) {

--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -207,6 +207,19 @@ struct ClientImplDetails;
  */
 class Client {
  public:
+  /**
+   * Build a new client.
+   *
+   * @param opts the configuration parameters for the `Client`.
+   *
+   * @see #ClientOptionList for a list of useful options.
+   *
+   * @par Idempotency Policy Example
+   * @snippet storage_object_samples.cc insert object strict idempotency
+   *
+   * @par Modified Retry Policy Example
+   * @snippet storage_object_samples.cc insert object modified retry
+   */
   explicit Client(Options opts = {});
 
   /**
@@ -219,14 +232,9 @@ class Client {
    *   retried, or what operations cannot be retried because they are not
    *   idempotent.
    *
-   * @par Idempotency Policy Example
-   * @snippet storage_object_samples.cc insert object strict idempotency
-   *
-   * @par Modified Retry Policy Example
-   * @snippet storage_object_samples.cc insert object modified retry
+   * @deprecated use the constructor from `google::cloud::Options` instead.
    */
   template <typename... Policies>
-  GOOGLE_CLOUD_CPP_DEPRECATED("TODO(#6161)")
   explicit Client(ClientOptions options, Policies&&... policies)
       : Client(InternalOnly{}, internal::ApplyPolicies(
                                    internal::MakeOptions(std::move(options)),
@@ -241,14 +249,9 @@ class Client {
    *   retried, or what operations cannot be retried because they are not
    *   idempotent.
    *
-   * @par Idempotency Policy Example
-   * @snippet storage_object_samples.cc insert object strict idempotency
-   *
-   * @par Modified Retry Policy Example
-   * @snippet storage_object_samples.cc insert object modified retry
+   * @deprecated use the constructor from `google::cloud::Options` instead.
    */
   template <typename... Policies>
-  GOOGLE_CLOUD_CPP_DEPRECATED("TODO(#6161)")
   explicit Client(std::shared_ptr<oauth2::Credentials> credentials,
                   Policies&&... policies)
       : Client(InternalOnly{},
@@ -256,8 +259,11 @@ class Client {
                    internal::DefaultOptions(std::move(credentials), {}),
                    std::forward<Policies>(policies)...)) {}
 
-  /// Create a Client using ClientOptions::CreateDefaultClientOptions().
-  GOOGLE_CLOUD_CPP_DEPRECATED("TODO(#6161)")
+  /**
+   * Create a Client using ClientOptions::CreateDefaultClientOptions().
+   *
+   * @deprecated use the constructor from `google::cloud::Options` instead.
+   */
   static StatusOr<Client> CreateDefaultClient();
 
   /// Builds a client and maybe override the retry, idempotency, and/or backoff

--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -207,6 +207,8 @@ struct ClientImplDetails;
  */
 class Client {
  public:
+  explicit Client(Options opts = {});
+
   /**
    * Creates the default client type given the options.
    *
@@ -224,6 +226,7 @@ class Client {
    * @snippet storage_object_samples.cc insert object modified retry
    */
   template <typename... Policies>
+  GOOGLE_CLOUD_CPP_DEPRECATED("TODO(#6161)")
   explicit Client(ClientOptions options, Policies&&... policies)
       : Client(InternalOnly{}, internal::ApplyPolicies(
                                    internal::MakeOptions(std::move(options)),
@@ -245,6 +248,7 @@ class Client {
    * @snippet storage_object_samples.cc insert object modified retry
    */
   template <typename... Policies>
+  GOOGLE_CLOUD_CPP_DEPRECATED("TODO(#6161)")
   explicit Client(std::shared_ptr<oauth2::Credentials> credentials,
                   Policies&&... policies)
       : Client(InternalOnly{},
@@ -253,6 +257,7 @@ class Client {
                    std::forward<Policies>(policies)...)) {}
 
   /// Create a Client using ClientOptions::CreateDefaultClientOptions().
+  GOOGLE_CLOUD_CPP_DEPRECATED("TODO(#6161)")
   static StatusOr<Client> CreateDefaultClient();
 
   /// Builds a client and maybe override the retry, idempotency, and/or backoff
@@ -275,7 +280,7 @@ class Client {
                CreateDefaultInternalClient(
                    internal::ApplyPolicies(
                        internal::DefaultOptions(
-                           client->client_options().credentials()),
+                           client->client_options().credentials(), {}),
                        std::forward<Policies>(policies)...),
                    client)) {
   }
@@ -3134,7 +3139,6 @@ class Client {
  private:
   friend internal::ClientImplDetails;
 
-  Client() = default;
   struct InternalOnly {};
   struct InternalOnlyNoDecorations {};
 
@@ -3254,12 +3258,14 @@ struct ClientImplDetails {
   static std::shared_ptr<RawClient> GetRawClient(Client& c) {
     return c.raw_client_;
   }
+
   static StatusOr<ObjectMetadata> UploadStreamResumable(
       Client& client, std::istream& source,
       internal::ResumableUploadRequest const& request) {
     return client.UploadStreamResumable(source, request);
   }
   template <typename... Policies>
+
   static Client CreateClient(std::shared_ptr<internal::RawClient> c,
                              Policies&&... p) {
     auto opts =
@@ -3268,18 +3274,10 @@ struct ClientImplDetails {
     return Client(Client::InternalOnlyNoDecorations{},
                   Client::CreateDefaultInternalClient(opts, std::move(c)));
   }
+
   static Client CreateWithoutDecorations(
       std::shared_ptr<internal::RawClient> c) {
     return Client(Client::InternalOnlyNoDecorations{}, std::move(c));
-  }
-
-  // TODO(#6161) - this should become a public API and the *recommended* way to
-  //     create a Client.
-  static Client CreateClient(std::shared_ptr<oauth2::Credentials> credentials,
-                             Options opts = {}) {
-    opts = DefaultOptions(std::move(credentials), std::move(opts));
-    return Client(Client::InternalOnlyNoDecorations{},
-                  Client::CreateDefaultInternalClient(opts));
   }
 };
 

--- a/google/cloud/storage/client_options.h
+++ b/google/cloud/storage/client_options.h
@@ -52,7 +52,8 @@ Options ApplyPolicies(Options opts, P&& head, Policies&&... tail) {
 }
 
 Options DefaultOptions(std::shared_ptr<oauth2::Credentials> credentials,
-                       Options opts = {});
+                       Options opts);
+Options DefaultOptionsWithCredentials(Options opts);
 
 }  // namespace internal
 
@@ -116,26 +117,26 @@ class ClientOptions {
       ChannelOptions const& channel_options);
 
   std::shared_ptr<oauth2::Credentials> credentials() const {
-    return opts_.get<internal::Oauth2CredentialsOption>();
+    return opts_.get<Oauth2CredentialsOption>();
   }
   ClientOptions& set_credentials(std::shared_ptr<oauth2::Credentials> c) {
-    opts_.set<internal::Oauth2CredentialsOption>(std::move(c));
+    opts_.set<Oauth2CredentialsOption>(std::move(c));
     return *this;
   }
 
   std::string const& endpoint() const {
-    return opts_.get<internal::RestEndpointOption>();
+    return opts_.get<RestEndpointOption>();
   }
   ClientOptions& set_endpoint(std::string endpoint) {
-    opts_.set<internal::RestEndpointOption>(std::move(endpoint));
+    opts_.set<RestEndpointOption>(std::move(endpoint));
     return *this;
   }
 
   std::string const& iam_endpoint() const {
-    return opts_.get<internal::IamEndpointOption>();
+    return opts_.get<IamEndpointOption>();
   }
   ClientOptions& set_iam_endpoint(std::string endpoint) {
-    opts_.set<internal::IamEndpointOption>(std::move(endpoint));
+    opts_.set<IamEndpointOption>(std::move(endpoint));
     return *this;
   }
 
@@ -153,29 +154,27 @@ class ClientOptions {
   bool enable_raw_client_tracing() const;
   ClientOptions& set_enable_raw_client_tracing(bool enable);
 
-  std::string const& project_id() const {
-    return opts_.get<internal::ProjectIdOption>();
-  }
+  std::string const& project_id() const { return opts_.get<ProjectIdOption>(); }
   ClientOptions& set_project_id(std::string v) {
-    opts_.set<internal::ProjectIdOption>(std::move(v));
+    opts_.set<ProjectIdOption>(std::move(v));
     return *this;
   }
 
   std::size_t connection_pool_size() const {
-    return opts_.get<internal::ConnectionPoolSizeOption>();
+    return opts_.get<ConnectionPoolSizeOption>();
   }
   ClientOptions& set_connection_pool_size(std::size_t size) {
-    opts_.set<internal::ConnectionPoolSizeOption>(size);
+    opts_.set<ConnectionPoolSizeOption>(size);
     return *this;
   }
 
   std::size_t download_buffer_size() const {
-    return opts_.get<internal::DownloadBufferSizeOption>();
+    return opts_.get<DownloadBufferSizeOption>();
   }
   ClientOptions& SetDownloadBufferSize(std::size_t size);
 
   std::size_t upload_buffer_size() const {
-    return opts_.get<internal::UploadBufferSizeOption>();
+    return opts_.get<UploadBufferSizeOption>();
   }
   ClientOptions& SetUploadBufferSize(std::size_t size);
 
@@ -195,10 +194,10 @@ class ClientOptions {
   }
 
   std::size_t maximum_simple_upload_size() const {
-    return opts_.get<internal::MaximumSimpleUploadSizeOption>();
+    return opts_.get<MaximumSimpleUploadSizeOption>();
   }
   ClientOptions& set_maximum_simple_upload_size(std::size_t v) {
-    opts_.set<internal::MaximumSimpleUploadSizeOption>(v);
+    opts_.set<MaximumSimpleUploadSizeOption>(v);
     return *this;
   }
 
@@ -207,34 +206,34 @@ class ClientOptions {
    * callbacks for locking.
    */
   bool enable_ssl_locking_callbacks() const {
-    return opts_.get<internal::EnableCurlSslLockingOption>();
+    return opts_.get<EnableCurlSslLockingOption>();
   }
   ClientOptions& set_enable_ssl_locking_callbacks(bool v) {
-    opts_.set<internal::EnableCurlSslLockingOption>(v);
+    opts_.set<EnableCurlSslLockingOption>(v);
     return *this;
   }
 
   bool enable_sigpipe_handler() const {
-    return opts_.get<internal::EnableCurlSigpipeHandlerOption>();
+    return opts_.get<EnableCurlSigpipeHandlerOption>();
   }
   ClientOptions& set_enable_sigpipe_handler(bool v) {
-    opts_.set<internal::EnableCurlSigpipeHandlerOption>(v);
+    opts_.set<EnableCurlSigpipeHandlerOption>(v);
     return *this;
   }
 
   std::size_t maximum_socket_recv_size() const {
-    return opts_.get<internal::MaximumCurlSocketRecvSizeOption>();
+    return opts_.get<MaximumCurlSocketRecvSizeOption>();
   }
   ClientOptions& set_maximum_socket_recv_size(std::size_t v) {
-    opts_.set<internal::MaximumCurlSocketRecvSizeOption>(v);
+    opts_.set<MaximumCurlSocketRecvSizeOption>(v);
     return *this;
   }
 
   std::size_t maximum_socket_send_size() const {
-    return opts_.get<internal::MaximumCurlSocketSendSizeOption>();
+    return opts_.get<MaximumCurlSocketSendSizeOption>();
   }
   ClientOptions& set_maximum_socket_send_size(std::size_t v) {
-    opts_.set<internal::MaximumCurlSocketSendSizeOption>(v);
+    opts_.set<MaximumCurlSocketSendSizeOption>(v);
     return *this;
   }
 
@@ -252,10 +251,10 @@ class ClientOptions {
    * The default value is 2 minutes. Can be disabled by setting the value to 0.
    */
   std::chrono::seconds download_stall_timeout() const {
-    return opts_.get<internal::DownloadStallTimeoutOption>();
+    return opts_.get<DownloadStallTimeoutOption>();
   }
   ClientOptions& set_download_stall_timeout(std::chrono::seconds v) {
-    opts_.set<internal::DownloadStallTimeoutOption>(std::move(v));
+    opts_.set<DownloadStallTimeoutOption>(std::move(v));
     return *this;
   }
   //@}

--- a/google/cloud/storage/client_options_test.cc
+++ b/google/cloud/storage/client_options_test.cc
@@ -308,36 +308,33 @@ TEST_F(ClientOptionsTest, MakeOptionsFromDefault) {
   google::cloud::internal::SetEnv("GOOGLE_CLOUD_PROJECT", "test-project-id");
   auto const opts = internal::MakeOptions(
       ClientOptions(oauth2::CreateAnonymousCredentials()));
-  EXPECT_EQ("https://storage.googleapis.com",
-            opts.get<internal::RestEndpointOption>());
+  EXPECT_EQ("https://storage.googleapis.com", opts.get<RestEndpointOption>());
   EXPECT_EQ("https://iamcredentials.googleapis.com/v1",
-            opts.get<internal::IamEndpointOption>());
-  EXPECT_TRUE(opts.has<internal::Oauth2CredentialsOption>());
+            opts.get<IamEndpointOption>());
+  EXPECT_TRUE(opts.has<Oauth2CredentialsOption>());
   EXPECT_EQ("v1", opts.get<internal::TargetApiVersionOption>());
-  EXPECT_EQ("test-project-id", opts.get<internal::ProjectIdOption>());
-  EXPECT_LT(0, opts.get<internal::ConnectionPoolSizeOption>());
-  EXPECT_LT(0, opts.get<internal::DownloadBufferSizeOption>());
-  EXPECT_LT(0, opts.get<internal::UploadBufferSizeOption>());
-  EXPECT_LT(0, opts.get<internal::MaximumSimpleUploadSizeOption>());
-  EXPECT_TRUE(opts.has<internal::EnableCurlSslLockingOption>());
-  EXPECT_TRUE(opts.has<internal::EnableCurlSigpipeHandlerOption>());
-  EXPECT_EQ(0, opts.get<internal::MaximumCurlSocketSendSizeOption>());
-  EXPECT_EQ(0, opts.get<internal::MaximumCurlSocketRecvSizeOption>());
-  EXPECT_LT(0, opts.get<internal::DownloadStallTimeoutOption>().count());
+  EXPECT_EQ("test-project-id", opts.get<ProjectIdOption>());
+  EXPECT_LT(0, opts.get<ConnectionPoolSizeOption>());
+  EXPECT_LT(0, opts.get<DownloadBufferSizeOption>());
+  EXPECT_LT(0, opts.get<UploadBufferSizeOption>());
+  EXPECT_LT(0, opts.get<MaximumSimpleUploadSizeOption>());
+  EXPECT_TRUE(opts.has<EnableCurlSslLockingOption>());
+  EXPECT_TRUE(opts.has<EnableCurlSigpipeHandlerOption>());
+  EXPECT_EQ(0, opts.get<MaximumCurlSocketSendSizeOption>());
+  EXPECT_EQ(0, opts.get<MaximumCurlSocketRecvSizeOption>());
+  EXPECT_LT(0, opts.get<DownloadStallTimeoutOption>().count());
   EXPECT_THAT(opts.get<CARootsFilePathOption>(), IsEmpty());
 }
 
 TEST_F(ClientOptionsTest, DefaultOptions) {
   auto o = internal::DefaultOptions(oauth2::CreateAnonymousCredentials(), {});
-  EXPECT_EQ("https://storage.googleapis.com",
-            o.get<internal::RestEndpointOption>());
+  EXPECT_EQ("https://storage.googleapis.com", o.get<RestEndpointOption>());
 
   // Verify any set values are respected overriden.
-  o = internal::DefaultOptions(oauth2::CreateAnonymousCredentials(),
-                               Options{}.set<internal::RestEndpointOption>(
-                                   "https://private.googleapis.com"));
-  EXPECT_EQ("https://private.googleapis.com",
-            o.get<internal::RestEndpointOption>());
+  o = internal::DefaultOptions(
+      oauth2::CreateAnonymousCredentials(),
+      Options{}.set<RestEndpointOption>("https://private.googleapis.com"));
+  EXPECT_EQ("https://private.googleapis.com", o.get<RestEndpointOption>());
 }
 
 }  // namespace

--- a/google/cloud/storage/client_sign_policy_document_test.cc
+++ b/google/cloud/storage/client_sign_policy_document_test.cc
@@ -61,7 +61,7 @@ StatusOr<Client> CreateClientForTest() {
   auto creds = oauth2::CreateServiceAccountCredentialsFromJsonContents(
       kJsonKeyfileContents);
   if (!creds) return std::move(creds).status();
-  return Client(*creds);
+  return Client(Options{}.set<Oauth2CredentialsOption>(*creds));
 }
 
 /**

--- a/google/cloud/storage/client_sign_url_test.cc
+++ b/google/cloud/storage/client_sign_url_test.cc
@@ -54,7 +54,7 @@ TEST_F(CreateSignedUrlTest, V2Sign) {
   auto creds = oauth2::CreateServiceAccountCredentialsFromJsonContents(
       kJsonKeyfileContents);
   ASSERT_STATUS_OK(creds);
-  Client client(*creds);
+  Client client(Options{}.set<Oauth2CredentialsOption>(*creds));
 
   auto actual = client.CreateV2SignedUrl("GET", "test-bucket", "test-object");
   ASSERT_STATUS_OK(actual);
@@ -67,7 +67,7 @@ TEST_F(CreateSignedUrlTest, V2SignBucketOnly) {
   auto creds = oauth2::CreateServiceAccountCredentialsFromJsonContents(
       kJsonKeyfileContents);
   ASSERT_STATUS_OK(creds);
-  Client client(*creds);
+  Client client(Options{}.set<Oauth2CredentialsOption>(*creds));
 
   auto actual = client.CreateV2SignedUrl("GET", "test-bucket", "", WithAcl());
   ASSERT_STATUS_OK(actual);
@@ -79,7 +79,7 @@ TEST_F(CreateSignedUrlTest, V2SignEscape) {
   auto creds = oauth2::CreateServiceAccountCredentialsFromJsonContents(
       kJsonKeyfileContents);
   ASSERT_STATUS_OK(creds);
-  Client client(*creds);
+  Client client(Options{}.set<Oauth2CredentialsOption>(*creds));
 
   auto actual = client.CreateV2SignedUrl("GET", "test-bucket", "test+object");
   ASSERT_STATUS_OK(actual);
@@ -152,7 +152,7 @@ TEST_F(CreateSignedUrlTest, V4SignGet) {
   auto creds = oauth2::CreateServiceAccountCredentialsFromJsonContents(
       kJsonKeyfileContentsForV4);
   ASSERT_STATUS_OK(creds);
-  Client client(*creds);
+  Client client(Options{}.set<Oauth2CredentialsOption>(*creds));
 
   std::string const bucket_name = "test-bucket";
   std::string const object_name = "test-object";
@@ -195,7 +195,7 @@ TEST_F(CreateSignedUrlTest, V4SignPut) {
   auto creds = oauth2::CreateServiceAccountCredentialsFromJsonContents(
       kJsonKeyfileContentsForV4);
   ASSERT_STATUS_OK(creds);
-  Client client(*creds);
+  Client client(Options{}.set<Oauth2CredentialsOption>(*creds));
 
   std::string const bucket_name = "test-bucket";
   std::string const object_name = "test-object";

--- a/google/cloud/storage/client_test.cc
+++ b/google/cloud/storage/client_test.cc
@@ -141,8 +141,8 @@ TEST_F(ClientTest, OverrideBothPolicies) {
 TEST_F(ClientTest, DefaultDecorators) {
   // Create a client, use the anonymous credentials because on the CI
   // environment there may not be other credentials configured.
-  ClientOptions options(oauth2::CreateAnonymousCredentials());
-  Client tested(options);
+  auto tested = Client(
+      Options{}.set<UnifiedCredentialsOption>(MakeInsecureCredentials()));
 
   EXPECT_TRUE(ClientImplDetails::GetRawClient(tested) != nullptr);
   auto* retry = dynamic_cast<internal::RetryClient*>(
@@ -157,9 +157,10 @@ TEST_F(ClientTest, DefaultDecorators) {
 TEST_F(ClientTest, LoggingDecorators) {
   // Create a client, use the anonymous credentials because on the CI
   // environment there may not be other credentials configured.
-  ClientOptions options(oauth2::CreateAnonymousCredentials());
-  options.set_enable_raw_client_tracing(true);
-  Client tested(options);
+  auto tested =
+      Client(Options{}
+                 .set<UnifiedCredentialsOption>(MakeInsecureCredentials())
+                 .set<TracingComponentsOption>({"raw-client"}));
 
   EXPECT_TRUE(ClientImplDetails::GetRawClient(tested) != nullptr);
   auto* retry = dynamic_cast<internal::RetryClient*>(

--- a/google/cloud/storage/examples/storage_auth_samples.cc
+++ b/google/cloud/storage/examples/storage_auth_samples.cc
@@ -51,10 +51,8 @@ void DefaultClient(std::vector<std::string> const& argv) {
   //! [default-client]
   namespace gcs = google::cloud::storage;
   [](std::string const& bucket_name, std::string const& object_name) {
-    auto client = gcs::Client::CreateDefaultClient();
-    if (!client) throw std::runtime_error(client.status().message());
-
-    PerformSomeOperations(*client, bucket_name, object_name);
+    auto client = gcs::Client();
+    PerformSomeOperations(client, bucket_name, object_name);
   }
   //! [default-client]
   (argv.at(0), argv.at(1));
@@ -75,8 +73,10 @@ void ServiceAccountKeyfileJson(std::vector<std::string> const& argv) {
         gcs::oauth2::CreateServiceAccountCredentialsFromFilePath(filename);
     if (!credentials) throw std::runtime_error(credentials.status().message());
 
-    PerformSomeOperations(gcs::Client(gcs::ClientOptions(*credentials)),
-                          bucket_name, object_name);
+    PerformSomeOperations(
+        gcs::Client(google::cloud::Options{}.set<gcs::Oauth2CredentialsOption>(
+            *credentials)),
+        bucket_name, object_name);
   }
   //! [service-account-keyfile-json]
   (argv.at(0), argv.at(1), argv.at(2));
@@ -101,8 +101,10 @@ void ServiceAccountContentsJson(std::vector<std::string> const& argv) {
         gcs::oauth2::CreateServiceAccountCredentialsFromJsonContents(contents);
     if (!credentials) throw std::runtime_error(credentials.status().message());
 
-    PerformSomeOperations(gcs::Client(gcs::ClientOptions(*credentials)),
-                          bucket_name, object_name);
+    PerformSomeOperations(
+        gcs::Client(google::cloud::Options{}.set<gcs::Oauth2CredentialsOption>(
+            *credentials)),
+        bucket_name, object_name);
   }
   //! [service-account-contents-json]
   (argv.at(0), argv.at(1), argv.at(2));
@@ -120,7 +122,7 @@ void RunAll(std::vector<std::string> const& argv) {
       google::cloud::internal::GetEnv("GOOGLE_CLOUD_PROJECT").value();
   auto generator = google::cloud::internal::DefaultPRNG(std::random_device{}());
   auto const bucket_name = examples::MakeRandomBucketName(generator);
-  auto client = gcs::Client::CreateDefaultClient().value();
+  auto client = gcs::Client();
   std::cout << "\nCreating bucket to run the example (" << bucket_name << ")"
             << std::endl;
   (void)client

--- a/google/cloud/storage/examples/storage_bucket_acl_samples.cc
+++ b/google/cloud/storage/examples/storage_bucket_acl_samples.cc
@@ -242,7 +242,7 @@ void RunAll(std::vector<std::string> const& argv) {
   auto generator = google::cloud::internal::DefaultPRNG(std::random_device{}());
   auto const bucket_name = examples::MakeRandomBucketName(generator);
   auto const entity = "user-" + service_account;
-  auto client = gcs::Client::CreateDefaultClient().value();
+  auto client = gcs::Client();
   std::cout << "\nCreating bucket to run the example (" << bucket_name << ")"
             << std::endl;
   (void)client

--- a/google/cloud/storage/examples/storage_bucket_cors_samples.cc
+++ b/google/cloud/storage/examples/storage_bucket_cors_samples.cc
@@ -95,7 +95,7 @@ void RunAll(std::vector<std::string> const& argv) {
       google::cloud::internal::GetEnv("GOOGLE_CLOUD_PROJECT").value();
   auto generator = google::cloud::internal::DefaultPRNG(std::random_device{}());
   auto const bucket_name = examples::MakeRandomBucketName(generator);
-  auto client = gcs::Client::CreateDefaultClient().value();
+  auto client = gcs::Client();
 
   std::cout << "\nCreating bucket to run the example (" << bucket_name << ")"
             << std::endl;

--- a/google/cloud/storage/examples/storage_bucket_default_kms_key_samples.cc
+++ b/google/cloud/storage/examples/storage_bucket_default_kms_key_samples.cc
@@ -108,7 +108,7 @@ void RunAll(std::vector<std::string> const& argv) {
           .value();
   auto generator = google::cloud::internal::DefaultPRNG(std::random_device{}());
   auto const bucket_name = examples::MakeRandomBucketName(generator);
-  auto client = gcs::Client::CreateDefaultClient().value();
+  auto client = gcs::Client();
 
   std::cout << "\nCreating bucket to run the example (" << bucket_name << ")"
             << std::endl;

--- a/google/cloud/storage/examples/storage_bucket_iam_samples.cc
+++ b/google/cloud/storage/examples/storage_bucket_iam_samples.cc
@@ -268,7 +268,7 @@ void RunAll(std::vector<std::string> const& argv) {
           .value();
   auto generator = google::cloud::internal::DefaultPRNG(std::random_device{}());
   auto const bucket_name = examples::MakeRandomBucketName(generator);
-  auto client = gcs::Client::CreateDefaultClient().value();
+  auto client = gcs::Client();
   std::cout << "\nCreating bucket to run the examples (" << bucket_name << ")"
             << std::endl;
 

--- a/google/cloud/storage/examples/storage_bucket_requester_pays_samples.cc
+++ b/google/cloud/storage/examples/storage_bucket_requester_pays_samples.cc
@@ -182,7 +182,7 @@ void RunAll(std::vector<std::string> const& argv) {
   auto const bucket_name = examples::MakeRandomBucketName(generator);
   auto const object_name =
       examples::MakeRandomObjectName(generator, "object-") + ".txt";
-  auto client = gcs::Client::CreateDefaultClient().value();
+  auto client = gcs::Client();
 
   std::cout << "\nCreating bucket to run the example (" << bucket_name << ")"
             << std::endl;

--- a/google/cloud/storage/examples/storage_bucket_samples.cc
+++ b/google/cloud/storage/examples/storage_bucket_samples.cc
@@ -450,7 +450,7 @@ void RunAll(std::vector<std::string> const& argv) {
       google::cloud::internal::GetEnv("GOOGLE_CLOUD_PROJECT").value();
   auto generator = google::cloud::internal::DefaultPRNG(std::random_device{}());
   auto const bucket_name = examples::MakeRandomBucketName(generator);
-  auto client = gcs::Client::CreateDefaultClient().value();
+  auto client = gcs::Client();
 
   // This is the only example that cleans up stale buckets. The examples run in
   // parallel (within a build and across the builds), having multiple examples

--- a/google/cloud/storage/examples/storage_default_object_acl_samples.cc
+++ b/google/cloud/storage/examples/storage_default_object_acl_samples.cc
@@ -199,7 +199,7 @@ void RunAll(std::vector<std::string> const& argv) {
   auto generator = google::cloud::internal::DefaultPRNG(std::random_device{}());
   auto const bucket_name = examples::MakeRandomBucketName(generator);
   auto const entity = "user-" + service_account;
-  auto client = gcs::Client::CreateDefaultClient().value();
+  auto client = gcs::Client();
   std::cout << "\nCreating bucket to run the example (" << bucket_name << ")"
             << std::endl;
   (void)client

--- a/google/cloud/storage/examples/storage_event_based_hold_samples.cc
+++ b/google/cloud/storage/examples/storage_event_based_hold_samples.cc
@@ -120,7 +120,7 @@ void RunAll(std::vector<std::string> const& argv) {
       google::cloud::internal::GetEnv("GOOGLE_CLOUD_PROJECT").value();
   auto generator = google::cloud::internal::DefaultPRNG(std::random_device{}());
   auto const bucket_name = examples::MakeRandomBucketName(generator);
-  auto client = gcs::Client::CreateDefaultClient().value();
+  auto client = gcs::Client();
 
   std::cout << "\nCreating bucket to run the examples" << std::endl;
   (void)client.CreateBucketForProject(bucket_name, project_id,

--- a/google/cloud/storage/examples/storage_examples_common.cc
+++ b/google/cloud/storage/examples/storage_examples_common.cc
@@ -57,7 +57,7 @@ Commands::value_type CreateCommandEntry(
       }
       throw Usage{std::move(os).str()};
     }
-    auto client = google::cloud::storage::Client::CreateDefaultClient().value();
+    auto client = google::cloud::storage::Client();
     command(std::move(client), std::move(argv));
   };
   return {name, std::move(adapter)};

--- a/google/cloud/storage/examples/storage_grpc_samples.cc
+++ b/google/cloud/storage/examples/storage_grpc_samples.cc
@@ -65,7 +65,7 @@ void GrpcReadWriteCommand(std::vector<std::string> argv) {
 void GrpcClientWithProject(std::string project_id) {
   namespace gcs = google::cloud::storage;
   auto client = google::cloud::storage_experimental::DefaultGrpcClient(
-      google::cloud::Options{}.set<gcs::internal::ProjectIdOption>(
+      google::cloud::Options{}.set<gcs::ProjectIdOption>(
           std::move(project_id)));
   if (!client) throw std::runtime_error(client.status().message());
   std::cout << "Successfully created a gcs::Client configured to use gRPC\n";

--- a/google/cloud/storage/examples/storage_lifecycle_management_samples.cc
+++ b/google/cloud/storage/examples/storage_lifecycle_management_samples.cc
@@ -126,7 +126,7 @@ void RunAll(std::vector<std::string> const& argv) {
       google::cloud::internal::GetEnv("GOOGLE_CLOUD_PROJECT").value();
   auto generator = google::cloud::internal::DefaultPRNG(std::random_device{}());
   auto const bucket_name = examples::MakeRandomBucketName(generator);
-  auto client = gcs::Client::CreateDefaultClient().value();
+  auto client = gcs::Client();
 
   std::cout << "\nCreating bucket to run the examples" << std::endl;
   (void)client.CreateBucketForProject(bucket_name, project_id,

--- a/google/cloud/storage/examples/storage_notification_samples.cc
+++ b/google/cloud/storage/examples/storage_notification_samples.cc
@@ -125,7 +125,7 @@ void RunAll(std::vector<std::string> const& argv) {
                               .value();
   auto generator = google::cloud::internal::DefaultPRNG(std::random_device{}());
   auto const bucket_name = examples::MakeRandomBucketName(generator);
-  auto client = gcs::Client::CreateDefaultClient().value();
+  auto client = gcs::Client();
 
   std::cout << "\nCreating bucket to run the example (" << bucket_name << ")"
             << std::endl;

--- a/google/cloud/storage/examples/storage_object_acl_samples.cc
+++ b/google/cloud/storage/examples/storage_object_acl_samples.cc
@@ -255,7 +255,7 @@ void RunAll(std::vector<std::string> const& argv) {
   auto generator = google::cloud::internal::DefaultPRNG(std::random_device{}());
   auto const bucket_name = examples::MakeRandomBucketName(generator);
   auto const entity = "user-" + service_account;
-  auto client = gcs::Client::CreateDefaultClient().value();
+  auto client = gcs::Client();
   std::cout << "\nCreating bucket to run the example (" << bucket_name << ")"
             << std::endl;
   (void)client

--- a/google/cloud/storage/examples/storage_object_cmek_samples.cc
+++ b/google/cloud/storage/examples/storage_object_cmek_samples.cc
@@ -106,7 +106,7 @@ void RunAll(std::vector<std::string> const& argv) {
           .value();
   auto generator = google::cloud::internal::DefaultPRNG(std::random_device{}());
   auto const bucket_name = examples::MakeRandomBucketName(generator);
-  auto client = gcs::Client::CreateDefaultClient().value();
+  auto client = gcs::Client();
 
   std::cout << "\nCreating bucket to run the example (" << bucket_name << ")"
             << std::endl;

--- a/google/cloud/storage/examples/storage_object_csek_samples.cc
+++ b/google/cloud/storage/examples/storage_object_csek_samples.cc
@@ -223,7 +223,7 @@ void RunAll(std::vector<std::string> const& argv) {
   auto const object_name =
       examples::MakeRandomObjectName(generator, "ob-resumable-upload-");
 
-  auto client = gcs::Client::CreateDefaultClient().value();
+  auto client = gcs::Client();
 
   auto const encrypted_object_name =
       examples::MakeRandomObjectName(generator, "enc-obj-");

--- a/google/cloud/storage/examples/storage_object_file_transfer_samples.cc
+++ b/google/cloud/storage/examples/storage_object_file_transfer_samples.cc
@@ -132,7 +132,7 @@ void RunAll(std::vector<std::string> const& argv) {
   auto generator = google::cloud::internal::DefaultPRNG(std::random_device{}());
   auto const filename_1 = MakeRandomFilename(generator);
   auto const object_name = examples::MakeRandomObjectName(generator, "ob-");
-  auto client = gcs::Client::CreateDefaultClient().value();
+  auto client = gcs::Client();
 
   std::string const text = R"""(
 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor

--- a/google/cloud/storage/examples/storage_object_hold_samples.cc
+++ b/google/cloud/storage/examples/storage_object_hold_samples.cc
@@ -133,7 +133,7 @@ void RunAll(std::vector<std::string> const& argv) {
   auto const bucket_name = google::cloud::internal::GetEnv(
                                "GOOGLE_CLOUD_CPP_STORAGE_TEST_BUCKET_NAME")
                                .value();
-  auto client = gcs::Client::CreateDefaultClient().value();
+  auto client = gcs::Client();
 
   auto generator = google::cloud::internal::DefaultPRNG(std::random_device{}());
   auto const object_name_1 =

--- a/google/cloud/storage/examples/storage_object_resumable_write_samples.cc
+++ b/google/cloud/storage/examples/storage_object_resumable_write_samples.cc
@@ -129,7 +129,7 @@ void RunAll(std::vector<std::string> const& argv) {
   auto const object_name =
       examples::MakeRandomObjectName(generator, "ob-resumable-upload-");
 
-  auto client = gcs::Client::CreateDefaultClient().value();
+  auto client = gcs::Client();
 
   std::cout << "\nRunning StartResumableUpload() example" << std::endl;
   StartResumableUpload(client, {bucket_name, object_name});

--- a/google/cloud/storage/examples/storage_object_rewrite_samples.cc
+++ b/google/cloud/storage/examples/storage_object_rewrite_samples.cc
@@ -172,7 +172,7 @@ void RunAll(std::vector<std::string> const& argv) {
           "GOOGLE_CLOUD_CPP_STORAGE_TEST_DESTINATION_BUCKET_NAME")
           .value();
 
-  auto client = gcs::Client::CreateDefaultClient().value();
+  auto client = gcs::Client();
   auto generator = google::cloud::internal::DefaultPRNG(std::random_device{}());
   auto const src_object_name =
       examples::MakeRandomObjectName(generator, "object-") + ".txt";

--- a/google/cloud/storage/examples/storage_object_versioning_samples.cc
+++ b/google/cloud/storage/examples/storage_object_versioning_samples.cc
@@ -166,7 +166,7 @@ void RunAll(std::vector<std::string> const& argv) {
           .value();
   auto generator = google::cloud::internal::DefaultPRNG(std::random_device{}());
   auto const bucket_name = examples::MakeRandomBucketName(generator);
-  auto client = gcs::Client::CreateDefaultClient().value();
+  auto client = gcs::Client();
 
   std::cout << "\nCreating bucket to run the example (" << bucket_name << ")"
             << std::endl;

--- a/google/cloud/storage/examples/storage_policy_doc_samples.cc
+++ b/google/cloud/storage/examples/storage_policy_doc_samples.cc
@@ -140,7 +140,7 @@ void RunAll(std::vector<std::string> const& argv) {
   auto const bucket_name = examples::MakeRandomBucketName(generator);
   auto const object_name =
       examples::MakeRandomObjectName(generator, "upload-object-");
-  auto client = gcs::Client::CreateDefaultClient().value();
+  auto client = gcs::Client();
   std::cout << "\nCreating bucket to run the example (" << bucket_name << ")"
             << std::endl;
   (void)client

--- a/google/cloud/storage/examples/storage_public_object_samples.cc
+++ b/google/cloud/storage/examples/storage_public_object_samples.cc
@@ -49,7 +49,9 @@ void ReadObjectUnauthenticated(std::vector<std::string> const& argv) {
   namespace gcs = google::cloud::storage;
   [](std::string const& bucket_name, std::string const& object_name) {
     // Create a client that does not authenticate with the server.
-    gcs::Client client{gcs::oauth2::CreateAnonymousCredentials()};
+    auto client = gcs::Client{
+        google::cloud::Options{}.set<google::cloud::UnifiedCredentialsOption>(
+            google::cloud::MakeInsecureCredentials())};
 
     // Read an object, the object must have been made public.
     gcs::ObjectReadStream stream = client.ReadObject(bucket_name, object_name);
@@ -82,7 +84,7 @@ void RunAll(std::vector<std::string> const& argv) {
   auto generator = google::cloud::internal::DefaultPRNG(std::random_device{}());
   auto const object_name =
       examples::MakeRandomObjectName(generator, "public-object-") + ".txt";
-  auto client = gcs::Client::CreateDefaultClient().value();
+  auto client = gcs::Client();
 
   auto constexpr kText = R"""(A bit of text to store in the test object.
 The actual contents are not interesting.

--- a/google/cloud/storage/examples/storage_quickstart.cc
+++ b/google/cloud/storage/examples/storage_quickstart.cc
@@ -31,12 +31,10 @@ void StorageQuickstart(std::string const& bucket_name) {
 
   // Create a client to communicate with Google Cloud Storage. This client
   // uses the default configuration for authentication and project id.
-  google::cloud::StatusOr<gcs::Client> client =
-      gcs::Client::CreateDefaultClient();
-  if (!client) throw std::runtime_error(client.status().message());
+  auto client = gcs::Client();
 
   // Create a bucket
-  google::cloud::StatusOr<gcs::BucketMetadata> metadata = client->CreateBucket(
+  google::cloud::StatusOr<gcs::BucketMetadata> metadata = client.CreateBucket(
       bucket_name, gcs::BucketMetadata().set_location("US").set_storage_class(
                        gcs::storage_class::Standard()));
   if (!metadata) throw std::runtime_error(metadata.status().message());
@@ -68,7 +66,7 @@ void RunAll(std::vector<std::string> const& argv) {
   std::cout << "\nRunning StorageQuickStart() example" << std::endl;
   StorageQuickstartCommand({bucket_name});
 
-  auto client = gcs::Client::CreateDefaultClient().value();
+  auto client = gcs::Client();
   (void)examples::RemoveBucketAndContents(client, bucket_name);
 }
 

--- a/google/cloud/storage/examples/storage_retention_policy_samples.cc
+++ b/google/cloud/storage/examples/storage_retention_policy_samples.cc
@@ -172,7 +172,7 @@ void RunAll(std::vector<std::string> const& argv) {
       google::cloud::internal::GetEnv("GOOGLE_CLOUD_PROJECT").value();
   auto generator = google::cloud::internal::DefaultPRNG(std::random_device{}());
   auto const bucket_name = examples::MakeRandomBucketName(generator);
-  auto client = gcs::Client::CreateDefaultClient().value();
+  auto client = gcs::Client();
 
   std::cout << "\nCreating bucket to run the examples" << std::endl;
   (void)client.CreateBucketForProject(bucket_name, project_id,

--- a/google/cloud/storage/examples/storage_service_account_samples.cc
+++ b/google/cloud/storage/examples/storage_service_account_samples.cc
@@ -247,7 +247,7 @@ void RunAll(std::vector<std::string> const& argv) {
       google::cloud::internal::GetEnv(
           "GOOGLE_CLOUD_CPP_STORAGE_TEST_HMAC_SERVICE_ACCOUNT")
           .value();
-  auto client = gcs::Client::CreateDefaultClient().value();
+  auto client = gcs::Client();
 
   std::cout << "\nRunning GetServiceAccountForProject() example" << std::endl;
   GetServiceAccountForProject(client, {project_id});

--- a/google/cloud/storage/examples/storage_signed_url_v2_samples.cc
+++ b/google/cloud/storage/examples/storage_signed_url_v2_samples.cc
@@ -88,7 +88,7 @@ void RunAll(std::vector<std::string> const& argv) {
   auto const object_name =
       examples::MakeRandomObjectName(generator, "cloud-cpp-test-examples-");
 
-  auto client = gcs::Client::CreateDefaultClient().value();
+  auto client = gcs::Client();
 
   if (examples::UsingEmulator()) {
     std::cout << "Signed URL examples are only runnable against production\n";

--- a/google/cloud/storage/examples/storage_signed_url_v4_samples.cc
+++ b/google/cloud/storage/examples/storage_signed_url_v4_samples.cc
@@ -86,7 +86,7 @@ void RunAll(std::vector<std::string> const& argv) {
   auto const object_name =
       examples::MakeRandomObjectName(generator, "cloud-cpp-test-examples-");
 
-  auto client = gcs::Client::CreateDefaultClient().value();
+  auto client = gcs::Client();
 
   if (examples::UsingEmulator()) {
     std::cout << "Signed URL examples are only runnable against production\n";

--- a/google/cloud/storage/examples/storage_website_samples.cc
+++ b/google/cloud/storage/examples/storage_website_samples.cc
@@ -136,7 +136,7 @@ void RunAll(std::vector<std::string> const& argv) {
       google::cloud::internal::GetEnv("GOOGLE_CLOUD_PROJECT").value();
   auto generator = google::cloud::internal::DefaultPRNG(std::random_device{}());
   auto const bucket_name = examples::MakeRandomBucketName(generator);
-  auto client = gcs::Client::CreateDefaultClient().value();
+  auto client = gcs::Client();
   std::cout << "\nCreating bucket to run the example (" << bucket_name << ")"
             << std::endl;
   (void)client

--- a/google/cloud/storage/grpc_plugin.cc
+++ b/google/cloud/storage/grpc_plugin.cc
@@ -38,14 +38,13 @@ StatusOr<google::cloud::storage::Client> DefaultGrpcClient(Options opts) {
         storage::internal::GrpcClient::Create(opts));
   }
   // The hybrid client might need the OAuth2 credentials
-  if (!opts.has<storage::internal::Oauth2CredentialsOption>()) {
+  if (!opts.has<storage::Oauth2CredentialsOption>()) {
     storage::ChannelOptions channel_options;
     channel_options.set_ssl_root_path(opts.get<CARootsFilePathOption>());
     auto credentials =
         storage::oauth2::GoogleDefaultCredentials(channel_options);
     if (!credentials) return std::move(credentials).status();
-    opts.set<storage::internal::Oauth2CredentialsOption>(
-        *std::move(credentials));
+    opts.set<storage::Oauth2CredentialsOption>(*std::move(credentials));
   }
   return storage::internal::ClientImplDetails::CreateClient(
       storage::internal::HybridClient::Create(opts));

--- a/google/cloud/storage/internal/curl_resumable_upload_session_test.cc
+++ b/google/cloud/storage/internal/curl_resumable_upload_session_test.cc
@@ -35,8 +35,8 @@ class MockCurlClient : public CurlClient {
   }
 
   MockCurlClient()
-      : CurlClient(
-            internal::DefaultOptions(oauth2::CreateAnonymousCredentials())) {}
+      : CurlClient(internal::DefaultOptions(
+            oauth2::CreateAnonymousCredentials(), {})) {}
 
   MOCK_METHOD(StatusOr<ResumableUploadResponse>, UploadChunk,
               (UploadChunkRequest const&), (override));

--- a/google/cloud/storage/internal/grpc_client_failures_test.cc
+++ b/google/cloud/storage/internal/grpc_client_failures_test.cc
@@ -52,11 +52,10 @@ class GrpcClientFailuresTest
                                     grpc_config);
     auto options =
         Options{}
-            .set<internal::RestEndpointOption>("http://localhost:1")
-            .set<internal::IamEndpointOption>("http://localhost:1")
+            .set<RestEndpointOption>("http://localhost:1")
+            .set<IamEndpointOption>("http://localhost:1")
             .set<EndpointOption>("localhost:1")
-            .set<internal::Oauth2CredentialsOption>(
-                oauth2::CreateAnonymousCredentials())
+            .set<Oauth2CredentialsOption>(oauth2::CreateAnonymousCredentials())
             .set<GrpcCredentialOption>(grpc::InsecureChannelCredentials());
     if (grpc_config == "metadata") {
       client_ = GrpcClient::Create(DefaultOptionsGrpc(std::move(options)));

--- a/google/cloud/storage/options.h
+++ b/google/cloud/storage/options.h
@@ -44,9 +44,6 @@ struct CAPathOption {
 
 }  // namespace internal
 
-// TODO(#6161) - move the following options to the public API
-namespace internal {
-
 /// Configure the REST endpoint for the GCS client library.
 struct RestEndpointOption {
   using Type = std::string;
@@ -211,14 +208,13 @@ struct IdempotencyPolicyOption {
 /// The complete list of options accepted by `storage::Client`.
 using ClientOptionList = ::google::cloud::OptionList<
     RestEndpointOption, IamEndpointOption, Oauth2CredentialsOption,
-    TargetApiVersionOption, ProjectIdOption, ProjectIdOption,
-    ConnectionPoolSizeOption, DownloadBufferSizeOption, UploadBufferSizeOption,
+    ProjectIdOption, ProjectIdOption, ConnectionPoolSizeOption,
+    DownloadBufferSizeOption, UploadBufferSizeOption,
     EnableCurlSslLockingOption, EnableCurlSigpipeHandlerOption,
     MaximumCurlSocketRecvSizeOption, MaximumCurlSocketSendSizeOption,
     DownloadStallTimeoutOption, RetryPolicyOption, BackoffPolicyOption,
     IdempotencyPolicyOption, CARootsFilePathOption>;
 
-}  // namespace internal
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage
 }  // namespace cloud

--- a/google/cloud/storage/testing/storage_integration_test.cc
+++ b/google/cloud/storage/testing/storage_integration_test.cc
@@ -74,10 +74,9 @@ StorageIntegrationTest::MakeIntegrationTestClient(
   auto client_options = ClientOptions::CreateDefaultClientOptions();
   if (!client_options) return std::move(client_options).status();
 
-  auto opts =
-      internal::MakeOptions(*std::move(client_options))
-          .set<internal::RetryPolicyOption>(std::move(retry_policy))
-          .set<internal::BackoffPolicyOption>(std::move(backoff_policy));
+  auto opts = internal::MakeOptions(*std::move(client_options))
+                  .set<RetryPolicyOption>(std::move(retry_policy))
+                  .set<BackoffPolicyOption>(std::move(backoff_policy));
 
 #if GOOGLE_CLOUD_CPP_STORAGE_HAVE_GRPC
   if (UseGrpcForMedia() || UseGrpcForMetadata()) {
@@ -89,16 +88,14 @@ StorageIntegrationTest::MakeIntegrationTestClient(
       google::cloud::internal::GetEnv("CLOUD_STORAGE_IDEMPOTENCY")
           .value_or("always-retry");
   if (idempotency == "strict") {
-    opts.set<internal::IdempotencyPolicyOption>(
-        StrictIdempotencyPolicy{}.clone());
+    opts.set<IdempotencyPolicyOption>(StrictIdempotencyPolicy{}.clone());
   } else if (idempotency != "always-retry") {
     return Status(
         StatusCode::kInvalidArgument,
         "Invalid value for CLOUD_STORAGE_IDEMPOTENCY environment variable");
   }
-  auto credentials = opts.get<internal::Oauth2CredentialsOption>();
-  return internal::ClientImplDetails::CreateClient(std::move(credentials),
-                                                   std::move(opts));
+  auto credentials = opts.get<Oauth2CredentialsOption>();
+  return Client(std::move(opts));
 }
 
 std::unique_ptr<BackoffPolicy> StorageIntegrationTest::TestBackoffPolicy() {

--- a/google/cloud/storage/tests/key_file_integration_test.cc
+++ b/google/cloud/storage/tests/key_file_integration_test.cc
@@ -73,7 +73,7 @@ TEST_P(KeyFileIntegrationTest, ObjectWriteSignAndReadDefaultAccount) {
       oauth2::CreateServiceAccountCredentialsFromFilePath(key_filename_);
   ASSERT_STATUS_OK(credentials);
 
-  Client client(*credentials);
+  Client client(Options{}.set<Oauth2CredentialsOption>(*credentials));
 
   auto object_name = MakeRandomObjectName();
   std::string expected = LoremIpsum();
@@ -106,7 +106,7 @@ TEST_P(KeyFileIntegrationTest, ObjectWriteSignAndReadExplicitAccount) {
       oauth2::CreateServiceAccountCredentialsFromFilePath(key_filename_);
   ASSERT_STATUS_OK(credentials);
 
-  Client client(*credentials);
+  Client client(Options{}.set<Oauth2CredentialsOption>(*credentials));
 
   auto object_name = MakeRandomObjectName();
   std::string expected = LoremIpsum();

--- a/google/cloud/storage/tests/object_checksum_integration_test.cc
+++ b/google/cloud/storage/tests/object_checksum_integration_test.cc
@@ -155,11 +155,7 @@ TEST_F(ObjectChecksumIntegrationTest, InsertWithComputedCrc32c) {
 
 /// @test Verify that CRC32C checksums are computed by default.
 TEST_F(ObjectChecksumIntegrationTest, DefaultCrc32cInsertXML) {
-  auto client_options = ClientOptions::CreateDefaultClientOptions();
-  ASSERT_STATUS_OK(client_options);
-  Client client((*client_options)
-                    .set_enable_raw_client_tracing(true)
-                    .set_enable_http_tracing(true));
+  Client client(Options{}.set<TracingComponentsOption>({"raw-client", "http"}));
   auto object_name = MakeRandomObjectName();
 
   testing_util::ScopedLog log;
@@ -176,11 +172,7 @@ TEST_F(ObjectChecksumIntegrationTest, DefaultCrc32cInsertXML) {
 
 /// @test Verify that CRC32C checksums are computed by default.
 TEST_F(ObjectChecksumIntegrationTest, DefaultCrc32cInsertJSON) {
-  auto client_options = ClientOptions::CreateDefaultClientOptions();
-  ASSERT_STATUS_OK(client_options);
-  Client client((*client_options)
-                    .set_enable_raw_client_tracing(true)
-                    .set_enable_http_tracing(true));
+  Client client(Options{}.set<TracingComponentsOption>({"raw-client", "http"}));
   auto object_name = MakeRandomObjectName();
 
   testing_util::ScopedLog log;

--- a/google/cloud/storage/tests/object_file_integration_test.cc
+++ b/google/cloud/storage/tests/object_file_integration_test.cc
@@ -50,6 +50,11 @@ class ObjectFileIntegrationTest
   std::string bucket_name_;
 };
 
+// Create a client configured to always use resumable uploads for files.
+Client ClientWithSimpleUploadDisabled() {
+  return Client(Options{}.set<MaximumSimpleUploadSizeOption>(0));
+}
+
 TEST_F(ObjectFileIntegrationTest, XmlDownloadFile) {
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
@@ -405,10 +410,7 @@ TEST_F(ObjectFileIntegrationTest, XmlUploadFile) {
 }
 
 TEST_F(ObjectFileIntegrationTest, UploadFileResumableBySize) {
-  // Create a client that always uses resumable uploads.
-  auto client_options = ClientOptions::CreateDefaultClientOptions();
-  ASSERT_STATUS_OK(client_options);
-  Client client(client_options->set_maximum_simple_upload_size(0));
+  auto client = ClientWithSimpleUploadDisabled();
   auto file_name = ::testing::TempDir() + MakeRandomFilename();
   auto object_name = MakeRandomObjectName();
 
@@ -485,10 +487,7 @@ TEST_F(ObjectFileIntegrationTest, UploadFileResumableByOption) {
 }
 
 TEST_F(ObjectFileIntegrationTest, UploadFileResumableQuantum) {
-  // Create a client that always uses resumable uploads.
-  auto client_options = ClientOptions::CreateDefaultClientOptions();
-  ASSERT_STATUS_OK(client_options);
-  Client client(client_options->set_maximum_simple_upload_size(0));
+  auto client = ClientWithSimpleUploadDisabled();
   auto file_name = ::testing::TempDir() + MakeRandomFilename();
   auto object_name = MakeRandomObjectName();
 
@@ -525,10 +524,7 @@ TEST_F(ObjectFileIntegrationTest, UploadFileResumableQuantum) {
 }
 
 TEST_F(ObjectFileIntegrationTest, UploadFileResumableNonQuantum) {
-  // Create a client that always uses resumable uploads.
-  auto client_options = ClientOptions::CreateDefaultClientOptions();
-  ASSERT_STATUS_OK(client_options);
-  Client client(client_options->set_maximum_simple_upload_size(0));
+  auto client = ClientWithSimpleUploadDisabled();
   auto file_name = ::testing::TempDir() + MakeRandomFilename();
   auto object_name = MakeRandomObjectName();
 
@@ -564,10 +560,7 @@ TEST_F(ObjectFileIntegrationTest, UploadFileResumableNonQuantum) {
 }
 
 TEST_F(ObjectFileIntegrationTest, UploadFileResumableUploadFailure) {
-  // Create a client that always uses resumable uploads.
-  auto client_options = ClientOptions::CreateDefaultClientOptions();
-  ASSERT_STATUS_OK(client_options);
-  Client client(client_options->set_maximum_simple_upload_size(0));
+  auto client = ClientWithSimpleUploadDisabled();
   auto file_name = ::testing::TempDir() + MakeRandomFilename();
   auto bucket_name = MakeRandomBucketName();
   auto object_name = MakeRandomObjectName();

--- a/google/cloud/storage/tests/object_hash_integration_test.cc
+++ b/google/cloud/storage/tests/object_hash_integration_test.cc
@@ -47,11 +47,7 @@ class ObjectHashIntegrationTest
 
 /// @test Verify that MD5 hashes are disabled by default.
 TEST_F(ObjectHashIntegrationTest, DefaultMD5HashXML) {
-  auto client_options = ClientOptions::CreateDefaultClientOptions();
-  ASSERT_STATUS_OK(client_options);
-  Client client((*client_options)
-                    .set_enable_raw_client_tracing(true)
-                    .set_enable_http_tracing(true));
+  Client client(Options{}.set<TracingComponentsOption>({"raw-client", "http"}));
   auto object_name = MakeRandomObjectName();
 
   testing_util::ScopedLog log;
@@ -69,11 +65,7 @@ TEST_F(ObjectHashIntegrationTest, DefaultMD5HashXML) {
 
 /// @test Verify that MD5 hashes are disabled by default.
 TEST_F(ObjectHashIntegrationTest, DefaultMD5HashJSON) {
-  auto client_options = ClientOptions::CreateDefaultClientOptions();
-  ASSERT_STATUS_OK(client_options);
-  Client client((*client_options)
-                    .set_enable_raw_client_tracing(true)
-                    .set_enable_http_tracing(true));
+  Client client(Options{}.set<TracingComponentsOption>({"raw-client", "http"}));
   auto object_name = MakeRandomObjectName();
 
   testing_util::ScopedLog log;
@@ -102,11 +94,7 @@ TEST_F(ObjectHashIntegrationTest, DefaultMD5HashJSON) {
 
 /// @test Verify that `DisableMD5Hash` actually disables the header.
 TEST_F(ObjectHashIntegrationTest, DisableMD5HashXML) {
-  auto client_options = ClientOptions::CreateDefaultClientOptions();
-  ASSERT_STATUS_OK(client_options);
-  Client client((*client_options)
-                    .set_enable_raw_client_tracing(true)
-                    .set_enable_http_tracing(true));
+  Client client(Options{}.set<TracingComponentsOption>({"raw-client", "http"}));
   auto object_name = MakeRandomObjectName();
 
   testing_util::ScopedLog log;
@@ -124,11 +112,7 @@ TEST_F(ObjectHashIntegrationTest, DisableMD5HashXML) {
 
 /// @test Verify that `DisableMD5Hash` actually disables the payload.
 TEST_F(ObjectHashIntegrationTest, DisableMD5HashJSON) {
-  auto client_options = ClientOptions::CreateDefaultClientOptions();
-  ASSERT_STATUS_OK(client_options);
-  Client client((*client_options)
-                    .set_enable_raw_client_tracing(true)
-                    .set_enable_http_tracing(true));
+  Client client(Options{}.set<TracingComponentsOption>({"raw-client", "http"}));
   auto object_name = MakeRandomObjectName();
 
   testing_util::ScopedLog log;

--- a/google/cloud/storage/tests/object_insert_integration_test.cc
+++ b/google/cloud/storage/tests/object_insert_integration_test.cc
@@ -549,11 +549,7 @@ TEST_P(ObjectInsertIntegrationTest, XmlInsertPredefinedAclPublicRead) {
  * on the logging facilities in the library, which is ugly to do.
  */
 TEST_P(ObjectInsertIntegrationTest, InsertWithQuotaUser) {
-  auto opts = ClientOptions::CreateDefaultClientOptions();
-  ASSERT_STATUS_OK(opts);
-  Client client((*std::move(opts))
-                    .set_enable_raw_client_tracing(true)
-                    .set_enable_http_tracing(true));
+  Client client(Options{}.set<TracingComponentsOption>({"raw-client", "http"}));
   auto object_name = MakeRandomObjectName();
 
   testing_util::ScopedLog log;
@@ -581,11 +577,7 @@ TEST_P(ObjectInsertIntegrationTest, InsertWithQuotaUser) {
  * on the logging facilities in the library, which is ugly to do.
  */
 TEST_P(ObjectInsertIntegrationTest, InsertWithUserIp) {
-  auto opts = ClientOptions::CreateDefaultClientOptions();
-  ASSERT_STATUS_OK(opts);
-  Client client((*std::move(opts))
-                    .set_enable_raw_client_tracing(true)
-                    .set_enable_http_tracing(true));
+  Client client(Options{}.set<TracingComponentsOption>({"raw-client", "http"}));
   auto object_name = MakeRandomObjectName();
 
   testing_util::ScopedLog log;
@@ -613,11 +605,7 @@ TEST_P(ObjectInsertIntegrationTest, InsertWithUserIp) {
  * on the logging facilities in the library, which is ugly to do.
  */
 TEST_P(ObjectInsertIntegrationTest, InsertWithUserIpBlank) {
-  auto opts = ClientOptions::CreateDefaultClientOptions();
-  ASSERT_STATUS_OK(opts);
-  Client client((*std::move(opts))
-                    .set_enable_raw_client_tracing(true)
-                    .set_enable_http_tracing(true));
+  Client client(Options{}.set<TracingComponentsOption>({"raw-client", "http"}));
   auto object_name = MakeRandomObjectName();
 
   // Make sure at least one connection was created before we run the test, the

--- a/google/cloud/storage/tests/object_integration_test.cc
+++ b/google/cloud/storage/tests/object_integration_test.cc
@@ -915,9 +915,7 @@ TEST_F(ObjectIntegrationTest, DeleteResumableUpload) {
   auto status = client->DeleteResumableUpload(session_id);
   EXPECT_STATUS_OK(status);
 
-  auto client_options = ClientOptions::CreateDefaultClientOptions();
-  ASSERT_STATUS_OK(client_options);
-  Client client_resumable(client_options->set_maximum_simple_upload_size(0));
+  Client client_resumable(Options{}.set<MaximumSimpleUploadSizeOption>(0));
   auto stream_resumable = client_resumable.WriteObject(
       bucket_name_, object_name, RestoreResumableUploadSession(session_id));
   stream_resumable << LoremIpsum();

--- a/google/cloud/storage/tests/object_media_integration_test.cc
+++ b/google/cloud/storage/tests/object_media_integration_test.cc
@@ -535,9 +535,11 @@ TEST_F(ObjectMediaIntegrationTest, ReadByChunk) {
 
 TEST_F(ObjectMediaIntegrationTest, ConnectionFailureReadJSON) {
   ScopedEnvironment disable_emulator("CLOUD_STORAGE_EMULATOR_ENDPOINT", {});
-  Client client{ClientOptions(oauth2::CreateAnonymousCredentials())
-                    .set_endpoint("http://localhost:1"),
-                LimitedErrorCountRetryPolicy(2)};
+  Client client{
+      Options{}
+          .set<UnifiedCredentialsOption>(MakeInsecureCredentials())
+          .set<RestEndpointOption>("http://localhost:1")
+          .set<RetryPolicyOption>(LimitedErrorCountRetryPolicy(2).clone())};
 
   auto object_name = MakeRandomObjectName();
 
@@ -556,9 +558,11 @@ TEST_F(ObjectMediaIntegrationTest, ConnectionFailureReadJSON) {
 
 TEST_F(ObjectMediaIntegrationTest, ConnectionFailureReadXML) {
   ScopedEnvironment emulator("CLOUD_STORAGE_EMULATOR_ENDPOINT", {});
-  Client client{ClientOptions(oauth2::CreateAnonymousCredentials())
-                    .set_endpoint("http://localhost:1"),
-                LimitedErrorCountRetryPolicy(2)};
+  Client client{
+      Options{}
+          .set<UnifiedCredentialsOption>(MakeInsecureCredentials())
+          .set<RestEndpointOption>("http://localhost:1")
+          .set<RetryPolicyOption>(LimitedErrorCountRetryPolicy(2).clone())};
 
   auto object_name = MakeRandomObjectName();
 
@@ -573,9 +577,11 @@ TEST_F(ObjectMediaIntegrationTest, ConnectionFailureReadXML) {
 
 TEST_F(ObjectMediaIntegrationTest, ConnectionFailureWriteJSON) {
   ScopedEnvironment emulator("CLOUD_STORAGE_EMULATOR_ENDPOINT", {});
-  Client client{ClientOptions(oauth2::CreateAnonymousCredentials())
-                    .set_endpoint("http://localhost:1"),
-                LimitedErrorCountRetryPolicy(2)};
+  Client client{
+      Options{}
+          .set<UnifiedCredentialsOption>(MakeInsecureCredentials())
+          .set<RestEndpointOption>("http://localhost:1")
+          .set<RetryPolicyOption>(LimitedErrorCountRetryPolicy(2).clone())};
 
   auto object_name = MakeRandomObjectName();
 
@@ -592,9 +598,11 @@ TEST_F(ObjectMediaIntegrationTest, ConnectionFailureWriteJSON) {
 
 TEST_F(ObjectMediaIntegrationTest, ConnectionFailureWriteXML) {
   ScopedEnvironment emulator("CLOUD_STORAGE_EMULATOR_ENDPOINT", {});
-  Client client{ClientOptions(oauth2::CreateAnonymousCredentials())
-                    .set_endpoint("http://localhost:1"),
-                LimitedErrorCountRetryPolicy(2)};
+  Client client{
+      Options{}
+          .set<UnifiedCredentialsOption>(MakeInsecureCredentials())
+          .set<RestEndpointOption>("http://localhost:1")
+          .set<RetryPolicyOption>(LimitedErrorCountRetryPolicy(2).clone())};
 
   auto object_name = MakeRandomObjectName();
 
@@ -609,9 +617,11 @@ TEST_F(ObjectMediaIntegrationTest, ConnectionFailureWriteXML) {
 TEST_F(ObjectMediaIntegrationTest, ConnectionFailureDownloadFile) {
   google::cloud::testing_util::ScopedEnvironment endpoint(
       "CLOUD_STORAGE_EMULATOR_ENDPOINT", "http://localhost:1");
-  Client client{ClientOptions(oauth2::CreateAnonymousCredentials())
-                    .set_endpoint("http://localhost:1"),
-                LimitedErrorCountRetryPolicy(2)};
+  Client client{
+      Options{}
+          .set<UnifiedCredentialsOption>(MakeInsecureCredentials())
+          .set<RestEndpointOption>("http://localhost:1")
+          .set<RetryPolicyOption>(LimitedErrorCountRetryPolicy(2).clone())};
 
   auto object_name = MakeRandomObjectName();
   auto file_name = MakeRandomFilename();
@@ -622,9 +632,11 @@ TEST_F(ObjectMediaIntegrationTest, ConnectionFailureDownloadFile) {
 
 TEST_F(ObjectMediaIntegrationTest, ConnectionFailureUploadFile) {
   ScopedEnvironment emulator("CLOUD_STORAGE_EMULATOR_ENDPOINT", {});
-  Client client{ClientOptions(oauth2::CreateAnonymousCredentials())
-                    .set_endpoint("http://localhost:1"),
-                LimitedErrorCountRetryPolicy(2)};
+  Client client{
+      Options{}
+          .set<UnifiedCredentialsOption>(MakeInsecureCredentials())
+          .set<RestEndpointOption>("http://localhost:1")
+          .set<RetryPolicyOption>(LimitedErrorCountRetryPolicy(2).clone())};
 
   auto object_name = MakeRandomObjectName();
   auto file_name = MakeRandomFilename();
@@ -645,8 +657,10 @@ TEST_F(ObjectMediaIntegrationTest, StreamingReadTimeout) {
   auto options = ClientOptions::CreateDefaultClientOptions();
   ASSERT_STATUS_OK(options);
 
-  Client client(options->set_download_stall_timeout(std::chrono::seconds(3)),
-                LimitedErrorCountRetryPolicy(3));
+  Client client(
+      Options{}
+          .set<DownloadStallTimeoutOption>(std::chrono::seconds(3))
+          .set<RetryPolicyOption>(LimitedErrorCountRetryPolicy(3).clone()));
 
   auto object_name = MakeRandomObjectName();
 
@@ -675,11 +689,10 @@ TEST_F(ObjectMediaIntegrationTest, StreamingReadTimeout) {
 TEST_F(ObjectMediaIntegrationTest, StreamingReadTimeoutContinues) {
   if (!UsingEmulator()) GTEST_SKIP();
 
-  auto options = ClientOptions::CreateDefaultClientOptions();
-  ASSERT_STATUS_OK(options);
-
-  Client client(options->set_download_stall_timeout(std::chrono::seconds(3)),
-                LimitedErrorCountRetryPolicy(10));
+  Client client(
+      Options{}
+          .set<DownloadStallTimeoutOption>(std::chrono::seconds(3))
+          .set<RetryPolicyOption>(LimitedErrorCountRetryPolicy(10).clone()));
 
   auto object_name = MakeRandomObjectName();
 
@@ -714,11 +727,10 @@ TEST_F(ObjectMediaIntegrationTest, StreamingReadTimeoutContinues) {
 TEST_F(ObjectMediaIntegrationTest, StreamingReadInternalError) {
   if (!UsingEmulator()) GTEST_SKIP();
 
-  auto options = ClientOptions::CreateDefaultClientOptions();
-  ASSERT_STATUS_OK(options);
-
-  Client client(options->set_download_stall_timeout(std::chrono::seconds(3)),
-                LimitedErrorCountRetryPolicy(5));
+  Client client(
+      Options{}
+          .set<DownloadStallTimeoutOption>(std::chrono::seconds(3))
+          .set<RetryPolicyOption>(LimitedErrorCountRetryPolicy(5).clone()));
 
   auto object_name = MakeRandomObjectName();
   auto contents = MakeRandomData(512 * 1024);

--- a/google/cloud/storage/tests/object_resumable_write_integration_test.cc
+++ b/google/cloud/storage/tests/object_resumable_write_integration_test.cc
@@ -313,9 +313,7 @@ TEST_F(ObjectResumableWriteIntegrationTest, WithXUploadContentLength) {
   auto constexpr kMiB = 1024 * 1024L;
   auto constexpr kChunkSize = 2 * kMiB;
 
-  auto options = ClientOptions::CreateDefaultClientOptions();
-  ASSERT_STATUS_OK(options);
-  Client client(options->SetUploadBufferSize(kChunkSize));
+  Client client(Options{}.set<UploadBufferSizeOption>(kChunkSize));
 
   auto const chunk = MakeRandomData(kChunkSize);
 
@@ -349,9 +347,7 @@ TEST_F(ObjectResumableWriteIntegrationTest, WithXUploadContentLengthRandom) {
   auto constexpr kQuantum = 256 * 1024L;
   size_t constexpr kChunkSize = 2 * kQuantum;
 
-  auto options = ClientOptions::CreateDefaultClientOptions();
-  ASSERT_STATUS_OK(options);
-  Client client(options->SetUploadBufferSize(kChunkSize));
+  Client client(Options{}.set<UploadBufferSizeOption>(kChunkSize));
 
   auto const chunk = MakeRandomData(kChunkSize);
 

--- a/google/cloud/storage/tests/service_account_integration_test.cc
+++ b/google/cloud/storage/tests/service_account_integration_test.cc
@@ -54,9 +54,7 @@ TEST_F(ServiceAccountIntegrationTest, Get) {
   ASSERT_STATUS_OK(a1);
   EXPECT_FALSE(a1->email_address().empty());
 
-  auto client_options = ClientOptions::CreateDefaultClientOptions();
-  ASSERT_STATUS_OK(client_options);
-  Client client_with_default(client_options->set_project_id(project_id_));
+  Client client_with_default(Options{}.set<ProjectIdOption>(project_id_));
   StatusOr<ServiceAccount> a2 = client_with_default.GetServiceAccount();
   ASSERT_STATUS_OK(a2);
   EXPECT_FALSE(a2->email_address().empty());
@@ -65,10 +63,7 @@ TEST_F(ServiceAccountIntegrationTest, Get) {
 }
 
 TEST_F(ServiceAccountIntegrationTest, CreateHmacKeyForProject) {
-  auto client_options = ClientOptions::CreateDefaultClientOptions();
-  ASSERT_STATUS_OK(client_options);
-
-  Client client(client_options->set_project_id(project_id_));
+  Client client(Options{}.set<ProjectIdOption>(project_id_));
 
   StatusOr<std::pair<HmacKeyMetadata, std::string>> key = client.CreateHmacKey(
       service_account_, OverrideDefaultProject(project_id_));
@@ -86,10 +81,7 @@ TEST_F(ServiceAccountIntegrationTest, CreateHmacKeyForProject) {
 }
 
 TEST_F(ServiceAccountIntegrationTest, HmacKeyCRUD) {
-  auto client_options = ClientOptions::CreateDefaultClientOptions();
-  ASSERT_STATUS_OK(client_options);
-
-  Client client(client_options->set_project_id(project_id_));
+  Client client(Options{}.set<ProjectIdOption>(project_id_));
 
   auto get_current_access_ids = [&client, this]() {
     std::vector<std::string> access_ids;
@@ -138,10 +130,7 @@ TEST_F(ServiceAccountIntegrationTest, HmacKeyCRUD) {
 }
 
 TEST_F(ServiceAccountIntegrationTest, HmacKeyCRUDFailures) {
-  auto client_options = ClientOptions::CreateDefaultClientOptions();
-  ASSERT_STATUS_OK(client_options);
-
-  Client client(client_options->set_project_id(project_id_));
+  Client client(Options{}.set<ProjectIdOption>(project_id_));
 
   // Test failures in the HmacKey operations by using an invalid project id:
   auto create_status = client.CreateHmacKey("invalid-service-account",

--- a/google/cloud/storage/tests/signed_url_conformance_test.cc
+++ b/google/cloud/storage/tests/signed_url_conformance_test.cc
@@ -78,10 +78,10 @@ class V4PostPolicyConformanceTest : public V4SignedUrlConformanceTest {};
 TEST_P(V4SignedUrlConformanceTest, V4SignJson) {
   auto creds = oauth2::CreateServiceAccountCredentialsFromJsonFilePath(
       service_account_key_filename_);
-
   ASSERT_STATUS_OK(creds);
-  std::string account_email = creds->get()->AccountEmail();
-  Client client(*creds);
+
+  std::string account_email = (*creds)->AccountEmail();
+  Client client(Options{}.set<Oauth2CredentialsOption>(*creds));
   std::string actual_canonical_request;
   std::string actual_string_to_sign;
 
@@ -179,10 +179,10 @@ INSTANTIATE_TEST_SUITE_P(
 TEST_P(V4PostPolicyConformanceTest, V4PostPolicy) {
   auto creds = oauth2::CreateServiceAccountCredentialsFromJsonFilePath(
       service_account_key_filename_);
-
   ASSERT_STATUS_OK(creds);
-  std::string account_email = creds->get()->AccountEmail();
-  Client client(*creds);
+
+  std::string account_email = (*creds)->AccountEmail();
+  Client client(Options{}.set<Oauth2CredentialsOption>(*creds));
 
   auto const& test_params = (*post_policy_tests)[GetParam()];
   auto const& input = test_params.policyinput();

--- a/google/cloud/storage/tests/thread_integration_test.cc
+++ b/google/cloud/storage/tests/thread_integration_test.cc
@@ -178,11 +178,7 @@ class CaptureSendHeaderBackend : public LogBackend {
 TEST_F(ThreadIntegrationTest, ReuseConnections) {
   auto log_backend = std::make_shared<CaptureSendHeaderBackend>();
 
-  auto client_options = ClientOptions::CreateDefaultClientOptions();
-  ASSERT_STATUS_OK(client_options);
-  Client client((*client_options)
-                    .set_enable_raw_client_tracing(true)
-                    .set_enable_http_tracing(true));
+  Client client(Options{}.set<TracingComponentsOption>({"raw-client", "http"}));
 
   std::string bucket_name = MakeRandomBucketName();
 
@@ -208,9 +204,9 @@ TEST_F(ThreadIntegrationTest, ReuseConnections) {
   std::vector<std::chrono::steady_clock::duration> delete_elapsed;
   for (auto const& name : objects) {
     auto start = std::chrono::steady_clock::now();
-    StatusOr<ObjectMetadata> meta = client.InsertObject(
+    StatusOr<ObjectMetadata> insert = client.InsertObject(
         bucket_name, name, LoremIpsum(), IfGenerationMatch(0));
-    ASSERT_STATUS_OK(meta);
+    ASSERT_STATUS_OK(insert);
     create_elapsed.emplace_back(std::chrono::steady_clock::now() - start);
   }
   for (auto const& name : objects) {


### PR DESCRIPTION
With this PR the constructors for `google::cloud::storage::Client` using
`google::cloud::Options` become public. The documentation, examples, and
tests change to recommend using these constructors.

Part of the work for #6161

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6640)
<!-- Reviewable:end -->
