### PR TITLE
refactor: move mocks for golden stubs to headers

### DIFF
--- a/generator/integration_tests/golden/CMakeLists.txt
+++ b/generator/integration_tests/golden/CMakeLists.txt
@@ -98,7 +98,9 @@ add_library(
     internal/golden_thing_admin_stub_factory.cc
     internal/golden_thing_admin_stub_factory.h
     mocks/mock_golden_kitchen_sink_connection.h
+    mocks/mock_golden_kitchen_sink_stub.h
     mocks/mock_golden_thing_admin_connection.h
+    mocks/mock_golden_thing_admin_stub.h
     retry_traits.h
     streaming.cc)
 

--- a/generator/integration_tests/golden/mocks/mock_golden_kitchen_sink_stub.h
+++ b/generator/integration_tests/golden/mocks/mock_golden_kitchen_sink_stub.h
@@ -1,0 +1,75 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_MOCKS_MOCK_GOLDEN_KITCHEN_SINK_STUB_H
+#define GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_MOCKS_MOCK_GOLDEN_KITCHEN_SINK_STUB_H
+
+#include "generator/integration_tests/golden/internal/golden_kitchen_sink_stub.h"
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+namespace golden_internal {
+inline namespace GOOGLE_CLOUD_CPP_GENERATED_NS {
+
+class MockGoldenKitchenSinkStub : public GoldenKitchenSinkStub {
+ public:
+  ~MockGoldenKitchenSinkStub() override = default;
+
+  MOCK_METHOD(
+      StatusOr<
+          ::google::test::admin::database::v1::GenerateAccessTokenResponse>,
+      GenerateAccessToken,
+      (grpc::ClientContext&,
+       ::google::test::admin::database::v1::GenerateAccessTokenRequest const&),
+      (override));
+  MOCK_METHOD(
+      StatusOr<::google::test::admin::database::v1::GenerateIdTokenResponse>,
+      GenerateIdToken,
+      (grpc::ClientContext&,
+       ::google::test::admin::database::v1::GenerateIdTokenRequest const&),
+      (override));
+  MOCK_METHOD(
+      StatusOr<::google::test::admin::database::v1::WriteLogEntriesResponse>,
+      WriteLogEntries,
+      (grpc::ClientContext&,
+       ::google::test::admin::database::v1::WriteLogEntriesRequest const&),
+      (override));
+  MOCK_METHOD(StatusOr<::google::test::admin::database::v1::ListLogsResponse>,
+              ListLogs,
+              (grpc::ClientContext&,
+               ::google::test::admin::database::v1::ListLogsRequest const&),
+              (override));
+  MOCK_METHOD(
+      (std::unique_ptr<internal::StreamingReadRpc<
+           ::google::test::admin::database::v1::TailLogEntriesResponse>>),
+      TailLogEntries,
+      (std::unique_ptr<grpc::ClientContext> context,
+       ::google::test::admin::database::v1::TailLogEntriesRequest const&),
+      (override));
+  MOCK_METHOD(
+      StatusOr<
+          ::google::test::admin::database::v1::ListServiceAccountKeysResponse>,
+      ListServiceAccountKeys,
+      (grpc::ClientContext&, ::google::test::admin::database::v1::
+                                 ListServiceAccountKeysRequest const&),
+      (override));
+};
+
+}  // namespace GOOGLE_CLOUD_CPP_GENERATED_NS
+}  // namespace golden_internal
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_MOCKS_MOCK_GOLDEN_KITCHEN_SINK_STUB_H

