### PR TITLE
fix(storage): pre-conditions are too restrictive

### DIFF
--- a/google/cloud/storage/parallel_upload.h
+++ b/google/cloud/storage/parallel_upload.h
@@ -664,9 +664,9 @@ NonResumableParallelUploadState::Create(Client client,
       [client, bucket_name, delete_options](std::string const& object_name,
                                             std::int64_t generation) mutable {
         return google::cloud::internal::apply(
-            DeleteApplyHelper{client, std::move(bucket_name), object_name},
-            std::tuple_cat(std::make_tuple(IfGenerationMatch(generation)),
-                           std::move(delete_options)));
+            DeleteApplyHelper{client, std::move(bucket_name), object_name,
+                              generation},
+            std::move(delete_options));
       });
 
   auto compose_options = StaticTupleFilter<
@@ -725,9 +725,9 @@ std::shared_ptr<ScopedDeleter> ResumableParallelUploadState::CreateDeleter(
       [client, bucket_name, delete_options](std::string const& object_name,
                                             std::int64_t generation) mutable {
         return google::cloud::internal::apply(
-            DeleteApplyHelper{client, std::move(bucket_name), object_name},
-            std::tuple_cat(std::make_tuple(IfGenerationMatch(generation)),
-                           std::move(delete_options)));
+            DeleteApplyHelper{client, std::move(bucket_name), object_name,
+                              generation},
+            std::move(delete_options));
       });
 }
 


### PR DESCRIPTION
Some of our helper functions (`ParallelFileUpload()`,
`DeleteObjectsByPrefix()`) used pre-conditions to avoid deleting new
versions of an object. In most cases that is too restrictive, it
prevents acting on an object that has been modified, even if the version
we want is still available. We can use `storage::Generation()` to just
delete the version we want, even if there is a newer version.

Fixes #6910

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6923)
<!-- Reviewable:end -->
