### PR TITLE
ci(spanner): run spanner integration tests against prod

### DIFF
--- a/ci/cloudbuild/builds/integration-daily.sh
+++ b/ci/cloudbuild/builds/integration-daily.sh
@@ -23,7 +23,7 @@
 # `ci/cloudbuild/triggers` directory. "Manual" triggers exist only within the
 # GCB UI at the time of this writing. Users with the appropriate access can run
 # this build by hand with:
-#   `ci/cloudbuild/build.sh --distro fedora integration-daily --project cloud-cpp-testing-resources`
+#   `ci/cloudbuild/build.sh --distro fedora-34 integration-daily --project cloud-cpp-testing-resources`
 
 set -eu
 
@@ -44,3 +44,4 @@ export GOOGLE_CLOUD_CPP_SPANNER_SLOW_INTEGRATION_TESTS="instance,backup"
 export GOOGLE_CLOUD_CPP_IAM_QUOTA_LIMITED_INTEGRATION_TESTS="yes"
 mapfile -t integration_args < <(integration::bazel_args)
 integration::bazel_with_emulators test "${args[@]}" "${integration_args[@]}"
+integration::bazel_without_emulators test "${args[@]}" "${integration_args[@]}"

--- a/ci/cloudbuild/builds/integration-daily.sh
+++ b/ci/cloudbuild/builds/integration-daily.sh
@@ -44,4 +44,7 @@ export GOOGLE_CLOUD_CPP_SPANNER_SLOW_INTEGRATION_TESTS="instance,backup"
 export GOOGLE_CLOUD_CPP_IAM_QUOTA_LIMITED_INTEGRATION_TESTS="yes"
 mapfile -t integration_args < <(integration::bazel_args)
 integration::bazel_with_emulators test "${args[@]}" "${integration_args[@]}"
-integration::bazel_without_emulators test "${args[@]}" "${integration_args[@]}"
+
+io::log_h2 "Running Spanner integration tests (against prod)"
+bazel test "${args[@]}" "${integration_args[@]}" \
+  --test_tag_filters="integration-test" google/cloud/spanner/...

--- a/ci/cloudbuild/builds/lib/integration.sh
+++ b/ci/cloudbuild/builds/lib/integration.sh
@@ -220,22 +220,6 @@ function integration::bazel_with_emulators() {
     //google/cloud/examples/...
 }
 
-# Runs integration tests with bazel, like above, but without using emulators.
-function integration::bazel_without_emulators() {
-  if [[ $# == 0 ]]; then
-    io::log_red "error: bazel verb required"
-    return 1
-  fi
-
-  local verb="$1"
-  local args=("${@:2}")
-
-  io::log_h2 "Running Spanner integration tests"
-  bazel "${verb}" "${args[@]}" \
-    --test_tag_filters="integration-test" -- \
-    "//google/cloud/spanner/...:all"
-}
-
 # Runs integration tests with CTest using emulators. This function requires a
 # first argument that is the "cmake-out" directory where the tests live.
 #

--- a/ci/cloudbuild/builds/lib/integration.sh
+++ b/ci/cloudbuild/builds/lib/integration.sh
@@ -41,7 +41,7 @@ curl -sSL --retry 10 -o /dev/shm/roots.pem https://pki.google.com/roots.pem
 #
 #   mapfile -t args < <(bazel::common_args)
 #   mapfile -t integration_args < <(integration::bazel_args)
-#   integration::bazel_with_emulators test "${args[@]}" "${integration_args}"
+#   integration::bazel_with_emulators test "${args[@]}" "${integration_args[@]}"
 #
 function integration::bazel_args() {
   declare -a args
@@ -134,7 +134,7 @@ function integration::bazel_args() {
 #
 #   mapfile -t args < <(bazel::common_args)
 #   mapfile -t integration_args < <(integration::bazel_args)
-#   integration::bazel_with_emulators test "${args[@]}" "${integration_args}"
+#   integration::bazel_with_emulators test "${args[@]}" "${integration_args[@]}"
 #
 function integration::bazel_with_emulators() {
   readonly EMULATOR_SCRIPT="run_integration_tests_emulator_bazel.sh"
@@ -218,6 +218,22 @@ function integration::bazel_with_emulators() {
     "--test_env=GOOGLE_CLOUD_CPP_TEST_HELLO_WORLD_GRPC_URL=${hello_world_grpc}" \
     "--test_env=GOOGLE_CLOUD_CPP_TEST_HELLO_WORLD_SERVICE_ACCOUNT=${GOOGLE_CLOUD_CPP_TEST_HELLO_WORLD_SERVICE_ACCOUNT}" \
     //google/cloud/examples/...
+}
+
+# Runs integration tests with bazel, like above, but without using emulators.
+function integration::bazel_without_emulators() {
+  if [[ $# == 0 ]]; then
+    io::log_red "error: bazel verb required"
+    return 1
+  fi
+
+  local verb="$1"
+  local args=("${@:2}")
+
+  io::log_h2 "Running Spanner integration tests"
+  bazel "${verb}" "${args[@]}" \
+    --test_tag_filters="integration-test" -- \
+    "//google/cloud/spanner/...:all"
 }
 
 # Runs integration tests with CTest using emulators. This function requires a

--- a/google/cloud/spanner/testing/policies.h
+++ b/google/cloud/spanner/testing/policies.h
@@ -25,9 +25,8 @@ namespace google {
 namespace cloud {
 namespace spanner_testing {
 inline namespace SPANNER_CLIENT_NS {
-// For some tests, use 15 minutes as the maximum polling and retry periods. The
-// default is longer, but we need to timeout earlier in the CI builds.
-auto constexpr kMaximumWaitTimeMinutes = 15;
+
+auto constexpr kMaximumWaitTimeMinutes = 30;  // test timeout notwithstanding
 auto constexpr kBackoffScaling = 2.0;
 
 inline std::unique_ptr<spanner::RetryPolicy> TestRetryPolicy() {


### PR DESCRIPTION
Add a hook for running integration tests without the emulator,
execute the Spanner tests from it, and call the hook during
the `integration-daily` build.

The Spanner samples/tests have cases that are skipped or
short-circuited when running against the emulator, so we lost
some coverage when we move to using the emulator exclusively
from the "normal" builds.  Now we'll at least hit those cases
during `integration-daily`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6888)
<!-- Reviewable:end -->
