### PR TITLE
ci(macos): simplify the brew install commands

### DIFF
--- a/ci/kokoro/macos/build-cmake.sh
+++ b/ci/kokoro/macos/build-cmake.sh
@@ -31,10 +31,10 @@ NCPU="$(sysctl -n hw.logicalcpu)"
 readonly NCPU
 
 io::log_h2 "Update or install dependencies"
-brew install openssl
-brew install ccache || ccache --version
-brew install cmake || cmake --version
-brew install ninja || ninja --version
+brew list --versions openssl || brew install openssl
+brew list --versions ccache || brew install ccache
+brew list --versions cmake || brew install cmake
+brew list --versions ninja || brew install ninja
 
 io::log_h2 "ccache stats"
 ccache --show-stats

--- a/ci/kokoro/macos/build-quickstart-cmake.sh
+++ b/ci/kokoro/macos/build-quickstart-cmake.sh
@@ -23,7 +23,7 @@ source module /ci/etc/quickstart-config.sh
 io::log_h2 "Update or install dependencies"
 
 # vcpkg needs this
-brew install pkg-config || pkg-config --version
+brew list --versions pkg-config || brew install pkg-config
 
 # Fetch vcpkg at the specified hash.
 vcpkg_dir="${HOME}/vcpkg-quickstart"

--- a/ci/kokoro/macos/build.sh
+++ b/ci/kokoro/macos/build.sh
@@ -139,7 +139,6 @@ CACHE_NAME="cache-macos-${BUILD_NAME}"
 readonly CACHE_NAME
 
 io::log_h1 "Downloading cache"
-# brew install coreutils # To get gtimeout
 gtimeout 1200 "${PROJECT_ROOT}/ci/kokoro/macos/download-cache.sh" \
   "${CACHE_FOLDER}" "${CACHE_NAME}" || true
 

--- a/ci/kokoro/macos/build.sh
+++ b/ci/kokoro/macos/build.sh
@@ -106,7 +106,9 @@ brew list --versions --cask
 export HOMEBREW_NO_AUTO_UPDATE=1
 export HOMEBREW_NO_INSTALL_CLEANUP=1
 brew list --versions coreutils || brew install coreutils
-brew list --versions --cask google-cloud-sdk || brew install --cask google-cloud-sdk
+# We re-install google-cloud-sdk because the package is broken on some kokoro
+# machines, but we ignore errors here because maybe the local version works.
+brew reinstall google-cloud-sdk || true
 
 io::log_h1 "Starting Build: ${BUILD_NAME}"
 

--- a/ci/kokoro/macos/build.sh
+++ b/ci/kokoro/macos/build.sh
@@ -99,18 +99,16 @@ printf "%10s %s\n" "bazel:" "$(bazel --version 2>&1 | head -1)"
 printf "%10s %s\n" "brew:" "$(brew --version 2>&1 | head -1)"
 printf "%10s %s\n" "branch:" "${BRANCH}"
 
-io::log_h1 "Starting Build: ${BUILD_NAME}"
+io::log_h2 "Brew packages"
+brew list --versions --formula
+brew list --versions --cask
 
-# In some versions of Kokoro `google-cloud-sdk` is not installed by default, or
-# it is just partially installed. This gives us a more consistent environment.
-io::log_h2 "Updating google-cloud-sdk with brew"
 export HOMEBREW_NO_AUTO_UPDATE=1
 export HOMEBREW_NO_INSTALL_CLEANUP=1
-brew --config
-# Ignore errors, maybe the local version is functional.
-brew reinstall google-cloud-sdk || brew install google-cloud-sdk || true
-# Continue despite `brew doctor` errors and warnings.
-brew doctor || true
+brew list --versions coreutils || brew install coreutils
+brew list --versions --cask google-cloud-sdk || brew install --cask google-cloud-sdk
+
+io::log_h1 "Starting Build: ${BUILD_NAME}"
 
 KOKORO_GFILE_DIR="${KOKORO_GFILE_DIR:-/private/var/tmp}"
 readonly KOKORO_GFILE_DIR
@@ -141,7 +139,7 @@ CACHE_NAME="cache-macos-${BUILD_NAME}"
 readonly CACHE_NAME
 
 io::log_h1 "Downloading cache"
-brew install coreutils # To get gtimeout
+# brew install coreutils # To get gtimeout
 gtimeout 1200 "${PROJECT_ROOT}/ci/kokoro/macos/download-cache.sh" \
   "${CACHE_FOLDER}" "${CACHE_NAME}" || true
 


### PR DESCRIPTION
This PR will verify that needed packages are installed (via brew), else they'll be installed. Versions are printed, but they're not verified to be any particular value.

UPDATE: It turns out that we do still need to always re-install the `google-cloud-sdk` package, sadly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6712)
<!-- Reviewable:end -->
