### PR TITLE
cleanup: move Make*Connection overload to internal

### DIFF
--- a/generator/integration_tests/golden/golden_kitchen_sink_connection.cc
+++ b/generator/integration_tests/golden/golden_kitchen_sink_connection.cc
@@ -221,17 +221,28 @@ std::shared_ptr<GoldenKitchenSinkConnection> MakeGoldenKitchenSinkConnection(
       golden_internal::CreateDefaultGoldenKitchenSinkStub(options), options);
 }
 
-std::shared_ptr<GoldenKitchenSinkConnection> MakeGoldenKitchenSinkConnection(
-    std::shared_ptr<golden_internal::GoldenKitchenSinkStub> stub,
+}  // namespace GOOGLE_CLOUD_CPP_GENERATED_NS
+}  // namespace golden
+}  // namespace cloud
+}  // namespace google
+
+namespace google {
+namespace cloud {
+namespace golden_internal {
+inline namespace GOOGLE_CLOUD_CPP_GENERATED_NS {
+
+std::shared_ptr<golden::GoldenKitchenSinkConnection>
+MakeGoldenKitchenSinkConnection(
+    std::shared_ptr<GoldenKitchenSinkStub> stub,
     Options options) {
-  options = golden_internal::GoldenKitchenSinkDefaultOptions(
+  options = GoldenKitchenSinkDefaultOptions(
       std::move(options));
-  return std::make_shared<GoldenKitchenSinkConnectionImpl>(
+  return std::make_shared<golden::GoldenKitchenSinkConnectionImpl>(
       std::move(stub), std::move(options));
 }
 
 }  // namespace GOOGLE_CLOUD_CPP_GENERATED_NS
-}  // namespace golden
+}  // namespace golden_internal
 }  // namespace cloud
 }  // namespace google
 

--- a/generator/integration_tests/golden/golden_kitchen_sink_connection.h
+++ b/generator/integration_tests/golden/golden_kitchen_sink_connection.h
@@ -74,12 +74,23 @@ class GoldenKitchenSinkConnection {
 std::shared_ptr<GoldenKitchenSinkConnection> MakeGoldenKitchenSinkConnection(
     Options options = {});
 
-std::shared_ptr<GoldenKitchenSinkConnection> MakeGoldenKitchenSinkConnection(
-    std::shared_ptr<golden_internal::GoldenKitchenSinkStub> stub,
+}  // namespace GOOGLE_CLOUD_CPP_GENERATED_NS
+}  // namespace golden
+}  // namespace cloud
+}  // namespace google
+
+namespace google {
+namespace cloud {
+namespace golden_internal {
+inline namespace GOOGLE_CLOUD_CPP_GENERATED_NS {
+
+std::shared_ptr<golden::GoldenKitchenSinkConnection>
+MakeGoldenKitchenSinkConnection(
+    std::shared_ptr<GoldenKitchenSinkStub> stub,
     Options options = {});
 
 }  // namespace GOOGLE_CLOUD_CPP_GENERATED_NS
-}  // namespace golden
+}  // namespace golden_internal
 }  // namespace cloud
 }  // namespace google
 

--- a/generator/integration_tests/golden/golden_thing_admin_connection.cc
+++ b/generator/integration_tests/golden/golden_thing_admin_connection.cc
@@ -594,17 +594,28 @@ std::shared_ptr<GoldenThingAdminConnection> MakeGoldenThingAdminConnection(
       golden_internal::CreateDefaultGoldenThingAdminStub(options), options);
 }
 
