### PR TITLE
cleanup(storage): simplify gRPC plugin initialization

### DIFF
--- a/google/cloud/storage/benchmarks/throughput_experiment.cc
+++ b/google/cloud/storage/benchmarks/throughput_experiment.cc
@@ -339,8 +339,7 @@ std::vector<std::unique_ptr<ThroughputExperiment>> CreateUploadExperiments(
       case ApiName::kApiRawGrpc: {
         gcs::Client grpc_client =
             google::cloud::storage_experimental::DefaultGrpcClient(
-                client_options)
-                .value();
+                client_options);
         result.push_back(
             absl::make_unique<UploadObject>(grpc_client, a, contents, false));
         result.push_back(
@@ -380,8 +379,7 @@ std::vector<std::unique_ptr<ThroughputExperiment>> CreateDownloadExperiments(
       case ApiName::kApiGrpc:
         result.push_back(absl::make_unique<DownloadObject>(
             google::cloud::storage_experimental::DefaultGrpcClient(
-                client_options)
-                .value(),
+                client_options),
             a));
         break;
 #else

--- a/google/cloud/storage/examples/storage_grpc_samples.cc
+++ b/google/cloud/storage/examples/storage_grpc_samples.cc
@@ -35,11 +35,11 @@ non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
   auto client = google::cloud::storage_experimental::DefaultGrpcClient();
   //! [grpc-default-client]
 
-  auto object = client->InsertObject(bucket_name, "lorem.txt", kText);
+  auto object = client.InsertObject(bucket_name, "lorem.txt", kText);
   if (!object) throw std::runtime_error(object.status().message());
 
-  auto input = client->ReadObject(bucket_name, "lorem.txt",
-                                  gcs::Generation(object->generation()));
+  auto input = client.ReadObject(bucket_name, "lorem.txt",
+                                 gcs::Generation(object->generation()));
   std::string const actual(std::istreambuf_iterator<char>{input}, {});
   std::cout << "The contents read back are:\n"
             << actual
@@ -67,7 +67,6 @@ void GrpcClientWithProject(std::string project_id) {
   auto client = google::cloud::storage_experimental::DefaultGrpcClient(
       google::cloud::Options{}.set<gcs::ProjectIdOption>(
           std::move(project_id)));
-  if (!client) throw std::runtime_error(client.status().message());
   std::cout << "Successfully created a gcs::Client configured to use gRPC\n";
 }
 //! [grpc-client-with-project]

--- a/google/cloud/storage/grpc_plugin.cc
+++ b/google/cloud/storage/grpc_plugin.cc
@@ -31,20 +31,11 @@ bool UseGrpcForMetadata() {
 }
 }  // namespace
 
-StatusOr<google::cloud::storage::Client> DefaultGrpcClient(Options opts) {
+google::cloud::storage::Client DefaultGrpcClient(Options opts) {
   opts = google::cloud::storage::internal::DefaultOptionsGrpc(std::move(opts));
   if (UseGrpcForMetadata()) {
     return storage::internal::ClientImplDetails::CreateClient(
         storage::internal::GrpcClient::Create(opts));
-  }
-  // The hybrid client might need the OAuth2 credentials
-  if (!opts.has<storage::Oauth2CredentialsOption>()) {
-    storage::ChannelOptions channel_options;
-    channel_options.set_ssl_root_path(opts.get<CARootsFilePathOption>());
-    auto credentials =
-        storage::oauth2::GoogleDefaultCredentials(channel_options);
-    if (!credentials) return std::move(credentials).status();
-    opts.set<storage::Oauth2CredentialsOption>(*std::move(credentials));
   }
   return storage::internal::ClientImplDetails::CreateClient(
       storage::internal::HybridClient::Create(opts));

--- a/google/cloud/storage/grpc_plugin.h
+++ b/google/cloud/storage/grpc_plugin.h
@@ -41,7 +41,7 @@ inline namespace STORAGE_CLIENT_NS {
  * @warning this is an experimental feature, and subject to change without
  *     notice.
  */
-StatusOr<google::cloud::storage::Client> DefaultGrpcClient(Options opts = {});
+google::cloud::storage::Client DefaultGrpcClient(Options opts = {});
 
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage_experimental

--- a/google/cloud/storage/quickstart/grpc/quickstart.cc
+++ b/google/cloud/storage/quickstart/grpc/quickstart.cc
@@ -30,13 +30,8 @@ int main(int argc, char* argv[]) {
   // Create a client to communicate with Google Cloud Storage. This client
   // uses the default configuration for authentication and project id.
   auto client = google::cloud::storage_experimental::DefaultGrpcClient();
-  if (!client) {
-    std::cerr << "Failed to create Storage Client, status=" << client.status()
-              << "\n";
-    return 1;
-  }
 
-  auto writer = client->WriteObject(bucket_name, "quickstart-grpc.txt");
+  auto writer = client.WriteObject(bucket_name, "quickstart-grpc.txt");
   writer << "Hello World!";
   writer.Close();
   if (writer.metadata()) {
@@ -47,7 +42,7 @@ int main(int argc, char* argv[]) {
     return 1;
   }
 
-  auto reader = client->ReadObject(bucket_name, "quickstart-grpc.txt");
+  auto reader = client.ReadObject(bucket_name, "quickstart-grpc.txt");
   if (!reader) {
     std::cerr << "Error reading object: " << reader.status() << "\n";
     return 1;

--- a/google/cloud/storage/tests/unified_credentials_integration_test.cc
+++ b/google/cloud/storage/tests/unified_credentials_integration_test.cc
@@ -68,8 +68,7 @@ class UnifiedCredentialsIntegrationTest
 #if GOOGLE_CLOUD_CPP_STORAGE_HAVE_GRPC
     if (client_type == "grpc") {
       return google::cloud::storage_experimental::DefaultGrpcClient(
-                 std::move(opts))
-          .value();
+          std::move(opts));
     }
 #endif  // GOOGLE_CLOUD_CPP_STORAGE_HAVE_GRPC
     return Client(std::move(opts));


### PR DESCRIPTION
Now that the plugin is initialized with the unified credentials it can
never "fail" (it can return a client that always fails). Likewise, the
credentials are easier to initialize, setting the unified credentials
works for both `internal::CurlClient` and `internal::GrpcClient`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6651)
<!-- Reviewable:end -->
