### PR TITLE
ci(macos): only upgrade google-cloud-sdk if the version is outdated

### DIFF
--- a/ci/kokoro/macos/build.sh
+++ b/ci/kokoro/macos/build.sh
@@ -106,9 +106,8 @@ brew list --versions --cask
 export HOMEBREW_NO_AUTO_UPDATE=1
 export HOMEBREW_NO_INSTALL_CLEANUP=1
 brew list --versions coreutils || brew install coreutils
-# We re-install google-cloud-sdk because the package is broken on some kokoro
-# machines, but we ignore errors here because maybe the local version works.
-brew reinstall google-cloud-sdk || true
+# Kokoro machines have an old and broken version of this SDK.
+brew upgrade google-cloud-sdk
 
 io::log_h1 "Starting Build: ${BUILD_NAME}"
 

--- a/ci/kokoro/macos/build.sh
+++ b/ci/kokoro/macos/build.sh
@@ -107,7 +107,7 @@ export HOMEBREW_NO_AUTO_UPDATE=1
 export HOMEBREW_NO_INSTALL_CLEANUP=1
 brew list --versions coreutils || brew install coreutils
 # Kokoro machines have an old and broken version of this SDK.
-brew upgrade google-cloud-sdk
+brew outdated google-cloud-sdk || brew upgrade google-cloud-sdk
 
 io::log_h1 "Starting Build: ${BUILD_NAME}"
 


### PR DESCRIPTION
This is useful because it will upgrade `google-cloud-sdk` on the Kokoro
machines, which have an old version, but it will not unnecessarily keep
re-installing it on developer machines, which have an up-to-date and
working version.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6735)
<!-- Reviewable:end -->
