### PR TITLE
refactor: move mock for GrpcAuthenticationStrategy

### DIFF
--- a/google/cloud/storage/internal/storage_auth_test.cc
+++ b/google/cloud/storage/internal/storage_auth_test.cc
@@ -14,6 +14,7 @@
 
 #include "google/cloud/storage/internal/storage_auth.h"
 #include "google/cloud/storage/testing/mock_storage_stub.h"
+#include "google/cloud/testing_util/mock_grpc_authentication_strategy.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
 
@@ -26,21 +27,11 @@ namespace {
 
 using ::google::cloud::internal::GrpcAuthenticationStrategy;
 using ::google::cloud::storage::testing::MockStorageStub;
+using ::google::cloud::testing_util::MockAuthenticationStrategy;
 using ::google::cloud::testing_util::StatusIs;
 using ::testing::IsNull;
 using ::testing::Not;
 using ::testing::Return;
-
-class MockAuthenticationStrategy : public GrpcAuthenticationStrategy {
- public:
-  MOCK_METHOD(std::shared_ptr<grpc::Channel>, CreateChannel,
-              (std::string const&, grpc::ChannelArguments const&), (override));
-  MOCK_METHOD(bool, RequiresConfigureContext, (), (const, override));
-  MOCK_METHOD(Status, ConfigureContext, (grpc::ClientContext&), (override));
-  MOCK_METHOD(future<StatusOr<std::unique_ptr<grpc::ClientContext>>>,
-              AsyncConfigureContext, (std::unique_ptr<grpc::ClientContext>),
-              (override));
-};
 
 std::shared_ptr<GrpcAuthenticationStrategy> MakeMockAuth() {
   auto auth = std::make_shared<MockAuthenticationStrategy>();

--- a/google/cloud/testing_util/CMakeLists.txt
+++ b/google/cloud/testing_util/CMakeLists.txt
@@ -102,6 +102,7 @@ if (BUILD_TESTING)
         is_proto_equal.h
         mock_async_response_reader.h
         mock_completion_queue_impl.h
+        mock_grpc_authentication_strategy.h
         validate_metadata.cc
         validate_metadata.h)
     target_link_libraries(

--- a/google/cloud/testing_util/google_cloud_cpp_testing_grpc.bzl
+++ b/google/cloud/testing_util/google_cloud_cpp_testing_grpc.bzl
@@ -21,6 +21,7 @@ google_cloud_cpp_testing_grpc_hdrs = [
     "is_proto_equal.h",
     "mock_async_response_reader.h",
     "mock_completion_queue_impl.h",
+    "mock_grpc_authentication_strategy.h",
     "validate_metadata.h",
 ]
 

--- a/google/cloud/testing_util/mock_grpc_authentication_strategy.h
+++ b/google/cloud/testing_util/mock_grpc_authentication_strategy.h
@@ -1,0 +1,43 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_TESTING_UTIL_MOCK_GRPC_AUTHENTICATION_STRATEGY_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_TESTING_UTIL_MOCK_GRPC_AUTHENTICATION_STRATEGY_H
+
+#include "google/cloud/internal/unified_grpc_credentials.h"
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+inline namespace GOOGLE_CLOUD_CPP_NS {
+namespace testing_util {
+
+class MockAuthenticationStrategy
+    : public ::google::cloud::internal::GrpcAuthenticationStrategy {
+ public:
+  MOCK_METHOD(std::shared_ptr<grpc::Channel>, CreateChannel,
+              (std::string const&, grpc::ChannelArguments const&), (override));
+  MOCK_METHOD(bool, RequiresConfigureContext, (), (const, override));
+  MOCK_METHOD(Status, ConfigureContext, (grpc::ClientContext&), (override));
+  MOCK_METHOD(future<StatusOr<std::unique_ptr<grpc::ClientContext>>>,
+              AsyncConfigureContext, (std::unique_ptr<grpc::ClientContext>),
+              (override));
+};
+
+}  // namespace testing_util
+}  // namespace GOOGLE_CLOUD_CPP_NS
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_TESTING_UTIL_MOCK_GRPC_AUTHENTICATION_STRATEGY_H


### PR DESCRIPTION
I need to write tests for the generated `*Auth` decorators, this will
come handy there.

Part of the work for #6721

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6745)
<!-- Reviewable:end -->
