### PR TITLE
refactor(spanner): Use background threads for database-admin LROs

### DIFF
--- a/google/cloud/spanner/internal/database_admin_logging.cc
+++ b/google/cloud/spanner/internal/database_admin_logging.cc
@@ -24,14 +24,16 @@ inline namespace SPANNER_CLIENT_NS {
 namespace gcsa = ::google::spanner::admin::database::v1;
 using ::google::cloud::internal::LogWrapper;
 
-StatusOr<google::longrunning::Operation> DatabaseAdminLogging::CreateDatabase(
-    grpc::ClientContext& context, gcsa::CreateDatabaseRequest const& request) {
-  return LogWrapper(
-      [this](grpc::ClientContext& context,
+future<StatusOr<google::longrunning::Operation>>
+DatabaseAdminLogging::AsyncCreateDatabase(
+    CompletionQueue& cq, std::unique_ptr<grpc::ClientContext> context,
+    gcsa::CreateDatabaseRequest const& request) {
+  return google::cloud::internal::LogWrapper(
+      [this](CompletionQueue& cq, std::unique_ptr<grpc::ClientContext> context,
              gcsa::CreateDatabaseRequest const& request) {
-        return child_->CreateDatabase(context, request);
+        return child_->AsyncCreateDatabase(cq, std::move(context), request);
       },
-      context, request, __func__, tracing_options_);
+      cq, std::move(context), request, __func__, tracing_options_);
 }
 
 StatusOr<gcsa::Database> DatabaseAdminLogging::GetDatabase(
@@ -54,16 +56,16 @@ StatusOr<gcsa::GetDatabaseDdlResponse> DatabaseAdminLogging::GetDatabaseDdl(
       context, request, __func__, tracing_options_);
 }
 
-StatusOr<google::longrunning::Operation> DatabaseAdminLogging::UpdateDatabase(
-    grpc::ClientContext& context,
-    google::spanner::admin::database::v1::UpdateDatabaseDdlRequest const&
-        request) {
-  return LogWrapper(
-      [this](grpc::ClientContext& context,
+future<StatusOr<google::longrunning::Operation>>
+DatabaseAdminLogging::AsyncUpdateDatabaseDdl(
+    CompletionQueue& cq, std::unique_ptr<grpc::ClientContext> context,
+    gcsa::UpdateDatabaseDdlRequest const& request) {
+  return google::cloud::internal::LogWrapper(
+      [this](CompletionQueue& cq, std::unique_ptr<grpc::ClientContext> context,
              gcsa::UpdateDatabaseDdlRequest const& request) {
-        return child_->UpdateDatabase(context, request);
+        return child_->AsyncUpdateDatabaseDdl(cq, std::move(context), request);
       },
-      context, request, __func__, tracing_options_);
+      cq, std::move(context), request, __func__, tracing_options_);
 }
 
 Status DatabaseAdminLogging::DropDatabase(
@@ -88,14 +90,16 @@ DatabaseAdminLogging::ListDatabases(
       context, request, __func__, tracing_options_);
 }
 
-StatusOr<google::longrunning::Operation> DatabaseAdminLogging::RestoreDatabase(
-    grpc::ClientContext& context, gcsa::RestoreDatabaseRequest const& request) {
-  return LogWrapper(
-      [this](grpc::ClientContext& context,
+future<StatusOr<google::longrunning::Operation>>
+DatabaseAdminLogging::AsyncRestoreDatabase(
+    CompletionQueue& cq, std::unique_ptr<grpc::ClientContext> context,
+    gcsa::RestoreDatabaseRequest const& request) {
+  return google::cloud::internal::LogWrapper(
+      [this](CompletionQueue& cq, std::unique_ptr<grpc::ClientContext> context,
              gcsa::RestoreDatabaseRequest const& request) {
-        return child_->RestoreDatabase(context, request);
+        return child_->AsyncRestoreDatabase(cq, std::move(context), request);
       },
-      context, request, __func__, tracing_options_);
+      cq, std::move(context), request, __func__, tracing_options_);
 }
 
 StatusOr<google::iam::v1::Policy> DatabaseAdminLogging::GetIamPolicy(
@@ -132,14 +136,16 @@ DatabaseAdminLogging::TestIamPermissions(
       context, request, __func__, tracing_options_);
 }
 
-StatusOr<google::longrunning::Operation> DatabaseAdminLogging::CreateBackup(
-    grpc::ClientContext& context, gcsa::CreateBackupRequest const& request) {
-  return LogWrapper(
-      [this](grpc::ClientContext& context,
+future<StatusOr<google::longrunning::Operation>>
+DatabaseAdminLogging::AsyncCreateBackup(
+    CompletionQueue& cq, std::unique_ptr<grpc::ClientContext> context,
+    gcsa::CreateBackupRequest const& request) {
+  return google::cloud::internal::LogWrapper(
+      [this](CompletionQueue& cq, std::unique_ptr<grpc::ClientContext> context,
              gcsa::CreateBackupRequest const& request) {
-        return child_->CreateBackup(context, request);
+        return child_->AsyncCreateBackup(cq, std::move(context), request);
       },
-      context, request, __func__, tracing_options_);
+      cq, std::move(context), request, __func__, tracing_options_);
 }
 
 StatusOr<gcsa::Backup> DatabaseAdminLogging::GetBackup(
@@ -212,26 +218,27 @@ DatabaseAdminLogging::ListDatabaseOperations(
       context, request, __func__, tracing_options_);
 }
 
-StatusOr<google::longrunning::Operation> DatabaseAdminLogging::GetOperation(
-    grpc::ClientContext& context,
+future<StatusOr<google::longrunning::Operation>>
+DatabaseAdminLogging::AsyncGetOperation(
+    CompletionQueue& cq, std::unique_ptr<grpc::ClientContext> context,
     google::longrunning::GetOperationRequest const& request) {
-  return LogWrapper(
-      [this](grpc::ClientContext& context,
+  return google::cloud::internal::LogWrapper(
+      [this](CompletionQueue& cq, std::unique_ptr<grpc::ClientContext> context,
              google::longrunning::GetOperationRequest const& request) {
-        return child_->GetOperation(context, request);
+        return child_->AsyncGetOperation(cq, std::move(context), request);
       },
-      context, request, __func__, tracing_options_);
+      cq, std::move(context), request, __func__, tracing_options_);
 }
 
-Status DatabaseAdminLogging::CancelOperation(
-    grpc::ClientContext& context,
+future<Status> DatabaseAdminLogging::AsyncCancelOperation(
+    CompletionQueue& cq, std::unique_ptr<grpc::ClientContext> context,
     google::longrunning::CancelOperationRequest const& request) {
-  return LogWrapper(
-      [this](grpc::ClientContext& context,
+  return google::cloud::internal::LogWrapper(
+      [this](CompletionQueue& cq, std::unique_ptr<grpc::ClientContext> context,
              google::longrunning::CancelOperationRequest const& request) {
-        return child_->CancelOperation(context, request);
+        return child_->AsyncCancelOperation(cq, std::move(context), request);
       },
-      context, request, __func__, tracing_options_);
+      cq, std::move(context), request, __func__, tracing_options_);
 }
 
 }  // namespace SPANNER_CLIENT_NS

--- a/google/cloud/spanner/internal/database_admin_logging.h
+++ b/google/cloud/spanner/internal/database_admin_logging.h
@@ -45,10 +45,10 @@ class DatabaseAdminLogging : public DatabaseAdminStub {
    * Run the logging loop (if appropriate) for the child DatabaseAdminStub.
    */
   ///
-  StatusOr<google::longrunning::Operation> CreateDatabase(
-      grpc::ClientContext& context,
-      google::spanner::admin::database::v1::CreateDatabaseRequest const&
-          request) override;
+  future<StatusOr<google::longrunning::Operation>> AsyncCreateDatabase(
+      CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
+      google::spanner::admin::database::v1::CreateDatabaseRequest const&)
+      override;
 
   StatusOr<google::spanner::admin::database::v1::Database> GetDatabase(
       grpc::ClientContext&,
@@ -60,10 +60,10 @@ class DatabaseAdminLogging : public DatabaseAdminStub {
       google::spanner::admin::database::v1::GetDatabaseDdlRequest const&)
       override;
 
-  StatusOr<google::longrunning::Operation> UpdateDatabase(
-      grpc::ClientContext& context,
-      google::spanner::admin::database::v1::UpdateDatabaseDdlRequest const&
-          request) override;
+  future<StatusOr<google::longrunning::Operation>> AsyncUpdateDatabaseDdl(
+      CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
+      google::spanner::admin::database::v1::UpdateDatabaseDdlRequest const&)
+      override;
 
   Status DropDatabase(
       grpc::ClientContext& context,
@@ -76,10 +76,10 @@ class DatabaseAdminLogging : public DatabaseAdminStub {
       google::spanner::admin::database::v1::ListDatabasesRequest const&)
       override;
 
-  StatusOr<google::longrunning::Operation> RestoreDatabase(
-      grpc::ClientContext& context,
-      google::spanner::admin::database::v1::RestoreDatabaseRequest const&
-          request) override;
+  future<StatusOr<google::longrunning::Operation>> AsyncRestoreDatabase(
+      CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
+      google::spanner::admin::database::v1::RestoreDatabaseRequest const&)
+      override;
 
   StatusOr<google::iam::v1::Policy> GetIamPolicy(
       grpc::ClientContext& context,
@@ -93,9 +93,9 @@ class DatabaseAdminLogging : public DatabaseAdminStub {
       grpc::ClientContext& context,
       google::iam::v1::TestIamPermissionsRequest const& request) override;
 
-  StatusOr<google::longrunning::Operation> CreateBackup(
-      grpc::ClientContext& context,
-      google::spanner::admin::database::v1::CreateBackupRequest const& request)
+  future<StatusOr<google::longrunning::Operation>> AsyncCreateBackup(
+      CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
+      google::spanner::admin::database::v1::CreateBackupRequest const&)
       override;
 
   StatusOr<google::spanner::admin::database::v1::Backup> GetBackup(
@@ -129,13 +129,13 @@ class DatabaseAdminLogging : public DatabaseAdminStub {
                          google::spanner::admin::database::v1::
                              ListDatabaseOperationsRequest const&) override;
 
-  StatusOr<google::longrunning::Operation> GetOperation(
-      grpc::ClientContext& context,
-      google::longrunning::GetOperationRequest const& request) override;
+  future<StatusOr<google::longrunning::Operation>> AsyncGetOperation(
+      CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
+      google::longrunning::GetOperationRequest const&) override;
 
-  Status CancelOperation(
-      grpc::ClientContext& context,
-      google::longrunning::CancelOperationRequest const& request) override;
+  future<Status> AsyncCancelOperation(
+      CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
+      google::longrunning::CancelOperationRequest const&) override;
   //@}
 
  private:

--- a/google/cloud/spanner/internal/database_admin_logging_test.cc
+++ b/google/cloud/spanner/internal/database_admin_logging_test.cc
@@ -47,13 +47,20 @@ class DatabaseAdminLoggingTest : public ::testing::Test {
 };
 
 TEST_F(DatabaseAdminLoggingTest, CreateDatabase) {
-  EXPECT_CALL(*mock_, CreateDatabase).WillOnce(Return(TransientError()));
+  EXPECT_CALL(*mock_, AsyncCreateDatabase)
+      .WillOnce([](CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
+                   gcsa::CreateDatabaseRequest const&) {
+        return make_ready_future(
+            StatusOr<google::longrunning::Operation>(TransientError()));
+      });
 
   DatabaseAdminLogging stub(mock_, TracingOptions{});
 
-  grpc::ClientContext context;
-  auto status = stub.CreateDatabase(context, gcsa::CreateDatabaseRequest{});
-  EXPECT_EQ(TransientError(), status.status());
+  CompletionQueue cq;
+  std::unique_ptr<grpc::ClientContext> context(new grpc::ClientContext);
+  auto response = stub.AsyncCreateDatabase(cq, std::move(context),
+                                           gcsa::CreateDatabaseRequest{});
+  EXPECT_EQ(TransientError(), response.get().status());
 
   auto const log_lines = log_.ExtractLines();
   EXPECT_THAT(log_lines, Contains(HasSubstr("CreateDatabase")));
@@ -89,13 +96,20 @@ TEST_F(DatabaseAdminLoggingTest, GetDatabaseDdl) {
 }
 
 TEST_F(DatabaseAdminLoggingTest, UpdateDatabase) {
-  EXPECT_CALL(*mock_, UpdateDatabase).WillOnce(Return(TransientError()));
+  EXPECT_CALL(*mock_, AsyncUpdateDatabaseDdl)
+      .WillOnce([](CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
+                   gcsa::UpdateDatabaseDdlRequest const&) {
+        return make_ready_future(
+            StatusOr<google::longrunning::Operation>(TransientError()));
+      });
 
   DatabaseAdminLogging stub(mock_, TracingOptions{});
 
-  grpc::ClientContext context;
-  auto status = stub.UpdateDatabase(context, gcsa::UpdateDatabaseDdlRequest{});
-  EXPECT_EQ(TransientError(), status.status());
+  CompletionQueue cq;
+  std::unique_ptr<grpc::ClientContext> context(new grpc::ClientContext);
+  auto response = stub.AsyncUpdateDatabaseDdl(cq, std::move(context),
+                                              gcsa::UpdateDatabaseDdlRequest{});
+  EXPECT_EQ(TransientError(), response.get().status());
 
   auto const log_lines = log_.ExtractLines();
   EXPECT_THAT(log_lines, Contains(HasSubstr("UpdateDatabase")));
@@ -131,13 +145,20 @@ TEST_F(DatabaseAdminLoggingTest, ListDatabases) {
 }
 
 TEST_F(DatabaseAdminLoggingTest, RestoreDatabase) {
-  EXPECT_CALL(*mock_, RestoreDatabase).WillOnce(Return(TransientError()));
+  EXPECT_CALL(*mock_, AsyncRestoreDatabase)
+      .WillOnce([](CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
+                   gcsa::RestoreDatabaseRequest const&) {
+        return make_ready_future(
+            StatusOr<google::longrunning::Operation>(TransientError()));
+      });
 
   DatabaseAdminLogging stub(mock_, TracingOptions{});
 
-  grpc::ClientContext context;
-  auto status = stub.RestoreDatabase(context, gcsa::RestoreDatabaseRequest{});
-  EXPECT_EQ(TransientError(), status.status());
+  CompletionQueue cq;
+  std::unique_ptr<grpc::ClientContext> context(new grpc::ClientContext);
+  auto response = stub.AsyncRestoreDatabase(cq, std::move(context),
+                                            gcsa::RestoreDatabaseRequest{});
+  EXPECT_EQ(TransientError(), response.get().status());
 
   auto const log_lines = log_.ExtractLines();
   EXPECT_THAT(log_lines, Contains(HasSubstr("RestoreDatabase")));
@@ -190,13 +211,20 @@ TEST_F(DatabaseAdminLoggingTest, TestIamPermissions) {
 }
 
 TEST_F(DatabaseAdminLoggingTest, CreateBackup) {
-  EXPECT_CALL(*mock_, CreateBackup).WillOnce(Return(TransientError()));
+  EXPECT_CALL(*mock_, AsyncCreateBackup)
+      .WillOnce([](CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
+                   gcsa::CreateBackupRequest const&) {
+        return make_ready_future(
+            StatusOr<google::longrunning::Operation>(TransientError()));
+      });
 
   DatabaseAdminLogging stub(mock_, TracingOptions{});
 
-  grpc::ClientContext context;
-  auto status = stub.CreateBackup(context, gcsa::CreateBackupRequest{});
-  EXPECT_EQ(TransientError(), status.status());
+  CompletionQueue cq;
+  std::unique_ptr<grpc::ClientContext> context(new grpc::ClientContext);
+  auto response = stub.AsyncCreateBackup(cq, std::move(context),
+                                         gcsa::CreateBackupRequest{});
+  EXPECT_EQ(TransientError(), response.get().status());
 
   auto const log_lines = log_.ExtractLines();
   EXPECT_THAT(log_lines, Contains(HasSubstr("CreateBackup")));
@@ -291,14 +319,20 @@ TEST_F(DatabaseAdminLoggingTest, ListDatabaseOperations) {
 }
 
 TEST_F(DatabaseAdminLoggingTest, GetOperation) {
-  EXPECT_CALL(*mock_, GetOperation).WillOnce(Return(TransientError()));
+  EXPECT_CALL(*mock_, AsyncGetOperation)
+      .WillOnce([](CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
+                   google::longrunning::GetOperationRequest const&) {
+        return make_ready_future(
+            StatusOr<google::longrunning::Operation>(TransientError()));
+      });
 
   DatabaseAdminLogging stub(mock_, TracingOptions{});
 
-  grpc::ClientContext context;
-  auto status =
-      stub.GetOperation(context, google::longrunning::GetOperationRequest{});
-  EXPECT_EQ(TransientError(), status.status());
+  CompletionQueue cq;
+  std::unique_ptr<grpc::ClientContext> context(new grpc::ClientContext);
+  auto response = stub.AsyncGetOperation(
+      cq, std::move(context), google::longrunning::GetOperationRequest{});
+  EXPECT_EQ(TransientError(), response.get().status());
 
   auto const log_lines = log_.ExtractLines();
   EXPECT_THAT(log_lines, Contains(HasSubstr("GetOperation")));
@@ -306,14 +340,19 @@ TEST_F(DatabaseAdminLoggingTest, GetOperation) {
 }
 
 TEST_F(DatabaseAdminLoggingTest, CancelOperation) {
-  EXPECT_CALL(*mock_, CancelOperation).WillOnce(Return(TransientError()));
+  EXPECT_CALL(*mock_, AsyncCancelOperation)
+      .WillOnce([](CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
+                   google::longrunning::CancelOperationRequest const&) {
+        return make_ready_future(TransientError());
+      });
 
   DatabaseAdminLogging stub(mock_, TracingOptions{});
 
-  grpc::ClientContext context;
-  auto status = stub.CancelOperation(
-      context, google::longrunning::CancelOperationRequest{});
-  EXPECT_EQ(TransientError(), status);
+  CompletionQueue cq;
+  std::unique_ptr<grpc::ClientContext> context(new grpc::ClientContext);
+  auto status = stub.AsyncCancelOperation(
+      cq, std::move(context), google::longrunning::CancelOperationRequest{});
+  EXPECT_EQ(TransientError(), status.get());
 
   auto const log_lines = log_.ExtractLines();
   EXPECT_THAT(log_lines, Contains(HasSubstr("CancelOperation")));

--- a/google/cloud/spanner/internal/database_admin_metadata.cc
+++ b/google/cloud/spanner/internal/database_admin_metadata.cc
@@ -28,10 +28,12 @@ DatabaseAdminMetadata::DatabaseAdminMetadata(
     : child_(std::move(child)),
       api_client_header_(google::cloud::internal::ApiClientHeader()) {}
 
-StatusOr<google::longrunning::Operation> DatabaseAdminMetadata::CreateDatabase(
-    grpc::ClientContext& context, gcsa::CreateDatabaseRequest const& request) {
-  SetMetadata(context, "parent=" + request.parent());
-  return child_->CreateDatabase(context, request);
+future<StatusOr<google::longrunning::Operation>>
+DatabaseAdminMetadata::AsyncCreateDatabase(
+    CompletionQueue& cq, std::unique_ptr<grpc::ClientContext> context,
+    gcsa::CreateDatabaseRequest const& request) {
+  SetMetadata(*context, "parent=" + request.parent());
+  return child_->AsyncCreateDatabase(cq, std::move(context), request);
 }
 
 StatusOr<gcsa::Database> DatabaseAdminMetadata::GetDatabase(
@@ -46,12 +48,12 @@ StatusOr<gcsa::GetDatabaseDdlResponse> DatabaseAdminMetadata::GetDatabaseDdl(
   return child_->GetDatabaseDdl(context, request);
 }
 
-StatusOr<google::longrunning::Operation> DatabaseAdminMetadata::UpdateDatabase(
-    grpc::ClientContext& context,
-    google::spanner::admin::database::v1::UpdateDatabaseDdlRequest const&
-        request) {
-  SetMetadata(context, "database=" + request.database());
-  return child_->UpdateDatabase(context, request);
+future<StatusOr<google::longrunning::Operation>>
+DatabaseAdminMetadata::AsyncUpdateDatabaseDdl(
+    CompletionQueue& cq, std::unique_ptr<grpc::ClientContext> context,
+    gcsa::UpdateDatabaseDdlRequest const& request) {
+  SetMetadata(*context, "database=" + request.database());
+  return child_->AsyncUpdateDatabaseDdl(cq, std::move(context), request);
 }
 
 Status DatabaseAdminMetadata::DropDatabase(
@@ -69,10 +71,12 @@ DatabaseAdminMetadata::ListDatabases(
   return child_->ListDatabases(context, request);
 }
 
-StatusOr<google::longrunning::Operation> DatabaseAdminMetadata::RestoreDatabase(
-    grpc::ClientContext& context, gcsa::RestoreDatabaseRequest const& request) {
-  SetMetadata(context, "parent=" + request.parent());
-  return child_->RestoreDatabase(context, request);
+future<StatusOr<google::longrunning::Operation>>
+DatabaseAdminMetadata::AsyncRestoreDatabase(
+    CompletionQueue& cq, std::unique_ptr<grpc::ClientContext> context,
+    gcsa::RestoreDatabaseRequest const& request) {
+  SetMetadata(*context, "parent=" + request.parent());
+  return child_->AsyncRestoreDatabase(cq, std::move(context), request);
 }
 
 StatusOr<google::iam::v1::Policy> DatabaseAdminMetadata::GetIamPolicy(
@@ -97,10 +101,12 @@ DatabaseAdminMetadata::TestIamPermissions(
   return child_->TestIamPermissions(context, request);
 }
 
-StatusOr<google::longrunning::Operation> DatabaseAdminMetadata::CreateBackup(
-    grpc::ClientContext& context, gcsa::CreateBackupRequest const& request) {
-  SetMetadata(context, "parent=" + request.parent());
-  return child_->CreateBackup(context, request);
+future<StatusOr<google::longrunning::Operation>>
+DatabaseAdminMetadata::AsyncCreateBackup(
+    CompletionQueue& cq, std::unique_ptr<grpc::ClientContext> context,
+    gcsa::CreateBackupRequest const& request) {
+  SetMetadata(*context, "parent=" + request.parent());
+  return child_->AsyncCreateBackup(cq, std::move(context), request);
 }
 
 StatusOr<gcsa::Backup> DatabaseAdminMetadata::GetBackup(
@@ -148,18 +154,19 @@ DatabaseAdminMetadata::ListDatabaseOperations(
   return child_->ListDatabaseOperations(context, request);
 }
 
-StatusOr<google::longrunning::Operation> DatabaseAdminMetadata::GetOperation(
-    grpc::ClientContext& context,
+future<StatusOr<google::longrunning::Operation>>
+DatabaseAdminMetadata::AsyncGetOperation(
+    CompletionQueue& cq, std::unique_ptr<grpc::ClientContext> context,
     google::longrunning::GetOperationRequest const& request) {
-  SetMetadata(context, "name=" + request.name());
-  return child_->GetOperation(context, request);
+  SetMetadata(*context, "name=" + request.name());
+  return child_->AsyncGetOperation(cq, std::move(context), request);
 }
 
-Status DatabaseAdminMetadata::CancelOperation(
-    grpc::ClientContext& context,
+future<Status> DatabaseAdminMetadata::AsyncCancelOperation(
+    CompletionQueue& cq, std::unique_ptr<grpc::ClientContext> context,
     google::longrunning::CancelOperationRequest const& request) {
-  SetMetadata(context, "name=" + request.name());
-  return child_->CancelOperation(context, request);
+  SetMetadata(*context, "name=" + request.name());
+  return child_->AsyncCancelOperation(cq, std::move(context), request);
 }
 
 void DatabaseAdminMetadata::SetMetadata(grpc::ClientContext& context,

--- a/google/cloud/spanner/internal/database_admin_metadata.h
+++ b/google/cloud/spanner/internal/database_admin_metadata.h
@@ -37,10 +37,10 @@ class DatabaseAdminMetadata : public DatabaseAdminStub {
   /**
    * @name Override the functions from `DatabaseAdminStub`.
    */
-  StatusOr<google::longrunning::Operation> CreateDatabase(
-      grpc::ClientContext& context,
-      google::spanner::admin::database::v1::CreateDatabaseRequest const&
-          request) override;
+  future<StatusOr<google::longrunning::Operation>> AsyncCreateDatabase(
+      CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
+      google::spanner::admin::database::v1::CreateDatabaseRequest const&)
+      override;
 
   StatusOr<google::spanner::admin::database::v1::Database> GetDatabase(
       grpc::ClientContext&,
@@ -52,10 +52,10 @@ class DatabaseAdminMetadata : public DatabaseAdminStub {
       google::spanner::admin::database::v1::GetDatabaseDdlRequest const&)
       override;
 
-  StatusOr<google::longrunning::Operation> UpdateDatabase(
-      grpc::ClientContext& context,
-      google::spanner::admin::database::v1::UpdateDatabaseDdlRequest const&
-          request) override;
+  future<StatusOr<google::longrunning::Operation>> AsyncUpdateDatabaseDdl(
+      CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
+      google::spanner::admin::database::v1::UpdateDatabaseDdlRequest const&)
+      override;
 
   Status DropDatabase(
       grpc::ClientContext& context,
@@ -68,10 +68,10 @@ class DatabaseAdminMetadata : public DatabaseAdminStub {
       google::spanner::admin::database::v1::ListDatabasesRequest const&)
       override;
 
-  StatusOr<google::longrunning::Operation> RestoreDatabase(
-      grpc::ClientContext& context,
-      google::spanner::admin::database::v1::RestoreDatabaseRequest const&
-          request) override;
+  future<StatusOr<google::longrunning::Operation>> AsyncRestoreDatabase(
+      CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
+      google::spanner::admin::database::v1::RestoreDatabaseRequest const&)
+      override;
 
   StatusOr<google::iam::v1::Policy> GetIamPolicy(
       grpc::ClientContext& context,
@@ -85,9 +85,9 @@ class DatabaseAdminMetadata : public DatabaseAdminStub {
       grpc::ClientContext& context,
       google::iam::v1::TestIamPermissionsRequest const& request) override;
 
-  StatusOr<google::longrunning::Operation> CreateBackup(
-      grpc::ClientContext& context,
-      google::spanner::admin::database::v1::CreateBackupRequest const& request)
+  future<StatusOr<google::longrunning::Operation>> AsyncCreateBackup(
+      CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
+      google::spanner::admin::database::v1::CreateBackupRequest const&)
       override;
 
   StatusOr<google::spanner::admin::database::v1::Backup> GetBackup(
@@ -122,13 +122,13 @@ class DatabaseAdminMetadata : public DatabaseAdminStub {
       google::spanner::admin::database::v1::ListDatabaseOperationsRequest const&
           request) override;
 
-  StatusOr<google::longrunning::Operation> GetOperation(
-      grpc::ClientContext& context,
-      google::longrunning::GetOperationRequest const& request) override;
+  future<StatusOr<google::longrunning::Operation>> AsyncGetOperation(
+      CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
+      google::longrunning::GetOperationRequest const&) override;
 
-  Status CancelOperation(
-      grpc::ClientContext& context,
-      google::longrunning::CancelOperationRequest const& request) override;
+  future<Status> AsyncCancelOperation(
+      CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
+      google::longrunning::CancelOperationRequest const&) override;
   //@}
 
  private:

--- a/google/cloud/spanner/internal/database_admin_metadata_test.cc
+++ b/google/cloud/spanner/internal/database_admin_metadata_test.cc
@@ -48,48 +48,54 @@ class DatabaseAdminMetadataTest : public ::testing::Test {
 };
 
 TEST_F(DatabaseAdminMetadataTest, CreateDatabase) {
-  EXPECT_CALL(*mock_, CreateDatabase)
-      .WillOnce([this](grpc::ClientContext& context,
+  EXPECT_CALL(*mock_, AsyncCreateDatabase)
+      .WillOnce([this](CompletionQueue&,
+                       std::unique_ptr<grpc::ClientContext> context,
                        gcsa::CreateDatabaseRequest const&) {
         EXPECT_STATUS_OK(
-            IsContextMDValid(context,
+            IsContextMDValid(*context,
                              "google.spanner.admin.database.v1.DatabaseAdmin."
                              "CreateDatabase",
                              expected_api_client_header_));
-        return TransientError();
+        return make_ready_future(
+            StatusOr<google::longrunning::Operation>(TransientError()));
       });
 
   DatabaseAdminMetadata stub(mock_);
-  grpc::ClientContext context;
+  CompletionQueue cq;
+  std::unique_ptr<grpc::ClientContext> context(new grpc::ClientContext);
   gcsa::CreateDatabaseRequest request;
   request.set_parent(
       "projects/test-project-id/"
       "instances/test-instance-id");
-  auto status = stub.CreateDatabase(context, request);
-  EXPECT_EQ(TransientError(), status.status());
+  auto response = stub.AsyncCreateDatabase(cq, std::move(context), request);
+  EXPECT_EQ(TransientError(), response.get().status());
 }
 
 TEST_F(DatabaseAdminMetadataTest, UpdateDatabase) {
-  EXPECT_CALL(*mock_, UpdateDatabase)
-      .WillOnce([this](grpc::ClientContext& context,
+  EXPECT_CALL(*mock_, AsyncUpdateDatabaseDdl)
+      .WillOnce([this](CompletionQueue&,
+                       std::unique_ptr<grpc::ClientContext> context,
                        gcsa::UpdateDatabaseDdlRequest const&) {
         EXPECT_STATUS_OK(
-            IsContextMDValid(context,
+            IsContextMDValid(*context,
                              "google.spanner.admin.database.v1.DatabaseAdmin."
                              "UpdateDatabaseDdl",
                              expected_api_client_header_));
-        return TransientError();
+        return make_ready_future(
+            StatusOr<google::longrunning::Operation>(TransientError()));
       });
 
   DatabaseAdminMetadata stub(mock_);
-  grpc::ClientContext context;
+  CompletionQueue cq;
+  std::unique_ptr<grpc::ClientContext> context(new grpc::ClientContext);
   gcsa::UpdateDatabaseDdlRequest request;
   request.set_database(
       "projects/test-project-id/"
       "instances/test-instance-id/"
       "databases/test-database");
-  auto status = stub.UpdateDatabase(context, request);
-  EXPECT_EQ(TransientError(), status.status());
+  auto response = stub.AsyncUpdateDatabaseDdl(cq, std::move(context), request);
+  EXPECT_EQ(TransientError(), response.get().status());
 }
 
 TEST_F(DatabaseAdminMetadataTest, DropDatabase) {
@@ -138,25 +144,28 @@ TEST_F(DatabaseAdminMetadataTest, ListDatabases) {
 }
 
 TEST_F(DatabaseAdminMetadataTest, RestoreDatabase) {
-  EXPECT_CALL(*mock_, RestoreDatabase)
-      .WillOnce([this](grpc::ClientContext& context,
+  EXPECT_CALL(*mock_, AsyncRestoreDatabase)
+      .WillOnce([this](CompletionQueue&,
+                       std::unique_ptr<grpc::ClientContext> context,
                        gcsa::RestoreDatabaseRequest const&) {
         EXPECT_STATUS_OK(
-            IsContextMDValid(context,
+            IsContextMDValid(*context,
                              "google.spanner.admin.database.v1.DatabaseAdmin."
                              "RestoreDatabase",
                              expected_api_client_header_));
-        return TransientError();
+        return make_ready_future(
+            StatusOr<google::longrunning::Operation>(TransientError()));
       });
 
   DatabaseAdminMetadata stub(mock_);
-  grpc::ClientContext context;
+  CompletionQueue cq;
+  std::unique_ptr<grpc::ClientContext> context(new grpc::ClientContext);
   gcsa::RestoreDatabaseRequest request;
   request.set_parent(
       "projects/test-project-id/"
       "instances/test-instance-id");
-  auto status = stub.RestoreDatabase(context, request);
-  EXPECT_EQ(TransientError(), status.status());
+  auto response = stub.AsyncRestoreDatabase(cq, std::move(context), request);
+  EXPECT_EQ(TransientError(), response.get().status());
 }
 
 TEST_F(DatabaseAdminMetadataTest, GetIamPolicy) {
@@ -235,25 +244,28 @@ TEST_F(DatabaseAdminMetadataTest, TestIamPermissions) {
 }
 
 TEST_F(DatabaseAdminMetadataTest, CreateBackup) {
-  EXPECT_CALL(*mock_, CreateBackup)
-      .WillOnce([this](grpc::ClientContext& context,
+  EXPECT_CALL(*mock_, AsyncCreateBackup)
+      .WillOnce([this](CompletionQueue&,
+                       std::unique_ptr<grpc::ClientContext> context,
                        gcsa::CreateBackupRequest const&) {
         EXPECT_STATUS_OK(
-            IsContextMDValid(context,
+            IsContextMDValid(*context,
                              "google.spanner.admin.database.v1.DatabaseAdmin."
                              "CreateBackup",
                              expected_api_client_header_));
-        return TransientError();
+        return make_ready_future(
+            StatusOr<google::longrunning::Operation>(TransientError()));
       });
 
   DatabaseAdminMetadata stub(mock_);
-  grpc::ClientContext context;
+  CompletionQueue cq;
+  std::unique_ptr<grpc::ClientContext> context(new grpc::ClientContext);
   gcsa::CreateBackupRequest request;
   request.set_parent(
       "projects/test-project-id/"
       "instances/test-instance-id");
-  auto status = stub.CreateBackup(context, request);
-  EXPECT_EQ(TransientError(), status.status());
+  auto response = stub.AsyncCreateBackup(cq, std::move(context), request);
+  EXPECT_EQ(TransientError(), response.get().status());
 }
 
 TEST_F(DatabaseAdminMetadataTest, GetBackup) {
@@ -392,39 +404,44 @@ TEST_F(DatabaseAdminMetadataTest, ListDatabaseOperations) {
 }
 
 TEST_F(DatabaseAdminMetadataTest, GetOperation) {
-  EXPECT_CALL(*mock_, GetOperation)
-      .WillOnce([this](grpc::ClientContext& context,
+  EXPECT_CALL(*mock_, AsyncGetOperation)
+      .WillOnce([this](CompletionQueue&,
+                       std::unique_ptr<grpc::ClientContext> context,
                        google::longrunning::GetOperationRequest const&) {
         EXPECT_STATUS_OK(IsContextMDValid(
-            context, "google.longrunning.Operations.GetOperation",
+            *context, "google.longrunning.Operations.GetOperation",
             expected_api_client_header_));
-        return TransientError();
+        return make_ready_future(
+            StatusOr<google::longrunning::Operation>(TransientError()));
       });
 
   DatabaseAdminMetadata stub(mock_);
-  grpc::ClientContext context;
+  CompletionQueue cq;
+  std::unique_ptr<grpc::ClientContext> context(new grpc::ClientContext);
   google::longrunning::GetOperationRequest request;
   request.set_name("operations/fake-operation-name");
-  auto status = stub.GetOperation(context, request);
-  EXPECT_EQ(TransientError(), status.status());
+  auto response = stub.AsyncGetOperation(cq, std::move(context), request);
+  EXPECT_EQ(TransientError(), response.get().status());
 }
 
 TEST_F(DatabaseAdminMetadataTest, CancelOperation) {
-  EXPECT_CALL(*mock_, CancelOperation)
-      .WillOnce([this](grpc::ClientContext& context,
+  EXPECT_CALL(*mock_, AsyncCancelOperation)
+      .WillOnce([this](CompletionQueue&,
+                       std::unique_ptr<grpc::ClientContext> context,
                        google::longrunning::CancelOperationRequest const&) {
         EXPECT_STATUS_OK(IsContextMDValid(
-            context, "google.longrunning.Operations.CancelOperation",
+            *context, "google.longrunning.Operations.CancelOperation",
             expected_api_client_header_));
-        return TransientError();
+        return make_ready_future(TransientError());
       });
 
   DatabaseAdminMetadata stub(mock_);
-  grpc::ClientContext context;
+  CompletionQueue cq;
+  std::unique_ptr<grpc::ClientContext> context(new grpc::ClientContext);
   google::longrunning::CancelOperationRequest request;
   request.set_name("operations/fake-operation-name");
-  auto status = stub.CancelOperation(context, request);
-  EXPECT_EQ(TransientError(), status);
+  auto status = stub.AsyncCancelOperation(cq, std::move(context), request);
+  EXPECT_EQ(TransientError(), status.get());
 }
 
 }  // namespace

--- a/google/cloud/spanner/internal/database_admin_stub.h
+++ b/google/cloud/spanner/internal/database_admin_stub.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/spanner/connection_options.h"
 #include "google/cloud/spanner/version.h"
+#include "google/cloud/completion_queue.h"
 #include "google/cloud/future.h"
 #include "google/cloud/options.h"
 #include "google/cloud/status_or.h"
@@ -35,10 +36,9 @@ class DatabaseAdminStub {
   virtual ~DatabaseAdminStub() = 0;
 
   /// Start the long-running operation to create a new Cloud Spanner database.
-  virtual StatusOr<google::longrunning::Operation> CreateDatabase(
-      grpc::ClientContext& client_context,
-      google::spanner::admin::database::v1::CreateDatabaseRequest const&
-          request) = 0;
+  virtual future<StatusOr<google::longrunning::Operation>> AsyncCreateDatabase(
+      CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
+      google::spanner::admin::database::v1::CreateDatabaseRequest const&) = 0;
 
   /// Fetch the metadata for a particular database.
   virtual StatusOr<google::spanner::admin::database::v1::Database> GetDatabase(
@@ -52,9 +52,10 @@ class DatabaseAdminStub {
       google::spanner::admin::database::v1::GetDatabaseDdlRequest const&) = 0;
 
   /// Start a database update, using a sequence of DDL statements.
-  virtual StatusOr<google::longrunning::Operation> UpdateDatabase(
-      grpc::ClientContext&, google::spanner::admin::database::v1::
-                                UpdateDatabaseDdlRequest const&) = 0;
+  virtual future<StatusOr<google::longrunning::Operation>>
+  AsyncUpdateDatabaseDdl(CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
+                         google::spanner::admin::database::v1::
+                             UpdateDatabaseDdlRequest const&) = 0;
 
   /// Drop an existing Cloud Spanner database.
   virtual Status DropDatabase(
@@ -70,10 +71,9 @@ class DatabaseAdminStub {
 
   /// Start the long-running operation to restore a database from a given
   /// backup.
-  virtual StatusOr<google::longrunning::Operation> RestoreDatabase(
-      grpc::ClientContext& client_context,
-      google::spanner::admin::database::v1::RestoreDatabaseRequest const&
-          request) = 0;
+  virtual future<StatusOr<google::longrunning::Operation>> AsyncRestoreDatabase(
+      CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
+      google::spanner::admin::database::v1::RestoreDatabaseRequest const&) = 0;
 
   /// Fetch the IAM policy for a particular database.
   virtual StatusOr<google::iam::v1::Policy> GetIamPolicy(
@@ -89,10 +89,9 @@ class DatabaseAdminStub {
                      google::iam::v1::TestIamPermissionsRequest const&) = 0;
 
   /// Start the long-running operation to create a new Cloud Spanner backup.
-  virtual StatusOr<google::longrunning::Operation> CreateBackup(
-      grpc::ClientContext& client_context,
-      google::spanner::admin::database::v1::CreateBackupRequest const&
-          request) = 0;
+  virtual future<StatusOr<google::longrunning::Operation>> AsyncCreateBackup(
+      CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
+      google::spanner::admin::database::v1::CreateBackupRequest const&) = 0;
 
   /// Get metadata on a pending or completed Backup.
   virtual StatusOr<google::spanner::admin::database::v1::Backup> GetBackup(
@@ -133,14 +132,14 @@ class DatabaseAdminStub {
                              ListDatabaseOperationsRequest const&) = 0;
 
   /// Poll a long-running operation.
-  virtual StatusOr<google::longrunning::Operation> GetOperation(
-      grpc::ClientContext& client_context,
-      google::longrunning::GetOperationRequest const& request) = 0;
+  virtual future<StatusOr<google::longrunning::Operation>> AsyncGetOperation(
+      CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
+      google::longrunning::GetOperationRequest const&) = 0;
 
   /// Cancel a long-running operation.
-  virtual Status CancelOperation(
-      grpc::ClientContext& client_context,
-      google::longrunning::CancelOperationRequest const& request) = 0;
+  virtual future<Status> AsyncCancelOperation(
+      CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
+      google::longrunning::CancelOperationRequest const&) = 0;
 };
 
 /**

--- a/google/cloud/spanner/testing/mock_database_admin_stub.h
+++ b/google/cloud/spanner/testing/mock_database_admin_stub.h
@@ -29,8 +29,8 @@ class MockDatabaseAdminStub
     : public google::cloud::spanner_internal::DatabaseAdminStub {
  public:
   MOCK_METHOD(
-      StatusOr<google::longrunning::Operation>, CreateDatabase,
-      (grpc::ClientContext&,
+      future<StatusOr<google::longrunning::Operation>>, AsyncCreateDatabase,
+      (CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
        google::spanner::admin::database::v1::CreateDatabaseRequest const&),
       (override));
 
@@ -48,8 +48,8 @@ class MockDatabaseAdminStub
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::longrunning::Operation>, UpdateDatabase,
-      (grpc::ClientContext&,
+      future<StatusOr<google::longrunning::Operation>>, AsyncUpdateDatabaseDdl,
+      (CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
        google::spanner::admin::database::v1::UpdateDatabaseDdlRequest const&),
       (override));
 
@@ -67,8 +67,8 @@ class MockDatabaseAdminStub
       (override));
 
   MOCK_METHOD(
-      StatusOr<google::longrunning::Operation>, RestoreDatabase,
-      (grpc::ClientContext&,
+      future<StatusOr<google::longrunning::Operation>>, AsyncRestoreDatabase,
+      (CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
        google::spanner::admin::database::v1::RestoreDatabaseRequest const&),
       (override));
 
@@ -89,8 +89,8 @@ class MockDatabaseAdminStub
               (override));
 
   MOCK_METHOD(
-      StatusOr<google::longrunning::Operation>, CreateBackup,
-      (grpc::ClientContext&,
+      future<StatusOr<google::longrunning::Operation>>, AsyncCreateBackup,
+      (CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
        google::spanner::admin::database::v1::CreateBackupRequest const&),
       (override));
 
@@ -134,13 +134,14 @@ class MockDatabaseAdminStub
                                  ListDatabaseOperationsRequest const&),
       (override));
 
-  MOCK_METHOD(StatusOr<google::longrunning::Operation>, GetOperation,
-              (grpc::ClientContext&,
+  MOCK_METHOD(future<StatusOr<google::longrunning::Operation>>,
+              AsyncGetOperation,
+              (CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
                google::longrunning::GetOperationRequest const&),
               (override));
 
-  MOCK_METHOD(Status, CancelOperation,
-              (grpc::ClientContext&,
+  MOCK_METHOD(future<Status>, AsyncCancelOperation,
+              (CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
                google::longrunning::CancelOperationRequest const&),
               (override));
 };


### PR DESCRIPTION
Use the new, common `async_long_running_operation.h` support
to implement `DatabaseAdminConnection::CreateDatabase()`,
`UpdateDatabase()`, `CreateBackup()`, and `RestoreDatabase()`
using the existing background threads (and not a detached
`std::thread`).

Part of #4038.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6853)
<!-- Reviewable:end -->
