### PR TITLE
feat(storage): make auto-finalization optional

### DIFF
--- a/google/cloud/storage/CMakeLists.txt
+++ b/google/cloud/storage/CMakeLists.txt
@@ -57,6 +57,8 @@ find_package(ZLIB REQUIRED)
 # the client library
 add_library(
     google_cloud_cpp_storage # cmake-format: sort
+    auto_finalize.cc
+    auto_finalize.h
     bucket_access_control.cc
     bucket_access_control.h
     bucket_metadata.cc
@@ -453,6 +455,7 @@ if (BUILD_TESTING)
     # List the unit tests, then setup the targets and dependencies.
     set(storage_client_unit_tests
         # cmake-format: sort
+        auto_finalize_test.cc
         bucket_access_control_test.cc
         bucket_metadata_test.cc
         bucket_test.cc

--- a/google/cloud/storage/auto_finalize.cc
+++ b/google/cloud/storage/auto_finalize.cc
@@ -1,0 +1,33 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/storage/auto_finalize.h"
+#include <ostream>
+
+namespace google {
+namespace cloud {
+namespace storage {
+inline namespace STORAGE_CLIENT_NS {
+
+std::ostream& operator<<(std::ostream& os, AutoFinalize const& rhs) {
+  if (!rhs.has_value()) return os << AutoFinalize::name() << "=<not-set>";
+  auto const* value =
+      (rhs.value() == AutoFinalizeConfig::kEnabled) ? "enabled" : "disabled";
+  return os << AutoFinalize::name() << "=" << value;
+}
+
+}  // namespace STORAGE_CLIENT_NS
+}  // namespace storage
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/storage/auto_finalize.cc
+++ b/google/cloud/storage/auto_finalize.cc
@@ -21,7 +21,6 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 
 std::ostream& operator<<(std::ostream& os, AutoFinalize const& rhs) {
-  if (!rhs.has_value()) return os << AutoFinalize::name() << "=<not-set>";
   auto const* value =
       (rhs.value() == AutoFinalizeConfig::kEnabled) ? "enabled" : "disabled";
   return os << AutoFinalize::name() << "=" << value;

--- a/google/cloud/storage/auto_finalize.h
+++ b/google/cloud/storage/auto_finalize.h
@@ -1,0 +1,65 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_AUTO_FINALIZE_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_AUTO_FINALIZE_H
+
+#include "google/cloud/storage/internal/complex_option.h"
+#include "google/cloud/storage/version.h"
+#include <iosfwd>
+
+namespace google {
+namespace cloud {
+namespace storage {
+inline namespace STORAGE_CLIENT_NS {
+
+enum class AutoFinalizeConfig {
+  kDisabled,
+  kEnabled,
+};
+
+/**
+ * Control whether upload streams auto-finalize on destruction.
+ *
+ * Some applications need to disable auto-finalization of resumable uploads,
+ * this option (or rather the `AutoFinalizeDisabled()` helper) configures
+ * whether ObjectWriteStream objects finalize an upload when the object is
+ * destructed.
+ */
+struct AutoFinalize
+    : public internal::ComplexOption<AutoFinalize, AutoFinalizeConfig> {
+  using ComplexOption::ComplexOption;
+  AutoFinalize() : ComplexOption(AutoFinalizeConfig::kEnabled) {}
+
+  static char const* name() { return "auto-finalize"; }
+};
+
+/// Configure a stream to automatically finalize an upload on destruction.
+inline AutoFinalize AutoFinalizeEnabled() {
+  return AutoFinalize(AutoFinalizeConfig::kEnabled);
+}
+
+/// Configure a stream to leave uploads pending (not finalized) on destruction.
+inline AutoFinalize AutoFinalizeDisabled() {
+  return AutoFinalize(AutoFinalizeConfig::kDisabled);
+}
+
+std::ostream& operator<<(std::ostream& os, AutoFinalize const& rhs);
+
+}  // namespace STORAGE_CLIENT_NS
+}  // namespace storage
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_AUTO_FINALIZE_H

--- a/google/cloud/storage/auto_finalize.h
+++ b/google/cloud/storage/auto_finalize.h
@@ -32,14 +32,14 @@ enum class AutoFinalizeConfig {
 /**
  * Control whether upload streams auto-finalize on destruction.
  *
- * Some applications need to disable auto-finalization of resumable uploads,
- * this option (or rather the `AutoFinalizeDisabled()` helper) configures
+ * Some applications need to disable auto-finalization of resumable uploads.
+ * This option (or rather the `AutoFinalizeDisabled()` helper) configures
  * whether ObjectWriteStream objects finalize an upload when the object is
  * destructed.
  */
 struct AutoFinalize
     : public internal::ComplexOption<AutoFinalize, AutoFinalizeConfig> {
-  using ComplexOption::ComplexOption;
+  explicit AutoFinalize(AutoFinalizeConfig value) : ComplexOption(value) {}
   AutoFinalize() : ComplexOption(AutoFinalizeConfig::kEnabled) {}
 
   static char const* name() { return "auto-finalize"; }

--- a/google/cloud/storage/auto_finalize_test.cc
+++ b/google/cloud/storage/auto_finalize_test.cc
@@ -1,0 +1,56 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/storage/auto_finalize.h"
+#include <gmock/gmock.h>
+#include <sstream>
+
+namespace google {
+namespace cloud {
+namespace storage {
+inline namespace STORAGE_CLIENT_NS {
+namespace {
+
+TEST(AutoFinalizeTest, Default) {
+  auto const actual = AutoFinalize{};
+  ASSERT_TRUE(actual.has_value());
+  EXPECT_EQ(actual.value(), AutoFinalizeConfig::kEnabled);
+  std::ostringstream os;
+  os << actual;
+  EXPECT_EQ("auto-finalize=enabled", std::move(os).str());
+}
+
+TEST(AutoFinalizeTest, Enabled) {
+  auto const actual = AutoFinalizeEnabled();
+  ASSERT_TRUE(actual.has_value());
+  EXPECT_EQ(actual.value(), AutoFinalizeConfig::kEnabled);
+  std::ostringstream os;
+  os << actual;
+  EXPECT_EQ("auto-finalize=enabled", std::move(os).str());
+}
+
+TEST(AutoFinalizeTest, Disabled) {
+  auto const actual = AutoFinalizeDisabled();
+  ASSERT_TRUE(actual.has_value());
+  EXPECT_EQ(actual.value(), AutoFinalizeConfig::kDisabled);
+  std::ostringstream os;
+  os << actual;
+  EXPECT_EQ("auto-finalize=disabled", std::move(os).str());
+}
+
+}  // namespace
+}  // namespace STORAGE_CLIENT_NS
+}  // namespace storage
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/storage/client.cc
+++ b/google/cloud/storage/client.cc
@@ -94,14 +94,17 @@ ObjectWriteStream Client::WriteObjectImpl(
     ObjectWriteStream error_stream(
         absl::make_unique<internal::ObjectWriteStreambuf>(
             std::move(error), 0,
-            absl::make_unique<internal::NullHashValidator>()));
+            absl::make_unique<internal::NullHashValidator>(),
+            AutoFinalizeConfig::kDisabled));
     error_stream.setstate(std::ios::badbit | std::ios::eofbit);
     error_stream.Close();
     return error_stream;
   }
   return ObjectWriteStream(absl::make_unique<internal::ObjectWriteStreambuf>(
       *std::move(session), raw_client_->client_options().upload_buffer_size(),
-      internal::CreateHashValidator(request)));
+      internal::CreateHashValidator(request),
+      request.GetOption<AutoFinalize>().value_or(
+          AutoFinalizeConfig::kEnabled)));
 }
 
 bool Client::UseSimpleUpload(std::string const& file_name,

--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -1202,7 +1202,7 @@ class Client {
    *   `IfMetagenerationMatch`, `IfMetagenerationNotMatch`, `KmsKeyName`,
    *   `MD5HashValue`, `PredefinedAcl`, `Projection`,
    *   `UseResumableUploadSession`, `UserProject`, `WithObjectMetadata` and
-   *   `UploadContentLength`.
+   *   `UploadContentLength`, `AutoFinalize`.
    *
    * @par Idempotency
    * This operation is only idempotent if restricted by pre-conditions, in this

--- a/google/cloud/storage/google_cloud_cpp_storage.bzl
+++ b/google/cloud/storage/google_cloud_cpp_storage.bzl
@@ -17,6 +17,7 @@
 """Automatically generated source lists for google_cloud_cpp_storage - DO NOT EDIT."""
 
 google_cloud_cpp_storage_hdrs = [
+    "auto_finalize.h",
     "bucket_access_control.h",
     "bucket_metadata.h",
     "client.h",
@@ -128,6 +129,7 @@ google_cloud_cpp_storage_hdrs = [
 ]
 
 google_cloud_cpp_storage_srcs = [
+    "auto_finalize.cc",
     "bucket_access_control.cc",
     "bucket_metadata.cc",
     "client.cc",

--- a/google/cloud/storage/internal/object_requests.h
+++ b/google/cloud/storage/internal/object_requests.h
@@ -15,6 +15,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_OBJECT_REQUESTS_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_OBJECT_REQUESTS_H
 
+#include "google/cloud/storage/auto_finalize.h"
 #include "google/cloud/storage/download_options.h"
 #include "google/cloud/storage/hashing_options.h"
 #include "google/cloud/storage/internal/const_buffer.h"
@@ -346,7 +347,7 @@ class ResumableUploadRequest
           IfMetagenerationMatch, IfMetagenerationNotMatch, KmsKeyName,
           MD5HashValue, PredefinedAcl, Projection, UseResumableUploadSession,
           UserProject, UploadFromOffset, UploadLimit, WithObjectMetadata,
-          UploadContentLength> {
+          UploadContentLength, AutoFinalize> {
  public:
   ResumableUploadRequest() = default;
 

--- a/google/cloud/storage/internal/object_streambuf.h
+++ b/google/cloud/storage/internal/object_streambuf.h
@@ -150,8 +150,8 @@ class ObjectWriteStreambuf : public std::basic_streambuf<char> {
    *
    * Called by the ObjectWriteStream destructor, some applications prefer to
    * explicitly finalize an upload. For example, they may start an upload,
-   * checkpoint the upload id, then upload in chunks and may want *not* finalize
-   * the upload in the presence of exceptions that destroy any
+   * checkpoint the upload id, then upload in chunks and may *not* want to
+   * finalize the upload in the presence of exceptions that destroy any
    * ObjectWriteStream.
    */
   void AutoFlushFinal();

--- a/google/cloud/storage/object_stream.cc
+++ b/google/cloud/storage/object_stream.cc
@@ -61,25 +61,19 @@ ObjectWriteStream::ObjectWriteStream(
   init(buf_.get());
   // If buf_ is already closed, update internal state to represent
   // the fact that no more bytes can be uploaded to this object.
-  if (!buf_->IsOpen()) {
-    CloseBuf();
-  }
+  if (buf_ && !buf_->IsOpen()) CloseBuf();
 }
 
 ObjectWriteStream::~ObjectWriteStream() {
-  if (!IsOpen()) {
-    return;
-  }
+  if (!IsOpen()) return;
   // Disable exceptions, even if the application had enabled exceptions the
   // destructor is supposed to mask them.
   exceptions(std::ios_base::goodbit);
-  Close();
+  buf_->AutoFlushFinal();
 }
 
 void ObjectWriteStream::Close() {
-  if (!buf_) {
-    return;
-  }
+  if (!buf_) return;
   CloseBuf();
 }
 

--- a/google/cloud/storage/object_stream.h
+++ b/google/cloud/storage/object_stream.h
@@ -408,6 +408,8 @@ class ObjectWriteStream : public std::basic_ostream<char> {
    * function results in undefined behavior. Applications should copy any
    * necessary state (such as the value `resumable_session_id()`) before calling
    * this function.
+   *
+   * @snippet storage_object_resumable_write_samples.cc suspend resumable upload
    */
   void Suspend() &&;
 

--- a/google/cloud/storage/object_stream_test.cc
+++ b/google/cloud/storage/object_stream_test.cc
@@ -42,7 +42,8 @@ ObjectWriteStream CreateWriter() {
   auto validator = absl::make_unique<internal::NullHashValidator>();
 
   ObjectWriteStream writer(absl::make_unique<internal::ObjectWriteStreambuf>(
-      std::move(session), 0, std::move(validator)));
+      std::move(session), 0, std::move(validator),
+      AutoFinalizeConfig::kEnabled));
   writer.setstate(std::ios::badbit | std::ios::eofbit);
   writer.Close();
   return writer;

--- a/google/cloud/storage/parallel_upload.cc
+++ b/google/cloud/storage/parallel_upload.cc
@@ -31,7 +31,8 @@ class ParallelObjectWriteStreambuf : public ObjectWriteStreambuf {
       std::size_t max_buffer_size,
       std::unique_ptr<HashValidator> hash_validator)
       : ObjectWriteStreambuf(std::move(upload_session), max_buffer_size,
-                             std::move(hash_validator)),
+                             std::move(hash_validator),
+                             AutoFinalizeConfig::kEnabled),
         state_(std::move(state)),
         stream_idx_(stream_idx) {}
 

--- a/google/cloud/storage/storage_client_unit_tests.bzl
+++ b/google/cloud/storage/storage_client_unit_tests.bzl
@@ -17,6 +17,7 @@
 """Automatically generated unit tests list - DO NOT EDIT."""
 
 storage_client_unit_tests = [
+    "auto_finalize_test.cc",
     "bucket_access_control_test.cc",
     "bucket_metadata_test.cc",
     "bucket_test.cc",

--- a/google/cloud/storage/tests/CMakeLists.txt
+++ b/google/cloud/storage/tests/CMakeLists.txt
@@ -17,6 +17,7 @@
 set(storage_client_integration_tests
     # cmake-format : sort
     alternative_endpoint_integration_test.cc
+    auto_finalize_integration_test.cc
     bucket_integration_test.cc
     create_client_integration_test.cc
     curl_download_request_integration_test.cc

--- a/google/cloud/storage/tests/auto_finalize_integration_test.cc
+++ b/google/cloud/storage/tests/auto_finalize_integration_test.cc
@@ -1,0 +1,145 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/storage/client.h"
+#include "google/cloud/storage/testing/storage_integration_test.h"
+#include "google/cloud/internal/getenv.h"
+#include "google/cloud/testing_util/status_matchers.h"
+#include <gmock/gmock.h>
+#include <fstream>
+
+namespace google {
+namespace cloud {
+namespace storage {
+inline namespace STORAGE_CLIENT_NS {
+namespace {
+
+using ::google::cloud::testing_util::IsOk;
+using ::google::cloud::testing_util::StatusIs;
+
+class AutoFinalizeIntegrationTest
+    : public google::cloud::storage::testing::StorageIntegrationTest {
+ protected:
+  void SetUp() override {
+    google::cloud::storage::testing::StorageIntegrationTest::SetUp();
+    bucket_name_ = google::cloud::internal::GetEnv(
+                       "GOOGLE_CLOUD_CPP_STORAGE_TEST_BUCKET_NAME")
+                       .value_or("");
+    ASSERT_FALSE(bucket_name_.empty());
+  }
+
+  std::string const& bucket_name() const { return bucket_name_; }
+
+ private:
+  std::string bucket_name_;
+};
+
+TEST_F(AutoFinalizeIntegrationTest, DefaultIsEnabled) {
+  StatusOr<Client> client = MakeIntegrationTestClient();
+  ASSERT_STATUS_OK(client);
+
+  auto const object_name = MakeRandomObjectName();
+  auto const expected_text = LoremIpsum();
+  {
+    auto stream =
+        client->WriteObject(bucket_name(), object_name, IfGenerationMatch(0));
+    stream << expected_text;
+  }
+  auto reader = client->ReadObject(bucket_name(), object_name);
+  ASSERT_TRUE(reader.good());
+  ASSERT_STATUS_OK(reader.status());
+  auto const actual =
+      std::string{std::istreambuf_iterator<char>{reader.rdbuf()}, {}};
+  EXPECT_EQ(expected_text, actual);
+
+  (void)client->DeleteObject(bucket_name(), object_name);
+}
+
+TEST_F(AutoFinalizeIntegrationTest, ExplicitlyEnabled) {
+  StatusOr<Client> client = MakeIntegrationTestClient();
+  ASSERT_STATUS_OK(client);
+
+  auto const object_name = MakeRandomObjectName();
+  auto const expected_text = LoremIpsum();
+  {
+    auto stream =
+        client->WriteObject(bucket_name(), object_name, IfGenerationMatch(0),
+                            AutoFinalizeEnabled());
+    stream << expected_text;
+  }
+  auto reader = client->ReadObject(bucket_name(), object_name);
+  EXPECT_TRUE(reader.good());
+  EXPECT_STATUS_OK(reader.status());
+  auto const actual =
+      std::string{std::istreambuf_iterator<char>{reader.rdbuf()}, {}};
+  EXPECT_EQ(expected_text, actual);
+
+  (void)client->DeleteObject(bucket_name(), object_name);
+}
+
+TEST_F(AutoFinalizeIntegrationTest, Disabled) {
+  StatusOr<Client> client = MakeIntegrationTestClient();
+  ASSERT_STATUS_OK(client);
+
+  auto const object_name = MakeRandomObjectName();
+  auto constexpr kQuantum = internal::UploadChunkRequest::kChunkSizeQuantum;
+  auto constexpr kSize = 8 * kQuantum;
+  auto const expected_text = MakeRandomData(kSize);
+  auto const upload_session = [&] {
+    auto os = client->WriteObject(bucket_name(), object_name,
+                                  IfGenerationMatch(0), AutoFinalizeDisabled());
+    auto id = os.resumable_session_id();
+    os.write(expected_text.data(), kQuantum);
+    os << std::flush;
+    return id;
+  }();
+
+  {
+    // The upload is not finalized, so the object should not exist:
+    auto reader = client->ReadObject(bucket_name(), object_name);
+    ASSERT_THAT(reader.status(), StatusIs(StatusCode::kNotFound));
+  }
+
+  for (std::uint64_t from = 0; kQuantum <= (kSize - from);) {
+    auto os =
+        client->WriteObject(bucket_name(), object_name, AutoFinalizeDisabled(),
+                            UseResumableUploadSession(upload_session));
+    from = os.next_expected_byte();
+    if (from >= kSize) break;
+    os.write(expected_text.data() + from, kQuantum);
+    os << std::flush;
+    EXPECT_TRUE(os.good());
+  }
+  auto os =
+      client->WriteObject(bucket_name(), object_name, AutoFinalizeDisabled(),
+                          UseResumableUploadSession(upload_session));
+  os.Close();
+  ASSERT_THAT(os.metadata(), IsOk());
+  EXPECT_EQ(os.metadata()->size(), kSize);
+
+  auto reader = client->ReadObject(bucket_name(), object_name);
+  EXPECT_TRUE(reader.good());
+  EXPECT_STATUS_OK(reader.status());
+  auto const actual =
+      std::string{std::istreambuf_iterator<char>{reader.rdbuf()}, {}};
+  EXPECT_EQ(expected_text, actual);
+
+  (void)client->DeleteObject(bucket_name(), object_name);
+}
+
+}  // namespace
+}  // namespace STORAGE_CLIENT_NS
+}  // namespace storage
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/storage/tests/auto_finalize_integration_test.cc
+++ b/google/cloud/storage/tests/auto_finalize_integration_test.cc
@@ -89,6 +89,8 @@ TEST_F(AutoFinalizeIntegrationTest, ExplicitlyEnabled) {
 }
 
 TEST_F(AutoFinalizeIntegrationTest, Disabled) {
+  // TODO(#6875) - enable this test once GCS+gRPC supports resuming uploads.
+  if (UsingGrpc()) GTEST_SKIP();
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 

--- a/google/cloud/storage/tests/object_write_streambuf_integration_test.cc
+++ b/google/cloud/storage/tests/object_write_streambuf_integration_test.cc
@@ -56,7 +56,7 @@ class ObjectWriteStreambufIntegrationTest
         internal::ClientImplDetails::GetRawClient(*client)
             ->client_options()
             .upload_buffer_size(),
-        absl::make_unique<NullHashValidator>()));
+        absl::make_unique<NullHashValidator>(), AutoFinalizeConfig::kEnabled));
 
     std::ostringstream expected_stream;
     WriteRandomLines(writer, expected_stream, line_count, line_size);

--- a/google/cloud/storage/tests/storage_client_integration_tests.bzl
+++ b/google/cloud/storage/tests/storage_client_integration_tests.bzl
@@ -18,6 +18,7 @@
 
 storage_client_integration_tests = [
     "alternative_endpoint_integration_test.cc",
+    "auto_finalize_integration_test.cc",
     "bucket_integration_test.cc",
     "create_client_integration_test.cc",
     "curl_download_request_integration_test.cc",


### PR DESCRIPTION
Some applications need to delay upload finalization until they
explicitly call `.Close()`, even if the upload stream's destructor is
called. Typically such applications may use resumable uploads,
checkpoint the session id in some external storage, and would prefer to
resume the upload with a new stream object rather than having the
library automatically finalize the upload.

Fixes #6844

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6874)
<!-- Reviewable:end -->