-std::shared_ptr<GoldenThingAdminConnection> MakeGoldenThingAdminConnection(
-    std::shared_ptr<golden_internal::GoldenThingAdminStub> stub,
+}  // namespace GOOGLE_CLOUD_CPP_GENERATED_NS
+}  // namespace golden
+}  // namespace cloud
+}  // namespace google
+
+namespace google {
+namespace cloud {
+namespace golden_internal {
+inline namespace GOOGLE_CLOUD_CPP_GENERATED_NS {
+
+std::shared_ptr<golden::GoldenThingAdminConnection>
+MakeGoldenThingAdminConnection(
+    std::shared_ptr<GoldenThingAdminStub> stub,
     Options options) {
-  options = golden_internal::GoldenThingAdminDefaultOptions(
+  options = GoldenThingAdminDefaultOptions(
       std::move(options));
-  return std::make_shared<GoldenThingAdminConnectionImpl>(
+  return std::make_shared<golden::GoldenThingAdminConnectionImpl>(
       std::move(stub), std::move(options));
 }
 
 }  // namespace GOOGLE_CLOUD_CPP_GENERATED_NS
-}  // namespace golden
+}  // namespace golden_internal
 }  // namespace cloud
 }  // namespace google
 

--- a/generator/integration_tests/golden/golden_thing_admin_connection.h
+++ b/generator/integration_tests/golden/golden_thing_admin_connection.h
@@ -106,12 +106,23 @@ class GoldenThingAdminConnection {
 std::shared_ptr<GoldenThingAdminConnection> MakeGoldenThingAdminConnection(
     Options options = {});
 
-std::shared_ptr<GoldenThingAdminConnection> MakeGoldenThingAdminConnection(
-    std::shared_ptr<golden_internal::GoldenThingAdminStub> stub,
+}  // namespace GOOGLE_CLOUD_CPP_GENERATED_NS
+}  // namespace golden
+}  // namespace cloud
+}  // namespace google
+
+namespace google {
+namespace cloud {
+namespace golden_internal {
+inline namespace GOOGLE_CLOUD_CPP_GENERATED_NS {
+
+std::shared_ptr<golden::GoldenThingAdminConnection>
+MakeGoldenThingAdminConnection(
+    std::shared_ptr<GoldenThingAdminStub> stub,
     Options options = {});
 
 }  // namespace GOOGLE_CLOUD_CPP_GENERATED_NS
-}  // namespace golden
+}  // namespace golden_internal
 }  // namespace cloud
 }  // namespace google
 

--- a/generator/integration_tests/golden/tests/golden_kitchen_sink_connection_test.cc
+++ b/generator/integration_tests/golden/tests/golden_kitchen_sink_connection_test.cc
@@ -98,8 +98,8 @@ std::shared_ptr<golden::GoldenKitchenSinkConnection> CreateTestingConnection(
   Options options;
   options.set<golden::GoldenKitchenSinkRetryPolicyOption>(retry.clone());
   options.set<golden::GoldenKitchenSinkBackoffPolicyOption>(backoff.clone());
-  return golden::MakeGoldenKitchenSinkConnection(std::move(mock),
-                                                 std::move(options));
+  return golden_internal::MakeGoldenKitchenSinkConnection(std::move(mock),
+                                                          std::move(options));
 }
 
 TEST(GoldenKitchenSinkConnectionTest, GenerateAccessTokenSuccess) {

--- a/generator/integration_tests/golden/tests/golden_thing_admin_connection_test.cc
+++ b/generator/integration_tests/golden/tests/golden_thing_admin_connection_test.cc
@@ -164,8 +164,8 @@ std::shared_ptr<golden::GoldenThingAdminConnection> CreateTestingConnection(
   options.set<golden::GoldenThingAdminRetryPolicyOption>(retry.clone());
   options.set<golden::GoldenThingAdminBackoffPolicyOption>(backoff.clone());
   options.set<golden::GoldenThingAdminPollingPolicyOption>(polling.clone());
-  return golden::MakeGoldenThingAdminConnection(std::move(mock),
-                                                std::move(options));
+  return golden_internal::MakeGoldenThingAdminConnection(std::move(mock),
+                                                         std::move(options));
 }
 
 /// @test Verify that we can list databases in multiple pages.

--- a/generator/internal/connection_generator.cc
+++ b/generator/internal/connection_generator.cc
@@ -155,14 +155,18 @@ Status ConnectionGenerator::GenerateHeader() {
     "    Options options = {});\n\n");
   // clang-format on
 
+  HeaderCloseNamespaces();
+
+  HeaderOpenNamespaces(NamespaceType::kInternal);
   HeaderPrint(
       // clang-format off
-    "std::shared_ptr<$connection_class_name$> Make$connection_class_name$(\n"
-    "    std::shared_ptr<$product_internal_namespace$::$stub_class_name$> stub,\n"
-    "    Options options = {});\n\n");
+      "std::shared_ptr<$product_namespace$::$connection_class_name$>\n"
+      "Make$connection_class_name$(\n"
+      "    std::shared_ptr<$stub_class_name$> stub,\n"
+      "    Options options = {});\n\n");
   // clang-format on
