### PR TITLE
ci(macos): stop syncing macos clocks

### DIFF
--- a/ci/kokoro/macos/build.sh
+++ b/ci/kokoro/macos/build.sh
@@ -99,22 +99,6 @@ else
   exit 1
 fi
 
-# Sadly, the Kokoro machines seem to be out of sync
-if [[ "${RUNNING_CI:-}" != "yes" ]]; then
-  io::log_yellow "Skipping clock sync for interactive build"
-elif type ntpdate >/dev/null 2>&1; then
-  echo "================================================================"
-  io::log_yellow "using ntpdate to synchronize clock from time.google.com."
-  sudo ntpdate time.google.com
-elif type sntp >/dev/null 2>&1; then
-  echo "================================================================"
-  io::log_yellow "using sntp to synchronize clock from time.google.com."
-  sudo sntp -sS time.google.com
-else
-  echo "================================================================"
-  io::log_red "no command available to sync clock"
-fi
-
 # We need this environment variable because on macOS gRPC crashes if it cannot
 # find the credentials, even if you do not use them. Some of the unit tests do
 # exactly that.


### PR DESCRIPTION
We're now running on macOS machines that shouldn't need this time
synchronization. Removing this simplifies the build scripts.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6690)
<!-- Reviewable:end -->
