### PR TITLE
chore: warn if ADC credentials missing for integration tests

### DIFF
--- a/ci/cloudbuild/builds/lib/integration.sh
+++ b/ci/cloudbuild/builds/lib/integration.sh
@@ -34,6 +34,12 @@ python3 -m pip install --quiet --user -r "${PROJECT_ROOT}/google/cloud/storage/e
 rm -f /dev/shm/roots.pem
 curl -sSL --retry 10 -o /dev/shm/roots.pem https://pki.google.com/roots.pem
 
+if [[ ! -r "${HOME}/.config/gcloud/application_default_credentials.json" ]]; then
+  io::log_red "WARNING: Integration tests may fail because of missing file:" \
+    "${HOME}/.config/gcloud/application_default_credentials.json"
+  io::log_red "Fix with: gcloud auth application-default login"
+fi
+
 # Outputs a list of Bazel arguments that should be used when running
 # integration tests. These do not include the common `bazel::common_args`.
 #


### PR DESCRIPTION
If these credentials are missing, several integration tests will fail.
I've been bitten by this a few times in the past two weeks, and a
warning like this would have helped be debug it quicker.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6729)
<!-- Reviewable:end -->
