### PR TITLE
cleanup(storage): update docs for unified credentials

### DIFF
--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -76,47 +76,30 @@ struct ClientImplDetails;
  *
  * @par Credentials
  * The default approach for creating a Client uses Google Application Default
- * %Credentials (ADCs). Because finding or loading ADCs can fail, the returned
- * `StatusOr<Client>` from `CreateDefaultClient()` should be verified before
- * using it. However, explicitly passing `Credentials` when creating a Client
- * does not have the same potential to fail, so the resulting `Client` is not
- * wrapped in a `StatusOr`.  If you wish to use `AnonymousCredentials` or to
- * supply a specific `Credentials` type, you can use the functions declared in
- * google_credentials.h:
- * @code
- * namespace gcs = google::cloud::storage;
+ * %Credentials (ADCs). Note that a default-constructed client uses the ADCs:
  *
- * // Implicitly use ADCs:
- * StatusOr<gcs::Client> client = gcs::Client::CreateDefaultClient();
- * if (!client) {
- *   // Handle failure and return.
- * }
+ * @snippet storage_auth_client.cc default-client
  *
- * // Or explicitly use ADCs:
- * auto creds = gcs::oauth2::GoogleDefaultCredentials();
- * if (!creds) {
- *   // Handle failure and return.
- * }
- * // Status was OK, so create a Client with the given Credentials.
- * gcs::Client client(gcs::ClientOptions(*creds));
+ * Finding or loading the ADCs can fail, this will result in run-time errors
+ * when making requests.
  *
- * // Use service account credentials from a JSON keyfile:
- * std::string path = "/path/to/keyfile.json";
- * auto creds =
- *     gcs::oauth2::CreateServiceAccountCredentialsFromJsonFilePath(path);
- * if (!creds) {
- *   // Handle failure and return.
- * }
- * gcs::Client client(gcs::ClientOptions(*creds));
+ * If you prefer to explicitly load the ADCs, use:
  *
- * // Use Compute Engine credentials for the instance's default service account.
- * gcs::Client client(
- *     gcs::ClientOptions(gcs::oauth2::CreateComputeEngineCredentials()));
+ * @snippet storage_auth_client.cc explicit-adcs
  *
- * // Use no credentials:
- * gcs::Client client(
- *     gcs::ClientOptions(gcs::oauth2::CreateAnonymousCredentials()));
- * @endcode
+ * Other credential types are available, including:
+ *
+ * - `google::cloud::MakeInsecureCredentials()` for anonymous access to public
+ *   GCS buckets or objects.
+ * - `google::cloud::MakeAccessTokenCredentials()` to use an access token
+ *   obtained through any out-of-band mechanisms.
+ * - `google::cloud::MakeImpersonateServiceAccountCredentials()` to use the IAM
+ *   credentials service and [impersonate a service account].
+ * - `google::cloud::MakeServiceAccountCredentials()` to use a service account
+ *   key file.
+ *
+ * [impersonate service account]:
+ * https://cloud.google.com/iam/docs/impersonating-service-accounts
  *
  * @par Error Handling
  * This class uses `StatusOr<T>` to report errors. When an operation fails to

--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -78,14 +78,18 @@ struct ClientImplDetails;
  * The default approach for creating a Client uses Google Application Default
  * %Credentials (ADCs). Note that a default-constructed client uses the ADCs:
  *
- * @snippet storage_auth_client.cc default-client
+ * @snippet storage_auth_samples.cc default-client
  *
  * Finding or loading the ADCs can fail, this will result in run-time errors
  * when making requests.
  *
- * If you prefer to explicitly load the ADCs, use:
+ * If you prefer to explicitly load the ADCs use:
  *
- * @snippet storage_auth_client.cc explicit-adcs
+ * @snippet storage_auth_samples.cc explicit-adcs
+ *
+ * To load a service account credentials key file use:
+ *
+ * @snippet storage_auth_samples.cc service-account-keyfile-json
  *
  * Other credential types are available, including:
  *

--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -76,11 +76,11 @@ struct ClientImplDetails;
  *
  * @par Credentials
  * The default approach for creating a Client uses Google Application Default
- * %Credentials (ADCs). Note that a default-constructed client uses the ADCs:
+ * Credentials (ADCs). Note that a default-constructed client uses the ADCs:
  *
  * @snippet storage_auth_samples.cc default-client
  *
- * Finding or loading the ADCs can fail, this will result in run-time errors
+ * Finding or loading the ADCs can fail. This will result in run-time errors
  * when making requests.
  *
  * If you prefer to explicitly load the ADCs use:
@@ -96,7 +96,7 @@ struct ClientImplDetails;
  * - `google::cloud::MakeInsecureCredentials()` for anonymous access to public
  *   GCS buckets or objects.
  * - `google::cloud::MakeAccessTokenCredentials()` to use an access token
