### PR TITLE
fix(storage): use JSON for reads with pre-conditions

### DIFF
--- a/google/cloud/storage/internal/curl_client.cc
+++ b/google/cloud/storage/internal/curl_client.cc
@@ -583,6 +583,8 @@ StatusOr<std::unique_ptr<ObjectReadSource>> CurlClient::ReadObject(
     ReadObjectRangeRequest const& request) {
   if (xml_enabled_ && !request.HasOption<IfMetagenerationNotMatch>() &&
       !request.HasOption<IfGenerationNotMatch>() &&
+      !request.HasOption<IfMetagenerationMatch>() &&
+      !request.HasOption<IfGenerationMatch>() &&
       !request.HasOption<QuotaUser>() && !request.HasOption<UserIp>()) {
     return ReadObjectXml(request);
   }
@@ -1289,18 +1291,8 @@ StatusOr<std::unique_ptr<ObjectReadSource>> CurlClient::ReadObjectXml(
   //
   builder.AddOption(request.GetOption<EncryptionKey>());
   builder.AddOption(request.GetOption<Generation>());
-  if (request.HasOption<IfGenerationMatch>()) {
-    builder.AddHeader(
-        "x-goog-if-generation-match: " +
-        std::to_string(request.GetOption<IfGenerationMatch>().value()));
-  }
-  // IfGenerationNotMatch cannot be set, checked by the caller.
-  if (request.HasOption<IfMetagenerationMatch>()) {
-    builder.AddHeader(
-        "x-goog-if-meta-generation-match: " +
-        std::to_string(request.GetOption<IfMetagenerationMatch>().value()));
-  }
-  // IfMetagenerationNotMatch cannot be set, checked by the caller.
+  // None of the IfGeneration*Match nor IfMetageneration*Match can be set. This
+  // is checked by the caller (in this class).
   builder.AddOption(request.GetOption<UserProject>());
 
   //

--- a/google/cloud/storage/tests/object_read_preconditions_integration_test.cc
+++ b/google/cloud/storage/tests/object_read_preconditions_integration_test.cc
@@ -230,8 +230,8 @@ TEST_P(ObjectReadPreconditionsIntegrationTest,
 
 INSTANTIATE_TEST_SUITE_P(XmlDisabled, ObjectReadPreconditionsIntegrationTest,
                          ::testing::Values(TestParam{"disable-xml"}));
-// INSTANTIATE_TEST_SUITE_P(XmlEnabled, ObjectReadPreconditionsIntegrationTest,
-//                         ::testing::Values(TestParam{absl::nullopt}));
+INSTANTIATE_TEST_SUITE_P(XmlEnabled, ObjectReadPreconditionsIntegrationTest,
+                         ::testing::Values(TestParam{absl::nullopt}));
 
 }  // namespace
 }  // namespace STORAGE_CLIENT_NS


### PR DESCRIPTION
The `x-goog-if-*-match:` headers do not work for reads in XML.

AFAICT, this is a bug in the service, but it will take several months for it to
be fixed (assuming the team has the time).  I think it is better to the library
to work correctly in the interim, we can restore the functionality when the
service is fixed.

Using JSON has a small performance hit, but that is shrinking over time,
and these features are used rarely, if ever.

Fixes #6896

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6900)
<!-- Reviewable:end -->
