### PR TITLE
fix(storage): treat 304 errors as kFailedPrecondition

### DIFF
--- a/google/cloud/storage/examples/CMakeLists.txt
+++ b/google/cloud/storage/examples/CMakeLists.txt
@@ -40,6 +40,7 @@ if (BUILD_TESTING)
         storage_object_csek_samples.cc
         storage_object_file_transfer_samples.cc
         storage_object_hold_samples.cc
+        storage_object_preconditions_samples.cc
         storage_object_resumable_write_samples.cc
         storage_object_rewrite_samples.cc
         storage_object_samples.cc

--- a/google/cloud/storage/examples/storage_examples.bzl
+++ b/google/cloud/storage/examples/storage_examples.bzl
@@ -34,6 +34,7 @@ storage_examples = [
     "storage_object_csek_samples.cc",
     "storage_object_file_transfer_samples.cc",
     "storage_object_hold_samples.cc",
+    "storage_object_preconditions_samples.cc",
     "storage_object_resumable_write_samples.cc",
     "storage_object_rewrite_samples.cc",
     "storage_object_samples.cc",

--- a/google/cloud/storage/examples/storage_object_preconditions_samples.cc
+++ b/google/cloud/storage/examples/storage_object_preconditions_samples.cc
@@ -1,4 +1,4 @@
-// Copyright 2018 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,7 +19,6 @@
 #include "google/cloud/internal/getenv.h"
 #include <iostream>
 #include <map>
-#include <sstream>
 #include <string>
 #include <thread>
 

--- a/google/cloud/storage/examples/storage_object_preconditions_samples.cc
+++ b/google/cloud/storage/examples/storage_object_preconditions_samples.cc
@@ -51,18 +51,13 @@ void ReadObjectIfGenerationMatch(google::cloud::storage::Client client,
   using ::google::cloud::StatusOr;
   [](gcs::Client client, std::string const& bucket_name,
      std::string const& object_name, std::int64_t generation) {
-    auto reader = client.ReadObject(bucket_name, object_name,
-                                    gcs::IfGenerationMatch(generation));
+    auto is = client.ReadObject(bucket_name, object_name,
+                                gcs::IfGenerationMatch(generation));
     std::string line;
-    while (std::getline(reader, line)) {
+    while (std::getline(is, line)) {
       std::cout << line << "\n";
     }
-    reader.Close();
-    if (!reader.status().ok()) {
-      std::ostringstream os;
-      os << reader.status();
-      throw std::runtime_error(std::move(os).str());
-    }
+    if (!is.status().ok()) throw std::runtime_error(is.status().message());
   }
   //! [read-object-if-generation-match]
   (std::move(client), argv.at(0), argv.at(1), std::stoll(argv.at(2)));
@@ -75,18 +70,13 @@ void ReadObjectIfMetagenerationMatch(google::cloud::storage::Client client,
   using ::google::cloud::StatusOr;
   [](gcs::Client client, std::string const& bucket_name,
      std::string const& object_name, std::int64_t metageneration) {
-    auto reader = client.ReadObject(bucket_name, object_name,
-                                    gcs::IfMetagenerationMatch(metageneration));
+    auto is = client.ReadObject(bucket_name, object_name,
+                                gcs::IfMetagenerationMatch(metageneration));
     std::string line;
-    while (std::getline(reader, line)) {
+    while (std::getline(is, line)) {
       std::cout << line << "\n";
     }
-    reader.Close();
-    if (!reader.status().ok()) {
-      std::ostringstream os;
-      os << reader.status();
-      throw std::runtime_error(std::move(os).str());
-    }
+    if (!is.status().ok()) throw std::runtime_error(is.status().message());
   }
   //! [read-object-if-metageneration-match]
   (std::move(client), argv.at(0), argv.at(1), std::stoll(argv.at(2)));
@@ -99,18 +89,13 @@ void ReadObjectIfGenerationNotMatch(google::cloud::storage::Client client,
   using ::google::cloud::StatusOr;
   [](gcs::Client client, std::string const& bucket_name,
      std::string const& object_name, std::int64_t generation) {
-    auto reader = client.ReadObject(bucket_name, object_name,
-                                    gcs::IfGenerationNotMatch(generation));
+    auto is = client.ReadObject(bucket_name, object_name,
+                                gcs::IfGenerationNotMatch(generation));
     std::string line;
-    while (std::getline(reader, line)) {
+    while (std::getline(is, line)) {
       std::cout << line << "\n";
     }
-    reader.Close();
-    if (!reader.status().ok()) {
-      std::ostringstream os;
-      os << reader.status();
-      throw std::runtime_error(std::move(os).str());
-    }
+    if (!is.status().ok()) throw std::runtime_error(is.status().message());
   }
   //! [read-object-if-generation-not-match]
   (std::move(client), argv.at(0), argv.at(1), std::stoll(argv.at(2)));
@@ -123,19 +108,13 @@ void ReadObjectIfMetagenerationNotMatch(google::cloud::storage::Client client,
   using ::google::cloud::StatusOr;
   [](gcs::Client client, std::string const& bucket_name,
      std::string const& object_name, std::int64_t metageneration) {
-    auto reader =
-        client.ReadObject(bucket_name, object_name,
-                          gcs::IfMetagenerationNotMatch(metageneration));
+    auto is = client.ReadObject(bucket_name, object_name,
+                                gcs::IfMetagenerationNotMatch(metageneration));
     std::string line;
-    while (std::getline(reader, line)) {
+    while (std::getline(is, line)) {
       std::cout << line << "\n";
     }
-    reader.Close();
-    if (!reader.status().ok()) {
-      std::ostringstream os;
-      os << reader.status();
-      throw std::runtime_error(std::move(os).str());
-    }
+    if (!is.status().ok()) throw std::runtime_error(is.status().message());
   }
   //! [read-object-if-metageneration-not-match]
   (std::move(client), argv.at(0), argv.at(1), std::stoll(argv.at(2)));

--- a/google/cloud/storage/examples/storage_object_preconditions_samples.cc
+++ b/google/cloud/storage/examples/storage_object_preconditions_samples.cc
@@ -26,7 +26,7 @@ namespace {
 
 void InsertOnlyIfDoesNotExists(google::cloud::storage::Client client,
                                std::vector<std::string> const& argv) {
-  //! [insert only if does not exists]
+  //! [insert-only-if-does-not-exists]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
   [](gcs::Client client, std::string const& bucket_name,
@@ -39,7 +39,7 @@ void InsertOnlyIfDoesNotExists(google::cloud::storage::Client client,
     std::cout << "The object " << metadata->name() << " was created in bucket "
               << metadata->bucket() << "\nFull metadata: " << *metadata << "\n";
   }
-  //! [insert only if does not exists]
+  //! [insert-only-if-does-not-exists]
   (std::move(client), argv.at(0), argv.at(1));
 }
 
@@ -136,7 +136,7 @@ void RunAll(std::vector<std::string> const& argv) {
   std::string const object_media("The quick brown fox jumps over the lazy dog");
   auto const object_name = examples::MakeRandomObjectName(generator, "object-");
 
-  std::cout << "\nRunning InsertOnlyIfDoesNotExists() example [1]" << std::endl;
+  std::cout << "\nRunning InsertOnlyIfDoesNotExists() example" << std::endl;
   InsertOnlyIfDoesNotExists(client, {bucket_name, object_name, object_media});
 
   std::cout << "\nRunning ReadObjectIfGenerationMatch() example" << std::endl;

--- a/google/cloud/storage/examples/storage_object_preconditions_samples.cc
+++ b/google/cloud/storage/examples/storage_object_preconditions_samples.cc
@@ -1,0 +1,219 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/storage/client.h"
+#include "google/cloud/storage/examples/storage_examples_common.h"
+#include "google/cloud/storage/parallel_upload.h"
+#include "google/cloud/storage/well_known_parameters.h"
+#include "google/cloud/internal/getenv.h"
+#include <iostream>
+#include <map>
+#include <sstream>
+#include <string>
+#include <thread>
+
+namespace {
+
+void InsertOnlyIfDoesNotExists(google::cloud::storage::Client client,
+                               std::vector<std::string> const& argv) {
+  //! [insert only if does not exists]
+  namespace gcs = google::cloud::storage;
+  using ::google::cloud::StatusOr;
+  [](gcs::Client client, std::string const& bucket_name,
+     std::string const& object_name) {
+    auto metadata = client.InsertObject(
+        bucket_name, object_name, "The quick brown fox jumps over the lazy dog",
+        gcs::IfGenerationMatch(0));
+    if (!metadata) throw std::runtime_error(metadata.status().message());
+
+    std::cout << "The object " << metadata->name() << " was created in bucket "
+              << metadata->bucket() << "\nFull metadata: " << *metadata << "\n";
+  }
+  //! [insert only if does not exists]
+  (std::move(client), argv.at(0), argv.at(1));
+}
+
+void ReadObjectIfGenerationMatch(google::cloud::storage::Client client,
+                                 std::vector<std::string> const& argv) {
+  //! [read-object-if-generation-match]
+  namespace gcs = google::cloud::storage;
+  using ::google::cloud::StatusOr;
+  [](gcs::Client client, std::string const& bucket_name,
+     std::string const& object_name, std::int64_t generation) {
+    auto reader = client.ReadObject(bucket_name, object_name,
+                                    gcs::IfGenerationMatch(generation));
+    std::string line;
+    while (std::getline(reader, line)) {
+      std::cout << line << "\n";
+    }
+    reader.Close();
+    if (!reader.status().ok()) {
+      std::ostringstream os;
+      os << reader.status();
+      throw std::runtime_error(std::move(os).str());
+    }
+  }
+  //! [read-object-if-generation-match]
+  (std::move(client), argv.at(0), argv.at(1), std::stoll(argv.at(2)));
+}
+
+void ReadObjectIfMetagenerationMatch(google::cloud::storage::Client client,
+                                     std::vector<std::string> const& argv) {
+  //! [read-object-if-metageneration-match]
+  namespace gcs = google::cloud::storage;
+  using ::google::cloud::StatusOr;
+  [](gcs::Client client, std::string const& bucket_name,
+     std::string const& object_name, std::int64_t metageneration) {
+    auto reader = client.ReadObject(bucket_name, object_name,
+                                    gcs::IfMetagenerationMatch(metageneration));
+    std::string line;
+    while (std::getline(reader, line)) {
+      std::cout << line << "\n";
+    }
+    reader.Close();
+    if (!reader.status().ok()) {
+      std::ostringstream os;
+      os << reader.status();
+      throw std::runtime_error(std::move(os).str());
+    }
+  }
+  //! [read-object-if-metageneration-match]
+  (std::move(client), argv.at(0), argv.at(1), std::stoll(argv.at(2)));
+}
+
+void ReadObjectIfGenerationNotMatch(google::cloud::storage::Client client,
+                                    std::vector<std::string> const& argv) {
+  //! [read-object-if-generation-not-match]
+  namespace gcs = google::cloud::storage;
+  using ::google::cloud::StatusOr;
+  [](gcs::Client client, std::string const& bucket_name,
+     std::string const& object_name, std::int64_t generation) {
+    auto reader = client.ReadObject(bucket_name, object_name,
+                                    gcs::IfGenerationNotMatch(generation));
+    std::string line;
+    while (std::getline(reader, line)) {
+      std::cout << line << "\n";
+    }
+    reader.Close();
+    if (!reader.status().ok()) {
+      std::ostringstream os;
+      os << reader.status();
+      throw std::runtime_error(std::move(os).str());
+    }
+  }
+  //! [read-object-if-generation-not-match]
+  (std::move(client), argv.at(0), argv.at(1), std::stoll(argv.at(2)));
+}
+
+void ReadObjectIfMetagenerationNotMatch(google::cloud::storage::Client client,
+                                        std::vector<std::string> const& argv) {
+  //! [read-object-if-metageneration-not-match]
+  namespace gcs = google::cloud::storage;
+  using ::google::cloud::StatusOr;
+  [](gcs::Client client, std::string const& bucket_name,
+     std::string const& object_name, std::int64_t metageneration) {
+    auto reader =
+        client.ReadObject(bucket_name, object_name,
+                          gcs::IfMetagenerationNotMatch(metageneration));
+    std::string line;
+    while (std::getline(reader, line)) {
+      std::cout << line << "\n";
+    }
+    reader.Close();
+    if (!reader.status().ok()) {
+      std::ostringstream os;
+      os << reader.status();
+      throw std::runtime_error(std::move(os).str());
+    }
+  }
+  //! [read-object-if-metageneration-not-match]
+  (std::move(client), argv.at(0), argv.at(1), std::stoll(argv.at(2)));
+}
+
+void RunAll(std::vector<std::string> const& argv) {
+  namespace examples = ::google::cloud::storage::examples;
+  namespace gcs = ::google::cloud::storage;
+
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet({
+      "GOOGLE_CLOUD_CPP_STORAGE_TEST_BUCKET_NAME",
+  });
+  auto const bucket_name = google::cloud::internal::GetEnv(
+                               "GOOGLE_CLOUD_CPP_STORAGE_TEST_BUCKET_NAME")
+                               .value();
+  auto generator = google::cloud::internal::DefaultPRNG(std::random_device{}());
+  auto client = gcs::Client();
+
+  std::string const object_media("The quick brown fox jumps over the lazy dog");
+  auto const object_name = examples::MakeRandomObjectName(generator, "object-");
+
+  std::cout << "\nRunning InsertOnlyIfDoesNotExists() example [1]" << std::endl;
+  InsertOnlyIfDoesNotExists(client, {bucket_name, object_name, object_media});
+
+  std::cout << "\nRunning ReadObjectIfGenerationMatch() example" << std::endl;
+  auto object = client.GetObjectMetadata(bucket_name, object_name).value();
+  ReadObjectIfGenerationMatch(
+      client, {bucket_name, object_name, std::to_string(object.generation())});
+
+  std::cout << "\nRunning ReadObjectIfMetagenerationMatch() example"
+            << std::endl;
+  ReadObjectIfMetagenerationMatch(
+      client,
+      {bucket_name, object_name, std::to_string(object.metageneration())});
+
+  std::cout << "\nRunning ReadObjectIfGenerationNotMatch() example"
+            << std::endl;
+  ReadObjectIfGenerationNotMatch(
+      client,
+      {bucket_name, object_name, std::to_string(object.generation() + 1)});
+
+  std::cout << "\nRunning ReadObjectIfMetagenerationNotMatch() example"
+            << std::endl;
+  ReadObjectIfMetagenerationNotMatch(
+      client,
+      {bucket_name, object_name, std::to_string(object.metageneration() + 1)});
+
+  (void)client.DeleteObject(bucket_name, object_name,
+                            gcs::Generation(object.generation()));
+}
+}  // namespace
+
+int main(int argc, char* argv[]) {
+  namespace examples = ::google::cloud::storage::examples;
+  auto make_entry = [](std::string const& name,
+                       std::vector<std::string> arg_names,
+                       examples::ClientCommand const& cmd) {
+    arg_names.insert(arg_names.begin(), "<bucket-name>");
+    return examples::CreateCommandEntry(name, std::move(arg_names), cmd);
+  };
+
+  examples::Example example({
+      make_entry("insert-only-if-does-not-exists", {"<object-name>"},
+                 InsertOnlyIfDoesNotExists),
+      make_entry("read-object-if-generation-match",
+                 {"<object-name>", "<generation>"},
+                 ReadObjectIfGenerationMatch),
+      make_entry("read-object-if-generation-not-match",
+                 {"<object-name>", "<generation>"},
+                 ReadObjectIfGenerationNotMatch),
+      make_entry("read-object-if-metageneration-match",
+                 {"<object-name>", "<metageneration>"},
+                 ReadObjectIfMetagenerationMatch),
+      make_entry("read-object-if-metageneration-not-match",
+                 {"<object-name>", "<metageneration>"},
+                 ReadObjectIfMetagenerationNotMatch),
+      {"auto", RunAll},
+  });
+  return example.Run(argc, argv);
+}

--- a/google/cloud/storage/internal/http_response.h
+++ b/google/cloud/storage/internal/http_response.h
@@ -47,7 +47,7 @@ enum HttpStatusCode {
   // The libcurl library handles (most) redirects, so anything above 300 is
   // actually an error.
   kMinNotSuccess = 300,
-  // This is returned in some download requests instead of 412
+  // This is returned in some download requests instead of 412.
   kNotModified = 304,
 
   kBadRequest = 400,

--- a/google/cloud/storage/internal/http_response.h
+++ b/google/cloud/storage/internal/http_response.h
@@ -47,6 +47,8 @@ enum HttpStatusCode {
   // The libcurl library handles (most) redirects, so anything above 300 is
   // actually an error.
   kMinNotSuccess = 300,
+  // This is returned in some download requests instead of 412
+  kNotModified = 304,
 
   kBadRequest = 400,
   kUnauthorized = 401,

--- a/google/cloud/storage/internal/http_response_test.cc
+++ b/google/cloud/storage/internal/http_response_test.cc
@@ -49,6 +49,8 @@ TEST(HttpResponseTest, AsStatus) {
   EXPECT_STATUS_OK(AsStatus(HttpResponse{299, "success", {}}));
   EXPECT_THAT(AsStatus(HttpResponse{300, "libcurl should handle this", {}}),
               StatusIs(StatusCode::kUnknown));
+  EXPECT_THAT(AsStatus(HttpResponse{304, "nothing changed", {}}),
+              StatusIs(StatusCode::kFailedPrecondition));
   EXPECT_THAT(AsStatus(HttpResponse{308, "pending", {}}),
               StatusIs(StatusCode::kFailedPrecondition));
   EXPECT_THAT(AsStatus(HttpResponse{400, "invalid something", {}}),

--- a/google/cloud/storage/tests/CMakeLists.txt
+++ b/google/cloud/storage/tests/CMakeLists.txt
@@ -41,6 +41,7 @@ set(storage_client_integration_tests
     object_parallel_upload_integration_test.cc
     object_plenty_clients_serially_integration_test.cc
     object_plenty_clients_simultaneously_integration_test.cc
+    object_read_preconditions_integration_test.cc
     object_read_range_integration_test.cc
     object_resumable_parallel_upload_integration_test.cc
     object_resumable_write_integration_test.cc

--- a/google/cloud/storage/tests/object_read_preconditions_integration_test.cc
+++ b/google/cloud/storage/tests/object_read_preconditions_integration_test.cc
@@ -219,7 +219,7 @@ TEST_P(ObjectReadPreconditionsIntegrationTest,
 
 INSTANTIATE_TEST_SUITE_P(XmlDisabled, ObjectReadPreconditionsIntegrationTest,
                          ::testing::Values(TestParam{"disable-xml"}));
-//INSTANTIATE_TEST_SUITE_P(XmlEnabled, ObjectReadPreconditionsIntegrationTest,
+// INSTANTIATE_TEST_SUITE_P(XmlEnabled, ObjectReadPreconditionsIntegrationTest,
 //                         ::testing::Values(TestParam{absl::nullopt}));
 
 }  // namespace

--- a/google/cloud/storage/tests/object_read_preconditions_integration_test.cc
+++ b/google/cloud/storage/tests/object_read_preconditions_integration_test.cc
@@ -1,0 +1,229 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/storage/client.h"
+#include "google/cloud/storage/testing/storage_integration_test.h"
+#include "google/cloud/internal/getenv.h"
+#include "google/cloud/testing_util/scoped_environment.h"
+#include "google/cloud/testing_util/status_matchers.h"
+#include "absl/types/optional.h"
+#include <gmock/gmock.h>
+#include <string>
+
+namespace google {
+namespace cloud {
+namespace storage {
+inline namespace STORAGE_CLIENT_NS {
+namespace {
+
+using ::google::cloud::internal::GetEnv;
+using ::google::cloud::testing_util::IsOk;
+using ::google::cloud::testing_util::StatusIs;
+using ::testing::IsEmpty;
+using ::testing::Not;
+
+struct TestParam {
+  absl::optional<std::string> rest_config;
+};
+
+class ObjectReadPreconditionsIntegrationTest
+    : public ::google::cloud::storage::testing::StorageIntegrationTest,
+      public ::testing::WithParamInterface<TestParam> {
+ protected:
+  ObjectReadPreconditionsIntegrationTest()
+      : config_("GOOGLE_CLOUD_CPP_STORAGE_REST_CONFIG",
+                GetParam().rest_config) {}
+
+  void SetUp() override {
+    bucket_name_ =
+        GetEnv("GOOGLE_CLOUD_CPP_STORAGE_TEST_BUCKET_NAME").value_or("");
+
+    ASSERT_THAT(bucket_name_, Not(IsEmpty()));
+  }
+
+  std::string const& bucket_name() const { return bucket_name_; }
+
+ private:
+  std::string bucket_name_;
+  google::cloud::testing_util::ScopedEnvironment config_;
+};
+
+TEST_P(ObjectReadPreconditionsIntegrationTest, IfGenerationMatchSuccess) {
+  StatusOr<Client> client = MakeIntegrationTestClient();
+  ASSERT_STATUS_OK(client);
+
+  auto const object_name = MakeRandomObjectName();
+  auto const expected_text = LoremIpsum();
+  auto meta = client->InsertObject(bucket_name(), object_name, expected_text,
+                                   IfGenerationMatch(0));
+  ASSERT_THAT(meta, IsOk());
+
+  auto reader = client->ReadObject(bucket_name(), object_name,
+                                   IfGenerationMatch(meta->generation()));
+  reader.Close();
+  EXPECT_THAT(reader.status(), IsOk());
+
+  (void)client->DeleteObject(bucket_name(), object_name,
+                             Generation(meta->generation()));
+}
+
+TEST_P(ObjectReadPreconditionsIntegrationTest, IfGenerationMatchFailure) {
+  StatusOr<Client> client = MakeIntegrationTestClient();
+  ASSERT_STATUS_OK(client);
+
+  auto const object_name = MakeRandomObjectName();
+  auto const expected_text = LoremIpsum();
+  auto meta = client->InsertObject(bucket_name(), object_name, expected_text,
+                                   IfGenerationMatch(0));
+  ASSERT_THAT(meta, IsOk());
+
+  auto reader = client->ReadObject(bucket_name(), object_name,
+                                   IfGenerationMatch(meta->generation() + 1));
+  reader.Close();
+  EXPECT_THAT(reader.status(), StatusIs(StatusCode::kFailedPrecondition));
+
+  (void)client->DeleteObject(bucket_name(), object_name,
+                             Generation(meta->generation()));
+}
+
+TEST_P(ObjectReadPreconditionsIntegrationTest, IfGenerationNotMatchSuccess) {
+  StatusOr<Client> client = MakeIntegrationTestClient();
+  ASSERT_STATUS_OK(client);
+
+  auto const object_name = MakeRandomObjectName();
+  auto const expected_text = LoremIpsum();
+  auto meta = client->InsertObject(bucket_name(), object_name, expected_text,
+                                   IfGenerationMatch(0));
+  ASSERT_THAT(meta, IsOk());
+
+  auto reader = client->ReadObject(
+      bucket_name(), object_name, IfGenerationNotMatch(meta->generation() + 1));
+  reader.Close();
+  EXPECT_THAT(reader.status(), IsOk());
+
+  (void)client->DeleteObject(bucket_name(), object_name,
+                             Generation(meta->generation()));
+}
+
+TEST_P(ObjectReadPreconditionsIntegrationTest, IfGenerationNotMatchFailure) {
+  StatusOr<Client> client = MakeIntegrationTestClient();
+  ASSERT_STATUS_OK(client);
+
+  auto const object_name = MakeRandomObjectName();
+  auto const expected_text = LoremIpsum();
+  auto meta = client->InsertObject(bucket_name(), object_name, expected_text,
+                                   IfGenerationMatch(0));
+  ASSERT_THAT(meta, IsOk());
+
+  auto reader = client->ReadObject(bucket_name(), object_name,
+                                   IfGenerationNotMatch(meta->generation()));
+  reader.Close();
+  EXPECT_THAT(reader.status(), StatusIs(StatusCode::kFailedPrecondition));
+
+  (void)client->DeleteObject(bucket_name(), object_name,
+                             Generation(meta->generation()));
+}
+
+TEST_P(ObjectReadPreconditionsIntegrationTest, IfMetagenerationMatchSuccess) {
+  StatusOr<Client> client = MakeIntegrationTestClient();
+  ASSERT_STATUS_OK(client);
+
+  auto const object_name = MakeRandomObjectName();
+  auto const expected_text = LoremIpsum();
+  auto meta = client->InsertObject(bucket_name(), object_name, expected_text,
+                                   IfGenerationMatch(0));
+  ASSERT_THAT(meta, IsOk());
+
+  auto reader =
+      client->ReadObject(bucket_name(), object_name,
+                         IfMetagenerationMatch(meta->metageneration()));
+  reader.Close();
+  EXPECT_THAT(reader.status(), IsOk());
+
+  (void)client->DeleteObject(bucket_name(), object_name,
+                             Generation(meta->generation()));
+}
+
+TEST_P(ObjectReadPreconditionsIntegrationTest, IfMetagenerationMatchFailure) {
+  StatusOr<Client> client = MakeIntegrationTestClient();
+  ASSERT_STATUS_OK(client);
+
+  auto const object_name = MakeRandomObjectName();
+  auto const expected_text = LoremIpsum();
+  auto meta = client->InsertObject(bucket_name(), object_name, expected_text,
+                                   IfGenerationMatch(0));
+  ASSERT_THAT(meta, IsOk());
+
+  auto reader =
+      client->ReadObject(bucket_name(), object_name,
+                         IfMetagenerationMatch(meta->metageneration() + 1));
+  reader.Close();
+  EXPECT_THAT(reader.status(), StatusIs(StatusCode::kFailedPrecondition));
+
+  (void)client->DeleteObject(bucket_name(), object_name,
+                             Generation(meta->generation()));
+}
+
+TEST_P(ObjectReadPreconditionsIntegrationTest,
+       IfMetagenerationNotMatchSuccess) {
+  StatusOr<Client> client = MakeIntegrationTestClient();
+  ASSERT_STATUS_OK(client);
+
+  auto const object_name = MakeRandomObjectName();
+  auto const expected_text = LoremIpsum();
+  auto meta = client->InsertObject(bucket_name(), object_name, expected_text,
+                                   IfGenerationMatch(0));
+  ASSERT_THAT(meta, IsOk());
+
+  auto reader =
+      client->ReadObject(bucket_name(), object_name,
+                         IfMetagenerationNotMatch(meta->generation() + 1));
+  reader.Close();
+  EXPECT_THAT(reader.status(), IsOk());
+
+  (void)client->DeleteObject(bucket_name(), object_name,
+                             Generation(meta->generation()));
+}
+
+TEST_P(ObjectReadPreconditionsIntegrationTest,
+       IfMetagenerationNotMatchFailure) {
+  StatusOr<Client> client = MakeIntegrationTestClient();
+  ASSERT_STATUS_OK(client);
+
+  auto const object_name = MakeRandomObjectName();
+  auto const expected_text = LoremIpsum();
+  auto meta = client->InsertObject(bucket_name(), object_name, expected_text,
+                                   IfGenerationMatch(0));
+  ASSERT_THAT(meta, IsOk());
+
+  auto reader =
+      client->ReadObject(bucket_name(), object_name,
+                         IfMetagenerationNotMatch(meta->metageneration()));
+  reader.Close();
+  EXPECT_THAT(reader.status(), StatusIs(StatusCode::kFailedPrecondition));
+
+  (void)client->DeleteObject(bucket_name(), object_name,
+                             Generation(meta->generation()));
+}
+
+INSTANTIATE_TEST_SUITE_P(XmlDisabled, ObjectReadPreconditionsIntegrationTest,
+                         ::testing::Values(TestParam{"disable-xml"}));
+//INSTANTIATE_TEST_SUITE_P(XmlEnabled, ObjectReadPreconditionsIntegrationTest,
+//                         ::testing::Values(TestParam{absl::nullopt}));
+
+}  // namespace
+}  // namespace STORAGE_CLIENT_NS
+}  // namespace storage
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/storage/tests/storage_client_integration_tests.bzl
+++ b/google/cloud/storage/tests/storage_client_integration_tests.bzl
@@ -42,6 +42,7 @@ storage_client_integration_tests = [
     "object_parallel_upload_integration_test.cc",
     "object_plenty_clients_serially_integration_test.cc",
     "object_plenty_clients_simultaneously_integration_test.cc",
+    "object_read_preconditions_integration_test.cc",
     "object_read_range_integration_test.cc",
     "object_resumable_parallel_upload_integration_test.cc",
     "object_resumable_write_integration_test.cc",


### PR DESCRIPTION
GCS returns a 304 (Not Modified) for downloads with a
`ifMetagenerationNotMatch` pre-condition that is not met.  Methinks that
is a confusing error to return ("not modified" for a read-only operation
that was not going to modify anything? wut?).  In any case, we need to
map this to our error namespace, and `kFailedPrecondition` seems like
the best mapping.

I added integration tests for the failure and success cases of each
pre-condition, so far we only had unit tests and obviously we were
missing some problems. I also added some samples because we got
questions about how to do this.

Note: some tests are disabled, will fix as part of #6896

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6897)
<!-- Reviewable:end -->
