### PR TITLE
ci: use Fedora:34 for msan build

### DIFF
--- a/bazel/google_cloud_cpp_deps.bzl
+++ b/bazel/google_cloud_cpp_deps.bzl
@@ -52,11 +52,11 @@ def google_cloud_cpp_deps():
     if "com_google_googletest" not in native.existing_rules():
         http_archive(
             name = "com_google_googletest",
-            strip_prefix = "googletest-release-1.10.0",
+            strip_prefix = "googletest-release-1.11.0",
             urls = [
-                "https://github.com/google/googletest/archive/release-1.10.0.tar.gz",
+                "https://github.com/google/googletest/archive/release-1.11.0.tar.gz",
             ],
-            sha256 = "9dc9157a9a1551ec7a7e43daea9a694a0bb5fb8bec81235d8a1e6ef64c716dcb",
+            sha256 = "b4870bf121ff7795ba20d20bcdd8627b8e088f2d1dab299a031c1034eddc93d5",
         )
 
     # Load a version of benchmark that we know works.

--- a/ci/cloudbuild/dockerfiles/fedora-34.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/fedora-34.Dockerfile
@@ -56,7 +56,7 @@ RUN curl -sSL https://github.com/abseil/abseil-cpp/archive/20210324.2.tar.gz | \
 # Install googletest, remove the downloaded files and the temporary artifacts
 # after a successful build to keep the image smaller (and with fewer layers)
 WORKDIR /var/tmp/build
-RUN curl -sSL https://github.com/google/googletest/archive/release-1.10.0.tar.gz | \
+RUN curl -sSL https://github.com/google/googletest/archive/release-1.11.0.tar.gz | \
     tar -xzf - --strip-components=1 && \
     cmake \
       -DCMAKE_BUILD_TYPE="Release" \

--- a/ci/cloudbuild/dockerfiles/fedora-msan.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/fedora-msan.Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM fedora:33
+FROM fedora:34
 ARG NCPU=4
 
 # Install the minimal packages needed to compile libcxx, install Bazel, and

--- a/super/external/googletest.cmake
+++ b/super/external/googletest.cmake
@@ -20,9 +20,9 @@ if (NOT TARGET googletest-project)
     # Give application developers a hook to configure the version and hash
     # downloaded from GitHub.
     set(GOOGLE_CLOUD_CPP_GOOGLETEST_URL
-        "https://github.com/google/googletest/archive/release-1.10.0.tar.gz")
+        "https://github.com/google/googletest/archive/release-1.11.0.tar.gz")
     set(GOOGLE_CLOUD_CPP_GOOGLETEST_SHA256
-        "9dc9157a9a1551ec7a7e43daea9a694a0bb5fb8bec81235d8a1e6ef64c716dcb")
+        "b4870bf121ff7795ba20d20bcdd8627b8e088f2d1dab299a031c1034eddc93d5")
 
     set_external_project_build_parallel_level(PARALLEL)
     set_external_project_vars()


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6757)
<!-- Reviewable:end -->
