### PR TITLE
fix: GrpcNumChannels option can be zero

### DIFF
--- a/google/cloud/spanner/client.cc
+++ b/google/cloud/spanner/client.cc
@@ -347,13 +347,13 @@ std::shared_ptr<spanner::Connection> MakeConnection(spanner::Database const& db,
       spanner_internal::SessionPoolClockOption, SpannerPolicyOptionList>(
       opts, __func__);
   opts = spanner_internal::DefaultOptions(std::move(opts));
-  std::vector<std::shared_ptr<spanner_internal::SpannerStub>> stubs;
-  int num_channels = opts.get<GrpcNumChannelsOption>();
-  stubs.reserve(num_channels);
-  for (int channel_id = 0; channel_id < num_channels; ++channel_id) {
-    stubs.push_back(
-        spanner_internal::CreateDefaultSpannerStub(db, opts, channel_id));
-  }
+
+  std::vector<std::shared_ptr<spanner_internal::SpannerStub>> stubs(
+      (std::max)(1, opts.get<GrpcNumChannelsOption>()));
+  int id = 0;
+  std::generate(stubs.begin(), stubs.end(), [&id, db, opts] {
+    return spanner_internal::CreateDefaultSpannerStub(db, opts, id++);
+  });
   return std::make_shared<spanner_internal::ConnectionImpl>(
       std::move(db), std::move(stubs), opts);
 }

--- a/google/cloud/storage/internal/grpc_client.cc
+++ b/google/cloud/storage/internal/grpc_client.cc
@@ -21,15 +21,11 @@
 #include "google/cloud/storage/internal/storage_auth.h"
 #include "google/cloud/storage/internal/storage_round_robin.h"
 #include "google/cloud/storage/internal/storage_stub.h"
-#include "google/cloud/storage/oauth2/anonymous_credentials.h"
-#include "google/cloud/grpc_error_delegate.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/big_endian.h"
 #include "google/cloud/internal/format_time_point.h"
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/internal/invoke_result.h"
-#include "google/cloud/internal/streaming_read_rpc.h"
-#include "google/cloud/internal/streaming_write_rpc.h"
 #include "google/cloud/internal/time_utils.h"
 #include "google/cloud/internal/unified_grpc_credentials.h"
 #include "google/cloud/log.h"
@@ -123,7 +119,7 @@ std::shared_ptr<StorageStub> CreateStorageStub(CompletionQueue cq,
                                                Options const& opts) {
   auto auth = CreateAuthenticationStrategy(std::move(cq), opts);
   std::vector<std::shared_ptr<StorageStub>> children(
-      opts.get<GrpcNumChannelsOption>());
+      (std::max)(1, opts.get<GrpcNumChannelsOption>()));
   int id = 0;
   std::generate(children.begin(), children.end(), [&id, &auth, opts] {
     return MakeDefaultStorageStub(CreateGrpcChannel(*auth, opts, id++));


### PR DESCRIPTION
Applications might set this option to zero or a negative number, this is
almost always a bug or an accident. It seems reasonable to use `1` in
such cases.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6926)
<!-- Reviewable:end -->
