### PR TITLE
cleanup(ci): use bash colon builtin to set vars with defaults

### DIFF
--- a/ci/cloudbuild/build.sh
+++ b/ci/cloudbuild/build.sh
@@ -162,8 +162,8 @@ fi
 : "${TRIGGER_TYPE:=manual}"
 : "${BRANCH_NAME:=$(git branch --show-current)}"
 : "${COMMIT_SHA:=$(git rev-parse HEAD)}"
-: "${CODECOV_TOKEN:="$(tr -d '[:space:]' <<<"${CODECOV_TOKEN:-}")"}"
-: "${LOG_LINKER_PAT:="$(tr -d '[:space:]' <<<"${LOG_LINKER_PAT:-}")"}"
+CODECOV_TOKEN="$(tr -d '[:space:]' <<<"${CODECOV_TOKEN:-}")"
+LOG_LINKER_PAT="$(tr -d '[:space:]' <<<"${LOG_LINKER_PAT:-}")"
 
 export TRIGGER_TYPE
 export BRANCH_NAME

--- a/ci/cloudbuild/build.sh
+++ b/ci/cloudbuild/build.sh
@@ -144,10 +144,8 @@ if [[ -n "${TRIGGER_FLAG}" ]]; then
     io::log_red "Cannot open ${trigger_file}"
     exit 1
   fi
-  build="$(grep _BUILD_NAME "${trigger_file}" | awk '{print $2}')"
-  distro="$(grep _DISTRO "${trigger_file}" | awk '{print $2}')"
-  test -z "${BUILD_NAME}" && BUILD_NAME="${build}"
-  test -z "${DISTRO_FLAG}" && DISTRO_FLAG="${distro}"
+  : "${BUILD_NAME:="$(grep _BUILD_NAME "${trigger_file}" | awk '{print $2}')"}"
+  : "${DISTRO_FLAG:="$(grep _DISTRO "${trigger_file}" | awk '{print $2}')"}"
 fi
 readonly BUILD_NAME
 readonly DISTRO_FLAG
@@ -161,11 +159,11 @@ fi
 # Sets some env vars that usually come from GCB, but need to be set explicitly
 # when doing --local or --docker builds. See also `cloudbuild.yaml` and
 # https://cloud.google.com/build/docs/configuring-builds/substitute-variable-values
-TRIGGER_TYPE="${TRIGGER_TYPE:-manual}"
-BRANCH_NAME="${BRANCH_NAME:-$(git branch --show-current)}"
-COMMIT_SHA="${COMMIT_SHA:-$(git rev-parse HEAD)}"
-CODECOV_TOKEN="$(tr -d '[:space:]' <<<"${CODECOV_TOKEN:-}")"
-LOG_LINKER_PAT="$(tr -d '[:space:]' <<<"${LOG_LINKER_PAT:-}")"
+: "${TRIGGER_TYPE:=manual}"
+: "${BRANCH_NAME:=$(git branch --show-current)}"
+: "${COMMIT_SHA:=$(git rev-parse HEAD)}"
+: "${CODECOV_TOKEN:="$(tr -d '[:space:]' <<<"${CODECOV_TOKEN:-}")"}"
+: "${LOG_LINKER_PAT:="$(tr -d '[:space:]' <<<"${LOG_LINKER_PAT:-}")"}"
 
 export TRIGGER_TYPE
 export BRANCH_NAME


### PR DESCRIPTION
Uses the bash `:` builtin and `:=` in the parameter expansion to set
some bash variables with default values in a more succinct way.

See:
- https://www.gnu.org/savannah-checkouts/gnu/bash/manual/bash.html#Bourne-Shell-Builtins
- https://www.gnu.org/software/bash/manual/html_node/Shell-Parameter-Expansion.html

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6722)
<!-- Reviewable:end -->
