### PR TITLE
fix(storage): allow overwrites in parallel uploads

### DIFF
--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -3539,7 +3539,7 @@ StatusOr<ObjectMetadata> ComposeMany(
           internal::ComposeApplyHelper{client, bucket_name,
                                        std::move(compose_range),
                                        std::move(destination_object_name)},
-          std::tuple_cat(std::make_tuple(IfGenerationMatch(0)), all_options));
+          all_options);
     }
     return google::cloud::internal::apply(
         internal::ComposeApplyHelper{client, bucket_name,


### PR DESCRIPTION
In `ParallelUploadFile()` we were not allowing overwrites of the target
object. In some cases applications may absolutely want to overwite the
target (say because they are replacing its contents). In some
applications they may not, in which case they can provide a
pre-condition.

Fixes #6907

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6908)
<!-- Reviewable:end -->
