### PR TITLE
test(spanner): relax emulator SPANNER_STATISTICS expectation

### DIFF
--- a/google/cloud/spanner/integration_tests/client_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/client_integration_test.cc
@@ -31,6 +31,7 @@ namespace {
 
 using ::google::cloud::testing_util::IsOk;
 using ::google::cloud::testing_util::StatusIs;
+using ::testing::AnyOf;
 using ::testing::UnorderedElementsAre;
 using ::testing::UnorderedElementsAreArray;
 
@@ -934,7 +935,8 @@ TEST_F(ClientIntegrationTest, SpannerStatistics) {
   using RowType = std::tuple<std::string, std::string, bool>;
   for (auto& row : StreamOf<RowType>(rows)) {
     if (emulator_) {
-      EXPECT_THAT(row, StatusIs(StatusCode::kInvalidArgument));
+      EXPECT_THAT(row, StatusIs(AnyOf(StatusCode::kInvalidArgument,
+                                      StatusCode::kUnimplemented)));
     } else {
       EXPECT_THAT(row, IsOk());
     }


### PR DESCRIPTION
I did not track down exactly why, but the error code from the
emulator when reading the INFORMATION_SCHEMA.SPANNER_STATISTICS
table has changed from `kInvalidArgument` in the Cloud SDK
build to `kUnimplemented` in an emulator built from source.
So, allow both.

We could be even less restrictive (like `Not(IsOk())`), but
being as exacting as possible allows us to learn of changes
in emulator behavior. For example, in some places we still
`if (emulator) GTEST_SKIP()`, but that will never let us know
when the emulator starts supporting a feature.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6756)
<!-- Reviewable:end -->
