### PR TITLE
cleanup(storage): simplify integration test cleanup

### DIFF
--- a/google/cloud/storage/testing/storage_integration_test.cc
+++ b/google/cloud/storage/testing/storage_integration_test.cc
@@ -38,6 +38,20 @@ static bool UseGrpcForMedia() {
   return v.find("media") != std::string::npos;
 }
 
+void StorageIntegrationTest::TearDown() {
+  // The client configured to create and delete buckets is good for our
+  // purposes.
+  auto client = MakeBucketIntegrationTestClient();
+  if (!client) return;
+  for (auto& o : objects_to_delete_) {
+    (void)client->DeleteObject(o.bucket(), o.name(),
+                               Generation(o.generation()));
+  }
+  for (auto& b : buckets_to_delete_) {
+    (void)client->DeleteBucket(b.name());
+  }
+}
+
 google::cloud::StatusOr<google::cloud::storage::Client>
 StorageIntegrationTest::MakeIntegrationTestClient() {
   return MakeIntegrationTestClient(TestRetryPolicy());

--- a/google/cloud/storage/testing/storage_integration_test.cc
+++ b/google/cloud/storage/testing/storage_integration_test.cc
@@ -38,7 +38,7 @@ static bool UseGrpcForMedia() {
   return v.find("media") != std::string::npos;
 }
 
-void StorageIntegrationTest::TearDown() {
+StorageIntegrationTest::~StorageIntegrationTest() {
   // The client configured to create and delete buckets is good for our
   // purposes.
   auto client = MakeBucketIntegrationTestClient();

--- a/google/cloud/storage/testing/storage_integration_test.h
+++ b/google/cloud/storage/testing/storage_integration_test.h
@@ -35,6 +35,8 @@ namespace testing {
 class StorageIntegrationTest
     : public ::google::cloud::testing_util::IntegrationTest {
  protected:
+  void TearDown() override;
+
   /**
    * Return a client suitable for most integration tests.
    *
@@ -92,6 +94,20 @@ class StorageIntegrationTest
 
   google::cloud::internal::DefaultPRNG generator_ =
       google::cloud::internal::MakeDefaultPRNG();
+
+  /// Delete the given object during the test teardown.
+  void ScheduleForDelete(ObjectMetadata meta) {
+    objects_to_delete_.push_back(std::move(meta));
+  }
+
+  /// Delete the given bucket during the test teardown.
+  void ScheduleForDelete(BucketMetadata meta) {
+    buckets_to_delete_.push_back(std::move(meta));
+  }
+
+ private:
+  std::vector<ObjectMetadata> objects_to_delete_;
+  std::vector<BucketMetadata> buckets_to_delete_;
 };
 
 /**

--- a/google/cloud/storage/testing/storage_integration_test.h
+++ b/google/cloud/storage/testing/storage_integration_test.h
@@ -35,7 +35,7 @@ namespace testing {
 class StorageIntegrationTest
     : public ::google::cloud::testing_util::IntegrationTest {
  protected:
-  void TearDown() override;
+  ~StorageIntegrationTest() override;
 
   /**
    * Return a client suitable for most integration tests.

--- a/google/cloud/storage/tests/auto_finalize_integration_test.cc
+++ b/google/cloud/storage/tests/auto_finalize_integration_test.cc
@@ -127,6 +127,7 @@ TEST_F(AutoFinalizeIntegrationTest, Disabled) {
                           UseResumableUploadSession(upload_session));
   os.Close();
   ASSERT_THAT(os.metadata(), IsOk());
+  ScheduleForDelete(*os.metadata());
   EXPECT_EQ(os.metadata()->size(), kSize);
 
   auto reader = client->ReadObject(bucket_name(), object_name);
@@ -135,8 +136,6 @@ TEST_F(AutoFinalizeIntegrationTest, Disabled) {
   auto const actual =
       std::string{std::istreambuf_iterator<char>{reader.rdbuf()}, {}};
   EXPECT_EQ(expected_text, actual);
-
-  (void)client->DeleteObject(bucket_name(), object_name);
 }
 
 }  // namespace

--- a/google/cloud/storage/tests/error_injection_integration_test.cc
+++ b/google/cloud/storage/tests/error_injection_integration_test.cc
@@ -263,7 +263,8 @@ TEST_F(ErrorInjectionIntegrationTest, InjectRecvErrorOnRead) {
                    static_cast<int>(kDownloadBufferSize) * 3 / 80);
   os.Close();
   EXPECT_TRUE(os);
-  EXPECT_STATUS_OK(os.metadata());
+  ASSERT_STATUS_OK(os.metadata());
+  ScheduleForDelete(*os.metadata());
 
   auto is = client.ReadObject(bucket_name_, object_name);
   std::vector<char> read_buf(kDownloadBufferSize + 1);
@@ -275,9 +276,6 @@ TEST_F(ErrorInjectionIntegrationTest, InjectRecvErrorOnRead) {
   ASSERT_STATUS_OK(is.status());
   is.Close();
   EXPECT_EQ(SymbolInterceptor::Instance().StopFailingRecv(), kInjectedErrors);
-
-  auto status = client.DeleteObject(bucket_name_, object_name);
-  EXPECT_STATUS_OK(status);
 }
 
 TEST_F(ErrorInjectionIntegrationTest, InjectSendErrorOnRead) {
@@ -302,7 +300,8 @@ TEST_F(ErrorInjectionIntegrationTest, InjectSendErrorOnRead) {
   WriteRandomLines(os, expected, 80, kDownloadBufferSize * 3 / 80);
   os.Close();
   EXPECT_TRUE(os);
-  EXPECT_STATUS_OK(os.metadata());
+  ASSERT_STATUS_OK(os.metadata());
+  ScheduleForDelete(*os.metadata());
 
   auto is = client.ReadObject(bucket_name_, object_name);
   std::vector<char> read_buf(kDownloadBufferSize + 1);
@@ -318,9 +317,6 @@ TEST_F(ErrorInjectionIntegrationTest, InjectSendErrorOnRead) {
   EXPECT_THAT(is.status(), StatusIs(StatusCode::kUnavailable));
   EXPECT_GE(SymbolInterceptor::Instance().StopFailingSend(), 1);
   EXPECT_GE(SymbolInterceptor::Instance().StopFailingRecv(), 1);
-
-  auto status = client.DeleteObject(bucket_name_, object_name);
-  EXPECT_STATUS_OK(status);
 }
 
 #endif  // _WIN32

--- a/google/cloud/storage/tests/key_file_integration_test.cc
+++ b/google/cloud/storage/tests/key_file_integration_test.cc
@@ -82,6 +82,7 @@ TEST_P(KeyFileIntegrationTest, ObjectWriteSignAndReadDefaultAccount) {
   auto meta = client.InsertObject(bucket_name_, object_name, expected,
                                   IfGenerationMatch(0));
   ASSERT_STATUS_OK(meta);
+  ScheduleForDelete(*meta);
 
   StatusOr<std::string> signed_url =
       client.CreateV4SignedUrl("GET", bucket_name_, object_name);
@@ -96,9 +97,6 @@ TEST_P(KeyFileIntegrationTest, ObjectWriteSignAndReadDefaultAccount) {
   EXPECT_EQ(200, response->status_code);
 
   EXPECT_EQ(expected, response->payload);
-
-  auto deleted = client.DeleteObject(bucket_name_, object_name);
-  ASSERT_STATUS_OK(deleted);
 }
 
 TEST_P(KeyFileIntegrationTest, ObjectWriteSignAndReadExplicitAccount) {
@@ -115,6 +113,7 @@ TEST_P(KeyFileIntegrationTest, ObjectWriteSignAndReadExplicitAccount) {
   auto meta = client.InsertObject(bucket_name_, object_name, expected,
                                   IfGenerationMatch(0));
   ASSERT_STATUS_OK(meta);
+  ScheduleForDelete(*meta);
 
   StatusOr<std::string> signed_url = client.CreateV4SignedUrl(
       "GET", bucket_name_, object_name, SigningAccount(service_account_));
@@ -129,9 +128,6 @@ TEST_P(KeyFileIntegrationTest, ObjectWriteSignAndReadExplicitAccount) {
   EXPECT_EQ(200, response->status_code);
 
   EXPECT_EQ(expected, response->payload);
-
-  auto deleted = client.DeleteObject(bucket_name_, object_name);
-  ASSERT_STATUS_OK(deleted);
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/google/cloud/storage/tests/object_basic_crud_integration_test.cc
+++ b/google/cloud/storage/tests/object_basic_crud_integration_test.cc
@@ -145,6 +145,7 @@ TEST_F(ObjectBasicCRUDIntegrationTest, BasicCRUD) {
   EXPECT_EQ(desired_patch.content_language(), patched_meta->content_language())
       << *patched_meta;
 
+  // This is the test for Object CRUD, we cannot rely on `ScheduleForDelete()`.
   auto status = client->DeleteObject(bucket_name_, object_name);
   ASSERT_STATUS_OK(status);
   EXPECT_THAT(list_object_names(), Not(Contains(object_name)));
@@ -176,14 +177,12 @@ TEST_F(ObjectBasicCRUDIntegrationTest, NonDefaultEndpointInsertJSON) {
   auto const expected = LoremIpsum();
   auto insert = client.InsertObject(bucket_name_, object_name, expected);
   ASSERT_STATUS_OK(insert);
+  ScheduleForDelete(*insert);
   auto stream =
       client.ReadObject(bucket_name_, object_name, IfGenerationNotMatch(0));
   EXPECT_STATUS_OK(stream.status());
   std::string const actual(std::istreambuf_iterator<char>{stream}, {});
   EXPECT_EQ(expected, actual);
-
-  auto status = client.DeleteObject(bucket_name_, object_name);
-  EXPECT_STATUS_OK(status);
 }
 
 /// @test Verify that the client works with non-default endpoints.
@@ -194,13 +193,11 @@ TEST_F(ObjectBasicCRUDIntegrationTest, NonDefaultEndpointInsertXml) {
   auto insert =
       client.InsertObject(bucket_name_, object_name, expected, Fields(""));
   ASSERT_STATUS_OK(insert);
+  ScheduleForDelete(*insert);
   auto stream = client.ReadObject(bucket_name_, object_name);
   EXPECT_STATUS_OK(stream.status());
   std::string const actual(std::istreambuf_iterator<char>{stream}, {});
   EXPECT_EQ(expected, actual);
-
-  auto status = client.DeleteObject(bucket_name_, object_name);
-  EXPECT_STATUS_OK(status);
 }
 
 /// @test Verify that the client works with non-default endpoints.
@@ -212,14 +209,12 @@ TEST_F(ObjectBasicCRUDIntegrationTest, NonDefaultEndpointWriteJSON) {
   writer << expected;
   writer.Close();
   ASSERT_STATUS_OK(writer.metadata());
+  ScheduleForDelete(*writer.metadata());
   auto stream =
       client.ReadObject(bucket_name_, object_name, IfGenerationNotMatch(0));
   EXPECT_STATUS_OK(stream.status());
   std::string const actual(std::istreambuf_iterator<char>{stream}, {});
   EXPECT_EQ(expected, actual);
-
-  auto status = client.DeleteObject(bucket_name_, object_name);
-  EXPECT_STATUS_OK(status);
 }
 
 /// @test Verify that the client works with non-default endpoints.
@@ -231,13 +226,11 @@ TEST_F(ObjectBasicCRUDIntegrationTest, NonDefaultEndpointWriteXml) {
   writer << expected;
   writer.Close();
   ASSERT_STATUS_OK(writer.metadata());
+  ScheduleForDelete(*writer.metadata());
   auto stream = client.ReadObject(bucket_name_, object_name);
   EXPECT_STATUS_OK(stream.status());
   std::string const actual(std::istreambuf_iterator<char>{stream}, {});
   EXPECT_EQ(expected, actual);
-
-  auto status = client.DeleteObject(bucket_name_, object_name);
-  EXPECT_STATUS_OK(status);
 }
 
 }  // anonymous namespace

--- a/google/cloud/storage/tests/object_compose_many_integration_test.cc
+++ b/google/cloud/storage/tests/object_compose_many_integration_test.cc
@@ -60,15 +60,12 @@ TEST_F(ObjectComposeManyIntegrationTest, ComposeMany) {
                          dest_object_name, false);
 
   ASSERT_STATUS_OK(res);
+  ScheduleForDelete(*res);
   EXPECT_EQ(dest_object_name, res->name());
 
   auto stream = client->ReadObject(bucket_name_, dest_object_name);
   std::string actual(std::istreambuf_iterator<char>{stream}, {});
   EXPECT_EQ(expected, actual);
-
-  auto deletion_status = client->DeleteObject(
-      bucket_name_, dest_object_name, IfGenerationMatch(res->generation()));
-  ASSERT_STATUS_OK(deletion_status);
 }
 
 }  // anonymous namespace

--- a/google/cloud/storage/tests/object_insert_integration_test.cc
+++ b/google/cloud/storage/tests/object_insert_integration_test.cc
@@ -83,6 +83,7 @@ TEST_P(ObjectInsertIntegrationTest, SimpleInsertWithNonUrlSafeName) {
       bucket_name_, object_name, expected, IfGenerationMatch(0),
       DisableCrc32cChecksum(true), DisableMD5Hash(true));
   ASSERT_STATUS_OK(meta);
+  ScheduleForDelete(*meta);
   EXPECT_EQ(object_name, meta->name());
   EXPECT_EQ(bucket_name_, meta->bucket());
 
@@ -90,9 +91,6 @@ TEST_P(ObjectInsertIntegrationTest, SimpleInsertWithNonUrlSafeName) {
   auto stream = client->ReadObject(bucket_name_, object_name);
   std::string actual(std::istreambuf_iterator<char>{stream}, {});
   EXPECT_EQ(expected, actual);
-
-  auto status = client->DeleteObject(bucket_name_, object_name);
-  ASSERT_STATUS_OK(status);
 }
 
 TEST_P(ObjectInsertIntegrationTest, XmlInsertWithNonUrlSafeName) {
@@ -107,6 +105,7 @@ TEST_P(ObjectInsertIntegrationTest, XmlInsertWithNonUrlSafeName) {
   StatusOr<ObjectMetadata> meta = client->InsertObject(
       bucket_name_, object_name, expected, IfGenerationMatch(0), Fields(""));
   ASSERT_STATUS_OK(meta);
+  ScheduleForDelete(*meta);
   EXPECT_EQ(object_name, meta->name());
   EXPECT_EQ(bucket_name_, meta->bucket());
 
@@ -114,9 +113,6 @@ TEST_P(ObjectInsertIntegrationTest, XmlInsertWithNonUrlSafeName) {
   auto stream = client->ReadObject(bucket_name_, object_name);
   std::string actual(std::istreambuf_iterator<char>{stream}, {});
   EXPECT_EQ(expected, actual);
-
-  auto status = client->DeleteObject(bucket_name_, object_name);
-  ASSERT_STATUS_OK(status);
 }
 
 TEST_P(ObjectInsertIntegrationTest, MultipartInsertWithNonUrlSafeName) {
@@ -131,6 +127,7 @@ TEST_P(ObjectInsertIntegrationTest, MultipartInsertWithNonUrlSafeName) {
   StatusOr<ObjectMetadata> meta = client->InsertObject(
       bucket_name_, object_name, expected, IfGenerationMatch(0));
   ASSERT_STATUS_OK(meta);
+  ScheduleForDelete(*meta);
   EXPECT_EQ(object_name, meta->name());
   EXPECT_EQ(bucket_name_, meta->bucket());
 
@@ -138,9 +135,6 @@ TEST_P(ObjectInsertIntegrationTest, MultipartInsertWithNonUrlSafeName) {
   auto stream = client->ReadObject(bucket_name_, object_name);
   std::string actual(std::istreambuf_iterator<char>{stream}, {});
   EXPECT_EQ(expected, actual);
-
-  auto status = client->DeleteObject(bucket_name_, object_name);
-  ASSERT_STATUS_OK(status);
 }
 
 TEST_P(ObjectInsertIntegrationTest, InsertWithMD5) {
@@ -156,6 +150,7 @@ TEST_P(ObjectInsertIntegrationTest, InsertWithMD5) {
       bucket_name_, object_name, expected, IfGenerationMatch(0),
       MD5HashValue("96HF9K981B+JfoQuTVnyCg=="));
   ASSERT_STATUS_OK(meta);
+  ScheduleForDelete(*meta);
   EXPECT_EQ(object_name, meta->name());
   EXPECT_EQ(bucket_name_, meta->bucket());
 
@@ -163,9 +158,6 @@ TEST_P(ObjectInsertIntegrationTest, InsertWithMD5) {
   auto stream = client->ReadObject(bucket_name_, object_name);
   std::string actual(std::istreambuf_iterator<char>{stream}, {});
   EXPECT_EQ(expected, actual);
-
-  auto status = client->DeleteObject(bucket_name_, object_name);
-  ASSERT_STATUS_OK(status);
 }
 
 TEST_P(ObjectInsertIntegrationTest, InsertWithComputedMD5) {
@@ -181,6 +173,7 @@ TEST_P(ObjectInsertIntegrationTest, InsertWithComputedMD5) {
       bucket_name_, object_name, expected, IfGenerationMatch(0),
       MD5HashValue(ComputeMD5Hash(expected)));
   ASSERT_STATUS_OK(meta);
+  ScheduleForDelete(*meta);
   EXPECT_EQ(object_name, meta->name());
   EXPECT_EQ(bucket_name_, meta->bucket());
 
@@ -188,9 +181,6 @@ TEST_P(ObjectInsertIntegrationTest, InsertWithComputedMD5) {
   auto stream = client->ReadObject(bucket_name_, object_name);
   std::string actual(std::istreambuf_iterator<char>{stream}, {});
   EXPECT_EQ(expected, actual);
-
-  auto status = client->DeleteObject(bucket_name_, object_name);
-  ASSERT_STATUS_OK(status);
 }
 
 TEST_P(ObjectInsertIntegrationTest, XmlInsertWithMD5) {
@@ -206,6 +196,7 @@ TEST_P(ObjectInsertIntegrationTest, XmlInsertWithMD5) {
       bucket_name_, object_name, expected, IfGenerationMatch(0), Fields(""),
       MD5HashValue("96HF9K981B+JfoQuTVnyCg=="));
   ASSERT_STATUS_OK(meta);
+  ScheduleForDelete(*meta);
   EXPECT_EQ(object_name, meta->name());
   EXPECT_EQ(bucket_name_, meta->bucket());
 
@@ -213,9 +204,6 @@ TEST_P(ObjectInsertIntegrationTest, XmlInsertWithMD5) {
   auto stream = client->ReadObject(bucket_name_, object_name);
   std::string actual(std::istreambuf_iterator<char>{stream}, {});
   EXPECT_EQ(expected, actual);
-
-  auto status = client->DeleteObject(bucket_name_, object_name);
-  ASSERT_STATUS_OK(status);
 }
 
 TEST_P(ObjectInsertIntegrationTest, InsertWithMetadata) {
@@ -233,6 +221,7 @@ TEST_P(ObjectInsertIntegrationTest, InsertWithMetadata) {
                              .upsert_metadata("test-key", "test-value")
                              .set_content_type("text/plain")));
   ASSERT_STATUS_OK(meta);
+  ScheduleForDelete(*meta);
   EXPECT_EQ(object_name, meta->name());
   EXPECT_EQ(bucket_name_, meta->bucket());
   EXPECT_TRUE(meta->has_metadata("test-key"));
@@ -243,9 +232,6 @@ TEST_P(ObjectInsertIntegrationTest, InsertWithMetadata) {
   auto stream = client->ReadObject(bucket_name_, object_name);
   std::string actual(std::istreambuf_iterator<char>{stream}, {});
   EXPECT_EQ(expected, actual);
-
-  auto status = client->DeleteObject(bucket_name_, object_name);
-  ASSERT_STATUS_OK(status);
 }
 
 TEST_P(ObjectInsertIntegrationTest, InsertPredefinedAclAuthenticatedRead) {
@@ -258,14 +244,13 @@ TEST_P(ObjectInsertIntegrationTest, InsertPredefinedAclAuthenticatedRead) {
       bucket_name_, object_name, LoremIpsum(), IfGenerationMatch(0),
       PredefinedAcl::AuthenticatedRead(), Projection::Full());
   ASSERT_STATUS_OK(meta);
+  ScheduleForDelete(*meta);
+
   EXPECT_LT(0, CountMatchingEntities(meta->acl(),
                                      ObjectAccessControl()
                                          .set_entity("allAuthenticatedUsers")
                                          .set_role("READER")))
       << *meta;
-
-  auto status = client->DeleteObject(bucket_name_, object_name);
-  ASSERT_STATUS_OK(status);
 }
 
 TEST_P(ObjectInsertIntegrationTest, InsertPredefinedAclBucketOwnerFullControl) {
@@ -284,13 +269,12 @@ TEST_P(ObjectInsertIntegrationTest, InsertPredefinedAclBucketOwnerFullControl) {
       bucket_name_, object_name, LoremIpsum(), IfGenerationMatch(0),
       PredefinedAcl::BucketOwnerFullControl(), Projection::Full());
   ASSERT_STATUS_OK(meta);
+  ScheduleForDelete(*meta);
+
   EXPECT_LT(0, CountMatchingEntities(
                    meta->acl(),
                    ObjectAccessControl().set_entity(owner).set_role("OWNER")))
       << *meta;
-
-  auto status = client->DeleteObject(bucket_name_, object_name);
-  ASSERT_STATUS_OK(status);
 }
 
 TEST_P(ObjectInsertIntegrationTest, InsertPredefinedAclBucketOwnerRead) {
@@ -309,14 +293,12 @@ TEST_P(ObjectInsertIntegrationTest, InsertPredefinedAclBucketOwnerRead) {
       bucket_name_, object_name, LoremIpsum(), IfGenerationMatch(0),
       PredefinedAcl::BucketOwnerRead(), Projection::Full());
   ASSERT_STATUS_OK(meta);
+  ScheduleForDelete(*meta);
 
   EXPECT_LT(0, CountMatchingEntities(
                    meta->acl(),
                    ObjectAccessControl().set_entity(owner).set_role("READER")))
       << *meta;
-
-  auto status = client->DeleteObject(bucket_name_, object_name);
-  ASSERT_STATUS_OK(status);
 }
 
 TEST_P(ObjectInsertIntegrationTest, InsertPredefinedAclPrivate) {
@@ -329,6 +311,7 @@ TEST_P(ObjectInsertIntegrationTest, InsertPredefinedAclPrivate) {
       bucket_name_, object_name, LoremIpsum(), IfGenerationMatch(0),
       PredefinedAcl::Private(), Projection::Full());
   ASSERT_STATUS_OK(meta);
+  ScheduleForDelete(*meta);
 
   ASSERT_TRUE(meta->has_owner());
   EXPECT_LT(0, CountMatchingEntities(meta->acl(),
@@ -336,9 +319,6 @@ TEST_P(ObjectInsertIntegrationTest, InsertPredefinedAclPrivate) {
                                          .set_entity(meta->owner().entity)
                                          .set_role("OWNER")))
       << *meta;
-
-  auto status = client->DeleteObject(bucket_name_, object_name);
-  ASSERT_STATUS_OK(status);
 }
 
 TEST_P(ObjectInsertIntegrationTest, InsertPredefinedAclProjectPrivate) {
@@ -351,15 +331,14 @@ TEST_P(ObjectInsertIntegrationTest, InsertPredefinedAclProjectPrivate) {
       bucket_name_, object_name, LoremIpsum(), IfGenerationMatch(0),
       PredefinedAcl::ProjectPrivate(), Projection::Full());
   ASSERT_STATUS_OK(meta);
+  ScheduleForDelete(*meta);
+
   ASSERT_TRUE(meta->has_owner());
   EXPECT_LT(0, CountMatchingEntities(meta->acl(),
                                      ObjectAccessControl()
                                          .set_entity(meta->owner().entity)
                                          .set_role("OWNER")))
       << *meta;
-
-  auto status = client->DeleteObject(bucket_name_, object_name);
-  ASSERT_STATUS_OK(status);
 }
 
 TEST_P(ObjectInsertIntegrationTest, InsertPredefinedAclPublicRead) {
@@ -372,14 +351,13 @@ TEST_P(ObjectInsertIntegrationTest, InsertPredefinedAclPublicRead) {
       bucket_name_, object_name, LoremIpsum(), IfGenerationMatch(0),
       PredefinedAcl::PublicRead(), Projection::Full());
   ASSERT_STATUS_OK(meta);
+  ScheduleForDelete(*meta);
+
   EXPECT_LT(
       0, CountMatchingEntities(
              meta->acl(),
              ObjectAccessControl().set_entity("allUsers").set_role("READER")))
       << *meta;
-
-  auto status = client->DeleteObject(bucket_name_, object_name);
-  ASSERT_STATUS_OK(status);
 }
 
 TEST_P(ObjectInsertIntegrationTest, XmlInsertPredefinedAclAuthenticatedRead) {
@@ -396,14 +374,13 @@ TEST_P(ObjectInsertIntegrationTest, XmlInsertPredefinedAclAuthenticatedRead) {
   StatusOr<ObjectMetadata> meta =
       client->GetObjectMetadata(bucket_name_, object_name, Projection::Full());
   ASSERT_STATUS_OK(meta);
+  ScheduleForDelete(*meta);
+
   EXPECT_LT(0, CountMatchingEntities(meta->acl(),
                                      ObjectAccessControl()
                                          .set_entity("allAuthenticatedUsers")
                                          .set_role("READER")))
       << *meta;
-
-  auto status = client->DeleteObject(bucket_name_, object_name);
-  ASSERT_STATUS_OK(status);
 }
 
 TEST_P(ObjectInsertIntegrationTest,
@@ -427,13 +404,12 @@ TEST_P(ObjectInsertIntegrationTest,
   StatusOr<ObjectMetadata> meta =
       client->GetObjectMetadata(bucket_name_, object_name, Projection::Full());
   ASSERT_STATUS_OK(meta);
+  ScheduleForDelete(*meta);
+
   EXPECT_LT(0, CountMatchingEntities(
                    meta->acl(),
                    ObjectAccessControl().set_entity(owner).set_role("OWNER")))
       << *meta;
-
-  auto status = client->DeleteObject(bucket_name_, object_name);
-  ASSERT_STATUS_OK(status);
 }
 
 TEST_P(ObjectInsertIntegrationTest, XmlInsertPredefinedAclBucketOwnerRead) {
@@ -456,13 +432,12 @@ TEST_P(ObjectInsertIntegrationTest, XmlInsertPredefinedAclBucketOwnerRead) {
   StatusOr<ObjectMetadata> meta =
       client->GetObjectMetadata(bucket_name_, object_name, Projection::Full());
   ASSERT_STATUS_OK(meta);
+  ScheduleForDelete(*meta);
+
   EXPECT_LT(0, CountMatchingEntities(
                    meta->acl(),
                    ObjectAccessControl().set_entity(owner).set_role("READER")))
       << *meta;
-
-  auto status = client->DeleteObject(bucket_name_, object_name);
-  ASSERT_STATUS_OK(status);
 }
 
 TEST_P(ObjectInsertIntegrationTest, XmlInsertPredefinedAclPrivate) {
@@ -479,15 +454,14 @@ TEST_P(ObjectInsertIntegrationTest, XmlInsertPredefinedAclPrivate) {
   StatusOr<ObjectMetadata> meta =
       client->GetObjectMetadata(bucket_name_, object_name, Projection::Full());
   ASSERT_STATUS_OK(meta);
+  ScheduleForDelete(*meta);
+
   ASSERT_TRUE(meta->has_owner());
   EXPECT_LT(0, CountMatchingEntities(meta->acl(),
                                      ObjectAccessControl()
                                          .set_entity(meta->owner().entity)
                                          .set_role("OWNER")))
       << *meta;
-
-  auto status = client->DeleteObject(bucket_name_, object_name);
-  ASSERT_STATUS_OK(status);
 }
 
 TEST_P(ObjectInsertIntegrationTest, XmlInsertPredefinedAclProjectPrivate) {
@@ -504,15 +478,14 @@ TEST_P(ObjectInsertIntegrationTest, XmlInsertPredefinedAclProjectPrivate) {
   StatusOr<ObjectMetadata> meta =
       client->GetObjectMetadata(bucket_name_, object_name, Projection::Full());
   ASSERT_STATUS_OK(meta);
+  ScheduleForDelete(*meta);
+
   ASSERT_TRUE(meta->has_owner());
   EXPECT_LT(0, CountMatchingEntities(meta->acl(),
                                      ObjectAccessControl()
                                          .set_entity(meta->owner().entity)
                                          .set_role("OWNER")))
       << *meta;
-
-  auto status = client->DeleteObject(bucket_name_, object_name);
-  ASSERT_STATUS_OK(status);
 }
 
 TEST_P(ObjectInsertIntegrationTest, XmlInsertPredefinedAclPublicRead) {
@@ -529,14 +502,13 @@ TEST_P(ObjectInsertIntegrationTest, XmlInsertPredefinedAclPublicRead) {
   StatusOr<ObjectMetadata> meta =
       client->GetObjectMetadata(bucket_name_, object_name, Projection::Full());
   ASSERT_STATUS_OK(meta);
+  ScheduleForDelete(*meta);
+
   EXPECT_LT(
       0, CountMatchingEntities(
              meta->acl(),
              ObjectAccessControl().set_entity("allUsers").set_role("READER")))
       << *meta;
-
-  auto status = client->DeleteObject(bucket_name_, object_name);
-  ASSERT_STATUS_OK(status);
 }
 
 /**
@@ -557,14 +529,12 @@ TEST_P(ObjectInsertIntegrationTest, InsertWithQuotaUser) {
       client.InsertObject(bucket_name_, object_name, LoremIpsum(),
                           IfGenerationMatch(0), QuotaUser("test-quota-user"));
   ASSERT_STATUS_OK(insert_meta);
+  ScheduleForDelete(*insert_meta);
 
   EXPECT_THAT(log.ExtractLines(),
               Contains(AllOf(HasSubstr(" POST "),
                              HasSubstr("/b/" + bucket_name_ + "/o"),
                              HasSubstr("quotaUser=test-quota-user"))));
-
-  auto status = client.DeleteObject(bucket_name_, object_name);
-  ASSERT_STATUS_OK(status);
 }
 
 /**
@@ -585,14 +555,12 @@ TEST_P(ObjectInsertIntegrationTest, InsertWithUserIp) {
       client.InsertObject(bucket_name_, object_name, LoremIpsum(),
                           IfGenerationMatch(0), UserIp("127.0.0.1"));
   ASSERT_STATUS_OK(insert_meta);
+  ScheduleForDelete(*insert_meta);
 
   EXPECT_THAT(log.ExtractLines(),
               Contains(AllOf(HasSubstr(" POST "),
                              HasSubstr("/b/" + bucket_name_ + "/o"),
                              HasSubstr("userIp=127.0.0.1"))));
-
-  auto status = client.DeleteObject(bucket_name_, object_name);
-  ASSERT_STATUS_OK(status);
 }
 
 /**
@@ -616,8 +584,7 @@ TEST_P(ObjectInsertIntegrationTest, InsertWithUserIpBlank) {
     auto insert =
         client.InsertObject(bucket_name_, seed_object_name, LoremIpsum());
     ASSERT_STATUS_OK(insert);
-    auto status = client.DeleteObject(bucket_name_, seed_object_name);
-    ASSERT_STATUS_OK(status);
+    ScheduleForDelete(*insert);
   }
 
   testing_util::ScopedLog log;
@@ -625,14 +592,12 @@ TEST_P(ObjectInsertIntegrationTest, InsertWithUserIpBlank) {
       client.InsertObject(bucket_name_, object_name, LoremIpsum(),
                           IfGenerationMatch(0), UserIp(""));
   ASSERT_STATUS_OK(insert_meta);
+  ScheduleForDelete(*insert_meta);
 
   EXPECT_THAT(log.ExtractLines(),
               Contains(AllOf(HasSubstr(" POST "),
                              HasSubstr("/b/" + bucket_name_ + "/o"),
                              HasSubstr("userIp="))));
-
-  auto status = client.DeleteObject(bucket_name_, object_name);
-  ASSERT_STATUS_OK(status);
 }
 
 TEST_P(ObjectInsertIntegrationTest, InsertWithContentType) {
@@ -646,11 +611,9 @@ TEST_P(ObjectInsertIntegrationTest, InsertWithContentType) {
       client->InsertObject(bucket_name_, object_name, LoremIpsum(),
                            IfGenerationMatch(0), ContentType("text/plain"));
   ASSERT_STATUS_OK(meta);
+  ScheduleForDelete(*meta);
 
   EXPECT_EQ("text/plain", meta->content_type());
-
-  auto status = client->DeleteObject(bucket_name_, object_name);
-  ASSERT_STATUS_OK(status);
 }
 
 TEST_P(ObjectInsertIntegrationTest, InsertFailure) {
@@ -665,6 +628,7 @@ TEST_P(ObjectInsertIntegrationTest, InsertFailure) {
   StatusOr<ObjectMetadata> insert = client->InsertObject(
       bucket_name_, object_name, expected, IfGenerationMatch(0));
   ASSERT_STATUS_OK(insert);
+  ScheduleForDelete(*insert);
   EXPECT_EQ(object_name, insert->name());
   EXPECT_EQ(bucket_name_, insert->bucket());
 
@@ -672,9 +636,6 @@ TEST_P(ObjectInsertIntegrationTest, InsertFailure) {
   StatusOr<ObjectMetadata> failure = client->InsertObject(
       bucket_name_, object_name, expected, IfGenerationMatch(0));
   EXPECT_THAT(failure, Not(IsOk())) << "metadata=" << failure.value();
-
-  auto status = client->DeleteObject(bucket_name_, object_name);
-  ASSERT_STATUS_OK(status);
 }
 
 TEST_P(ObjectInsertIntegrationTest, InsertXmlFailure) {
@@ -689,6 +650,7 @@ TEST_P(ObjectInsertIntegrationTest, InsertXmlFailure) {
   StatusOr<ObjectMetadata> insert = client->InsertObject(
       bucket_name_, object_name, expected, Fields(""), IfGenerationMatch(0));
   ASSERT_STATUS_OK(insert);
+  ScheduleForDelete(*insert);
 
   EXPECT_EQ(object_name, insert->name());
   EXPECT_EQ(bucket_name_, insert->bucket());
@@ -697,9 +659,6 @@ TEST_P(ObjectInsertIntegrationTest, InsertXmlFailure) {
   StatusOr<ObjectMetadata> failure = client->InsertObject(
       bucket_name_, object_name, expected, Fields(""), IfGenerationMatch(0));
   EXPECT_THAT(failure, Not(IsOk())) << "metadata=" << failure.value();
-
-  auto status = client->DeleteObject(bucket_name_, object_name);
-  ASSERT_STATUS_OK(status);
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/google/cloud/storage/tests/object_insert_preconditions_integration_test.cc
+++ b/google/cloud/storage/tests/object_insert_preconditions_integration_test.cc
@@ -70,16 +70,13 @@ TEST_P(ObjectInsertPreconditionsIntegrationTest, IfGenerationMatchSuccess) {
   auto meta = client->InsertObject(bucket_name(), object_name, expected_text,
                                    IfGenerationMatch(0));
   ASSERT_THAT(meta, IsOk());
+  ScheduleForDelete(*meta);
 
   auto insert = client->InsertObject(bucket_name(), object_name, expected_text,
                                      GetParam().fields,
                                      IfGenerationMatch(meta->generation()));
   ASSERT_THAT(insert, IsOk());
-
-  (void)client->DeleteObject(bucket_name(), object_name,
-                             Generation(insert->generation()));
-  (void)client->DeleteObject(bucket_name(), object_name,
-                             Generation(meta->generation()));
+  ScheduleForDelete(*insert);
 }
 
 TEST_P(ObjectInsertPreconditionsIntegrationTest, IfGenerationMatchFailure) {
@@ -91,14 +88,12 @@ TEST_P(ObjectInsertPreconditionsIntegrationTest, IfGenerationMatchFailure) {
   auto meta = client->InsertObject(bucket_name(), object_name, expected_text,
                                    IfGenerationMatch(0));
   ASSERT_THAT(meta, IsOk());
+  ScheduleForDelete(*meta);
 
   auto insert = client->InsertObject(bucket_name(), object_name, expected_text,
                                      GetParam().fields,
                                      IfGenerationMatch(meta->generation() + 1));
   ASSERT_THAT(insert, StatusIs(StatusCode::kFailedPrecondition));
-
-  (void)client->DeleteObject(bucket_name(), object_name,
-                             Generation(meta->generation()));
 }
 
 TEST_P(ObjectInsertPreconditionsIntegrationTest, IfGenerationNotMatchSuccess) {
@@ -110,16 +105,13 @@ TEST_P(ObjectInsertPreconditionsIntegrationTest, IfGenerationNotMatchSuccess) {
   auto meta = client->InsertObject(bucket_name(), object_name, expected_text,
                                    IfGenerationMatch(0));
   ASSERT_THAT(meta, IsOk());
+  ScheduleForDelete(*meta);
 
   auto insert = client->InsertObject(
       bucket_name(), object_name, expected_text, GetParam().fields,
       IfGenerationNotMatch(meta->generation() + 1));
   ASSERT_THAT(insert, IsOk());
-
-  (void)client->DeleteObject(bucket_name(), object_name,
-                             Generation(insert->generation()));
-  (void)client->DeleteObject(bucket_name(), object_name,
-                             Generation(meta->generation()));
+  ScheduleForDelete(*insert);
 }
 
 TEST_P(ObjectInsertPreconditionsIntegrationTest, IfGenerationNotMatchFailure) {
@@ -131,15 +123,13 @@ TEST_P(ObjectInsertPreconditionsIntegrationTest, IfGenerationNotMatchFailure) {
   auto meta = client->InsertObject(bucket_name(), object_name, expected_text,
                                    IfGenerationMatch(0));
   ASSERT_THAT(meta, IsOk());
+  ScheduleForDelete(*meta);
 
   auto insert = client->InsertObject(bucket_name(), object_name, expected_text,
                                      GetParam().fields,
                                      IfGenerationNotMatch(meta->generation()));
   ASSERT_THAT(insert, StatusIs(AnyOf(StatusCode::kFailedPrecondition,
                                      StatusCode::kAborted)));
-
-  (void)client->DeleteObject(bucket_name(), object_name,
-                             Generation(meta->generation()));
 }
 
 TEST_P(ObjectInsertPreconditionsIntegrationTest, IfMetagenerationMatchSuccess) {
@@ -151,16 +141,13 @@ TEST_P(ObjectInsertPreconditionsIntegrationTest, IfMetagenerationMatchSuccess) {
   auto meta = client->InsertObject(bucket_name(), object_name, expected_text,
                                    IfGenerationMatch(0));
   ASSERT_THAT(meta, IsOk());
+  ScheduleForDelete(*meta);
 
   auto insert = client->InsertObject(
       bucket_name(), object_name, expected_text, GetParam().fields,
       IfMetagenerationMatch(meta->metageneration()));
   ASSERT_THAT(insert, IsOk());
-
-  (void)client->DeleteObject(bucket_name(), object_name,
-                             Generation(insert->generation()));
-  (void)client->DeleteObject(bucket_name(), object_name,
-                             Generation(meta->generation()));
+  ScheduleForDelete(*insert);
 }
 
 TEST_P(ObjectInsertPreconditionsIntegrationTest, IfMetagenerationMatchFailure) {
@@ -172,14 +159,12 @@ TEST_P(ObjectInsertPreconditionsIntegrationTest, IfMetagenerationMatchFailure) {
   auto meta = client->InsertObject(bucket_name(), object_name, expected_text,
                                    IfGenerationMatch(0));
   ASSERT_THAT(meta, IsOk());
+  ScheduleForDelete(*meta);
 
   auto insert = client->InsertObject(
       bucket_name(), object_name, expected_text, GetParam().fields,
       IfMetagenerationMatch(meta->metageneration() + 1));
   ASSERT_THAT(insert, StatusIs(StatusCode::kFailedPrecondition));
-
-  (void)client->DeleteObject(bucket_name(), object_name,
-                             Generation(meta->generation()));
 }
 
 TEST_P(ObjectInsertPreconditionsIntegrationTest,
@@ -192,16 +177,13 @@ TEST_P(ObjectInsertPreconditionsIntegrationTest,
   auto meta = client->InsertObject(bucket_name(), object_name, expected_text,
                                    IfGenerationMatch(0));
   ASSERT_THAT(meta, IsOk());
+  ScheduleForDelete(*meta);
 
   auto insert = client->InsertObject(
       bucket_name(), object_name, expected_text, GetParam().fields,
       IfMetagenerationNotMatch(meta->metageneration() + 1));
   ASSERT_THAT(insert, IsOk());
-
-  (void)client->DeleteObject(bucket_name(), object_name,
-                             Generation(insert->generation()));
-  (void)client->DeleteObject(bucket_name(), object_name,
-                             Generation(meta->generation()));
+  ScheduleForDelete(*insert);
 }
 
 TEST_P(ObjectInsertPreconditionsIntegrationTest,
@@ -214,15 +196,13 @@ TEST_P(ObjectInsertPreconditionsIntegrationTest,
   auto meta = client->InsertObject(bucket_name(), object_name, expected_text,
                                    IfGenerationMatch(0));
   ASSERT_THAT(meta, IsOk());
+  ScheduleForDelete(*meta);
 
   auto insert = client->InsertObject(
       bucket_name(), object_name, expected_text, GetParam().fields,
       IfMetagenerationNotMatch(meta->metageneration()));
   ASSERT_THAT(insert, StatusIs(AnyOf(StatusCode::kFailedPrecondition,
                                      StatusCode::kAborted)));
-
-  (void)client->DeleteObject(bucket_name(), object_name,
-                             Generation(meta->generation()));
 }
 
 INSTANTIATE_TEST_SUITE_P(XmlEnabledAndUsed,

--- a/google/cloud/storage/tests/object_media_integration_test.cc
+++ b/google/cloud/storage/tests/object_media_integration_test.cc
@@ -70,6 +70,7 @@ TEST_F(ObjectMediaIntegrationTest, StreamingReadClose) {
   StatusOr<ObjectMetadata> source_meta = client->InsertObject(
       bucket_name_, object_name, large_text, IfGenerationMatch(0));
   ASSERT_STATUS_OK(source_meta);
+  ScheduleForDelete(*source_meta);
 
   // Create an iostream to read the object back.
   auto stream = client->ReadObject(bucket_name_, object_name);
@@ -80,9 +81,6 @@ TEST_F(ObjectMediaIntegrationTest, StreamingReadClose) {
   EXPECT_EQ(large_text.substr(0, 1024), actual);
   stream.Close();
   EXPECT_STATUS_OK(stream.status());
-
-  auto status = client->DeleteObject(bucket_name_, object_name);
-  EXPECT_STATUS_OK(status);
 }
 
 /// @test Read a portion of a relatively large object using the JSON API.
@@ -110,9 +108,7 @@ TEST_F(ObjectMediaIntegrationTest, ReadRangeJSON) {
   StatusOr<ObjectMetadata> source_meta = client->InsertObject(
       bucket_name_, object_name, large_text, IfGenerationMatch(0));
   ASSERT_STATUS_OK(source_meta);
-
-  EXPECT_EQ(object_name, source_meta->name());
-  EXPECT_EQ(bucket_name_, source_meta->bucket());
+  ScheduleForDelete(*source_meta);
 
   // Create an iostream to read the object back.
   auto stream = client->ReadObject(bucket_name_, object_name,
@@ -121,9 +117,6 @@ TEST_F(ObjectMediaIntegrationTest, ReadRangeJSON) {
   std::string actual(std::istreambuf_iterator<char>{stream}, {});
   EXPECT_EQ(1 * kChunk, actual.size());
   EXPECT_EQ(large_text.substr(1 * kChunk, 1 * kChunk), actual);
-
-  auto status = client->DeleteObject(bucket_name_, object_name);
-  EXPECT_STATUS_OK(status);
 }
 
 /// @test Read a portion of a relatively large object using the XML API.
@@ -151,9 +144,7 @@ TEST_F(ObjectMediaIntegrationTest, ReadRangeXml) {
   StatusOr<ObjectMetadata> source_meta = client->InsertObject(
       bucket_name_, object_name, large_text, IfGenerationMatch(0));
   ASSERT_STATUS_OK(source_meta);
-
-  EXPECT_EQ(object_name, source_meta->name());
-  EXPECT_EQ(bucket_name_, source_meta->bucket());
+  ScheduleForDelete(*source_meta);
 
   // Create an iostream to read the object back.
   auto stream = client->ReadObject(bucket_name_, object_name,
@@ -161,9 +152,6 @@ TEST_F(ObjectMediaIntegrationTest, ReadRangeXml) {
   std::string actual(std::istreambuf_iterator<char>{stream}, {});
   EXPECT_EQ(1 * kChunk, actual.size());
   EXPECT_EQ(large_text.substr(1 * kChunk, 1 * kChunk), actual);
-
-  auto status = client->DeleteObject(bucket_name_, object_name);
-  EXPECT_STATUS_OK(status);
 }
 
 /// @test Read a portion of a relatively large object using the JSON API.
@@ -191,9 +179,7 @@ TEST_F(ObjectMediaIntegrationTest, ReadFromOffsetJSON) {
   StatusOr<ObjectMetadata> source_meta = client->InsertObject(
       bucket_name_, object_name, large_text, IfGenerationMatch(0));
   ASSERT_STATUS_OK(source_meta);
-
-  EXPECT_EQ(object_name, source_meta->name());
-  EXPECT_EQ(bucket_name_, source_meta->bucket());
+  ScheduleForDelete(*source_meta);
 
   // Create an iostream to read the object back.
   auto stream =
@@ -202,9 +188,6 @@ TEST_F(ObjectMediaIntegrationTest, ReadFromOffsetJSON) {
   std::string actual(std::istreambuf_iterator<char>{stream}, {});
   EXPECT_EQ(2 * kChunk, actual.size());
   EXPECT_EQ(large_text.substr(2 * kChunk), actual);
-
-  auto status = client->DeleteObject(bucket_name_, object_name);
-  EXPECT_STATUS_OK(status);
 }
 
 /// @test Read a portion of a relatively large object using the XML API.
@@ -232,9 +215,7 @@ TEST_F(ObjectMediaIntegrationTest, ReadFromOffsetXml) {
   StatusOr<ObjectMetadata> source_meta = client->InsertObject(
       bucket_name_, object_name, large_text, IfGenerationMatch(0));
   ASSERT_STATUS_OK(source_meta);
-
-  EXPECT_EQ(object_name, source_meta->name());
-  EXPECT_EQ(bucket_name_, source_meta->bucket());
+  ScheduleForDelete(*source_meta);
 
   // Create an iostream to read the object back.
   auto stream =
@@ -242,9 +223,6 @@ TEST_F(ObjectMediaIntegrationTest, ReadFromOffsetXml) {
   std::string actual(std::istreambuf_iterator<char>{stream}, {});
   EXPECT_EQ(2 * kChunk, actual.size());
   EXPECT_EQ(large_text.substr(2 * kChunk), actual);
-
-  auto status = client->DeleteObject(bucket_name_, object_name);
-  EXPECT_STATUS_OK(status);
 }
 
 /// @test Read a relatively large object using chunks of different sizes.
@@ -272,9 +250,7 @@ TEST_F(ObjectMediaIntegrationTest, ReadMixedChunks) {
   StatusOr<ObjectMetadata> source_meta = client->InsertObject(
       bucket_name_, object_name, large_text, IfGenerationMatch(0));
   ASSERT_STATUS_OK(source_meta);
-
-  EXPECT_EQ(object_name, source_meta->name());
-  EXPECT_EQ(bucket_name_, source_meta->bucket());
+  ScheduleForDelete(*source_meta);
 
   // Create an iostream to read the object back.
   auto stream = client->ReadObject(bucket_name_, object_name);
@@ -304,9 +280,6 @@ TEST_F(ObjectMediaIntegrationTest, ReadMixedChunks) {
 
   EXPECT_EQ(kObjectSize, actual.size());
   EXPECT_EQ(large_text, actual);
-
-  auto status = client->DeleteObject(bucket_name_, object_name);
-  EXPECT_STATUS_OK(status);
 }
 
 /// @test Read the last chunk of an object.
@@ -338,9 +311,7 @@ TEST_F(ObjectMediaIntegrationTest, ReadLastChunk) {
   StatusOr<ObjectMetadata> source_meta = client->InsertObject(
       bucket_name_, object_name, large_text, IfGenerationMatch(0));
   ASSERT_STATUS_OK(source_meta);
-
-  EXPECT_EQ(object_name, source_meta->name());
-  EXPECT_EQ(bucket_name_, source_meta->bucket());
+  ScheduleForDelete(*source_meta);
 
   // Create an iostream to read the last 256KiB of the object, but simulate an
   // application that does not know how large that last chunk is.
@@ -355,9 +326,6 @@ TEST_F(ObjectMediaIntegrationTest, ReadLastChunk) {
   EXPECT_EQ(kObjectSize - 3 * kMiB, stream.gcount());
   std::string actual(buffer.data(), static_cast<std::size_t>(stream.gcount()));
   EXPECT_EQ(large_text.substr(3 * kMiB), actual);
-
-  auto status = client->DeleteObject(bucket_name_, object_name);
-  EXPECT_STATUS_OK(status);
 }
 
 /// @test Verify left over data in the spill buffer is read.
@@ -385,6 +353,7 @@ TEST_F(ObjectMediaIntegrationTest, ReadFromSpill) {
   StatusOr<ObjectMetadata> source_meta = client->InsertObject(
       bucket_name_, object_name, contents, IfGenerationMatch(0));
   ASSERT_STATUS_OK(source_meta);
+  ScheduleForDelete(*source_meta);
 
   // Create an iostream to read just the first few bytes of the object.
   auto stream = client->ReadObject(bucket_name_, object_name);
@@ -405,9 +374,6 @@ TEST_F(ObjectMediaIntegrationTest, ReadFromSpill) {
   EXPECT_TRUE(stream.fail());
   EXPECT_FALSE(stream.bad());
   EXPECT_FALSE(stream.IsOpen());
-
-  auto status = client->DeleteObject(bucket_name_, object_name);
-  EXPECT_STATUS_OK(status);
 }
 
 /// @test Read the last chunk of an object by setting ReadLast option.
@@ -439,9 +405,7 @@ TEST_F(ObjectMediaIntegrationTest, ReadLastChunkReadLast) {
   StatusOr<ObjectMetadata> source_meta = client->InsertObject(
       bucket_name_, object_name, large_text, IfGenerationMatch(0));
   ASSERT_STATUS_OK(source_meta);
-
-  EXPECT_EQ(object_name, source_meta->name());
-  EXPECT_EQ(bucket_name_, source_meta->bucket());
+  ScheduleForDelete(*source_meta);
 
   // Create an iostream to read the last 129KiB of the object, but simulate an
   // application that does not know how large that last chunk is.
@@ -456,9 +420,6 @@ TEST_F(ObjectMediaIntegrationTest, ReadLastChunkReadLast) {
   EXPECT_EQ(129 * kKiB, stream.gcount());
   std::string actual(buffer.data(), static_cast<std::size_t>(stream.gcount()));
   EXPECT_EQ(large_text.substr(kObjectSize - 129 * kKiB), actual);
-
-  auto status = client->DeleteObject(bucket_name_, object_name);
-  EXPECT_STATUS_OK(status);
 }
 
 /// @test Read an object by chunks of equal size.
@@ -489,9 +450,7 @@ TEST_F(ObjectMediaIntegrationTest, ReadByChunk) {
   StatusOr<ObjectMetadata> source_meta = client->InsertObject(
       bucket_name_, object_name, large_text, IfGenerationMatch(0));
   ASSERT_STATUS_OK(source_meta);
-
-  EXPECT_EQ(object_name, source_meta->name());
-  EXPECT_EQ(bucket_name_, source_meta->bucket());
+  ScheduleForDelete(*source_meta);
 
   std::vector<char> buffer(1 * kMiB);
   for (int i = 0; i != 3; ++i) {
@@ -525,9 +484,6 @@ TEST_F(ObjectMediaIntegrationTest, ReadByChunk) {
   auto expected = large_text.substr(3 * kMiB);
   EXPECT_EQ(expected.size(), actual.size());
   EXPECT_EQ(expected, actual);
-
-  auto status = client->DeleteObject(bucket_name_, object_name);
-  EXPECT_STATUS_OK(status);
 }
 
 TEST_F(ObjectMediaIntegrationTest, ConnectionFailureReadJSON) {
@@ -669,6 +625,7 @@ TEST_F(ObjectMediaIntegrationTest, StreamingReadTimeout) {
   StatusOr<ObjectMetadata> source_meta = client.InsertObject(
       bucket_name_, object_name, large_text, IfGenerationMatch(0));
   ASSERT_STATUS_OK(source_meta);
+  ScheduleForDelete(*source_meta);
 
   auto stream = client.ReadObject(
       bucket_name_, object_name,
@@ -678,9 +635,6 @@ TEST_F(ObjectMediaIntegrationTest, StreamingReadTimeout) {
   stream.read(buffer.data(), kObjectSize);
   EXPECT_TRUE(stream.bad());
   EXPECT_FALSE(stream.status().ok());
-
-  auto status = client.DeleteObject(bucket_name_, object_name);
-  EXPECT_STATUS_OK(status);
 }
 
 TEST_F(ObjectMediaIntegrationTest, StreamingReadTimeoutContinues) {
@@ -702,6 +656,7 @@ TEST_F(ObjectMediaIntegrationTest, StreamingReadTimeoutContinues) {
   StatusOr<ObjectMetadata> source_meta = client.InsertObject(
       bucket_name_, object_name, large_text, IfGenerationMatch(0));
   ASSERT_STATUS_OK(source_meta);
+  ScheduleForDelete(*source_meta);
 
   auto stream = client.ReadObject(
       bucket_name_, object_name,
@@ -716,9 +671,6 @@ TEST_F(ObjectMediaIntegrationTest, StreamingReadTimeoutContinues) {
   EXPECT_TRUE(stream.eof());
   EXPECT_EQ(0, stream.gcount());
   EXPECT_STATUS_OK(stream.status());
-
-  auto status = client.DeleteObject(bucket_name_, object_name);
-  EXPECT_STATUS_OK(status);
 }
 
 TEST_F(ObjectMediaIntegrationTest, StreamingReadInternalError) {
@@ -734,6 +686,7 @@ TEST_F(ObjectMediaIntegrationTest, StreamingReadInternalError) {
   StatusOr<ObjectMetadata> source_meta = client.InsertObject(
       bucket_name_, object_name, contents, IfGenerationMatch(0));
   ASSERT_STATUS_OK(source_meta);
+  ScheduleForDelete(*source_meta);
 
   auto stream = client.ReadObject(
       bucket_name_, object_name,
@@ -750,9 +703,6 @@ TEST_F(ObjectMediaIntegrationTest, StreamingReadInternalError) {
     EXPECT_EQ(expected_count, stream.gcount());
     EXPECT_STATUS_OK(stream.status());
   }
-
-  auto status = client.DeleteObject(bucket_name_, object_name);
-  EXPECT_STATUS_OK(status);
 }
 
 }  // anonymous namespace

--- a/google/cloud/storage/tests/object_plenty_clients_serially_integration_test.cc
+++ b/google/cloud/storage/tests/object_plenty_clients_serially_integration_test.cc
@@ -45,13 +45,10 @@ TEST_F(ObjectPlentyClientsSeriallyIntegrationTest, PlentyClientsSerially) {
 
   std::string expected = LoremIpsum();
 
-  // Create the object, but only if it does not exist already.
   StatusOr<ObjectMetadata> meta = client->InsertObject(
       bucket_name_, object_name, expected, IfGenerationMatch(0));
   ASSERT_STATUS_OK(meta);
-
-  EXPECT_EQ(object_name, meta->name());
-  EXPECT_EQ(bucket_name_, meta->bucket());
+  ScheduleForDelete(*meta);
 
   // Create a iostream to read the object back.
 
@@ -91,9 +88,6 @@ TEST_F(ObjectPlentyClientsSeriallyIntegrationTest, PlentyClientsSerially) {
     EXPECT_EQ(*num_fds_before_test, *num_fds_after_test)
         << "Clients are leaking descriptors";
   }
-
-  auto status = client->DeleteObject(bucket_name_, object_name);
-  ASSERT_STATUS_OK(status);
 }
 
 }  // anonymous namespace

--- a/google/cloud/storage/tests/object_plenty_clients_simultaneously_integration_test.cc
+++ b/google/cloud/storage/tests/object_plenty_clients_simultaneously_integration_test.cc
@@ -50,9 +50,7 @@ TEST_F(ObjectPlentyClientsSimultaneouslyIntegrationTest,
   StatusOr<ObjectMetadata> meta = client->InsertObject(
       bucket_name_, object_name, expected, IfGenerationMatch(0));
   ASSERT_STATUS_OK(meta);
-
-  EXPECT_EQ(object_name, meta->name());
-  EXPECT_EQ(bucket_name_, meta->bucket());
+  ScheduleForDelete(*meta);
 
   // Create a iostream to read the object back.
   auto num_fds_before_test = GetNumOpenFiles();
@@ -88,9 +86,6 @@ TEST_F(ObjectPlentyClientsSimultaneouslyIntegrationTest,
     EXPECT_EQ(StatusCode::kUnimplemented, num_fds_during_test.status().code());
     EXPECT_EQ(StatusCode::kUnimplemented, num_fds_after_test.status().code());
   }
-
-  auto status = client->DeleteObject(bucket_name_, object_name);
-  ASSERT_STATUS_OK(status);
 }
 
 }  // anonymous namespace

--- a/google/cloud/storage/tests/object_read_headers_integration_test.cc
+++ b/google/cloud/storage/tests/object_read_headers_integration_test.cc
@@ -59,6 +59,7 @@ TEST_F(ObjectReadHeadersIntegrationTest, SmokeTest) {
   auto insert = client->InsertObject(bucket_name(), object_name, LoremIpsum(),
                                      IfGenerationMatch(0));
   ASSERT_THAT(insert, IsOk());
+  ScheduleForDelete(*insert);
 
   auto is = client->ReadObject(bucket_name(), object_name,
                                Generation(insert->generation()));
@@ -85,9 +86,6 @@ TEST_F(ObjectReadHeadersIntegrationTest, SmokeTest) {
                 IsSupersetOf({"x-guploader-uploadid", "x-goog-hash",
                               "x-goog-generation"}));
   }
-
-  (void)client->DeleteObject(bucket_name(), object_name,
-                             Generation(insert->generation()));
 }
 
 }  // namespace

--- a/google/cloud/storage/tests/object_read_preconditions_integration_test.cc
+++ b/google/cloud/storage/tests/object_read_preconditions_integration_test.cc
@@ -69,14 +69,12 @@ TEST_P(ObjectReadPreconditionsIntegrationTest, IfGenerationMatchSuccess) {
   auto meta = client->InsertObject(bucket_name(), object_name, expected_text,
                                    IfGenerationMatch(0));
   ASSERT_THAT(meta, IsOk());
+  ScheduleForDelete(*meta);
 
   auto reader = client->ReadObject(bucket_name(), object_name,
                                    IfGenerationMatch(meta->generation()));
   reader.Close();
   EXPECT_THAT(reader.status(), IsOk());
-
-  (void)client->DeleteObject(bucket_name(), object_name,
-                             Generation(meta->generation()));
 }
 
 TEST_P(ObjectReadPreconditionsIntegrationTest, IfGenerationMatchFailure) {
@@ -88,14 +86,12 @@ TEST_P(ObjectReadPreconditionsIntegrationTest, IfGenerationMatchFailure) {
   auto meta = client->InsertObject(bucket_name(), object_name, expected_text,
                                    IfGenerationMatch(0));
   ASSERT_THAT(meta, IsOk());
+  ScheduleForDelete(*meta);
 
   auto reader = client->ReadObject(bucket_name(), object_name,
                                    IfGenerationMatch(meta->generation() + 1));
   reader.Close();
   EXPECT_THAT(reader.status(), StatusIs(StatusCode::kFailedPrecondition));
-
-  (void)client->DeleteObject(bucket_name(), object_name,
-                             Generation(meta->generation()));
 }
 
 TEST_P(ObjectReadPreconditionsIntegrationTest, IfGenerationNotMatchSuccess) {
@@ -107,14 +103,12 @@ TEST_P(ObjectReadPreconditionsIntegrationTest, IfGenerationNotMatchSuccess) {
   auto meta = client->InsertObject(bucket_name(), object_name, expected_text,
                                    IfGenerationMatch(0));
   ASSERT_THAT(meta, IsOk());
+  ScheduleForDelete(*meta);
 
   auto reader = client->ReadObject(
       bucket_name(), object_name, IfGenerationNotMatch(meta->generation() + 1));
   reader.Close();
   EXPECT_THAT(reader.status(), IsOk());
-
-  (void)client->DeleteObject(bucket_name(), object_name,
-                             Generation(meta->generation()));
 }
 
 TEST_P(ObjectReadPreconditionsIntegrationTest, IfGenerationNotMatchFailure) {
@@ -126,6 +120,7 @@ TEST_P(ObjectReadPreconditionsIntegrationTest, IfGenerationNotMatchFailure) {
   auto meta = client->InsertObject(bucket_name(), object_name, expected_text,
                                    IfGenerationMatch(0));
   ASSERT_THAT(meta, IsOk());
+  ScheduleForDelete(*meta);
 
   auto reader = client->ReadObject(bucket_name(), object_name,
                                    IfGenerationNotMatch(meta->generation()));
@@ -136,9 +131,6 @@ TEST_P(ObjectReadPreconditionsIntegrationTest, IfGenerationNotMatchFailure) {
   // taking place.
   EXPECT_THAT(reader.status(), StatusIs(AnyOf(StatusCode::kFailedPrecondition,
                                               StatusCode::kAborted)));
-
-  (void)client->DeleteObject(bucket_name(), object_name,
-                             Generation(meta->generation()));
 }
 
 TEST_P(ObjectReadPreconditionsIntegrationTest, IfMetagenerationMatchSuccess) {
@@ -150,15 +142,13 @@ TEST_P(ObjectReadPreconditionsIntegrationTest, IfMetagenerationMatchSuccess) {
   auto meta = client->InsertObject(bucket_name(), object_name, expected_text,
                                    IfGenerationMatch(0));
   ASSERT_THAT(meta, IsOk());
+  ScheduleForDelete(*meta);
 
   auto reader =
       client->ReadObject(bucket_name(), object_name,
                          IfMetagenerationMatch(meta->metageneration()));
   reader.Close();
   EXPECT_THAT(reader.status(), IsOk());
-
-  (void)client->DeleteObject(bucket_name(), object_name,
-                             Generation(meta->generation()));
 }
 
 TEST_P(ObjectReadPreconditionsIntegrationTest, IfMetagenerationMatchFailure) {
@@ -170,15 +160,13 @@ TEST_P(ObjectReadPreconditionsIntegrationTest, IfMetagenerationMatchFailure) {
   auto meta = client->InsertObject(bucket_name(), object_name, expected_text,
                                    IfGenerationMatch(0));
   ASSERT_THAT(meta, IsOk());
+  ScheduleForDelete(*meta);
 
   auto reader =
       client->ReadObject(bucket_name(), object_name,
                          IfMetagenerationMatch(meta->metageneration() + 1));
   reader.Close();
   EXPECT_THAT(reader.status(), StatusIs(StatusCode::kFailedPrecondition));
-
-  (void)client->DeleteObject(bucket_name(), object_name,
-                             Generation(meta->generation()));
 }
 
 TEST_P(ObjectReadPreconditionsIntegrationTest,
@@ -191,15 +179,13 @@ TEST_P(ObjectReadPreconditionsIntegrationTest,
   auto meta = client->InsertObject(bucket_name(), object_name, expected_text,
                                    IfGenerationMatch(0));
   ASSERT_THAT(meta, IsOk());
+  ScheduleForDelete(*meta);
 
   auto reader =
       client->ReadObject(bucket_name(), object_name,
                          IfMetagenerationNotMatch(meta->generation() + 1));
   reader.Close();
   EXPECT_THAT(reader.status(), IsOk());
-
-  (void)client->DeleteObject(bucket_name(), object_name,
-                             Generation(meta->generation()));
 }
 
 TEST_P(ObjectReadPreconditionsIntegrationTest,
@@ -212,6 +198,7 @@ TEST_P(ObjectReadPreconditionsIntegrationTest,
   auto meta = client->InsertObject(bucket_name(), object_name, expected_text,
                                    IfGenerationMatch(0));
   ASSERT_THAT(meta, IsOk());
+  ScheduleForDelete(*meta);
 
   auto reader =
       client->ReadObject(bucket_name(), object_name,
@@ -223,9 +210,6 @@ TEST_P(ObjectReadPreconditionsIntegrationTest,
   // taking place.
   EXPECT_THAT(reader.status(), StatusIs(AnyOf(StatusCode::kFailedPrecondition,
                                               StatusCode::kAborted)));
-
-  (void)client->DeleteObject(bucket_name(), object_name,
-                             Generation(meta->generation()));
 }
 
 INSTANTIATE_TEST_SUITE_P(XmlDisabled, ObjectReadPreconditionsIntegrationTest,

--- a/google/cloud/storage/tests/object_read_range_integration_test.cc
+++ b/google/cloud/storage/tests/object_read_range_integration_test.cc
@@ -57,6 +57,7 @@ TEST_F(ObjectReadRangeIntegrationTest, ReadRangeSmall) {
   auto insert = client->InsertObject(bucket_name(), object_name, contents,
                                      IfGenerationMatch(0));
   ASSERT_THAT(insert, IsOk());
+  ScheduleForDelete(*insert);
   EXPECT_THAT(contents.size(), insert->size());
 
   auto const size = static_cast<std::int64_t>(insert->size());
@@ -81,8 +82,6 @@ TEST_F(ObjectReadRangeIntegrationTest, ReadRangeSmall) {
     EXPECT_THAT(reader.status(), IsOk());
     EXPECT_EQ(test.expected, actual);
   }
-
-  (void)client->DeleteObject(bucket_name(), object_name);
 }
 
 TEST_F(ObjectReadRangeIntegrationTest, ReadFromOffset) {
@@ -95,6 +94,7 @@ TEST_F(ObjectReadRangeIntegrationTest, ReadFromOffset) {
   auto insert = client->InsertObject(bucket_name(), object_name, contents,
                                      IfGenerationMatch(0));
   ASSERT_THAT(insert, IsOk());
+  ScheduleForDelete(*insert);
   EXPECT_THAT(contents.size(), insert->size());
 
   auto const size = static_cast<std::int64_t>(insert->size());
@@ -117,8 +117,6 @@ TEST_F(ObjectReadRangeIntegrationTest, ReadFromOffset) {
     EXPECT_THAT(reader.status(), IsOk());
     EXPECT_EQ(test.expected, actual);
   }
-
-  (void)client->DeleteObject(bucket_name(), object_name);
 }
 
 TEST_F(ObjectReadRangeIntegrationTest, ReadLast) {
@@ -131,6 +129,7 @@ TEST_F(ObjectReadRangeIntegrationTest, ReadLast) {
   auto insert = client->InsertObject(bucket_name(), object_name, contents,
                                      IfGenerationMatch(0));
   ASSERT_THAT(insert, IsOk());
+  ScheduleForDelete(*insert);
   EXPECT_THAT(contents.size(), insert->size());
 
   auto const size = static_cast<std::int64_t>(insert->size());
@@ -153,8 +152,6 @@ TEST_F(ObjectReadRangeIntegrationTest, ReadLast) {
     EXPECT_THAT(reader.status(), IsOk());
     EXPECT_EQ(test.expected, actual);
   }
-
-  (void)client->DeleteObject(bucket_name(), object_name);
 }
 
 }  // namespace

--- a/google/cloud/storage/tests/object_resumable_parallel_upload_integration_test.cc
+++ b/google/cloud/storage/tests/object_resumable_parallel_upload_integration_test.cc
@@ -69,15 +69,13 @@ TEST_F(ObjectResumableParallelUploadIntegrationTest, ResumableParallelUpload) {
     state->shards().clear();
     auto res = state->WaitForCompletion().get();
     ASSERT_STATUS_OK(res);
+    ScheduleForDelete(*res);
     res_gen = res->generation();
   }
   auto stream = client->ReadObject(bucket_name_, dest_object_name,
                                    IfGenerationMatch(res_gen));
   std::string actual(std::istreambuf_iterator<char>{stream}, {});
   EXPECT_EQ("1234", actual);
-  auto deletion_status = client->DeleteObject(bucket_name_, dest_object_name,
-                                              IfGenerationMatch(res_gen));
-  ASSERT_STATUS_OK(deletion_status);
 }
 
 TEST_F(ObjectResumableParallelUploadIntegrationTest, ResumeParallelUploadFile) {
@@ -112,6 +110,7 @@ TEST_F(ObjectResumableParallelUploadIntegrationTest, ResumeParallelUploadFile) {
       MinStreamSize(0), IfGenerationMatch(0),
       UseResumableUploadSession(resumable_session_id));
   ASSERT_STATUS_OK(object_metadata);
+  ScheduleForDelete(*object_metadata);
 
   auto stream =
       client->ReadObject(bucket_name_, dest_object_name,
@@ -129,11 +128,6 @@ TEST_F(ObjectResumableParallelUploadIntegrationTest, ResumeParallelUploadFile) {
   }
   ASSERT_EQ(1U, objects.size());
   ASSERT_EQ(prefix + ".dest", objects[0].name());
-
-  auto deletion_status =
-      client->DeleteObject(bucket_name_, dest_object_name,
-                           IfGenerationMatch(object_metadata->generation()));
-  ASSERT_STATUS_OK(deletion_status);
 }
 
 }  // anonymous namespace

--- a/google/cloud/storage/tests/object_write_preconditions_integration_test.cc
+++ b/google/cloud/storage/tests/object_write_preconditions_integration_test.cc
@@ -61,17 +61,14 @@ TEST_F(ObjectWritePreconditionsIntegrationTest, IfGenerationMatchSuccess) {
   auto meta = client->InsertObject(bucket_name(), object_name, expected_text,
                                    IfGenerationMatch(0));
   ASSERT_THAT(meta, IsOk());
+  ScheduleForDelete(*meta);
 
   auto os = client->WriteObject(bucket_name(), object_name,
                                 IfGenerationMatch(meta->generation()));
   os << expected_text;
   os.Close();
   ASSERT_THAT(os.metadata(), IsOk());
-
-  (void)client->DeleteObject(bucket_name(), object_name,
-                             Generation(os.metadata()->generation()));
-  (void)client->DeleteObject(bucket_name(), object_name,
-                             Generation(meta->generation()));
+  ScheduleForDelete(*os.metadata());
 }
 
 TEST_F(ObjectWritePreconditionsIntegrationTest, IfGenerationMatchFailure) {
@@ -83,15 +80,13 @@ TEST_F(ObjectWritePreconditionsIntegrationTest, IfGenerationMatchFailure) {
   auto meta = client->InsertObject(bucket_name(), object_name, expected_text,
                                    IfGenerationMatch(0));
   ASSERT_THAT(meta, IsOk());
+  ScheduleForDelete(*meta);
 
   auto os = client->WriteObject(bucket_name(), object_name,
                                 IfGenerationMatch(meta->generation() + 1));
   os << expected_text;
   os.Close();
   ASSERT_THAT(os.metadata(), StatusIs(StatusCode::kFailedPrecondition));
-
-  (void)client->DeleteObject(bucket_name(), object_name,
-                             Generation(meta->generation()));
 }
 
 TEST_F(ObjectWritePreconditionsIntegrationTest, IfGenerationNotMatchSuccess) {
@@ -103,17 +98,14 @@ TEST_F(ObjectWritePreconditionsIntegrationTest, IfGenerationNotMatchSuccess) {
   auto meta = client->InsertObject(bucket_name(), object_name, expected_text,
                                    IfGenerationMatch(0));
   ASSERT_THAT(meta, IsOk());
+  ScheduleForDelete(*meta);
 
   auto os = client->WriteObject(bucket_name(), object_name,
                                 IfGenerationNotMatch(meta->generation() + 1));
   os << expected_text;
   os.Close();
   ASSERT_THAT(os.metadata(), IsOk());
-
-  (void)client->DeleteObject(bucket_name(), object_name,
-                             Generation(os.metadata()->generation()));
-  (void)client->DeleteObject(bucket_name(), object_name,
-                             Generation(meta->generation()));
+  ScheduleForDelete(*os.metadata());
 }
 
 TEST_F(ObjectWritePreconditionsIntegrationTest, IfGenerationNotMatchFailure) {
@@ -125,6 +117,7 @@ TEST_F(ObjectWritePreconditionsIntegrationTest, IfGenerationNotMatchFailure) {
   auto meta = client->InsertObject(bucket_name(), object_name, expected_text,
                                    IfGenerationMatch(0));
   ASSERT_THAT(meta, IsOk());
+  ScheduleForDelete(*meta);
 
   auto os = client->WriteObject(bucket_name(), object_name,
                                 IfGenerationNotMatch(meta->generation()));
@@ -132,9 +125,6 @@ TEST_F(ObjectWritePreconditionsIntegrationTest, IfGenerationNotMatchFailure) {
   os.Close();
   ASSERT_THAT(os.metadata(), StatusIs(AnyOf(StatusCode::kFailedPrecondition,
                                             StatusCode::kAborted)));
-
-  (void)client->DeleteObject(bucket_name(), object_name,
-                             Generation(meta->generation()));
 }
 
 TEST_F(ObjectWritePreconditionsIntegrationTest, IfMetagenerationMatchSuccess) {
@@ -146,17 +136,13 @@ TEST_F(ObjectWritePreconditionsIntegrationTest, IfMetagenerationMatchSuccess) {
   auto meta = client->InsertObject(bucket_name(), object_name, expected_text,
                                    IfGenerationMatch(0));
   ASSERT_THAT(meta, IsOk());
+  ScheduleForDelete(*meta);
 
   auto os = client->WriteObject(bucket_name(), object_name,
                                 IfMetagenerationMatch(meta->metageneration()));
   os << expected_text;
   os.Close();
   ASSERT_THAT(os.metadata(), IsOk());
-
-  (void)client->DeleteObject(bucket_name(), object_name,
-                             Generation(os.metadata()->generation()));
-  (void)client->DeleteObject(bucket_name(), object_name,
-                             Generation(meta->generation()));
 }
 
 TEST_F(ObjectWritePreconditionsIntegrationTest, IfMetagenerationMatchFailure) {
@@ -168,6 +154,7 @@ TEST_F(ObjectWritePreconditionsIntegrationTest, IfMetagenerationMatchFailure) {
   auto meta = client->InsertObject(bucket_name(), object_name, expected_text,
                                    IfGenerationMatch(0));
   ASSERT_THAT(meta, IsOk());
+  ScheduleForDelete(*meta);
 
   auto os =
       client->WriteObject(bucket_name(), object_name,
@@ -175,9 +162,6 @@ TEST_F(ObjectWritePreconditionsIntegrationTest, IfMetagenerationMatchFailure) {
   os << expected_text;
   os.Close();
   ASSERT_THAT(os.metadata(), StatusIs(StatusCode::kFailedPrecondition));
-
-  (void)client->DeleteObject(bucket_name(), object_name,
-                             Generation(meta->generation()));
 }
 
 TEST_F(ObjectWritePreconditionsIntegrationTest,
@@ -190,6 +174,7 @@ TEST_F(ObjectWritePreconditionsIntegrationTest,
   auto meta = client->InsertObject(bucket_name(), object_name, expected_text,
                                    IfGenerationMatch(0));
   ASSERT_THAT(meta, IsOk());
+  ScheduleForDelete(*meta);
 
   auto os =
       client->WriteObject(bucket_name(), object_name,
@@ -197,11 +182,7 @@ TEST_F(ObjectWritePreconditionsIntegrationTest,
   os << expected_text;
   os.Close();
   ASSERT_THAT(os.metadata(), IsOk());
-
-  (void)client->DeleteObject(bucket_name(), object_name,
-                             Generation(os.metadata()->generation()));
-  (void)client->DeleteObject(bucket_name(), object_name,
-                             Generation(meta->generation()));
+  ScheduleForDelete(*os.metadata());
 }
 
 TEST_F(ObjectWritePreconditionsIntegrationTest,
@@ -214,6 +195,7 @@ TEST_F(ObjectWritePreconditionsIntegrationTest,
   auto meta = client->InsertObject(bucket_name(), object_name, expected_text,
                                    IfGenerationMatch(0));
   ASSERT_THAT(meta, IsOk());
+  ScheduleForDelete(*meta);
 
   auto os =
       client->WriteObject(bucket_name(), object_name,
@@ -222,9 +204,6 @@ TEST_F(ObjectWritePreconditionsIntegrationTest,
   os.Close();
   ASSERT_THAT(os.metadata(), StatusIs(AnyOf(StatusCode::kFailedPrecondition,
                                             StatusCode::kAborted)));
-
-  (void)client->DeleteObject(bucket_name(), object_name,
-                             Generation(meta->generation()));
 }
 
 }  // namespace

--- a/google/cloud/storage/tests/object_write_streambuf_integration_test.cc
+++ b/google/cloud/storage/tests/object_write_streambuf_integration_test.cc
@@ -61,9 +61,8 @@ class ObjectWriteStreambufIntegrationTest
     std::ostringstream expected_stream;
     WriteRandomLines(writer, expected_stream, line_count, line_size);
     writer.Close();
-    ObjectMetadata metadata = writer.metadata().value();
-    EXPECT_EQ(object_name, metadata.name());
-    EXPECT_EQ(bucket_name_, metadata.bucket());
+    ASSERT_STATUS_OK(writer.metadata());
+    ScheduleForDelete(*writer.metadata());
 
     ObjectReadStream reader = client->ReadObject(bucket_name_, object_name);
 
@@ -72,10 +71,6 @@ class ObjectWriteStreambufIntegrationTest
     std::string expected = std::move(expected_stream).str();
     ASSERT_EQ(expected.size(), actual.size());
     EXPECT_EQ(expected, actual);
-
-    auto status = client->DeleteObject(bucket_name_, object_name,
-                                       Generation(metadata.generation()));
-    ASSERT_STATUS_OK(status);
   }
 
   std::string bucket_name_;

--- a/google/cloud/storage/tests/signed_url_integration_test.cc
+++ b/google/cloud/storage/tests/signed_url_integration_test.cc
@@ -71,6 +71,7 @@ TEST_F(SignedUrlIntegrationTest, CreateV2SignedUrlGet) {
   auto meta = client->InsertObject(bucket_name_, object_name, expected,
                                    IfGenerationMatch(0));
   ASSERT_STATUS_OK(meta);
+  ScheduleForDelete(*meta);
 
   StatusOr<std::string> signed_url = client->CreateV2SignedUrl(
       "GET", bucket_name_, object_name, SigningAccount(service_account_));
@@ -85,9 +86,6 @@ TEST_F(SignedUrlIntegrationTest, CreateV2SignedUrlGet) {
   EXPECT_EQ(200, response->status_code);
 
   EXPECT_EQ(expected, response->payload);
-
-  auto deleted = client->DeleteObject(bucket_name_, object_name);
-  ASSERT_STATUS_OK(deleted);
 }
 
 TEST_F(SignedUrlIntegrationTest, CreateV2SignedUrlPut) {
@@ -137,6 +135,7 @@ TEST_F(SignedUrlIntegrationTest, CreateV4SignedUrlGet) {
   auto meta = client->InsertObject(bucket_name_, object_name, expected,
                                    IfGenerationMatch(0));
   ASSERT_STATUS_OK(meta);
+  ScheduleForDelete(*meta);
 
   StatusOr<std::string> signed_url = client->CreateV4SignedUrl(
       "GET", bucket_name_, object_name, SigningAccount(service_account_));
@@ -151,9 +150,6 @@ TEST_F(SignedUrlIntegrationTest, CreateV4SignedUrlGet) {
   EXPECT_EQ(200, response->status_code);
 
   EXPECT_EQ(expected, response->payload);
-
-  auto deleted = client->DeleteObject(bucket_name_, object_name);
-  ASSERT_STATUS_OK(deleted);
 }
 
 TEST_F(SignedUrlIntegrationTest, CreateV4SignedUrlPut) {

--- a/google/cloud/storage/tests/slow_reader_chunk_integration_test.cc
+++ b/google/cloud/storage/tests/slow_reader_chunk_integration_test.cc
@@ -54,6 +54,7 @@ TEST_F(SlowReaderChunkIntegrationTest, LongPauses) {
   StatusOr<ObjectMetadata> source_meta = client->InsertObject(
       bucket_name_, object_name, large_text, IfGenerationMatch(0));
   ASSERT_STATUS_OK(source_meta);
+  ScheduleForDelete(*source_meta);
 
   // Create an iostream to read the object back. When running against the
   // emulator we can fail quickly by asking the emulator to break the stream
@@ -103,9 +104,6 @@ TEST_F(SlowReaderChunkIntegrationTest, LongPauses) {
 
   stream.Close();
   EXPECT_STATUS_OK(stream.status());
-
-  auto status = client->DeleteObject(bucket_name_, object_name);
-  EXPECT_STATUS_OK(status);
 }
 
 }  // anonymous namespace

--- a/google/cloud/storage/tests/slow_reader_stream_integration_test.cc
+++ b/google/cloud/storage/tests/slow_reader_stream_integration_test.cc
@@ -54,6 +54,7 @@ TEST_F(SlowReaderStreamIntegrationTest, LongPauses) {
   StatusOr<ObjectMetadata> source_meta = client->InsertObject(
       bucket_name_, object_name, large_text, IfGenerationMatch(0));
   ASSERT_STATUS_OK(source_meta);
+  ScheduleForDelete(*source_meta);
 
   // Create an iostream to read the object back. When running against the
   // emulator we can fail quickly by asking the emulator to break the stream
@@ -95,9 +96,6 @@ TEST_F(SlowReaderStreamIntegrationTest, LongPauses) {
 
   stream.Close();
   EXPECT_STATUS_OK(stream.status());
-
-  auto status = client->DeleteObject(bucket_name_, object_name);
-  EXPECT_STATUS_OK(status);
 }
 
 }  // anonymous namespace

--- a/google/cloud/storage/tests/small_reads_integration_test.cc
+++ b/google/cloud/storage/tests/small_reads_integration_test.cc
@@ -58,8 +58,8 @@ TEST_F(SmallReadsIntegrationTest, Repro5096) {
     writer.write(block.data(), block.size());
   }
   writer.Close();
-  auto write_status = writer.metadata().status();
-  ASSERT_STATUS_OK(write_status);
+  ASSERT_STATUS_OK(writer.metadata());
+  ScheduleForDelete(*writer.metadata());
 
   auto reader = client->ReadObject(bucket_name_, object_name);
 
@@ -82,9 +82,6 @@ TEST_F(SmallReadsIntegrationTest, Repro5096) {
     last = ts;
     offset += reader.gcount();
   }
-
-  auto status = client->DeleteObject(bucket_name_, object_name);
-  EXPECT_STATUS_OK(status);
 }
 
 }  // anonymous namespace

--- a/google/cloud/storage/tests/tracing_integration_test.cc
+++ b/google/cloud/storage/tests/tracing_integration_test.cc
@@ -45,24 +45,21 @@ class TracingIntegrationTest
 
   std::string const& bucket_name() const { return bucket_name_; }
 
+  void UseClient(Client client, std::string const& bucket_name,
+                 std::string const& object_name, std::string const& payload) {
+    StatusOr<ObjectMetadata> meta = client.InsertObject(
+        bucket_name, object_name, payload, IfGenerationMatch(0));
+    ASSERT_THAT(meta, IsOk());
+    ScheduleForDelete(*meta);
+
+    auto stream = client.ReadObject(bucket_name, object_name);
+    std::string actual(std::istreambuf_iterator<char>{stream}, {});
+    EXPECT_EQ(payload, actual);
+  }
+
  private:
   std::string bucket_name_;
 };
-
-void UseClient(Client client, std::string const& bucket_name,
-               std::string const& object_name, std::string const& payload) {
-  StatusOr<ObjectMetadata> meta = client.InsertObject(
-      bucket_name, object_name, payload, IfGenerationMatch(0));
-  ASSERT_THAT(meta, IsOk());
-  EXPECT_EQ(object_name, meta->name());
-
-  auto stream = client.ReadObject(bucket_name, object_name);
-  std::string actual(std::istreambuf_iterator<char>{stream}, {});
-  EXPECT_EQ(payload, actual);
-
-  auto status = client.DeleteObject(bucket_name, object_name);
-  EXPECT_THAT(status, IsOk());
-}
 
 TEST_F(TracingIntegrationTest, RawClient) {
   auto client =


### PR DESCRIPTION
Most of our integration tests create some objects, which then need to be
deleted when the test ends. In addition to having to remember to delete
the object, some of the tests are a bit unnatural, as they should use
`ASSERT_*()` but they use `EXPECT_*()` to ensure the cleanup step runs.

With this change the cleanup is performed by a common `TearDown()`
function, the tests just add objects (and buckets if applicable) to a
list that will be deleted at the end.

In some tests the `DeleteObject()` function is actually part of the
test, i.e., we are testing the `DeleteObject()` function. In these cases
I left the code alone. I also left unchanged some tests where objects
are created without a `gcs::ObjectMetadata` becoming available,
typically because the test is using an streaming upload  implicitly
finalized by the stream's destructor.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6913)
<!-- Reviewable:end -->
