### PR TITLE
chore: update googletest to 1.11.0

### DIFF
--- a/bazel/google_cloud_cpp_deps.bzl
+++ b/bazel/google_cloud_cpp_deps.bzl
@@ -52,11 +52,11 @@ def google_cloud_cpp_deps():
     if "com_google_googletest" not in native.existing_rules():
         http_archive(
             name = "com_google_googletest",
-            strip_prefix = "googletest-release-1.10.0",
+            strip_prefix = "googletest-release-1.11.0",
             urls = [
-                "https://github.com/google/googletest/archive/release-1.10.0.tar.gz",
+                "https://github.com/google/googletest/archive/release-1.11.0.tar.gz",
             ],
-            sha256 = "9dc9157a9a1551ec7a7e43daea9a694a0bb5fb8bec81235d8a1e6ef64c716dcb",
+            sha256 = "b4870bf121ff7795ba20d20bcdd8627b8e088f2d1dab299a031c1034eddc93d5",
         )
 
     # Load a version of benchmark that we know works.

--- a/ci/cloudbuild/dockerfiles/fedora-34.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/fedora-34.Dockerfile
@@ -56,7 +56,7 @@ RUN curl -sSL https://github.com/abseil/abseil-cpp/archive/20210324.2.tar.gz | \
 # Install googletest, remove the downloaded files and the temporary artifacts
 # after a successful build to keep the image smaller (and with fewer layers)
 WORKDIR /var/tmp/build
-RUN curl -sSL https://github.com/google/googletest/archive/release-1.10.0.tar.gz | \
+RUN curl -sSL https://github.com/google/googletest/archive/release-1.11.0.tar.gz | \
     tar -xzf - --strip-components=1 && \
     cmake \
       -DCMAKE_BUILD_TYPE="Release" \

--- a/google/cloud/storage/benchmarks/throughput_result_test.cc
+++ b/google/cloud/storage/benchmarks/throughput_result_test.cc
@@ -32,7 +32,7 @@ MATCHER_P(
   // The status field is the 10th value.
   std::size_t pos = 0;
   for (int i = 0; i < 9; ++i) {
-    pos = arg.find(",", pos);
+    pos = arg.find(',', pos);
     if (pos == std::string::npos) {
       *result_listener << "Couldn't find status field: " << arg;
       return false;

--- a/google/cloud/testing_util/expect_exception.h
+++ b/google/cloud/testing_util/expect_exception.h
@@ -75,6 +75,7 @@ void ExpectException(
     std::function<void(ExpectedException const& ex)> const& validator,
     char const* expected_message) {
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+  // NOLINTNEXTLINE(misc-throw-by-value-catch-by-reference)
   EXPECT_THROW(
       try { expression(); } catch (ExpectedException const& ex) {
         validator(ex);

--- a/super/external/googletest.cmake
+++ b/super/external/googletest.cmake
@@ -20,9 +20,9 @@ if (NOT TARGET googletest-project)
     # Give application developers a hook to configure the version and hash
     # downloaded from GitHub.
     set(GOOGLE_CLOUD_CPP_GOOGLETEST_URL
-        "https://github.com/google/googletest/archive/release-1.10.0.tar.gz")
+        "https://github.com/google/googletest/archive/release-1.11.0.tar.gz")
     set(GOOGLE_CLOUD_CPP_GOOGLETEST_SHA256
-        "9dc9157a9a1551ec7a7e43daea9a694a0bb5fb8bec81235d8a1e6ef64c716dcb")
+        "b4870bf121ff7795ba20d20bcdd8627b8e088f2d1dab299a031c1034eddc93d5")
 
     set_external_project_build_parallel_level(PARALLEL)
     set_external_project_vars()
@@ -37,6 +37,7 @@ if (NOT TARGET googletest-project)
         URL_HASH SHA256=${GOOGLE_CLOUD_CPP_GOOGLETEST_SHA256}
         LIST_SEPARATOR |
         CMAKE_ARGS ${GOOGLE_CLOUD_CPP_EXTERNAL_PROJECT_CMAKE_FLAGS}
+                   -DCMAKE_CXX_STANDARD=11
                    -DCMAKE_PREFIX_PATH=${GOOGLE_CLOUD_CPP_PREFIX_PATH}
                    -DCMAKE_INSTALL_RPATH=${GOOGLE_CLOUD_CPP_INSTALL_RPATH}
                    -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>


### PR DESCRIPTION
Update the builds to use googletest-1.11.0. It seems like this triggers
some more warnings with Clang-12. One of them was useful (yay!), the
other looked like a false positive and I disabled it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6759)
<!-- Reviewable:end -->
