### PR TITLE
ci: pass USE_BAZEL_VERSION to docker

### DIFF
--- a/ci/cloudbuild/build.sh
+++ b/ci/cloudbuild/build.sh
@@ -251,6 +251,7 @@ if [[ "${DOCKER_FLAG}" = "true" ]]; then
     "--env=BRANCH_NAME=${BRANCH_NAME}"
     "--env=COMMIT_SHA=${COMMIT_SHA}"
     "--env=TRIGGER_TYPE=${TRIGGER_TYPE:-}"
+    "--env=USE_BAZEL_VERSION=${USE_BAZEL_VERSION:-}"
     # Mounts an empty volume over "build-out" to isolate builds from each
     # other. Doesn't affect GCB builds, but it helps our local docker builds.
     "--volume=/workspace/build-out"

--- a/ci/cloudbuild/build.sh
+++ b/ci/cloudbuild/build.sh
@@ -70,6 +70,11 @@
 #   Runs the checkers in your local docker
 #   NOTE: This is a good way to format your code and check for style issues.
 #   $ build.sh -t checkers-pr --docker
+#
+# Note: Builds with the `--docker` flag inherit some (but not all) environment
+# variables from the calling process, such as USE_BAZEL_VERSION
+# (https://github.com/bazelbuild/bazelisk), CODECOV_TOKEN
+# (https://codecov.io/), and every variable starting with GOOGLE_CLOUD_.
 
 set -euo pipefail
 


### PR DESCRIPTION
This lets us easily run our existing bazel builds with different
versions of bazel. Examples

```shell
# Uses the build's default version, which today is 3.5.0
$ ci/cloudbuild/build.sh -t asan-pr --docker
# Equivalent to...
$ USE_BAZEL_VERSION=3.5.0 ci/cloudbuild/build.sh -t asan-pr --docker

# Uses the latest released version, which today is 4.1.0
$ USE_BAZEL_VERSION=latest ci/cloudbuild/build.sh -t asan-pr --docker

# Uses the most recent commit that had a green build
$ USE_BAZEL_VERSION=last_green ci/cloudbuild/build.sh -t asan-pr --docker
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6739)
<!-- Reviewable:end -->
