### PR TITLE
ci(vcpkg): create lib/vcpkg.sh used by several builds

### DIFF
--- a/ci/cloudbuild/builds/cmake-oldest-deps.sh
+++ b/ci/cloudbuild/builds/cmake-oldest-deps.sh
@@ -16,27 +16,17 @@
 
 set -eu
 
-source "$(dirname "$0")/../../lib/init.sh"
-source module ci/cloudbuild/builds/lib/cmake.sh
-source module ci/cloudbuild/builds/lib/integration.sh
-
 export CC=clang
 export CXX=clang++
 
-vcpkg_root="${PROJECT_ROOT}/cmake-out/vcpkg"
-if [[ ! -d "${vcpkg_root}" ]]; then
-  mkdir -p "${vcpkg_root}"
-  # To enable versioning we need to clone the vcpkg history. It seems that
-  # vcpkg uses `git` to find out what was the state of their packages at a
-  # given "baseline" (totally reasonable, otherwise they would need to
-  # implement another version control system).
-  git clone https://github.com/microsoft/vcpkg.git "${vcpkg_root}"
-fi
-
-io::log_h2 "Bootstrapping vcpkg"
-env CC="ccache ${CC}" CXX="ccache ${CXX}" "${vcpkg_root}"/bootstrap-vcpkg.sh
+source "$(dirname "$0")/../../lib/init.sh"
+source module ci/cloudbuild/builds/lib/cmake.sh
+source module ci/cloudbuild/builds/lib/integration.sh
+source module ci/cloudbuild/builds/lib/vcpkg.sh
+source module ci/lib/io.sh
 
 io::log_h2 "Configuring"
+vcpkg_root="$(vcpkg::root_dir)"
 cmake -GNinja -S . -B cmake-out/build \
   "-DCMAKE_TOOLCHAIN_FILE=${vcpkg_root}/scripts/buildsystems/vcpkg.cmake" \
   "-DVCPKG_MANIFEST_DIR=ci/etc/oldest-deps" \

--- a/ci/cloudbuild/builds/lib/vcpkg.sh
+++ b/ci/cloudbuild/builds/lib/vcpkg.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+#
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Make our include guard clean against set -o nounset.
+test -n "${CI_CLOUDBUILD_BUILDS_LIB_VCPKG_SH__:-}" || declare -i CI_CLOUDBUILD_BUILDS_LIB_VCPKG_SH__=0
+if ((CI_CLOUDBUILD_BUILDS_LIB_VCPKG_SH__++ != 0)); then
+  return 0
+fi # include guard
+
+source module ci/lib/io.sh
+
+TIMEFORMAT="==> 🕑 vcpkg installed in %R seconds"
+time {
+  VCPKG_RELEASE_VERSION="2021.05.12"
+  VCPKG_ROOT_DIR="${HOME}/vcpkg-${VCPKG_RELEASE_VERSION}"
+  io::log_h2 "Installing vcpkg ${VCPKG_RELEASE_VERSION} -> ${VCPKG_ROOT_DIR}"
+  if [[ ! -d "${VCPKG_ROOT_DIR}" ]]; then
+    mkdir -p "${VCPKG_ROOT_DIR}"
+    # vcpkg needs git history to support versioning, so we clone a recent
+    # release tag rather than just extracting a tarball without history.
+    git clone https://github.com/microsoft/vcpkg.git "${VCPKG_ROOT_DIR}" \
+      -b "${VCPKG_RELEASE_VERSION}"
+  fi
+  env -C "${VCPKG_ROOT_DIR}" CC="ccache ${CC}" CXX="ccache ${CXX}" \
+    ./bootstrap-vcpkg.sh
+}
+
+# Outputs the root directory where vcpkg is installed (and bootstrapped)
+function vcpkg::root_dir() {
+  echo "${VCPKG_ROOT_DIR}"
+}

--- a/ci/cloudbuild/builds/quickstart-cmake.sh
+++ b/ci/cloudbuild/builds/quickstart-cmake.sh
@@ -16,23 +16,17 @@
 
 set -eu
 
-source "$(dirname "$0")/../../lib/init.sh"
-source module ci/cloudbuild/builds/lib/cmake.sh
-source module ci/etc/quickstart-config.sh
-source module ci/lib/io.sh
-
 export CC=gcc
 export CXX=g++
 
-io::log_h2 "Installing vcpkg"
-vcpkg_dir="${HOME}/vcpkg-quickstart"
-mkdir -p "${vcpkg_dir}"
-io::log "Downloading vcpkg into ${vcpkg_dir}..."
-curl -sSL "https://github.com/microsoft/vcpkg/archive/2021.05.12.tar.gz" |
-  tar -C "${vcpkg_dir}" --strip-components=1 -zxf -
-env -C "${vcpkg_dir}" CC="ccache ${CC}" CXX="ccache ${CXX}" ./bootstrap-vcpkg.sh
+source "$(dirname "$0")/../../lib/init.sh"
+source module ci/cloudbuild/builds/lib/cmake.sh
+source module ci/cloudbuild/builds/lib/vcpkg.sh
+source module ci/etc/quickstart-config.sh
+source module ci/lib/io.sh
 
 io::log_h2 "Installing google-cloud-cpp with vcpkg"
+vcpkg_dir="$(vcpkg::root_dir)"
 env -C "${vcpkg_dir}" ./vcpkg remove --outdated --recurse
 env -C "${vcpkg_dir}" ./vcpkg install google-cloud-cpp
 


### PR DESCRIPTION
Fixes: https://github.com/googleapis/google-cloud-cpp/issues/6699

This PR factors the code to fetch the vcpkg repo into a library that's
reused in a couple places. It also clones the repo at a recent release
tag rather than cloning at HEAD which may break our builds and is not
hermetic, or downloading a tarball, which lacks git history.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6701)
<!-- Reviewable:end -->
