### PR TITLE
feat(common): cancel long-running operations

### DIFF
--- a/google/cloud/internal/async_polling_loop_test.cc
+++ b/google/cloud/internal/async_polling_loop_test.cc
@@ -395,8 +395,9 @@ TEST(AsyncPollingLoopTest, PollThenCancelDuringTimer) {
 
   timer_sequencer.PopFront().set_value(std::chrono::system_clock::now());
   get_sequencer.PopFront().set_value(starting_op);
+  auto t = timer_sequencer.PopFront();
   pending.cancel();
-  timer_sequencer.PopFront().set_value(std::chrono::system_clock::now());
+  t.set_value(std::chrono::system_clock::now());
 
   auto actual = pending.get();
   EXPECT_THAT(actual, StatusIs(Not(Eq(StatusCode::kOk)),
@@ -449,8 +450,9 @@ TEST(AsyncPollingLoopTest, PollThenCancelDuringPoll) {
   timer_sequencer.PopFront().set_value(std::chrono::system_clock::now());
   get_sequencer.PopFront().set_value(starting_op);
   timer_sequencer.PopFront().set_value(std::chrono::system_clock::now());
+  auto g = get_sequencer.PopFront();
   pending.cancel();
-  get_sequencer.PopFront().set_value(starting_op);
+  g.set_value(starting_op);
 
   auto actual = pending.get();
   EXPECT_THAT(actual, StatusIs(Not(Eq(StatusCode::kOk)),


### PR DESCRIPTION
This time for realsies, I need to return the future created by
`AsyncPollingLoop()` because this is where the cancel callback is
initialized.

Part of the work for #6821

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6831)
<!-- Reviewable:end -->
