### PR TITLE
cleanup(storage): restore GCS+gRPC production integration tests

### DIFF
--- a/ci/cloudbuild/builds/gcs-grpc.sh
+++ b/ci/cloudbuild/builds/gcs-grpc.sh
@@ -23,13 +23,16 @@ source module ci/cloudbuild/builds/lib/integration.sh
 export CC=clang
 export CXX=clang++
 
-mapfile -t args < <(bazel::common_args)
-bazel test "${args[@]}" --test_tag_filters=-integration-test google/cloud/storage/...
+excluded_rules=(
+  "-//google/cloud/storage/examples:storage_service_account_samples"
+  "-//google/cloud/storage/tests:service_account_integration_test"
+  "-//google/cloud/storage/tests:grpc_integration_test"
+)
 
-mapfile -t integration_args < <(integration::bazel_args)
+mapfile -t args < <(bazel::common_args)
+# Run as many of the integration tests as possible using production and gRPC:
 # "media" says to use the hybrid gRPC/REST client. For more details see
 # https://github.com/googleapis/google-cloud-cpp/issues/6268
-GOOGLE_CLOUD_CPP_STORAGE_GRPC_CONFIG=media # Uses the gRPC data plane
-io::log_h2 "Running Storage integration tests (with emulator)"
-google/cloud/storage/ci/run_integration_tests_emulator_bazel.sh \
-  bazel test "${args[@]}" "${integration_args[@]}"
+readonly GOOGLE_CLOUD_CPP_STORAGE_GRPC_CONFIG=media
+mapfile -t integration_args < <(integration::bazel_args)
+bazel test "${args[@]}" "${integration_args[@]}" -- //google/cloud/storage/... "${excluded_rules[@]}"

--- a/ci/cloudbuild/builds/install-gcs-grpc.sh
+++ b/ci/cloudbuild/builds/install-gcs-grpc.sh
@@ -35,5 +35,4 @@ cmake --build cmake-out --target install
 
 # Tests the installed artifacts by building and running the quickstarts.
 quickstart::build_gcs_grpc_quickstart "${INSTALL_PREFIX}"
-# TODO(#6062) - GCS+gRPC integration tests are currently disabled
-# quickstart::run_gcs_grpc_quickstart "${INSTALL_PREFIX}"
+quickstart::run_gcs_grpc_quickstart "${INSTALL_PREFIX}"

--- a/ci/kokoro/macos/build-bazel.sh
+++ b/ci/kokoro/macos/build-bazel.sh
@@ -153,6 +153,7 @@ if should_run_integration_tests; then
     "-//google/cloud/storage/examples:storage_service_account_samples"
     "-//google/cloud/storage/tests:service_account_integration_test"
     "-//google/cloud/examples:grpc_credential_types"
+    "-//google/cloud/storage/tests:grpc_integration_test"
   )
 
   "${BAZEL_BIN}" test \

--- a/ci/kokoro/macos/build-bazel.sh
+++ b/ci/kokoro/macos/build-bazel.sh
@@ -153,10 +153,6 @@ if should_run_integration_tests; then
     "-//google/cloud/storage/examples:storage_service_account_samples"
     "-//google/cloud/storage/tests:service_account_integration_test"
     "-//google/cloud/examples:grpc_credential_types"
-
-    # TODO(#6062) - enable gRPC integration tests again
-    "-//google/cloud/storage/examples:storage_grpc_samples"
-    "-//google/cloud/storage/tests:grpc_integration_test"
   )
 
   "${BAZEL_BIN}" test \

--- a/ci/kokoro/windows/build-bazel.ps1
+++ b/ci/kokoro/windows/build-bazel.ps1
@@ -215,6 +215,7 @@ if (Integration-Tests-Enabled) {
         "-//google/cloud/storage/examples:storage_service_account_samples",
         "-//google/cloud/storage/tests:service_account_integration_test",
         "-//google/cloud/examples:grpc_credential_types",
+        "-//google/cloud/storage/tests:grpc_integration_test"
     )
     bazel $common_flags test $test_flags $integration_flags `
         "--test_tag_filters=integration-test" `

