### PR TITLE
fix(ci): avoid centos-8 bug w/ dnf update

### DIFF
--- a/ci/cloudbuild/dockerfiles/demo-centos-8.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-centos-8.Dockerfile
@@ -22,6 +22,7 @@ ARG NCPU=4
 
 # ```bash
 RUN dnf makecache && \
+    dnf update -y && \
     dnf install -y epel-release && \
     dnf makecache && \
     dnf install -y ccache cmake gcc-c++ git make openssl-devel patch pkgconfig \

--- a/doc/packaging.md
+++ b/doc/packaging.md
@@ -1222,6 +1222,7 @@ library (required by gRPC):
 
 ```bash
 sudo dnf makecache && \
+sudo dnf update -y && \
 sudo dnf install -y epel-release && \
 sudo dnf makecache && \
 sudo dnf install -y ccache cmake gcc-c++ git make openssl-devel patch pkgconfig \


### PR DESCRIPTION
@dbolduc noticed a build break in our demo-centos-8 build and also found
the cause and the fix https://bugs.centos.org/view.php?id=18212.

Example build break: https://storage.googleapis.com/cloud-cpp-community-publiclogs/logs/google-cloud-cpp/6739/92e59f91cb066b67edd3dd7d04060f2787fa53c9/demo-centos-8-demo-install/log-259d8ad0-178c-48f6-a48b-462775bc0df7.txt

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6741)
<!-- Reviewable:end -->
