### PR TITLE
ci: run sed checkers in parallel

### DIFF
--- a/ci/cloudbuild/builds/checkers.sh
+++ b/ci/cloudbuild/builds/checkers.sh
@@ -115,7 +115,7 @@ time {
 printf "%-30s" "Running Abseil header fixes:" >&2
 time {
   expressions=("-e" "'s;#include \"absl/strings/str_\(cat\|replace\|join\).h\";#include \"google/cloud/internal/absl_str_\1_quiet.h\";'")
-  expressions+=("-e" "'s;#include \"absl/container/\\(flat_hash_map\\).h\";#include \"google/cloud/internal/absl_\\1_quiet.h\";'")
+  expressions+=("-e" "'s;#include \"absl/container/\(flat_hash_map\).h\";#include \"google/cloud/internal/absl_\1_quiet.h\";'")
   git ls-files -z |
     grep -zv 'google/cloud/internal/absl_.*quiet.h$' |
     grep -zE '\.(h|cc)$' |

--- a/ci/cloudbuild/builds/checkers.sh
+++ b/ci/cloudbuild/builds/checkers.sh
@@ -20,22 +20,27 @@ source "$(dirname "$0")/../../lib/init.sh"
 source module ci/lib/io.sh
 source module ci/cloudbuild/builds/lib/git.sh
 
-# Replaces a file only if it changed. This is needed because sed -i and perl -i
-# will modify the mtime even if no edits are made, which will cause code to be
-# recompiled unnecessarily.
-function replace_original_if_changed() {
-  if [[ $# != 2 ]]; then
-    return 1
-  fi
-  local original="$1"
-  local reformatted="$2"
-  if cmp -s "${original}" "${reformatted}"; then
-    rm -f "${reformatted}"
-  else
-    chmod --reference="${original}" "${reformatted}"
-    mv -f "${reformatted}" "${original}"
-  fi
+# Runs a single sed expression over the given files, editing them in place, and
+# updating the file's mtime only if edits were made. Tis function is exported
+# so it can be run in subshells, such as with xargs -P. Example:
+#
+#   sed_edit 's/foo/bar/g' hello.txt
+#
+function sed_edit() {
+  local expression="$1"
+  shift
+  for file in "$@"; do
+    local tmp="${file}.tmp"
+    cp -p "${file}" "${tmp}"
+    sed -i -e "${expression}" "${tmp}"
+    if cmp -s "${file}" "${tmp}"; then
+      rm -f "${tmp}"
+    else
+      mv -f "${tmp}" "${file}"
+    fi
+  done
 }
+export -f sed_edit
 
 # TODO(#6513): Delete this once we have clang-format version 13 and can use:
 # https://github.com/googleapis/google-cloud-cpp/issues/6513
@@ -100,12 +105,13 @@ time {
   git ls-files -z |
     grep -zv 'google/cloud/internal/absl_.*quiet.h$' |
     grep -zE '\.(h|cc)$' |
-    while IFS= read -r -d $'\0' file; do
-      sed -e 's;#include "absl/strings/str_\(cat\|replace\|join\).h";#include "google/cloud/internal/absl_str_\1_quiet.h";' \
-        -e 's;#include "absl/container/\(flat_hash_map\).h";#include "google/cloud/internal/absl_\1_quiet.h";' \
-        "${file}" >"${file}.tmp"
-      replace_original_if_changed "${file}" "${file}.tmp"
-    done
+    xargs -P "$(nproc)" -0 \
+      bash -c "sed_edit 's;#include \"absl/strings/str_\(cat\|replace\|join\).h\";#include \"google/cloud/internal/absl_str_\1_quiet.h\";' \$0"
+  git ls-files -z |
+    grep -zv 'google/cloud/internal/absl_.*quiet.h$' |
+    grep -zE '\.(h|cc)$' |
+    xargs -P "$(nproc)" -0 \
+      bash -c "sed_edit 's;#include \"absl/container/\(flat_hash_map\).h\";#include \"google/cloud/internal/absl_\1_quiet.h\";' \$0"
 }
 
 # Apply clang-format(1) to fix whitespace and other formatting rules.
@@ -159,17 +165,14 @@ time {
 printf "%-30s" "Running include fixes:" >&2
 time {
   git ls-files -z | grep -zE '\.(cc|h)$' |
-    while IFS= read -r -d $'\0' file; do
-      # We used to run run `sed -i` to apply these changes, but that touches the
-      # files even if there are no changes applied, forcing a rebuild each time.
-      # So we first apply the change to a temporary file, and replace the original
-      # only if something changed.
-      sed -e 's/grpc::\([A-Z][A-Z_][A-Z_]*\)/grpc::StatusCode::\1/g' \
-        -e 's;#include <grpc\\+\\+/grpc\+\+.h>;#include <grpcpp/grpcpp.h>;' \
-        -e 's;#include <grpc\\+\\+/;#include <grpcpp/;' \
-        "${file}" >"${file}.tmp"
-      replace_original_if_changed "${file}" "${file}.tmp"
-    done
+    xargs -P "$(nproc)" -0 \
+      bash -c "sed_edit 's/grpc::\([A-Z][A-Z_][A-Z_]*\)/grpc::StatusCode::\1/g' \$0"
+  git ls-files -z | grep -zE '\.(cc|h)$' |
+    xargs -P "$(nproc)" -0 \
+      bash -c "sed_edit 's;#include <grpc\\+\\+/grpc\+\+.h>;#include <grpcpp/grpcpp.h>;' \$0"
+  git ls-files -z | grep -zE '\.(cc|h)$' |
+    xargs -P "$(nproc)" -0 \
+      bash -c "sed_edit 's;#include <grpc\\+\\+/;#include <grpcpp/;' \$0"
 }
 
 # Apply transformations to fix whitespace formatting in files not handled by
@@ -179,11 +182,7 @@ time {
 printf "%-30s" "Running whitespace fixes:" >&2
 time {
   git ls-files -z | grep -zv '\.gz$' |
-    while IFS= read -r -d $'\0' file; do
-      sed -e 's/[[:blank:]][[:blank:]]*$//' \
-        "${file}" >"${file}.tmp"
-      replace_original_if_changed "${file}" "${file}.tmp"
-    done
+    xargs -P "$(nproc)" -0 bash -c "sed_edit 's/[[:blank:]]\+$//' \$0"
 }
 
 # Report the differences, which should break the build.

--- a/ci/cloudbuild/builds/checkers.sh
+++ b/ci/cloudbuild/builds/checkers.sh
@@ -32,6 +32,7 @@ function sed_edit() {
   while [[ $# -gt 0 ]]; do
     case "$1" in
     -e)
+      test -z "$2" && return 1
       expressions+=("-e" "$2")
       shift 2
       ;;
@@ -119,7 +120,7 @@ time {
   git ls-files -z |
     grep -zv 'google/cloud/internal/absl_.*quiet.h$' |
     grep -zE '\.(h|cc)$' |
-    xargs -P "$(nproc)" -n 50 -0 bash -c "sed_edit ${expressions[*]} \$0 \$@"
+    xargs -P "$(nproc)" -n 50 -0 bash -c "sed_edit ${expressions[*]} \"\$0\" \"\$@\""
 }
 
 # Apply clang-format(1) to fix whitespace and other formatting rules.
@@ -176,7 +177,7 @@ time {
   expressions+=("-e" "'s;#include <grpc++/grpc++.h>;#include <grpcpp/grpcpp.h>;'")
   expressions+=("-e" "'s;#include <grpc++/;#include <grpcpp/;'")
   git ls-files -z | grep -zE '\.(cc|h)$' |
-    xargs -P "$(nproc)" -n 50 -0 bash -c "sed_edit ${expressions[*]} \$0 \$@"
+    xargs -P "$(nproc)" -n 50 -0 bash -c "sed_edit ${expressions[*]} \"\$0\" \"\$@\""
 }
 
 # Apply transformations to fix whitespace formatting in files not handled by
@@ -186,7 +187,7 @@ time {
 printf "%-30s" "Running whitespace fixes:" >&2
 time {
   git ls-files -z | grep -zv '\.gz$' |
-    xargs -P "$(nproc)" -n 50 -0 bash -c "sed_edit -e 's/[[:blank:]]\+$//' \$0 \$@"
+    xargs -P "$(nproc)" -n 50 -0 bash -c "sed_edit -e 's/[[:blank:]]\+$//' \"\$0\" \"\$@\""
 }
 
 # Report the differences, which should break the build.


### PR DESCRIPTION
This PR speeds up the `Running Abseil header fixes`, `Running include fixes`, and `Running whitespace fixes` steps by making each step work in parallel with `xargs -P`. This cuts the overall `checkers-pr` time in half on my laptop. For the mentioned three steps they drop from about 15 seconds to about 3 seconds.

Speed improvements to this build are valuable because this is a build that most of us run frequently, and certainly before sending a PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6660)
<!-- Reviewable:end -->
