### PR TITLE
feat(common): long-running operations cancel support

### DIFF
--- a/google/cloud/internal/async_long_running_operation_test.cc
+++ b/google/cloud/internal/async_long_running_operation_test.cc
@@ -43,6 +43,10 @@ class MockStub {
               (CompletionQueue & cq, std::unique_ptr<grpc::ClientContext>,
                google::longrunning::GetOperationRequest const&),
               ());
+  MOCK_METHOD(future<Status>, AsyncCancelOperation,
+              (CompletionQueue & cq, std::unique_ptr<grpc::ClientContext>,
+               google::longrunning::CancelOperationRequest const&),
+              ());
 };
 
 class MockPollingPolicy : public PollingPolicy {
@@ -117,6 +121,11 @@ TEST(AsyncLongRunningTest, RequestPollThenSuccessMetadata) {
                  google::longrunning::GetOperationRequest const& request) {
             return mock->AsyncGetOperation(cq, std::move(context), request);
           },
+          [mock](CompletionQueue& cq,
+                 std::unique_ptr<grpc::ClientContext> context,
+                 google::longrunning::CancelOperationRequest const& request) {
+            return mock->AsyncCancelOperation(cq, std::move(context), request);
+          },
           &ExtractLongRunningResultMetadata<Instance>, TestRetryPolicy(),
           TestBackoffPolicy(), Idempotency::kIdempotent, std::move(policy),
           "test-function")
@@ -173,6 +182,11 @@ TEST(AsyncLongRunningTest, RequestPollThenSuccessResponse) {
                  std::unique_ptr<grpc::ClientContext> context,
                  google::longrunning::GetOperationRequest const& request) {
             return mock->AsyncGetOperation(cq, std::move(context), request);
+          },
+          [mock](CompletionQueue& cq,
+                 std::unique_ptr<grpc::ClientContext> context,
+                 google::longrunning::CancelOperationRequest const& request) {
+            return mock->AsyncCancelOperation(cq, std::move(context), request);
           },
           &ExtractLongRunningResultResponse<Instance>, TestRetryPolicy(),
           TestBackoffPolicy(), Idempotency::kIdempotent, std::move(policy),

