### PR TITLE
feat(common): support response in long-running operations

### DIFF
--- a/google/cloud/internal/extract_long_running_result.cc
+++ b/google/cloud/internal/extract_long_running_result.cc
@@ -20,7 +20,7 @@ namespace cloud {
 inline namespace GOOGLE_CLOUD_CPP_NS {
 namespace internal {
 
-Status ExtractOperationResultImpl(
+Status ExtractOperationResultMetadataImpl(
     StatusOr<google::longrunning::Operation> op,
     google::protobuf::Message& result,
     absl::FunctionRef<bool(google::protobuf::Any const&)> validate_any,
@@ -40,6 +40,32 @@ Status ExtractOperationResultImpl(
         StatusCode::kInternal,
         location +
             "() operation completed with an invalid metadata type, name=" +
+            op->name());
+  }
+  any.UnpackTo(&result);
+  return Status{};
+}
+
+Status ExtractOperationResultResponseImpl(
+    StatusOr<google::longrunning::Operation> op,
+    google::protobuf::Message& result,
+    absl::FunctionRef<bool(google::protobuf::Any const&)> validate_any,
+    std::string const& location) {
+  if (!op) return std::move(op).status();
+  if (op->has_error()) return MakeStatusFromRpcError(op->error());
+  if (!op->has_response()) {
+    return Status(StatusCode::kInternal,
+                  location +
+                      "() cannot extract value from operation without error or "
+                      "response, name=" +
+                      op->name());
+  }
+  google::protobuf::Any const& any = op->response();
+  if (!validate_any(any)) {
+    return Status(
+        StatusCode::kInternal,
+        location +
+            "() operation completed with an invalid response type, name=" +
             op->name());
   }
   any.UnpackTo(&result);


### PR DESCRIPTION
Some long-running operations return their value in the `response` field,
while others use the `metadata` field, with this change both are
supported.

Part of the work for #6821

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6822)
<!-- Reviewable:end -->
