### PR TITLE
ci(mac): refactor build scripts to look more like GCB scripts

### DIFF
--- a/ci/kokoro/lib/cache.sh
+++ b/ci/kokoro/lib/cache.sh
@@ -36,10 +36,6 @@ cache_download_enabled() {
     return 1
   fi
 
-  if [[ "${KOKORO_JOB_TYPE:-}" = "CONTINUOUS_INTEGRATION" && "${BUILD_TOOL:-}" = "Bazel" ]]; then
-    io::log "Cache not downloaded as this is a full CI build for Bazel."
-    return 1
-  fi
   return 0
 }
 

--- a/ci/kokoro/macos/builds/bazel.sh
+++ b/ci/kokoro/macos/builds/bazel.sh
@@ -15,9 +15,9 @@
 
 set -eu
 
-source "$(dirname "$0")/../../lib/init.sh"
-source module /ci/etc/integration-tests-config.sh
-source module /ci/lib/io.sh
+source "$(dirname "$0")/../../../lib/init.sh"
+source module ci/etc/integration-tests-config.sh
+source module ci/lib/io.sh
 
 # NOTE: In this file use the command `bazelisk` rather than bazel, because
 # Kokoro has both installed and we want to make sure to use the former.
@@ -35,10 +35,8 @@ bazel_args=(
   "--action_env=GOOGLE_APPLICATION_CREDENTIALS=${GOOGLE_APPLICATION_CREDENTIALS}"
   "--test_output=errors"
   "--verbose_failures=true"
-  "--keep_going")
-if [[ -n "${BAZEL_CONFIG}" ]]; then
-  bazel_args+=("--config" "${BAZEL_CONFIG}")
-fi
+  "--keep_going"
+)
 
 readonly CONFIG_DIR="${KOKORO_GFILE_DIR:-/private/var/tmp}"
 readonly TEST_KEY_FILE_JSON="${CONFIG_DIR}/kokoro-run-key.json"

--- a/ci/kokoro/macos/builds/cmake-super.sh
+++ b/ci/kokoro/macos/builds/cmake-super.sh
@@ -15,17 +15,12 @@
 
 set -eu
 
-source "$(dirname "$0")/../../lib/init.sh"
-source module /ci/etc/integration-tests-config.sh
-source module /ci/lib/io.sh
+source "$(dirname "$0")/../../../lib/init.sh"
+source module ci/etc/integration-tests-config.sh
+source module ci/lib/io.sh
 
-if [[ $# -ne 2 ]]; then
-  echo "Usage: $(basename "$0")  <source-directory> <binary-directory>"
-  exit 1
-fi
-
-readonly SOURCE_DIR="$1"
-readonly BINARY_DIR="$2"
+readonly SOURCE_DIR="super"
+readonly BINARY_DIR="cmake-out/macos"
 
 NCPU="$(sysctl -n hw.logicalcpu)"
 readonly NCPU
@@ -42,8 +37,6 @@ brew list --versions ninja || brew install ninja
 io::log_h2 "ccache stats"
 ccache --show-stats
 ccache --zero-stats
-
-cd "${PROJECT_ROOT}"
 
 # Sets OPENSSL_ROOT_DIR to its install path from homebrew.
 homebrew_prefix="$(brew --prefix)"
@@ -121,4 +114,3 @@ ccache --show-stats
 ccache --zero-stats
 
 io::log_green "Build finished successfully"
-exit 0

--- a/ci/kokoro/macos/builds/quickstart-bazel.sh
+++ b/ci/kokoro/macos/builds/quickstart-bazel.sh
@@ -15,10 +15,10 @@
 
 set -eu
 
-source "$(dirname "$0")/../../lib/init.sh"
-source module /ci/etc/integration-tests-config.sh
-source module /ci/etc/quickstart-config.sh
-source module /ci/lib/io.sh
+source "$(dirname "$0")/../../../lib/init.sh"
+source module ci/etc/integration-tests-config.sh
+source module ci/etc/quickstart-config.sh
+source module ci/lib/io.sh
 
 # NOTE: In this file use the command `bazelisk` rather than bazel, because
 # Kokoro has both installed and we want to make sure to use the former.
@@ -61,8 +61,6 @@ if [[ -r "${CREDENTIALS_FILE}" ]]; then
   fi
 fi
 readonly run_quickstart
-
-cd "${PROJECT_ROOT}"
 
 build_quickstart() {
   local -r library="$1"

--- a/ci/kokoro/macos/builds/quickstart-cmake.sh
+++ b/ci/kokoro/macos/builds/quickstart-cmake.sh
@@ -15,16 +15,15 @@
 
 set -eu
 
-source "$(dirname "$0")/../../lib/init.sh"
-source module /ci/lib/io.sh
-source module /ci/etc/integration-tests-config.sh
-source module /ci/etc/quickstart-config.sh
+source "$(dirname "$0")/../../../lib/init.sh"
+source module ci/lib/io.sh
+source module ci/etc/integration-tests-config.sh
+source module ci/etc/quickstart-config.sh
 
 io::log_h2 "Using CMake version"
 cmake --version
 
 io::log_h2 "Update or install dependencies"
-
 # vcpkg needs this
 brew list --versions pkg-config || brew install pkg-config
 
@@ -54,7 +53,6 @@ if [[ -r "${CREDENTIALS_FILE}" ]]; then
 fi
 readonly run_quickstart
 
-cd "${PROJECT_ROOT}"
 export NINJA_STATUS="T+%es [%f/%t] "
 cmake_flags=(
   "-DCMAKE_TOOLCHAIN_FILE=${vcpkg_dir}/scripts/buildsystems/vcpkg.cmake"
@@ -107,5 +105,3 @@ else
   io::log_red "Build failed for ${errors}"
   exit 1
 fi
-
-exit 0

--- a/ci/kokoro/macos/download-cache.sh
+++ b/ci/kokoro/macos/download-cache.sh
@@ -16,9 +16,9 @@
 set -eu
 
 source "$(dirname "$0")/../../lib/init.sh"
-source module /ci/lib/io.sh
-source module /ci/kokoro/lib/gcloud.sh
-source module /ci/kokoro/lib/cache.sh
+source module ci/lib/io.sh
+source module ci/kokoro/lib/gcloud.sh
+source module ci/kokoro/lib/cache.sh
 
 if [[ $# != 2 ]]; then
   echo "Usage: $(basename "$0") <cache-folder> <cache-name>"

--- a/ci/kokoro/macos/upload-cache.sh
+++ b/ci/kokoro/macos/upload-cache.sh
@@ -16,11 +16,11 @@
 set -eu
 
 source "$(dirname "$0")/../../lib/init.sh"
-source module /ci/etc/integration-tests-config.sh
-source module /ci/etc/quickstart-config.sh
-source module /ci/kokoro/lib/gcloud.sh
-source module /ci/kokoro/lib/cache.sh
-source module /ci/lib/io.sh
+source module ci/etc/integration-tests-config.sh
+source module ci/etc/quickstart-config.sh
+source module ci/kokoro/lib/gcloud.sh
+source module ci/kokoro/lib/cache.sh
+source module ci/lib/io.sh
 
 if [[ $# != 2 ]]; then
   echo "Usage: $(basename "$0") <cache-folder> <cache-name>"


### PR DESCRIPTION
Assuming that consistency is good, making the mac scripts look similar
to the `ci/cloudbuild/` scripts is probably good too.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6748)
<!-- Reviewable:end -->
