### PR TITLE
ci: split checkers build to its own Dockerfile

### DIFF
--- a/ci/cloudbuild/dockerfiles/checkers.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/checkers.Dockerfile
@@ -1,0 +1,43 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This Dockerfile only contains the tools needed to run the `checkers.sh`
+# build. The specific Linux distro and version don't really matter much, other
+# than to the extent that certain distros offer certain versions of software
+# that the build needs. It's fine to add more deps that are needed by the
+# `checkers.sh` build.
+FROM fedora:34
+ARG NCPU=4
+
+RUN dnf makecache && \
+    dnf install -y \
+        cargo \
+        clang-tools-extra \
+        diffutils \
+        findutils \
+        git \
+        python-pip \
+        ShellCheck
+
+RUN curl -L -o /usr/bin/buildifier https://github.com/bazelbuild/buildtools/releases/download/0.29.0/buildifier && \
+    chmod 755 /usr/bin/buildifier
+
+RUN curl -L -o /usr/local/bin/shfmt https://github.com/mvdan/sh/releases/download/v3.1.0/shfmt_v3.1.0_linux_amd64 && \
+    chmod 755 /usr/local/bin/shfmt
+
+RUN pip3 install --upgrade pip
+RUN pip3 install cmake_format==0.6.8
+RUN pip3 install black==19.3b0
+
+RUN cargo install typos-cli --version 1.0.3 --root /usr/local

--- a/ci/cloudbuild/dockerfiles/fedora-34.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/fedora-34.Dockerfile
@@ -20,12 +20,12 @@ ARG NCPU=4
 # tools to compile the dependencies:
 RUN dnf makecache && \
     dnf install -y abi-compliance-checker abi-dumper autoconf automake \
-        cargo ccache clang clang-analyzer clang-tools-extra \
+        ccache clang clang-analyzer clang-tools-extra \
         cmake diffutils doxygen findutils gcc-c++ git \
         grpc-devel grpc-plugins lcov libcxx-devel libcxxabi-devel \
         libasan libubsan libtsan libcurl-devel make ninja-build \
         openssl-devel patch pkgconfig protobuf-compiler python python3.8 \
-        python-pip ShellCheck tar unzip w3m wget which zip zlib-devel
+        python-pip tar unzip w3m wget which zip zlib-devel
 
 # Sets root's password to the empty string to enable users to get a root shell
 # inside the container with `su -` and no password. Sudo would not work because
@@ -33,32 +33,10 @@ RUN dnf makecache && \
 # the container's /etc/passwd file.
 RUN echo 'root:' | chpasswd
 
-# Install the buildifier tool to detect formatting errors in BUILD files.
-RUN wget -q -O /usr/bin/buildifier https://github.com/bazelbuild/buildtools/releases/download/0.29.0/buildifier
-RUN chmod 755 /usr/bin/buildifier
-
-# Install shfmt to automatically format the Shell scripts.
-RUN curl -L -o /usr/local/bin/shfmt \
-    "https://github.com/mvdan/sh/releases/download/v3.1.0/shfmt_v3.1.0_linux_amd64" && \
-    chmod 755 /usr/local/bin/shfmt
-
-# Install cmake_format to automatically format the CMake list files.
-#     https://github.com/cheshirekow/cmake_format
-# Pin this to an specific version because the formatting changes when the
-# "latest" version is updated, and we do not want the builds to break just
-# because some third party changed something.
-RUN pip3 install --upgrade pip
-RUN pip3 install cmake_format==0.6.8
-
-# Install black to automatically format the Python files.
-RUN pip3 install black==19.3b0
-
 # Install the Python modules needed to run the storage emulator
 RUN dnf makecache && dnf install -y python3-devel
+RUN pip3 install --upgrade pip
 RUN pip3 install setuptools wheel
-
-# Install typos for spell checking.
-RUN cargo install typos-cli --version 1.0.3 --root /usr/local
 
 # Install Abseil, remove the downloaded files and the temporary artifacts
 # after a successful build to keep the image smaller (and with fewer layers)

--- a/ci/cloudbuild/triggers/checkers-ci.yaml
+++ b/ci/cloudbuild/triggers/checkers-ci.yaml
@@ -7,7 +7,7 @@ github:
 name: checkers-ci
 substitutions:
   _BUILD_NAME: checkers
-  _DISTRO: fedora-34
+  _DISTRO: checkers
   _TRIGGER_TYPE: ci
 tags:
 - ci

--- a/ci/cloudbuild/triggers/checkers-pr.yaml
+++ b/ci/cloudbuild/triggers/checkers-pr.yaml
@@ -8,7 +8,7 @@ github:
 name: checkers-pr
 substitutions:
   _BUILD_NAME: checkers
-  _DISTRO: fedora-34
+  _DISTRO: checkers
   _TRIGGER_TYPE: pr
 tags:
 - pr


### PR DESCRIPTION
This is useful because the "checkers" build is unique in that it doesn't
actually compile any code, rather it simply checks things _about_ the
code, such as formatting, whitespace, etc. Therefore, the docker
container in which it runs may likely need to be quite different than
normal builds which will need compilers, etc. To keep a bit separate and
to minimize unneeded cross-dependencies, it seems reasonable to split
this build out into its own dockerfile.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6661)
<!-- Reviewable:end -->
