### PR TITLE
cleanup(common): avoid spurious warnings

### DIFF
--- a/google/cloud/internal/streaming_read_rpc.h
+++ b/google/cloud/internal/streaming_read_rpc.h
@@ -74,7 +74,8 @@ class StreamingReadRpcImpl : public StreamingReadRpc<ResponseType> {
     if (finished_) return;
     Cancel();
     auto status = Finish();
-    if (status.ok()) return;
+    // Getting a kCancelled here is expected, as we just canceled the RPC.
+    if (status.ok() && status.code() != StatusCode::kCancelled) return;
     StreamingReadRpcReportUnhandledError(status, typeid(ResponseType).name());
   }
 


### PR DESCRIPTION
With gRPC, one must finish a streaming RPC before destroying it, which
also requires capturing the output. We do this in the destructor, and
print a warning if some error goes undetected. However, `kCancelled` is
not an unexpected error, the destructor cancels the RPC, there is no
reason to print anything in this case.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6876)
<!-- Reviewable:end -->