- *   obtained through any out-of-band mechanisms.
+ *   obtained through any out-of-band mechanism.
  * - `google::cloud::MakeImpersonateServiceAccountCredentials()` to use the IAM
  *   credentials service and [impersonate a service account].
  * - `google::cloud::MakeServiceAccountCredentials()` to use a service account

--- a/google/cloud/storage/examples/storage_auth_samples.cc
+++ b/google/cloud/storage/examples/storage_auth_samples.cc
@@ -57,6 +57,26 @@ void DefaultClient(std::vector<std::string> const& argv) {
   (argv.at(0), argv.at(1));
 }
 
+void ExplicitADCs(std::vector<std::string> const& argv) {
+  namespace examples = ::google::cloud::storage::examples;
+  if ((argv.size() == 1 && argv[0] == "--help") || argv.size() != 2) {
+    throw examples::Usage{
+        "explicit-adcs"
+        " <bucket-name> <object-name>"};
+  }
+  //! [explicit-adcs]
+  namespace gcs = google::cloud::storage;
+  using google::cloud::Options;
+  using google::cloud::UnifiedCredentialsOption;
+  [](std::string const& bucket_name, std::string const& object_name) {
+    auto client = gcs::Client(Options{}.set<UnifiedCredentialsOption>(
+        google::cloud::MakeGoogleDefaultCredentials()));
+    PerformSomeOperations(client, bucket_name, object_name);
+  }
+  //! [explicit-adcs]
+  (argv.at(0), argv.at(1));
+}
+
 void ServiceAccountKeyfileJson(std::vector<std::string> const& argv) {
   namespace examples = ::google::cloud::storage::examples;
   if ((argv.size() == 1 && argv[0] == "--help") || argv.size() != 3) {
@@ -113,6 +133,9 @@ void RunAll(std::vector<std::string> const& argv) {
   auto const object_name = examples::MakeRandomObjectName(generator, "object-");
   DefaultClient({bucket_name, object_name});
 
+  std::cout << "\nRunning ExplicitADCs()" << std::endl;
+  ExplicitADCs({bucket_name, object_name});
+
   auto const filename = google::cloud::internal::GetEnv(
       "GOOGLE_CLOUD_CPP_STORAGE_TEST_KEY_FILE_JSON");
   if (filename.has_value()) {
@@ -130,6 +153,7 @@ int main(int argc, char* argv[]) {
   namespace examples = ::google::cloud::storage::examples;
   examples::Example example({
       {"default-client", DefaultClient},
+      {"explicit-adcs", ExplicitADCs},
       {"service-account-keyfile-json", ServiceAccountKeyfileJson},
       {"auto", RunAll},
   });

--- a/google/cloud/storage/examples/storage_auth_samples.cc
+++ b/google/cloud/storage/examples/storage_auth_samples.cc
@@ -27,7 +27,7 @@ namespace {
 void PerformSomeOperations(google::cloud::storage::Client client,
                            std::string const& bucket_name,
                            std::string const& object_name) {
-  namespace gcs = google::cloud::storage;
+  namespace gcs = ::google::cloud::storage;
   auto constexpr kText = "The quick brown fox jumps over the lazy dog\n";
 
   auto object = client.InsertObject(bucket_name, object_name, kText).value();
@@ -48,7 +48,7 @@ void DefaultClient(std::vector<std::string> const& argv) {
         " <bucket-name> <object-name>"};
   }
   //! [default-client]
-  namespace gcs = google::cloud::storage;
+  namespace gcs = ::google::cloud::storage;
   [](std::string const& bucket_name, std::string const& object_name) {
     auto client = gcs::Client();
     PerformSomeOperations(client, bucket_name, object_name);
@@ -65,7 +65,7 @@ void ExplicitADCs(std::vector<std::string> const& argv) {
         " <bucket-name> <object-name>"};
   }
   //! [explicit-adcs]
-  namespace gcs = google::cloud::storage;
+  namespace gcs = ::google::cloud::storage;
   using google::cloud::Options;
   using google::cloud::UnifiedCredentialsOption;
   [](std::string const& bucket_name, std::string const& object_name) {
@@ -85,7 +85,7 @@ void ServiceAccountKeyfileJson(std::vector<std::string> const& argv) {
         " <service-account-file> <bucket-name> <object-name>"};
   }
   //! [service-account-keyfile-json]
-  namespace gcs = google::cloud::storage;
+  namespace gcs = ::google::cloud::storage;
   [](std::string const& filename, std::string const& bucket_name,
      std::string const& object_name) {
     auto is = std::ifstream(filename);


### PR DESCRIPTION
Some of the Doxygen documentation still referenced the
`google::cloud::oauth2::*` classes.

Part of the work for #6612

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6648)
<!-- Reviewable:end -->
