### PR TITLE
fix(storage): use correct header for XML pre-conditions

### DIFF
--- a/google/cloud/storage/emulator/utils/common.py
+++ b/google/cloud/storage/emulator/utils/common.py
@@ -92,7 +92,7 @@ class FakeRequest(types.SimpleNamespace):
     def xml_headers_to_json_args(cls, headers):
         field_map = {
             "x-goog-if-generation-match": "ifGenerationMatch",
-            "x-goog-if-meta-generation-match": "ifMetagenerationMatch",
+            "x-goog-if-metageneration-match": "ifMetagenerationMatch",
             "x-goog-acl": "predefinedAcl",
         }
         args = {}

--- a/google/cloud/storage/internal/curl_client.cc
+++ b/google/cloud/storage/internal/curl_client.cc
@@ -1222,7 +1222,7 @@ StatusOr<ObjectMetadata> CurlClient::InsertObjectMediaXml(
   // IfGenerationNotMatch cannot be set, checked by the caller.
   if (request.HasOption<IfMetagenerationMatch>()) {
     builder.AddHeader(
-        "x-goog-if-meta-generation-match: " +
+        "x-goog-if-metageneration-match: " +
         std::to_string(request.GetOption<IfMetagenerationMatch>().value()));
   }
   // IfMetagenerationNotMatch cannot be set, checked by the caller.

--- a/google/cloud/storage/tests/CMakeLists.txt
+++ b/google/cloud/storage/tests/CMakeLists.txt
@@ -35,6 +35,7 @@ set(storage_client_integration_tests
     object_file_multi_threaded_test.cc
     object_hash_integration_test.cc
     object_insert_integration_test.cc
+    object_insert_preconditions_integration_test.cc
     object_integration_test.cc
     object_list_objects_versions_integration_test.cc
     object_media_integration_test.cc

--- a/google/cloud/storage/tests/object_insert_preconditions_integration_test.cc
+++ b/google/cloud/storage/tests/object_insert_preconditions_integration_test.cc
@@ -1,0 +1,242 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/storage/client.h"
+#include "google/cloud/storage/testing/storage_integration_test.h"
+#include "google/cloud/internal/getenv.h"
+#include "google/cloud/testing_util/scoped_environment.h"
+#include "google/cloud/testing_util/status_matchers.h"
+#include "absl/types/optional.h"
+#include <gmock/gmock.h>
+#include <string>
+
+namespace google {
+namespace cloud {
+namespace storage {
+inline namespace STORAGE_CLIENT_NS {
+namespace {
+
+using ::google::cloud::internal::GetEnv;
+using ::google::cloud::testing_util::IsOk;
+using ::google::cloud::testing_util::StatusIs;
+using ::testing::AnyOf;
+using ::testing::IsEmpty;
+using ::testing::Not;
+
+struct TestParam {
+  absl::optional<std::string> rest_config;
+  Fields fields;
+};
+
+class ObjectInsertPreconditionsIntegrationTest
+    : public ::google::cloud::storage::testing::StorageIntegrationTest,
+      public ::testing::WithParamInterface<TestParam> {
+ protected:
+  ObjectInsertPreconditionsIntegrationTest()
+      : config_("GOOGLE_CLOUD_CPP_STORAGE_REST_CONFIG",
+                GetParam().rest_config) {}
+
+  void SetUp() override {
+    bucket_name_ =
+        GetEnv("GOOGLE_CLOUD_CPP_STORAGE_TEST_BUCKET_NAME").value_or("");
+
+    ASSERT_THAT(bucket_name_, Not(IsEmpty()));
+  }
+
+  std::string const& bucket_name() const { return bucket_name_; }
+
+ private:
+  std::string bucket_name_;
+  google::cloud::testing_util::ScopedEnvironment config_;
+};
+
+TEST_P(ObjectInsertPreconditionsIntegrationTest, IfGenerationMatchSuccess) {
+  StatusOr<Client> client = MakeIntegrationTestClient();
+  ASSERT_STATUS_OK(client);
+
+  auto const object_name = MakeRandomObjectName();
+  auto const expected_text = LoremIpsum();
+  auto meta = client->InsertObject(bucket_name(), object_name, expected_text,
+                                   IfGenerationMatch(0));
+  ASSERT_THAT(meta, IsOk());
+
+  auto insert = client->InsertObject(bucket_name(), object_name, expected_text,
+                                     GetParam().fields,
+                                     IfGenerationMatch(meta->generation()));
+  ASSERT_THAT(insert, IsOk());
+
+  (void)client->DeleteObject(bucket_name(), object_name,
+                             Generation(insert->generation()));
+  (void)client->DeleteObject(bucket_name(), object_name,
+                             Generation(meta->generation()));
+}
+
+TEST_P(ObjectInsertPreconditionsIntegrationTest, IfGenerationMatchFailure) {
+  StatusOr<Client> client = MakeIntegrationTestClient();
+  ASSERT_STATUS_OK(client);
+
+  auto const object_name = MakeRandomObjectName();
+  auto const expected_text = LoremIpsum();
+  auto meta = client->InsertObject(bucket_name(), object_name, expected_text,
+                                   IfGenerationMatch(0));
+  ASSERT_THAT(meta, IsOk());
+
+  auto insert = client->InsertObject(bucket_name(), object_name, expected_text,
+                                     GetParam().fields,
+                                     IfGenerationMatch(meta->generation() + 1));
+  ASSERT_THAT(insert, StatusIs(StatusCode::kFailedPrecondition));
+
+  (void)client->DeleteObject(bucket_name(), object_name,
+                             Generation(meta->generation()));
+}
+
+TEST_P(ObjectInsertPreconditionsIntegrationTest, IfGenerationNotMatchSuccess) {
+  StatusOr<Client> client = MakeIntegrationTestClient();
+  ASSERT_STATUS_OK(client);
+
+  auto const object_name = MakeRandomObjectName();
+  auto const expected_text = LoremIpsum();
+  auto meta = client->InsertObject(bucket_name(), object_name, expected_text,
+                                   IfGenerationMatch(0));
+  ASSERT_THAT(meta, IsOk());
+
+  auto insert = client->InsertObject(
+      bucket_name(), object_name, expected_text, GetParam().fields,
+      IfGenerationNotMatch(meta->generation() + 1));
+  ASSERT_THAT(insert, IsOk());
+
+  (void)client->DeleteObject(bucket_name(), object_name,
+                             Generation(insert->generation()));
+  (void)client->DeleteObject(bucket_name(), object_name,
+                             Generation(meta->generation()));
+}
+
+TEST_P(ObjectInsertPreconditionsIntegrationTest, IfGenerationNotMatchFailure) {
+  StatusOr<Client> client = MakeIntegrationTestClient();
+  ASSERT_STATUS_OK(client);
+
+  auto const object_name = MakeRandomObjectName();
+  auto const expected_text = LoremIpsum();
+  auto meta = client->InsertObject(bucket_name(), object_name, expected_text,
+                                   IfGenerationMatch(0));
+  ASSERT_THAT(meta, IsOk());
+
+  auto insert = client->InsertObject(bucket_name(), object_name, expected_text,
+                                     GetParam().fields,
+                                     IfGenerationNotMatch(meta->generation()));
+  ASSERT_THAT(insert, StatusIs(AnyOf(StatusCode::kFailedPrecondition,
+                                     StatusCode::kAborted)));
+
+  (void)client->DeleteObject(bucket_name(), object_name,
+                             Generation(meta->generation()));
+}
+
+TEST_P(ObjectInsertPreconditionsIntegrationTest, IfMetagenerationMatchSuccess) {
+  StatusOr<Client> client = MakeIntegrationTestClient();
+  ASSERT_STATUS_OK(client);
+
+  auto const object_name = MakeRandomObjectName();
+  auto const expected_text = LoremIpsum();
+  auto meta = client->InsertObject(bucket_name(), object_name, expected_text,
+                                   IfGenerationMatch(0));
+  ASSERT_THAT(meta, IsOk());
+
+  auto insert = client->InsertObject(
+      bucket_name(), object_name, expected_text, GetParam().fields,
+      IfMetagenerationMatch(meta->metageneration()));
+  ASSERT_THAT(insert, IsOk());
+
+  (void)client->DeleteObject(bucket_name(), object_name,
+                             Generation(insert->generation()));
+  (void)client->DeleteObject(bucket_name(), object_name,
+                             Generation(meta->generation()));
+}
+
+TEST_P(ObjectInsertPreconditionsIntegrationTest, IfMetagenerationMatchFailure) {
+  StatusOr<Client> client = MakeIntegrationTestClient();
+  ASSERT_STATUS_OK(client);
+
+  auto const object_name = MakeRandomObjectName();
+  auto const expected_text = LoremIpsum();
+  auto meta = client->InsertObject(bucket_name(), object_name, expected_text,
+                                   IfGenerationMatch(0));
+  ASSERT_THAT(meta, IsOk());
+
+  auto insert = client->InsertObject(
+      bucket_name(), object_name, expected_text, GetParam().fields,
+      IfMetagenerationMatch(meta->metageneration() + 1));
+  ASSERT_THAT(insert, StatusIs(StatusCode::kFailedPrecondition));
+
+  (void)client->DeleteObject(bucket_name(), object_name,
+                             Generation(meta->generation()));
+}
+
+TEST_P(ObjectInsertPreconditionsIntegrationTest,
+       IfMetagenerationNotMatchSuccess) {
+  StatusOr<Client> client = MakeIntegrationTestClient();
+  ASSERT_STATUS_OK(client);
+
+  auto const object_name = MakeRandomObjectName();
+  auto const expected_text = LoremIpsum();
+  auto meta = client->InsertObject(bucket_name(), object_name, expected_text,
+                                   IfGenerationMatch(0));
+  ASSERT_THAT(meta, IsOk());
+
+  auto insert = client->InsertObject(
+      bucket_name(), object_name, expected_text, GetParam().fields,
+      IfMetagenerationNotMatch(meta->metageneration() + 1));
+  ASSERT_THAT(insert, IsOk());
+
+  (void)client->DeleteObject(bucket_name(), object_name,
+                             Generation(insert->generation()));
+  (void)client->DeleteObject(bucket_name(), object_name,
+                             Generation(meta->generation()));
+}
+
+TEST_P(ObjectInsertPreconditionsIntegrationTest,
+       IfMetagenerationNotMatchFailure) {
+  StatusOr<Client> client = MakeIntegrationTestClient();
+  ASSERT_STATUS_OK(client);
+
+  auto const object_name = MakeRandomObjectName();
+  auto const expected_text = LoremIpsum();
+  auto meta = client->InsertObject(bucket_name(), object_name, expected_text,
+                                   IfGenerationMatch(0));
+  ASSERT_THAT(meta, IsOk());
+
+  auto insert = client->InsertObject(
+      bucket_name(), object_name, expected_text, GetParam().fields,
+      IfMetagenerationNotMatch(meta->metageneration()));
+  ASSERT_THAT(insert, StatusIs(AnyOf(StatusCode::kFailedPrecondition,
+                                     StatusCode::kAborted)));
+
+  (void)client->DeleteObject(bucket_name(), object_name,
+                             Generation(meta->generation()));
+}
+
+INSTANTIATE_TEST_SUITE_P(XmlEnabledAndUsed,
+                         ObjectInsertPreconditionsIntegrationTest,
+                         ::testing::Values(TestParam{absl::nullopt,
+                                                     Fields("")}));
+INSTANTIATE_TEST_SUITE_P(XmlEnabledNotUsed,
+                         ObjectInsertPreconditionsIntegrationTest,
+                         ::testing::Values(TestParam{absl::nullopt, Fields()}));
+INSTANTIATE_TEST_SUITE_P(XmlDisabled, ObjectInsertPreconditionsIntegrationTest,
+                         ::testing::Values(TestParam{"disable-xml", Fields()}));
+
+}  // namespace
+}  // namespace STORAGE_CLIENT_NS
+}  // namespace storage
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/storage/tests/storage_client_integration_tests.bzl
+++ b/google/cloud/storage/tests/storage_client_integration_tests.bzl
@@ -36,6 +36,7 @@ storage_client_integration_tests = [
     "object_file_multi_threaded_test.cc",
     "object_hash_integration_test.cc",
     "object_insert_integration_test.cc",
+    "object_insert_preconditions_integration_test.cc",
     "object_integration_test.cc",
     "object_list_objects_versions_integration_test.cc",
     "object_media_integration_test.cc",


### PR DESCRIPTION
Fix the header name (`metageneration` should be one word) for `IfMetagenerationMatch`. Add
integration tests for all pre-conditions too.

Motivated by #6896.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6903)
<!-- Reviewable:end -->