-
   HeaderCloseNamespaces();
+
   // close header guard
   HeaderPrint(  // clang-format off
     "#endif  // $header_include_guard$\n");
@@ -529,13 +533,17 @@ Status ConnectionGenerator::GenerateCc() {
     "}\n\n");
   // clang-format on
 
+  CcCloseNamespaces();
+  CcOpenNamespaces(NamespaceType::kInternal);
+
   CcPrint(  // clang-format off
-    "std::shared_ptr<$connection_class_name$> Make$connection_class_name$(\n"
-    "    std::shared_ptr<$product_internal_namespace$::$stub_class_name$> stub,\n"
+    "std::shared_ptr<$product_namespace$::$connection_class_name$>\n"
+    "Make$connection_class_name$(\n"
+    "    std::shared_ptr<$stub_class_name$> stub,\n"
     "    Options options) {\n"
-    "  options = $product_internal_namespace$::$service_name$DefaultOptions(\n"
+    "  options = $service_name$DefaultOptions(\n"
     "      std::move(options));\n"
-    "  return std::make_shared<$connection_class_name$Impl>(\n"
+    "  return std::make_shared<$product_namespace$::$connection_class_name$Impl>(\n"
     "      std::move(stub), std::move(options));\n"
     "}\n\n");
   // clang-format on

--- a/google/cloud/bigquery/bigquery_read_connection.cc
+++ b/google/cloud/bigquery/bigquery_read_connection.cc
@@ -144,15 +144,24 @@ std::shared_ptr<BigQueryReadConnection> MakeBigQueryReadConnection(
       bigquery_internal::CreateDefaultBigQueryReadStub(options), options);
 }
 
-std::shared_ptr<BigQueryReadConnection> MakeBigQueryReadConnection(
-    std::shared_ptr<bigquery_internal::BigQueryReadStub> stub,
-    Options options) {
-  options = bigquery_internal::BigQueryReadDefaultOptions(std::move(options));
-  return std::make_shared<BigQueryReadConnectionImpl>(std::move(stub),
-                                                      std::move(options));
+}  // namespace GOOGLE_CLOUD_CPP_GENERATED_NS
+}  // namespace bigquery
+}  // namespace cloud
+}  // namespace google
+
+namespace google {
+namespace cloud {
+namespace bigquery_internal {
+inline namespace GOOGLE_CLOUD_CPP_GENERATED_NS {
+
+std::shared_ptr<bigquery::BigQueryReadConnection> MakeBigQueryReadConnection(
+    std::shared_ptr<BigQueryReadStub> stub, Options options) {
+  options = BigQueryReadDefaultOptions(std::move(options));
+  return std::make_shared<bigquery::BigQueryReadConnectionImpl>(
+      std::move(stub), std::move(options));
 }
 
 }  // namespace GOOGLE_CLOUD_CPP_GENERATED_NS
-}  // namespace bigquery
+}  // namespace bigquery_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/bigquery/bigquery_read_connection.h
+++ b/google/cloud/bigquery/bigquery_read_connection.h
@@ -71,12 +71,21 @@ class BigQueryReadConnection {
 std::shared_ptr<BigQueryReadConnection> MakeBigQueryReadConnection(
     Options options = {});
 
-std::shared_ptr<BigQueryReadConnection> MakeBigQueryReadConnection(
-    std::shared_ptr<bigquery_internal::BigQueryReadStub> stub,
-    Options options = {});
-
 }  // namespace GOOGLE_CLOUD_CPP_GENERATED_NS
 }  // namespace bigquery
+}  // namespace cloud
+}  // namespace google
+
+namespace google {
+namespace cloud {
+namespace bigquery_internal {
+inline namespace GOOGLE_CLOUD_CPP_GENERATED_NS {
+
+std::shared_ptr<bigquery::BigQueryReadConnection> MakeBigQueryReadConnection(
+    std::shared_ptr<BigQueryReadStub> stub, Options options = {});
+
+}  // namespace GOOGLE_CLOUD_CPP_GENERATED_NS
+}  // namespace bigquery_internal
 }  // namespace cloud
 }  // namespace google
 

