### PR TITLE
feat(bigtable): add Backup IAM Policy snippets

### DIFF
--- a/google/cloud/bigtable/examples/bigtable_table_admin_backup_snippets.cc
+++ b/google/cloud/bigtable/examples/bigtable_table_admin_backup_snippets.cc
@@ -176,8 +176,7 @@ void GetIamPolicy(google::cloud::bigtable::TableAdmin const& admin,
     StatusOr<google::iam::v1::Policy> policy =
         admin.GetIamPolicy(cluster_id, backup_id);
     if (!policy) throw std::runtime_error(policy.status().message());
-    std::cout << "The IAM Policy is:\n"
-              << policy->DebugString() << "\n";
+    std::cout << "The IAM Policy is:\n" << policy->DebugString() << "\n";
   }
   //! [get backup iam policy]
   (admin, argv.at(0), argv.at(1));
@@ -210,8 +209,7 @@ void SetIamPolicy(google::cloud::bigtable::TableAdmin const& admin,
     StatusOr<google::iam::v1::Policy> policy =
         admin.SetIamPolicy(cluster_id, backup_id, *current);
     if (!policy) throw std::runtime_error(policy.status().message());
-    std::cout << "The IAM Policy is:\n"
-              << policy->DebugString() << "\n";
+    std::cout << "The IAM Policy is:\n" << policy->DebugString() << "\n";
   }
   //! [set backup iam policy]
   (std::move(admin), argv.at(0), argv.at(1), argv.at(2), argv.at(3));

--- a/google/cloud/bigtable/examples/bigtable_table_admin_backup_snippets.cc
+++ b/google/cloud/bigtable/examples/bigtable_table_admin_backup_snippets.cc
@@ -176,8 +176,7 @@ void GetIamPolicy(google::cloud::bigtable::TableAdmin const& admin,
     StatusOr<google::iam::v1::Policy> policy =
         admin.GetIamPolicy(cluster_id, backup_id);
     if (!policy) throw std::runtime_error(policy.status().message());
-    std::cout << "The IAM Policy for "
-              << admin.BackupName(cluster_id, backup_id) << " is\n"
+    std::cout << "The IAM Policy is:\n"
               << policy->DebugString() << "\n";
   }
   //! [get backup iam policy]
@@ -211,8 +210,7 @@ void SetIamPolicy(google::cloud::bigtable::TableAdmin const& admin,
     StatusOr<google::iam::v1::Policy> policy =
         admin.SetIamPolicy(cluster_id, backup_id, *current);
     if (!policy) throw std::runtime_error(policy.status().message());
-    std::cout << "The IAM Policy for "
-              << admin.BackupName(cluster_id, backup_id) << " is\n"
+    std::cout << "The IAM Policy is:\n"
               << policy->DebugString() << "\n";
   }
   //! [set backup iam policy]

--- a/google/cloud/bigtable/table_admin.h
+++ b/google/cloud/bigtable/table_admin.h
@@ -876,8 +876,7 @@ class TableAdmin {
    * and using different copies in each thread.
    *
    * @par Example
-   * TODO(#5931) - example is missing:
-   *     snippet table_admin_iam_policy_snippets.cc get iam policy backup
+   * @snippet bigtable_table_admin_backup_snippets.cc get backup iam policy
    */
   StatusOr<google::iam::v1::Policy> GetIamPolicy(std::string const& cluster_id,
                                                  std::string const& backup_id);
@@ -885,9 +884,9 @@ class TableAdmin {
   /**
    * Sets the IAM policy for a table.
    *
-   * This is the preferred way to the overload for `IamBindings`. This is more
-   * closely coupled to the underlying protocol, enable more actions and is more
-   * likely to tolerate future protocol changes.
+   * This is the preferred way to overload `IamBindings`. This is more closely
+   * coupled to the underlying protocol, enable more actions and is more likely
+   * to tolerate future protocol changes.
    *
    * @param table_id which table to set the IAM policy for.
    * @param iam_policy google::iam::v1::Policy object containing role and
@@ -913,9 +912,9 @@ class TableAdmin {
   /**
    * Sets the IAM policy for a backup.
    *
-   * This is the preferred way to the overload for `IamBindings`. This is more
-   * closely coupled to the underlying protocol, enable more actions and is more
-   * likely to tolerate future protocol changes.
+   * This is the preferred way to overload `IamBindings`. This is more closely
+   * coupled to the underlying protocol, enable more actions and is more likely
+   * to tolerate future protocol changes.
    *
    * @param cluster_id which is the cluster containing the backup.
    * @param backup_id which backup to set the IAM policy for.
@@ -934,8 +933,7 @@ class TableAdmin {
    * and using different copies in each thread.
    *
    * @par Example
-   * TODO(#5931) - example is missing:
-   *     snippet table_admin_iam_policy_snippets.cc set iam policy backup
+   * @snippet bigtable_table_admin_backup_snippets.cc set backup iam policy
    */
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
       std::string const& cluster_id, std::string const& backup_id,


### PR DESCRIPTION
Fixes #5931

there are non-functional things I want to cleanup in the test (like variable names: `table_1`, `table_id_1`, `backup_id_1`) but I will do so in a subsequent PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6847)
<!-- Reviewable:end -->
