### PR TITLE
cleanup: bigtable emulator scripts

### DIFF
--- a/ci/cloudbuild/builds/lib/integration.sh
+++ b/ci/cloudbuild/builds/lib/integration.sh
@@ -182,11 +182,7 @@ function integration::bazel_with_emulators() {
 
   # We retry these tests because the emulator crashes due to #441.
   io::log_h2 "Running Bigtable integration tests (with emulator)"
-  env \
-    CBT=/usr/local/google-cloud-sdk/bin/cbt \
-    CBT_EMULATOR=/usr/local/google-cloud-sdk/platform/bigtable-emulator/cbtemulator \
-    GOPATH="${GOPATH:-}" \
-    ci/retry-command.sh 3 0 \
+  ci/retry-command.sh 3 0 \
     "google/cloud/bigtable/ci/${EMULATOR_SCRIPT}" \
     bazel "${verb}" "${args[@]}"
 
@@ -263,10 +259,7 @@ function integration::ctest_with_emulators() {
     "${cmake_out}" "${ctest_args[@]}" -L integration-test-emulator
 
   io::log_h2 "Running Bigtable integration tests (with emulator)"
-  env CBT=/usr/local/google-cloud-sdk/bin/cbt \
-    CBT_EMULATOR=/usr/local/google-cloud-sdk/platform/bigtable-emulator/cbtemulator \
-    GOPATH="${GOPATH:-}" \
-    ci/retry-command.sh 3 0 \
+  ci/retry-command.sh 3 0 \
     "google/cloud/bigtable/ci/${EMULATOR_SCRIPT}" \
     "${cmake_out}" "${ctest_args[@]}" -L integration-test-emulator
 }

--- a/google/cloud/bigtable/ci/run_integration_tests_emulator_cmake.sh
+++ b/google/cloud/bigtable/ci/run_integration_tests_emulator_cmake.sh
@@ -38,7 +38,7 @@ source module /google/cloud/bigtable/tools/run_emulator_utils.sh
 export ENABLE_BIGTABLE_ADMIN_INTEGRATION_TESTS="yes"
 
 cd "${BINARY_DIR}"
-start_emulators
+start_emulators 8480 8490
 
 ctest -R "^bigtable_" "${ctest_args[@]}"
 exit_status=$?

--- a/google/cloud/bigtable/tools/run_emulator_utils.sh
+++ b/google/cloud/bigtable/tools/run_emulator_utils.sh
@@ -13,64 +13,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set -eu
+
+source "$(dirname "$0")/../../../../ci/lib/init.sh"
+source module ci/lib/io.sh
+
 EMULATOR_PID=0
 INSTANCE_ADMIN_EMULATOR_PID=0
 
-readonly CBT_CMD="${CBT:-${GOPATH}/bin/cbt}"
-readonly CBT_EMULATOR_CMD="${CBT_EMULATOR:-${GOPATH}/bin/emulator}"
-if [ -z "${CBT_INSTANCE_ADMIN_EMULATOR_CMD+x}" ]; then
-  readonly CBT_INSTANCE_ADMIN_EMULATOR_CMD="../tests/instance_admin_emulator"
-fi
-
 function kill_emulators() {
-  echo -n "Killing Bigtable Emulators [${EMULATOR_PID} ${INSTANCE_ADMIN_EMULATOR_PID}] "
+  io::log "Killing Bigtable Emulators..."
+  echo -n "EMULATOR_PID=${EMULATOR_PID} "
   kill "${EMULATOR_PID}" || echo -n "-"
   echo -n "."
   wait "${EMULATOR_PID}" >/dev/null 2>&1 || echo -n "+"
-  echo -n "."
+  echo "."
+  echo -n "INSTANCE_ADMIN_EMULATOR_PID=${INSTANCE_ADMIN_EMULATOR_PID} "
   kill "${INSTANCE_ADMIN_EMULATOR_PID}" || echo -n "-"
   echo -n "."
   wait "${INSTANCE_ADMIN_EMULATOR_PID}" >/dev/null 2>&1 || echo -n "+"
-  echo -n "."
-  echo " done."
-}
-
-################################################
-# Wait until the port number is printed in the log file for one of the
-# emulators
-# Globals:
-#   None
-# Arguments:
-#   logfile: the name of the logfile to wait on.
-# Returns:
-#   None
-################################################
-wait_for_port() {
-  local -r logfile="$1"
-  shift
-
-  local emulator_port="0"
-  local -r expected='Cloud Bigtable emulator running on'
-  for attempt in $(seq 1 8); do
-    if grep -q "${expected}" "${logfile}"; then
-      # The port number is whatever is after the last ':'. Note that on IPv6
-      # there may be multiple ':' characters, and recall that regular
-      # expressions are greedy. If grep has multiple matches this breaks,
-      # which is Okay because then the emulator is exhibiting unexpected
-      # behavior.
-      emulator_port=$(grep "${expected}" "${logfile}" | sed 's/^.*://')
-      break
-    fi
-    sleep 1
-  done
-
-  if [[ "${emulator_port}" = "0" ]]; then
-    echo "Cannot determine Bigtable emulator port." >&2
-    kill_emulators
-    exit 1
-  fi
-
-  echo "${emulator_port}"
+  echo "."
 }
 
 ################################################
@@ -88,49 +50,48 @@ function wait_until_emulator_connects() {
   local subcmd=$2
   shift 2
 
-  local -a CBT_ARGS=("-project" "emulated" "-instance" "emulated" "-creds" "default")
+  local cmd=(
+    "/usr/local/google-cloud-sdk/bin/cbt"
+    "-project" "emulated"
+    "-instance" "emulated"
+    "-creds" "default"
+    "${subcmd}"
+  )
+
   # Wait until the emulator starts responding.
   delay=1
-  connected=no
-  local -r attempts=$(seq 1 8)
-  for _ in ${attempts}; do
-    if env BIGTABLE_EMULATOR_HOST="${address}" \
-      "${CBT_CMD}" "${CBT_ARGS[@]}" "${subcmd}" >/dev/null 2>&1; then
-      connected=yes
-      break
+  for _ in $(seq 1 8); do
+    if env BIGTABLE_EMULATOR_HOST="${address}" "${cmd[@]}" >/dev/null 2>&1; then
+      io::log_green "Connected to the Cloud Bigtable emulator on ${address}"
+      return
     fi
+    io::log "waiting for emulator to start on ${address}..."
     sleep $delay
     delay=$((delay * 2))
   done
 
-  if [[ "${connected}" = "no" ]]; then
-    echo "Cannot connect to Cloud Bigtable emulator; aborting test." >&2
-    exit 1
-  fi
-
-  echo "Successfully connected to the Cloud Bigtable emulator on ${address}."
+  io::log_red "Cannot connect to Cloud Bigtable emulator; aborting test." >&2
+  exit 1
 }
 
 function start_emulators() {
-  local -r initial_port="${1:-0}"
-  local -r initial_instance_admin_port="${2:-0}"
+  local -r emulator_port="$1"
+  local -r instance_admin_emulator_port="$2"
 
-  echo "Launching Cloud Bigtable emulators in the background"
+  io::log "Launching Cloud Bigtable emulators in the background"
   trap kill_emulators EXIT
 
-  # The tests typically run in a Docker container, where the ports are largely
-  # free; when using in manual tests, you can set EMULATOR_PORT.
-  "${CBT_EMULATOR_CMD}" -port "${initial_port}" >emulator.log 2>&1 </dev/null &
+  local -r CBT_EMULATOR_CMD="/usr/local/google-cloud-sdk/platform/bigtable-emulator/cbtemulator"
+  "${CBT_EMULATOR_CMD}" -port "${emulator_port}" >emulator.log 2>&1 </dev/null &
   EMULATOR_PID=$!
-  local -r emulator_port="$(wait_for_port emulator.log)"
 
-  "${CBT_INSTANCE_ADMIN_EMULATOR_CMD}" "${initial_instance_admin_port}" >instance-admin-emulator.log 2>&1 </dev/null &
+  # The path to this command must be set by the caller.
+  "${CBT_INSTANCE_ADMIN_EMULATOR_CMD}" "${instance_admin_emulator_port}" >instance-admin-emulator.log 2>&1 </dev/null &
   INSTANCE_ADMIN_EMULATOR_PID=$!
-  local -r instance_admin_port="$(wait_for_port instance-admin-emulator.log)"
 
   wait_until_emulator_connects "localhost:${emulator_port}" "ls"
-  wait_until_emulator_connects "localhost:${instance_admin_port}" "listinstances"
+  wait_until_emulator_connects "localhost:${instance_admin_emulator_port}" "listinstances"
 
   export BIGTABLE_EMULATOR_HOST="localhost:${emulator_port}"
-  export BIGTABLE_INSTANCE_ADMIN_EMULATOR_HOST="localhost:${instance_admin_port}"
+  export BIGTABLE_INSTANCE_ADMIN_EMULATOR_HOST="localhost:${instance_admin_emulator_port}"
 }


### PR DESCRIPTION
This PR doesn't really fix anything, but I spent some time looking into
BT emulator flakes and noticed some small cleanups that I could do.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6859)
<!-- Reviewable:end -->
