### PR TITLE
fix(storage): crashes with tracing enabled

### DIFF
--- a/google/cloud/storage/internal/curl_handle.cc
+++ b/google/cloud/storage/internal/curl_handle.cc
@@ -148,7 +148,8 @@ void CurlHandle::ResetSocketCallback() {
 
 void CurlHandle::EnableLogging(bool enabled) {
   if (enabled) {
-    SetOption(CURLOPT_DEBUGDATA, &debug_info_);
+    debug_info_ = std::make_shared<DebugInfo>();
+    SetOption(CURLOPT_DEBUGDATA, debug_info_.get());
     SetOption(CURLOPT_DEBUGFUNCTION, &CurlHandleDebugCallback);
     SetOption(CURLOPT_VERBOSE, 1L);
   } else {
@@ -159,13 +160,13 @@ void CurlHandle::EnableLogging(bool enabled) {
 }
 
 void CurlHandle::FlushDebug(char const* where) {
-  if (debug_info_.buffer.empty()) return;
-  GCP_LOG(DEBUG) << where << " recv_count=" << debug_info_.recv_count << " ("
-                 << debug_info_.recv_zero_count
-                 << " with no data), send_count=" << debug_info_.send_count
-                 << " (" << debug_info_.send_zero_count << " with no data).";
-  GCP_LOG(DEBUG) << where << ' ' << debug_info_.buffer;
-  debug_info_ = DebugInfo{};
+  if (!debug_info_ || debug_info_->buffer.empty()) return;
+  GCP_LOG(DEBUG) << where << " recv_count=" << debug_info_->recv_count << " ("
+                 << debug_info_->recv_zero_count
+                 << " with no data), send_count=" << debug_info_->send_count
+                 << " (" << debug_info_->send_zero_count << " with no data).";
+  GCP_LOG(DEBUG) << where << ' ' << debug_info_->buffer;
+  *debug_info_ = DebugInfo{};
 }
 
 Status CurlHandle::AsStatus(CURLcode e, char const* where) {

--- a/google/cloud/storage/internal/curl_handle.h
+++ b/google/cloud/storage/internal/curl_handle.h
@@ -43,12 +43,13 @@ class CurlHandle {
   CurlHandle(CurlHandle const&) = delete;
   CurlHandle& operator=(CurlHandle const&) = delete;
 
-  // Allow moves, some care is needed to guarantee the
-  // pointers passed to the C callbacks are stable. For
-  // the debug callback (used rarely), we use a
-  // `std::shared_ptr<>`. For other callbacks they callback
-  // is set up only once the object is stable and won't move
-  // for the lifetime of the callback.
+  // Allow moves, some care is needed to guarantee the pointers passed to the
+  // libcurl C callbacks (`debug`, and `socket`) are stable.
+  // * For the `debug` callback (used rarely), we use a `std::shared_ptr<>`.
+  // * For the `socket` callback, the only classes that use it are
+  //   `CurlDownloadRequest` and `CurlRequest`, those classes guarantee the
+  //   object is not move-constructed-from or move-assigned-from once the
+  //   callback is set up.
   CurlHandle(CurlHandle&&) = default;
   CurlHandle& operator=(CurlHandle&&) = default;
 

--- a/google/cloud/storage/internal/curl_handle.h
+++ b/google/cloud/storage/internal/curl_handle.h
@@ -47,7 +47,7 @@ class CurlHandle {
   // libcurl C callbacks (`debug`, and `socket`) are stable.
   // * For the `debug` callback (used rarely), we use a `std::shared_ptr<>`.
   // * For the `socket` callback, the only classes that use it are
-  //   `CurlDownloadRequest` and `CurlRequest`, those classes guarantee the
+  //   `CurlDownloadRequest` and `CurlRequest`.  These classes guarantee the
   //   object is not move-constructed-from or move-assigned-from once the
   //   callback is set up.
   CurlHandle(CurlHandle&&) = default;

--- a/google/cloud/storage/internal/curl_handle.h
+++ b/google/cloud/storage/internal/curl_handle.h
@@ -43,7 +43,12 @@ class CurlHandle {
   CurlHandle(CurlHandle const&) = delete;
   CurlHandle& operator=(CurlHandle const&) = delete;
 
-  // Allow moves, they immediately disable callbacks.
+  // Allow moves, some care is needed to guarantee the
+  // pointers passed to the C callbacks are stable. For
+  // the debug callback (used rarely), we use a
+  // `std::shared_ptr<>`. For other callbacks they callback
+  // is set up only once the object is stable and won't move
+  // for the lifetime of the callback.
   CurlHandle(CurlHandle&&) = default;
   CurlHandle& operator=(CurlHandle&&) = default;
 
@@ -139,7 +144,7 @@ class CurlHandle {
   }
 
   CurlPtr handle_;
-  DebugInfo debug_info_;
+  std::shared_ptr<DebugInfo> debug_info_;
   SocketOptions socket_options_;
 };
 

--- a/google/cloud/storage/tests/CMakeLists.txt
+++ b/google/cloud/storage/tests/CMakeLists.txt
@@ -52,6 +52,7 @@ set(storage_client_integration_tests
     small_reads_integration_test.cc
     storage_include_test.cc
     thread_integration_test.cc
+    tracing_integration_test.cc
     unified_credentials_integration_test.cc)
 
 # Signed URL conformance tests are parsed using protos. In order to simplify the

--- a/google/cloud/storage/tests/storage_client_integration_tests.bzl
+++ b/google/cloud/storage/tests/storage_client_integration_tests.bzl
@@ -53,5 +53,6 @@ storage_client_integration_tests = [
     "small_reads_integration_test.cc",
     "storage_include_test.cc",
     "thread_integration_test.cc",
+    "tracing_integration_test.cc",
     "unified_credentials_integration_test.cc",
 ]

--- a/google/cloud/storage/tests/tracing_integration_test.cc
+++ b/google/cloud/storage/tests/tracing_integration_test.cc
@@ -1,0 +1,89 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/storage/client.h"
+#include "google/cloud/storage/testing/storage_integration_test.h"
+#include "google/cloud/internal/getenv.h"
+#include "google/cloud/testing_util/scoped_log.h"
+#include "google/cloud/testing_util/status_matchers.h"
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+namespace storage {
+inline namespace STORAGE_CLIENT_NS {
+namespace {
+
+using ::google::cloud::internal::GetEnv;
+using ::google::cloud::testing_util::IsOk;
+using ::google::cloud::testing_util::ScopedLog;
+using ::testing::Contains;
+using ::testing::HasSubstr;
+using ::testing::IsEmpty;
+using ::testing::Not;
+
+class TracingIntegrationTest
+    : public ::google::cloud::storage::testing::StorageIntegrationTest {
+ protected:
+  void SetUp() override {
+    bucket_name_ =
+        GetEnv("GOOGLE_CLOUD_CPP_STORAGE_TEST_BUCKET_NAME").value_or("");
+
+    ASSERT_THAT(bucket_name_, Not(IsEmpty()));
+  }
+
+  std::string const& bucket_name() const { return bucket_name_; }
+
+ private:
+  std::string bucket_name_;
+};
+
+void UseClient(Client client, std::string const& bucket_name,
+               std::string const& object_name, std::string const& payload) {
+  StatusOr<ObjectMetadata> meta = client.InsertObject(
+      bucket_name, object_name, payload, IfGenerationMatch(0));
+  ASSERT_THAT(meta, IsOk());
+  EXPECT_EQ(object_name, meta->name());
+
+  auto stream = client.ReadObject(bucket_name, object_name);
+  std::string actual(std::istreambuf_iterator<char>{stream}, {});
+  EXPECT_EQ(payload, actual);
+
+  auto status = client.DeleteObject(bucket_name, object_name);
+  EXPECT_THAT(status, IsOk());
+}
+
+TEST_F(TracingIntegrationTest, RawClient) {
+  auto client =
+      Client(Options{}.set<TracingComponentsOption>({"raw-client", "http"}));
+
+  ScopedLog log;
+  auto const object_name = MakeRandomObjectName();
+  ASSERT_NO_FATAL_FAILURE(
+      UseClient(client, bucket_name(), object_name, LoremIpsum()));
+  auto const lines = log.ExtractLines();
+  EXPECT_THAT(lines, Contains(HasSubstr("object_name=" + object_name)));
+  EXPECT_THAT(lines, Contains(HasSubstr("/o/" + object_name)));
+  EXPECT_THAT(lines, Contains(HasSubstr("curl(Info)")));
+  EXPECT_THAT(lines, Contains(HasSubstr("curl(Send Header)")));
+  EXPECT_THAT(lines, Contains(HasSubstr("curl(Recv Header)")));
+  EXPECT_THAT(lines, Contains(HasSubstr("curl(Send Data)")));
+  EXPECT_THAT(lines, Contains(HasSubstr("curl(Recv Data)")));
+}
+
+}  // namespace
+}  // namespace STORAGE_CLIENT_NS
+}  // namespace storage
+}  // namespace cloud
+}  // namespace google


### PR DESCRIPTION
With some MSVC configurations (2019+Debug, 2017+Debug, or 2017+Release)
enabling HTTP tracing creates a crash. I think because in other
compilers the move constructor and assignments are not used, and luckily
that means the pointers were stable, but this is not the case for those
versions/configurations of MSVC.

The integration test crashes before this change and succeeds after the
change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6870)
<!-- Reviewable:end -->
