### PR TITLE
refactor(spanner): Use background threads for instance-admin LROs

### DIFF
--- a/google/cloud/spanner/instance_admin_connection.cc
+++ b/google/cloud/spanner/instance_admin_connection.cc
@@ -64,12 +64,10 @@ class InstanceAdminConnectionImpl : public InstanceAdminConnection {
       CreateInstanceParams p) override {
     auto stub = stub_;
     return google::cloud::internal::AsyncLongRunningOperation<gcsa::Instance>(
-        background_threads_->cq(), p.request,
-        [stub](
-            google::cloud::CompletionQueue& cq,
-            std::unique_ptr<grpc::ClientContext> context,
-            google::spanner::admin::instance::v1::CreateInstanceRequest const&
-                request) {
+        background_threads_->cq(), std::move(p.request),
+        [stub](google::cloud::CompletionQueue& cq,
+               std::unique_ptr<grpc::ClientContext> context,
+               gcsa::CreateInstanceRequest const& request) {
           return stub->AsyncCreateInstance(cq, std::move(context), request);
         },
         [stub](google::cloud::CompletionQueue& cq,
@@ -93,12 +91,10 @@ class InstanceAdminConnectionImpl : public InstanceAdminConnection {
       UpdateInstanceParams p) override {
     auto stub = stub_;
     return google::cloud::internal::AsyncLongRunningOperation<gcsa::Instance>(
-        background_threads_->cq(), p.request,
-        [stub](
-            google::cloud::CompletionQueue& cq,
-            std::unique_ptr<grpc::ClientContext> context,
-            google::spanner::admin::instance::v1::UpdateInstanceRequest const&
-                request) {
+        background_threads_->cq(), std::move(p.request),
+        [stub](google::cloud::CompletionQueue& cq,
+               std::unique_ptr<grpc::ClientContext> context,
+               gcsa::UpdateInstanceRequest const& request) {
           return stub->AsyncUpdateInstance(cq, std::move(context), request);
         },
         [stub](google::cloud::CompletionQueue& cq,

--- a/google/cloud/spanner/internal/instance_admin_logging.cc
+++ b/google/cloud/spanner/internal/instance_admin_logging.cc
@@ -34,24 +34,28 @@ StatusOr<gcsa::Instance> InstanceAdminLogging::GetInstance(
       context, request, __func__, tracing_options_);
 }
 
-StatusOr<google::longrunning::Operation> InstanceAdminLogging::CreateInstance(
-    grpc::ClientContext& context, gcsa::CreateInstanceRequest const& request) {
+future<StatusOr<google::longrunning::Operation>>
+InstanceAdminLogging::AsyncCreateInstance(
+    CompletionQueue& cq, std::unique_ptr<grpc::ClientContext> context,
+    gcsa::CreateInstanceRequest const& request) {
   return LogWrapper(
-      [this](grpc::ClientContext& context,
+      [this](CompletionQueue& cq, std::unique_ptr<grpc::ClientContext> context,
              gcsa::CreateInstanceRequest const& request) {
-        return child_->CreateInstance(context, request);
+        return child_->AsyncCreateInstance(cq, std::move(context), request);
       },
-      context, request, __func__, tracing_options_);
+      cq, std::move(context), request, __func__, tracing_options_);
 }
 
-StatusOr<google::longrunning::Operation> InstanceAdminLogging::UpdateInstance(
-    grpc::ClientContext& context, gcsa::UpdateInstanceRequest const& request) {
-  return LogWrapper(
-      [this](grpc::ClientContext& context,
+future<StatusOr<google::longrunning::Operation>>
+InstanceAdminLogging::AsyncUpdateInstance(
+    CompletionQueue& cq, std::unique_ptr<grpc::ClientContext> context,
+    gcsa::UpdateInstanceRequest const& request) {
+  return google::cloud::internal::LogWrapper(
+      [this](CompletionQueue& cq, std::unique_ptr<grpc::ClientContext> context,
              gcsa::UpdateInstanceRequest const& request) {
-        return child_->UpdateInstance(context, request);
+        return child_->AsyncUpdateInstance(cq, std::move(context), request);
       },
-      context, request, __func__, tracing_options_);
+      cq, std::move(context), request, __func__, tracing_options_);
 }
 
 Status InstanceAdminLogging::DeleteInstance(
@@ -131,15 +135,27 @@ InstanceAdminLogging::TestIamPermissions(
       context, request, __func__, tracing_options_);
 }
 
-StatusOr<google::longrunning::Operation> InstanceAdminLogging::GetOperation(
-    grpc::ClientContext& context,
+future<StatusOr<google::longrunning::Operation>>
+InstanceAdminLogging::AsyncGetOperation(
+    CompletionQueue& cq, std::unique_ptr<grpc::ClientContext> context,
     google::longrunning::GetOperationRequest const& request) {
-  return LogWrapper(
-      [this](grpc::ClientContext& context,
+  return google::cloud::internal::LogWrapper(
+      [this](CompletionQueue& cq, std::unique_ptr<grpc::ClientContext> context,
              google::longrunning::GetOperationRequest const& request) {
-        return child_->GetOperation(context, request);
+        return child_->AsyncGetOperation(cq, std::move(context), request);
       },
-      context, request, __func__, tracing_options_);
+      cq, std::move(context), request, __func__, tracing_options_);
+}
+
+future<Status> InstanceAdminLogging::AsyncCancelOperation(
+    CompletionQueue& cq, std::unique_ptr<grpc::ClientContext> context,
+    google::longrunning::CancelOperationRequest const& request) {
+  return google::cloud::internal::LogWrapper(
+      [this](CompletionQueue& cq, std::unique_ptr<grpc::ClientContext> context,
+             google::longrunning::CancelOperationRequest const& request) {
+        return child_->AsyncCancelOperation(cq, std::move(context), request);
+      },
+      cq, std::move(context), request, __func__, tracing_options_);
 }
 
 }  // namespace SPANNER_CLIENT_NS

--- a/google/cloud/spanner/internal/instance_admin_logging.h
+++ b/google/cloud/spanner/internal/instance_admin_logging.h
@@ -49,13 +49,13 @@ class InstanceAdminLogging : public InstanceAdminStub {
       grpc::ClientContext&,
       google::spanner::admin::instance::v1::GetInstanceRequest const&) override;
 
-  StatusOr<google::longrunning::Operation> CreateInstance(
-      grpc::ClientContext&,
+  future<StatusOr<google::longrunning::Operation>> AsyncCreateInstance(
+      CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
       google::spanner::admin::instance::v1::CreateInstanceRequest const&)
       override;
 
-  StatusOr<google::longrunning::Operation> UpdateInstance(
-      grpc::ClientContext&,
+  future<StatusOr<google::longrunning::Operation>> AsyncUpdateInstance(
+      CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
       google::spanner::admin::instance::v1::UpdateInstanceRequest const&)
       override;
 
@@ -94,9 +94,13 @@ class InstanceAdminLogging : public InstanceAdminStub {
       grpc::ClientContext&,
       google::iam::v1::TestIamPermissionsRequest const&) override;
 
-  StatusOr<google::longrunning::Operation> GetOperation(
-      grpc::ClientContext& context,
-      google::longrunning::GetOperationRequest const& request) override;
+  future<StatusOr<google::longrunning::Operation>> AsyncGetOperation(
+      CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
+      google::longrunning::GetOperationRequest const&) override;
+
+  future<Status> AsyncCancelOperation(
+      CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
+      google::longrunning::CancelOperationRequest const&) override;
   //@}
 
  private:

--- a/google/cloud/spanner/internal/instance_admin_logging_test.cc
+++ b/google/cloud/spanner/internal/instance_admin_logging_test.cc
@@ -61,13 +61,20 @@ TEST_F(InstanceAdminLoggingTest, GetInstance) {
 }
 
 TEST_F(InstanceAdminLoggingTest, CreateInstance) {
-  EXPECT_CALL(*mock_, CreateInstance).WillOnce(Return(TransientError()));
+  EXPECT_CALL(*mock_, AsyncCreateInstance)
+      .WillOnce([](CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
+                   gcsa::CreateInstanceRequest const&) {
+        return make_ready_future(
+            StatusOr<google::longrunning::Operation>(TransientError()));
+      });
 
   InstanceAdminLogging stub(mock_, TracingOptions{});
 
-  grpc::ClientContext context;
-  auto response = stub.CreateInstance(context, gcsa::CreateInstanceRequest{});
-  EXPECT_EQ(TransientError(), response.status());
+  CompletionQueue cq;
+  std::unique_ptr<grpc::ClientContext> context(new grpc::ClientContext);
+  auto response = stub.AsyncCreateInstance(cq, std::move(context),
+                                           gcsa::CreateInstanceRequest{});
+  EXPECT_EQ(TransientError(), response.get().status());
 
   auto const log_lines = log_.ExtractLines();
   EXPECT_THAT(log_lines, Contains(HasSubstr("CreateInstance")));
@@ -75,13 +82,20 @@ TEST_F(InstanceAdminLoggingTest, CreateInstance) {
 }
 
 TEST_F(InstanceAdminLoggingTest, UpdateInstance) {
-  EXPECT_CALL(*mock_, UpdateInstance).WillOnce(Return(TransientError()));
+  EXPECT_CALL(*mock_, AsyncUpdateInstance)
+      .WillOnce([](CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
+                   gcsa::UpdateInstanceRequest const&) {
+        return make_ready_future(
+            StatusOr<google::longrunning::Operation>(TransientError()));
+      });
 
   InstanceAdminLogging stub(mock_, TracingOptions{});
 
-  grpc::ClientContext context;
-  auto response = stub.UpdateInstance(context, gcsa::UpdateInstanceRequest{});
-  EXPECT_EQ(TransientError(), response.status());
+  CompletionQueue cq;
+  std::unique_ptr<grpc::ClientContext> context(new grpc::ClientContext);
+  auto response = stub.AsyncUpdateInstance(cq, std::move(context),
+                                           gcsa::UpdateInstanceRequest{});
+  EXPECT_EQ(TransientError(), response.get().status());
 
   auto const log_lines = log_.ExtractLines();
   EXPECT_THAT(log_lines, Contains(HasSubstr("UpdateInstance")));

--- a/google/cloud/spanner/internal/instance_admin_metadata.cc
+++ b/google/cloud/spanner/internal/instance_admin_metadata.cc
@@ -34,16 +34,20 @@ StatusOr<gcsa::Instance> InstanceAdminMetadata::GetInstance(
   return child_->GetInstance(context, request);
 }
 
-StatusOr<google::longrunning::Operation> InstanceAdminMetadata::CreateInstance(
-    grpc::ClientContext& context, gcsa::CreateInstanceRequest const& request) {
-  SetMetadata(context, "parent=" + request.parent());
-  return child_->CreateInstance(context, request);
+future<StatusOr<google::longrunning::Operation>>
+InstanceAdminMetadata::AsyncCreateInstance(
+    CompletionQueue& cq, std::unique_ptr<grpc::ClientContext> context,
+    gcsa::CreateInstanceRequest const& request) {
+  SetMetadata(*context, "parent=" + request.parent());
+  return child_->AsyncCreateInstance(cq, std::move(context), request);
 }
 
-StatusOr<google::longrunning::Operation> InstanceAdminMetadata::UpdateInstance(
-    grpc::ClientContext& context, gcsa::UpdateInstanceRequest const& request) {
-  SetMetadata(context, "instance.name=" + request.instance().name());
-  return child_->UpdateInstance(context, request);
+future<StatusOr<google::longrunning::Operation>>
+InstanceAdminMetadata::AsyncUpdateInstance(
+    CompletionQueue& cq, std::unique_ptr<grpc::ClientContext> context,
+    gcsa::UpdateInstanceRequest const& request) {
+  SetMetadata(*context, "instance.name=" + request.instance().name());
+  return child_->AsyncUpdateInstance(cq, std::move(context), request);
 }
 
 Status InstanceAdminMetadata::DeleteInstance(
@@ -95,11 +99,19 @@ InstanceAdminMetadata::TestIamPermissions(
   return child_->TestIamPermissions(context, request);
 }
 
-StatusOr<google::longrunning::Operation> InstanceAdminMetadata::GetOperation(
-    grpc::ClientContext& context,
+future<StatusOr<google::longrunning::Operation>>
+InstanceAdminMetadata::AsyncGetOperation(
+    CompletionQueue& cq, std::unique_ptr<grpc::ClientContext> context,
     google::longrunning::GetOperationRequest const& request) {
-  SetMetadata(context, "name=" + request.name());
-  return child_->GetOperation(context, request);
+  SetMetadata(*context, "name=" + request.name());
+  return child_->AsyncGetOperation(cq, std::move(context), request);
+}
+
+future<Status> InstanceAdminMetadata::AsyncCancelOperation(
+    CompletionQueue& cq, std::unique_ptr<grpc::ClientContext> context,
+    google::longrunning::CancelOperationRequest const& request) {
+  SetMetadata(*context, "name=" + request.name());
+  return child_->AsyncCancelOperation(cq, std::move(context), request);
 }
 
 void InstanceAdminMetadata::SetMetadata(grpc::ClientContext& context,

--- a/google/cloud/spanner/internal/instance_admin_metadata.h
+++ b/google/cloud/spanner/internal/instance_admin_metadata.h
@@ -43,13 +43,13 @@ class InstanceAdminMetadata : public InstanceAdminStub {
       grpc::ClientContext&,
       google::spanner::admin::instance::v1::GetInstanceRequest const&) override;
 
-  StatusOr<google::longrunning::Operation> CreateInstance(
-      grpc::ClientContext&,
+  future<StatusOr<google::longrunning::Operation>> AsyncCreateInstance(
+      CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
       google::spanner::admin::instance::v1::CreateInstanceRequest const&)
       override;
 
-  StatusOr<google::longrunning::Operation> UpdateInstance(
-      grpc::ClientContext&,
+  future<StatusOr<google::longrunning::Operation>> AsyncUpdateInstance(
+      CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
       google::spanner::admin::instance::v1::UpdateInstanceRequest const&)
       override;
 
@@ -88,9 +88,13 @@ class InstanceAdminMetadata : public InstanceAdminStub {
       grpc::ClientContext&,
       google::iam::v1::TestIamPermissionsRequest const&) override;
 
-  StatusOr<google::longrunning::Operation> GetOperation(
-      grpc::ClientContext& context,
-      google::longrunning::GetOperationRequest const& request) override;
+  future<StatusOr<google::longrunning::Operation>> AsyncGetOperation(
+      CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
+      google::longrunning::GetOperationRequest const&) override;
+
+  future<Status> AsyncCancelOperation(
+      CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
+      google::longrunning::CancelOperationRequest const&) override;
   //@}
 
  private:

--- a/google/cloud/spanner/internal/instance_admin_metadata_test.cc
+++ b/google/cloud/spanner/internal/instance_admin_metadata_test.cc
@@ -112,45 +112,51 @@ TEST_F(InstanceAdminMetadataTest, ListInstanceConfigs) {
 }
 
 TEST_F(InstanceAdminMetadataTest, CreateInstance) {
-  EXPECT_CALL(*mock_, CreateInstance)
-      .WillOnce([this](grpc::ClientContext& context,
+  EXPECT_CALL(*mock_, AsyncCreateInstance)
+      .WillOnce([this](CompletionQueue&,
+                       std::unique_ptr<grpc::ClientContext> context,
                        gcsa::CreateInstanceRequest const&) {
         EXPECT_STATUS_OK(
-            IsContextMDValid(context,
+            IsContextMDValid(*context,
                              "google.spanner.admin.instance.v1.InstanceAdmin."
                              "CreateInstance",
                              expected_api_client_header_));
-        return TransientError();
+        return make_ready_future(
+            StatusOr<google::longrunning::Operation>(TransientError()));
       });
 
   InstanceAdminMetadata stub(mock_);
-  grpc::ClientContext context;
+  CompletionQueue cq;
+  std::unique_ptr<grpc::ClientContext> context(new grpc::ClientContext);
   gcsa::CreateInstanceRequest request;
   request.set_parent("projects/test-project-id");
   request.set_instance_id("test-instance-id");
-  auto response = stub.CreateInstance(context, request);
-  EXPECT_EQ(TransientError(), response.status());
+  auto response = stub.AsyncCreateInstance(cq, std::move(context), request);
+  EXPECT_EQ(TransientError(), response.get().status());
 }
 
 TEST_F(InstanceAdminMetadataTest, UpdateInstance) {
-  EXPECT_CALL(*mock_, UpdateInstance)
-      .WillOnce([this](grpc::ClientContext& context,
+  EXPECT_CALL(*mock_, AsyncUpdateInstance)
+      .WillOnce([this](CompletionQueue&,
+                       std::unique_ptr<grpc::ClientContext> context,
                        gcsa::UpdateInstanceRequest const&) {
         EXPECT_STATUS_OK(
-            IsContextMDValid(context,
+            IsContextMDValid(*context,
                              "google.spanner.admin.instance.v1.InstanceAdmin."
                              "UpdateInstance",
                              expected_api_client_header_));
-        return TransientError();
+        return make_ready_future(
+            StatusOr<google::longrunning::Operation>(TransientError()));
       });
 
   InstanceAdminMetadata stub(mock_);
-  grpc::ClientContext context;
+  CompletionQueue cq;
+  std::unique_ptr<grpc::ClientContext> context(new grpc::ClientContext);
   gcsa::UpdateInstanceRequest request;
   request.mutable_instance()->set_name(
       "projects/test-project-id/instances/test-instance-id");
-  auto response = stub.UpdateInstance(context, request);
-  EXPECT_EQ(TransientError(), response.status());
+  auto response = stub.AsyncUpdateInstance(cq, std::move(context), request);
+  EXPECT_EQ(TransientError(), response.get().status());
 }
 
 TEST_F(InstanceAdminMetadataTest, DeleteInstance) {

--- a/google/cloud/spanner/internal/instance_admin_stub.h
+++ b/google/cloud/spanner/internal/instance_admin_stub.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/spanner/connection_options.h"
 #include "google/cloud/spanner/version.h"
+#include "google/cloud/completion_queue.h"
 #include "google/cloud/future.h"
 #include "google/cloud/options.h"
 #include "google/cloud/status_or.h"
@@ -39,12 +40,12 @@ class InstanceAdminStub {
       grpc::ClientContext&,
       google::spanner::admin::instance::v1::GetInstanceRequest const&) = 0;
 
-  virtual StatusOr<google::longrunning::Operation> CreateInstance(
-      grpc::ClientContext&,
+  virtual future<StatusOr<google::longrunning::Operation>> AsyncCreateInstance(
+      CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
       google::spanner::admin::instance::v1::CreateInstanceRequest const&) = 0;
 
-  virtual StatusOr<google::longrunning::Operation> UpdateInstance(
-      grpc::ClientContext&,
+  virtual future<StatusOr<google::longrunning::Operation>> AsyncUpdateInstance(
+      CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
       google::spanner::admin::instance::v1::UpdateInstanceRequest const&) = 0;
 
   virtual Status DeleteInstance(
@@ -76,9 +77,14 @@ class InstanceAdminStub {
   virtual StatusOr<google::iam::v1::TestIamPermissionsResponse>
   TestIamPermissions(grpc::ClientContext&,
                      google::iam::v1::TestIamPermissionsRequest const&) = 0;
-  virtual StatusOr<google::longrunning::Operation> GetOperation(
-      grpc::ClientContext& client_context,
-      google::longrunning::GetOperationRequest const& request) = 0;
+
+  virtual future<StatusOr<google::longrunning::Operation>> AsyncGetOperation(
+      CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
+      google::longrunning::GetOperationRequest const&) = 0;
+
+  virtual future<Status> AsyncCancelOperation(
+      CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
+      google::longrunning::CancelOperationRequest const&) = 0;
 };
 
 /**

--- a/google/cloud/spanner/testing/mock_instance_admin_stub.h
+++ b/google/cloud/spanner/testing/mock_instance_admin_stub.h
@@ -34,13 +34,13 @@ class MockInstanceAdminStub
                google::spanner::admin::instance::v1::GetInstanceRequest const&),
               (override));
   MOCK_METHOD(
-      StatusOr<google::longrunning::Operation>, CreateInstance,
-      (grpc::ClientContext&,
+      future<StatusOr<google::longrunning::Operation>>, AsyncCreateInstance,
+      (CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
        google::spanner::admin::instance::v1::CreateInstanceRequest const&),
       (override));
   MOCK_METHOD(
-      StatusOr<google::longrunning::Operation>, UpdateInstance,
-      (grpc::ClientContext&,
+      future<StatusOr<google::longrunning::Operation>>, AsyncUpdateInstance,
+      (CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
        google::spanner::admin::instance::v1::UpdateInstanceRequest const&),
       (override));
   MOCK_METHOD(
@@ -80,9 +80,14 @@ class MockInstanceAdminStub
               (grpc::ClientContext&,
                google::iam::v1::TestIamPermissionsRequest const&),
               (override));
-  MOCK_METHOD(StatusOr<google::longrunning::Operation>, GetOperation,
-              (grpc::ClientContext&,
+  MOCK_METHOD(future<StatusOr<google::longrunning::Operation>>,
+              AsyncGetOperation,
+              (CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
                google::longrunning::GetOperationRequest const&),
+              (override));
+  MOCK_METHOD(future<Status>, AsyncCancelOperation,
+              (CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
+               google::longrunning::CancelOperationRequest const&),
               (override));
 };
 


### PR DESCRIPTION
Use the new, common `async_long_running_operation.h` support
to implement `InstanceAdminConnection::CreateInstance()` and
`UpdateInstance()` using the existing background threads (and
not a detached `std::thread`).

Part of #4038.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6835)
<!-- Reviewable:end -->
