### PR TITLE
ci(macos): reinstall g-c-sdk only when running CI

### DIFF
--- a/ci/kokoro/macos/build.sh
+++ b/ci/kokoro/macos/build.sh
@@ -106,7 +106,9 @@ export HOMEBREW_NO_INSTALL_CLEANUP=1
 brew list --versions coreutils || brew install coreutils
 # We re-install google-cloud-sdk because the package is broken on some kokoro
 # machines, but we ignore errors here because maybe the local version works.
-brew reinstall google-cloud-sdk || true
+if [[ "${RUNNING_CI:-}" = "yes" ]]; then
+  brew reinstall google-cloud-sdk || true
+fi
 
 io::log_h1 "Starting Build: ${BUILD_NAME}"
 


### PR DESCRIPTION
This avoids constantly re-installing `google-cloud-sdk` on dev machines
that have a recent, working copy.