### PR TITLE
ci: increase the GCB timeout

### DIFF
--- a/ci/cloudbuild/cloudbuild.yaml
+++ b/ci/cloudbuild/cloudbuild.yaml
@@ -43,7 +43,7 @@ substitutions:
   _TRIGGER_TYPE: 'manual'
   _LOGS_BUCKET: 'cloud-cpp-community-publiclogs'
 
-timeout: 3600s
+timeout: 7200s
 tags: [
   '${_TRIGGER_TYPE}',
   '${_BUILD_NAME}',


### PR DESCRIPTION
We've been seeing some timeouts from the `integration-daily`
build since disabling CI-build test-result caching.  This
should not be too surprising given that the slow Spanner
backup/instance tests and samples already take a good part
of the allotted 1h, and are subject to scheduling delays in
the backend.  So, increase the timeout to 2h.

I couldn't, for the life of me, figure out how to parameterize
the timeout with a `gcloud builds submit --substitutions=`,
and chose not to move the value out to a `--timeout=` flag,
so this simply raises the limit for all builds.  Alternative
ideas are welcomed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6795)
<!-- Reviewable:end -->
