### PR TITLE
cleanup(storage): use unified credentials in examples

### DIFF
--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -219,6 +219,9 @@ class Client {
    *
    * @par Modified Retry Policy Example
    * @snippet storage_object_samples.cc insert object modified retry
+   *
+   * @par Change Credentials Example
+   * @snippet storage_auth_samples.cc service-account-keyfile-json
    */
   explicit Client(Options opts = {});
 

--- a/google/cloud/storage/examples/storage_client_mock_samples.cc
+++ b/google/cloud/storage/examples/storage_client_mock_samples.cc
@@ -14,9 +14,7 @@
 
 #include "google/cloud/storage/client.h"
 #include "google/cloud/storage/internal/object_requests.h"
-#include "google/cloud/storage/oauth2/google_credentials.h"
 #include "google/cloud/storage/testing/mock_client.h"
-#include "google/cloud/storage/well_known_parameters.h"
 #include "absl/memory/memory.h"
 #include <gmock/gmock.h>
 #include <iostream>

--- a/google/cloud/storage/examples/storage_object_csek_samples.cc
+++ b/google/cloud/storage/examples/storage_object_csek_samples.cc
@@ -14,13 +14,11 @@
 
 #include "google/cloud/storage/client.h"
 #include "google/cloud/storage/examples/storage_examples_common.h"
-#include "google/cloud/storage/oauth2/google_credentials.h"
 #include "google/cloud/storage/parallel_upload.h"
-#include "google/cloud/storage/well_known_parameters.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/internal/getenv.h"
 #include <iostream>
 #include <map>
-#include <sstream>
 #include <string>
 #include <thread>
 

--- a/google/cloud/storage/examples/storage_object_resumable_write_samples.cc
+++ b/google/cloud/storage/examples/storage_object_resumable_write_samples.cc
@@ -14,14 +14,10 @@
 
 #include "google/cloud/storage/client.h"
 #include "google/cloud/storage/examples/storage_examples_common.h"
-#include "google/cloud/storage/oauth2/google_credentials.h"
 #include "google/cloud/storage/parallel_upload.h"
-#include "google/cloud/storage/well_known_parameters.h"
 #include "google/cloud/internal/getenv.h"
-#include <fstream>
 #include <iostream>
 #include <map>
-#include <sstream>
 #include <string>
 #include <thread>
 

--- a/google/cloud/storage/examples/storage_object_samples.cc
+++ b/google/cloud/storage/examples/storage_object_samples.cc
@@ -14,7 +14,6 @@
 
 #include "google/cloud/storage/client.h"
 #include "google/cloud/storage/examples/storage_examples_common.h"
-#include "google/cloud/storage/oauth2/google_credentials.h"
 #include "google/cloud/storage/parallel_upload.h"
 #include "google/cloud/storage/well_known_parameters.h"
 #include "google/cloud/internal/getenv.h"


### PR DESCRIPTION
Change the examples to use the unified credentials. In the process I
discovered that many examples included `storage/oauth2/credentials.h`
without using it.

Part of the work for #6612

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6646)
<!-- Reviewable:end -->
