### PR TITLE
feature(spanner): add optimizer_statistics_package to QueryOptions

### DIFF
--- a/google/cloud/spanner/client.cc
+++ b/google/cloud/spanner/client.cc
@@ -311,6 +311,8 @@ QueryOptions Client::OverlayQueryOptions(QueryOptions const& preferred) {
   // GetEnv() is not super fast, so we look it up once and cache it.
   static auto const* const kOptimizerVersionEnvValue =
       new auto(google::cloud::internal::GetEnv("SPANNER_OPTIMIZER_VERSION"));
+  static auto const* const kOptimizerStatisticsPackageEnvValue = new auto(
+      google::cloud::internal::GetEnv("SPANNER_OPTIMIZER_STATISTICS_PACKAGE"));
 
   QueryOptions const& fallback = opts_.query_options();
   QueryOptions opts;
@@ -322,6 +324,17 @@ QueryOptions Client::OverlayQueryOptions(QueryOptions const& preferred) {
     opts.set_optimizer_version(fallback.optimizer_version());
   } else if (kOptimizerVersionEnvValue->has_value()) {
     opts.set_optimizer_version(*kOptimizerVersionEnvValue);
+  }
+
+  // Choose the `optimizer_statistics_package` option.
+  if (preferred.optimizer_statistics_package().has_value()) {
+    opts.set_optimizer_statistics_package(
+        preferred.optimizer_statistics_package());
+  } else if (fallback.optimizer_statistics_package().has_value()) {
+    opts.set_optimizer_statistics_package(
+        fallback.optimizer_statistics_package());
+  } else if (kOptimizerStatisticsPackageEnvValue->has_value()) {
+    opts.set_optimizer_statistics_package(*kOptimizerVersionEnvValue);
   }
 
   return opts;

--- a/google/cloud/spanner/client.h
+++ b/google/cloud/spanner/client.h
@@ -51,6 +51,7 @@ namespace cloud {
 namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
 
+// clang-format off
 /**
  * Performs database client operations on Spanner.
  *
@@ -105,15 +106,18 @@ inline namespace SPANNER_CLIENT_NS {
  * table shows the environment variables that may optionally be set and the
  * `QueryOptions` setting that they affect.
  *
- * Environment Variable         | QueryOptions setting
- * ---------------------------- | --------------------
- * `SPANNER_OPTIMIZER_VERSION`  | `QueryOptions::optimizer_version()`
+ * Environment Variable                   | QueryOptions setting
+ * -------------------------------------- | --------------------
+ * `SPANNER_OPTIMIZER_VERSION`            | `QueryOptions::optimizer_version()`
+ * `SPANNER_OPTIMIZER_STATISTICS_PACKAGE` | `QueryOptions::optimizer_statistics_package()`
  *
  * @see https://cloud.google.com/spanner/docs/reference/rest/v1/QueryOptions
+ * @see http://cloud/spanner/docs/query-optimizer/manage-query-optimizer
  *
  * [spanner-doc-link]:
  * https://cloud.google.com/spanner/docs/api-libraries-overview
  */
+// clang-format on
 class Client {
  public:
   /**

--- a/google/cloud/spanner/internal/connection_impl.cc
+++ b/google/cloud/spanner/internal/connection_impl.cc
@@ -551,6 +551,10 @@ StatusOr<ResultType> ConnectionImpl::ExecuteSqlImpl(
     request.mutable_query_options()->set_optimizer_version(
         *params.query_options.optimizer_version());
   }
+  if (params.query_options.optimizer_statistics_package()) {
+    request.mutable_query_options()->set_optimizer_statistics_package(
+        *params.query_options.optimizer_statistics_package());
+  }
   request.mutable_request_options()->set_priority(
       ProtoRequestPriority(params.query_options.request_priority()));
 

--- a/google/cloud/spanner/query_options.h
+++ b/google/cloud/spanner/query_options.h
@@ -31,6 +31,7 @@ inline namespace SPANNER_CLIENT_NS {
  * queries executes on the server.
  *
  * @see https://cloud.google.com/spanner/docs/reference/rest/v1/QueryOptions
+ * @see http://cloud/spanner/docs/query-optimizer/manage-query-optimizer
  */
 class QueryOptions {
  public:
@@ -55,6 +56,21 @@ class QueryOptions {
     return *this;
   }
 
+  /// Returns the optimizer statistics package
+  absl::optional<std::string> const& optimizer_statistics_package() const {
+    return optimizer_statistics_package_;
+  }
+
+  /**
+   * Sets the optimizer statistics package to the specified string. Setting to
+   * the empty string will use the database default.
+   */
+  QueryOptions& set_optimizer_statistics_package(
+      absl::optional<std::string> stats_package) {
+    optimizer_statistics_package_ = std::move(stats_package);
+    return *this;
+  }
+
   /// Returns the request priority.
   absl::optional<RequestPriority> const& request_priority() const {
     return request_priority_;
@@ -68,7 +84,8 @@ class QueryOptions {
 
   friend bool operator==(QueryOptions const& a, QueryOptions const& b) {
     return a.request_priority_ == b.request_priority_ &&
-           a.optimizer_version_ == b.optimizer_version_;
+           a.optimizer_version_ == b.optimizer_version_ &&
+           a.optimizer_statistics_package_ == b.optimizer_statistics_package_;
   }
 
   friend bool operator!=(QueryOptions const& a, QueryOptions const& b) {
@@ -77,6 +94,7 @@ class QueryOptions {
 
  private:
   absl::optional<std::string> optimizer_version_;
+  absl::optional<std::string> optimizer_statistics_package_;
   absl::optional<RequestPriority> request_priority_;
 };
 

--- a/google/cloud/spanner/query_options_test.cc
+++ b/google/cloud/spanner/query_options_test.cc
@@ -32,10 +32,32 @@ TEST(QueryOptionsTest, Values) {
 
   copy.set_optimizer_version("");
   EXPECT_NE(copy, default_constructed);
+  EXPECT_EQ("", copy.optimizer_version().value());
+
   copy.set_optimizer_version("foo");
   EXPECT_NE(copy, default_constructed);
+  EXPECT_EQ("foo", copy.optimizer_version().value());
 
-  copy.set_optimizer_version(absl::optional<std::string>{});
+  copy.set_optimizer_version(absl::nullopt);
+  EXPECT_EQ(copy, default_constructed);
+}
+
+TEST(QueryOptionsTest, OptimizerStatisticsPackage) {
+  QueryOptions const default_constructed{};
+  EXPECT_FALSE(default_constructed.optimizer_statistics_package().has_value());
+
+  auto copy = default_constructed;
+  EXPECT_EQ(copy, default_constructed);
+
+  copy.set_optimizer_statistics_package("");
+  EXPECT_NE(copy, default_constructed);
+  EXPECT_EQ("", copy.optimizer_statistics_package().value());
+
+  copy.set_optimizer_statistics_package("foo");
+  EXPECT_NE(copy, default_constructed);
+  EXPECT_EQ("foo", copy.optimizer_statistics_package().value());
+
+  copy.set_optimizer_statistics_package(absl::nullopt);
   EXPECT_EQ(copy, default_constructed);
 
   copy.set_request_priority(RequestPriority::kLow);

--- a/google/cloud/spanner/samples/samples.cc
+++ b/google/cloud/spanner/samples/samples.cc
@@ -1976,7 +1976,9 @@ void CreateClientWithQueryOptions(std::string const& project_id,
   spanner::Client client(
       spanner::MakeConnection(db),
       spanner::ClientOptions().set_query_options(
-          spanner::QueryOptions().set_optimizer_version("1")));
+          spanner::QueryOptions()
+              .set_optimizer_version("1")
+              .set_optimizer_statistics_package("auto_20191128_14_47_22UTC")));
   //! [END spanner_create_client_with_query_options]
 }
 
@@ -1993,7 +1995,9 @@ void CreateClientWithQueryOptionsCommand(std::vector<std::string> argv) {
 void QueryWithQueryOptions(google::cloud::spanner::Client client) {
   namespace spanner = ::google::cloud::spanner;
   auto sql = spanner::SqlStatement("SELECT SingerId, FirstName FROM Singers");
-  auto opts = spanner::QueryOptions().set_optimizer_version("1");
+  auto opts = spanner::QueryOptions()
+                  .set_optimizer_version("1")
+                  .set_optimizer_statistics_package("latest");
   auto rows = client.ExecuteQuery(std::move(sql), std::move(opts));
 
   using RowType = std::tuple<std::int64_t, std::string>;


### PR DESCRIPTION
Support setting `optimizer_statistics_package` (1) on `Client` query
operations, (2) in `Client` construction (via `ClientOptions`), or
(3) from `${SPANNER_OPTIMIZER_STATISTICS_PACKAGE}`.

The first setting in that list will be passed to the backend in each
`ExecuteSqlRequest`.

Include examples in the `spanner_create_client_with_query_options`
and `spanner_query_with_query_options` samples.

Fixes #4820.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6727)
<!-- Reviewable:end -->
