### PR TITLE
fix(ci): fix iam account flag when deleting keys

### DIFF
--- a/ci/cloudbuild/builds/rotate-keys.sh
+++ b/ci/cloudbuild/builds/rotate-keys.sh
@@ -99,6 +99,6 @@ args=(
 )
 for old_key in $(gcloud iam service-accounts keys list "${args[@]}"); do
   io::log "Deleting key: ${old_key}"
-  gcloud iam service-accounts keys delete "${old_key}" --account="${account}"
+  gcloud iam service-accounts keys delete "${old_key}" --iam-account="${account}"
 done
 echo


### PR DESCRIPTION
Our `rotate-keys` build failed with the following error:
```
ERROR: (gcloud.iam.service-accounts.keys.delete) argument --iam-account: Must be specified.
Usage: gcloud iam service-accounts keys delete KEY-ID --iam-account=IAM_ACCOUNT [optional flags]
  optional flags may be  --help
```

So we should switch our flag from `--account=` to `--iam-account=`.

This is confirmed by the [documentation](https://cloud.google.com/sdk/gcloud/reference/iam/service-accounts/keys/delete).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6899)
<!-- Reviewable:end -->
