### PR TITLE
ci: disable test result cache on CI builds

### DIFF
--- a/ci/cloudbuild/builds/lib/bazel.sh
+++ b/ci/cloudbuild/builds/lib/bazel.sh
@@ -56,6 +56,7 @@ function bazel::common_args() {
     "--verbose_failures=true"
     "--keep_going"
     "--experimental_convenience_symlinks=ignore"
+    "--cache_test_results=$([ "${TRIGGER_TYPE}" = ci ] && echo no || echo yes)"
   )
   if [[ -n "${BAZEL_REMOTE_CACHE:-}" ]]; then
     args+=("--remote_cache=${BAZEL_REMOTE_CACHE}")


### PR DESCRIPTION
@coryan observed that our flakiness data from looking at CI builds only
was not accurate for bazel builds because the PR builds would have
already populated the cache, and the following CI build would just hit
the cache and not even run the test, thus hiding potential flakes.

This PR avoids that issue by forcing CI builds to ignore the
test-results cache with `--cache_test_results=no`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6773)
<!-- Reviewable:end -->