--- a/google/cloud/iam/iam_connection.cc
+++ b/google/cloud/iam/iam_connection.cc
@@ -658,14 +658,24 @@ std::shared_ptr<IAMConnection> MakeIAMConnection(Options options) {
       iam_internal::CreateDefaultIAMStub(options), options);
 }
 
-std::shared_ptr<IAMConnection> MakeIAMConnection(
-    std::shared_ptr<iam_internal::IAMStub> stub, Options options) {
-  options = iam_internal::IAMDefaultOptions(std::move(options));
-  return std::make_shared<IAMConnectionImpl>(std::move(stub),
-                                             std::move(options));
+}  // namespace GOOGLE_CLOUD_CPP_GENERATED_NS
+}  // namespace iam
+}  // namespace cloud
+}  // namespace google
+
+namespace google {
+namespace cloud {
+namespace iam_internal {
+inline namespace GOOGLE_CLOUD_CPP_GENERATED_NS {
+
+std::shared_ptr<iam::IAMConnection> MakeIAMConnection(
+    std::shared_ptr<IAMStub> stub, Options options) {
+  options = IAMDefaultOptions(std::move(options));
+  return std::make_shared<iam::IAMConnectionImpl>(std::move(stub),
+                                                  std::move(options));
 }
 
 }  // namespace GOOGLE_CLOUD_CPP_GENERATED_NS
-}  // namespace iam
+}  // namespace iam_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/iam/iam_connection.h
+++ b/google/cloud/iam/iam_connection.h
@@ -137,11 +137,21 @@ class IAMConnection {
 
 std::shared_ptr<IAMConnection> MakeIAMConnection(Options options = {});
 
-std::shared_ptr<IAMConnection> MakeIAMConnection(
-    std::shared_ptr<iam_internal::IAMStub> stub, Options options = {});
-
 }  // namespace GOOGLE_CLOUD_CPP_GENERATED_NS
 }  // namespace iam
+}  // namespace cloud
+}  // namespace google
+
+namespace google {
+namespace cloud {
+namespace iam_internal {
+inline namespace GOOGLE_CLOUD_CPP_GENERATED_NS {
+
+std::shared_ptr<iam::IAMConnection> MakeIAMConnection(
+    std::shared_ptr<IAMStub> stub, Options options = {});
+
+}  // namespace GOOGLE_CLOUD_CPP_GENERATED_NS
+}  // namespace iam_internal
 }  // namespace cloud
 }  // namespace google
 

--- a/google/cloud/iam/iam_credentials_connection.cc
+++ b/google/cloud/iam/iam_credentials_connection.cc
@@ -140,14 +140,24 @@ std::shared_ptr<IAMCredentialsConnection> MakeIAMCredentialsConnection(
       iam_internal::CreateDefaultIAMCredentialsStub(options), options);
 }
 
-std::shared_ptr<IAMCredentialsConnection> MakeIAMCredentialsConnection(
-    std::shared_ptr<iam_internal::IAMCredentialsStub> stub, Options options) {
-  options = iam_internal::IAMCredentialsDefaultOptions(std::move(options));
-  return std::make_shared<IAMCredentialsConnectionImpl>(std::move(stub),
-                                                        std::move(options));
+}  // namespace GOOGLE_CLOUD_CPP_GENERATED_NS
+}  // namespace iam
+}  // namespace cloud
+}  // namespace google
+
+namespace google {
+namespace cloud {
+namespace iam_internal {
+inline namespace GOOGLE_CLOUD_CPP_GENERATED_NS {
+
+std::shared_ptr<iam::IAMCredentialsConnection> MakeIAMCredentialsConnection(
+    std::shared_ptr<IAMCredentialsStub> stub, Options options) {
+  options = IAMCredentialsDefaultOptions(std::move(options));
+  return std::make_shared<iam::IAMCredentialsConnectionImpl>(
+      std::move(stub), std::move(options));
 }
 
 }  // namespace GOOGLE_CLOUD_CPP_GENERATED_NS
-}  // namespace iam
+}  // namespace iam_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/iam/iam_credentials_connection.h
+++ b/google/cloud/iam/iam_credentials_connection.h
@@ -66,12 +66,21 @@ class IAMCredentialsConnection {
 std::shared_ptr<IAMCredentialsConnection> MakeIAMCredentialsConnection(
     Options options = {});
 
-std::shared_ptr<IAMCredentialsConnection> MakeIAMCredentialsConnection(
-    std::shared_ptr<iam_internal::IAMCredentialsStub> stub,
-    Options options = {});
-
 }  // namespace GOOGLE_CLOUD_CPP_GENERATED_NS
 }  // namespace iam
