### PR TITLE
cleanup(spanner): Prefer absl::make_unique<T>() over std::unique_ptr<T>(new T)

### DIFF
--- a/google/cloud/spanner/internal/database_admin_logging_test.cc
+++ b/google/cloud/spanner/internal/database_admin_logging_test.cc
@@ -58,9 +58,9 @@ TEST_F(DatabaseAdminLoggingTest, CreateDatabase) {
   DatabaseAdminLogging stub(mock_, TracingOptions{});
 
   CompletionQueue cq;
-  auto context = absl::make_unique<grpc::ClientContext>();
-  auto response = stub.AsyncCreateDatabase(cq, std::move(context),
-                                           gcsa::CreateDatabaseRequest{});
+  auto response =
+      stub.AsyncCreateDatabase(cq, absl::make_unique<grpc::ClientContext>(),
+                               gcsa::CreateDatabaseRequest{});
   EXPECT_EQ(TransientError(), response.get().status());
 
   auto const log_lines = log_.ExtractLines();
@@ -107,9 +107,9 @@ TEST_F(DatabaseAdminLoggingTest, UpdateDatabase) {
   DatabaseAdminLogging stub(mock_, TracingOptions{});
 
   CompletionQueue cq;
-  auto context = absl::make_unique<grpc::ClientContext>();
-  auto response = stub.AsyncUpdateDatabaseDdl(cq, std::move(context),
-                                              gcsa::UpdateDatabaseDdlRequest{});
+  auto response =
+      stub.AsyncUpdateDatabaseDdl(cq, absl::make_unique<grpc::ClientContext>(),
+                                  gcsa::UpdateDatabaseDdlRequest{});
   EXPECT_EQ(TransientError(), response.get().status());
 
   auto const log_lines = log_.ExtractLines();
@@ -156,9 +156,9 @@ TEST_F(DatabaseAdminLoggingTest, RestoreDatabase) {
   DatabaseAdminLogging stub(mock_, TracingOptions{});
 
   CompletionQueue cq;
-  auto context = absl::make_unique<grpc::ClientContext>();
-  auto response = stub.AsyncRestoreDatabase(cq, std::move(context),
-                                            gcsa::RestoreDatabaseRequest{});
+  auto response =
+      stub.AsyncRestoreDatabase(cq, absl::make_unique<grpc::ClientContext>(),
+                                gcsa::RestoreDatabaseRequest{});
   EXPECT_EQ(TransientError(), response.get().status());
 
   auto const log_lines = log_.ExtractLines();
@@ -222,9 +222,9 @@ TEST_F(DatabaseAdminLoggingTest, CreateBackup) {
   DatabaseAdminLogging stub(mock_, TracingOptions{});
 
   CompletionQueue cq;
-  auto context = absl::make_unique<grpc::ClientContext>();
-  auto response = stub.AsyncCreateBackup(cq, std::move(context),
-                                         gcsa::CreateBackupRequest{});
+  auto response =
+      stub.AsyncCreateBackup(cq, absl::make_unique<grpc::ClientContext>(),
+                             gcsa::CreateBackupRequest{});
   EXPECT_EQ(TransientError(), response.get().status());
 
   auto const log_lines = log_.ExtractLines();
@@ -330,9 +330,9 @@ TEST_F(DatabaseAdminLoggingTest, GetOperation) {
   DatabaseAdminLogging stub(mock_, TracingOptions{});
 
   CompletionQueue cq;
-  auto context = absl::make_unique<grpc::ClientContext>();
-  auto response = stub.AsyncGetOperation(
-      cq, std::move(context), google::longrunning::GetOperationRequest{});
+  auto response =
+      stub.AsyncGetOperation(cq, absl::make_unique<grpc::ClientContext>(),
+                             google::longrunning::GetOperationRequest{});
   EXPECT_EQ(TransientError(), response.get().status());
 
   auto const log_lines = log_.ExtractLines();
@@ -350,9 +350,9 @@ TEST_F(DatabaseAdminLoggingTest, CancelOperation) {
   DatabaseAdminLogging stub(mock_, TracingOptions{});
 
   CompletionQueue cq;
-  auto context = absl::make_unique<grpc::ClientContext>();
-  auto status = stub.AsyncCancelOperation(
-      cq, std::move(context), google::longrunning::CancelOperationRequest{});
+  auto status =
+      stub.AsyncCancelOperation(cq, absl::make_unique<grpc::ClientContext>(),
+                                google::longrunning::CancelOperationRequest{});
   EXPECT_EQ(TransientError(), status.get());
 
   auto const log_lines = log_.ExtractLines();

--- a/google/cloud/spanner/internal/database_admin_logging_test.cc
+++ b/google/cloud/spanner/internal/database_admin_logging_test.cc
@@ -18,6 +18,7 @@
 #include "google/cloud/log.h"
 #include "google/cloud/testing_util/scoped_log.h"
 #include "google/cloud/testing_util/status_matchers.h"
+#include "absl/memory/memory.h"
 #include <gmock/gmock.h>
 #include <grpcpp/grpcpp.h>
 
@@ -57,7 +58,7 @@ TEST_F(DatabaseAdminLoggingTest, CreateDatabase) {
   DatabaseAdminLogging stub(mock_, TracingOptions{});
 
   CompletionQueue cq;
-  std::unique_ptr<grpc::ClientContext> context(new grpc::ClientContext);
+  auto context = absl::make_unique<grpc::ClientContext>();
   auto response = stub.AsyncCreateDatabase(cq, std::move(context),
                                            gcsa::CreateDatabaseRequest{});
   EXPECT_EQ(TransientError(), response.get().status());
@@ -106,7 +107,7 @@ TEST_F(DatabaseAdminLoggingTest, UpdateDatabase) {
   DatabaseAdminLogging stub(mock_, TracingOptions{});
 
   CompletionQueue cq;
-  std::unique_ptr<grpc::ClientContext> context(new grpc::ClientContext);
+  auto context = absl::make_unique<grpc::ClientContext>();
   auto response = stub.AsyncUpdateDatabaseDdl(cq, std::move(context),
                                               gcsa::UpdateDatabaseDdlRequest{});
   EXPECT_EQ(TransientError(), response.get().status());
@@ -155,7 +156,7 @@ TEST_F(DatabaseAdminLoggingTest, RestoreDatabase) {
   DatabaseAdminLogging stub(mock_, TracingOptions{});
 
   CompletionQueue cq;
-  std::unique_ptr<grpc::ClientContext> context(new grpc::ClientContext);
+  auto context = absl::make_unique<grpc::ClientContext>();
   auto response = stub.AsyncRestoreDatabase(cq, std::move(context),
                                             gcsa::RestoreDatabaseRequest{});
   EXPECT_EQ(TransientError(), response.get().status());
@@ -221,7 +222,7 @@ TEST_F(DatabaseAdminLoggingTest, CreateBackup) {
   DatabaseAdminLogging stub(mock_, TracingOptions{});
 
   CompletionQueue cq;
-  std::unique_ptr<grpc::ClientContext> context(new grpc::ClientContext);
+  auto context = absl::make_unique<grpc::ClientContext>();
   auto response = stub.AsyncCreateBackup(cq, std::move(context),
                                          gcsa::CreateBackupRequest{});
   EXPECT_EQ(TransientError(), response.get().status());
@@ -329,7 +330,7 @@ TEST_F(DatabaseAdminLoggingTest, GetOperation) {
   DatabaseAdminLogging stub(mock_, TracingOptions{});
 
   CompletionQueue cq;
-  std::unique_ptr<grpc::ClientContext> context(new grpc::ClientContext);
+  auto context = absl::make_unique<grpc::ClientContext>();
   auto response = stub.AsyncGetOperation(
       cq, std::move(context), google::longrunning::GetOperationRequest{});
   EXPECT_EQ(TransientError(), response.get().status());
@@ -349,7 +350,7 @@ TEST_F(DatabaseAdminLoggingTest, CancelOperation) {
   DatabaseAdminLogging stub(mock_, TracingOptions{});
 
   CompletionQueue cq;
-  std::unique_ptr<grpc::ClientContext> context(new grpc::ClientContext);
+  auto context = absl::make_unique<grpc::ClientContext>();
   auto status = stub.AsyncCancelOperation(
       cq, std::move(context), google::longrunning::CancelOperationRequest{});
   EXPECT_EQ(TransientError(), status.get());

--- a/google/cloud/spanner/internal/database_admin_metadata_test.cc
+++ b/google/cloud/spanner/internal/database_admin_metadata_test.cc
@@ -64,12 +64,12 @@ TEST_F(DatabaseAdminMetadataTest, CreateDatabase) {
 
   DatabaseAdminMetadata stub(mock_);
   CompletionQueue cq;
-  auto context = absl::make_unique<grpc::ClientContext>();
   gcsa::CreateDatabaseRequest request;
   request.set_parent(
       "projects/test-project-id/"
       "instances/test-instance-id");
-  auto response = stub.AsyncCreateDatabase(cq, std::move(context), request);
+  auto response = stub.AsyncCreateDatabase(
+      cq, absl::make_unique<grpc::ClientContext>(), request);
   EXPECT_EQ(TransientError(), response.get().status());
 }
 
@@ -89,13 +89,13 @@ TEST_F(DatabaseAdminMetadataTest, UpdateDatabase) {
 
   DatabaseAdminMetadata stub(mock_);
   CompletionQueue cq;
-  auto context = absl::make_unique<grpc::ClientContext>();
   gcsa::UpdateDatabaseDdlRequest request;
   request.set_database(
       "projects/test-project-id/"
       "instances/test-instance-id/"
       "databases/test-database");
-  auto response = stub.AsyncUpdateDatabaseDdl(cq, std::move(context), request);
+  auto response = stub.AsyncUpdateDatabaseDdl(
+      cq, absl::make_unique<grpc::ClientContext>(), request);
   EXPECT_EQ(TransientError(), response.get().status());
 }
 
@@ -160,12 +160,12 @@ TEST_F(DatabaseAdminMetadataTest, RestoreDatabase) {
 
   DatabaseAdminMetadata stub(mock_);
   CompletionQueue cq;
-  auto context = absl::make_unique<grpc::ClientContext>();
   gcsa::RestoreDatabaseRequest request;
   request.set_parent(
       "projects/test-project-id/"
       "instances/test-instance-id");
-  auto response = stub.AsyncRestoreDatabase(cq, std::move(context), request);
+  auto response = stub.AsyncRestoreDatabase(
+      cq, absl::make_unique<grpc::ClientContext>(), request);
   EXPECT_EQ(TransientError(), response.get().status());
 }
 
@@ -260,12 +260,12 @@ TEST_F(DatabaseAdminMetadataTest, CreateBackup) {
 
   DatabaseAdminMetadata stub(mock_);
   CompletionQueue cq;
-  auto context = absl::make_unique<grpc::ClientContext>();
   gcsa::CreateBackupRequest request;
   request.set_parent(
       "projects/test-project-id/"
       "instances/test-instance-id");
-  auto response = stub.AsyncCreateBackup(cq, std::move(context), request);
+  auto response = stub.AsyncCreateBackup(
+      cq, absl::make_unique<grpc::ClientContext>(), request);
   EXPECT_EQ(TransientError(), response.get().status());
 }
 
@@ -418,10 +418,10 @@ TEST_F(DatabaseAdminMetadataTest, GetOperation) {
 
   DatabaseAdminMetadata stub(mock_);
   CompletionQueue cq;
-  auto context = absl::make_unique<grpc::ClientContext>();
   google::longrunning::GetOperationRequest request;
   request.set_name("operations/fake-operation-name");
-  auto response = stub.AsyncGetOperation(cq, std::move(context), request);
+  auto response = stub.AsyncGetOperation(
+      cq, absl::make_unique<grpc::ClientContext>(), request);
   EXPECT_EQ(TransientError(), response.get().status());
 }
 
@@ -438,10 +438,10 @@ TEST_F(DatabaseAdminMetadataTest, CancelOperation) {
 
   DatabaseAdminMetadata stub(mock_);
   CompletionQueue cq;
-  auto context = absl::make_unique<grpc::ClientContext>();
   google::longrunning::CancelOperationRequest request;
   request.set_name("operations/fake-operation-name");
-  auto status = stub.AsyncCancelOperation(cq, std::move(context), request);
+  auto status = stub.AsyncCancelOperation(
+      cq, absl::make_unique<grpc::ClientContext>(), request);
   EXPECT_EQ(TransientError(), status.get());
 }
 

--- a/google/cloud/spanner/internal/database_admin_metadata_test.cc
+++ b/google/cloud/spanner/internal/database_admin_metadata_test.cc
@@ -17,6 +17,7 @@
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include "google/cloud/testing_util/validate_metadata.h"
+#include "absl/memory/memory.h"
 #include <gmock/gmock.h>
 #include <grpcpp/grpcpp.h>
 
@@ -63,7 +64,7 @@ TEST_F(DatabaseAdminMetadataTest, CreateDatabase) {
 
   DatabaseAdminMetadata stub(mock_);
   CompletionQueue cq;
-  std::unique_ptr<grpc::ClientContext> context(new grpc::ClientContext);
+  auto context = absl::make_unique<grpc::ClientContext>();
   gcsa::CreateDatabaseRequest request;
   request.set_parent(
       "projects/test-project-id/"
@@ -88,7 +89,7 @@ TEST_F(DatabaseAdminMetadataTest, UpdateDatabase) {
 
   DatabaseAdminMetadata stub(mock_);
   CompletionQueue cq;
-  std::unique_ptr<grpc::ClientContext> context(new grpc::ClientContext);
+  auto context = absl::make_unique<grpc::ClientContext>();
   gcsa::UpdateDatabaseDdlRequest request;
   request.set_database(
       "projects/test-project-id/"
@@ -159,7 +160,7 @@ TEST_F(DatabaseAdminMetadataTest, RestoreDatabase) {
 
   DatabaseAdminMetadata stub(mock_);
   CompletionQueue cq;
-  std::unique_ptr<grpc::ClientContext> context(new grpc::ClientContext);
+  auto context = absl::make_unique<grpc::ClientContext>();
   gcsa::RestoreDatabaseRequest request;
   request.set_parent(
       "projects/test-project-id/"
@@ -259,7 +260,7 @@ TEST_F(DatabaseAdminMetadataTest, CreateBackup) {
 
   DatabaseAdminMetadata stub(mock_);
   CompletionQueue cq;
-  std::unique_ptr<grpc::ClientContext> context(new grpc::ClientContext);
+  auto context = absl::make_unique<grpc::ClientContext>();
   gcsa::CreateBackupRequest request;
   request.set_parent(
       "projects/test-project-id/"
@@ -417,7 +418,7 @@ TEST_F(DatabaseAdminMetadataTest, GetOperation) {
 
   DatabaseAdminMetadata stub(mock_);
   CompletionQueue cq;
-  std::unique_ptr<grpc::ClientContext> context(new grpc::ClientContext);
+  auto context = absl::make_unique<grpc::ClientContext>();
   google::longrunning::GetOperationRequest request;
   request.set_name("operations/fake-operation-name");
   auto response = stub.AsyncGetOperation(cq, std::move(context), request);
@@ -437,7 +438,7 @@ TEST_F(DatabaseAdminMetadataTest, CancelOperation) {
 
   DatabaseAdminMetadata stub(mock_);
   CompletionQueue cq;
-  std::unique_ptr<grpc::ClientContext> context(new grpc::ClientContext);
+  auto context = absl::make_unique<grpc::ClientContext>();
   google::longrunning::CancelOperationRequest request;
   request.set_name("operations/fake-operation-name");
   auto status = stub.AsyncCancelOperation(cq, std::move(context), request);

--- a/google/cloud/spanner/internal/instance_admin_logging_test.cc
+++ b/google/cloud/spanner/internal/instance_admin_logging_test.cc
@@ -18,6 +18,7 @@
 #include "google/cloud/log.h"
 #include "google/cloud/testing_util/scoped_log.h"
 #include "google/cloud/testing_util/status_matchers.h"
+#include "absl/memory/memory.h"
 #include <gmock/gmock.h>
 #include <grpcpp/grpcpp.h>
 
@@ -71,7 +72,7 @@ TEST_F(InstanceAdminLoggingTest, CreateInstance) {
   InstanceAdminLogging stub(mock_, TracingOptions{});
 
   CompletionQueue cq;
-  std::unique_ptr<grpc::ClientContext> context(new grpc::ClientContext);
+  auto context = absl::make_unique<grpc::ClientContext>();
   auto response = stub.AsyncCreateInstance(cq, std::move(context),
                                            gcsa::CreateInstanceRequest{});
   EXPECT_EQ(TransientError(), response.get().status());
@@ -92,7 +93,7 @@ TEST_F(InstanceAdminLoggingTest, UpdateInstance) {
   InstanceAdminLogging stub(mock_, TracingOptions{});
 
   CompletionQueue cq;
-  std::unique_ptr<grpc::ClientContext> context(new grpc::ClientContext);
+  auto context = absl::make_unique<grpc::ClientContext>();
   auto response = stub.AsyncUpdateInstance(cq, std::move(context),
                                            gcsa::UpdateInstanceRequest{});
   EXPECT_EQ(TransientError(), response.get().status());

--- a/google/cloud/spanner/internal/instance_admin_logging_test.cc
+++ b/google/cloud/spanner/internal/instance_admin_logging_test.cc
@@ -72,9 +72,9 @@ TEST_F(InstanceAdminLoggingTest, CreateInstance) {
   InstanceAdminLogging stub(mock_, TracingOptions{});
 
   CompletionQueue cq;
-  auto context = absl::make_unique<grpc::ClientContext>();
-  auto response = stub.AsyncCreateInstance(cq, std::move(context),
-                                           gcsa::CreateInstanceRequest{});
+  auto response =
+      stub.AsyncCreateInstance(cq, absl::make_unique<grpc::ClientContext>(),
+                               gcsa::CreateInstanceRequest{});
   EXPECT_EQ(TransientError(), response.get().status());
 
   auto const log_lines = log_.ExtractLines();
@@ -93,9 +93,9 @@ TEST_F(InstanceAdminLoggingTest, UpdateInstance) {
   InstanceAdminLogging stub(mock_, TracingOptions{});
 
   CompletionQueue cq;
-  auto context = absl::make_unique<grpc::ClientContext>();
-  auto response = stub.AsyncUpdateInstance(cq, std::move(context),
-                                           gcsa::UpdateInstanceRequest{});
+  auto response =
+      stub.AsyncUpdateInstance(cq, absl::make_unique<grpc::ClientContext>(),
+                               gcsa::UpdateInstanceRequest{});
   EXPECT_EQ(TransientError(), response.get().status());
 
   auto const log_lines = log_.ExtractLines();

--- a/google/cloud/spanner/internal/instance_admin_metadata_test.cc
+++ b/google/cloud/spanner/internal/instance_admin_metadata_test.cc
@@ -17,6 +17,7 @@
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include "google/cloud/testing_util/validate_metadata.h"
+#include "absl/memory/memory.h"
 #include <gmock/gmock.h>
 #include <grpcpp/grpcpp.h>
 
@@ -127,7 +128,7 @@ TEST_F(InstanceAdminMetadataTest, CreateInstance) {
 
   InstanceAdminMetadata stub(mock_);
   CompletionQueue cq;
-  std::unique_ptr<grpc::ClientContext> context(new grpc::ClientContext);
+  auto context = absl::make_unique<grpc::ClientContext>();
   gcsa::CreateInstanceRequest request;
   request.set_parent("projects/test-project-id");
   request.set_instance_id("test-instance-id");
@@ -151,7 +152,7 @@ TEST_F(InstanceAdminMetadataTest, UpdateInstance) {
 
   InstanceAdminMetadata stub(mock_);
   CompletionQueue cq;
-  std::unique_ptr<grpc::ClientContext> context(new grpc::ClientContext);
+  auto context = absl::make_unique<grpc::ClientContext>();
   gcsa::UpdateInstanceRequest request;
   request.mutable_instance()->set_name(
       "projects/test-project-id/instances/test-instance-id");

--- a/google/cloud/spanner/internal/instance_admin_metadata_test.cc
+++ b/google/cloud/spanner/internal/instance_admin_metadata_test.cc
@@ -128,11 +128,11 @@ TEST_F(InstanceAdminMetadataTest, CreateInstance) {
 
   InstanceAdminMetadata stub(mock_);
   CompletionQueue cq;
-  auto context = absl::make_unique<grpc::ClientContext>();
   gcsa::CreateInstanceRequest request;
   request.set_parent("projects/test-project-id");
   request.set_instance_id("test-instance-id");
-  auto response = stub.AsyncCreateInstance(cq, std::move(context), request);
+  auto response = stub.AsyncCreateInstance(
+      cq, absl::make_unique<grpc::ClientContext>(), request);
   EXPECT_EQ(TransientError(), response.get().status());
 }
 
@@ -152,11 +152,11 @@ TEST_F(InstanceAdminMetadataTest, UpdateInstance) {
 
   InstanceAdminMetadata stub(mock_);
   CompletionQueue cq;
-  auto context = absl::make_unique<grpc::ClientContext>();
   gcsa::UpdateInstanceRequest request;
   request.mutable_instance()->set_name(
       "projects/test-project-id/instances/test-instance-id");
-  auto response = stub.AsyncUpdateInstance(cq, std::move(context), request);
+  auto response = stub.AsyncUpdateInstance(
+      cq, absl::make_unique<grpc::ClientContext>(), request);
   EXPECT_EQ(TransientError(), response.get().status());
 }
 

--- a/google/cloud/spanner/internal/partial_result_set_source_test.cc
+++ b/google/cloud/spanner/internal/partial_result_set_source_test.cc
@@ -84,7 +84,6 @@ TEST(PartialResultSetSourceTest, ReadSuccessThenFailure) {
   Status finish_status(StatusCode::kCancelled, "cancelled");
   EXPECT_CALL(*grpc_reader, Finish()).WillOnce(Return(finish_status));
   // The first call to NextRow() yields a row but the second gives an error.
-  auto context = absl::make_unique<grpc::ClientContext>();
   auto reader = PartialResultSetSource::Create(std::move(grpc_reader));
   EXPECT_STATUS_OK(reader.status());
   EXPECT_THAT((*reader)->NextRow(),
@@ -102,7 +101,6 @@ TEST(PartialResultSetSourceTest, MissingMetadata) {
   // The destructor should try to cancel the RPC to avoid deadlocks.
   EXPECT_CALL(*grpc_reader, TryCancel()).Times(1);
 
-  auto context = absl::make_unique<grpc::ClientContext>();
   auto reader = PartialResultSetSource::Create(std::move(grpc_reader));
   EXPECT_THAT(reader, StatusIs(StatusCode::kInternal,
                                "response contained no metadata"));
@@ -122,7 +120,6 @@ TEST(PartialResultSetSourceTest, MissingRowTypeNoData) {
       .WillOnce(Return(absl::optional<spanner_proto::PartialResultSet>{}));
   EXPECT_CALL(*grpc_reader, Finish()).WillOnce(Return(Status()));
 
-  auto context = absl::make_unique<grpc::ClientContext>();
   auto reader = PartialResultSetSource::Create(std::move(grpc_reader));
   ASSERT_STATUS_OK(reader);
   EXPECT_THAT((*reader)->NextRow(), IsValidAndEquals(spanner::Row{}));
@@ -144,7 +141,6 @@ TEST(PartialResultSetSourceTest, MissingRowTypeWithData) {
   // The destructor should try to cancel the RPC to avoid deadlocks.
   EXPECT_CALL(*grpc_reader, TryCancel()).Times(1);
 
-  auto context = absl::make_unique<grpc::ClientContext>();
   auto reader = PartialResultSetSource::Create(std::move(grpc_reader));
   ASSERT_STATUS_OK(reader);
   StatusOr<spanner::Row> row = (*reader)->NextRow();
@@ -198,7 +194,6 @@ TEST(PartialResultSetSourceTest, SingleResponse) {
       .WillOnce(Return(absl::optional<spanner_proto::PartialResultSet>{}));
   EXPECT_CALL(*grpc_reader, Finish()).WillOnce(Return(Status()));
 
-  auto context = absl::make_unique<grpc::ClientContext>();
   auto reader = PartialResultSetSource::Create(std::move(grpc_reader));
   EXPECT_STATUS_OK(reader.status());
 
@@ -321,7 +316,6 @@ TEST(PartialResultSetSourceTest, MultipleResponses) {
       .WillOnce(Return(absl::optional<spanner_proto::PartialResultSet>{}));
   EXPECT_CALL(*grpc_reader, Finish()).WillOnce(Return(Status()));
 
-  auto context = absl::make_unique<grpc::ClientContext>();
   auto reader = PartialResultSetSource::Create(std::move(grpc_reader));
   EXPECT_STATUS_OK(reader.status());
 
@@ -377,7 +371,6 @@ TEST(PartialResultSetSourceTest, ResponseWithNoValues) {
       .WillOnce(Return(absl::optional<spanner_proto::PartialResultSet>{}));
   EXPECT_CALL(*grpc_reader, Finish()).WillOnce(Return(Status()));
 
-  auto context = absl::make_unique<grpc::ClientContext>();
   auto reader = PartialResultSetSource::Create(std::move(grpc_reader));
   EXPECT_STATUS_OK(reader.status());
 
@@ -441,7 +434,6 @@ TEST(PartialResultSetSourceTest, ChunkedStringValueWellFormed) {
       .WillOnce(Return(absl::optional<spanner_proto::PartialResultSet>{}));
   EXPECT_CALL(*grpc_reader, Finish()).WillOnce(Return(Status()));
 
-  auto context = absl::make_unique<grpc::ClientContext>();
   auto reader = PartialResultSetSource::Create(std::move(grpc_reader));
   EXPECT_STATUS_OK(reader.status());
 
@@ -490,7 +482,6 @@ TEST(PartialResultSetSourceTest, ChunkedValueSetNoValue) {
   // The destructor should try to cancel the RPC to avoid deadlocks.
   EXPECT_CALL(*grpc_reader, TryCancel()).Times(1);
 
-  auto context = absl::make_unique<grpc::ClientContext>();
   auto reader = PartialResultSetSource::Create(std::move(grpc_reader));
   EXPECT_STATUS_OK(reader.status());
 
@@ -534,7 +525,6 @@ TEST(PartialResultSetSourceTest, ChunkedValueSetNoFollowingValue) {
   // The destructor should try to cancel the RPC to avoid deadlocks.
   EXPECT_CALL(*grpc_reader, TryCancel()).Times(1);
 
-  auto context = absl::make_unique<grpc::ClientContext>();
   auto reader = PartialResultSetSource::Create(std::move(grpc_reader));
   EXPECT_STATUS_OK(reader.status());
 
@@ -577,7 +567,6 @@ TEST(PartialResultSetSourceTest, ChunkedValueSetAtEndOfStream) {
       .WillOnce(Return(absl::optional<spanner_proto::PartialResultSet>{}));
   EXPECT_CALL(*grpc_reader, Finish()).WillOnce(Return(Status()));
 
-  auto context = absl::make_unique<grpc::ClientContext>();
   auto reader = PartialResultSetSource::Create(std::move(grpc_reader));
   EXPECT_STATUS_OK(reader.status());
 
@@ -625,7 +614,6 @@ TEST(PartialResultSetSourceTest, ChunkedValueMergeFailure) {
   // The destructor should try to cancel the RPC to avoid deadlocks.
   EXPECT_CALL(*grpc_reader, TryCancel()).Times(1);
 
-  auto context = absl::make_unique<grpc::ClientContext>();
   auto reader = PartialResultSetSource::Create(std::move(grpc_reader));
   EXPECT_STATUS_OK(reader.status());
 
@@ -698,7 +686,6 @@ TEST(PartialResultSetSourceTest, ErrorOnIncompleteRow) {
       .WillOnce(Return(absl::optional<spanner_proto::PartialResultSet>{}));
   EXPECT_CALL(*grpc_reader, Finish()).WillOnce(Return(Status()));
 
-  auto context = absl::make_unique<grpc::ClientContext>();
   auto reader = PartialResultSetSource::Create(std::move(grpc_reader));
   EXPECT_STATUS_OK(reader.status());
 

--- a/google/cloud/spanner/samples/mock_execute_query.cc
+++ b/google/cloud/spanner/samples/mock_execute_query.cc
@@ -17,6 +17,7 @@
 //! [required-includes]
 #include "google/cloud/spanner/client.h"
 #include "google/cloud/spanner/mocks/mock_spanner_connection.h"
+#include "absl/memory/memory.h"
 #include <google/protobuf/text_format.h>
 #include <gmock/gmock.h>
 //! [required-includes]
@@ -32,8 +33,7 @@ TEST(MockSpannerClient, SuccessfulExecuteQuery) {
   // Create a mock object to stream the results of a ExecuteQuery.
   //! [create-streaming-source]
   auto source =
-      std::unique_ptr<google::cloud::spanner_mocks::MockResultSetSource>(
-          new google::cloud::spanner_mocks::MockResultSetSource);
+      absl::make_unique<google::cloud::spanner_mocks::MockResultSetSource>();
   //! [create-streaming-source]
 
   // Setup the return type of the ExecuteQuery results:


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6866)
<!-- Reviewable:end -->
