### PR TITLE
cleanup(storage): run benchmarks with fewer privileges

### DIFF
--- a/google/cloud/storage/benchmarks/storage_file_transfer_benchmark.cc
+++ b/google/cloud/storage/benchmarks/storage_file_transfer_benchmark.cc
@@ -90,8 +90,8 @@ int main(int argc, char* argv[]) {
                         gcs::BucketMetadata()
                             .set_storage_class(gcs::storage_class::Standard())
                             .set_location(options->region),
-                        gcs::PredefinedAcl("private"),
-                        gcs::PredefinedDefaultObjectAcl("projectPrivate"),
+                        gcs::PredefinedAcl::ProjectPrivate(),
+                        gcs::PredefinedDefaultObjectAcl::ProjectPrivate(),
                         gcs::Projection("full"))
           .value();
   std::cout << "# Running test on bucket: " << meta.name() << "\n";

--- a/google/cloud/storage/benchmarks/storage_parallel_uploads_benchmark.cc
+++ b/google/cloud/storage/benchmarks/storage_parallel_uploads_benchmark.cc
@@ -191,8 +191,8 @@ int main(int argc, char* argv[]) {
                         gcs::BucketMetadata()
                             .set_storage_class(gcs::storage_class::Standard())
                             .set_location(options->region),
-                        gcs::PredefinedAcl("private"),
-                        gcs::PredefinedDefaultObjectAcl("projectPrivate"),
+                        gcs::PredefinedAcl::ProjectPrivate(),
+                        gcs::PredefinedDefaultObjectAcl::ProjectPrivate(),
                         gcs::Projection("full"))
           .value();
 

--- a/google/cloud/storage/benchmarks/storage_shard_throughput_benchmark.cc
+++ b/google/cloud/storage/benchmarks/storage_shard_throughput_benchmark.cc
@@ -122,8 +122,8 @@ int main(int argc, char* argv[]) {
                         gcs::BucketMetadata()
                             .set_storage_class(gcs::storage_class::Standard())
                             .set_location(options->region),
-                        gcs::PredefinedAcl("private"),
-                        gcs::PredefinedDefaultObjectAcl("projectPrivate"),
+                        gcs::PredefinedAcl::ProjectPrivate(),
+                        gcs::PredefinedDefaultObjectAcl::ProjectPrivate(),
                         gcs::Projection("full"))
           .value();
   std::cout << "# Running test on bucket: " << meta.name() << "\n";

--- a/google/cloud/storage/benchmarks/storage_throughput_vs_cpu_benchmark.cc
+++ b/google/cloud/storage/benchmarks/storage_throughput_vs_cpu_benchmark.cc
@@ -184,8 +184,8 @@ int main(int argc, char* argv[]) {
                           gcs::BucketMetadata()
                               .set_storage_class(gcs::storage_class::Standard())
                               .set_location(options->region),
-                          gcs::PredefinedAcl("private"),
-                          gcs::PredefinedDefaultObjectAcl("projectPrivate"),
+                          gcs::PredefinedAcl::ProjectPrivate(),
+                          gcs::PredefinedDefaultObjectAcl::ProjectPrivate(),
                           gcs::Projection("full"));
   if (!meta) {
     std::cerr << "Error creating bucket: " << meta.status() << "\n";


### PR DESCRIPTION
The benchmarks were creating buckets with `PredefinedAcl::Private()`,
that is, a bucket that requires project owner privileges to create
objects in it. This changes the bucket permissions to
`PredefinedAcl::ProjectPrivate()`, that is, a bucket where project
editors can create objects.

I also changed the benchmarks to use the `PredefinedAcl::*()` helper
functions, they are there to prevent misspelling, might as well use
them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6871)
<!-- Reviewable:end -->
