### PR TITLE
fix(GCS+gRPC): avoid duplicate headers in downloads

### DIFF
--- a/google/cloud/storage/internal/grpc_object_read_source.cc
+++ b/google/cloud/storage/internal/grpc_object_read_source.cc
@@ -24,7 +24,9 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace internal {
 namespace {
+
 using HeadersMap = std::multimap<std::string, std::string>;
+
 HeadersMap MakeHeadersFromChecksums(
     google::storage::v1::ObjectChecksums const& checksums) {
   HeadersMap headers;
@@ -82,7 +84,9 @@ StatusOr<ReadSourceResult> GrpcObjectReadSource::Read(char* buf,
                 std::move(
                     *response.mutable_checksummed_data()->mutable_content())));
       }
+      if (self.checksumms_known_) return {};
       if (!response.has_object_checksums()) return {};
+      self.checksumms_known_ = true;
       return MakeHeadersFromChecksums(response.object_checksums());
     }
   };

--- a/google/cloud/storage/internal/grpc_object_read_source.cc
+++ b/google/cloud/storage/internal/grpc_object_read_source.cc
@@ -84,9 +84,9 @@ StatusOr<ReadSourceResult> GrpcObjectReadSource::Read(char* buf,
                 std::move(
                     *response.mutable_checksummed_data()->mutable_content())));
       }
-      if (self.checksumms_known_) return {};
+      if (self.checksums_known_) return {};
       if (!response.has_object_checksums()) return {};
-      self.checksumms_known_ = true;
+      self.checksums_known_ = true;
       return MakeHeadersFromChecksums(response.object_checksums());
     }
   };

--- a/google/cloud/storage/internal/grpc_object_read_source.h
+++ b/google/cloud/storage/internal/grpc_object_read_source.h
@@ -66,7 +66,9 @@ class GrpcObjectReadSource : public ObjectReadSource {
   // The status of the request.
   google::cloud::Status status_;
 
-  bool checksumms_known_ = false;
+  // If set the checksums for the object are known and `Read()` does not need
+  // to return them, even if present in the response.
+  bool checksums_known_ = false;
 };
 
 }  // namespace internal

--- a/google/cloud/storage/internal/grpc_object_read_source.h
+++ b/google/cloud/storage/internal/grpc_object_read_source.h
@@ -65,6 +65,8 @@ class GrpcObjectReadSource : public ObjectReadSource {
 
   // The status of the request.
   google::cloud::Status status_;
+
+  bool checksumms_known_ = false;
 };
 
 }  // namespace internal

--- a/google/cloud/storage/internal/grpc_object_read_source_test.cc
+++ b/google/cloud/storage/internal/grpc_object_read_source_test.cc
@@ -200,10 +200,16 @@ TEST(GrpcObjectReadSource, PreserveChecksums) {
             GrpcClient::Crc32cToProto(expected_crc32c));
         return response;
       })
-      .WillOnce([]() {
+      .WillOnce([&] {
         storage_proto::GetObjectMediaResponse response;
         response.mutable_checksummed_data()->set_content(
             " fox jumps over the lazy dog");
+        // The headers may be included more than once in the stream,
+        // `GrpcObjectReadSource` should return them only once.
+        response.mutable_object_checksums()->set_md5_hash(
+            GrpcClient::MD5ToProto(expected_md5));
+        response.mutable_object_checksums()->mutable_crc32c()->set_value(
+            GrpcClient::Crc32cToProto(expected_crc32c));
         return response;
       })
       .WillOnce(Return(Status{}));


### PR DESCRIPTION
The checksum headers could be duplicated in many `Read()` requests.
Because headers are stored in a multimap associated with each
`storage::ObjectReadStream` this resulted in slower processing and
additional memory consumed during the download.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6891)
<!-- Reviewable:end -->
