### PR TITLE
ci: use Fedora:34 for msan build

### DIFF
--- a/ci/cloudbuild/builds/lib/integration.sh
+++ b/ci/cloudbuild/builds/lib/integration.sh
@@ -154,8 +154,13 @@ function integration::bazel_with_emulators() {
     "google/cloud/logging/..."
   )
 
+  tag_filters="integration-test"
+  if echo "${args[@]}" | grep -w -q -- "--config=msan"; then
+    tag_filters="integration-test,-no-msan"
+  fi
+
   io::log_h2 "Running integration tests that require production access"
-  bazel "${verb}" "${args[@]}" --test_tag_filters=integration-test \
+  bazel "${verb}" "${args[@]}" --test_tag_filters="${tag_filters}" \
     "${production_integration_tests[@]}"
 
   io::log_h2 "Running Pub/Sub integration tests (with emulator)"

--- a/ci/cloudbuild/builds/msan.sh
+++ b/ci/cloudbuild/builds/msan.sh
@@ -25,7 +25,7 @@ export CXX=clang++
 
 mapfile -t args < <(bazel::common_args)
 args+=("--config=msan")
-bazel test "${args[@]}" --test_tag_filters=-integration-test ...
+bazel test "${args[@]}" --test_tag_filters=-integration-test,-no-msan ...
 
 mapfile -t integration_args < <(integration::bazel_args)
 integration::bazel_with_emulators test "${args[@]}" "${integration_args[@]}"

--- a/ci/cloudbuild/dockerfiles/fedora-msan.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/fedora-msan.Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM fedora:33
+FROM fedora:34
 ARG NCPU=4
 
 # Install the minimal packages needed to compile libcxx, install Bazel, and

--- a/generator/integration_tests/BUILD
+++ b/generator/integration_tests/BUILD
@@ -74,6 +74,7 @@ load(":google_cloud_cpp_generator_integration_tests.bzl", "google_cloud_cpp_gene
     ],
     tags = [
         "integration-test",
+        "no-msan",
     ],
     deps = [
         "//generator:google_cloud_cpp_generator",

--- a/google/cloud/internal/filesystem.cc
+++ b/google/cloud/internal/filesystem.cc
@@ -103,7 +103,7 @@ file_type ExtractFileType(os_stat_type const& s) {
 
 // NOLINTNEXTLINE(readability-identifier-naming)
 file_status status(std::string const& path, std::error_code& ec) noexcept {
-  os_stat_type stat;
+  os_stat_type stat{};
   ec.clear();
 #if _WIN32
   int r = ::_stat(path.c_str(), &stat);
@@ -149,7 +149,7 @@ std::uintmax_t file_size(std::string const& path) {
 // NOLINTNEXTLINE(readability-identifier-naming)
 std::uintmax_t file_size(std::string const& path,
                          std::error_code& ec) noexcept {
-  os_stat_type stat;
+  os_stat_type stat{};
   ec.clear();
 #if _WIN32
   int r = ::_stat(path.c_str(), &stat);


### PR DESCRIPTION
I had to disable the integration test for the generator, some function
inside protobuf uses an unitialized variable (maybe).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6782)
<!-- Reviewable:end -->
