### PR TITLE
fix(pubsub): save refresh timer for cancellation

### DIFF
--- a/google/cloud/pubsub/internal/subscription_lease_management.cc
+++ b/google/cloud/pubsub/internal/subscription_lease_management.cc
@@ -135,11 +135,12 @@ void SubscriptionLeaseManagement::StartRefreshTimer(
   auto deadline = new_server_deadline - kAckDeadlineSlack;
 
   shutdown_manager_->StartOperation(__func__, "OnRefreshTimer", [&] {
-    if (refresh_timer_.valid()) refresh_timer_.cancel();
     using TimerFuture = future<StatusOr<std::chrono::system_clock::time_point>>;
-    cq_.MakeDeadlineTimer(deadline).then([weak](TimerFuture tp) {
-      if (auto self = weak.lock()) self->OnRefreshTimer(!tp.get());
-    });
+    if (refresh_timer_.valid()) refresh_timer_.cancel();
+    refresh_timer_ =
+        cq_.MakeDeadlineTimer(deadline).then([weak](TimerFuture tp) {
+          if (auto self = weak.lock()) self->OnRefreshTimer(!tp.get());
+        });
   });
 }
 


### PR DESCRIPTION
Without this change some of the tests took 8 seconds to complete,
and presumably applications would take longer to shutdown too.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6662)
<!-- Reviewable:end -->
