### PR TITLE
cleanup(storage): simplify MockClient initialization

### DIFF
--- a/google/cloud/storage/client_test.cc
+++ b/google/cloud/storage/client_test.cc
@@ -29,7 +29,6 @@ namespace {
 using ::google::cloud::storage::internal::ClientImplDetails;
 using ::google::cloud::storage::testing::canonical_errors::TransientError;
 using ::testing::Return;
-using ::testing::ReturnRef;
 
 class ObservableRetryPolicy : public LimitedErrorCountRetryPolicy {
  public:

--- a/google/cloud/storage/client_test.cc
+++ b/google/cloud/storage/client_test.cc
@@ -84,8 +84,6 @@ class ClientTest : public ::testing::Test {
 };
 
 TEST_F(ClientTest, OverrideRetryPolicy) {
-  auto const mock_options = ClientOptions(oauth2::CreateAnonymousCredentials());
-  EXPECT_CALL(*mock_, client_options()).WillRepeatedly(ReturnRef(mock_options));
   auto client = internal::ClientImplDetails::CreateClient(
       std::shared_ptr<internal::RawClient>(mock_), ObservableRetryPolicy(3));
 
@@ -103,8 +101,6 @@ TEST_F(ClientTest, OverrideRetryPolicy) {
 
 TEST_F(ClientTest, OverrideBackoffPolicy) {
   using ms = std::chrono::milliseconds;
-  auto const mock_options = ClientOptions(oauth2::CreateAnonymousCredentials());
-  EXPECT_CALL(*mock_, client_options()).WillRepeatedly(ReturnRef(mock_options));
   auto client = internal::ClientImplDetails::CreateClient(
       std::shared_ptr<internal::RawClient>(mock_),
       ObservableBackoffPolicy(ms(20), ms(100), 2.0));
@@ -121,8 +117,6 @@ TEST_F(ClientTest, OverrideBackoffPolicy) {
 
 TEST_F(ClientTest, OverrideBothPolicies) {
   using ms = std::chrono::milliseconds;
-  auto const mock_options = ClientOptions(oauth2::CreateAnonymousCredentials());
-  EXPECT_CALL(*mock_, client_options()).WillRepeatedly(ReturnRef(mock_options));
   auto client = internal::ClientImplDetails::CreateClient(
       std::shared_ptr<internal::RawClient>(mock_),
       ObservableBackoffPolicy(ms(20), ms(100), 2.0), ObservableRetryPolicy(3));
@@ -177,15 +171,12 @@ TEST_F(ClientTest, LoggingDecorators) {
 #include "google/cloud/internal/disable_deprecation_warnings.inc"
 
 TEST_F(ClientTest, DeprecatedButNotDecommissioned) {
-  auto options = ClientOptions(oauth2::CreateAnonymousCredentials());
   auto m1 = std::make_shared<testing::MockClient>();
-  EXPECT_CALL(*m1, client_options).WillRepeatedly(ReturnRef(options));
 
   auto c1 = storage::Client(m1, Client::NoDecorations{});
   EXPECT_EQ(c1.raw_client().get(), m1.get());
 
   auto m2 = std::make_shared<testing::MockClient>();
-  EXPECT_CALL(*m2, client_options).WillRepeatedly(ReturnRef(options));
   auto c2 = storage::Client(m2, LimitedErrorCountRetryPolicy(3));
   EXPECT_NE(c2.raw_client().get(), m2.get());
 }

--- a/google/cloud/storage/examples/storage_client_mock_samples.cc
+++ b/google/cloud/storage/examples/storage_client_mock_samples.cc
@@ -23,20 +23,13 @@
 namespace {
 
 using ::testing::Return;
-using ::testing::ReturnRef;
 
 //! [mock successful readobject]
 TEST(StorageMockingSamples, MockReadObject) {
   namespace gcs = google::cloud::storage;
 
-  gcs::ClientOptions client_options =
-      gcs::ClientOptions(gcs::oauth2::CreateAnonymousCredentials());
-
   std::shared_ptr<gcs::testing::MockClient> mock =
       std::make_shared<gcs::testing::MockClient>();
-  EXPECT_CALL(*mock, client_options())
-      .WillRepeatedly(ReturnRef(client_options));
-
   auto client = gcs::testing::ClientFromMock(mock);
 
   std::string const text = "this is a mock http response";
@@ -78,14 +71,9 @@ TEST(StorageMockingSamples, MockReadObject) {
 //! [mock successful writeobject]
 TEST(StorageMockingSamples, MockWriteObject) {
   namespace gcs = google::cloud::storage;
-  gcs::ClientOptions client_options =
-      gcs::ClientOptions(gcs::oauth2::CreateAnonymousCredentials());
 
   std::shared_ptr<gcs::testing::MockClient> mock =
       std::make_shared<gcs::testing::MockClient>();
-  EXPECT_CALL(*mock, client_options())
-      .WillRepeatedly(ReturnRef(client_options));
-
   auto client = gcs::testing::ClientFromMock(mock);
 
   gcs::ObjectMetadata expected_metadata;
@@ -129,14 +117,8 @@ TEST(StorageMockingSamples, MockWriteObject) {
 TEST(StorageMockingSamples, MockReadObjectFailure) {
   namespace gcs = google::cloud::storage;
 
-  gcs::ClientOptions client_options =
-      gcs::ClientOptions(gcs::oauth2::CreateAnonymousCredentials());
-
   std::shared_ptr<gcs::testing::MockClient> mock =
       std::make_shared<gcs::testing::MockClient>();
-  EXPECT_CALL(*mock, client_options())
-      .WillRepeatedly(ReturnRef(client_options));
-
   auto client = gcs::testing::ClientFromMock(mock);
 
   std::string text = "this is a mock http response";
@@ -167,14 +149,9 @@ TEST(StorageMockingSamples, MockReadObjectFailure) {
 //! [mock failed writeobject]
 TEST(StorageMockingSamples, MockWriteObjectFailure) {
   namespace gcs = google::cloud::storage;
-  gcs::ClientOptions client_options =
-      gcs::ClientOptions(gcs::oauth2::CreateAnonymousCredentials());
 
   std::shared_ptr<gcs::testing::MockClient> mock =
       std::make_shared<gcs::testing::MockClient>();
-  EXPECT_CALL(*mock, client_options())
-      .WillRepeatedly(ReturnRef(client_options));
-
   auto client = gcs::testing::ClientFromMock(mock);
 
   EXPECT_CALL(*mock, CreateResumableSession)

--- a/google/cloud/storage/object_test.cc
+++ b/google/cloud/storage/object_test.cc
@@ -431,8 +431,6 @@ TEST_F(ObjectTest, DeleteByPrefix) {
   // Pretend ListObjects returns object-1, object-2, object-3.
 
   auto mock = std::make_shared<testing::MockClient>();
-  auto const mock_options = ClientOptions(oauth2::CreateAnonymousCredentials());
-  EXPECT_CALL(*mock, client_options()).WillRepeatedly(ReturnRef(mock_options));
   EXPECT_CALL(*mock, ListObjects)
       .WillOnce([](internal::ListObjectsRequest const& req)
                     -> StatusOr<internal::ListObjectsResponse> {
@@ -474,8 +472,6 @@ TEST_F(ObjectTest, DeleteByPrefixNoOptions) {
   // Pretend ListObjects returns object-1, object-2, object-3.
 
   auto mock = std::make_shared<testing::MockClient>();
-  auto const mock_options = ClientOptions(oauth2::CreateAnonymousCredentials());
-  EXPECT_CALL(*mock, client_options()).WillRepeatedly(ReturnRef(mock_options));
   EXPECT_CALL(*mock, ListObjects)
       .WillOnce([](internal::ListObjectsRequest const& req)
                     -> StatusOr<internal::ListObjectsResponse> {
@@ -513,8 +509,6 @@ TEST_F(ObjectTest, DeleteByPrefixListFailure) {
   // Pretend ListObjects returns object-1, object-2, object-3.
 
   auto mock = std::make_shared<testing::MockClient>();
-  auto const mock_options = ClientOptions(oauth2::CreateAnonymousCredentials());
-  EXPECT_CALL(*mock, client_options()).WillRepeatedly(ReturnRef(mock_options));
   EXPECT_CALL(*mock, ListObjects)
       .WillOnce(Return(StatusOr<internal::ListObjectsResponse>(
           Status(StatusCode::kPermissionDenied, ""))));
@@ -528,8 +522,6 @@ TEST_F(ObjectTest, DeleteByPrefixDeleteFailure) {
   // Pretend ListObjects returns object-1, object-2, object-3.
 
   auto mock = std::make_shared<testing::MockClient>();
-  auto const mock_options = ClientOptions(oauth2::CreateAnonymousCredentials());
-  EXPECT_CALL(*mock, client_options()).WillRepeatedly(ReturnRef(mock_options));
   EXPECT_CALL(*mock, ListObjects)
       .WillOnce([](internal::ListObjectsRequest const& req)
                     -> StatusOr<internal::ListObjectsResponse> {
@@ -557,8 +549,6 @@ TEST_F(ObjectTest, DeleteByPrefixDeleteFailure) {
 
 TEST_F(ObjectTest, ComposeManyNone) {
   auto mock = std::make_shared<testing::MockClient>();
-  auto const mock_options = ClientOptions(oauth2::CreateAnonymousCredentials());
-  EXPECT_CALL(*mock, client_options()).WillRepeatedly(ReturnRef(mock_options));
   auto client = testing::ClientFromMock(mock);
   auto res =
       ComposeMany(client, "test-bucket", std::vector<ComposeSourceObject>{},
@@ -598,8 +588,6 @@ ObjectMetadata MockObject(std::string const& bucket_name,
 
 TEST_F(ObjectTest, ComposeManyOne) {
   auto mock = std::make_shared<testing::MockClient>();
-  auto const mock_options = ClientOptions(oauth2::CreateAnonymousCredentials());
-  EXPECT_CALL(*mock, client_options()).WillRepeatedly(ReturnRef(mock_options));
   EXPECT_CALL(*mock, ComposeObject)
       .WillOnce([](internal::ComposeObjectRequest const& req)
                     -> StatusOr<ObjectMetadata> {
@@ -635,8 +623,6 @@ TEST_F(ObjectTest, ComposeManyOne) {
 
 TEST_F(ObjectTest, ComposeManyThree) {
   auto mock = std::make_shared<testing::MockClient>();
-  auto const mock_options = ClientOptions(oauth2::CreateAnonymousCredentials());
-  EXPECT_CALL(*mock, client_options()).WillRepeatedly(ReturnRef(mock_options));
   EXPECT_CALL(*mock, ComposeObject)
       .WillOnce([](internal::ComposeObjectRequest const& req)
                     -> StatusOr<ObjectMetadata> {
@@ -678,8 +664,6 @@ TEST_F(ObjectTest, ComposeManyThree) {
 
 TEST_F(ObjectTest, ComposeManyThreeLayers) {
   auto mock = std::make_shared<testing::MockClient>();
-  auto const mock_options = ClientOptions(oauth2::CreateAnonymousCredentials());
-  EXPECT_CALL(*mock, client_options()).WillRepeatedly(ReturnRef(mock_options));
 
   // Test 63 sources.
 
@@ -768,8 +752,6 @@ TEST_F(ObjectTest, ComposeManyThreeLayers) {
 
 TEST_F(ObjectTest, ComposeManyComposeFails) {
   auto mock = std::make_shared<testing::MockClient>();
-  auto const mock_options = ClientOptions(oauth2::CreateAnonymousCredentials());
-  EXPECT_CALL(*mock, client_options()).WillRepeatedly(ReturnRef(mock_options));
 
   // Test 63 sources - second composition fails.
 
@@ -816,8 +798,6 @@ TEST_F(ObjectTest, ComposeManyComposeFails) {
 
 TEST_F(ObjectTest, ComposeManyCleanupFailsLoudly) {
   auto mock = std::make_shared<testing::MockClient>();
-  auto const mock_options = ClientOptions(oauth2::CreateAnonymousCredentials());
-  EXPECT_CALL(*mock, client_options()).WillRepeatedly(ReturnRef(mock_options));
 
   // Test 63 sources - second composition fails.
 
@@ -856,8 +836,6 @@ TEST_F(ObjectTest, ComposeManyCleanupFailsLoudly) {
 
 TEST_F(ObjectTest, ComposeManyCleanupFailsSilently) {
   auto mock = std::make_shared<testing::MockClient>();
-  auto const mock_options = ClientOptions(oauth2::CreateAnonymousCredentials());
-  EXPECT_CALL(*mock, client_options()).WillRepeatedly(ReturnRef(mock_options));
 
   // Test 63 sources - second composition fails.
 
@@ -897,8 +875,6 @@ TEST_F(ObjectTest, ComposeManyCleanupFailsSilently) {
 
 TEST_F(ObjectTest, ComposeManyLockingPrefixFails) {
   auto mock = std::make_shared<testing::MockClient>();
-  auto const mock_options = ClientOptions(oauth2::CreateAnonymousCredentials());
-  EXPECT_CALL(*mock, client_options()).WillRepeatedly(ReturnRef(mock_options));
 
   EXPECT_CALL(*mock, InsertObjectMedia)
       .WillOnce(Return(

--- a/google/cloud/storage/object_test.cc
+++ b/google/cloud/storage/object_test.cc
@@ -34,7 +34,6 @@ using ::google::cloud::storage::testing::canonical_errors::TransientError;
 using ::google::cloud::testing_util::StatusIs;
 using ::testing::HasSubstr;
 using ::testing::Return;
-using ::testing::ReturnRef;
 using ms = std::chrono::milliseconds;
 
 /**

--- a/google/cloud/storage/testing/mock_client.h
+++ b/google/cloud/storage/testing/mock_client.h
@@ -28,6 +28,13 @@ namespace testing {
 
 class MockClient : public google::cloud::storage::internal::RawClient {
  public:
+  MockClient()
+      : client_options_(
+            google::cloud::storage::oauth2::CreateAnonymousCredentials()) {
+    EXPECT_CALL(*this, client_options())
+        .WillRepeatedly(::testing::ReturnRef(client_options_));
+  }
+
   MOCK_METHOD(ClientOptions const&, client_options, (), (const, override));
   MOCK_METHOD(StatusOr<internal::ListBucketsResponse>, ListBuckets,
               (internal::ListBucketsRequest const&), (override));
@@ -149,6 +156,9 @@ class MockClient : public google::cloud::storage::internal::RawClient {
   MOCK_METHOD(
       StatusOr<std::string>, AuthorizationHeader,
       (std::shared_ptr<google::cloud::storage::oauth2::Credentials> const&));
+
+ private:
+  ClientOptions client_options_;
 };
 
 class MockResumableUploadSession


### PR DESCRIPTION
This makes it easier to use a `MockClient`, and avoids using
`storage::oauth2::Credentials` in the examples for `MockClient`.

Part of the work for #6612 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6649)
<!-- Reviewable:end -->
