### PR TITLE
fix(cmake-oldest-deps): use vcpkg release tarball rather than clone

### DIFF
--- a/ci/cloudbuild/builds/cmake-oldest-deps.sh
+++ b/ci/cloudbuild/builds/cmake-oldest-deps.sh
@@ -23,18 +23,13 @@ source module ci/cloudbuild/builds/lib/integration.sh
 export CC=clang
 export CXX=clang++
 
+io::log_h2 "Installing vcpkg"
 vcpkg_root="${PROJECT_ROOT}/cmake-out/vcpkg"
-if [[ ! -d "${vcpkg_root}" ]]; then
-  mkdir -p "${vcpkg_root}"
-  # To enable versioning we need to clone the vcpkg history. It seems that
-  # vcpkg uses `git` to find out what was the state of their packages at a
-  # given "baseline" (totally reasonable, otherwise they would need to
-  # implement another version control system).
-  git clone https://github.com/microsoft/vcpkg.git "${vcpkg_root}"
-fi
-
-io::log_h2 "Bootstrapping vcpkg"
-env CC="ccache ${CC}" CXX="ccache ${CXX}" "${vcpkg_root}"/bootstrap-vcpkg.sh
+mkdir -p "${vcpkg_root}"
+io::log "Downloading vcpkg into ${vcpkg_root}..."
+curl -sSL "https://github.com/microsoft/vcpkg/archive/2021.05.12.tar.gz" |
+  tar -C "${vcpkg_root}" --strip-components=1 -zxf -
+env -C "${vcpkg_root}" CC="ccache ${CC}" CXX="ccache ${CXX}" ./bootstrap-vcpkg.sh
 
 io::log_h2 "Configuring"
 cmake -GNinja -S . -B cmake-out/build \


### PR DESCRIPTION
Fixes: https://github.com/googleapis/google-cloud-cpp/issues/6699

This PR changes the `cmake-oldest-deps` build to use a release tarball
of vcpkg, the same as our other builds that use vcpkg, instead of
cloning the whole vcpkg repo, which picks up new changes from vcpkg that
can break our build unexpectedly.

This change appears to work in my local tests, but I'm concerned that
it's wrong because the previous code had a comment saying that cloning
the repo was required. So I suppose this PR is just for discussion to
see if this is the right direction or if we should fix the issue some
other way.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6700)
<!-- Reviewable:end -->
