### PR TITLE
fix(common): synchronize cancel for long-running operations

### DIFF
--- a/google/cloud/internal/async_polling_loop.cc
+++ b/google/cloud/internal/async_polling_loop.cc
@@ -60,7 +60,6 @@ class AsyncPollingLoopImpl
     google::longrunning::CancelOperationRequest request;
     {
       std::unique_lock<std::mutex> lk(mu_);
-      canceled_ = true;
       if (op_name_.empty()) return;
       request.set_name(op_name_);
     }
@@ -83,7 +82,7 @@ class AsyncPollingLoopImpl
     {
       std::unique_lock<std::mutex> lk(mu_);
       if (canceled_) return Cancelled();
-      op_name_ = std::move(op)->name();
+      op_name_ = std::move(*op->mutable_name());
     }
     Wait();
   }
@@ -134,7 +133,7 @@ class AsyncPollingLoopImpl
     if (op) {
       std::unique_lock<std::mutex> lk(mu_);
       if (canceled_) return Cancelled();
-      op_name_ = std::move(op)->name();
+      op_name_ = std::move(*op->mutable_name());
     }
     Wait();
   }


### PR DESCRIPTION
Cancellation of a long-running operation (1) happens asynchronously
with the flow of callbacks, and (2) requires access to the currently
running operation name. This means we must serialize reads/writes of
that name, so introduce a member mutex.

And given that we now have a mutex, use it to guard `canceled_`
as well, avoiding the need for atomic operations. Also mark the
operation as cancelled when that happens before the operation name
is first set.

Finally, update the `DatabaseAdminConnectionTest.CreateBackupCancel`
test to allow for `AsyncCancelOperation()` not being called before
the polling policy expires.

Fixes #6854.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6855)
<!-- Reviewable:end -->
