### PR TITLE
feat(generator): use async for long-running operations

### DIFF
--- a/generator/integration_tests/golden/golden_thing_admin_connection.cc
+++ b/generator/integration_tests/golden/golden_thing_admin_connection.cc
@@ -22,8 +22,8 @@
 #include "generator/integration_tests/golden/internal/golden_thing_admin_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/grpc_options.h"
+#include "google/cloud/internal/async_long_running_operation.h"
 #include "google/cloud/internal/pagination_range.h"
-#include "google/cloud/internal/polling_loop.h"
 #include "google/cloud/internal/retry_loop.h"
 #include <memory>
 
@@ -219,23 +219,30 @@ class GoldenThingAdminConnectionImpl : public GoldenThingAdminConnection {
   }
 
   future<StatusOr<google::test::admin::database::v1::Database>>
-  CreateDatabase(
-      google::test::admin::database::v1::CreateDatabaseRequest const& request) override {
-    auto operation = google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->CreateDatabase(request),
-        [this](grpc::ClientContext& context,
-               google::test::admin::database::v1::CreateDatabaseRequest const& request) {
-          return stub_->CreateDatabase(context, request);
-        },
-        request, __func__);
-    if (!operation) {
-      return google::cloud::make_ready_future(
-          StatusOr<google::test::admin::database::v1::Database>(operation.status()));
-    }
-
-    return AwaitCreateDatabase(*std::move(operation));
-}
+  CreateDatabase(google::test::admin::database::v1::CreateDatabaseRequest const& request) override {
+    auto stub = stub_;
+    return google::cloud::internal::AsyncLongRunningOperation<google::test::admin::database::v1::Database>(
+          background_->cq(), request,
+          [stub](google::cloud::CompletionQueue& cq,
+                 std::unique_ptr<grpc::ClientContext> context,
+                 google::test::admin::database::v1::CreateDatabaseRequest const& request) {
+            return stub->AsyncCreateDatabase(cq, std::move(context), request);
+          },
+          [stub](google::cloud::CompletionQueue& cq,
+                 std::unique_ptr<grpc::ClientContext> context,
+                 google::longrunning::GetOperationRequest const& request) {
+            return stub->AsyncGetOperation(cq, std::move(context), request);
+          },
+          [stub](google::cloud::CompletionQueue& cq,
+                 std::unique_ptr<grpc::ClientContext> context,
+                 google::longrunning::CancelOperationRequest const& request) {
+            return stub->AsyncCancelOperation(cq, std::move(context), request);
+          },
+          &google::cloud::internal::ExtractLongRunningResultResponse<google::test::admin::database::v1::Database>,
+          retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
+          idempotency_policy_->CreateDatabase(request),
+          polling_policy_prototype_->clone(), __func__);
+  }
 
   StatusOr<google::test::admin::database::v1::Database>
   GetDatabase(
@@ -251,23 +258,30 @@ class GoldenThingAdminConnectionImpl : public GoldenThingAdminConnection {
 }
 
   future<StatusOr<google::test::admin::database::v1::UpdateDatabaseDdlMetadata>>
-  UpdateDatabaseDdl(
-      google::test::admin::database::v1::UpdateDatabaseDdlRequest const& request) override {
-    auto operation = google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->UpdateDatabaseDdl(request),
-        [this](grpc::ClientContext& context,
-               google::test::admin::database::v1::UpdateDatabaseDdlRequest const& request) {
-          return stub_->UpdateDatabaseDdl(context, request);
-        },
-        request, __func__);
-    if (!operation) {
-      return google::cloud::make_ready_future(
-          StatusOr<google::test::admin::database::v1::UpdateDatabaseDdlMetadata>(operation.status()));
-    }
-
-    return AwaitUpdateDatabaseDdl(*std::move(operation));
-}
+  UpdateDatabaseDdl(google::test::admin::database::v1::UpdateDatabaseDdlRequest const& request) override {
+    auto stub = stub_;
+    return google::cloud::internal::AsyncLongRunningOperation<google::test::admin::database::v1::UpdateDatabaseDdlMetadata>(
+          background_->cq(), request,
+          [stub](google::cloud::CompletionQueue& cq,
+                 std::unique_ptr<grpc::ClientContext> context,
+                 google::test::admin::database::v1::UpdateDatabaseDdlRequest const& request) {
+            return stub->AsyncUpdateDatabaseDdl(cq, std::move(context), request);
+          },
+          [stub](google::cloud::CompletionQueue& cq,
+                 std::unique_ptr<grpc::ClientContext> context,
+                 google::longrunning::GetOperationRequest const& request) {
+            return stub->AsyncGetOperation(cq, std::move(context), request);
+          },
+          [stub](google::cloud::CompletionQueue& cq,
+                 std::unique_ptr<grpc::ClientContext> context,
+                 google::longrunning::CancelOperationRequest const& request) {
+            return stub->AsyncCancelOperation(cq, std::move(context), request);
+          },
+          &google::cloud::internal::ExtractLongRunningResultMetadata<google::test::admin::database::v1::UpdateDatabaseDdlMetadata>,
+          retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
+          idempotency_policy_->UpdateDatabaseDdl(request),
+          polling_policy_prototype_->clone(), __func__);
+  }
 
   Status
   DropDatabase(
@@ -335,23 +349,30 @@ class GoldenThingAdminConnectionImpl : public GoldenThingAdminConnection {
 }
 
   future<StatusOr<google::test::admin::database::v1::Backup>>
-  CreateBackup(
-      google::test::admin::database::v1::CreateBackupRequest const& request) override {
-    auto operation = google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->CreateBackup(request),
-        [this](grpc::ClientContext& context,
-               google::test::admin::database::v1::CreateBackupRequest const& request) {
-          return stub_->CreateBackup(context, request);
-        },
-        request, __func__);
-    if (!operation) {
-      return google::cloud::make_ready_future(
-          StatusOr<google::test::admin::database::v1::Backup>(operation.status()));
-    }
-
-    return AwaitCreateBackup(*std::move(operation));
-}
+  CreateBackup(google::test::admin::database::v1::CreateBackupRequest const& request) override {
+    auto stub = stub_;
+    return google::cloud::internal::AsyncLongRunningOperation<google::test::admin::database::v1::Backup>(
+          background_->cq(), request,
+          [stub](google::cloud::CompletionQueue& cq,
+                 std::unique_ptr<grpc::ClientContext> context,
+                 google::test::admin::database::v1::CreateBackupRequest const& request) {
+            return stub->AsyncCreateBackup(cq, std::move(context), request);
+          },
+          [stub](google::cloud::CompletionQueue& cq,
+                 std::unique_ptr<grpc::ClientContext> context,
+                 google::longrunning::GetOperationRequest const& request) {
+            return stub->AsyncGetOperation(cq, std::move(context), request);
+          },
+          [stub](google::cloud::CompletionQueue& cq,
+                 std::unique_ptr<grpc::ClientContext> context,
+                 google::longrunning::CancelOperationRequest const& request) {
+            return stub->AsyncCancelOperation(cq, std::move(context), request);
+          },
+          &google::cloud::internal::ExtractLongRunningResultResponse<google::test::admin::database::v1::Backup>,
+          retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
+          idempotency_policy_->CreateBackup(request),
+          polling_policy_prototype_->clone(), __func__);
+  }
 
   StatusOr<google::test::admin::database::v1::Backup>
   GetBackup(
@@ -424,23 +445,30 @@ class GoldenThingAdminConnectionImpl : public GoldenThingAdminConnection {
   }
 
   future<StatusOr<google::test::admin::database::v1::Database>>
-  RestoreDatabase(
-      google::test::admin::database::v1::RestoreDatabaseRequest const& request) override {
-    auto operation = google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->RestoreDatabase(request),
-        [this](grpc::ClientContext& context,
-               google::test::admin::database::v1::RestoreDatabaseRequest const& request) {
-          return stub_->RestoreDatabase(context, request);
-        },
-        request, __func__);
-    if (!operation) {
-      return google::cloud::make_ready_future(
-          StatusOr<google::test::admin::database::v1::Database>(operation.status()));
-    }
-
-    return AwaitRestoreDatabase(*std::move(operation));
-}
+  RestoreDatabase(google::test::admin::database::v1::RestoreDatabaseRequest const& request) override {
+    auto stub = stub_;
+    return google::cloud::internal::AsyncLongRunningOperation<google::test::admin::database::v1::Database>(
+          background_->cq(), request,
+          [stub](google::cloud::CompletionQueue& cq,
+                 std::unique_ptr<grpc::ClientContext> context,
+                 google::test::admin::database::v1::RestoreDatabaseRequest const& request) {
+            return stub->AsyncRestoreDatabase(cq, std::move(context), request);
+          },
+          [stub](google::cloud::CompletionQueue& cq,
+                 std::unique_ptr<grpc::ClientContext> context,
+                 google::longrunning::GetOperationRequest const& request) {
+            return stub->AsyncGetOperation(cq, std::move(context), request);
+          },
+          [stub](google::cloud::CompletionQueue& cq,
+                 std::unique_ptr<grpc::ClientContext> context,
+                 google::longrunning::CancelOperationRequest const& request) {
+            return stub->AsyncCancelOperation(cq, std::move(context), request);
+          },
+          &google::cloud::internal::ExtractLongRunningResultResponse<google::test::admin::database::v1::Database>,
+          retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
+          idempotency_policy_->RestoreDatabase(request),
+          polling_policy_prototype_->clone(), __func__);
+  }
 
   StreamRange<google::longrunning::Operation> ListDatabaseOperations(
       google::test::admin::database::v1::ListDatabaseOperationsRequest request) override {
@@ -505,82 +533,6 @@ class GoldenThingAdminConnectionImpl : public GoldenThingAdminConnection {
   }
 
  private:
-  template <typename MethodResponse, template<typename> class Extractor,
-    typename Stub>
-  future<StatusOr<MethodResponse>>
-  AwaitLongrunningOperation(google::longrunning::Operation operation) {  // NOLINT
-    using ResponseExtractor = Extractor<MethodResponse>;
-    std::weak_ptr<Stub> cancel_stub(stub_);
-    promise<typename ResponseExtractor::ReturnType> pr(
-        [cancel_stub, operation]() {
-          grpc::ClientContext context;
-          context.set_deadline(std::chrono::system_clock::now() +
-            std::chrono::seconds(60));
-          google::longrunning::CancelOperationRequest request;
-          request.set_name(operation.name());
-          if (auto ptr = cancel_stub.lock()) {
-            ptr->CancelOperation(context, request);
-          }
-    });
-    auto f = pr.get_future();
-    std::thread t(
-        [](std::shared_ptr<Stub> stub,
-           google::longrunning::Operation operation,
-           std::unique_ptr<PollingPolicy> polling_policy,
-           google::cloud::promise<typename ResponseExtractor::ReturnType> promise,
-           char const* location) mutable {
-          auto result = google::cloud::internal::PollingLoop<ResponseExtractor>(
-              std::move(polling_policy),
-              [stub](grpc::ClientContext& context,
-                     google::longrunning::GetOperationRequest const& request) {
-                return stub->GetOperation(context, request);
-              },
-              std::move(operation), location);
-          stub.reset();
-          promise.set_value(std::move(result));
-        },
-        stub_, std::move(operation), polling_policy_prototype_->clone(),
-        std::move(pr), __func__);
-    t.detach();
-    return f;
-  }
-
-  future<StatusOr<google::test::admin::database::v1::Database>>
-  AwaitCreateDatabase(
-      google::longrunning::Operation operation) {
-    return AwaitLongrunningOperation<
-        google::test::admin::database::v1::Database,
-        google::cloud::internal::PollingLoopResponseExtractor,
-        golden_internal::GoldenThingAdminStub>(std::move(operation));
-  }
-
-  future<StatusOr<google::test::admin::database::v1::UpdateDatabaseDdlMetadata>>
-  AwaitUpdateDatabaseDdl(
-      google::longrunning::Operation operation) {
-    return AwaitLongrunningOperation<
-        google::test::admin::database::v1::UpdateDatabaseDdlMetadata,
-        google::cloud::internal::PollingLoopMetadataExtractor,
-        golden_internal::GoldenThingAdminStub>(std::move(operation));
-  }
-
-  future<StatusOr<google::test::admin::database::v1::Backup>>
-  AwaitCreateBackup(
-      google::longrunning::Operation operation) {
-    return AwaitLongrunningOperation<
-        google::test::admin::database::v1::Backup,
-        google::cloud::internal::PollingLoopResponseExtractor,
-        golden_internal::GoldenThingAdminStub>(std::move(operation));
-  }
-
-  future<StatusOr<google::test::admin::database::v1::Database>>
-  AwaitRestoreDatabase(
-      google::longrunning::Operation operation) {
-    return AwaitLongrunningOperation<
-        google::test::admin::database::v1::Database,
-        google::cloud::internal::PollingLoopResponseExtractor,
-        golden_internal::GoldenThingAdminStub>(std::move(operation));
-  }
-
   std::unique_ptr<google::cloud::BackgroundThreads> background_;
   std::shared_ptr<golden_internal::GoldenThingAdminStub> stub_;
   std::unique_ptr<GoldenThingAdminRetryPolicy const> retry_policy_prototype_;

--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_auth_decorator.h
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_auth_decorator.h
@@ -40,26 +40,21 @@ class GoldenKitchenSinkAuth : public GoldenKitchenSinkStub {
       std::shared_ptr<google::cloud::internal::GrpcAuthenticationStrategy> auth,
       std::shared_ptr<GoldenKitchenSinkStub> child);
 
-
   StatusOr<google::test::admin::database::v1::GenerateAccessTokenResponse> GenerateAccessToken(
       grpc::ClientContext& context,
       google::test::admin::database::v1::GenerateAccessTokenRequest const& request) override;
-
 
   StatusOr<google::test::admin::database::v1::GenerateIdTokenResponse> GenerateIdToken(
       grpc::ClientContext& context,
       google::test::admin::database::v1::GenerateIdTokenRequest const& request) override;
 
-
   StatusOr<google::test::admin::database::v1::WriteLogEntriesResponse> WriteLogEntries(
       grpc::ClientContext& context,
       google::test::admin::database::v1::WriteLogEntriesRequest const& request) override;
 
-
   StatusOr<google::test::admin::database::v1::ListLogsResponse> ListLogs(
       grpc::ClientContext& context,
       google::test::admin::database::v1::ListLogsRequest const& request) override;
-
 
   std::unique_ptr<internal::StreamingReadRpc<google::test::admin::database::v1::TailLogEntriesResponse>>
   TailLogEntries(
@@ -69,7 +64,6 @@ class GoldenKitchenSinkAuth : public GoldenKitchenSinkStub {
   StatusOr<google::test::admin::database::v1::ListServiceAccountKeysResponse> ListServiceAccountKeys(
       grpc::ClientContext& context,
       google::test::admin::database::v1::ListServiceAccountKeysRequest const& request) override;
-
 
  private:
   std::shared_ptr<google::cloud::internal::GrpcAuthenticationStrategy> auth_;

--- a/generator/integration_tests/golden/internal/golden_thing_admin_auth_decorator.cc
+++ b/generator/integration_tests/golden/internal/golden_thing_admin_auth_decorator.cc
@@ -40,12 +40,22 @@ StatusOr<google::test::admin::database::v1::ListDatabasesResponse> GoldenThingAd
   return child_->ListDatabases(context, request);
 }
 
-StatusOr<google::longrunning::Operation> GoldenThingAdminAuth::CreateDatabase(
-    grpc::ClientContext& context,
-    google::test::admin::database::v1::CreateDatabaseRequest const& request) {
-  auto status = auth_->ConfigureContext(context);
-  if (!status.ok()) return status;
-  return child_->CreateDatabase(context, request);
+future<StatusOr<google::longrunning::Operation>>
+GoldenThingAdminAuth::AsyncCreateDatabase(
+      google::cloud::CompletionQueue& cq,
+      std::unique_ptr<grpc::ClientContext> context,
+      google::test::admin::database::v1::CreateDatabaseRequest const& request) {
+  using ReturnType = StatusOr<google::longrunning::Operation>;
+  auto child = child_;
+  return auth_->AsyncConfigureContext(std::move(context)).then(
+      [cq, child, request](
+          future<StatusOr<std::unique_ptr<grpc::ClientContext>>> f) mutable {
+        auto context = f.get();
+        if (!context) {
+          return make_ready_future(ReturnType(std::move(context).status()));
+        }
+        return child->AsyncCreateDatabase(cq, *std::move(context), request);
+      });
 }
 
 StatusOr<google::test::admin::database::v1::Database> GoldenThingAdminAuth::GetDatabase(
@@ -56,12 +66,22 @@ StatusOr<google::test::admin::database::v1::Database> GoldenThingAdminAuth::GetD
   return child_->GetDatabase(context, request);
 }
 
-StatusOr<google::longrunning::Operation> GoldenThingAdminAuth::UpdateDatabaseDdl(
-    grpc::ClientContext& context,
-    google::test::admin::database::v1::UpdateDatabaseDdlRequest const& request) {
-  auto status = auth_->ConfigureContext(context);
-  if (!status.ok()) return status;
-  return child_->UpdateDatabaseDdl(context, request);
+future<StatusOr<google::longrunning::Operation>>
+GoldenThingAdminAuth::AsyncUpdateDatabaseDdl(
+      google::cloud::CompletionQueue& cq,
+      std::unique_ptr<grpc::ClientContext> context,
+      google::test::admin::database::v1::UpdateDatabaseDdlRequest const& request) {
+  using ReturnType = StatusOr<google::longrunning::Operation>;
+  auto child = child_;
+  return auth_->AsyncConfigureContext(std::move(context)).then(
+      [cq, child, request](
+          future<StatusOr<std::unique_ptr<grpc::ClientContext>>> f) mutable {
+        auto context = f.get();
+        if (!context) {
+          return make_ready_future(ReturnType(std::move(context).status()));
+        }
+        return child->AsyncUpdateDatabaseDdl(cq, *std::move(context), request);
+      });
 }
 
 Status GoldenThingAdminAuth::DropDatabase(
@@ -104,12 +124,22 @@ StatusOr<google::iam::v1::TestIamPermissionsResponse> GoldenThingAdminAuth::Test
   return child_->TestIamPermissions(context, request);
 }
 
-StatusOr<google::longrunning::Operation> GoldenThingAdminAuth::CreateBackup(
-    grpc::ClientContext& context,
-    google::test::admin::database::v1::CreateBackupRequest const& request) {
-  auto status = auth_->ConfigureContext(context);
-  if (!status.ok()) return status;
-  return child_->CreateBackup(context, request);
+future<StatusOr<google::longrunning::Operation>>
+GoldenThingAdminAuth::AsyncCreateBackup(
+      google::cloud::CompletionQueue& cq,
+      std::unique_ptr<grpc::ClientContext> context,
+      google::test::admin::database::v1::CreateBackupRequest const& request) {
+  using ReturnType = StatusOr<google::longrunning::Operation>;
+  auto child = child_;
+  return auth_->AsyncConfigureContext(std::move(context)).then(
+      [cq, child, request](
+          future<StatusOr<std::unique_ptr<grpc::ClientContext>>> f) mutable {
+        auto context = f.get();
+        if (!context) {
+          return make_ready_future(ReturnType(std::move(context).status()));
+        }
+        return child->AsyncCreateBackup(cq, *std::move(context), request);
+      });
 }
 
 StatusOr<google::test::admin::database::v1::Backup> GoldenThingAdminAuth::GetBackup(
@@ -144,12 +174,22 @@ StatusOr<google::test::admin::database::v1::ListBackupsResponse> GoldenThingAdmi
   return child_->ListBackups(context, request);
 }
 
-StatusOr<google::longrunning::Operation> GoldenThingAdminAuth::RestoreDatabase(
-    grpc::ClientContext& context,
-    google::test::admin::database::v1::RestoreDatabaseRequest const& request) {
-  auto status = auth_->ConfigureContext(context);
-  if (!status.ok()) return status;
-  return child_->RestoreDatabase(context, request);
+future<StatusOr<google::longrunning::Operation>>
+GoldenThingAdminAuth::AsyncRestoreDatabase(
+      google::cloud::CompletionQueue& cq,
+      std::unique_ptr<grpc::ClientContext> context,
+      google::test::admin::database::v1::RestoreDatabaseRequest const& request) {
+  using ReturnType = StatusOr<google::longrunning::Operation>;
+  auto child = child_;
+  return auth_->AsyncConfigureContext(std::move(context)).then(
+      [cq, child, request](
+          future<StatusOr<std::unique_ptr<grpc::ClientContext>>> f) mutable {
+        auto context = f.get();
+        if (!context) {
+          return make_ready_future(ReturnType(std::move(context).status()));
+        }
+        return child->AsyncRestoreDatabase(cq, *std::move(context), request);
+      });
 }
 
 StatusOr<google::test::admin::database::v1::ListDatabaseOperationsResponse> GoldenThingAdminAuth::ListDatabaseOperations(
@@ -168,20 +208,36 @@ StatusOr<google::test::admin::database::v1::ListBackupOperationsResponse> Golden
   return child_->ListBackupOperations(context, request);
 }
 
-StatusOr<google::longrunning::Operation> GoldenThingAdminAuth::GetOperation(
-    grpc::ClientContext& context,
+future<StatusOr<google::longrunning::Operation>>
+GoldenThingAdminAuth::AsyncGetOperation(
+    google::cloud::CompletionQueue& cq,
+    std::unique_ptr<grpc::ClientContext> context,
     google::longrunning::GetOperationRequest const& request) {
-  auto status = auth_->ConfigureContext(context);
-  if (!status.ok()) return status;
-  return child_->GetOperation(context, request);
+  using ReturnType = StatusOr<google::longrunning::Operation>;
+  auto child = child_;
+  return auth_->AsyncConfigureContext(std::move(context)).then(
+      [cq, child, request](
+          future<StatusOr<std::unique_ptr<grpc::ClientContext>>> f) mutable {
+        auto context = f.get();
+        if (!context) {
+          return make_ready_future(ReturnType(std::move(context).status()));
+        }
+        return child->AsyncGetOperation(cq, *std::move(context), request);
+      });
 }
 
-Status GoldenThingAdminAuth::CancelOperation(
-    grpc::ClientContext& context,
+future<Status> GoldenThingAdminAuth::AsyncCancelOperation(
+    google::cloud::CompletionQueue& cq,
+    std::unique_ptr<grpc::ClientContext> context,
     google::longrunning::CancelOperationRequest const& request) {
-  auto status = auth_->ConfigureContext(context);
-  if (!status.ok()) return status;
-  return child_->CancelOperation(context, request);
+  auto child = child_;
+  return auth_->AsyncConfigureContext(std::move(context)).then(
+      [cq, child, request](
+          future<StatusOr<std::unique_ptr<grpc::ClientContext>>> f) mutable {
+        auto context = f.get();
+        if (!context) return make_ready_future(std::move(context).status());
+        return child->AsyncCancelOperation(cq, *std::move(context), request);
+      });
 }
 }  // namespace GOOGLE_CLOUD_CPP_GENERATED_NS
 }  // namespace golden_internal

--- a/generator/integration_tests/golden/internal/golden_thing_admin_auth_decorator.h
+++ b/generator/integration_tests/golden/internal/golden_thing_admin_auth_decorator.h
@@ -41,26 +41,23 @@ class GoldenThingAdminAuth : public GoldenThingAdminStub {
       std::shared_ptr<google::cloud::internal::GrpcAuthenticationStrategy> auth,
       std::shared_ptr<GoldenThingAdminStub> child);
 
-
   StatusOr<google::test::admin::database::v1::ListDatabasesResponse> ListDatabases(
       grpc::ClientContext& context,
       google::test::admin::database::v1::ListDatabasesRequest const& request) override;
 
-
-  StatusOr<google::longrunning::Operation> CreateDatabase(
-      grpc::ClientContext& context,
+  future<StatusOr<google::longrunning::Operation>> AsyncCreateDatabase(
+      google::cloud::CompletionQueue& cq,
+      std::unique_ptr<grpc::ClientContext> context,
       google::test::admin::database::v1::CreateDatabaseRequest const& request) override;
-
 
   StatusOr<google::test::admin::database::v1::Database> GetDatabase(
       grpc::ClientContext& context,
       google::test::admin::database::v1::GetDatabaseRequest const& request) override;
 
-
-  StatusOr<google::longrunning::Operation> UpdateDatabaseDdl(
-      grpc::ClientContext& context,
+  future<StatusOr<google::longrunning::Operation>> AsyncUpdateDatabaseDdl(
+      google::cloud::CompletionQueue& cq,
+      std::unique_ptr<grpc::ClientContext> context,
       google::test::admin::database::v1::UpdateDatabaseDdlRequest const& request) override;
-
 
   Status DropDatabase(
       grpc::ClientContext& context,
@@ -70,36 +67,30 @@ class GoldenThingAdminAuth : public GoldenThingAdminStub {
       grpc::ClientContext& context,
       google::test::admin::database::v1::GetDatabaseDdlRequest const& request) override;
 
-
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
       grpc::ClientContext& context,
       google::iam::v1::SetIamPolicyRequest const& request) override;
-
 
   StatusOr<google::iam::v1::Policy> GetIamPolicy(
       grpc::ClientContext& context,
       google::iam::v1::GetIamPolicyRequest const& request) override;
 
-
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
       grpc::ClientContext& context,
       google::iam::v1::TestIamPermissionsRequest const& request) override;
 
-
-  StatusOr<google::longrunning::Operation> CreateBackup(
-      grpc::ClientContext& context,
+  future<StatusOr<google::longrunning::Operation>> AsyncCreateBackup(
+      google::cloud::CompletionQueue& cq,
+      std::unique_ptr<grpc::ClientContext> context,
       google::test::admin::database::v1::CreateBackupRequest const& request) override;
-
 
   StatusOr<google::test::admin::database::v1::Backup> GetBackup(
       grpc::ClientContext& context,
       google::test::admin::database::v1::GetBackupRequest const& request) override;
 
-
   StatusOr<google::test::admin::database::v1::Backup> UpdateBackup(
       grpc::ClientContext& context,
       google::test::admin::database::v1::UpdateBackupRequest const& request) override;
-
 
   Status DeleteBackup(
       grpc::ClientContext& context,
@@ -109,32 +100,28 @@ class GoldenThingAdminAuth : public GoldenThingAdminStub {
       grpc::ClientContext& context,
       google::test::admin::database::v1::ListBackupsRequest const& request) override;
 
-
-  StatusOr<google::longrunning::Operation> RestoreDatabase(
-      grpc::ClientContext& context,
+  future<StatusOr<google::longrunning::Operation>> AsyncRestoreDatabase(
+      google::cloud::CompletionQueue& cq,
+      std::unique_ptr<grpc::ClientContext> context,
       google::test::admin::database::v1::RestoreDatabaseRequest const& request) override;
-
 
   StatusOr<google::test::admin::database::v1::ListDatabaseOperationsResponse> ListDatabaseOperations(
       grpc::ClientContext& context,
       google::test::admin::database::v1::ListDatabaseOperationsRequest const& request) override;
 
-
   StatusOr<google::test::admin::database::v1::ListBackupOperationsResponse> ListBackupOperations(
       grpc::ClientContext& context,
       google::test::admin::database::v1::ListBackupOperationsRequest const& request) override;
 
+  future<StatusOr<google::longrunning::Operation>> AsyncGetOperation(
+      google::cloud::CompletionQueue& cq,
+      std::unique_ptr<grpc::ClientContext> context,
+      google::longrunning::GetOperationRequest const& request) override;
 
-    /// Poll a long-running operation.
-    StatusOr<google::longrunning::Operation> GetOperation(
-        grpc::ClientContext& context,
-        google::longrunning::GetOperationRequest const& request) override;
-
-    /// Cancel a long-running operation.
-    Status CancelOperation(
-        grpc::ClientContext& context,
-        google::longrunning::CancelOperationRequest const& request) override;
-
+  future<Status> AsyncCancelOperation(
+      google::cloud::CompletionQueue& cq,
+      std::unique_ptr<grpc::ClientContext> context,
+      google::longrunning::CancelOperationRequest const& request) override;
  private:
   std::shared_ptr<google::cloud::internal::GrpcAuthenticationStrategy> auth_;
   std::shared_ptr<GoldenThingAdminStub> child_;

--- a/generator/integration_tests/golden/internal/golden_thing_admin_logging_decorator.cc
+++ b/generator/integration_tests/golden/internal/golden_thing_admin_logging_decorator.cc
@@ -45,18 +45,20 @@ GoldenThingAdminLogging::ListDatabases(
       context, request, __func__, tracing_options_);
 }
 
-StatusOr<google::longrunning::Operation>
-GoldenThingAdminLogging::CreateDatabase(
-    grpc::ClientContext& context,
-    google::test::admin::database::v1::CreateDatabaseRequest const& request) {
-  return google::cloud::internal::LogWrapper(
-      [this](grpc::ClientContext& context,
-             google::test::admin::database::v1::CreateDatabaseRequest const& request) {
-        return child_->CreateDatabase(context, request);
-      },
-      context, request, __func__, tracing_options_);
-}
 
+future<StatusOr<google::longrunning::Operation>>
+GoldenThingAdminLogging::AsyncCreateDatabase(
+      google::cloud::CompletionQueue& cq,
+      std::unique_ptr<grpc::ClientContext> context,
+      google::test::admin::database::v1::CreateDatabaseRequest const& request) {
+  return google::cloud::internal::LogWrapper(
+      [this](google::cloud::CompletionQueue& cq,
+             std::unique_ptr<grpc::ClientContext> context,
+             google::test::admin::database::v1::CreateDatabaseRequest const& request) {
+        return child_->AsyncCreateDatabase(cq, std::move(context), request);
+      },
+      cq, std::move(context), request, __func__, tracing_options_);
+}
 StatusOr<google::test::admin::database::v1::Database>
 GoldenThingAdminLogging::GetDatabase(
     grpc::ClientContext& context,
@@ -69,18 +71,20 @@ GoldenThingAdminLogging::GetDatabase(
       context, request, __func__, tracing_options_);
 }
 
-StatusOr<google::longrunning::Operation>
-GoldenThingAdminLogging::UpdateDatabaseDdl(
-    grpc::ClientContext& context,
-    google::test::admin::database::v1::UpdateDatabaseDdlRequest const& request) {
-  return google::cloud::internal::LogWrapper(
-      [this](grpc::ClientContext& context,
-             google::test::admin::database::v1::UpdateDatabaseDdlRequest const& request) {
-        return child_->UpdateDatabaseDdl(context, request);
-      },
-      context, request, __func__, tracing_options_);
-}
 
+future<StatusOr<google::longrunning::Operation>>
+GoldenThingAdminLogging::AsyncUpdateDatabaseDdl(
+      google::cloud::CompletionQueue& cq,
+      std::unique_ptr<grpc::ClientContext> context,
+      google::test::admin::database::v1::UpdateDatabaseDdlRequest const& request) {
+  return google::cloud::internal::LogWrapper(
+      [this](google::cloud::CompletionQueue& cq,
+             std::unique_ptr<grpc::ClientContext> context,
+             google::test::admin::database::v1::UpdateDatabaseDdlRequest const& request) {
+        return child_->AsyncUpdateDatabaseDdl(cq, std::move(context), request);
+      },
+      cq, std::move(context), request, __func__, tracing_options_);
+}
 Status
 GoldenThingAdminLogging::DropDatabase(
     grpc::ClientContext& context,
@@ -141,18 +145,20 @@ GoldenThingAdminLogging::TestIamPermissions(
       context, request, __func__, tracing_options_);
 }
 
-StatusOr<google::longrunning::Operation>
-GoldenThingAdminLogging::CreateBackup(
-    grpc::ClientContext& context,
-    google::test::admin::database::v1::CreateBackupRequest const& request) {
-  return google::cloud::internal::LogWrapper(
-      [this](grpc::ClientContext& context,
-             google::test::admin::database::v1::CreateBackupRequest const& request) {
-        return child_->CreateBackup(context, request);
-      },
-      context, request, __func__, tracing_options_);
-}
 
+future<StatusOr<google::longrunning::Operation>>
+GoldenThingAdminLogging::AsyncCreateBackup(
+      google::cloud::CompletionQueue& cq,
+      std::unique_ptr<grpc::ClientContext> context,
+      google::test::admin::database::v1::CreateBackupRequest const& request) {
+  return google::cloud::internal::LogWrapper(
+      [this](google::cloud::CompletionQueue& cq,
+             std::unique_ptr<grpc::ClientContext> context,
+             google::test::admin::database::v1::CreateBackupRequest const& request) {
+        return child_->AsyncCreateBackup(cq, std::move(context), request);
+      },
+      cq, std::move(context), request, __func__, tracing_options_);
+}
 StatusOr<google::test::admin::database::v1::Backup>
 GoldenThingAdminLogging::GetBackup(
     grpc::ClientContext& context,
@@ -201,18 +207,20 @@ GoldenThingAdminLogging::ListBackups(
       context, request, __func__, tracing_options_);
 }
 
-StatusOr<google::longrunning::Operation>
-GoldenThingAdminLogging::RestoreDatabase(
-    grpc::ClientContext& context,
-    google::test::admin::database::v1::RestoreDatabaseRequest const& request) {
-  return google::cloud::internal::LogWrapper(
-      [this](grpc::ClientContext& context,
-             google::test::admin::database::v1::RestoreDatabaseRequest const& request) {
-        return child_->RestoreDatabase(context, request);
-      },
-      context, request, __func__, tracing_options_);
-}
 
+future<StatusOr<google::longrunning::Operation>>
+GoldenThingAdminLogging::AsyncRestoreDatabase(
+      google::cloud::CompletionQueue& cq,
+      std::unique_ptr<grpc::ClientContext> context,
+      google::test::admin::database::v1::RestoreDatabaseRequest const& request) {
+  return google::cloud::internal::LogWrapper(
+      [this](google::cloud::CompletionQueue& cq,
+             std::unique_ptr<grpc::ClientContext> context,
+             google::test::admin::database::v1::RestoreDatabaseRequest const& request) {
+        return child_->AsyncRestoreDatabase(cq, std::move(context), request);
+      },
+      cq, std::move(context), request, __func__, tracing_options_);
+}
 StatusOr<google::test::admin::database::v1::ListDatabaseOperationsResponse>
 GoldenThingAdminLogging::ListDatabaseOperations(
     grpc::ClientContext& context,
@@ -237,26 +245,32 @@ GoldenThingAdminLogging::ListBackupOperations(
       context, request, __func__, tracing_options_);
 }
 
-StatusOr<google::longrunning::Operation> GoldenThingAdminLogging::GetOperation(
-    grpc::ClientContext& context,
+
+future<StatusOr<google::longrunning::Operation>>
+GoldenThingAdminLogging::AsyncGetOperation(
+    google::cloud::CompletionQueue& cq,
+    std::unique_ptr<grpc::ClientContext> context,
     google::longrunning::GetOperationRequest const& request) {
   return google::cloud::internal::LogWrapper(
-      [this](grpc::ClientContext& context,
+      [this](google::cloud::CompletionQueue& cq,
+             std::unique_ptr<grpc::ClientContext> context,
              google::longrunning::GetOperationRequest const& request) {
-        return child_->GetOperation(context, request);
+        return child_->AsyncGetOperation(cq, std::move(context), request);
       },
-      context, request, __func__, tracing_options_);
+      cq, std::move(context), request, __func__, tracing_options_);
 }
 
-Status GoldenThingAdminLogging::CancelOperation(
-    grpc::ClientContext& context,
+future<Status> GoldenThingAdminLogging::AsyncCancelOperation(
+    google::cloud::CompletionQueue& cq,
+    std::unique_ptr<grpc::ClientContext> context,
     google::longrunning::CancelOperationRequest const& request) {
   return google::cloud::internal::LogWrapper(
-      [this](grpc::ClientContext& context,
+      [this](google::cloud::CompletionQueue& cq,
+             std::unique_ptr<grpc::ClientContext> context,
              google::longrunning::CancelOperationRequest const& request) {
-        return child_->CancelOperation(context, request);
+        return child_->AsyncCancelOperation(cq, std::move(context), request);
       },
-      context, request, __func__, tracing_options_);
+      cq, std::move(context), request, __func__, tracing_options_);
 }
 }  // namespace GOOGLE_CLOUD_CPP_GENERATED_NS
 }  // namespace golden_internal

--- a/generator/integration_tests/golden/internal/golden_thing_admin_logging_decorator.h
+++ b/generator/integration_tests/golden/internal/golden_thing_admin_logging_decorator.h
@@ -42,18 +42,20 @@ class GoldenThingAdminLogging : public GoldenThingAdminStub {
     grpc::ClientContext& context,
     google::test::admin::database::v1::ListDatabasesRequest const& request) override;
 
-  StatusOr<google::longrunning::Operation> CreateDatabase(
-    grpc::ClientContext& context,
-    google::test::admin::database::v1::CreateDatabaseRequest const& request) override;
 
+  future<StatusOr<google::longrunning::Operation>> AsyncCreateDatabase(
+      google::cloud::CompletionQueue& cq,
+      std::unique_ptr<grpc::ClientContext> context,
+      google::test::admin::database::v1::CreateDatabaseRequest const& request) override;
   StatusOr<google::test::admin::database::v1::Database> GetDatabase(
     grpc::ClientContext& context,
     google::test::admin::database::v1::GetDatabaseRequest const& request) override;
 
-  StatusOr<google::longrunning::Operation> UpdateDatabaseDdl(
-    grpc::ClientContext& context,
-    google::test::admin::database::v1::UpdateDatabaseDdlRequest const& request) override;
 
+  future<StatusOr<google::longrunning::Operation>> AsyncUpdateDatabaseDdl(
+      google::cloud::CompletionQueue& cq,
+      std::unique_ptr<grpc::ClientContext> context,
+      google::test::admin::database::v1::UpdateDatabaseDdlRequest const& request) override;
   Status DropDatabase(
     grpc::ClientContext& context,
     google::test::admin::database::v1::DropDatabaseRequest const& request) override;
@@ -74,10 +76,11 @@ class GoldenThingAdminLogging : public GoldenThingAdminStub {
     grpc::ClientContext& context,
     google::iam::v1::TestIamPermissionsRequest const& request) override;
 
-  StatusOr<google::longrunning::Operation> CreateBackup(
-    grpc::ClientContext& context,
-    google::test::admin::database::v1::CreateBackupRequest const& request) override;
 
+  future<StatusOr<google::longrunning::Operation>> AsyncCreateBackup(
+      google::cloud::CompletionQueue& cq,
+      std::unique_ptr<grpc::ClientContext> context,
+      google::test::admin::database::v1::CreateBackupRequest const& request) override;
   StatusOr<google::test::admin::database::v1::Backup> GetBackup(
     grpc::ClientContext& context,
     google::test::admin::database::v1::GetBackupRequest const& request) override;
@@ -94,10 +97,11 @@ class GoldenThingAdminLogging : public GoldenThingAdminStub {
     grpc::ClientContext& context,
     google::test::admin::database::v1::ListBackupsRequest const& request) override;
 
-  StatusOr<google::longrunning::Operation> RestoreDatabase(
-    grpc::ClientContext& context,
-    google::test::admin::database::v1::RestoreDatabaseRequest const& request) override;
 
+  future<StatusOr<google::longrunning::Operation>> AsyncRestoreDatabase(
+      google::cloud::CompletionQueue& cq,
+      std::unique_ptr<grpc::ClientContext> context,
+      google::test::admin::database::v1::RestoreDatabaseRequest const& request) override;
   StatusOr<google::test::admin::database::v1::ListDatabaseOperationsResponse> ListDatabaseOperations(
     grpc::ClientContext& context,
     google::test::admin::database::v1::ListDatabaseOperationsRequest const& request) override;
@@ -106,16 +110,16 @@ class GoldenThingAdminLogging : public GoldenThingAdminStub {
     grpc::ClientContext& context,
     google::test::admin::database::v1::ListBackupOperationsRequest const& request) override;
 
-  /// Poll a long-running operation.
-  StatusOr<google::longrunning::Operation> GetOperation(
-      grpc::ClientContext& context,
-      google::longrunning::GetOperationRequest const& request) override;
 
-  /// Cancel a long-running operation.
-  Status CancelOperation(
-      grpc::ClientContext& context,
-      google::longrunning::CancelOperationRequest const& request) override;
+future<StatusOr<google::longrunning::Operation>> AsyncGetOperation(
+    google::cloud::CompletionQueue& cq,
+    std::unique_ptr<grpc::ClientContext> context,
+    google::longrunning::GetOperationRequest const& request) override;
 
+future<Status> AsyncCancelOperation(
+    google::cloud::CompletionQueue& cq,
+    std::unique_ptr<grpc::ClientContext> context,
+    google::longrunning::CancelOperationRequest const& request) override;
  private:
   std::shared_ptr<GoldenThingAdminStub> child_;
   TracingOptions tracing_options_;

--- a/generator/integration_tests/golden/internal/golden_thing_admin_metadata_decorator.cc
+++ b/generator/integration_tests/golden/internal/golden_thing_admin_metadata_decorator.cc
@@ -39,14 +39,14 @@ GoldenThingAdminMetadata::ListDatabases(
   return child_->ListDatabases(context, request);
 }
 
-StatusOr<google::longrunning::Operation>
-GoldenThingAdminMetadata::CreateDatabase(
-    grpc::ClientContext& context,
+future<StatusOr<google::longrunning::Operation>>
+GoldenThingAdminMetadata::AsyncCreateDatabase(
+    google::cloud::CompletionQueue& cq,
+    std::unique_ptr<grpc::ClientContext> context,
     google::test::admin::database::v1::CreateDatabaseRequest const& request) {
-  SetMetadata(context, "parent=" + request.parent());
-  return child_->CreateDatabase(context, request);
+  SetMetadata(*context, "parent=" + request.parent());
+  return child_->AsyncCreateDatabase(cq, std::move(context), request);
 }
-
 StatusOr<google::test::admin::database::v1::Database>
 GoldenThingAdminMetadata::GetDatabase(
     grpc::ClientContext& context,
@@ -55,14 +55,14 @@ GoldenThingAdminMetadata::GetDatabase(
   return child_->GetDatabase(context, request);
 }
 
-StatusOr<google::longrunning::Operation>
-GoldenThingAdminMetadata::UpdateDatabaseDdl(
-    grpc::ClientContext& context,
+future<StatusOr<google::longrunning::Operation>>
+GoldenThingAdminMetadata::AsyncUpdateDatabaseDdl(
+    google::cloud::CompletionQueue& cq,
+    std::unique_ptr<grpc::ClientContext> context,
     google::test::admin::database::v1::UpdateDatabaseDdlRequest const& request) {
-  SetMetadata(context, "database=" + request.database());
-  return child_->UpdateDatabaseDdl(context, request);
+  SetMetadata(*context, "database=" + request.database());
+  return child_->AsyncUpdateDatabaseDdl(cq, std::move(context), request);
 }
-
 Status
 GoldenThingAdminMetadata::DropDatabase(
     grpc::ClientContext& context,
@@ -103,14 +103,14 @@ GoldenThingAdminMetadata::TestIamPermissions(
   return child_->TestIamPermissions(context, request);
 }
 
-StatusOr<google::longrunning::Operation>
-GoldenThingAdminMetadata::CreateBackup(
-    grpc::ClientContext& context,
+future<StatusOr<google::longrunning::Operation>>
+GoldenThingAdminMetadata::AsyncCreateBackup(
+    google::cloud::CompletionQueue& cq,
+    std::unique_ptr<grpc::ClientContext> context,
     google::test::admin::database::v1::CreateBackupRequest const& request) {
-  SetMetadata(context, "parent=" + request.parent());
-  return child_->CreateBackup(context, request);
+  SetMetadata(*context, "parent=" + request.parent());
+  return child_->AsyncCreateBackup(cq, std::move(context), request);
 }
-
 StatusOr<google::test::admin::database::v1::Backup>
 GoldenThingAdminMetadata::GetBackup(
     grpc::ClientContext& context,
@@ -143,14 +143,14 @@ GoldenThingAdminMetadata::ListBackups(
   return child_->ListBackups(context, request);
 }
 
-StatusOr<google::longrunning::Operation>
-GoldenThingAdminMetadata::RestoreDatabase(
-    grpc::ClientContext& context,
+future<StatusOr<google::longrunning::Operation>>
+GoldenThingAdminMetadata::AsyncRestoreDatabase(
+    google::cloud::CompletionQueue& cq,
+    std::unique_ptr<grpc::ClientContext> context,
     google::test::admin::database::v1::RestoreDatabaseRequest const& request) {
-  SetMetadata(context, "parent=" + request.parent());
-  return child_->RestoreDatabase(context, request);
+  SetMetadata(*context, "parent=" + request.parent());
+  return child_->AsyncRestoreDatabase(cq, std::move(context), request);
 }
-
 StatusOr<google::test::admin::database::v1::ListDatabaseOperationsResponse>
 GoldenThingAdminMetadata::ListDatabaseOperations(
     grpc::ClientContext& context,
@@ -167,18 +167,21 @@ GoldenThingAdminMetadata::ListBackupOperations(
   return child_->ListBackupOperations(context, request);
 }
 
-StatusOr<google::longrunning::Operation> GoldenThingAdminMetadata::GetOperation(
-    grpc::ClientContext& context,
+future<StatusOr<google::longrunning::Operation>>
+GoldenThingAdminMetadata::AsyncGetOperation(
+    google::cloud::CompletionQueue& cq,
+    std::unique_ptr<grpc::ClientContext> context,
     google::longrunning::GetOperationRequest const& request) {
-  SetMetadata(context, "name=" + request.name());
-  return child_->GetOperation(context, request);
+  SetMetadata(*context, "name=" + request.name());
+  return child_->AsyncGetOperation(cq, std::move(context), request);
 }
 
-Status GoldenThingAdminMetadata::CancelOperation(
-    grpc::ClientContext& context,
+future<Status> GoldenThingAdminMetadata::AsyncCancelOperation(
+    google::cloud::CompletionQueue& cq,
+    std::unique_ptr<grpc::ClientContext> context,
     google::longrunning::CancelOperationRequest const& request) {
-  SetMetadata(context, "name=" + request.name());
-  return child_->CancelOperation(context, request);
+  SetMetadata(*context, "name=" + request.name());
+  return child_->AsyncCancelOperation(cq, std::move(context), request);
 }
 
 void GoldenThingAdminMetadata::SetMetadata(grpc::ClientContext& context,

--- a/generator/integration_tests/golden/internal/golden_thing_admin_metadata_decorator.h
+++ b/generator/integration_tests/golden/internal/golden_thing_admin_metadata_decorator.h
@@ -38,18 +38,20 @@ class GoldenThingAdminMetadata : public GoldenThingAdminStub {
     grpc::ClientContext& context,
     google::test::admin::database::v1::ListDatabasesRequest const& request) override;
 
-  StatusOr<google::longrunning::Operation> CreateDatabase(
-    grpc::ClientContext& context,
-    google::test::admin::database::v1::CreateDatabaseRequest const& request) override;
 
+  future<StatusOr<google::longrunning::Operation>> AsyncCreateDatabase(
+      google::cloud::CompletionQueue& cq,
+      std::unique_ptr<grpc::ClientContext> context,
+      google::test::admin::database::v1::CreateDatabaseRequest const& request) override;
   StatusOr<google::test::admin::database::v1::Database> GetDatabase(
     grpc::ClientContext& context,
     google::test::admin::database::v1::GetDatabaseRequest const& request) override;
 
-  StatusOr<google::longrunning::Operation> UpdateDatabaseDdl(
-    grpc::ClientContext& context,
-    google::test::admin::database::v1::UpdateDatabaseDdlRequest const& request) override;
 
+  future<StatusOr<google::longrunning::Operation>> AsyncUpdateDatabaseDdl(
+      google::cloud::CompletionQueue& cq,
+      std::unique_ptr<grpc::ClientContext> context,
+      google::test::admin::database::v1::UpdateDatabaseDdlRequest const& request) override;
   Status DropDatabase(
     grpc::ClientContext& context,
     google::test::admin::database::v1::DropDatabaseRequest const& request) override;
@@ -70,10 +72,11 @@ class GoldenThingAdminMetadata : public GoldenThingAdminStub {
     grpc::ClientContext& context,
     google::iam::v1::TestIamPermissionsRequest const& request) override;
 
-  StatusOr<google::longrunning::Operation> CreateBackup(
-    grpc::ClientContext& context,
-    google::test::admin::database::v1::CreateBackupRequest const& request) override;
 
+  future<StatusOr<google::longrunning::Operation>> AsyncCreateBackup(
+      google::cloud::CompletionQueue& cq,
+      std::unique_ptr<grpc::ClientContext> context,
+      google::test::admin::database::v1::CreateBackupRequest const& request) override;
   StatusOr<google::test::admin::database::v1::Backup> GetBackup(
     grpc::ClientContext& context,
     google::test::admin::database::v1::GetBackupRequest const& request) override;
@@ -90,10 +93,11 @@ class GoldenThingAdminMetadata : public GoldenThingAdminStub {
     grpc::ClientContext& context,
     google::test::admin::database::v1::ListBackupsRequest const& request) override;
 
-  StatusOr<google::longrunning::Operation> RestoreDatabase(
-    grpc::ClientContext& context,
-    google::test::admin::database::v1::RestoreDatabaseRequest const& request) override;
 
+  future<StatusOr<google::longrunning::Operation>> AsyncRestoreDatabase(
+      google::cloud::CompletionQueue& cq,
+      std::unique_ptr<grpc::ClientContext> context,
+      google::test::admin::database::v1::RestoreDatabaseRequest const& request) override;
   StatusOr<google::test::admin::database::v1::ListDatabaseOperationsResponse> ListDatabaseOperations(
     grpc::ClientContext& context,
     google::test::admin::database::v1::ListDatabaseOperationsRequest const& request) override;
@@ -102,16 +106,16 @@ class GoldenThingAdminMetadata : public GoldenThingAdminStub {
     grpc::ClientContext& context,
     google::test::admin::database::v1::ListBackupOperationsRequest const& request) override;
 
-  /// Poll a long-running operation.
-  StatusOr<google::longrunning::Operation> GetOperation(
-      grpc::ClientContext& context,
+
+  future<StatusOr<google::longrunning::Operation>> AsyncGetOperation(
+      google::cloud::CompletionQueue& cq,
+      std::unique_ptr<grpc::ClientContext> context,
       google::longrunning::GetOperationRequest const& request) override;
 
-  /// Cancel a long-running operation.
-  Status CancelOperation(
-      grpc::ClientContext& context,
+  future<Status> AsyncCancelOperation(
+      google::cloud::CompletionQueue& cq,
+      std::unique_ptr<grpc::ClientContext> context,
       google::longrunning::CancelOperationRequest const& request) override;
-
  private:
   void SetMetadata(grpc::ClientContext& context,
                    std::string const& request_params);

--- a/generator/integration_tests/golden/internal/golden_thing_admin_stub.cc
+++ b/generator/integration_tests/golden/internal/golden_thing_admin_stub.cc
@@ -43,19 +43,20 @@ DefaultGoldenThingAdminStub::ListDatabases(
     return response;
 }
 
-StatusOr<google::longrunning::Operation>
-DefaultGoldenThingAdminStub::CreateDatabase(
-  grpc::ClientContext& client_context,
-  google::test::admin::database::v1::CreateDatabaseRequest const& request) {
-    google::longrunning::Operation response;
-    auto status =
-        grpc_stub_->CreateDatabase(&client_context, request, &response);
-    if (!status.ok()) {
-      return google::cloud::MakeStatusFromRpcError(status);
-    }
-    return response;
-}
 
+future<StatusOr<google::longrunning::Operation>>
+DefaultGoldenThingAdminStub::AsyncCreateDatabase(
+      google::cloud::CompletionQueue& cq,
+      std::unique_ptr<grpc::ClientContext> context,
+      google::test::admin::database::v1::CreateDatabaseRequest const& request) {
+  return cq.MakeUnaryRpc(
+      [this](grpc::ClientContext* context,
+             google::test::admin::database::v1::CreateDatabaseRequest const& request,
+             grpc::CompletionQueue* cq) {
+        return grpc_stub_->AsyncCreateDatabase(context, request, cq);
+      },
+      request, std::move(context));
+}
 StatusOr<google::test::admin::database::v1::Database>
 DefaultGoldenThingAdminStub::GetDatabase(
   grpc::ClientContext& client_context,
@@ -69,19 +70,20 @@ DefaultGoldenThingAdminStub::GetDatabase(
     return response;
 }
 
-StatusOr<google::longrunning::Operation>
-DefaultGoldenThingAdminStub::UpdateDatabaseDdl(
-  grpc::ClientContext& client_context,
-  google::test::admin::database::v1::UpdateDatabaseDdlRequest const& request) {
-    google::longrunning::Operation response;
-    auto status =
-        grpc_stub_->UpdateDatabaseDdl(&client_context, request, &response);
-    if (!status.ok()) {
-      return google::cloud::MakeStatusFromRpcError(status);
-    }
-    return response;
-}
 
+future<StatusOr<google::longrunning::Operation>>
+DefaultGoldenThingAdminStub::AsyncUpdateDatabaseDdl(
+      google::cloud::CompletionQueue& cq,
+      std::unique_ptr<grpc::ClientContext> context,
+      google::test::admin::database::v1::UpdateDatabaseDdlRequest const& request) {
+  return cq.MakeUnaryRpc(
+      [this](grpc::ClientContext* context,
+             google::test::admin::database::v1::UpdateDatabaseDdlRequest const& request,
+             grpc::CompletionQueue* cq) {
+        return grpc_stub_->AsyncUpdateDatabaseDdl(context, request, cq);
+      },
+      request, std::move(context));
+}
 Status
 DefaultGoldenThingAdminStub::DropDatabase(
   grpc::ClientContext& client_context,
@@ -147,19 +149,20 @@ DefaultGoldenThingAdminStub::TestIamPermissions(
     return response;
 }
 
-StatusOr<google::longrunning::Operation>
-DefaultGoldenThingAdminStub::CreateBackup(
-  grpc::ClientContext& client_context,
-  google::test::admin::database::v1::CreateBackupRequest const& request) {
-    google::longrunning::Operation response;
-    auto status =
-        grpc_stub_->CreateBackup(&client_context, request, &response);
-    if (!status.ok()) {
-      return google::cloud::MakeStatusFromRpcError(status);
-    }
-    return response;
-}
 
+future<StatusOr<google::longrunning::Operation>>
+DefaultGoldenThingAdminStub::AsyncCreateBackup(
+      google::cloud::CompletionQueue& cq,
+      std::unique_ptr<grpc::ClientContext> context,
+      google::test::admin::database::v1::CreateBackupRequest const& request) {
+  return cq.MakeUnaryRpc(
+      [this](grpc::ClientContext* context,
+             google::test::admin::database::v1::CreateBackupRequest const& request,
+             grpc::CompletionQueue* cq) {
+        return grpc_stub_->AsyncCreateBackup(context, request, cq);
+      },
+      request, std::move(context));
+}
 StatusOr<google::test::admin::database::v1::Backup>
 DefaultGoldenThingAdminStub::GetBackup(
   grpc::ClientContext& client_context,
@@ -212,19 +215,20 @@ DefaultGoldenThingAdminStub::ListBackups(
     return response;
 }
 
-StatusOr<google::longrunning::Operation>
-DefaultGoldenThingAdminStub::RestoreDatabase(
-  grpc::ClientContext& client_context,
-  google::test::admin::database::v1::RestoreDatabaseRequest const& request) {
-    google::longrunning::Operation response;
-    auto status =
-        grpc_stub_->RestoreDatabase(&client_context, request, &response);
-    if (!status.ok()) {
-      return google::cloud::MakeStatusFromRpcError(status);
-    }
-    return response;
-}
 
+future<StatusOr<google::longrunning::Operation>>
+DefaultGoldenThingAdminStub::AsyncRestoreDatabase(
+      google::cloud::CompletionQueue& cq,
+      std::unique_ptr<grpc::ClientContext> context,
+      google::test::admin::database::v1::RestoreDatabaseRequest const& request) {
+  return cq.MakeUnaryRpc(
+      [this](grpc::ClientContext* context,
+             google::test::admin::database::v1::RestoreDatabaseRequest const& request,
+             grpc::CompletionQueue* cq) {
+        return grpc_stub_->AsyncRestoreDatabase(context, request, cq);
+      },
+      request, std::move(context));
+}
 StatusOr<google::test::admin::database::v1::ListDatabaseOperationsResponse>
 DefaultGoldenThingAdminStub::ListDatabaseOperations(
   grpc::ClientContext& client_context,
@@ -251,31 +255,36 @@ DefaultGoldenThingAdminStub::ListBackupOperations(
     return response;
 }
 
-/// Poll a long-running operation.
-StatusOr<google::longrunning::Operation>
-DefaultGoldenThingAdminStub::GetOperation(
-    grpc::ClientContext& client_context,
+future<StatusOr<google::longrunning::Operation>>
+DefaultGoldenThingAdminStub::AsyncGetOperation(
+    google::cloud::CompletionQueue& cq,
+    std::unique_ptr<grpc::ClientContext> context,
     google::longrunning::GetOperationRequest const& request) {
-  google::longrunning::Operation response;
-  grpc::Status status =
-      operations_->GetOperation(&client_context, request, &response);
-  if (!status.ok()) {
-    return google::cloud::MakeStatusFromRpcError(status);
-  }
-  return response;
+  return cq.MakeUnaryRpc(
+      [this](grpc::ClientContext* context,
+             google::longrunning::GetOperationRequest const& request,
+             grpc::CompletionQueue* cq) {
+        return operations_->AsyncGetOperation(context, request, cq);
+      },
+      request, std::move(context));
 }
-/// Cancel a long-running operation.
-Status DefaultGoldenThingAdminStub::CancelOperation(
-    grpc::ClientContext& client_context,
+
+future<Status> DefaultGoldenThingAdminStub::AsyncCancelOperation(
+    google::cloud::CompletionQueue& cq,
+    std::unique_ptr<grpc::ClientContext> context,
     google::longrunning::CancelOperationRequest const& request) {
-  google::protobuf::Empty response;
-  grpc::Status status =
-      operations_->CancelOperation(&client_context, request, &response);
-  if (!status.ok()) {
-    return google::cloud::MakeStatusFromRpcError(status);
-  }
-  return google::cloud::Status();
+  return cq.MakeUnaryRpc(
+      [this](grpc::ClientContext* context,
+             google::longrunning::CancelOperationRequest const& request,
+             grpc::CompletionQueue* cq) {
+        return operations_->AsyncCancelOperation(context, request, cq);
+      },
+      request, std::move(context))
+      .then([](future<StatusOr<google::protobuf::Empty>> f) {
+        return f.get().status();
+      });
 }
+
 }  // namespace GOOGLE_CLOUD_CPP_GENERATED_NS
 }  // namespace golden_internal
 }  // namespace cloud

--- a/generator/integration_tests/golden/internal/golden_thing_admin_stub.h
+++ b/generator/integration_tests/golden/internal/golden_thing_admin_stub.h
@@ -18,6 +18,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_INTERNAL_GOLDEN_THING_ADMIN_STUB_H
 #define GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_INTERNAL_GOLDEN_THING_ADMIN_STUB_H
 
+#include "google/cloud/completion_queue.h"
+#include "google/cloud/future.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include <generator/integration_tests/test.grpc.pb.h>
@@ -37,17 +39,21 @@ class GoldenThingAdminStub {
     grpc::ClientContext& context,
     google::test::admin::database::v1::ListDatabasesRequest const& request) = 0;
 
-  virtual StatusOr<google::longrunning::Operation> CreateDatabase(
-    grpc::ClientContext& context,
-    google::test::admin::database::v1::CreateDatabaseRequest const& request) = 0;
+
+  virtual future<StatusOr<google::longrunning::Operation>> AsyncCreateDatabase(
+      google::cloud::CompletionQueue& cq,
+      std::unique_ptr<grpc::ClientContext> context,
+      google::test::admin::database::v1::CreateDatabaseRequest const& request) = 0;
 
   virtual StatusOr<google::test::admin::database::v1::Database> GetDatabase(
     grpc::ClientContext& context,
     google::test::admin::database::v1::GetDatabaseRequest const& request) = 0;
 
-  virtual StatusOr<google::longrunning::Operation> UpdateDatabaseDdl(
-    grpc::ClientContext& context,
-    google::test::admin::database::v1::UpdateDatabaseDdlRequest const& request) = 0;
+
+  virtual future<StatusOr<google::longrunning::Operation>> AsyncUpdateDatabaseDdl(
+      google::cloud::CompletionQueue& cq,
+      std::unique_ptr<grpc::ClientContext> context,
+      google::test::admin::database::v1::UpdateDatabaseDdlRequest const& request) = 0;
 
   virtual Status DropDatabase(
     grpc::ClientContext& context,
@@ -69,9 +75,11 @@ class GoldenThingAdminStub {
     grpc::ClientContext& context,
     google::iam::v1::TestIamPermissionsRequest const& request) = 0;
 
-  virtual StatusOr<google::longrunning::Operation> CreateBackup(
-    grpc::ClientContext& context,
-    google::test::admin::database::v1::CreateBackupRequest const& request) = 0;
+
+  virtual future<StatusOr<google::longrunning::Operation>> AsyncCreateBackup(
+      google::cloud::CompletionQueue& cq,
+      std::unique_ptr<grpc::ClientContext> context,
+      google::test::admin::database::v1::CreateBackupRequest const& request) = 0;
 
   virtual StatusOr<google::test::admin::database::v1::Backup> GetBackup(
     grpc::ClientContext& context,
@@ -89,9 +97,11 @@ class GoldenThingAdminStub {
     grpc::ClientContext& context,
     google::test::admin::database::v1::ListBackupsRequest const& request) = 0;
 
-  virtual StatusOr<google::longrunning::Operation> RestoreDatabase(
-    grpc::ClientContext& context,
-    google::test::admin::database::v1::RestoreDatabaseRequest const& request) = 0;
+
+  virtual future<StatusOr<google::longrunning::Operation>> AsyncRestoreDatabase(
+      google::cloud::CompletionQueue& cq,
+      std::unique_ptr<grpc::ClientContext> context,
+      google::test::admin::database::v1::RestoreDatabaseRequest const& request) = 0;
 
   virtual StatusOr<google::test::admin::database::v1::ListDatabaseOperationsResponse> ListDatabaseOperations(
     grpc::ClientContext& context,
@@ -101,16 +111,16 @@ class GoldenThingAdminStub {
     grpc::ClientContext& context,
     google::test::admin::database::v1::ListBackupOperationsRequest const& request) = 0;
 
-  /// Poll a long-running operation.
-  virtual StatusOr<google::longrunning::Operation> GetOperation(
-      grpc::ClientContext& client_context,
+
+  virtual future<StatusOr<google::longrunning::Operation>> AsyncGetOperation(
+      google::cloud::CompletionQueue& cq,
+      std::unique_ptr<grpc::ClientContext> context,
       google::longrunning::GetOperationRequest const& request) = 0;
 
-  /// Cancel a long-running operation.
-  virtual Status CancelOperation(
-      grpc::ClientContext& client_context,
+  virtual future<Status> AsyncCancelOperation(
+      google::cloud::CompletionQueue& cq,
+      std::unique_ptr<grpc::ClientContext> context,
       google::longrunning::CancelOperationRequest const& request) = 0;
-
 };
 
 class DefaultGoldenThingAdminStub : public GoldenThingAdminStub {
@@ -126,21 +136,21 @@ class DefaultGoldenThingAdminStub : public GoldenThingAdminStub {
     grpc::ClientContext& client_context,
     google::test::admin::database::v1::ListDatabasesRequest const& request) override;
 
-  StatusOr<google::longrunning::Operation>
-  CreateDatabase(
-    grpc::ClientContext& client_context,
-    google::test::admin::database::v1::CreateDatabaseRequest const& request) override;
 
+  future<StatusOr<google::longrunning::Operation>> AsyncCreateDatabase(
+      google::cloud::CompletionQueue& cq,
+      std::unique_ptr<grpc::ClientContext> context,
+      google::test::admin::database::v1::CreateDatabaseRequest const& request) override;
   StatusOr<google::test::admin::database::v1::Database>
   GetDatabase(
     grpc::ClientContext& client_context,
     google::test::admin::database::v1::GetDatabaseRequest const& request) override;
 
-  StatusOr<google::longrunning::Operation>
-  UpdateDatabaseDdl(
-    grpc::ClientContext& client_context,
-    google::test::admin::database::v1::UpdateDatabaseDdlRequest const& request) override;
 
+  future<StatusOr<google::longrunning::Operation>> AsyncUpdateDatabaseDdl(
+      google::cloud::CompletionQueue& cq,
+      std::unique_ptr<grpc::ClientContext> context,
+      google::test::admin::database::v1::UpdateDatabaseDdlRequest const& request) override;
   Status
   DropDatabase(
     grpc::ClientContext& client_context,
@@ -166,11 +176,11 @@ class DefaultGoldenThingAdminStub : public GoldenThingAdminStub {
     grpc::ClientContext& client_context,
     google::iam::v1::TestIamPermissionsRequest const& request) override;
 
-  StatusOr<google::longrunning::Operation>
-  CreateBackup(
-    grpc::ClientContext& client_context,
-    google::test::admin::database::v1::CreateBackupRequest const& request) override;
 
+  future<StatusOr<google::longrunning::Operation>> AsyncCreateBackup(
+      google::cloud::CompletionQueue& cq,
+      std::unique_ptr<grpc::ClientContext> context,
+      google::test::admin::database::v1::CreateBackupRequest const& request) override;
   StatusOr<google::test::admin::database::v1::Backup>
   GetBackup(
     grpc::ClientContext& client_context,
@@ -191,11 +201,11 @@ class DefaultGoldenThingAdminStub : public GoldenThingAdminStub {
     grpc::ClientContext& client_context,
     google::test::admin::database::v1::ListBackupsRequest const& request) override;
 
-  StatusOr<google::longrunning::Operation>
-  RestoreDatabase(
-    grpc::ClientContext& client_context,
-    google::test::admin::database::v1::RestoreDatabaseRequest const& request) override;
 
+  future<StatusOr<google::longrunning::Operation>> AsyncRestoreDatabase(
+      google::cloud::CompletionQueue& cq,
+      std::unique_ptr<grpc::ClientContext> context,
+      google::test::admin::database::v1::RestoreDatabaseRequest const& request) override;
   StatusOr<google::test::admin::database::v1::ListDatabaseOperationsResponse>
   ListDatabaseOperations(
     grpc::ClientContext& client_context,
@@ -206,16 +216,16 @@ class DefaultGoldenThingAdminStub : public GoldenThingAdminStub {
     grpc::ClientContext& client_context,
     google::test::admin::database::v1::ListBackupOperationsRequest const& request) override;
 
-  /// Poll a long-running operation.
-  StatusOr<google::longrunning::Operation> GetOperation(
-      grpc::ClientContext& client_context,
+
+  future<StatusOr<google::longrunning::Operation>> AsyncGetOperation(
+      google::cloud::CompletionQueue& cq,
+      std::unique_ptr<grpc::ClientContext> context,
       google::longrunning::GetOperationRequest const& request) override;
 
-  /// Cancel a long-running operation.
-  Status CancelOperation(
-      grpc::ClientContext& client_context,
+  future<Status> AsyncCancelOperation(
+      google::cloud::CompletionQueue& cq,
+      std::unique_ptr<grpc::ClientContext> context,
       google::longrunning::CancelOperationRequest const& request) override;
-
  private:
   std::unique_ptr<google::test::admin::database::v1::GoldenThingAdmin::StubInterface> grpc_stub_;
   std::unique_ptr<google::longrunning::Operations::StubInterface> operations_;

--- a/generator/integration_tests/golden/mocks/mock_golden_thing_admin_stub.h
+++ b/generator/integration_tests/golden/mocks/mock_golden_thing_admin_stub.h
@@ -35,8 +35,9 @@ class MockGoldenThingAdminStub
        ::google::test::admin::database::v1::ListDatabasesRequest const&),
       (override));
   MOCK_METHOD(
-      StatusOr<::google::longrunning::Operation>, CreateDatabase,
-      (grpc::ClientContext&,
+      future<StatusOr<::google::longrunning::Operation>>, AsyncCreateDatabase,
+      (google::cloud::CompletionQueue&,
+       std::unique_ptr<grpc::ClientContext>,
        ::google::test::admin::database::v1::CreateDatabaseRequest const&),
       (override));
   MOCK_METHOD(StatusOr<::google::test::admin::database::v1::Database>,
@@ -45,8 +46,9 @@ class MockGoldenThingAdminStub
                ::google::test::admin::database::v1::GetDatabaseRequest const&),
               (override));
   MOCK_METHOD(
-      StatusOr<::google::longrunning::Operation>, UpdateDatabaseDdl,
-      (grpc::ClientContext&,
+      future<StatusOr<::google::longrunning::Operation>>, AsyncUpdateDatabaseDdl,
+      (google::cloud::CompletionQueue&,
+          std::unique_ptr<grpc::ClientContext>,
        ::google::test::admin::database::v1::UpdateDatabaseDdlRequest const&),
       (override));
   MOCK_METHOD(Status, DropDatabase,
@@ -72,8 +74,9 @@ class MockGoldenThingAdminStub
               (grpc::ClientContext&,
                ::google::iam::v1::TestIamPermissionsRequest const&),
               (override));
-  MOCK_METHOD(StatusOr<::google::longrunning::Operation>, CreateBackup,
-              (grpc::ClientContext&,
+  MOCK_METHOD(future<StatusOr<::google::longrunning::Operation>>, AsyncCreateBackup,
+              (google::cloud::CompletionQueue&,
+                  std::unique_ptr<grpc::ClientContext>,
                ::google::test::admin::database::v1::CreateBackupRequest const&),
               (override));
   MOCK_METHOD(StatusOr<::google::test::admin::database::v1::Backup>, GetBackup,
@@ -96,8 +99,9 @@ class MockGoldenThingAdminStub
        ::google::test::admin::database::v1::ListBackupsRequest const&),
       (override));
   MOCK_METHOD(
-      StatusOr<::google::longrunning::Operation>, RestoreDatabase,
-      (grpc::ClientContext&,
+      future<StatusOr<::google::longrunning::Operation>>, AsyncRestoreDatabase,
+      (google::cloud::CompletionQueue&,
+          std::unique_ptr<grpc::ClientContext>,
        ::google::test::admin::database::v1::RestoreDatabaseRequest const&),
       (override));
   MOCK_METHOD(
@@ -115,13 +119,17 @@ class MockGoldenThingAdminStub
       (grpc::ClientContext&,
        ::google::test::admin::database::v1::ListBackupOperationsRequest const&),
       (override));
-  MOCK_METHOD(StatusOr<google::longrunning::Operation>, GetOperation,
-              (grpc::ClientContext&,
+
+  MOCK_METHOD(future<StatusOr<google::longrunning::Operation>>, AsyncGetOperation,
+              (google::cloud::CompletionQueue&,
+                  std::unique_ptr<grpc::ClientContext>,
                google::longrunning::GetOperationRequest const&),
               (override));
-  MOCK_METHOD(Status, CancelOperation,
-              (grpc::ClientContext&,
-               google::longrunning::CancelOperationRequest const&),
+
+  MOCK_METHOD(future<Status>, AsyncCancelOperation,
+              (google::cloud::CompletionQueue&,
+                  std::unique_ptr<grpc::ClientContext>,
+                  google::longrunning::CancelOperationRequest const&),
               (override));
 };
 

--- a/generator/integration_tests/golden/tests/golden_thing_admin_connection_test.cc
+++ b/generator/integration_tests/golden/tests/golden_thing_admin_connection_test.cc
@@ -324,7 +324,7 @@ TEST(GoldenThingAdminClientTest, UpdateDatabaseDdlCancel) {
   EXPECT_CALL(*mock, AsyncUpdateDatabaseDdl)
       .WillOnce([&](CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
                     ::google::test::admin::database::v1::
-                    UpdateDatabaseDdlRequest const&) {
+                        UpdateDatabaseDdlRequest const&) {
         return make_ready_future(make_status_or(op));
       });
 
@@ -660,11 +660,11 @@ TEST(GoldenThingAdminClientTest, CreateBackupCancel) {
   auto const op = CreateStartingOperation();
   auto mock = std::make_shared<MockGoldenThingAdminStub>();
   EXPECT_CALL(*mock, AsyncCreateBackup)
-      .WillOnce([&](CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
-                    ::google::test::admin::database::v1::
-                    CreateBackupRequest const&) {
-        return make_ready_future(make_status_or(op));
-      });
+      .WillOnce(
+          [&](CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
+              ::google::test::admin::database::v1::CreateBackupRequest const&) {
+            return make_ready_future(make_status_or(op));
+          });
 
   AsyncSequencer<StatusOr<google::longrunning::Operation>> get;
   EXPECT_CALL(*mock, AsyncGetOperation)
@@ -968,7 +968,7 @@ TEST(GoldenThingAdminClientTest, RestoreBackupCancel) {
   EXPECT_CALL(*mock, AsyncRestoreDatabase)
       .WillOnce([&](CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
                     ::google::test::admin::database::v1::
-                    RestoreDatabaseRequest const&) {
+                        RestoreDatabaseRequest const&) {
         return make_ready_future(make_status_or(op));
       });
 

--- a/generator/integration_tests/golden/tests/golden_thing_admin_stub_factory_test.cc
+++ b/generator/integration_tests/golden/tests/golden_thing_admin_stub_factory_test.cc
@@ -26,7 +26,7 @@ inline namespace GOOGLE_CLOUD_CPP_GENERATED_NS {
 namespace {
 
 using ::google::cloud::testing_util::IsOk;
-using ::google::longrunning::CancelOperationRequest;
+using ::google::test::admin::database::v1::GetBackupRequest;
 using ::testing::HasSubstr;
 using ::testing::IsEmpty;
 using ::testing::IsNull;
@@ -64,8 +64,7 @@ TEST_F(GoldenStubFactoryTest, DefaultStubWithAuth) {
   auto default_stub =
       CreateDefaultGoldenThingAdminStub(CompletionQueue{}, options);
   grpc::ClientContext context;
-  auto response =
-      default_stub->CancelOperation(context, CancelOperationRequest{});
+  auto response = default_stub->GetBackup(context, GetBackupRequest{});
   EXPECT_THAT(response, Not(IsOk()));
   EXPECT_THAT(context.credentials(), Not(IsNull()));
 }


### PR DESCRIPTION
For long-running operations we need to generate three different RPCs:
one to start the operation (e.g. `CreateDatabase()`), one to poll the
operation (`GetOperation()`), and one to cancel the operation
(`CancelOperation()`).  With this change all the three RPCs are
generated as asynchronous RPCs.

The `*Connection` class can use these asynchronous RPCs in the
background, using the background threads. This (1) avoids creating a
detached thread to poll the operation, (2) uses code that is more easily
unit tested separate from the generated libraries.

Fixes #6821

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6830)
<!-- Reviewable:end -->
