### PR TITLE
test(common): also log streaming RPCs after test/sample failure

### DIFF
--- a/ci/cloudbuild/builds/lib/integration.sh
+++ b/ci/cloudbuild/builds/lib/integration.sh
@@ -56,7 +56,7 @@ function integration::bazel_args() {
     "--test_env=GOOGLE_CLOUD_PROJECT=${GOOGLE_CLOUD_PROJECT}"
     "--test_env=GOOGLE_CLOUD_CPP_AUTO_RUN_EXAMPLES=yes"
     "--test_env=GOOGLE_CLOUD_CPP_EXPERIMENTAL_LOG_CONFIG=lastN,100,WARNING"
-    "--test_env=GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc"
+    "--test_env=GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc,rpc-streams"
     "--test_env=GOOGLE_CLOUD_CPP_TRACING_OPTIONS=truncate_string_field_longer_than=512"
     "--test_env=CLOUD_STORAGE_ENABLE_TRACING=raw-client"
     "--test_env=HOME=${HOME}"

--- a/ci/kokoro/macos/build-bazel.sh
+++ b/ci/kokoro/macos/build-bazel.sh
@@ -125,7 +125,7 @@ if should_run_integration_tests; then
     "--test_env=GOOGLE_CLOUD_PROJECT=${GOOGLE_CLOUD_PROJECT}"
     "--test_env=GOOGLE_CLOUD_CPP_AUTO_RUN_EXAMPLES=yes"
     "--test_env=GOOGLE_CLOUD_CPP_EXPERIMENTAL_LOG_CONFIG=lastN,100,WARNING"
-    "--test_env=GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc"
+    "--test_env=GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc,rpc-streams"
     "--test_env=GOOGLE_CLOUD_CPP_TRACING_OPTIONS=truncate_string_field_longer_than=512"
     "--test_env=CLOUD_STORAGE_ENABLE_TRACING=raw-client"
 

--- a/ci/kokoro/macos/build-cmake.sh
+++ b/ci/kokoro/macos/build-cmake.sh
@@ -104,7 +104,7 @@ if should_run_integration_tests; then
     export GOOGLE_CLOUD_CPP_STORAGE_TEST_SIGNING_CONFORMANCE_FILENAME="${PROJECT_ROOT}/google/cloud/storage/tests/v4_signatures.json"
     export GOOGLE_CLOUD_CPP_AUTO_RUN_EXAMPLES="yes"
     export GOOGLE_CLOUD_CPP_EXPERIMENTAL_LOG_CONFIG="lastN,100,WARNING"
-    export GOOGLE_CLOUD_CPP_ENABLE_TRACING="rpc"
+    export GOOGLE_CLOUD_CPP_ENABLE_TRACING="rpc,rpc-streams"
     export GOOGLE_CLOUD_CPP_TRACING_OPTIONS="truncate_string_field_longer_than=512"
     export CLOUD_STORAGE_ENABLE_TRACING="raw-client"
 

--- a/ci/kokoro/windows/build-bazel.ps1
+++ b/ci/kokoro/windows/build-bazel.ps1
@@ -178,7 +178,7 @@ if (Integration-Tests-Enabled) {
         "--test_env=GOOGLE_CLOUD_PROJECT=${env:GOOGLE_CLOUD_PROJECT}",
         "--test_env=GOOGLE_CLOUD_CPP_AUTO_RUN_EXAMPLES=yes",
         "--test_env=GOOGLE_CLOUD_CPP_EXPERIMENTAL_LOG_CONFIG=lastN,100,WARNING",
-        "--test_env=GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc",
+        "--test_env=GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc,rpc-streams",
         "--test_env=GOOGLE_CLOUD_CPP_TRACING_OPTIONS=truncate_string_field_longer_than=512",
         "--test_env=CLOUD_STORAGE_ENABLE_TRACING=raw-client",
 

--- a/google/cloud/bigtable/ci/run_integration_tests_emulator_bazel.sh
+++ b/google/cloud/bigtable/ci/run_integration_tests_emulator_bazel.sh
@@ -69,7 +69,7 @@ done
   --test_env="ENABLE_BIGTABLE_ADMIN_INTEGRATION_TESTS=yes" \
   --test_env="GOOGLE_CLOUD_CPP_AUTO_RUN_EXAMPLES=yes" \
   --test_env="GOOGLE_CLOUD_CPP_EXPERIMENTAL_LOG_CONFIG=lastN,100,WARNING" \
-  --test_env="GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc" \
+  --test_env="GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc,rpc-streams" \
   --test_env="GOOGLE_CLOUD_CPP_TRACING_OPTIONS=truncate_string_field_longer_than=512" \
   --test_tag_filters="integration-test" -- \
   "//google/cloud/bigtable/..." \

--- a/google/cloud/bigtable/ci/run_integration_tests_emulator_cmake.sh
+++ b/google/cloud/bigtable/ci/run_integration_tests_emulator_cmake.sh
@@ -39,7 +39,7 @@ source module /google/cloud/bigtable/tools/run_emulator_utils.sh
 # production. Easier to maintain just one copy.
 export GOOGLE_CLOUD_CPP_AUTO_RUN_EXAMPLES=yes
 export GOOGLE_CLOUD_CPP_EXPERIMENTAL_LOG_CONFIG="lastN,100,WARNING"
-export GOOGLE_CLOUD_CPP_ENABLE_TRACING="rpc"
+export GOOGLE_CLOUD_CPP_ENABLE_TRACING="rpc,rpc-streams"
 export GOOGLE_CLOUD_CPP_TRACING_OPTIONS="truncate_string_field_longer_than=512"
 export ENABLE_BIGTABLE_ADMIN_INTEGRATION_TESTS="yes"
 

--- a/google/cloud/pubsub/ci/run_integration_tests_emulator_bazel.sh
+++ b/google/cloud/pubsub/ci/run_integration_tests_emulator_bazel.sh
@@ -55,7 +55,7 @@ done
   --test_env="PUBSUB_EMULATOR_HOST=${PUBSUB_EMULATOR_HOST}" \
   --test_env="GOOGLE_CLOUD_CPP_AUTO_RUN_EXAMPLES=yes" \
   --test_env="GOOGLE_CLOUD_CPP_EXPERIMENTAL_LOG_CONFIG=lastN,100,WARNING" \
-  --test_env="GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc" \
+  --test_env="GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc,rpc-streams" \
   --test_env="GOOGLE_CLOUD_CPP_TRACING_OPTIONS=truncate_string_field_longer_than=512" \
   --test_tag_filters="integration-test" -- \
   "//google/cloud/pubsub/...:all" \

--- a/google/cloud/pubsub/ci/run_integration_tests_emulator_cmake.sh
+++ b/google/cloud/pubsub/ci/run_integration_tests_emulator_cmake.sh
@@ -36,7 +36,7 @@ ctest_args=("$@")
 # production. Easier to maintain just one copy.
 export GOOGLE_CLOUD_CPP_AUTO_RUN_EXAMPLES=yes
 export GOOGLE_CLOUD_CPP_EXPERIMENTAL_LOG_CONFIG="lastN,100,WARNING"
-export GOOGLE_CLOUD_CPP_ENABLE_TRACING="rpc"
+export GOOGLE_CLOUD_CPP_ENABLE_TRACING="rpc,rpc-streams"
 export GOOGLE_CLOUD_CPP_TRACING_OPTIONS="truncate_string_field_longer_than=512"
 
 cd "${BINARY_DIR}"

--- a/google/cloud/spanner/ci/run_integration_tests_emulator_cmake.sh
+++ b/google/cloud/spanner/ci/run_integration_tests_emulator_cmake.sh
@@ -38,7 +38,7 @@ ctest_args=("$@")
 # production. Easier to maintain just one copy.
 export GOOGLE_CLOUD_CPP_AUTO_RUN_EXAMPLES=yes
 export GOOGLE_CLOUD_CPP_EXPERIMENTAL_LOG_CONFIG="lastN,100,WARNING"
-export GOOGLE_CLOUD_CPP_ENABLE_TRACING="rpc"
+export GOOGLE_CLOUD_CPP_ENABLE_TRACING="rpc,rpc-streams"
 export GOOGLE_CLOUD_CPP_TRACING_OPTIONS="truncate_string_field_longer_than=512"
 export GOOGLE_CLOUD_CPP_SPANNER_SLOW_INTEGRATION_TESTS="instance,backup"
 

--- a/google/cloud/storage/ci/run_integration_tests_emulator_bazel.sh
+++ b/google/cloud/storage/ci/run_integration_tests_emulator_bazel.sh
@@ -104,7 +104,7 @@ emulator_args=(
   "--test_env=GOOGLE_CLOUD_CPP_STORAGE_TEST_HMAC_SERVICE_ACCOUNT=fake-service-account-sign@example.com"
   "--test_env=GOOGLE_CLOUD_CPP_AUTO_RUN_EXAMPLES=yes"
   "--test_env=GOOGLE_CLOUD_CPP_EXPERIMENTAL_LOG_CONFIG=lastN,100,WARNING"
-  "--test_env=GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc"
+  "--test_env=GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc,rpc-streams"
   "--test_env=GOOGLE_CLOUD_CPP_TRACING_OPTIONS=truncate_string_field_longer_than=512"
   "--test_env=CLOUD_STORAGE_ENABLE_TRACING=raw-client"
   "--test_env=EMULATOR_SHA=${EMULATOR_SHA}"

--- a/google/cloud/storage/ci/run_integration_tests_emulator_cmake.sh
+++ b/google/cloud/storage/ci/run_integration_tests_emulator_cmake.sh
@@ -36,7 +36,7 @@ ctest_args=("$@")
 # production. Easier to maintain just one copy.
 export GOOGLE_CLOUD_CPP_AUTO_RUN_EXAMPLES=yes
 export GOOGLE_CLOUD_CPP_EXPERIMENTAL_LOG_CONFIG="lastN,100,WARNING"
-export GOOGLE_CLOUD_CPP_ENABLE_TRACING="rpc"
+export GOOGLE_CLOUD_CPP_ENABLE_TRACING="rpc,rpc-streams"
 export GOOGLE_CLOUD_CPP_TRACING_OPTIONS="truncate_string_field_longer_than=512"
 export CLOUD_STORAGE_ENABLE_TRACING="raw-client"
 export GOOGLE_CLOUD_CPP_STORAGE_TEST_HMAC_SERVICE_ACCOUNT="fake-service-account-hmac@example.com"


### PR DESCRIPTION
Include streaming RPCs in the "lastN" tracing after an integration-test
or sample failure. This will make it a little easier to understand the
log after an occasional and difficult-to-reproduce error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6695)
<!-- Reviewable:end -->
