### PR TITLE
refactor: use helper to join testing::TempDir()

### DIFF
--- a/generator/integration_tests/generator_integration_test.cc
+++ b/generator/integration_tests/generator_integration_test.cc
@@ -91,6 +91,9 @@ class GeneratorIntegrationTest
     output_path_ = google::cloud::internal::GetEnv(
                        "GOOGLE_CLOUD_CPP_GENERATOR_OUTPUT_PATH")
                        .value_or(::testing::TempDir());
+    if (output_path_.empty() || output_path_.back() != '/') {
+      output_path_ += '/';
+    }
 
     google::cloud::generator::Generator generator;
     google::protobuf::compiler::CommandLineInterface cli;

--- a/generator/integration_tests/generator_integration_test.cc
+++ b/generator/integration_tests/generator_integration_test.cc
@@ -91,7 +91,7 @@ class GeneratorIntegrationTest
     output_path_ = google::cloud::internal::GetEnv(
                        "GOOGLE_CLOUD_CPP_GENERATOR_OUTPUT_PATH")
                        .value_or(::testing::TempDir());
-    if (output_path_.empty() || output_path_.back() != '/') {
+    if (!output_path_.empty() && output_path_.back() != '/') {
       output_path_ += '/';
     }
 

--- a/google/cloud/internal/filesystem.cc
+++ b/google/cloud/internal/filesystem.cc
@@ -170,6 +170,26 @@ std::uintmax_t file_size(std::string const& path,
   return static_cast<std::uintmax_t>(stat.st_size);
 }
 
+std::string PathAppend(std::string const& directory, std::string const& path) {
+#if _WIN32
+  auto constexpr kSeparator = '\\';
+#else
+  auto constexpr kSeparator = '/';
+#endif
+  if (path.empty()) return directory;
+  if (directory.empty()) return path;
+  if (directory.back() != kSeparator && path.front() != kSeparator) {
+    return directory + kSeparator + path;
+  }
+  if (directory.back() != kSeparator || path.front() != kSeparator) {
+    return directory + path;
+  }
+  auto r = directory;
+  r.pop_back();
+  r += path;
+  return r;
+}
+
 }  // namespace internal
 }  // namespace GOOGLE_CLOUD_CPP_NS
 }  // namespace cloud

