### PR TITLE
ci: upgrade to vcpkg 2021.05.12 which understands Apple M1

### DIFF
--- a/ci/cloudbuild/builds/quickstart-cmake.sh
+++ b/ci/cloudbuild/builds/quickstart-cmake.sh
@@ -26,16 +26,15 @@ export CXX=g++
 
 io::log_h2 "Installing vcpkg"
 vcpkg_dir="${HOME}/vcpkg-quickstart"
-vcpkg_bin="${vcpkg_dir}/vcpkg"
 mkdir -p "${vcpkg_dir}"
 io::log "Downloading vcpkg into ${vcpkg_dir}..."
-curl -sSL "https://github.com/microsoft/vcpkg/archive/2021.04.30.tar.gz" |
+curl -sSL "https://github.com/microsoft/vcpkg/archive/2021.05.12.tar.gz" |
   tar -C "${vcpkg_dir}" --strip-components=1 -zxf -
-env CC="ccache ${CC}" CXX="ccache ${CXX}" "${vcpkg_dir}"/bootstrap-vcpkg.sh
+env -C "${vcpkg_dir}" CC="ccache ${CC}" CXX="ccache ${CXX}" ./bootstrap-vcpkg.sh
 
 io::log_h2 "Installing google-cloud-cpp with vcpkg"
-"${vcpkg_bin}" remove --outdated --recurse
-"${vcpkg_bin}" install google-cloud-cpp
+env -C "${vcpkg_dir}" ./vcpkg remove --outdated --recurse
+env -C "${vcpkg_dir}" ./vcpkg install google-cloud-cpp
 
 # Compiles and runs all the quickstart CMake builds.
 for lib in $(quickstart::libraries); do

--- a/ci/kokoro/macos/build-quickstart-cmake.sh
+++ b/ci/kokoro/macos/build-quickstart-cmake.sh
@@ -25,16 +25,16 @@ io::log_yellow "Update or install dependencies."
 
 # Fetch vcpkg at the specified hash.
 vcpkg_dir="${HOME}/vcpkg-quickstart"
-vcpkg_bin="${vcpkg_dir}/vcpkg"
 mkdir -p "${vcpkg_dir}"
 echo "Downloading vcpkg into ${vcpkg_dir}..."
-curl -sSL "https://github.com/microsoft/vcpkg/archive/2021.04.30.tar.gz" |
+curl -sSL "https://github.com/microsoft/vcpkg/archive/2021.05.12.tar.gz" |
   tar -C "${vcpkg_dir}" --strip-components=1 -zxf -
-env CC="ccache cc" CXX="ccache c++" "${vcpkg_dir}/bootstrap-vcpkg.sh"
-
-"${vcpkg_bin}" remove --outdated --recurse
-"${PROJECT_ROOT}/ci/retry-command.sh" 2 5 \
-  "${vcpkg_bin}" install google-cloud-cpp
+(
+  cd "${vcpkg_dir}"
+  CC="ccache cc" CXX="ccache c++" ./bootstrap-vcpkg.sh
+  ./vcpkg remove --outdated --recurse
+  ./vcpkg install google-cloud-cpp
+)
 
 run_quickstart="false"
 readonly CONFIG_DIR="${KOKORO_GFILE_DIR:-/private/var/tmp}"

--- a/ci/kokoro/windows/build-cmake-dependencies.ps1
+++ b/ci/kokoro/windows/build-cmake-dependencies.ps1
@@ -126,7 +126,7 @@ if ($RunningCI -and $HasBuildCache) {
 
 # Integrate installed packages into the build environment.
 Push-Location "${vcpkg_dir}"
-&"vcpkg.exe" integrate install
+&".\vcpkg.exe" integrate install
 if ($LastExitCode) {
     Write-Host -ForegroundColor Red "vcpkg integrate failed with exit code $LastExitCode"
     Exit ${LastExitCode}
@@ -136,7 +136,7 @@ Pop-Location
 # Remove old versions of the packages.
 Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) Cleanup outdated vcpkg packages."
 Push-Location "${vcpkg_dir}"
-&"vcpkg.exe" remove ${vcpkg_flags} --outdated --recurse
+&".\vcpkg.exe" remove ${vcpkg_flags} --outdated --recurse
 if ($LastExitCode) {
     Write-Host -ForegroundColor Red "vcpkg remove --outdated failed with exit code $LastExitCode"
     Exit ${LastExitCode}
@@ -148,7 +148,7 @@ ForEach($_ in (1, 2, 3)) {
     Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) Warmup vcpkg [$_]"
     # Additional dependencies, these are not downloaded by `bazel fetch ...`,
     # but are needed to compile the code
-    &"vcpkg.exe" install ${vcpkg_flags} "crc32c"
+    &".\vcpkg.exe" install ${vcpkg_flags} "crc32c"
     if ($LastExitCode -eq 0) {
         break
     }
@@ -159,7 +159,7 @@ Pop-Location
 Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) Building vcpkg packages."
 Push-Location "${vcpkg_dir}"
 foreach ($pkg in $packages) {
-    &"vcpkg.exe" install ${vcpkg_flags} "${pkg}"
+    &".\vcpkg.exe" install ${vcpkg_flags} "${pkg}"
     if ($LastExitCode) {
         Write-Host -ForegroundColor Red "vcpkg install $pkg failed with exit code $LastExitCode"
         Exit ${LastExitCode}
@@ -169,7 +169,7 @@ Pop-Location
 
 Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) vcpkg list"
 Push-Location "${vcpkg_dir}"
-&"vcpkg.exe" list
+&".\vcpkg.exe" list
 Pop-Location
 
 Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) Cleanup vcpkg buildtrees"

--- a/ci/kokoro/windows/build-cmake-dependencies.ps1
+++ b/ci/kokoro/windows/build-cmake-dependencies.ps1
@@ -48,7 +48,7 @@ if ($args.count -ge 1) {
     $vcpkg_flags=("--triplet", "${env:VCPKG_TRIPLET}")
 }
 $vcpkg_dir = "cmake-out\${vcpkg_base}"
-$vcpkg_version = "2021.04.30"
+$vcpkg_version = "2021.05.12"
 
 New-Item -ItemType Directory -Path "cmake-out" -ErrorAction SilentlyContinue
 # Download the right version of `vcpkg`


### PR DESCRIPTION
Fixes: https://github.com/googleapis/google-cloud-cpp/issues/6687

This version of vcpkg sees the `vcpkg.json` file at the top of our repo
and thinks we're using it in manifest mode, so we need to run the vcpkg
commands from w/in the vcpkg dir.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6688)
<!-- Reviewable:end -->
