### PR TITLE
ci(macos): print elapsed time in Ninja builds

### DIFF
--- a/ci/kokoro/macos/build-cmake.sh
+++ b/ci/kokoro/macos/build-cmake.sh
@@ -53,6 +53,7 @@ cmake_flags=(
 )
 
 io::log_h2 "Configure CMake"
+export NINJA_STATUS="T+%es [%f/%t] "
 cmake -GNinja "-H${SOURCE_DIR}" "-B${BINARY_DIR}" "${cmake_flags[@]}"
 
 io::log_h2 "Compiling with ${NCPU} cpus"

--- a/ci/kokoro/macos/build-quickstart-cmake.sh
+++ b/ci/kokoro/macos/build-quickstart-cmake.sh
@@ -52,6 +52,7 @@ fi
 readonly run_quickstart
 
 cd "${PROJECT_ROOT}"
+export NINJA_STATUS="T+%es [%f/%t] "
 cmake_flags=(
   "-DCMAKE_TOOLCHAIN_FILE=${vcpkg_dir}/scripts/buildsystems/vcpkg.cmake"
 )


### PR DESCRIPTION
This matches our Ninja output from our GCB builds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6736)
<!-- Reviewable:end -->