--- a/generator/integration_tests/golden/mocks/mock_golden_thing_admin_stub.h
+++ b/generator/integration_tests/golden/mocks/mock_golden_thing_admin_stub.h
@@ -1,0 +1,133 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_MOCKS_MOCK_GOLDEN_THING_ADMIN_STUB_H
+#define GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_MOCKS_MOCK_GOLDEN_THING_ADMIN_STUB_H
+
+#include "generator/integration_tests/golden/internal/golden_thing_admin_stub.h"
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+namespace golden_internal {
+inline namespace GOOGLE_CLOUD_CPP_GENERATED_NS {
+
+class MockGoldenThingAdminStub
+    : public google::cloud::golden_internal::GoldenThingAdminStub {
+ public:
+  ~MockGoldenThingAdminStub() override = default;
+
+  MOCK_METHOD(
+      StatusOr<::google::test::admin::database::v1::ListDatabasesResponse>,
+      ListDatabases,
+      (grpc::ClientContext&,
+       ::google::test::admin::database::v1::ListDatabasesRequest const&),
+      (override));
+  MOCK_METHOD(
+      StatusOr<::google::longrunning::Operation>, CreateDatabase,
+      (grpc::ClientContext&,
+       ::google::test::admin::database::v1::CreateDatabaseRequest const&),
+      (override));
+  MOCK_METHOD(StatusOr<::google::test::admin::database::v1::Database>,
+              GetDatabase,
+              (grpc::ClientContext&,
+               ::google::test::admin::database::v1::GetDatabaseRequest const&),
+              (override));
+  MOCK_METHOD(
+      StatusOr<::google::longrunning::Operation>, UpdateDatabaseDdl,
+      (grpc::ClientContext&,
+       ::google::test::admin::database::v1::UpdateDatabaseDdlRequest const&),
+      (override));
+  MOCK_METHOD(Status, DropDatabase,
+              (grpc::ClientContext&,
+               ::google::test::admin::database::v1::DropDatabaseRequest const&),
+              (override));
+  MOCK_METHOD(
+      StatusOr<::google::test::admin::database::v1::GetDatabaseDdlResponse>,
+      GetDatabaseDdl,
+      (grpc::ClientContext&,
+       ::google::test::admin::database::v1::GetDatabaseDdlRequest const&),
+      (override));
+  MOCK_METHOD(StatusOr<::google::iam::v1::Policy>, SetIamPolicy,
+              (grpc::ClientContext&,
+               ::google::iam::v1::SetIamPolicyRequest const&),
+              (override));
+  MOCK_METHOD(StatusOr<::google::iam::v1::Policy>, GetIamPolicy,
+              (grpc::ClientContext&,
+               ::google::iam::v1::GetIamPolicyRequest const&),
+              (override));
+  MOCK_METHOD(StatusOr<::google::iam::v1::TestIamPermissionsResponse>,
+              TestIamPermissions,
+              (grpc::ClientContext&,
+               ::google::iam::v1::TestIamPermissionsRequest const&),
+              (override));
+  MOCK_METHOD(StatusOr<::google::longrunning::Operation>, CreateBackup,
+              (grpc::ClientContext&,
+               ::google::test::admin::database::v1::CreateBackupRequest const&),
+              (override));
+  MOCK_METHOD(StatusOr<::google::test::admin::database::v1::Backup>, GetBackup,
+              (grpc::ClientContext&,
+               ::google::test::admin::database::v1::GetBackupRequest const&),
+              (override));
+  MOCK_METHOD(StatusOr<::google::test::admin::database::v1::Backup>,
+              UpdateBackup,
+              (grpc::ClientContext&,
+               ::google::test::admin::database::v1::UpdateBackupRequest const&),
+              (override));
+  MOCK_METHOD(Status, DeleteBackup,
+              (grpc::ClientContext&,
+               ::google::test::admin::database::v1::DeleteBackupRequest const&),
+              (override));
+  MOCK_METHOD(
+      StatusOr<::google::test::admin::database::v1::ListBackupsResponse>,
+      ListBackups,
+      (grpc::ClientContext&,
+       ::google::test::admin::database::v1::ListBackupsRequest const&),
+      (override));
+  MOCK_METHOD(
+      StatusOr<::google::longrunning::Operation>, RestoreDatabase,
+      (grpc::ClientContext&,
+       ::google::test::admin::database::v1::RestoreDatabaseRequest const&),
+      (override));
+  MOCK_METHOD(
+      StatusOr<
+          ::google::test::admin::database::v1::ListDatabaseOperationsResponse>,
+      ListDatabaseOperations,
+      (grpc::ClientContext&,
+       ::google::test::admin::database::v1::ListDatabaseOperationsRequest const&
+           request),
+      (override));
+  MOCK_METHOD(
+      StatusOr<
+          ::google::test::admin::database::v1::ListBackupOperationsResponse>,
+      ListBackupOperations,
+      (grpc::ClientContext&,
+       ::google::test::admin::database::v1::ListBackupOperationsRequest const&),
+      (override));
+  MOCK_METHOD(StatusOr<google::longrunning::Operation>, GetOperation,
+              (grpc::ClientContext&,
+               google::longrunning::GetOperationRequest const&),
+              (override));
+  MOCK_METHOD(Status, CancelOperation,
+              (grpc::ClientContext&,
+               google::longrunning::CancelOperationRequest const&),
+              (override));
+};
+
+}  // namespace GOOGLE_CLOUD_CPP_GENERATED_NS
+}  // namespace golden_internal
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_MOCKS_MOCK_GOLDEN_THING_ADMIN_STUB_H

--- a/generator/integration_tests/golden/tests/golden_kitchen_sink_logging_decorator_test.cc
+++ b/generator/integration_tests/golden/tests/golden_kitchen_sink_logging_decorator_test.cc
@@ -11,13 +11,14 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 #include "generator/integration_tests/golden/internal/golden_kitchen_sink_logging_decorator.h"
 #include "google/cloud/log.h"
 #include "google/cloud/testing_util/scoped_log.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include "absl/memory/memory.h"
