### PR TITLE
ci: use cache_test_results=auto for non-ci/daily bazel builds

### DIFF
--- a/ci/cloudbuild/builds/lib/bazel.sh
+++ b/ci/cloudbuild/builds/lib/bazel.sh
@@ -59,7 +59,7 @@ function bazel::common_args() {
       echo no
       ;;
     *)
-      echo yes
+      echo auto
       ;;
     esac
   }


### PR DESCRIPTION
Recently we moved to `--cache_test_results=no` for CI, and then
daily bazel builds (see #6773 and #6806).  An upshot of this was
that we also moved to `--cache_test_results=yes` for the other
bazel builds.

However, `--cache_test_results=yes` is not the same as defaulting
the flag.  In particular, `yes` indicates that test failures
should be cached, which is undesirable when those tests are flaky.

So restore those other bazel builds to the default caching mode
of `--cache_test_results=auto`, which always reruns failed tests
(and also reruns under `--runs_per_test`).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6879)
<!-- Reviewable:end -->
