### PR TITLE
feat(GCS+gRPC): capture streaming RPCs metadata

### DIFF
--- a/generator/integration_tests/golden/mocks/mock_golden_kitchen_sink_stub.h
+++ b/generator/integration_tests/golden/mocks/mock_golden_kitchen_sink_stub.h
@@ -73,6 +73,8 @@ public:
   MOCK_METHOD(void, Cancel, (), (override));
   MOCK_METHOD((absl::variant<Status, ::google::test::admin::database::v1::TailLogEntriesResponse>), Read, (),
   (override));
+  MOCK_METHOD(internal::StreamingRpcMetadata, GetRequestMetadata, (),
+  (const, override));
 };
 
 }  // namespace GOOGLE_CLOUD_CPP_GENERATED_NS

--- a/google/cloud/CMakeLists.txt
+++ b/google/cloud/CMakeLists.txt
@@ -427,6 +427,7 @@ if (GOOGLE_CLOUD_CPP_ENABLE_GRPC)
         internal/setup_context.h
         internal/streaming_read_rpc.cc
         internal/streaming_read_rpc.h
+        internal/streaming_read_rpc_logging.cc
         internal/streaming_read_rpc_logging.h
         internal/streaming_write_rpc.cc
         internal/streaming_write_rpc.h

--- a/google/cloud/google_cloud_cpp_grpc_utils.bzl
+++ b/google/cloud/google_cloud_cpp_grpc_utils.bzl
@@ -77,6 +77,7 @@ google_cloud_cpp_grpc_utils_srcs = [
     "internal/minimal_iam_credentials_stub.cc",
     "internal/retry_loop_helpers.cc",
     "internal/streaming_read_rpc.cc",
+    "internal/streaming_read_rpc_logging.cc",
     "internal/streaming_write_rpc.cc",
     "internal/time_utils.cc",
     "internal/unified_grpc_credentials.cc",

--- a/google/cloud/internal/resumable_streaming_read_rpc.h
+++ b/google/cloud/internal/resumable_streaming_read_rpc.h
@@ -127,6 +127,10 @@ class ResumableStreamingReadRpc : public StreamingReadRpc<ResponseType> {
     return last_status;
   }
 
+  StreamingRpcMetadata GetRequestMetadata() const override {
+    return impl_ ? impl_->GetRequestMetadata() : StreamingRpcMetadata{};
+  }
+
  private:
   std::unique_ptr<RetryPolicy const> const retry_policy_prototype_;
   std::unique_ptr<BackoffPolicy const> const backoff_policy_prototype_;

--- a/google/cloud/internal/resumable_streaming_read_rpc_test.cc
+++ b/google/cloud/internal/resumable_streaming_read_rpc_test.cc
@@ -51,6 +51,7 @@ class MockStreamingReadRpc : public StreamingReadRpc<FakeResponse> {
  public:
   MOCK_METHOD(void, Cancel, (), (override));
   MOCK_METHOD(ReadReturn, Read, (), (override));
+  MOCK_METHOD(StreamingRpcMetadata, GetRequestMetadata, (), (const, override));
 };
 
 struct TestRetryablePolicy {

--- a/google/cloud/internal/streaming_read_rpc.cc
+++ b/google/cloud/internal/streaming_read_rpc.cc
@@ -14,11 +14,55 @@
 
 #include "google/cloud/internal/streaming_read_rpc.h"
 #include "google/cloud/log.h"
+#include <grpc/compression.h>
 
 namespace google {
 namespace cloud {
 inline namespace GOOGLE_CLOUD_CPP_NS {
 namespace internal {
+namespace {
+// AFAICT there is no C++ API to get the name, but the C core API is public and
+// documented:
+//    https://grpc.github.io/grpc/core/compression_8h.html
+std::string ToString(grpc_compression_algorithm algo) {
+  char const* name;
+  if (grpc_compression_algorithm_name(algo, &name) == 0) {
+    return "unknown";
+  }
+  return name;
+}
+}  // namespace
+
+StreamingRpcMetadata GetRequestMetadataFromContext(
+    grpc::ClientContext const& context) {
+  StreamingRpcMetadata metadata{
+      // Use invalid header names (starting with ':') to store the
+      // grpc::ClientContext metadata.
+      {":grpc-context-peer", context.peer()},
+      {":grpc-context-compression-algorithm",
+       ToString(context.compression_algorithm())},
+  };
+  auto hint = metadata.end();
+  for (auto const& kv : context.GetServerInitialMetadata()) {
+    // gRPC metadata is stored in `grpc::string_ref`, a type inspired by
+    // `std::string_view`. We need to explicitly convert these to `std::string`.
+    // In addition, we use a prefix to distinguish initial vs. trailing headers.
+    auto key = ":grpc-initial-" + std::string{kv.first.data(), kv.first.size()};
+    auto value = std::string{kv.second.data(), kv.second.size()};
+    hint = std::next(
+        metadata.emplace_hint(hint, std::move(key), std::move(value)));
+  }
+  hint = metadata.end();
+  for (auto const& kv : context.GetServerTrailingMetadata()) {
+    // Same as above, convert `grpc::string_ref` to `std::string`:
+    auto key =
+        ":grpc-trailing-" + std::string{kv.first.data(), kv.first.size()};
+    auto value = std::string{kv.second.data(), kv.second.size()};
+    hint = std::next(
+        metadata.emplace_hint(hint, std::move(key), std::move(value)));
+  }
+  return metadata;
+}
 
 void StreamingReadRpcReportUnhandledError(Status const& status,
                                           char const* tname) {

--- a/google/cloud/internal/streaming_read_rpc_logging.cc
+++ b/google/cloud/internal/streaming_read_rpc_logging.cc
@@ -1,0 +1,35 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/internal/streaming_read_rpc_logging.h"
+#include "google/cloud/internal/absl_str_cat_quiet.h"
+#include "google/cloud/internal/absl_str_join_quiet.h"
+
+namespace google {
+namespace cloud {
+inline namespace GOOGLE_CLOUD_CPP_NS {
+namespace internal {
+
+std::string FormatMetadata(StreamingRpcMetadata const& metadata) {
+  auto formatter = [](std::string* output,
+                      StreamingRpcMetadata::value_type const& p) {
+    *output += absl::StrCat("{", p.first, ": ", p.second, "}");
+  };
+  return absl::StrJoin(metadata.begin(), metadata.end(), ", ", formatter);
+}
+
+}  // namespace internal
+}  // namespace GOOGLE_CLOUD_CPP_NS
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/internal/streaming_read_rpc_logging.h
+++ b/google/cloud/internal/streaming_read_rpc_logging.h
@@ -32,6 +32,7 @@ namespace google {
 namespace cloud {
 inline namespace GOOGLE_CLOUD_CPP_NS {
 namespace internal {
+std::string FormatMetadata(StreamingRpcMetadata const& metadata);
 
 /**
  * Logging decorator for StreamingReadRpc.
@@ -60,6 +61,12 @@ class StreamingReadRpcLogging : public StreamingReadRpc<ResponseType> {
     GCP_LOG(DEBUG) << prefix << "() >> "
                    << absl::visit(ResultVisitor(tracing_options_), result);
     return result;
+  }
+  StreamingRpcMetadata GetRequestMetadata() const override {
+    auto metadata = reader_->GetRequestMetadata();
+    GCP_LOG(DEBUG) << __func__ << "() >> metadata={" << FormatMetadata(metadata)
+                   << "}";
+    return metadata;
   }
 
  private:

--- a/google/cloud/internal/streaming_read_rpc_logging_test.cc
+++ b/google/cloud/internal/streaming_read_rpc_logging_test.cc
@@ -111,7 +111,6 @@ TEST_F(StreamingReadRpcLoggingTest, FormatMetadata) {
       {{{"a", "b"}, {"k", "v"}}, "{a: b}, {k: v}"},
   };
   for (auto const& test : cases) {
-    SCOPED_TRACE("Testing for <" + test.expected + ">");
     auto const actual = FormatMetadata(test.metadata);
     EXPECT_EQ(test.expected, actual);
   }

--- a/google/cloud/storage/internal/grpc_object_read_source.cc
+++ b/google/cloud/storage/internal/grpc_object_read_source.cc
@@ -71,8 +71,9 @@ StatusOr<ReadSourceResult> GrpcObjectReadSource::Read(char* buf,
     HeadersMap operator()(Status s) {
       // A status, whether success or failure, closes the stream.
       self.status_ = std::move(s);
+      auto metadata = self.stream_->GetRequestMetadata();
       self.stream_ = nullptr;
-      return {};
+      return metadata;
     }
     HeadersMap operator()(
         google::storage::v1::GetObjectMediaResponse response) {

--- a/google/cloud/storage/internal/grpc_object_read_source_test.cc
+++ b/google/cloud/storage/internal/grpc_object_read_source_test.cc
@@ -41,6 +41,8 @@ class MockStream : public google::cloud::internal::StreamingReadRpc<
       absl::variant<Status, storage_proto::GetObjectMediaResponse>;
   MOCK_METHOD(ReadReturn, Read, (), (override));
   MOCK_METHOD(void, Cancel, (), (override));
+  MOCK_METHOD(google::cloud::internal::StreamingRpcMetadata, GetRequestMetadata,
+              (), (const, override));
 };
 
 TEST(GrpcObjectReadSource, Simple) {

--- a/google/cloud/storage/object_stream.h
+++ b/google/cloud/storage/object_stream.h
@@ -26,6 +26,10 @@ namespace google {
 namespace cloud {
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
+
+/// Represents the headers returned in a streaming upload or download operation.
+using HeadersMap = std::multimap<std::string, std::string>;
+
 /**
  * Report checksum mismatches as exceptions.
  */
@@ -148,10 +152,19 @@ class ObjectReadStream : public std::basic_istream<char> {
    */
   std::string const& computed_hash() const { return buf_->computed_hash(); }
 
-  /// The headers returned by the service, for debugging only.
-  std::multimap<std::string, std::string> const& headers() const {
-    return buf_->headers();
-  }
+  /**
+   * The headers (in any) returned by the service, for debugging only.
+   *
+   * @warning the contents of these headers may change without notice. Unless
+   *     documented in the API, headers may be removed or added by the service.
+   *     Also note that the client library uses both the XML and JSON API,
+   *     choosing between them based on the feature set (some functionality is
+   *     only available through the JSON API), and performance.  Consequently,
+   *     the headers may be different on requests using different features.
+   *     Likewise, the headers may change from one version of the library to the
+   *     next, as we find more (or different) opportunities for optimization.
+   */
+  HeadersMap const& headers() const { return buf_->headers(); }
   //@}
 
  private:
@@ -370,10 +383,19 @@ class ObjectWriteStream : public std::basic_ostream<char> {
    */
   std::string const& computed_hash() const { return buf_->computed_hash(); }
 
-  /// The headers returned by the service, for debugging only.
-  std::multimap<std::string, std::string> const& headers() const {
-    return headers_;
-  }
+  /**
+   * The headers (in any) returned by the service, for debugging only.
+   *
+   * @warning the contents of these headers may change without notice. Unless
+   *     documented in the API, headers may be removed or added by the service.
+   *     Also note that the client library uses both the XML and JSON API,
+   *     choosing between them based on the feature set (some functionality is
+   *     only available through the JSON API), and performance.  Consequently,
+   *     the headers may be different on requests using different features.
+   *     Likewise, the headers may change from one version of the library to the
+   *     next, as we find more (or different) opportunities for optimization.
+   */
+  HeadersMap const& headers() const { return headers_; }
 
   /// The returned payload as a raw string, for debugging only.
   std::string const& payload() const { return payload_; }

--- a/google/cloud/storage/object_stream.h
+++ b/google/cloud/storage/object_stream.h
@@ -153,7 +153,7 @@ class ObjectReadStream : public std::basic_istream<char> {
   std::string const& computed_hash() const { return buf_->computed_hash(); }
 
   /**
-   * The headers (in any) returned by the service, for debugging only.
+   * The headers (in any) returned by the service. For debugging only.
    *
    * @warning the contents of these headers may change without notice. Unless
    *     documented in the API, headers may be removed or added by the service.
@@ -384,7 +384,7 @@ class ObjectWriteStream : public std::basic_ostream<char> {
   std::string const& computed_hash() const { return buf_->computed_hash(); }
 
   /**
-   * The headers (in any) returned by the service, for debugging only.
+   * The headers (in any) returned by the service. For debugging only.
    *
    * @warning the contents of these headers may change without notice. Unless
    *     documented in the API, headers may be removed or added by the service.

--- a/google/cloud/storage/object_stream.h
+++ b/google/cloud/storage/object_stream.h
@@ -153,7 +153,7 @@ class ObjectReadStream : public std::basic_istream<char> {
   std::string const& computed_hash() const { return buf_->computed_hash(); }
 
   /**
-   * The headers (in any) returned by the service. For debugging only.
+   * The headers (if any) returned by the service. For debugging only.
    *
    * @warning the contents of these headers may change without notice. Unless
    *     documented in the API, headers may be removed or added by the service.
@@ -384,7 +384,7 @@ class ObjectWriteStream : public std::basic_ostream<char> {
   std::string const& computed_hash() const { return buf_->computed_hash(); }
 
   /**
-   * The headers (in any) returned by the service. For debugging only.
+   * The headers (if any) returned by the service. For debugging only.
    *
    * @warning the contents of these headers may change without notice. Unless
    *     documented in the API, headers may be removed or added by the service.

--- a/google/cloud/storage/tests/CMakeLists.txt
+++ b/google/cloud/storage/tests/CMakeLists.txt
@@ -41,6 +41,7 @@ set(storage_client_integration_tests
     object_parallel_upload_integration_test.cc
     object_plenty_clients_serially_integration_test.cc
     object_plenty_clients_simultaneously_integration_test.cc
+    object_read_headers_integration_test.cc
     object_read_preconditions_integration_test.cc
     object_read_range_integration_test.cc
     object_resumable_parallel_upload_integration_test.cc

--- a/google/cloud/storage/tests/object_read_headers_integration_test.cc
+++ b/google/cloud/storage/tests/object_read_headers_integration_test.cc
@@ -1,0 +1,98 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/storage/client.h"
+#include "google/cloud/storage/testing/storage_integration_test.h"
+#include "google/cloud/internal/getenv.h"
+#include "google/cloud/testing_util/status_matchers.h"
+#include <gmock/gmock.h>
+#include <algorithm>
+#include <string>
+#include <vector>
+
+namespace google {
+namespace cloud {
+namespace storage {
+inline namespace STORAGE_CLIENT_NS {
+namespace {
+
+using ::google::cloud::internal::GetEnv;
+using ::google::cloud::testing_util::IsOk;
+using ::testing::IsSupersetOf;
+
+class ObjectReadHeadersIntegrationTest
+    : public ::google::cloud::storage::testing::StorageIntegrationTest {
+ public:
+  ObjectReadHeadersIntegrationTest() = default;
+
+ protected:
+  void SetUp() override {
+    bucket_name_ =
+        GetEnv("GOOGLE_CLOUD_CPP_STORAGE_TEST_BUCKET_NAME").value_or("");
+
+    ASSERT_FALSE(bucket_name_.empty());
+  }
+
+  std::string const& bucket_name() const { return bucket_name_; }
+
+ private:
+  std::string bucket_name_;
+};
+
+TEST_F(ObjectReadHeadersIntegrationTest, SmokeTest) {
+  StatusOr<Client> client = MakeIntegrationTestClient();
+  ASSERT_STATUS_OK(client);
+
+  auto const object_name = MakeRandomObjectName();
+
+  auto insert = client->InsertObject(bucket_name(), object_name, LoremIpsum(),
+                                     IfGenerationMatch(0));
+  ASSERT_THAT(insert, IsOk());
+
+  auto is = client->ReadObject(bucket_name(), object_name,
+                               Generation(insert->generation()));
+  auto const actual = std::string{std::istreambuf_iterator<char>(is), {}};
+  is.Close();
+  EXPECT_THAT(is.status(), IsOk());
+
+  // The headers returned by the service depend on the API. This is not an
+  // implementation detail we want to hide, one of the uses of these headers
+  // is to help in troubleshooting by exposing API-specific information.
+  auto keys = [](HeadersMap const& headers) {
+    std::vector<std::string> keys(headers.size());
+    std::transform(headers.begin(), headers.end(), keys.begin(),
+                   [](HeadersMap::value_type const& p) { return p.first; });
+    return keys;
+  };
+  if (UsingGrpc()) {
+    EXPECT_THAT(keys(is.headers()),
+                IsSupersetOf({":grpc-context-peer", "x-goog-hash"}));
+  } else if (UsingEmulator()) {
+    EXPECT_THAT(keys(is.headers()), IsSupersetOf({"x-goog-hash"}));
+
+  } else {
+    EXPECT_THAT(keys(is.headers()),
+                IsSupersetOf({"x-guploader-uploadid", "x-goog-hash",
+                              "x-goog-generation"}));
+  }
+
+  (void)client->DeleteObject(bucket_name(), object_name,
+                             Generation(insert->generation()));
+}
+
+}  // namespace
+}  // namespace STORAGE_CLIENT_NS
+}  // namespace storage
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/storage/tests/object_read_headers_integration_test.cc
+++ b/google/cloud/storage/tests/object_read_headers_integration_test.cc
@@ -67,7 +67,7 @@ TEST_F(ObjectReadHeadersIntegrationTest, SmokeTest) {
   EXPECT_THAT(is.status(), IsOk());
 
   // The headers returned by the service depend on the API. This is not an
-  // implementation detail we want to hide, one of the uses of these headers
+  // implementation detail we want to hide, as one of the uses of these headers
   // is to help in troubleshooting by exposing API-specific information.
   auto keys = [](HeadersMap const& headers) {
     std::vector<std::string> keys(headers.size());
@@ -80,7 +80,6 @@ TEST_F(ObjectReadHeadersIntegrationTest, SmokeTest) {
                 IsSupersetOf({":grpc-context-peer", "x-goog-hash"}));
   } else if (UsingEmulator()) {
     EXPECT_THAT(keys(is.headers()), IsSupersetOf({"x-goog-hash"}));
-
   } else {
     EXPECT_THAT(keys(is.headers()),
                 IsSupersetOf({"x-guploader-uploadid", "x-goog-hash",

--- a/google/cloud/storage/tests/storage_client_integration_tests.bzl
+++ b/google/cloud/storage/tests/storage_client_integration_tests.bzl
@@ -42,6 +42,7 @@ storage_client_integration_tests = [
     "object_parallel_upload_integration_test.cc",
     "object_plenty_clients_serially_integration_test.cc",
     "object_plenty_clients_simultaneously_integration_test.cc",
+    "object_read_headers_integration_test.cc",
     "object_read_preconditions_integration_test.cc",
     "object_read_range_integration_test.cc",
     "object_resumable_parallel_upload_integration_test.cc",


### PR DESCRIPTION
gRPC returns metadata for all requests, including streaming RPCs. In the
storage service this is very useful for troubleshooting, this change
weaves the metadata (and some additional bits from
`grpc::ClientContext`) through the different layers. The metadata is
exposed as "headers", because that matches the existing APIs (and gRPC
uses HTTP/2 headers under the hood anyway).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6902)
<!-- Reviewable:end -->
