### PR TITLE
cleanup(bigtable)!: remove async functions that take `CompletionQueue` as a param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,19 @@
 
 ## v1.30.0 - TBD
 
+### Bigtable:
+
+**BREAKING CHANGES**:
+* `Async*` functions in `Table` that took `CompletionQueue&` as a parameter
+  have been removed. Users that need to update their code should use the
+  identically named functions which do not require a `CompletionQueue&`. If
+  users absolutely require a custom `CompletionQueue`, one can be supplied to
+  the `DataClient` used to construct the `Table`, via
+  `ClientOptions::DisableBackgroundThreads(CompletionQueue const&)`.
+  See [#2567][issue-2567] for more details.
+
+[issue-2567]: https://github.com/googleapis/google-cloud-cpp/issues/2567
+
 ## v1.29.0 - 2021-07
 
 ### Bigtable:

--- a/google/cloud/bigtable/table.cc
+++ b/google/cloud/bigtable/table.cc
@@ -149,10 +149,6 @@ future<Status> Table::AsyncApplyImpl(SingleRowMutation mut,
       });
 }
 
-future<Status> Table::AsyncApply(SingleRowMutation mut, CompletionQueue& cq) {
-  return AsyncApplyImpl(std::move(mut), cq);
-}
-
 future<Status> Table::AsyncApply(SingleRowMutation mut) {
   auto cq = background_threads_->cq();
   return AsyncApplyImpl(std::move(mut), cq);
@@ -192,11 +188,6 @@ future<std::vector<FailedMutation>> Table::AsyncBulkApplyImpl(
       cq, clone_rpc_retry_policy(), clone_rpc_backoff_policy(),
       *mutation_policy, clone_metadata_update_policy(), client_,
       app_profile_id_, table_name(), std::move(mut));
-}
-
-future<std::vector<FailedMutation>> Table::AsyncBulkApply(BulkMutation mut,
-                                                          CompletionQueue& cq) {
-  return AsyncBulkApplyImpl(std::move(mut), cq);
 }
 
 future<std::vector<FailedMutation>> Table::AsyncBulkApply(BulkMutation mut) {
@@ -314,14 +305,6 @@ future<StatusOr<MutationBranch>> Table::AsyncCheckAndMutateRowImpl(
                    ? MutationBranch::kPredicateMatched
                    : MutationBranch::kPredicateNotMatched;
       });
-}
-
-future<StatusOr<MutationBranch>> Table::AsyncCheckAndMutateRow(
-    std::string row_key, Filter filter, std::vector<Mutation> true_mutations,
-    std::vector<Mutation> false_mutations, CompletionQueue& cq) {
-  return AsyncCheckAndMutateRowImpl(std::move(row_key), std::move(filter),
-                                    std::move(true_mutations),
-                                    std::move(false_mutations), cq);
 }
 
 future<StatusOr<MutationBranch>> Table::AsyncCheckAndMutateRow(
@@ -488,12 +471,6 @@ future<StatusOr<std::pair<bool, Row>>> Table::AsyncReadRowImpl(
       },
       std::move(row_set), rows_limit, std::move(filter));
   return handler->GetFuture();
