### PR TITLE
fix(spanner): pick up tracing-option defaults in SetBasicDefaults()

### DIFF
--- a/google/cloud/spanner/client.h
+++ b/google/cloud/spanner/client.h
@@ -686,8 +686,8 @@ std::shared_ptr<spanner::Connection> MakeConnection(spanner::Database const& db,
  * @see `Connection`
  *
  * @param db See `Database`.
- * @param connection_options (optional) configure the `Connection` created by
- *     this function.
+ * @param connection_options configure the `Connection` created by this
+ *     function.
  * @param session_pool_options (optional) configure the `SessionPool` created
  *     by the `Connection`.
  */

--- a/google/cloud/spanner/internal/defaults.cc
+++ b/google/cloud/spanner/internal/defaults.cc
@@ -17,6 +17,7 @@
 #include "google/cloud/spanner/options.h"
 #include "google/cloud/spanner/session_pool_options.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/connection_options.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/internal/user_agent_prefix.h"
@@ -50,6 +51,12 @@ void SetBasicDefaults(Options& opts) {
   }
   if (!opts.has<GrpcNumChannelsOption>()) {
     opts.set<GrpcNumChannelsOption>(4);
+  }
+  if (!opts.has<TracingComponentsOption>()) {
+    opts.set<TracingComponentsOption>(internal::DefaultTracingComponents());
+  }
+  if (!opts.has<GrpcTracingOptionsOption>()) {
+    opts.set<GrpcTracingOptionsOption>(internal::DefaultTracingOptions());
   }
   // Inserts our user-agent string at the front.
   auto& products = opts.lookup<UserAgentProductsOption>();


### PR DESCRIPTION
The RPC tracing `ConnectionOption` defaults were not being set from
the new `MakeConnection(Database const&, Options)` overload, which
meant we were missing some tracing from integration tests and samples.
So, pick up the defaults (from `${GOOGLE_CLOUD_CPP_ENABLE_TRACING}`
and `${GOOGLE_CLOUD_CPP_TRACING_OPTIONS}`) when each option has not
already been set.

Add new `DefaultOptions()` test cases. Also tighten the context of
existing test cases that similarly depend on the environment.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6691)
<!-- Reviewable:end -->
