### PR TITLE
feat(storage): share client in throughput benchmark

### DIFF
--- a/google/cloud/storage/benchmarks/throughput_experiment.cc
+++ b/google/cloud/storage/benchmarks/throughput_experiment.cc
@@ -339,6 +339,8 @@ std::vector<std::unique_ptr<ThroughputExperiment>> CreateUploadExperiments(
   if (options.client_per_thread) {
     grpc_client = DefaultGrpcClient(client_options);
   }
+#else
+  if (options.client_per_thread) grpc_client = gcs::Client(client_options);
 #endif  // GOOGLE_CLOUD_CPP_STORAGE_HAVE_GRPC
 
   std::vector<std::unique_ptr<ThroughputExperiment>> result;

--- a/google/cloud/storage/benchmarks/throughput_experiment.h
+++ b/google/cloud/storage/benchmarks/throughput_experiment.h
@@ -56,6 +56,8 @@ class ThroughputExperiment {
  */
 std::vector<std::unique_ptr<ThroughputExperiment>> CreateUploadExperiments(
     ThroughputOptions const& options,
+    google::cloud::storage::Client rest_client,
+    google::cloud::storage::Client grpc_client,
     google::cloud::Options const& client_options);
 
 /**
@@ -66,6 +68,8 @@ std::vector<std::unique_ptr<ThroughputExperiment>> CreateUploadExperiments(
  */
 std::vector<std::unique_ptr<ThroughputExperiment>> CreateDownloadExperiments(
     ThroughputOptions const& options,
+    google::cloud::storage::Client rest_client,
+    google::cloud::storage::Client grpc_client,
     google::cloud::Options const& client_options, int thread_id);
 
 }  // namespace storage_benchmarks

--- a/google/cloud/storage/benchmarks/throughput_experiment_test.cc
+++ b/google/cloud/storage/benchmarks/throughput_experiment_test.cc
@@ -54,7 +54,7 @@ TEST_P(ThroughputExperimentIntegrationTest, Upload) {
   auto const& client_options =
       google::cloud::storage::internal::ClientImplDetails::GetRawClient(*client)
           ->client_options();
-  auto experiments = CreateUploadExperiments(options, {});
+  auto experiments = CreateUploadExperiments(options, *client, *client, {});
   for (auto& e : experiments) {
     auto object_name = MakeRandomObjectName();
     ThroughputExperimentConfig config{OpType::kOpInsert,
@@ -85,7 +85,8 @@ TEST_P(ThroughputExperimentIntegrationTest, Download) {
   auto const& client_options =
       google::cloud::storage::internal::ClientImplDetails::GetRawClient(*client)
           ->client_options();
-  auto experiments = CreateDownloadExperiments(options, {}, /*thread_id=*/0);
+  auto experiments =
+      CreateDownloadExperiments(options, *client, *client, {}, /*thread_id=*/0);
   for (auto& e : experiments) {
     auto object_name = MakeRandomObjectName();
 

--- a/google/cloud/storage/benchmarks/throughput_options.cc
+++ b/google/cloud/storage/benchmarks/throughput_options.cc
@@ -53,6 +53,10 @@ google::cloud::StatusOr<ThroughputOptions> ParseThroughputOptions(
        [&options](std::string const& val) {
          options.thread_count = std::stoi(val);
        }},
+      {"--client-per-thread", "use a separate client on each thread",
+       [&options](std::string const& val) {
+         options.client_per_thread = ParseBoolean(val).value_or(false);
+       }},
       {"--minimum-object-size", "configure the minimum object size",
        [&options](std::string const& val) {
          options.minimum_object_size = ParseSize(val);
@@ -207,6 +211,13 @@ google::cloud::StatusOr<ThroughputOptions> ParseThroughputOptions(
     std::ostringstream os;
     os << "Invalid range for sample range [" << options.minimum_sample_count
        << ',' << options.maximum_sample_count << "]";
+    return make_status(os);
+  }
+
+  if (options.thread_count <= 0) {
+    std::ostringstream os;
+    os << "Invalid --thread-count value (" << options.thread_count
+       << "), must be > 0";
     return make_status(os);
   }
 

--- a/google/cloud/storage/benchmarks/throughput_options.h
+++ b/google/cloud/storage/benchmarks/throughput_options.h
@@ -30,6 +30,7 @@ struct ThroughputOptions {
   std::chrono::seconds duration =
       std::chrono::seconds(std::chrono::minutes(15));
   int thread_count = 1;
+  bool client_per_thread = false;
   std::int64_t minimum_object_size = 32 * kMiB;
   std::int64_t maximum_object_size = 256 * kMiB;
   std::size_t minimum_write_size = 16 * kMiB;

--- a/google/cloud/storage/benchmarks/throughput_options_test.cc
+++ b/google/cloud/storage/benchmarks/throughput_options_test.cc
@@ -46,6 +46,7 @@ TEST(ThroughputOptions, Basic) {
       "--enabled-apis=JSON,GRPC,XML",
       "--enabled-crc32c=enabled",
       "--enabled-md5=disabled",
+      "--client-per-thread=false",
   });
   ASSERT_STATUS_OK(options);
   EXPECT_EQ("test-project", options->project_id);
@@ -160,6 +161,16 @@ TEST(ThroughputOptions, Validate) {
       "--region=r",
       "--minimum-sample-count=8",
       "--maximum-sample-count=4",
+  }));
+  EXPECT_FALSE(ParseThroughputOptions({
+      "self-test",
+      "--region=r",
+      "--thread-count=0",
+  }));
+  EXPECT_FALSE(ParseThroughputOptions({
+      "self-test",
+      "--region=r",
+      "--thread-count=-2",
   }));
 }
 


### PR DESCRIPTION
Now that the GCS+gRPC plugin supports multiple channels it makes more
sense to use the same client in all threads, at least by default.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6882)
<!-- Reviewable:end -->