-}
-
-future<StatusOr<std::pair<bool, Row>>> Table::AsyncReadRow(CompletionQueue& cq,
-                                                           std::string row_key,
-                                                           Filter filter) {
-  return AsyncReadRowImpl(cq, std::move(row_key), std::move(filter));
 }
 
 future<StatusOr<std::pair<bool, Row>>> Table::AsyncReadRow(std::string row_key,

--- a/google/cloud/bigtable/table.h
+++ b/google/cloud/bigtable/table.h
@@ -392,32 +392,6 @@ class Table {
    * (and then discards) the data in the mutation.  In general, a
    *     `SingleRowMutation` can be used to modify and/or delete
    * multiple cells, across different columns and column families.
-   * @param cq the completion queue that will execute the asynchronous
-   *    calls, the application must ensure that one or more threads are
-   *    blocked on `cq.Run()`.
-   *
-   * @par Idempotency
-   * This operation is idempotent if the provided mutations are idempotent. Note
-   * that `google::cloud::bigtable::SetCell()` without an explicit timestamp is
-   * **not** an idempotent operation.
-   *
-   * @par Example
-   * @snippet data_async_snippets.cc async-apply
-   */
-  GOOGLE_CLOUD_CPP_BIGTABLE_ASYNC_CQ_PARAM_DEPRECATED
-  future<Status> AsyncApply(SingleRowMutation mut, CompletionQueue& cq);
-
-  /**
-   * Makes asynchronous attempts to apply the mutation to a row.
-   *
-   * @warning This is an early version of the asynchronous APIs for Cloud
-   *     Bigtable. These APIs might be changed in backward-incompatible ways. It
-   *     is not subject to any SLA or deprecation policy.
-   *
-   * @param mut the mutation. Note that this function takes ownership
-   * (and then discards) the data in the mutation.  In general, a
-   *     `SingleRowMutation` can be used to modify and/or delete
-   * multiple cells, across different columns and column families.
    *
    * @par Idempotency
    * This operation is idempotent if the provided mutations are idempotent. Note
@@ -452,39 +426,6 @@ class Table {
    * @snippet data_snippets.cc bulk apply
    */
   std::vector<FailedMutation> BulkApply(BulkMutation mut);
-
-  /**
-   * Makes asynchronous attempts to apply mutations to multiple rows.
-   *
-   * @warning This is an early version of the asynchronous APIs for Cloud
-   *     Bigtable. These APIs might be changed in backward-incompatible ways. It
-   *     is not subject to any SLA or deprecation policy.
-   *
-   * @param mut the mutations, note that this function takes
-   *     ownership (and then discards) the data in the mutation. In general, a
-   *     `BulkMutation` can modify multiple rows, and the modifications for each
-   *     row can change (or create) multiple cells, across different columns and
-   *     column families.
-   * @param cq the completion queue that will execute the asynchronous calls,
-   *     the application must ensure that one or more threads are blocked on
-   *     `cq.Run()`.
-   *
-   * @par Idempotency
-   * This operation is idempotent if the provided mutations are idempotent. Note
-   * that `google::cloud::bigtable::SetCell()` without an explicit timestamp is
-   * **not** an idempotent operation.
-   *
-   * @par Thread-safety
-   * Two threads concurrently calling this member function on the same instance
-   * of this class are **not** guaranteed to work. Consider copying the object
-   * and using different copies in each thread.
-   *
-   * @par Example
-   * @snippet data_async_snippets.cc bulk async-bulk-apply
-   */
-  GOOGLE_CLOUD_CPP_BIGTABLE_ASYNC_CQ_PARAM_DEPRECATED
-  future<std::vector<FailedMutation>> AsyncBulkApply(BulkMutation mut,
-                                                     CompletionQueue& cq);
 
   /**
    * Makes asynchronous attempts to apply mutations to multiple rows.
@@ -630,41 +571,6 @@ class Table {
    *     true
    * @param false_mutations the mutations which will be performed if @p filter
    *     is false
-   * @param cq the completion queue that will execute the asynchronous calls,
-   *     the application must ensure that one or more threads are blocked on
-   *     `cq.Run()`.
-   *
-   * @par Idempotency
-   * This operation is always treated as non-idempotent.
-   *
-   * @par Thread-safety
-   * Two threads concurrently calling this member function on the same instance
-   * of this class are **not** guaranteed to work. Consider copying the object
-   * and using different copies in each thread.
-   *
-   * @par Example
-   * @snippet data_async_snippets.cc async check and mutate
-   */
-  GOOGLE_CLOUD_CPP_BIGTABLE_ASYNC_CQ_PARAM_DEPRECATED
-  future<StatusOr<MutationBranch>> AsyncCheckAndMutateRow(
-      std::string row_key, Filter filter, std::vector<Mutation> true_mutations,
-      std::vector<Mutation> false_mutations, CompletionQueue& cq);
-
-  /**
-   * Make an asynchronous request to conditionally mutate a row.
-   *
-   * @warning This is an early version of the asynchronous APIs for Cloud
-   *     Bigtable. These APIs might be changed in backward-incompatible ways. It
-   *     is not subject to any SLA or deprecation policy.
-   *
-   * @param row_key the row key on which the conditional mutation will be
-   *     performed
-   * @param filter the condition, depending on which the mutation will be
-   *     performed
-   * @param true_mutations the mutations which will be performed if @p filter is
-   *     true
-   * @param false_mutations the mutations which will be performed if @p filter
-   *     is false
    *
    * @par Idempotency
    * This operation is always treated as non-idempotent.
@@ -781,46 +687,6 @@ class Table {
    *     is not subject to any SLA or deprecation policy.
    *
    * @param row_key the row key on which modification will be performed
-   * @param cq the completion queue that will execute the asynchronous calls,
-   *     the application must ensure that one or more threads are blocked on
-   *     `cq.Run()`.
-   *
-   * @param rule to modify the row. Two types of rules are applied here
-   *     AppendValue which will read the existing value and append the
-   *     text provided to the value.
-   *     IncrementAmount which will read the existing uint64 big-endian-int
-   *     and add the value provided.
-   *     Both rules accept the family and column identifier to modify.
-   * @param rules is the zero or more ReadModifyWriteRules to apply on a row.
-   * @returns A future, that becomes satisfied when the operation completes,
-   *     at that point the future has the contents of all modified cells.
-   *
-   * @par Idempotency
-   * This operation is always treated as non-idempotent.
-   *
-   * @par Thread-safety
-   * Two threads concurrently calling this member function on the same instance
-   * of this class are **not** guaranteed to work.
-   *
-   * @par Example
-   * @snippet data_async_snippets.cc async read modify write
-   */
-  template <typename... Args>
-  GOOGLE_CLOUD_CPP_BIGTABLE_ASYNC_CQ_PARAM_DEPRECATED future<StatusOr<Row>>
-  AsyncReadModifyWriteRow(std::string row_key, CompletionQueue& cq,
-                          bigtable::ReadModifyWriteRule rule, Args&&... rules) {
-    return AsyncReadModifyWriteRowImpl(std::move(row_key), cq, std::move(rule),
-                                       std::forward<Args>(rules)...);
-  }
-
-  /**
-   * Make an asynchronous request to atomically read and modify a row.
-   *
-   * @warning This is an early version of the asynchronous APIs for Cloud
-   *     Bigtable. These APIs might be changed in backward-incompatible ways. It
-   *     is not subject to any SLA or deprecation policy.
-   *
-   * @param row_key the row key on which modification will be performed
    *
    * @param rule to modify the row. Two types of rules are applied here
    *     AppendValue which will read the existing value and append the
@@ -849,47 +715,6 @@ class Table {
     auto cq = background_threads_->cq();
     return AsyncReadModifyWriteRowImpl(std::move(row_key), cq, std::move(rule),
                                        std::forward<Args>(rules)...);
-  }
-
-  /**
-   * Asynchronously reads a set of rows from the table.
-   *
-   * @warning This is an early version of the asynchronous APIs for Cloud
-   *     Bigtable. These APIs might be changed in backward-incompatible ways. It
-   *     is not subject to any SLA or deprecation policy.
-   *
-   * @param cq the completion queue that will execute the asynchronous calls,
-   *     the application must ensure that one or more threads are blocked on
-   *     `cq.Run()`.
-   * @param on_row the callback to be invoked on each successfully read row; it
-   *     should be invocable with `Row` and return a future<bool>; the returned
-   *     `future<bool>` should be satisfied with `true` when the user is ready
-   *     to receive the next callback and with `false` when the user doesn't
-   *     want any more rows; if `on_row` throws, the results are undefined
-   * @param on_finish the callback to be invoked when the stream is closed; it
-   *     should be invocable with `Status` and not return anything; it will
-   *     always be called as the last callback; if `on_finish` throws, the
-   *     results are undefined
-   * @param row_set the rows to read from.
-   * @param filter is applied on the server-side to data in the rows.
-   *
-   * @tparam RowFunctor the type of the @p on_row callback.
-   * @tparam FinishFunctor the type of the @p on_finish callback.
-   *
-   * @par Thread-safety
-   * Two threads concurrently calling this member function on the same instance
-   * of this class are **not** guaranteed to work. Consider copying the object
-   * and using different copies in each thread.
-   *
-   * @par Example
-   * @snippet data_async_snippets.cc async read rows
-   */
-  template <typename RowFunctor, typename FinishFunctor>
-  GOOGLE_CLOUD_CPP_BIGTABLE_ASYNC_CQ_PARAM_DEPRECATED void AsyncReadRows(
-      CompletionQueue& cq, RowFunctor on_row, FinishFunctor on_finish,
-      RowSet row_set, Filter filter) {
-    return AsyncReadRowsImpl(cq, std::move(on_row), std::move(on_finish),
-                             std::move(row_set), std::move(filter));
   }
 
   /**
@@ -937,52 +762,6 @@ class Table {
    *     Bigtable. These APIs might be changed in backward-incompatible ways. It
    *     is not subject to any SLA or deprecation policy.
    *
-   * @param cq the completion queue that will execute the asynchronous calls,
-   *     the application must ensure that one or more threads are blocked on
-   *     `cq.Run()`.
-   * @param on_row the callback to be invoked on each successfully read row; it
-   *     should be invocable with `Row` and return a future<bool>; the returned
-   *     `future<bool>` should be satisfied with `true` when the user is ready
-   *     to receive the next callback and with `false` when the user doesn't
-   *     want any more rows; if `on_row` throws, the results are undefined
-   * @param on_finish the callback to be invoked when the stream is closed; it
-   *     should be invocable with `Status` and not return anything; it will
-   *     always be called as the last callback; if `on_finish` throws, the
-   *     results are undefined
-   * @param row_set the rows to read from.
-   * @param rows_limit the maximum number of rows to read. Cannot be a negative
-   *     number or zero. Use `AsyncReadRows(CompletionQueue, RowSet, Filter)` to
-   *     read all matching rows.
-   * @param filter is applied on the server-side to data in the rows.
-   *
-   * @tparam RowFunctor the type of the @p on_row callback.
-   * @tparam FinishFunctor the type of the @p on_finish callback.
-   *
-   * @par Thread-safety
-   * Two threads concurrently calling this member function on the same instance
-   * of this class are **not** guaranteed to work. Consider copying the object
-   * and using different copies in each thread. The callbacks passed to this
-   * function may be executed on any thread running the provided completion
-   * queue.
-   *
-   * @par Example
-   * @snippet data_async_snippets.cc async read rows with limit
-   */
-  template <typename RowFunctor, typename FinishFunctor>
-  GOOGLE_CLOUD_CPP_BIGTABLE_ASYNC_CQ_PARAM_DEPRECATED void AsyncReadRows(
-      CompletionQueue& cq, RowFunctor on_row, FinishFunctor on_finish,
-      RowSet row_set, std::int64_t rows_limit, Filter filter) {
-    AsyncReadRowsImpl(cq, std::move(on_row), std::move(on_finish),
-                      std::move(row_set), rows_limit, std::move(filter));
-  }
-
-  /**
-   * Asynchronously reads a set of rows from the table.
-   *
-   * @warning This is an early version of the asynchronous APIs for Cloud
-   *     Bigtable. These APIs might be changed in backward-incompatible ways. It
-   *     is not subject to any SLA or deprecation policy.
-   *
    * @param on_row the callback to be invoked on each successfully read row; it
    *     should be invocable with `Row` and return a future<bool>; the returned
    *     `future<bool>` should be satisfied with `true` when the user is ready
@@ -1018,43 +797,6 @@ class Table {
     AsyncReadRowsImpl(cq, std::move(on_row), std::move(on_finish),
                       std::move(row_set), rows_limit, std::move(filter));
   }
-
-  /**
-   * Asynchronously read and return a single row from the table.
-   *
-   * @warning This is an early version of the asynchronous APIs for Cloud
-   *     Bigtable. These APIs might be changed in backward-incompatible ways. It
-   *     is not subject to any SLA or deprecation policy.
-   *
-   * @param cq the completion queue that will execute the asynchronous calls,
-   *     the application must ensure that one or more threads are blocked on
-   *     `cq.Run()`.
-   * @param row_key the row to read.
-   * @param filter a filter expression, can be used to select a subset of the
-   *     column families and columns in the row.
-   * @returns a future satisfied when the operation completes, fails
-   *     permanently or keeps failing transiently, but the retry policy has been
-   *     exhausted. The future will return a tuple. The first element is a
-   *     boolean, with value `false` if the row does not exist.  If the first
-   *     element is `true` the second element has the contents of the Row.  Note
-   *     that the contents may be empty if the filter expression removes all
-   *     column families and columns.
-   *
-   * @par Idempotency
-   * This is a read-only operation and therefore it is always idempotent.
-   *
-   * @par Thread-safety
-   * Two threads concurrently calling this member function on the same instance
-   * of this class are **not** guaranteed to work. Consider copying the object
-   * and using different copies in each thread.
-   *
-   * @par Example
-   * @snippet data_async_snippets.cc async read row
-   */
-  GOOGLE_CLOUD_CPP_BIGTABLE_ASYNC_CQ_PARAM_DEPRECATED
-  future<StatusOr<std::pair<bool, Row>>> AsyncReadRow(CompletionQueue& cq,
-                                                      std::string row_key,
-                                                      Filter filter);
 
   /**
    * Asynchronously read and return a single row from the table.

--- a/google/cloud/bigtable/version.h
+++ b/google/cloud/bigtable/version.h
@@ -27,12 +27,6 @@
       " instead. The function will be removed on 2022-04-01 or shortly "       \
       "after. See GitHub issue #5929 for more information.")
 
-#define GOOGLE_CLOUD_CPP_BIGTABLE_ASYNC_CQ_PARAM_DEPRECATED                  \
-  GOOGLE_CLOUD_CPP_DEPRECATED(                                               \
-      "this experimental function will be removed on or shortly after "      \
-      "2021-07-01. See GitHub issue #2567 for more information. Please use " \
-      "an overload without the cq parameter.")
-
 #define BIGTABLE_CLIENT_NS                              \
   GOOGLE_CLOUD_CPP_VEVAL(BIGTABLE_CLIENT_VERSION_MAJOR, \
                          BIGTABLE_CLIENT_VERSION_MINOR)


### PR DESCRIPTION
Fixes #2567 

Note: this leaves a lot of `*Impl()`'s that are called only once. I will refactor these in a subsequent PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6921)
<!-- Reviewable:end -->
