### PR TITLE
cleanup(storage): reduce noise in debug log

### DIFF
--- a/google/cloud/storage/internal/curl_handle.h
+++ b/google/cloud/storage/internal/curl_handle.h
@@ -109,6 +109,14 @@ class CurlHandle {
   /// Convert a CURLE_* error code to a google::cloud::Status().
   static Status AsStatus(CURLcode e, char const* where);
 
+  struct DebugInfo {
+    std::string buffer;
+    std::uint64_t recv_zero_count = 0;
+    std::uint64_t recv_count = 0;
+    std::uint64_t send_zero_count = 0;
+    std::uint64_t send_count = 0;
+  };
+
  private:
   explicit CurlHandle(CurlPtr ptr) : handle_(std::move(ptr)) {}
 
@@ -131,7 +139,7 @@ class CurlHandle {
   }
 
   CurlPtr handle_;
-  std::string debug_buffer_;
+  DebugInfo debug_info_;
   SocketOptions socket_options_;
 };
 


### PR DESCRIPTION
Sometimes the debug callback gets invoked with a zero-sized buffer. We
were creating a log line for each, and in some cases this can generate a
lot of noise. With this change we only log the number of times this took
place.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6725)
<!-- Reviewable:end -->
