### PR TITLE
cleanup(storage): remove nextPageToken field in emulator list operations

### DIFF
--- a/google/cloud/storage/emulator/emulator.py
+++ b/google/cloud/storage/emulator/emulator.py
@@ -160,7 +160,6 @@ def bucket_list():
     fields = flask.request.args.get("fields", None)
     response = {
         "kind": "storage#buckets",
-        "nextPageToken": "",
         "items": [
             bucket.rest() for bucket in db.list_bucket(flask.request, project, None)
         ],
@@ -447,7 +446,6 @@ def object_list(bucket_name):
     items, prefixes, rest_onlys = db.list_object(flask.request, bucket_name, None)
     response = {
         "kind": "storage#objects",
-        "nextPageToken": "",
         "items": [
             gcs_type.object.Object.rest(blob, rest_only)
             for blob, rest_only in zip(items, rest_onlys)


### PR DESCRIPTION
This removes the `nextPageToken` field in the storage emulator list operations responses for the following reasons.

- The emulator currently is designed to return all items altogether, therefore no nextPageToken is needed.
-  Currently, [python-api-core](https://github.com/googleapis/python-api-core/blob/11032cf08ecc16dd252a6cda8b33b0b28ec4f4ba/google/api_core/page_iterator.py#L404) determines whether or not there are more pages with result by checking if `nextPageToken` is None. Therefore, empty page tokens causes infinite loops.
- Inspecting the JSON API with a one-page result `storage.objects.list`, it appears that there is no nextPageToken field within the response.

Fixes #6635

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6789)
<!-- Reviewable:end -->