+}  // namespace cloud
+}  // namespace google
+
+namespace google {
+namespace cloud {
+namespace iam_internal {
+inline namespace GOOGLE_CLOUD_CPP_GENERATED_NS {
+
+std::shared_ptr<iam::IAMCredentialsConnection> MakeIAMCredentialsConnection(
+    std::shared_ptr<IAMCredentialsStub> stub, Options options = {});
+
+}  // namespace GOOGLE_CLOUD_CPP_GENERATED_NS
+}  // namespace iam_internal
 }  // namespace cloud
 }  // namespace google
 

--- a/google/cloud/logging/logging_service_v2_connection.cc
+++ b/google/cloud/logging/logging_service_v2_connection.cc
@@ -242,16 +242,25 @@ std::shared_ptr<LoggingServiceV2Connection> MakeLoggingServiceV2Connection(
       logging_internal::CreateDefaultLoggingServiceV2Stub(options), options);
 }
 
-std::shared_ptr<LoggingServiceV2Connection> MakeLoggingServiceV2Connection(
-    std::shared_ptr<logging_internal::LoggingServiceV2Stub> stub,
-    Options options) {
-  options =
-      logging_internal::LoggingServiceV2DefaultOptions(std::move(options));
-  return std::make_shared<LoggingServiceV2ConnectionImpl>(std::move(stub),
-                                                          std::move(options));
+}  // namespace GOOGLE_CLOUD_CPP_GENERATED_NS
+}  // namespace logging
+}  // namespace cloud
+}  // namespace google
+
+namespace google {
+namespace cloud {
+namespace logging_internal {
+inline namespace GOOGLE_CLOUD_CPP_GENERATED_NS {
+
+std::shared_ptr<logging::LoggingServiceV2Connection>
+MakeLoggingServiceV2Connection(std::shared_ptr<LoggingServiceV2Stub> stub,
+                               Options options) {
+  options = LoggingServiceV2DefaultOptions(std::move(options));
+  return std::make_shared<logging::LoggingServiceV2ConnectionImpl>(
+      std::move(stub), std::move(options));
 }
 
 }  // namespace GOOGLE_CLOUD_CPP_GENERATED_NS
-}  // namespace logging
+}  // namespace logging_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/logging/logging_service_v2_connection.h
+++ b/google/cloud/logging/logging_service_v2_connection.h
@@ -69,12 +69,22 @@ class LoggingServiceV2Connection {
 std::shared_ptr<LoggingServiceV2Connection> MakeLoggingServiceV2Connection(
     Options options = {});
 
-std::shared_ptr<LoggingServiceV2Connection> MakeLoggingServiceV2Connection(
-    std::shared_ptr<logging_internal::LoggingServiceV2Stub> stub,
-    Options options = {});
-
 }  // namespace GOOGLE_CLOUD_CPP_GENERATED_NS
 }  // namespace logging
+}  // namespace cloud
+}  // namespace google
+
+namespace google {
+namespace cloud {
+namespace logging_internal {
+inline namespace GOOGLE_CLOUD_CPP_GENERATED_NS {
+
+std::shared_ptr<logging::LoggingServiceV2Connection>
+MakeLoggingServiceV2Connection(std::shared_ptr<LoggingServiceV2Stub> stub,
+                               Options options = {});
+
+}  // namespace GOOGLE_CLOUD_CPP_GENERATED_NS
+}  // namespace logging_internal
 }  // namespace cloud
 }  // namespace google
 


### PR DESCRIPTION
The overload for `Make*Connection()` taking a `*Stub` needs to be
internal-only. It is used in tests, and may be used to add decorators,
but should not be used by application developers.

Part of the changes for #6721

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6723)
<!-- Reviewable:end -->