--- a/ci/kokoro/windows/build-bazel.ps1
+++ b/ci/kokoro/windows/build-bazel.ps1
@@ -215,10 +215,6 @@ if (Integration-Tests-Enabled) {
         "-//google/cloud/storage/examples:storage_service_account_samples",
         "-//google/cloud/storage/tests:service_account_integration_test",
         "-//google/cloud/examples:grpc_credential_types",
-
-        # TODO(#6062) - enable gRPC integration tests again
-        "-//google/cloud/storage/examples:storage_grpc_samples",
-        "-//google/cloud/storage/tests:grpc_integration_test"
     )
     bazel $common_flags test $test_flags $integration_flags `
         "--test_tag_filters=integration-test" `

--- a/google/cloud/storage/benchmarks/throughput_experiment_test.cc
+++ b/google/cloud/storage/benchmarks/throughput_experiment_test.cc
@@ -123,13 +123,12 @@ INSTANTIATE_TEST_SUITE_P(ThroughputExperimentIntegrationTestRawJson,
 INSTANTIATE_TEST_SUITE_P(ThroughputExperimentIntegrationTestRawXml,
                          ThroughputExperimentIntegrationTest,
                          ::testing::Values(ApiName::kApiRawXml));
-// TODO(#6062) - enable gRPC integration tests again
-// INSTANTIATE_TEST_SUITE_P(ThroughputExperimentIntegrationTestGrpc,
-//                         ThroughputExperimentIntegrationTest,
-//                         ::testing::Values(ApiName::kApiGrpc));
-// INSTANTIATE_TEST_SUITE_P(ThroughputExperimentIntegrationTestRawGrpc,
-//                         ThroughputExperimentIntegrationTest,
-//                         ::testing::Values(ApiName::kApiRawGrpc));
+INSTANTIATE_TEST_SUITE_P(ThroughputExperimentIntegrationTestGrpc,
+                         ThroughputExperimentIntegrationTest,
+                         ::testing::Values(ApiName::kApiGrpc));
+INSTANTIATE_TEST_SUITE_P(ThroughputExperimentIntegrationTestRawGrpc,
+                         ThroughputExperimentIntegrationTest,
+                         ::testing::Values(ApiName::kApiRawGrpc));
 
 }  // namespace
 }  // namespace storage_benchmarks

--- a/google/cloud/storage/internal/grpc_client.cc
+++ b/google/cloud/storage/internal/grpc_client.cc
@@ -75,6 +75,11 @@ int DefaultGrpcNumChannels() {
 
 Options DefaultOptionsGrpc(Options options) {
   options = DefaultOptionsWithCredentials(std::move(options));
+  if (!options.has<UnifiedCredentialsOption>() &&
+      !options.has<GrpcCredentialOption>()) {
+    options.set<UnifiedCredentialsOption>(
+        google::cloud::MakeGoogleDefaultCredentials());
+  }
   if (!options.has<EndpointOption>()) {
     options.set<EndpointOption>("storage.googleapis.com");
   }
@@ -106,10 +111,9 @@ std::shared_ptr<grpc::Channel> CreateGrpcChannel(
 
 std::shared_ptr<GrpcAuthenticationStrategy> CreateAuthenticationStrategy(
     CompletionQueue cq, Options const& opts) {
-  if (opts.has<google::cloud::UnifiedCredentialsOption>()) {
+  if (opts.has<UnifiedCredentialsOption>()) {
     return google::cloud::internal::CreateAuthenticationStrategy(
-        opts.get<google::cloud::UnifiedCredentialsOption>(), std::move(cq),
-        opts);
+        opts.get<UnifiedCredentialsOption>(), std::move(cq), opts);
   }
   return google::cloud::internal::CreateAuthenticationStrategy(
       opts.get<google::cloud::GrpcCredentialOption>());


### PR DESCRIPTION
The integration tests against production were disabled because
production was broken. It has been working for a few weeks, so time to
enable them again. In the process I discovered that:

* I had broken the initialization of credentials, since the tests were
  running against the emulator only that went unnoticed.
* One of the unit test failed if `CLOUD_STORAGE_ENABLE_TRACING` was set.


Fixes #6062

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6737)
<!-- Reviewable:end -->
