### PR TITLE
chore(deps): upgrade pkg-config on CentOS-7 to avoid bug

### DIFF
--- a/doc/packaging.md
+++ b/doc/packaging.md
@@ -1378,8 +1378,7 @@ sudo yum install -y centos-release-scl yum-utils
 sudo yum-config-manager --enable rhel-server-rhscl-7-rpms
 sudo yum makecache && \
 sudo yum install -y automake ccache cmake3 curl-devel devtoolset-7 gcc gcc-c++ \
-        git libtool make openssl-devel patch pkgconfig re2-devel tar wget \
-        which zlib-devel
+        git libtool make openssl-devel patch re2-devel tar wget which zlib-devel
 sudo ln -sf /usr/bin/cmake3 /usr/bin/cmake && sudo ln -sf /usr/bin/ctest3 /usr/bin/ctest
 ```
 
@@ -1390,6 +1389,22 @@ by `devtoolset-7`.
 scl enable devtoolset-7 bash
 ```
 
+CentOS-7 ships with `pkg-config` 0.27.1, which has a
+[bug](https://bugs.freedesktop.org/show_bug.cgi?id=54716) that can make
+invocations take extremely long to complete. If you plan to use `pkg-config`
+with any of the installed artifacts, you'll want to upgrade it to something
+newer. If not, `sudo yum install pkgconfig` should work instead.
+
+```bash
+mkdir -p $HOME/Downloads/pkg-config-cpp && cd $HOME/Downloads/pkg-config-cpp
+curl -sSL https://pkgconfig.freedesktop.org/releases/pkg-config-0.29.2.tar.gz | \
+    tar -xzf - --strip-components=1 && \
+    ./configure --with-internal-glib && \
+    make -j ${NCPU:-4} && \
+sudo make install && \
+sudo ldconfig
+```
+
 The following steps will install libraries and tools in `/usr/local`. By
 default CentOS-7 does not search for shared libraries in these directories,
 there are multiple ways to solve this problem, the following steps are one
@@ -1398,7 +1413,7 @@ solution:
 ```bash
 (echo "/usr/local/lib" ; echo "/usr/local/lib64") | \
 sudo tee /etc/ld.so.conf.d/usrlocal.conf
-export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:/usr/local/lib64/pkgconfig
+export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:/usr/local/lib64/pkgconfig:/usr/lib64/pkgconfig
 export PATH=/usr/local/bin:${PATH}
 ```
 


### PR DESCRIPTION
There's a [bug] w/ CentOS-7's version of `pkg-config` that can cause
invocations to take a reeeeeaaaaly long time to complete. We discovered
this when upgrading to grpc-1.38.1 and had to [rollback] the upgrade.

The fix to `pkg-config` was rolled out about 8 years ago in `pkg-config`
0.28. This PR upgrades the pkg-config we use on CentOS-7 to the latest
as of this writing. After this, I think we should be able to upgrade
grpc again.

[bug]: https://bugs.freedesktop.org/show_bug.cgi?id=54716
[rollback]: https://github.com/googleapis/google-cloud-cpp/pull/6840

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6846)
<!-- Reviewable:end -->
