### PR TITLE
cleanup: fix ShellCheck errors

### DIFF
--- a/ci/cloudbuild/builds/lib/integration.sh
+++ b/ci/cloudbuild/builds/lib/integration.sh
@@ -46,7 +46,8 @@ curl -sSL --retry 10 -o /dev/shm/roots.pem https://pki.google.com/roots.pem
 function integration::bazel_args() {
   declare -a args
 
-  readonly bazel_output=$(bazel info output_base)
+  bazel_output=$(bazel info output_base)
+  readonly bazel_output
   readonly bazel_googleapis_path="${bazel_output}/external/com_google_googleapis/"
   readonly bazel_proto_path="${bazel_output}/external/com_google_protobuf/src/"
 

--- a/ci/generate-markdown/generate-bigtable-readme.sh
+++ b/ci/generate-markdown/generate-bigtable-readme.sh
@@ -16,7 +16,8 @@
 
 set -eu
 
-readonly BINDIR=$(dirname "$0")
+BINDIR=$(dirname "$0")
+readonly BINDIR
 
 cat <<_EOF_
 # Google Cloud Bigtable C++ Client Library

--- a/ci/generate-markdown/generate-packaging.sh
+++ b/ci/generate-markdown/generate-packaging.sh
@@ -16,7 +16,8 @@
 
 set -eu
 
-readonly BINDIR=$(dirname "$0")
+BINDIR=$(dirname "$0")
+readonly BINDIR
 
 cat <<'END_OF_PREAMBLE'
 # Packaging `google-cloud-cpp`

--- a/ci/generate-markdown/generate-pubsub-readme.sh
+++ b/ci/generate-markdown/generate-pubsub-readme.sh
@@ -16,7 +16,8 @@
 
 set -eu
 
-readonly BINDIR=$(dirname "$0")
+BINDIR=$(dirname "$0")
+readonly BINDIR
 
 cat <<_EOF_
 # Google Cloud Pub/Sub C++ Client Library

--- a/ci/generate-markdown/generate-readme.sh
+++ b/ci/generate-markdown/generate-readme.sh
@@ -16,7 +16,8 @@
 
 set -eu
 
-readonly BINDIR=$(dirname "$0")
+BINDIR=$(dirname "$0")
+readonly BINDIR
 
 # The initial portion of the preamble needs variable expansion:
 cat <<EOF

--- a/ci/generate-markdown/generate-spanner-readme.sh
+++ b/ci/generate-markdown/generate-spanner-readme.sh
@@ -16,7 +16,8 @@
 
 set -eu
 
-readonly BINDIR=$(dirname "$0")
+BINDIR=$(dirname "$0")
+readonly BINDIR
 
 cat <<_EOF_
 # Google Cloud Spanner C++ Client Library

--- a/ci/generate-markdown/generate-storage-readme.sh
+++ b/ci/generate-markdown/generate-storage-readme.sh
@@ -16,7 +16,8 @@
 
 set -eu
 
-readonly BINDIR=$(dirname "$0")
+BINDIR=$(dirname "$0")
+readonly BINDIR
 
 cat <<_EOF_
 # Google Cloud Storage C++ Client Library

--- a/ci/install-bazel.sh
+++ b/ci/install-bazel.sh
@@ -25,7 +25,8 @@ if [[ -z "${PROJECT_ROOT+x}" ]]; then
 fi
 source "${PROJECT_ROOT}/ci/etc/install-config.sh"
 
-readonly KERNEL="$(uname -s | tr '[:upper:]' '[:lower:]')"
+KERNEL="$(uname -s | tr '[:upper:]' '[:lower:]')"
+readonly KERNEL
 MACHINE="$(uname -m)"
 if [[ "${KERNEL}" = "darwin" ]]; then
   # Bazel currently doesn't offer a darwin + arm package, but the x86_64

--- a/ci/lib/io.sh
+++ b/ci/lib/io.sh
@@ -30,18 +30,23 @@ fi # include guard
 # logging functions below instead. For example, prefer `io::log_green "..."`
 # over `echo "${IO_COLOR_GREEN}...${IO_RESET}"`.
 if [ -t 0 ] && command -v tput >/dev/null; then
-  readonly IO_BOLD="$(tput bold)"
-  readonly IO_COLOR_RED="$(tput setaf 1)"
-  readonly IO_COLOR_GREEN="$(tput setaf 2)"
-  readonly IO_COLOR_YELLOW="$(tput setaf 3)"
-  readonly IO_RESET="$(tput sgr0)"
+  IO_BOLD="$(tput bold)"
+  IO_COLOR_RED="$(tput setaf 1)"
+  IO_COLOR_GREEN="$(tput setaf 2)"
+  IO_COLOR_YELLOW="$(tput setaf 3)"
+  IO_RESET="$(tput sgr0)"
 else
-  readonly IO_BOLD=""
-  readonly IO_COLOR_RED=""
-  readonly IO_COLOR_GREEN=""
-  readonly IO_COLOR_YELLOW=""
-  readonly IO_RESET=""
+  IO_BOLD=""
+  IO_COLOR_RED=""
+  IO_COLOR_GREEN=""
+  IO_COLOR_YELLOW=""
+  IO_RESET=""
 fi
+readonly IO_BOLD
+readonly IO_COLOR_RED
+readonly IO_COLOR_GREEN
+readonly IO_COLOR_YELLOW
+readonly IO_RESET
 
 # Logs a message using the given terminal capability. The first argument
 # must be one of the IO_* variables defined above, such as "${IO_COLOR_RED}".

--- a/release/release.sh
+++ b/release/release.sh
@@ -47,7 +47,8 @@
 set -eu
 
 # Extracts all the documentation at the top of this file as the usage text.
-readonly USAGE="$(sed -n '3,/^$/s/^# \?//p' "$0")"
+USAGE="$(sed -n '3,/^$/s/^# \?//p' "$0")"
+readonly USAGE
 
 # Takes an optional list of strings to be printed with a trailing newline and
 # exits the program with code 1
@@ -90,7 +91,8 @@ declare -r PROJECT_ARG
 declare -r VERSION_ARG
 
 readonly CLONE_URL="git@github.com:${PROJECT_ARG}.git"
-readonly TMP_DIR="$(mktemp -d "/tmp/${PROJECT_ARG//\//-}-release.XXXXXXXX")"
+TMP_DIR="$(mktemp -d "/tmp/${PROJECT_ARG//\//-}-release.XXXXXXXX")"
+readonly TMP_DIR
 readonly REPO_DIR="${TMP_DIR}/repo"
 
 function banner() {
@@ -165,13 +167,16 @@ fi
 banner "Starting release for ${PROJECT_ARG} (${CLONE_URL})"
 # Only clones the last 90 days worth of commits, which should be more than
 # enough to get the most recent release tags.
-readonly SINCE="$(date --date="90 days ago" +"%Y-%m-%d")"
+SINCE="$(date --date="90 days ago" +"%Y-%m-%d")"
+readonly SINCE
 hub clone --shallow-since="${SINCE}" "${PROJECT_ARG}" "${REPO_DIR}"
 cd "${REPO_DIR}"
 
 # Figures out the most recent tagged version, and computes the next version.
-readonly TAG="$(git describe --tags --abbrev=0 origin/main)"
-readonly CUR_TAG="$(test -n "${TAG}" && echo "${TAG}" || echo "v0.0.0")"
+TAG="$(git describe --tags --abbrev=0 origin/main)"
+readonly TAG
+CUR_TAG="$(test -n "${TAG}" && echo "${TAG}" || echo "v0.0.0")"
+readonly CUR_TAG
 readonly CUR_VERSION="${CUR_TAG#v}"
 
 NEW_VERSION=""
@@ -205,7 +210,8 @@ run git checkout -b "${NEW_BRANCH}" "${NEW_TAG}"
 run git push --set-upstream origin "${NEW_BRANCH}"
 
 banner "Using release notes for ${NEW_TAG}"
-readonly RELEASE_NOTES="$(get_release_notes "${NEW_TAG}")"
+RELEASE_NOTES="$(get_release_notes "${NEW_TAG}")"
+readonly RELEASE_NOTES
 echo "${RELEASE_NOTES}"
 
 banner "Creating release"


### PR DESCRIPTION
It seems that Fedora:34 recently got a new version of ShellCheck, which
warns about `readonly FOO=$(program)`:

https://github.com/koalaman/shellcheck/wiki/SC2155

Replace those by a separate assignment immediately followed by declaring
the variable `readonly`.

For future reference, the RPM changes can be tracked here:

https://src.fedoraproject.org/rpms/ShellCheck/commits/f34

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6652)
<!-- Reviewable:end -->
