### PR TITLE
chore(deps): renovate-bot also updates packaging.md

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,7 +6,10 @@
   ],
   "regexManagers": [
     {
-      "fileMatch":  [".*\\.Dockerfile$"],
+      "fileMatch":  [
+        ".*\\.Dockerfile$",
+        ".*packaging.md$"
+      ],
       "matchStrings": [
         "https://github\\.com/(?<depName>.*?)/archive/(?<currentValue>.*?)\\.tar\\.gz"
       ],

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,7 +8,7 @@
     {
       "fileMatch":  [
         ".*\\.Dockerfile$",
-        ".*packaging.md$"
+        ".*doc/packaging\\.md$"
       ],
       "matchStrings": [
         "https://github\\.com/(?<depName>.*?)/archive/(?<currentValue>.*?)\\.tar\\.gz"


### PR DESCRIPTION
Fixes #6657 

(we cant run a postUpgradeTask, but having renovate update `packaging.md` will probably catch all of the breaks due to checkers-pr)

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6672)
<!-- Reviewable:end -->
