### PR TITLE
chore: tweak renovate configuration

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,7 +2,7 @@
   "extends": [
     "config:base",
     "docker:disable",
-    "schedule:earlyMondays"
+    "schedule:weekdays"
   ],
   "regexManagers": [
     {
@@ -17,5 +17,5 @@
       "datasourceTemplate": "github-releases"
     }
   ],
-  "ignoreDeps": [ "com_google_googleapis" ]
+  "ignoreDeps": [ "boringssl", "com_google_googleapis" ]
 }


### PR DESCRIPTION
Run the project on all weekdays, we get too many PRs on Monday, and
maybe they are not keeping up.

Exclude the "boringssl" dependency (this is for Bazel), we are using a
branch and the PRs are constantly trying to "update" us to the default
branch.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6766)
<!-- Reviewable:end -->
