### PR TITLE
ci: use emulator for Spanner and Bazel

### DIFF
--- a/ci/cloudbuild/builds/lib/integration.sh
+++ b/ci/cloudbuild/builds/lib/integration.sh
@@ -175,9 +175,9 @@ function integration::bazel_with_emulators() {
   "google/cloud/storage/ci/${EMULATOR_SCRIPT}" \
     bazel "${verb}" "${args[@]}"
 
-  io::log_h2 "Running Spanner integration tests"
-  bazel "${verb}" "${args[@]}" --test_tag_filters=integration-test \
-    google/cloud/spanner/...
+  io::log_h2 "Running Spanner integration tests (with emulator)"
+  "google/cloud/spanner/ci/${EMULATOR_SCRIPT}" \
+    bazel "${verb}" "${args[@]}"
 
   # We retry these tests because the emulator crashes due to #441.
   io::log_h2 "Running Bigtable integration tests (with emulator)"

--- a/google/cloud/spanner/ci/lib/spanner_emulator.sh
+++ b/google/cloud/spanner/ci/lib/spanner_emulator.sh
@@ -53,6 +53,11 @@ function spanner_emulator::start() {
     return 1
   fi
 
+  local emulator_port=0
+  if [[ $# -ge 1 ]]; then
+    emulator_port=$1
+  fi
+
   # We cannot use `gcloud beta emulators spanner start` because there is no way
   # to kill the emulator at the end using that command.
   readonly SPANNER_EMULATOR_CMD="${CLOUD_SDK_LOCATION}/bin/cloud_spanner_emulator/emulator_main"
@@ -63,10 +68,10 @@ function spanner_emulator::start() {
 
   # The tests typically run in a Docker container, where the ports are largely
   # free; when using in manual tests, you can set EMULATOR_PORT.
-  "${SPANNER_EMULATOR_CMD}" --host_port localhost:0 >emulator.log 2>&1 </dev/null &
+  "${SPANNER_EMULATOR_CMD}" --host_port "localhost:${emulator_port}" >emulator.log 2>&1 </dev/null &
   SPANNER_EMULATOR_PID=$!
 
-  local -r emulator_port="$(spanner_emulator::internal::read_emulator_port emulator.log)"
+  emulator_port="$(spanner_emulator::internal::read_emulator_port emulator.log)"
   if [[ "${emulator_port}" = "0" ]]; then
     echo "Cannot determine Cloud Spanner emulator port." >&2
     spanner_emulator::kill

--- a/google/cloud/spanner/ci/run_integration_tests_emulator_bazel.sh
+++ b/google/cloud/spanner/ci/run_integration_tests_emulator_bazel.sh
@@ -45,5 +45,6 @@ trap spanner_emulator::kill EXIT
   --test_env="GOOGLE_CLOUD_CPP_EXPERIMENTAL_LOG_CONFIG=lastN,100,WARNING" \
   --test_env="GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc,rpc-streams" \
   --test_env="GOOGLE_CLOUD_CPP_TRACING_OPTIONS=truncate_string_field_longer_than=512" \
+  --test_env="GOOGLE_CLOUD_CPP_SPANNER_SLOW_INTEGRATION_TESTS=instance,backup" \
   --test_tag_filters="integration-test" -- \
   "//google/cloud/spanner/...:all"

--- a/google/cloud/spanner/ci/run_integration_tests_emulator_bazel.sh
+++ b/google/cloud/spanner/ci/run_integration_tests_emulator_bazel.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eu
+
+source "$(dirname "$0")/../../../../ci/lib/init.sh"
+source module /ci/etc/integration-tests-config.sh
+source module /ci/lib/io.sh
+source module /google/cloud/spanner/ci/lib/spanner_emulator.sh
+
+if [[ $# -lt 2 ]]; then
+  echo "Usage: $(basename "$0") <bazel-program> <bazel-verb> [bazel-test-args]"
+  exit 1
+fi
+
+BAZEL_BIN="$1"
+shift
+BAZEL_VERB="$1"
+shift
+bazel_test_args=("$@")
+
+# Start the emulator and arranges to kill it, run in $HOME because
+# pubsub_emulator::start creates unsightly *.log files in the workspace
+# otherwise.
+pushd "${HOME}" >/dev/null
+spanner_emulator::start
+popd
+trap pubsub_emulator::kill EXIT
+
+"${BAZEL_BIN}" "${BAZEL_VERB}" "${bazel_test_args[@]}" \
+  --test_env="SPANNER_EMULATOR_HOST=${SPANNER_EMULATOR_HOST}" \
+  --test_env="GOOGLE_CLOUD_CPP_AUTO_RUN_EXAMPLES=yes" \
+  --test_env="GOOGLE_CLOUD_CPP_EXPERIMENTAL_LOG_CONFIG=lastN,100,WARNING" \
+  --test_env="GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc,rpc-streams" \
+  --test_env="GOOGLE_CLOUD_CPP_TRACING_OPTIONS=truncate_string_field_longer_than=512" \
+  --test_tag_filters="integration-test" -- \
+  "//google/cloud/spanner/...:all"

--- a/google/cloud/spanner/ci/run_integration_tests_emulator_bazel.sh
+++ b/google/cloud/spanner/ci/run_integration_tests_emulator_bazel.sh
@@ -33,9 +33,9 @@ bazel_test_args=("$@")
 
 # Start the emulator and arranges to kill it, run in $HOME because
 # pubsub_emulator::start creates unsightly *.log files in the workspace
-# otherwise.
+# otherwise. Use a fixed port so Bazel can cache the test results.
 pushd "${HOME}" >/dev/null
-spanner_emulator::start
+spanner_emulator::start 8787
 popd
 trap spanner_emulator::kill EXIT
 

--- a/google/cloud/spanner/ci/run_integration_tests_emulator_bazel.sh
+++ b/google/cloud/spanner/ci/run_integration_tests_emulator_bazel.sh
@@ -37,7 +37,7 @@ bazel_test_args=("$@")
 pushd "${HOME}" >/dev/null
 spanner_emulator::start
 popd
-trap pubsub_emulator::kill EXIT
+trap spanner_emulator::kill EXIT
 
 "${BAZEL_BIN}" "${BAZEL_VERB}" "${bazel_test_args[@]}" \
   --test_env="SPANNER_EMULATOR_HOST=${SPANNER_EMULATOR_HOST}" \


### PR DESCRIPTION
Avoids some flakes by using the emulator. We still have
some builds hitting production, mostly macOS and Windows.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6812)
<!-- Reviewable:end -->