--- a/google/cloud/internal/filesystem.cc
+++ b/google/cloud/internal/filesystem.cc
@@ -171,17 +171,19 @@ std::uintmax_t file_size(std::string const& path,
 }
 
 std::string PathAppend(std::string const& directory, std::string const& path) {
+  auto is_separator = [](char c) {
 #if _WIN32
-  auto constexpr kSeparator = '\\';
+    return c == '\\' || c == '/';
 #else
-  auto constexpr kSeparator = '/';
+    return c == '/';
 #endif
+  };
   if (path.empty()) return directory;
   if (directory.empty()) return path;
-  if (directory.back() != kSeparator && path.front() != kSeparator) {
-    return directory + kSeparator + path;
+  if (!is_separator(directory.back()) && !is_separator(path.front())) {
+    return directory + '/' + path;
   }
-  if (directory.back() != kSeparator || path.front() != kSeparator) {
+  if (!is_separator(directory.back()) || !is_separator(path.front())) {
     return directory + path;
   }
   auto r = directory;

--- a/google/cloud/internal/filesystem.cc
+++ b/google/cloud/internal/filesystem.cc
@@ -171,17 +171,17 @@ std::uintmax_t file_size(std::string const& path,
 }
 
 std::string PathAppend(std::string const& directory, std::string const& path) {
-  auto is_separator = [](char c) {
 #if _WIN32
-    return c == '\\' || c == '/';
+  auto constexpr kSeparator = '\\';
+  auto is_separator = [](char c) { return c == '\\' || c == '/'; };
 #else
-    return c == '/';
+  auto constexpr kSeparator = '/';
+  auto is_separator = [](char c) { return c == '/'; };
 #endif
-  };
   if (path.empty()) return directory;
   if (directory.empty()) return path;
   if (!is_separator(directory.back()) && !is_separator(path.front())) {
-    return directory + '/' + path;
+    return directory + kSeparator + path;
   }
   if (!is_separator(directory.back()) || !is_separator(path.front())) {
     return directory + path;

--- a/google/cloud/internal/filesystem.h
+++ b/google/cloud/internal/filesystem.h
@@ -167,6 +167,9 @@ inline bool is_other(file_status s) noexcept {
 std::uintmax_t file_size(std::string const& path);
 std::uintmax_t file_size(std::string const& path, std::error_code& ec) noexcept;
 
+/// Append @p path (which may have subdirectories) to @p directory
+std::string PathAppend(std::string const& directory, std::string const& path);
+
 }  // namespace internal
 }  // namespace GOOGLE_CLOUD_CPP_NS
 }  // namespace cloud

--- a/google/cloud/internal/filesystem.h
+++ b/google/cloud/internal/filesystem.h
@@ -167,7 +167,7 @@ inline bool is_other(file_status s) noexcept {
 std::uintmax_t file_size(std::string const& path);
 std::uintmax_t file_size(std::string const& path, std::error_code& ec) noexcept;
 
-/// Append @p path (which may have subdirectories) to @p directory
+/// Append @p path (even if it is an absolute directory) to @p directory
 std::string PathAppend(std::string const& directory, std::string const& path);
 
 }  // namespace internal

--- a/google/cloud/internal/filesystem.h
+++ b/google/cloud/internal/filesystem.h
@@ -167,7 +167,7 @@ inline bool is_other(file_status s) noexcept {
 std::uintmax_t file_size(std::string const& path);
 std::uintmax_t file_size(std::string const& path, std::error_code& ec) noexcept;
 
-/// Append @p path (even if it is an absolute directory) to @p directory
+/// Append @p path (even if it is an absolute path) to @p directory
 std::string PathAppend(std::string const& directory, std::string const& path);
 
 }  // namespace internal

--- a/google/cloud/internal/filesystem_test.cc
+++ b/google/cloud/internal/filesystem_test.cc
@@ -29,7 +29,7 @@ namespace {
 using ::testing::HasSubstr;
 
 // When running on the internal Google CI systems we cannot write to the local
-// directory, GTest has a good temporary directory in that case.
+// directory, but GTest has a good temporary directory in that case.
 std::string CreateRandomFileName(
     std::string const& tmp = ::testing::TempDir()) {
   static DefaultPRNG generator = MakeDefaultPRNG();

--- a/google/cloud/internal/unified_grpc_credentials_test.cc
+++ b/google/cloud/internal/unified_grpc_credentials_test.cc
@@ -16,6 +16,7 @@
 #include "google/cloud/common_options.h"
 #include "google/cloud/grpc_error_delegate.h"
 #include "google/cloud/grpc_options.h"
+#include "google/cloud/internal/filesystem.h"
 #include "google/cloud/internal/random.h"
 #include "google/cloud/options.h"
 #include "google/cloud/testing_util/scoped_environment.h"
@@ -92,8 +93,9 @@ std::string CreateRandomFileName() {
   static DefaultPRNG generator = MakeDefaultPRNG();
   // When running on the internal Google CI systems we cannot write to the local
   // directory, GTest has a good temporary directory in that case.
-  return ::testing::TempDir() +
-         Sample(generator, 8, "abcdefghijklmnopqrstuvwxyz0123456789");
+  return google::cloud::internal::PathAppend(
+      ::testing::TempDir(),
+      Sample(generator, 8, "abcdefghijklmnopqrstuvwxyz0123456789"));
 }
 
 TEST(UnifiedGrpcCredentialsTest, LoadCAInfoNotExist) {

--- a/google/cloud/storage/client_options_test.cc
+++ b/google/cloud/storage/client_options_test.cc
@@ -14,6 +14,7 @@
 
 #include "google/cloud/storage/client_options.h"
 #include "google/cloud/storage/oauth2/google_credentials.h"
+#include "google/cloud/internal/filesystem.h"
 #include "google/cloud/internal/random.h"
 #include "google/cloud/internal/setenv.h"
 #include "google/cloud/testing_util/scoped_environment.h"
@@ -43,10 +44,11 @@ class ClientOptionsTest : public ::testing::Test {
   std::string CreateRandomFileName() {
     // When running on the internal Google CI systems we cannot write to the
     // local directory. GTest has a good temporary directory in that case.
-    return ::testing::TempDir() +
-           google::cloud::internal::Sample(
-               generator_, 8, "abcdefghijklmnopqrstuvwxyz0123456789") +
-           ".json";
+    return google::cloud::internal::PathAppend(
+        ::testing::TempDir(),
+        google::cloud::internal::Sample(
+            generator_, 8, "abcdefghijklmnopqrstuvwxyz0123456789") +
+            ".json");
   }
 
  protected:

--- a/google/cloud/storage/internal/unified_rest_credentials_test.cc
+++ b/google/cloud/storage/internal/unified_rest_credentials_test.cc
@@ -14,6 +14,7 @@
 
 #include "google/cloud/storage/internal/unified_rest_credentials.h"
 #include "google/cloud/storage/testing/constants.h"
+#include "google/cloud/internal/filesystem.h"
 #include "google/cloud/internal/random.h"
 #include "google/cloud/testing_util/scoped_environment.h"
 #include "google/cloud/testing_util/status_matchers.h"
@@ -42,10 +43,11 @@ class UnifiedRestCredentialsTest : public ::testing::Test {
   UnifiedRestCredentialsTest() : generator_(std::random_device{}()) {}
 
   std::string TempKeyFileName() {
-    return ::testing::TempDir() +
-           ::google::cloud::internal::Sample(
-               generator_, 16, "abcdefghijlkmnopqrstuvwxyz0123456789") +
-           ".json";
+    return google::cloud::internal::PathAppend(
+        ::testing::TempDir(),
+        ::google::cloud::internal::Sample(
+            generator_, 16, "abcdefghijlkmnopqrstuvwxyz0123456789") +
+            ".json");
   }
 
  private:

--- a/google/cloud/storage/oauth2/google_credentials_test.cc
+++ b/google/cloud/storage/oauth2/google_credentials_test.cc
@@ -21,6 +21,7 @@
 #include "google/cloud/storage/oauth2/service_account_credentials.h"
 #include "google/cloud/storage/testing/constants.h"
 #include "google/cloud/storage/testing/write_base64.h"
+#include "google/cloud/internal/filesystem.h"
 #include "google/cloud/internal/setenv.h"
 #include "google/cloud/testing_util/scoped_environment.h"
 #include "google/cloud/testing_util/status_matchers.h"
@@ -87,7 +88,8 @@ void SetupAuthorizedUserCredentialsFileForTest(std::string const& filename) {
  * make this an integration test.
  */
 TEST_F(GoogleCredentialsTest, LoadValidAuthorizedUserCredentialsViaEnvVar) {
-  std::string filename = ::testing::TempDir() + kAuthorizedUserCredFilename;
+  std::string filename = google::cloud::internal::PathAppend(
+      ::testing::TempDir(), kAuthorizedUserCredFilename);
   SetupAuthorizedUserCredentialsFileForTest(filename);
 
   // Test that the authorized user credentials are loaded as the default when
@@ -102,7 +104,8 @@ TEST_F(GoogleCredentialsTest, LoadValidAuthorizedUserCredentialsViaEnvVar) {
 }
 
 TEST_F(GoogleCredentialsTest, LoadValidAuthorizedUserCredentialsViaGcloudFile) {
-  std::string filename = ::testing::TempDir() + kAuthorizedUserCredFilename;
+  std::string filename = google::cloud::internal::PathAppend(
+      ::testing::TempDir(), kAuthorizedUserCredFilename);
   SetupAuthorizedUserCredentialsFileForTest(filename);
   // Test that the authorized user credentials are loaded as the default when
   // stored in the the well known gcloud ADC file path.
@@ -115,7 +118,8 @@ TEST_F(GoogleCredentialsTest, LoadValidAuthorizedUserCredentialsViaGcloudFile) {
 }
 
 TEST_F(GoogleCredentialsTest, LoadValidAuthorizedUserCredentialsFromFilename) {
-  std::string filename = ::testing::TempDir() + kAuthorizedUserCredFilename;
+  std::string filename = google::cloud::internal::PathAppend(
+      ::testing::TempDir(), kAuthorizedUserCredFilename);
   SetupAuthorizedUserCredentialsFileForTest(filename);
   auto creds = CreateAuthorizedUserCredentialsFromJsonFilePath(filename);
   ASSERT_STATUS_OK(creds);
@@ -135,7 +139,8 @@ TEST_F(GoogleCredentialsTest, LoadValidAuthorizedUserCredentialsFromContents) {
 
 TEST_F(GoogleCredentialsTest,
        LoadInvalidAuthorizedUserCredentialsFromFilename) {
-  std::string filename = ::testing::TempDir() + "invalid-credentials.json";
+  std::string filename = google::cloud::internal::PathAppend(
+      ::testing::TempDir(), "invalid-credentials.json");
   std::ofstream os(filename);
   std::string contents_str = R"""( not-a-json-object-string )""";
   os << contents_str;
@@ -196,7 +201,8 @@ void SetupServiceAccountCredentialsFileForTest(std::string const& filename) {
 }
 
 TEST_F(GoogleCredentialsTest, LoadValidServiceAccountCredentialsViaEnvVar) {
-  std::string filename = ::testing::TempDir() + kAuthorizedUserCredFilename;
+  std::string filename = google::cloud::internal::PathAppend(
+      ::testing::TempDir(), kAuthorizedUserCredFilename);
   SetupServiceAccountCredentialsFileForTest(filename);
 
   // Test that the service account credentials are loaded as the default when
@@ -211,7 +217,8 @@ TEST_F(GoogleCredentialsTest, LoadValidServiceAccountCredentialsViaEnvVar) {
 }
 
 TEST_F(GoogleCredentialsTest, LoadValidServiceAccountCredentialsViaGcloudFile) {
-  std::string filename = ::testing::TempDir() + kAuthorizedUserCredFilename;
+  std::string filename = google::cloud::internal::PathAppend(
+      ::testing::TempDir(), kAuthorizedUserCredFilename);
   SetupServiceAccountCredentialsFileForTest(filename);
 
   // Test that the service account credentials are loaded as the default when
@@ -225,7 +232,8 @@ TEST_F(GoogleCredentialsTest, LoadValidServiceAccountCredentialsViaGcloudFile) {
 }
 
 TEST_F(GoogleCredentialsTest, LoadValidServiceAccountCredentialsFromFilename) {
-  std::string filename = ::testing::TempDir() + kServiceAccountCredFilename;
+  std::string filename = google::cloud::internal::PathAppend(
+      ::testing::TempDir(), kServiceAccountCredFilename);
   SetupServiceAccountCredentialsFileForTest(filename);
 
   // Test that the service account credentials are loaded from a file.
@@ -250,7 +258,8 @@ TEST_F(GoogleCredentialsTest, LoadValidServiceAccountCredentialsFromFilename) {
 
 TEST_F(GoogleCredentialsTest,
        LoadValidServiceAccountCredentialsFromFilenameWithOptionalArgs) {
-  std::string filename = ::testing::TempDir() + kServiceAccountCredFilename;
+  std::string filename = google::cloud::internal::PathAppend(
+      ::testing::TempDir(), kServiceAccountCredFilename);
   SetupServiceAccountCredentialsFileForTest(filename);
 
   // Test that the service account credentials are loaded from a file.
@@ -264,7 +273,8 @@ TEST_F(GoogleCredentialsTest,
 
 TEST_F(GoogleCredentialsTest,
        LoadInvalidServiceAccountCredentialsFromFilename) {
-  std::string filename = ::testing::TempDir() + "invalid-credentials.json";
+  std::string filename = google::cloud::internal::PathAppend(
+      ::testing::TempDir(), "invalid-credentials.json");
   std::ofstream os(filename);
   std::string contents_str = R"""( not-a-json-object-string )""";
   os << contents_str;
@@ -278,7 +288,8 @@ TEST_F(GoogleCredentialsTest,
 
 TEST_F(GoogleCredentialsTest,
        LoadValidServiceAccountCredentialsFromDefaultPathsViaEnvVar) {
-  std::string filename = ::testing::TempDir() + kAuthorizedUserCredFilename;
+  std::string filename = google::cloud::internal::PathAppend(
+      ::testing::TempDir(), kAuthorizedUserCredFilename);
   SetupServiceAccountCredentialsFileForTest(filename);
 
   // Test that the service account credentials are loaded as the default when
@@ -294,7 +305,8 @@ TEST_F(GoogleCredentialsTest,
 
 TEST_F(GoogleCredentialsTest,
        LoadValidServiceAccountCredentialsFromDefaultPathsViaGcloudFile) {
-  std::string filename = ::testing::TempDir() + kAuthorizedUserCredFilename;
+  std::string filename = google::cloud::internal::PathAppend(
+      ::testing::TempDir(), kAuthorizedUserCredFilename);
   SetupServiceAccountCredentialsFileForTest(filename);
 
   // Test that the service account credentials are loaded as the default when
@@ -309,7 +321,8 @@ TEST_F(GoogleCredentialsTest,
 
 TEST_F(GoogleCredentialsTest,
        LoadValidServiceAccountCredentialsFromDefaultPathsWithOptionalArgs) {
-  std::string filename = ::testing::TempDir() + kAuthorizedUserCredFilename;
+  std::string filename = google::cloud::internal::PathAppend(
+      ::testing::TempDir(), kAuthorizedUserCredFilename);
   SetupServiceAccountCredentialsFileForTest(filename);
 
   // Test that the service account credentials are loaded as the default when
@@ -326,7 +339,8 @@ TEST_F(GoogleCredentialsTest,
 TEST_F(
     GoogleCredentialsTest,
     DoNotLoadAuthorizedUserCredentialsFromCreateServiceAccountCredentialsFromDefaultPaths) {
-  std::string filename = ::testing::TempDir() + kAuthorizedUserCredFilename;
+  std::string filename = google::cloud::internal::PathAppend(
+      ::testing::TempDir(), kAuthorizedUserCredFilename);
   SetupAuthorizedUserCredentialsFileForTest(filename);
 
   // Test that the authorized user credentials are loaded as the default when
@@ -414,7 +428,8 @@ TEST_F(GoogleCredentialsTest, CreateComputeEngineCredentialsWithExplicitEmail) {
 }
 
 TEST_F(GoogleCredentialsTest, LoadUnknownTypeCredentials) {
-  std::string filename = ::testing::TempDir() + "unknown-type-credentials.json";
+  std::string filename = google::cloud::internal::PathAppend(
+      ::testing::TempDir(), "unknown-type-credentials.json");
   std::ofstream os(filename);
   std::string contents_str = R"""({
   "type": "unknown_type"
@@ -430,7 +445,8 @@ TEST_F(GoogleCredentialsTest, LoadUnknownTypeCredentials) {
 }
 
 TEST_F(GoogleCredentialsTest, LoadInvalidCredentials) {
-  std::string filename = ::testing::TempDir() + "invalid-credentials.json";
+  std::string filename = google::cloud::internal::PathAppend(
+      ::testing::TempDir(), "invalid-credentials.json");
   std::ofstream os(filename);
   std::string contents_str = R"""( not-a-json-object-string )""";
   os << contents_str;
@@ -443,7 +459,8 @@ TEST_F(GoogleCredentialsTest, LoadInvalidCredentials) {
 }
 
 TEST_F(GoogleCredentialsTest, LoadInvalidAuthorizedUserCredentialsViaADC) {
-  std::string filename = ::testing::TempDir() + "invalid-au-credentials.json";
+  std::string filename = google::cloud::internal::PathAppend(
+      ::testing::TempDir(), "invalid-au-credentials.json");
   std::ofstream os(filename);
   std::string contents_str = R"""("type": "authorized_user")""";
   os << contents_str;
@@ -455,7 +472,8 @@ TEST_F(GoogleCredentialsTest, LoadInvalidAuthorizedUserCredentialsViaADC) {
 }
 
 TEST_F(GoogleCredentialsTest, LoadInvalidServiceAccountCredentialsViaADC) {
-  std::string filename = ::testing::TempDir() + "invalid-au-credentials.json";
+  std::string filename = google::cloud::internal::PathAppend(
+      ::testing::TempDir(), "invalid-au-credentials.json");
   std::ofstream os(filename);
   std::string contents_str = R"""("type": "service_account")""";
   os << contents_str;
@@ -494,7 +512,8 @@ TEST_F(GoogleCredentialsTest, MissingCredentialsViaGcloudFilePath) {
 TEST_F(GoogleCredentialsTest, LoadP12Credentials) {
   // Ensure that the parser detects that it's not a JSON file and parses it as
   // a P12 file.
-  std::string filename = ::testing::TempDir() + "credentials.p12";
+  std::string filename = google::cloud::internal::PathAppend(
+      ::testing::TempDir(), "credentials.p12");
   WriteBase64AsBinary(filename, kP12KeyFileContents);
   ScopedEnvironment adc_env_var(GoogleAdcEnvVar(), filename.c_str());
 

--- a/google/cloud/storage/oauth2/service_account_credentials_test.cc
+++ b/google/cloud/storage/oauth2/service_account_credentials_test.cc
@@ -19,6 +19,7 @@
 #include "google/cloud/storage/testing/mock_fake_clock.h"
 #include "google/cloud/storage/testing/mock_http_request.h"
 #include "google/cloud/storage/testing/write_base64.h"
+#include "google/cloud/internal/filesystem.h"
 #include "google/cloud/internal/random.h"
 #include "google/cloud/internal/setenv.h"
 #include "google/cloud/testing_util/status_matchers.h"
@@ -99,9 +100,10 @@ class ServiceAccountCredentialsTest : public ::testing::Test {
   std::string CreateRandomFileName() {
     // When running on the internal Google CI systems we cannot write to the
     // local directory, GTest has a good temporary directory in that case.
-    return ::testing::TempDir() +
-           google::cloud::internal::Sample(
-               generator_, 8, "abcdefghijklmnopqrstuvwxyz0123456789");
+    return google::cloud::internal::PathAppend(
+        ::testing::TempDir(),
+        google::cloud::internal::Sample(
+            generator_, 8, "abcdefghijklmnopqrstuvwxyz0123456789"));
   }
 
   google::cloud::internal::DefaultPRNG generator_ =
@@ -638,7 +640,8 @@ TEST_F(ServiceAccountCredentialsTest, ParseP12MissingKey) {
 }
 
 TEST_F(ServiceAccountCredentialsTest, ParseP12MissingCerts) {
-  std::string filename = ::testing::TempDir() + CreateRandomFileName() + ".p12";
+  std::string filename = google::cloud::internal::PathAppend(
+      ::testing::TempDir(), CreateRandomFileName() + ".p12");
   WriteBase64AsBinary(filename, kP12KeyFileMissingCerts);
   auto info = ParseServiceAccountP12File(filename);
   EXPECT_THAT(info, Not(IsOk()));

--- a/google/cloud/storage/testing/temp_file.cc
+++ b/google/cloud/storage/testing/temp_file.cc
@@ -14,6 +14,7 @@
 
 #include "google/cloud/storage/testing/temp_file.h"
 #include "google/cloud/storage/testing/random_names.h"
+#include "google/cloud/internal/filesystem.h"
 #include <gmock/gmock.h>
 #include <cstdio>
 #include <fstream>
@@ -26,7 +27,8 @@ namespace testing {
 TempFile::TempFile(std::string const& content) {
   static auto generator =
       google::cloud::internal::DefaultPRNG(std::random_device{}());
-  auto name = ::testing::TempDir() + MakeRandomFileName(generator);
+  auto name = google::cloud::internal::PathAppend(
+      ::testing::TempDir(), MakeRandomFileName(generator));
   std::ofstream f(name, std::ios::binary | std::ios::trunc);
   assert(f.good());
   f.write(content.data(), static_cast<std::streamsize>(content.size()));

--- a/google/cloud/storage/tests/object_file_integration_test.cc
+++ b/google/cloud/storage/tests/object_file_integration_test.cc
@@ -14,14 +14,13 @@
 
 #include "google/cloud/storage/client.h"
 #include "google/cloud/storage/testing/storage_integration_test.h"
+#include "google/cloud/internal/filesystem.h"
 #include "google/cloud/internal/getenv.h"
-#include "google/cloud/log.h"
 #include "google/cloud/testing_util/scoped_log.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
 #include <cstdio>
 #include <fstream>
-#include <regex>
 #include <thread>
 
 namespace google {
@@ -188,7 +187,8 @@ TEST_F(ObjectFileIntegrationTest, UploadFile) {
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
-  auto file_name = ::testing::TempDir() + MakeRandomFilename();
+  auto file_name = google::cloud::internal::PathAppend(::testing::TempDir(),
+                                                       MakeRandomFilename());
   auto object_name = MakeRandomObjectName();
 
   // We will construct the expected response while streaming the data up.
@@ -222,7 +222,8 @@ TEST_F(ObjectFileIntegrationTest, UploadFileBinary) {
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
-  auto file_name = ::testing::TempDir() + MakeRandomFilename();
+  auto file_name = google::cloud::internal::PathAppend(::testing::TempDir(),
+                                                       MakeRandomFilename());
   auto object_name = MakeRandomObjectName();
 
   // Create a file with the contents to upload.
@@ -264,7 +265,8 @@ TEST_F(ObjectFileIntegrationTest, UploadFileEmpty) {
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
-  auto file_name = ::testing::TempDir() + MakeRandomFilename();
+  auto file_name = google::cloud::internal::PathAppend(::testing::TempDir(),
+                                                       MakeRandomFilename());
   auto object_name = MakeRandomObjectName();
 
   // Create a file with the contents to upload.
@@ -305,7 +307,8 @@ TEST_F(ObjectFileIntegrationTest, UploadFileUploadFailure) {
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
-  auto file_name = ::testing::TempDir() + MakeRandomFilename();
+  auto file_name = google::cloud::internal::PathAppend(::testing::TempDir(),
+                                                       MakeRandomFilename());
   auto object_name = MakeRandomObjectName();
 
   // Create the file.
@@ -339,7 +342,8 @@ TEST_F(ObjectFileIntegrationTest, UploadFileNonRegularWarning) {
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
-  auto file_name = ::testing::TempDir() + MakeRandomFilename();
+  auto file_name = google::cloud::internal::PathAppend(::testing::TempDir(),
+                                                       MakeRandomFilename());
   auto object_name = MakeRandomObjectName();
 
   ASSERT_NE(-1, mkfifo(file_name.c_str(), 0777));
@@ -368,7 +372,8 @@ TEST_F(ObjectFileIntegrationTest, XmlUploadFile) {
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
-  auto file_name = ::testing::TempDir() + MakeRandomFilename();
+  auto file_name = google::cloud::internal::PathAppend(::testing::TempDir(),
+                                                       MakeRandomFilename());
   auto object_name = MakeRandomObjectName();
 
   // We will construct the expected response while streaming the data up.
@@ -411,7 +416,8 @@ TEST_F(ObjectFileIntegrationTest, XmlUploadFile) {
 
 TEST_F(ObjectFileIntegrationTest, UploadFileResumableBySize) {
   auto client = ClientWithSimpleUploadDisabled();
-  auto file_name = ::testing::TempDir() + MakeRandomFilename();
+  auto file_name = google::cloud::internal::PathAppend(::testing::TempDir(),
+                                                       MakeRandomFilename());
   auto object_name = MakeRandomObjectName();
 
   // We will construct the expected response while streaming the data up.
@@ -450,7 +456,8 @@ TEST_F(ObjectFileIntegrationTest, UploadFileResumableByOption) {
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
-  auto file_name = ::testing::TempDir() + MakeRandomFilename();
+  auto file_name = google::cloud::internal::PathAppend(::testing::TempDir(),
+                                                       MakeRandomFilename());
   auto object_name = MakeRandomObjectName();
 
   // We will construct the expected response while streaming the data up.
@@ -488,7 +495,8 @@ TEST_F(ObjectFileIntegrationTest, UploadFileResumableByOption) {
 
 TEST_F(ObjectFileIntegrationTest, UploadFileResumableQuantum) {
   auto client = ClientWithSimpleUploadDisabled();
-  auto file_name = ::testing::TempDir() + MakeRandomFilename();
+  auto file_name = google::cloud::internal::PathAppend(::testing::TempDir(),
+                                                       MakeRandomFilename());
   auto object_name = MakeRandomObjectName();
 
   // We will construct the expected response while streaming the data up.
@@ -525,7 +533,8 @@ TEST_F(ObjectFileIntegrationTest, UploadFileResumableQuantum) {
 
 TEST_F(ObjectFileIntegrationTest, UploadFileResumableNonQuantum) {
   auto client = ClientWithSimpleUploadDisabled();
-  auto file_name = ::testing::TempDir() + MakeRandomFilename();
+  auto file_name = google::cloud::internal::PathAppend(::testing::TempDir(),
+                                                       MakeRandomFilename());
   auto object_name = MakeRandomObjectName();
 
   // We will construct the expected response while streaming the data up.
@@ -561,7 +570,8 @@ TEST_F(ObjectFileIntegrationTest, UploadFileResumableNonQuantum) {
 
 TEST_F(ObjectFileIntegrationTest, UploadFileResumableUploadFailure) {
   auto client = ClientWithSimpleUploadDisabled();
-  auto file_name = ::testing::TempDir() + MakeRandomFilename();
+  auto file_name = google::cloud::internal::PathAppend(::testing::TempDir(),
+                                                       MakeRandomFilename());
   auto bucket_name = MakeRandomBucketName();
   auto object_name = MakeRandomObjectName();
 
@@ -580,7 +590,8 @@ TEST_F(ObjectFileIntegrationTest, UploadPortionRegularFile) {
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
-  auto file_name = ::testing::TempDir() + MakeRandomFilename();
+  auto file_name = google::cloud::internal::PathAppend(::testing::TempDir(),
+                                                       MakeRandomFilename());
   auto object_name = MakeRandomObjectName();
 
   // We will construct the expected response while streaming the data up.
@@ -618,7 +629,8 @@ TEST_F(ObjectFileIntegrationTest, ResumableUploadFileCustomHeader) {
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
-  auto file_name = ::testing::TempDir() + MakeRandomFilename();
+  auto file_name = google::cloud::internal::PathAppend(::testing::TempDir(),
+                                                       MakeRandomFilename());
   auto object_name = MakeRandomObjectName();
 
   // We will construct the expected response while streaming the data up.


### PR DESCRIPTION
With googletest >= 1.11 ::testing::tempDir() does not seem to end in a
forward slash. That is a problem because in many places we did
`::testing::TempDir() + path` to create a filepath, which can be invalid
or confuse things.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6758)
<!-- Reviewable:end -->
