### PR TITLE
test(storage): tune bucket creation

### DIFF
--- a/google/cloud/storage/tests/bucket_integration_test.cc
+++ b/google/cloud/storage/tests/bucket_integration_test.cc
@@ -458,7 +458,7 @@ TEST_F(BucketIntegrationTest, GetMetadataFields) {
 }
 
 TEST_F(BucketIntegrationTest, GetMetadataIfMetagenerationMatchSuccess) {
-  StatusOr<Client> client = MakeIntegrationTestClient();
+  StatusOr<Client> client = MakeBucketIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = MakeRandomBucketName();
@@ -483,7 +483,7 @@ TEST_F(BucketIntegrationTest, GetMetadataIfMetagenerationMatchSuccess) {
 }
 
 TEST_F(BucketIntegrationTest, GetMetadataIfMetagenerationNotMatchFailure) {
-  StatusOr<Client> client = MakeIntegrationTestClient();
+  StatusOr<Client> client = MakeBucketIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = MakeRandomBucketName();
@@ -873,7 +873,7 @@ TEST_F(BucketIntegrationTest, ListFailure) {
 }
 
 TEST_F(BucketIntegrationTest, CreateFailure) {
-  StatusOr<Client> client = MakeIntegrationTestClient();
+  StatusOr<Client> client = MakeBucketIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   // Try to create an invalid bucket (the name should not start with an
@@ -1110,7 +1110,7 @@ TEST_F(BucketIntegrationTest, DeleteDefaultAccessControlFailure) {
 
 TEST_F(BucketIntegrationTest, NativeIamWithRequestedPolicyVersion) {
   std::string bucket_name = MakeRandomBucketName();
-  StatusOr<Client> client = MakeIntegrationTestClient();
+  StatusOr<Client> client = MakeBucketIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   // Create a new bucket to run the test.

--- a/google/cloud/storage/tests/grpc_integration_test.cc
+++ b/google/cloud/storage/tests/grpc_integration_test.cc
@@ -397,12 +397,15 @@ TEST_P(GrpcIntegrationTest, NativeIamCRUD) {
 }
 
 TEST_P(GrpcIntegrationTest, WriteResume) {
+  auto bucket_client = MakeBucketIntegrationTestClient();
+  ASSERT_STATUS_OK(bucket_client);
+
   auto client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   auto bucket_name = MakeRandomBucketName();
   auto object_name = MakeRandomObjectName();
-  auto bucket_metadata = client->CreateBucketForProject(
+  auto bucket_metadata = bucket_client->CreateBucketForProject(
       bucket_name, project_id(), BucketMetadata());
   ASSERT_STATUS_OK(bucket_metadata);
 
@@ -438,7 +441,7 @@ TEST_P(GrpcIntegrationTest, WriteResume) {
   auto status = client->DeleteObject(bucket_name, object_name);
   EXPECT_STATUS_OK(status);
 
-  auto delete_bucket_status = client->DeleteBucket(bucket_name);
+  auto delete_bucket_status = bucket_client->DeleteBucket(bucket_name);
   EXPECT_STATUS_OK(delete_bucket_status);
 }
 

--- a/google/cloud/storage/tests/object_list_objects_versions_integration_test.cc
+++ b/google/cloud/storage/tests/object_list_objects_versions_integration_test.cc
@@ -37,11 +37,14 @@ using ObjectListObjectsVersionsIntegrationTest =
     ::google::cloud::storage::testing::ObjectIntegrationTest;
 
 TEST_F(ObjectListObjectsVersionsIntegrationTest, ListObjectsVersions) {
+  auto bucket_client = MakeBucketIntegrationTestClient();
+  ASSERT_STATUS_OK(bucket_client);
+
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = MakeRandomBucketName();
-  auto create = client->CreateBucketForProject(
+  auto create = bucket_client->CreateBucketForProject(
       bucket_name, project_id_,
       BucketMetadata{}.set_versioning(BucketVersioning{true}));
   ASSERT_STATUS_OK(create) << bucket_name;
@@ -78,7 +81,7 @@ TEST_F(ObjectListObjectsVersionsIntegrationTest, ListObjectsVersions) {
                                Generation(o->generation()));
   }
 
-  auto status = client->DeleteBucket(bucket_name);
+  auto status = bucket_client->DeleteBucket(bucket_name);
   ASSERT_STATUS_OK(status);
 }
 


### PR DESCRIPTION
A single project cannot create more than 1 bucket every 2 seconds. Some
of our integration tests (which do hit production) create buckets and
need a tuned client to backoff for at least 2 seconds on transient
problems.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6833)
<!-- Reviewable:end -->
