### PR TITLE
fix(GCS+gRPC): resumable uploads can resume

### DIFF
--- a/google/cloud/storage/internal/grpc_resumable_upload_session.h
+++ b/google/cloud/storage/internal/grpc_resumable_upload_session.h
@@ -58,14 +58,9 @@ class GrpcResumableUploadSession : public ResumableUploadSession {
   StatusOr<ResumableUploadResponse> UploadGeneric(ConstBufferSequence buffers,
                                                   bool final_chunk);
 
-  void CreateUploadWriter();
-
-  StatusOr<ResumableUploadResponse> HandleStreamClosed();
-
   std::shared_ptr<GrpcClient> client_;
   ResumableUploadSessionGrpcParams session_id_params_;
   std::string session_url_;
-  std::unique_ptr<GrpcClient::InsertStream> upload_writer_;
 
   std::uint64_t next_expected_ = 0;
   bool done_ = false;

--- a/google/cloud/storage/tests/auto_finalize_integration_test.cc
+++ b/google/cloud/storage/tests/auto_finalize_integration_test.cc
@@ -90,7 +90,6 @@ TEST_F(AutoFinalizeIntegrationTest, ExplicitlyEnabled) {
 
 TEST_F(AutoFinalizeIntegrationTest, Disabled) {
   // TODO(#6875) - enable this test once GCS+gRPC supports resuming uploads.
-  if (UsingGrpc()) GTEST_SKIP();
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
@@ -122,6 +121,7 @@ TEST_F(AutoFinalizeIntegrationTest, Disabled) {
     os.write(expected_text.data() + from, kQuantum);
     os << std::flush;
     EXPECT_TRUE(os.good());
+    EXPECT_THAT(os.last_status(), IsOk());
   }
   auto os =
       client->WriteObject(bucket_name(), object_name, AutoFinalizeDisabled(),

--- a/google/cloud/storage/tests/auto_finalize_integration_test.cc
+++ b/google/cloud/storage/tests/auto_finalize_integration_test.cc
@@ -89,7 +89,6 @@ TEST_F(AutoFinalizeIntegrationTest, ExplicitlyEnabled) {
 }
 
 TEST_F(AutoFinalizeIntegrationTest, Disabled) {
-  // TODO(#6875) - enable this test once GCS+gRPC supports resuming uploads.
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 


### PR DESCRIPTION
To make resumable uploads resumable we need to close the stream after
each chunk, and the byte accounting needed some fixing. I was able to
simplify some of the code after these changes.

In the process I discovered and fixed a bug in the emulator: it did not
handle partial uploads correctly.

The "last committed byte" accounting could use a cleanup, but that is
a matter for a future PR (see #6880).

Fixes #6875.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6881)
<!-- Reviewable:end -->
