### PR TITLE
ci: add a seconds delta to the "io" timestamps

### DIFF
--- a/ci/cloudbuild/build.sh
+++ b/ci/cloudbuild/build.sh
@@ -250,6 +250,7 @@ if [[ "${DOCKER_FLAG}" = "true" ]]; then
     "--env=USER=$(id -un)"
     "--env=TERM=$([[ -t 0 ]] && echo "${TERM:-dumb}" || echo dumb)"
     "--env=TZ=UTC0"
+    "--env=CI_LIB_IO_FIRST_TIMESTAMP=${CI_LIB_IO_FIRST_TIMESTAMP:-}"
     "--env=CODECOV_TOKEN=${CODECOV_TOKEN:-}"
     "--env=BRANCH_NAME=${BRANCH_NAME}"
     "--env=COMMIT_SHA=${COMMIT_SHA}"

--- a/ci/lib/io.sh
+++ b/ci/lib/io.sh
@@ -56,7 +56,7 @@ function io::internal::timestamp() {
   now=$(date '+%s')
   local when=(-d "@${now}")
   case "$(uname -s)" in
-  Darwin) when=(-r "${now}");;
+  Darwin) when=(-r "${now}") ;;
   esac
   echo "$(date "${when[@]}" -u '+%Y-%m-%dT%H:%M:%SZ')" \
     "$(printf '(%+ds)' $((now - CI_LIB_IO_FIRST_TIMESTAMP)))"

--- a/ci/lib/io.sh
+++ b/ci/lib/io.sh
@@ -54,7 +54,11 @@ export CI_LIB_IO_FIRST_TIMESTAMP=${CI_LIB_IO_FIRST_TIMESTAMP:-$(date '+%s')}
 function io::internal::timestamp() {
   local now
   now=$(date '+%s')
-  echo "$(date -d "@${now}" -u '+%Y-%m-%dT%H:%M:%SZ')" \
+  local when=(-d "@${now}")
+  case "$(uname -s)" in
+  Darwin) when=(-r "${now}");;
+  esac
+  echo "$(date "${when[@]}" -u '+%Y-%m-%dT%H:%M:%SZ')" \
     "$(printf '(%+ds)' $((now - CI_LIB_IO_FIRST_TIMESTAMP)))"
 }
 

--- a/ci/lib/io.sh
+++ b/ci/lib/io.sh
@@ -48,9 +48,14 @@ readonly IO_COLOR_GREEN
 readonly IO_COLOR_YELLOW
 readonly IO_RESET
 
+export CI_LIB_IO_FIRST_TIMESTAMP=${CI_LIB_IO_FIRST_TIMESTAMP:-$(date '+%s')}
+
 # Prints the current time as a string.
 function io::internal::timestamp() {
-  date -u "+%Y-%m-%dT%H:%M:%SZ"
+  local now
+  now=$(date '+%s')
+  echo "$(date -d "@${now}" -u '+%Y-%m-%dT%H:%M:%SZ')" \
+    "$(printf '(%+ds)' $((now - CI_LIB_IO_FIRST_TIMESTAMP)))"
 }
 
 # Logs a message using the given terminal capability. The first argument


### PR DESCRIPTION
Append "(+\<delta\>s)" to the `io::internal::timestamp()` to more
clearly indicate the duration since the beginning of the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6716)
<!-- Reviewable:end -->