--- a/google/cloud/internal/async_polling_loop.cc
+++ b/google/cloud/internal/async_polling_loop.cc
@@ -19,37 +19,72 @@ namespace cloud {
 inline namespace GOOGLE_CLOUD_CPP_NS {
 namespace internal {
 
+using ::google::longrunning::Operation;
+
 class AsyncPollingLoopImpl
     : public std::enable_shared_from_this<AsyncPollingLoopImpl> {
  public:
   AsyncPollingLoopImpl(google::cloud::CompletionQueue cq,
-                       google::longrunning::Operation op,
                        AsyncPollLongRunningOperation poll,
+                       AsyncCancelLongRunningOperation cancel,
                        std::unique_ptr<PollingPolicy> polling_policy,
                        std::string location)
       : cq_(std::move(cq)),
-        op_(std::move(op)),
         poll_(std::move(poll)),
+        cancel_(std::move(cancel)),
+        canceled_(false),
         polling_policy_(std::move(polling_policy)),
-        location_(std::move(location)) {}
+        location_(std::move(location)),
+        promise_(null_promise_t{}) {}
 
-  future<StatusOr<google::longrunning::Operation>> Start() {
-    if (op_.done()) {
-      promise_.set_value(std::move(op_));
-    } else {
-      Wait();
-    }
+  future<StatusOr<Operation>> Start(future<StatusOr<Operation>> op) {
+    auto self = shared_from_this();
+    auto w = WeakFromThis();
+    promise_ = promise<StatusOr<Operation>>([w] {
+      if (auto self = w.lock()) self->DoCancel();
+    });
+    op.then([self](future<StatusOr<Operation>> f) { self->OnStart(f.get()); });
     return promise_.get_future();
   }
 
  private:
+  using TimerResult = future<StatusOr<std::chrono::system_clock::time_point>>;
+
   std::weak_ptr<AsyncPollingLoopImpl> WeakFromThis() {
     return shared_from_this();
   }
 
-  using TimerResult = future<StatusOr<std::chrono::system_clock::time_point>>;
+  void DoCancel() {
+    if (op_.name().empty()) return;
+    google::longrunning::CancelOperationRequest request;
+    request.set_name(op_.name());
+    // Cancels are best effort, so we use weak pointers.
+    auto w = WeakFromThis();
+    cancel_(cq_, absl::make_unique<grpc::ClientContext>(), request)
+        .then([w](future<Status> f) {
+          if (auto self = w.lock()) self->OnCancel(f.get());
+        });
+  }
+
+  void OnCancel(Status const& status) {
+    if (!status.ok()) return;
+    canceled_.store(true);
+  }
+
+  void OnStart(StatusOr<Operation> op) {
+    if (!op || op->done()) return promise_.set_value(std::move(op));
+    op_ = *std::move(op);
+    Wait();
+  }
+
+  void Cancelled() {
+    promise_.set_value(
+        Status{StatusCode::kCancelled,
+               location_ + "() - polling loop terminated via cancel()"});
+  }
 
   void Wait() {
+    if (canceled_.load()) return Cancelled();
     auto self = shared_from_this();
     cq_.MakeRelativeTimer(polling_policy_->WaitPeriod())
         .then([self](TimerResult f) { self->OnTimer(std::move(f)); });
@@ -58,17 +93,18 @@ class AsyncPollingLoopImpl
   void OnTimer(TimerResult f) {
     auto t = f.get();
     if (!t) return promise_.set_value(std::move(t).status());
+    if (canceled_.load()) return Cancelled();
 
     auto self = shared_from_this();
     google::longrunning::GetOperationRequest request;
     request.set_name(op_.name());
     poll_(cq_, absl::make_unique<grpc::ClientContext>(), request)
-        .then([self](future<StatusOr<google::longrunning::Operation>> g) {
+        .then([self](future<StatusOr<Operation>> g) {
           self->OnPoll(std::move(g));
         });
   }
 
-  void OnPoll(future<StatusOr<google::longrunning::Operation>> f) {
+  void OnPoll(future<StatusOr<Operation>> f) {
     auto op = f.get();
     if (op && op->done()) {
       return promise_.set_value(*std::move(op));
@@ -77,10 +113,9 @@ class AsyncPollingLoopImpl
     // after too many polling attempts.
     if (!polling_policy_->OnFailure(op.status())) {
       if (op) {
-        return promise_.set_value(
-            Status(StatusCode::kDeadlineExceeded,
-                   "exhausted polling policy with no previous error from " +
-                       location_));
+        return promise_.set_value(Status(
+            StatusCode::kDeadlineExceeded,
+            location_ + "() - polling loop terminated by polling policy"));
       }
       return promise_.set_value(std::move(op).status());
     }
@@ -91,19 +126,25 @@ class AsyncPollingLoopImpl
   google::cloud::CompletionQueue cq_;
   google::longrunning::Operation op_;
   AsyncPollLongRunningOperation poll_;
+  AsyncCancelLongRunningOperation cancel_;
+  // This is the only member variable in the accessed concurrently. All other
+  // member variables are changed and used in `On*()` functions, which are
+  // synchronized by virtue of being called from the CompletionQueue one at a
+  // time.
+  std::atomic<bool> canceled_;
   std::unique_ptr<PollingPolicy> polling_policy_;
   std::string location_;
-  promise<StatusOr<google::longrunning::Operation>> promise_;
+  promise<StatusOr<Operation>> promise_;
 };
 
-future<StatusOr<google::longrunning::Operation>> AsyncPollingLoop(
-    google::cloud::CompletionQueue cq, google::longrunning::Operation op,
-    AsyncPollLongRunningOperation poll,
+future<StatusOr<Operation>> AsyncPollingLoop(
+    google::cloud::CompletionQueue cq, future<StatusOr<Operation>> op,
+    AsyncPollLongRunningOperation poll, AsyncCancelLongRunningOperation cancel,
     std::unique_ptr<PollingPolicy> polling_policy, std::string location) {
   auto loop = std::make_shared<AsyncPollingLoopImpl>(
-      std::move(cq), std::move(op), std::move(poll), std::move(polling_policy),
-      std::move(location));
-  return loop->Start();
+      std::move(cq), std::move(poll), std::move(cancel),
+      std::move(polling_policy), std::move(location));
+  return loop->Start(std::move(op));
 }
 
 }  // namespace internal

--- a/google/cloud/internal/async_polling_loop.cc
+++ b/google/cloud/internal/async_polling_loop.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/internal/async_polling_loop.h"
+#include <atomic>
 
 namespace google {
 namespace cloud {
@@ -127,7 +128,7 @@ class AsyncPollingLoopImpl
   google::longrunning::Operation op_;
   AsyncPollLongRunningOperation poll_;
   AsyncCancelLongRunningOperation cancel_;
-  // This is the only member variable in the accessed concurrently. All other
+  // This is the only member variable that is accessed concurrently. All other
   // member variables are changed and used in `On*()` functions, which are
   // synchronized by virtue of being called from the CompletionQueue one at a
   // time.


### PR DESCRIPTION
Add support for cancelling long-running operations, applications may
decide to stop a very slow operation.

Part of the work for #6821

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6824)
<!-- Reviewable:end -->