+#include "generator/integration_tests/golden/mocks/mock_golden_kitchen_sink_stub.h"
 #include <gmock/gmock.h>
-#include <grpcpp/impl/codegen/status_code_enum.h>
 #include <memory>
 
 namespace google {
@@ -31,55 +32,6 @@ using ::testing::ByMove;
 using ::testing::Contains;
 using ::testing::HasSubstr;
 using ::testing::Return;
-
-class MockGoldenKitchenSinkStub
-    : public google::cloud::golden_internal::GoldenKitchenSinkStub {
- public:
-  ~MockGoldenKitchenSinkStub() override = default;
-  MOCK_METHOD(
-      StatusOr<
-          ::google::test::admin::database::v1::GenerateAccessTokenResponse>,
-      GenerateAccessToken,
-      (grpc::ClientContext & context,
-       ::google::test::admin::database::v1::GenerateAccessTokenRequest const&
-           request),
-      (override));
-  MOCK_METHOD(
-      StatusOr<::google::test::admin::database::v1::GenerateIdTokenResponse>,
-      GenerateIdToken,
-      (grpc::ClientContext & context,
-       ::google::test::admin::database::v1::GenerateIdTokenRequest const&
-           request),
-      (override));
-  MOCK_METHOD(
-      StatusOr<::google::test::admin::database::v1::WriteLogEntriesResponse>,
-      WriteLogEntries,
-      (grpc::ClientContext & context,
-       ::google::test::admin::database::v1::WriteLogEntriesRequest const&
-           request),
-      (override));
-  MOCK_METHOD(
-      StatusOr<::google::test::admin::database::v1::ListLogsResponse>, ListLogs,
-      (grpc::ClientContext & context,
-       ::google::test::admin::database::v1::ListLogsRequest const& request),
-      (override));
-  MOCK_METHOD(
-      (std::unique_ptr<internal::StreamingReadRpc<
-           ::google::test::admin::database::v1::TailLogEntriesResponse>>),
-      TailLogEntries,
-      (std::unique_ptr<grpc::ClientContext> context,
-       ::google::test::admin::database::v1::TailLogEntriesRequest const&
-           request),
-      (override));
-  MOCK_METHOD(
-      StatusOr<
-          ::google::test::admin::database::v1::ListServiceAccountKeysResponse>,
-      ListServiceAccountKeys,
-      (grpc::ClientContext & context,
-       ::google::test::admin::database::v1::ListServiceAccountKeysRequest const&
-           request),
-      (override));
-};
 
 class LoggingDecoratorTest : public ::testing::Test {
  protected:

--- a/generator/integration_tests/golden/tests/golden_thing_admin_logging_decorator_test.cc
+++ b/generator/integration_tests/golden/tests/golden_thing_admin_logging_decorator_test.cc
@@ -16,6 +16,7 @@
 #include "google/cloud/log.h"
 #include "google/cloud/testing_util/scoped_log.h"
 #include "google/cloud/testing_util/status_matchers.h"
+#include "generator/integration_tests/golden/mocks/mock_golden_thing_admin_stub.h"
 #include <gmock/gmock.h>
 #include <memory>
 
@@ -29,145 +30,17 @@ using ::testing::Contains;
 using ::testing::HasSubstr;
 using ::testing::Return;
 
-class MockGoldenStub
-    : public google::cloud::golden_internal::GoldenThingAdminStub {
- public:
-  ~MockGoldenStub() override = default;
-  MOCK_METHOD(
-      StatusOr<::google::test::admin::database::v1::ListDatabasesResponse>,
-      ListDatabases,
-      (grpc::ClientContext & context,
-       ::google::test::admin::database::v1::ListDatabasesRequest const&
-           request),
-      (override));
-
-  MOCK_METHOD(StatusOr<::google::longrunning::Operation>, CreateDatabase,
-              (grpc::ClientContext & context,
-               ::google::test::admin::database::v1::CreateDatabaseRequest const&
-                   request),
-              (override));
-
-  MOCK_METHOD(
-      StatusOr<::google::test::admin::database::v1::Database>, GetDatabase,
-      (grpc::ClientContext & context,
-       ::google::test::admin::database::v1::GetDatabaseRequest const& request),
-      (override));
-
-  MOCK_METHOD(
-      StatusOr<::google::longrunning::Operation>, UpdateDatabaseDdl,
-      (grpc::ClientContext & context,
-       ::google::test::admin::database::v1::UpdateDatabaseDdlRequest const&
-           request),
-      (override));
-
-  MOCK_METHOD(
-      Status, DropDatabase,
-      (grpc::ClientContext & context,
-       ::google::test::admin::database::v1::DropDatabaseRequest const& request),
-      (override));
-
-  MOCK_METHOD(
-      StatusOr<::google::test::admin::database::v1::GetDatabaseDdlResponse>,
-      GetDatabaseDdl,
-      (grpc::ClientContext & context,
-       ::google::test::admin::database::v1::GetDatabaseDdlRequest const&
-           request),
-      (override));
-
-  MOCK_METHOD(StatusOr<::google::iam::v1::Policy>, SetIamPolicy,
-              (grpc::ClientContext & context,
-               ::google::iam::v1::SetIamPolicyRequest const& request),
-              (override));
-
-  MOCK_METHOD(StatusOr<::google::iam::v1::Policy>, GetIamPolicy,
-              (grpc::ClientContext & context,
-               ::google::iam::v1::GetIamPolicyRequest const& request),
-              (override));
-
-  MOCK_METHOD(StatusOr<::google::iam::v1::TestIamPermissionsResponse>,
-              TestIamPermissions,
-              (grpc::ClientContext & context,
-               ::google::iam::v1::TestIamPermissionsRequest const& request),
-              (override));
-
-  MOCK_METHOD(
-      StatusOr<::google::longrunning::Operation>, CreateBackup,
-      (grpc::ClientContext & context,
-       ::google::test::admin::database::v1::CreateBackupRequest const& request),
-      (override));
-
-  MOCK_METHOD(
-      StatusOr<::google::test::admin::database::v1::Backup>, GetBackup,
-      (grpc::ClientContext & context,
-       ::google::test::admin::database::v1::GetBackupRequest const& request),
-      (override));
-
-  MOCK_METHOD(
-      StatusOr<::google::test::admin::database::v1::Backup>, UpdateBackup,
-      (grpc::ClientContext & context,
-       ::google::test::admin::database::v1::UpdateBackupRequest const& request),
-      (override));
-
-  MOCK_METHOD(
-      Status, DeleteBackup,
-      (grpc::ClientContext & context,
-       ::google::test::admin::database::v1::DeleteBackupRequest const& request),
-      (override));
-
-  MOCK_METHOD(
-      StatusOr<::google::test::admin::database::v1::ListBackupsResponse>,
-      ListBackups,
-      (grpc::ClientContext & context,
-       ::google::test::admin::database::v1::ListBackupsRequest const& request),
-      (override));
-
-  MOCK_METHOD(
-      StatusOr<::google::longrunning::Operation>, RestoreDatabase,
-      (grpc::ClientContext & context,
-       ::google::test::admin::database::v1::RestoreDatabaseRequest const&
-           request),
-      (override));
-
-  MOCK_METHOD(
-      StatusOr<
-          ::google::test::admin::database::v1::ListDatabaseOperationsResponse>,
-      ListDatabaseOperations,
-      (grpc::ClientContext & context,
-       ::google::test::admin::database::v1::ListDatabaseOperationsRequest const&
-           request),
-      (override));
-
-  MOCK_METHOD(
-      StatusOr<
-          ::google::test::admin::database::v1::ListBackupOperationsResponse>,
-      ListBackupOperations,
-      (grpc::ClientContext & context,
-       ::google::test::admin::database::v1::ListBackupOperationsRequest const&
-           request),
-      (override));
-
-  /// Poll a long-running operation.
-  MOCK_METHOD(StatusOr<google::longrunning::Operation>, GetOperation,
-              (grpc::ClientContext & client_context,
-               google::longrunning::GetOperationRequest const& request),
-              (override));
-
-  /// Cancel a long-running operation.
-  MOCK_METHOD(Status, CancelOperation,
-              (grpc::ClientContext & client_context,
-               google::longrunning::CancelOperationRequest const& request),
-              (override));
-};
-
 class LoggingDecoratorTest : public ::testing::Test {
  protected:
-  void SetUp() override { mock_ = std::make_shared<MockGoldenStub>(); }
+  void SetUp() override {
+    mock_ = std::make_shared<MockGoldenThingAdminStub>();
+  }
 
   static Status TransientError() {
     return Status(StatusCode::kUnavailable, "try-again");
   }
 
-  std::shared_ptr<MockGoldenStub> mock_;
+  std::shared_ptr<MockGoldenThingAdminStub> mock_;
   testing_util::ScopedLog log_;
 };
 


### PR DESCRIPTION
I will also need these in new tests for the `*Auth` decorators. I
renamed one of them because name name did not make sense if used outside
a single test.

Part of the work for #6721

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6746)
<!-- Reviewable:end -->
