### PR TITLE
cleanup(storage): use unified credentials in unit tests

### DIFF
--- a/google/cloud/storage/client_sign_policy_document_test.cc
+++ b/google/cloud/storage/client_sign_policy_document_test.cc
@@ -57,11 +57,9 @@ std::string Dec64(std::string const& s) {
   return std::string(res.begin(), res.end());
 };
 
-StatusOr<Client> CreateClientForTest() {
-  auto creds = oauth2::CreateServiceAccountCredentialsFromJsonContents(
-      kJsonKeyfileContents);
-  if (!creds) return std::move(creds).status();
-  return Client(Options{}.set<Oauth2CredentialsOption>(*creds));
+Client CreateClientForTest() {
+  return Client(Options{}.set<UnifiedCredentialsOption>(
+      MakeServiceAccountCredentials(kJsonKeyfileContents)));
 }
 
 /**
@@ -90,9 +88,8 @@ PolicyDocument CreatePolicyDocumentForTest() {
 /// Test the CreateSignedPolicyDocument function in storage::Client.
 TEST(CreateSignedPolicyDocTest, Sign) {
   auto client = CreateClientForTest();
-  ASSERT_STATUS_OK(client);
   auto actual =
-      client->CreateSignedPolicyDocument(CreatePolicyDocumentForTest());
+      client.CreateSignedPolicyDocument(CreatePolicyDocumentForTest());
   ASSERT_STATUS_OK(actual);
 
   EXPECT_EQ("foo-email@foo-project.iam.gserviceaccount.com", actual->access_id);
@@ -186,8 +183,7 @@ PolicyDocumentV4 CreatePolicyDocumentV4ForTest() {
 
 TEST(CreateSignedPolicyDocTest, SignV4) {
   auto client = CreateClientForTest();
-  ASSERT_STATUS_OK(client);
-  auto actual = client->GenerateSignedPostPolicyV4(
+  auto actual = client.GenerateSignedPostPolicyV4(
       CreatePolicyDocumentV4ForTest(), AddExtensionFieldOption(),
       PredefinedAcl(), Scheme());
   ASSERT_STATUS_OK(actual);
@@ -233,8 +229,7 @@ TEST(CreateSignedPolicyDocTest, SignV4) {
 
 TEST(CreateSignedPolicyDocTest, SignV4AddExtensionField) {
   auto client = CreateClientForTest();
-  ASSERT_STATUS_OK(client);
-  auto actual = client->GenerateSignedPostPolicyV4(
+  auto actual = client.GenerateSignedPostPolicyV4(
       CreatePolicyDocumentV4ForTest(),
       AddExtensionField("my-field", "my-value"));
   ASSERT_STATUS_OK(actual);
@@ -244,8 +239,7 @@ TEST(CreateSignedPolicyDocTest, SignV4AddExtensionField) {
 
 TEST(CreateSignedPolicyDocTest, SignV4PredefinedAcl) {
   auto client = CreateClientForTest();
-  ASSERT_STATUS_OK(client);
-  auto actual = client->GenerateSignedPostPolicyV4(
+  auto actual = client.GenerateSignedPostPolicyV4(
       CreatePolicyDocumentV4ForTest(), PredefinedAcl::BucketOwnerRead());
   ASSERT_STATUS_OK(actual);
 
@@ -255,8 +249,7 @@ TEST(CreateSignedPolicyDocTest, SignV4PredefinedAcl) {
 
 TEST(CreateSignedPolicyDocTest, SignV4BucketBoundHostname) {
   auto client = CreateClientForTest();
-  ASSERT_STATUS_OK(client);
-  auto actual = client->GenerateSignedPostPolicyV4(
+  auto actual = client.GenerateSignedPostPolicyV4(
       CreatePolicyDocumentV4ForTest(), BucketBoundHostname("mydomain.tld"));
   ASSERT_STATUS_OK(actual);
 
@@ -265,8 +258,7 @@ TEST(CreateSignedPolicyDocTest, SignV4BucketBoundHostname) {
 
 TEST(CreateSignedPolicyDocTest, SignV4BucketBoundHostnameHTTP) {
   auto client = CreateClientForTest();
-  ASSERT_STATUS_OK(client);
-  auto actual = client->GenerateSignedPostPolicyV4(
+  auto actual = client.GenerateSignedPostPolicyV4(
       CreatePolicyDocumentV4ForTest(), BucketBoundHostname("mydomain.tld"),
       Scheme("http"));
   ASSERT_STATUS_OK(actual);
@@ -276,8 +268,7 @@ TEST(CreateSignedPolicyDocTest, SignV4BucketBoundHostnameHTTP) {
 
 TEST(CreateSignedPolicyDocTest, SignV4VirtualHostname) {
   auto client = CreateClientForTest();
-  ASSERT_STATUS_OK(client);
-  auto actual = client->GenerateSignedPostPolicyV4(
+  auto actual = client.GenerateSignedPostPolicyV4(
       CreatePolicyDocumentV4ForTest(), VirtualHostname(true));
   ASSERT_STATUS_OK(actual);
 

--- a/google/cloud/storage/client_sign_url_test.cc
+++ b/google/cloud/storage/client_sign_url_test.cc
@@ -51,10 +51,8 @@ class CreateSignedUrlTest
     : public ::google::cloud::storage::testing::ClientUnitTest {};
 
 TEST_F(CreateSignedUrlTest, V2Sign) {
-  auto creds = oauth2::CreateServiceAccountCredentialsFromJsonContents(
-      kJsonKeyfileContents);
-  ASSERT_STATUS_OK(creds);
-  Client client(Options{}.set<Oauth2CredentialsOption>(*creds));
+  Client client(Options{}.set<UnifiedCredentialsOption>(
+      MakeServiceAccountCredentials(kJsonKeyfileContents)));
 
   auto actual = client.CreateV2SignedUrl("GET", "test-bucket", "test-object");
   ASSERT_STATUS_OK(actual);
@@ -64,10 +62,8 @@ TEST_F(CreateSignedUrlTest, V2Sign) {
 }
 
 TEST_F(CreateSignedUrlTest, V2SignBucketOnly) {
-  auto creds = oauth2::CreateServiceAccountCredentialsFromJsonContents(
-      kJsonKeyfileContents);
-  ASSERT_STATUS_OK(creds);
-  Client client(Options{}.set<Oauth2CredentialsOption>(*creds));
+  Client client(Options{}.set<UnifiedCredentialsOption>(
+      MakeServiceAccountCredentials(kJsonKeyfileContents)));
 
   auto actual = client.CreateV2SignedUrl("GET", "test-bucket", "", WithAcl());
   ASSERT_STATUS_OK(actual);
@@ -76,10 +72,8 @@ TEST_F(CreateSignedUrlTest, V2SignBucketOnly) {
 }
 
 TEST_F(CreateSignedUrlTest, V2SignEscape) {
-  auto creds = oauth2::CreateServiceAccountCredentialsFromJsonContents(
-      kJsonKeyfileContents);
-  ASSERT_STATUS_OK(creds);
-  Client client(Options{}.set<Oauth2CredentialsOption>(*creds));
+  Client client(Options{}.set<UnifiedCredentialsOption>(
+      MakeServiceAccountCredentials(kJsonKeyfileContents)));
 
   auto actual = client.CreateV2SignedUrl("GET", "test-bucket", "test+object");
   ASSERT_STATUS_OK(actual);
@@ -149,10 +143,8 @@ constexpr char kJsonKeyfileContentsForV4[] = R"""({
 TEST_F(CreateSignedUrlTest, V4SignGet) {
   // This test uses a disabled key to create a V4 Signed URL for a GET
   // operation. The bucket name was generated at random too.
-  auto creds = oauth2::CreateServiceAccountCredentialsFromJsonContents(
-      kJsonKeyfileContentsForV4);
-  ASSERT_STATUS_OK(creds);
-  Client client(Options{}.set<Oauth2CredentialsOption>(*creds));
+  Client client(Options{}.set<UnifiedCredentialsOption>(
+      MakeServiceAccountCredentials(kJsonKeyfileContentsForV4)));
 
   std::string const bucket_name = "test-bucket";
   std::string const object_name = "test-object";
@@ -192,10 +184,8 @@ TEST_F(CreateSignedUrlTest, V4SignGet) {
 TEST_F(CreateSignedUrlTest, V4SignPut) {
   // This test uses a disabled key to create a V4 Signed URL for a PUT
   // operation. The bucket name was generated at random too.
-  auto creds = oauth2::CreateServiceAccountCredentialsFromJsonContents(
-      kJsonKeyfileContentsForV4);
-  ASSERT_STATUS_OK(creds);
-  Client client(Options{}.set<Oauth2CredentialsOption>(*creds));
+  Client client(Options{}.set<UnifiedCredentialsOption>(
+      MakeServiceAccountCredentials(kJsonKeyfileContentsForV4)));
 
   std::string const bucket_name = "test-bucket";
   std::string const object_name = "test-object";
@@ -236,9 +226,6 @@ TEST_F(CreateSignedUrlTest, V4SignPut) {
 
 /// @test Verify that CreateV4SignedUrl() uses the SignBlob API when needed.
 TEST_F(CreateSignedUrlTest, V4SignRemote) {
-  auto creds = oauth2::CreateServiceAccountCredentialsFromJsonContents(
-      kJsonKeyfileContents);
-  ASSERT_STATUS_OK(creds);
   // Use `echo -n test-signed-blob | openssl base64 -e` to create the magic
   // string.
   std::string expected_signed_blob = "dGVzdC1zaWduZWQtYmxvYg==";


### PR DESCRIPTION
Using the unified credentials simplifies some of the unit tests, so why
not?

Part of the work for #6612

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6650)
<!-- Reviewable:end -->
