### PR TITLE
feat(storage): benchmark aggregate download banwidth

### DIFF
--- a/google/cloud/storage/benchmarks/CMakeLists.txt
+++ b/google/cloud/storage/benchmarks/CMakeLists.txt
@@ -19,6 +19,8 @@ if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_GRPC)
 
     add_library(
         storage_benchmarks # cmake-format: sort
+        aggregate_throughput_options.cc
+        aggregate_throughput_options.h
         benchmark_utils.cc
         benchmark_utils.h
         bounded_queue.h
@@ -42,6 +44,7 @@ if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_GRPC)
 
     set(storage_benchmark_programs
         # cmake-format: sort
+        aggregate_throughput_benchmark.cc
         create_dataset.cc
         storage_file_transfer_benchmark.cc
         storage_parallel_uploads_benchmark.cc
@@ -75,6 +78,7 @@ if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_GRPC)
     # List the unit tests, then setup the targets and dependencies.
     set(storage_benchmarks_unit_tests
         # cmake-format: sort
+        aggregate_throughput_options_test.cc
         benchmark_make_random_test.cc
         benchmark_parser_test.cc
         create_dataset_options_test.cc

--- a/google/cloud/storage/benchmarks/aggregate_throughput_benchmark.cc
+++ b/google/cloud/storage/benchmarks/aggregate_throughput_benchmark.cc
@@ -1,0 +1,287 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/storage/benchmarks/aggregate_throughput_options.h"
+#include "google/cloud/storage/benchmarks/benchmark_utils.h"
+#include "google/cloud/storage/client.h"
+#include "google/cloud/storage/grpc_plugin.h"
+#include "google/cloud/grpc_options.h"
+#include "google/cloud/internal/build_info.h"
+#include "google/cloud/internal/getenv.h"
+#include "google/cloud/internal/random.h"
+#include "google/cloud/options.h"
+#include "absl/time/time.h"
+#include <algorithm>
+#include <atomic>
+#include <future>
+#include <random>
+#include <sstream>
+#include <thread>
+#include <vector>
+
+namespace {
+using ::google::cloud::storage_experimental::DefaultGrpcClient;
+namespace gcs = google::cloud::storage;
+namespace gcs_bm = google::cloud::storage_benchmarks;
+using gcs_bm::AggregateThroughputOptions;
+using gcs_bm::ApiName;
+
+char const kDescription[] = R"""(A benchmark for aggregated throughput.
+
+This program is used to evaluate the combined performance of GCS (the service)
+and the C++ client library for GCS. It is not recommended as a benchmark for
+the client library, as it introduces too many sources of performance variation.
+It is useful when the C++ client library team collaborates with the GCS team to
+measure changes in the service's performance.
+
+The program measures the observed download throughput given a fixed "dataset",
+that is, a collection of GCS objects contained in the same bucket, with a common
+prefix. If needed, synthetic datasets can be created using the
+`create_dataset.cc` in this directory. Given a dataset and some configuration
+parameters the program will:
+
+- Read the list of available objects in the dataset.
+- Launch `thread-count` *download threads*, see below for their description.
+- Every `reporting-interval` seconds the main thread will report the current
+  wall time and the total number of bytes downloaded by all the download
+  threads.
+- After `running-time` seconds the main thread ask all other threads to
+  terminate.
+- The main thread the waits for all the "download threads", collects any metrics
+  they choose to report, prints these metrics and then exits.
+
+While running each download thread performs the following loop:
+
+1) Create a gcs::Client(), see the `AggregateThroughputOptions` struct for
+   details about how this client object can be configured.
+2) Check if the program is shutting down, if so, just return some metrics.
+3) Pick one of the objects in the dataset at random.
+4) If so configured, pick a random portion of the object to download, otherwise
+   simply download the full object.
+5) Download the object, requesting `read-buffer-size` bytes from the client
+   library at a time.
+6) Once the requested buffer is received, increment a per-thread counter with
+   the number of bytes received so far.
+7) Keep track of the number of files downloaded, the gRPC peer used to download
+   the object (if applicable) and other counters.
+8) Go back to step (2) in this list.
+)""";
+
+google::cloud::StatusOr<AggregateThroughputOptions> ParseArgs(int argc,
+                                                              char* argv[]);
+
+struct ThreadConfig {
+  std::atomic<std::int64_t> bytes_received{0};
+  std::seed_seq::result_type seed;
+};
+
+using Counters = std::map<std::string, std::int64_t>;
+
+Counters RunThread(gcs::Client client,
+                   AggregateThroughputOptions const& options,
+                   std::vector<gcs::ObjectMetadata> const& objects,
+                   ThreadConfig& config);
+
+}  // namespace
+
+int main(int argc, char* argv[]) {
+  auto options = ParseArgs(argc, argv);
+  if (!options) {
+    std::cerr << options.status() << "\n";
+    return 1;
+  }
+  if (options->exit_after_parse) return 1;
+
+  auto client = gcs::Client();
+  if (options->api == ApiName::kApiGrpc) {
+    auto channels = options->grpc_channel_count;
+    if (channels == 0) channels = (std::max)(options->thread_count / 4, 4);
+    auto client_options = google::cloud::Options{};
+    client = DefaultGrpcClient(
+        google::cloud::Options{}.set<google::cloud::GrpcNumChannelsOption>(
+            channels));
+  }
+  std::vector<gcs::ObjectMetadata> objects;
+  std::uint64_t dataset_size = 0;
+  for (auto& o : client.ListObjects(options->bucket_name,
+                                    gcs::Prefix(options->object_prefix))) {
+    if (!o) break;
+    dataset_size += o->size();
+    objects.push_back(*std::move(o));
+  }
+  if (objects.empty()) {
+    std::cerr << "No objects found in bucket " << options->bucket_name
+              << " starting with prefix " << options->object_prefix << "\n"
+              << "Cannot run the benchmark with an empty dataset\n";
+    return 1;
+  }
+
+  std::string notes = google::cloud::storage::version_string() + ";" +
+                      google::cloud::internal::compiler() + ";" +
+                      google::cloud::internal::compiler_flags();
+  std::transform(notes.begin(), notes.end(), notes.begin(),
+                 [](char c) { return c == '\n' ? ';' : c; });
+
+  auto current_time = [] {
+    auto constexpr kFormat = "%E4Y-%m-%dT%H:%M:%E*SZ";
+    auto const t = absl::FromChrono(std::chrono::system_clock::now());
+    return absl::FormatTime(kFormat, t, absl::UTCTimeZone());
+  };
+
+  std::cout << "# Start time: " << current_time()
+            << "\n# Bucket Name: " << options->bucket_name
+            << "\n# Object Prefix: " << options->object_prefix
+            << "\n# Thread Count: " << options->thread_count
+            << "\n# Reporting Interval: "
+            << absl::FromChrono(options->reporting_interval)
+            << "\n# Running Time: " << absl::FromChrono(options->running_time)
+            << "\n# Read Size: " << options->read_size
+            << "\n# Read Buffer Size: " << options->read_buffer_size
+            << "\n# Build Info: " << notes
+            << "\n# Object Count: " << objects.size()
+            << "\n# Dataset size: " << dataset_size << std::endl;
+
+  auto configs = [](std::size_t count) {
+    std::random_device rd;
+    std::vector<std::seed_seq::result_type> seeds(count);
+    std::seed_seq({rd(), rd(), rd()}).generate(seeds.begin(), seeds.end());
+
+    std::vector<ThreadConfig> config(seeds.size());
+    for (std::size_t i = 0; i != config.size(); ++i) config[i].seed = seeds[i];
+    return config;
+  }(options->thread_count);
+
+  std::cout << "CurrentTime,BytesReceived,CpuTimeMicroseconds\n"
+            << current_time() << ",0,0\n";
+
+  std::vector<std::future<Counters>> tasks(configs.size());
+  std::transform(configs.begin(), configs.end(), tasks.begin(),
+                 [&](ThreadConfig& c) {
+                   return std::async(std::launch::async, RunThread, client,
+                                     *options, objects, std::ref(c));
+                 });
+
+  using clock = std::chrono::steady_clock;
+  auto const deadline = clock::now() + options->running_time;
+  while (clock::now() < deadline) {
+    std::this_thread::sleep_for(options->reporting_interval);
+    std::int64_t bytes_received = 0;
+    for (auto const& t : configs) {
+      bytes_received += t.bytes_received.load();
+    }
+    std::cout << current_time() << "," << bytes_received << std::endl;
+  }
+
+  Counters accumulated;
+  for (auto& t : tasks) {
+    auto counters = t.get();
+    for (auto const& kv : counters) accumulated[kv.first] += kv.second;
+  }
+  for (auto& kv : accumulated) {
+    std::cout << "# counter " << kv.first << ": " << kv.second << "\n";
+  }
+  return 0;
+}
+
+namespace {
+
+Counters RunThread(gcs::Client client,
+                   AggregateThroughputOptions const& options,
+                   std::vector<gcs::ObjectMetadata> const& objects,
+                   ThreadConfig& config) {
+  using clock = std::chrono::steady_clock;
+  auto const deadline = clock::now() + options.running_time;
+  auto generator = std::mt19937_64(config.seed);
+  auto index =
+      std::uniform_int_distribution<std::size_t>(0, objects.size() - 1);
+  std::vector<char> buffer(options.read_buffer_size);
+  auto const buffer_size = static_cast<std::streamsize>(buffer.size());
+  Counters counters{
+      {"file-count", 0},
+  };
+  // Using IfGenerationNotMatch(0) triggers JSON, as this feature is not
+  // supported by XML.  Using IfGenerationNotMatch() -- without a value -- has
+  // no effect.
+  auto xml_hack = options.api == ApiName::kApiXml ? gcs::IfGenerationNotMatch(0)
+                                                  : gcs::IfGenerationNotMatch();
+  while (clock::now() < deadline) {
+    auto const& object = objects[index(generator)];
+    auto const object_size = static_cast<std::int64_t>(object.size());
+    auto range = gcs::ReadRange();
+    if (options.read_size != 0 && options.read_size < object_size) {
+      auto start = std::uniform_int_distribution<std::int64_t>(0, object_size);
+      range = gcs::ReadRange(start(generator), options.read_size);
+    }
+    auto stream = client.ReadObject(object.bucket(), object.name(),
+                                    gcs::Generation(object.generation()), range,
+                                    xml_hack);
+    while (stream.read(buffer.data(), buffer_size)) {
+      config.bytes_received += stream.gcount();
+    }
+    stream.Close();
+    ++counters["download-count"];
+    auto peer = stream.headers().find(":grpc-context-peer");
+    if (peer != stream.headers().end()) {
+      ++counters[peer->first + "/" + peer->second];
+    }
+  }
+  return counters;
+}
+
+using ::google::cloud::internal::GetEnv;
+
+google::cloud::StatusOr<AggregateThroughputOptions> SelfTest(
+    char const* argv0) {
+  using google::cloud::internal::Sample;
+
+  for (auto const& var : {"GOOGLE_CLOUD_CPP_STORAGE_TEST_BUCKET_NAME"}) {
+    auto const value = GetEnv(var).value_or("");
+    if (!value.empty()) continue;
+    std::ostringstream os;
+    os << "The environment variable " << var << " is not set or empty";
+    return google::cloud::Status(google::cloud::StatusCode::kUnknown,
+                                 std::move(os).str());
+  }
+  auto bucket_name =
+      GetEnv("GOOGLE_CLOUD_CPP_STORAGE_TEST_BUCKET_NAME").value();
+  auto client = gcs::Client{};
+  (void)client.InsertObject(bucket_name,
+                            "aggregate-throughput-benchmark/32KiB.bin",
+                            std::string(32 * gcs_bm::kKiB, 'A'));
+  return gcs_bm::ParseAggregateThroughputOptions(
+      {
+          argv0,
+          "--bucket-name=" + bucket_name,
+          "--object-prefix=aggregate-throughput-benchmark/",
+          "--thread-count=1",
+          "--reporting-interval=5s",
+          "--running-time=15s",
+          "--read-size=16KiB",
+          "--read-buffer-size=1MiB",
+      },
+      kDescription);
+}
+
+google::cloud::StatusOr<AggregateThroughputOptions> ParseArgs(int argc,
+                                                              char* argv[]) {
+  bool auto_run =
+      google::cloud::internal::GetEnv("GOOGLE_CLOUD_CPP_AUTO_RUN_EXAMPLES")
+          .value_or("") == "yes";
+  if (auto_run) return SelfTest(argv[0]);
+
+  return gcs_bm::ParseAggregateThroughputOptions({argv, argv + argc},
+                                                 kDescription);
+}
+
+}  // namespace

--- a/google/cloud/storage/benchmarks/aggregate_throughput_benchmark.cc
+++ b/google/cloud/storage/benchmarks/aggregate_throughput_benchmark.cc
@@ -104,14 +104,15 @@ int main(int argc, char* argv[]) {
   if (options->exit_after_parse) return 1;
 
   auto client = gcs::Client();
+#if GOOGLE_CLOUD_CPP_STORAGE_HAVE_GRPC
   if (options->api == ApiName::kApiGrpc) {
     auto channels = options->grpc_channel_count;
     if (channels == 0) channels = (std::max)(options->thread_count / 4, 4);
-    auto client_options = google::cloud::Options{};
     client = DefaultGrpcClient(
         google::cloud::Options{}.set<google::cloud::GrpcNumChannelsOption>(
             channels));
   }
+#endif  // GOOGLE_CLOUD_CPP_STORAGE_HAVE_GRPC
   std::vector<gcs::ObjectMetadata> objects;
   std::uint64_t dataset_size = 0;
   for (auto& o : client.ListObjects(options->bucket_name,
@@ -269,6 +270,7 @@ google::cloud::StatusOr<AggregateThroughputOptions> SelfTest(
           "--running-time=15s",
           "--read-size=16KiB",
           "--read-buffer-size=1MiB",
+          "--api=JSON",
       },
       kDescription);
 }

--- a/google/cloud/storage/benchmarks/aggregate_throughput_benchmark.cc
+++ b/google/cloud/storage/benchmarks/aggregate_throughput_benchmark.cc
@@ -97,30 +97,30 @@ Counters RunThread(gcs::Client client,
                    ThreadConfig& config);
 
 template <typename Rep, typename Period>
-std::string FormatBandwidthGpbs(std::uintmax_t bytes,
+std::string FormatBandwidthGbps(std::uintmax_t bytes,
                                 std::chrono::duration<Rep, Period> elapsed) {
   using ns = ::std::chrono::nanoseconds;
   auto const elapsed_ns = std::chrono::duration_cast<ns>(elapsed);
   if (elapsed_ns == ns(0)) return "NaN";
 
-  auto const gbps =
+  auto const bandwidth =
       8 * static_cast<double>(bytes) / static_cast<double>(elapsed_ns.count());
   std::ostringstream os;
-  os << std::fixed << std::setprecision(2) << gbps;
+  os << std::fixed << std::setprecision(2) << bandwidth;
   return std::move(os).str();
 }
 
 template <typename Rep, typename Period>
-std::string FormatBandwidthMiBs(std::uintmax_t bytes,
+std::string FormatBandwidthGiBs(std::uintmax_t bytes,
                                 std::chrono::duration<Rep, Period> elapsed) {
   using ::std::chrono::seconds;
   auto const elapsed_s = std::chrono::duration_cast<seconds>(elapsed);
   if (elapsed_s == seconds(0)) return "NaN";
 
-  auto const MiBs = static_cast<double>(bytes) / gcs_bm::kMiB /
-                    static_cast<double>(elapsed_s.count());
+  auto const bandwidth = static_cast<double>(bytes) / gcs_bm::kGiB /
+                         static_cast<double>(elapsed_s.count());
   std::ostringstream os;
-  os << std::fixed << std::setprecision(2) << MiBs;
+  os << std::fixed << std::setprecision(2) << bandwidth;
   return std::move(os).str();
 }
 
@@ -224,9 +224,9 @@ int main(int argc, char* argv[]) {
   auto const bytes_received = accumulate_bytes_received();
   std::cout << "# Bytes Received: " << FormatSize(bytes_received)
             << "\n# Elapsed Time: " << absl::FromChrono(elapsed)
-            << "\n# Gpbs: " << FormatBandwidthGpbs(bytes_received, elapsed)
-            << "\n# MiBs: " << FormatBandwidthMiBs(bytes_received, elapsed)
-            << "\n";
+            << "\n# Bandwidth: " << FormatBandwidthGbps(bytes_received, elapsed)
+            << "Gbps  " << FormatBandwidthGiBs(bytes_received, elapsed)
+            << "GiB/s\n";
 
   Counters accumulated;
   for (auto& t : tasks) {

--- a/google/cloud/storage/benchmarks/aggregate_throughput_benchmark.cc
+++ b/google/cloud/storage/benchmarks/aggregate_throughput_benchmark.cc
@@ -208,9 +208,7 @@ Counters RunThread(gcs::Client client,
       std::uniform_int_distribution<std::size_t>(0, objects.size() - 1);
   std::vector<char> buffer(options.read_buffer_size);
   auto const buffer_size = static_cast<std::streamsize>(buffer.size());
-  Counters counters{
-      {"file-count", 0},
-  };
+  Counters counters{{"download-count", 0}};
   // Using IfGenerationNotMatch(0) triggers JSON, as this feature is not
   // supported by XML.  Using IfGenerationNotMatch() -- without a value -- has
   // no effect.
@@ -268,8 +266,8 @@ google::cloud::StatusOr<AggregateThroughputOptions> SelfTest(
           "--thread-count=1",
           "--reporting-interval=5s",
           "--running-time=15s",
-          "--read-size=16KiB",
-          "--read-buffer-size=1MiB",
+          "--read-size=32KiB",
+          "--read-buffer-size=16KiB",
           "--api=JSON",
       },
       kDescription);

--- a/google/cloud/storage/benchmarks/aggregate_throughput_options.cc
+++ b/google/cloud/storage/benchmarks/aggregate_throughput_options.cc
@@ -43,7 +43,7 @@ ParseAggregateThroughputOptions(std::vector<std::string> const& argv,
        [&options](std::string const& val) {
          options.thread_count = std::stoi(val);
        }},
-      {"--reporting-interval", "how often does the benchmark reports progress",
+      {"--reporting-interval", "how often the benchmark reports progress",
        [&options](std::string const& val) {
          options.reporting_interval = ParseDuration(val);
        }},
@@ -118,7 +118,7 @@ ParseAggregateThroughputOptions(std::vector<std::string> const& argv,
       std::set<ApiName>{ApiName::kApiGrpc, ApiName::kApiJson, ApiName::kApiXml};
   if (valid_apis.find(options.api) == valid_apis.end()) {
     std::ostringstream os;
-    os << "Unsupported api " << ToString(options.api) << "\n"
+    os << "Unsupported API " << ToString(options.api) << "\n"
        << "Choose from "
        << absl::StrJoin(valid_apis, ", ", [](std::string* out, ApiName api) {
             *out += ToString(api);

--- a/google/cloud/storage/benchmarks/aggregate_throughput_options.cc
+++ b/google/cloud/storage/benchmarks/aggregate_throughput_options.cc
@@ -14,6 +14,7 @@
 
 #include "google/cloud/storage/benchmarks/aggregate_throughput_options.h"
 #include "google/cloud/internal/absl_str_join_quiet.h"
+#include <iterator>
 #include <sstream>
 
 namespace google {
@@ -90,7 +91,10 @@ ParseAggregateThroughputOptions(std::vector<std::string> const& argv,
 
   if (unparsed.size() != 1) {
     std::ostringstream os;
-    os << "Unknown arguments or options\n" << usage << "\n";
+    os << "Unknown arguments or options: "
+       << absl::StrJoin(std::next(unparsed.begin()), unparsed.end(), ", ")
+       << "\n"
+       << usage << "\n";
     return make_status(os);
   }
   if (options.bucket_name.empty()) {

--- a/google/cloud/storage/benchmarks/aggregate_throughput_options.cc
+++ b/google/cloud/storage/benchmarks/aggregate_throughput_options.cc
@@ -1,0 +1,130 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/storage/benchmarks/aggregate_throughput_options.h"
+#include "google/cloud/internal/absl_str_join_quiet.h"
+#include <sstream>
+
+namespace google {
+namespace cloud {
+namespace storage_benchmarks {
+
+using ::google::cloud::testing_util::OptionDescriptor;
+
+google::cloud::StatusOr<AggregateThroughputOptions>
+ParseAggregateThroughputOptions(std::vector<std::string> const& argv,
+                                std::string const& description) {
+  AggregateThroughputOptions options;
+  bool wants_help = false;
+  bool wants_description = false;
+
+  std::vector<OptionDescriptor> desc{
+      {"--help", "print usage information",
+       [&wants_help](std::string const&) { wants_help = true; }},
+      {"--description", "print benchmark description",
+       [&wants_description](std::string const&) { wants_description = true; }},
+      {"--bucket-name", "the bucket where the dataset is located",
+       [&options](std::string const& val) { options.bucket_name = val; }},
+      {"--object-prefix", "the dataset prefix",
+       [&options](std::string const& val) { options.object_prefix = val; }},
+      {"--thread-count", "set the number of threads in the benchmark",
+       [&options](std::string const& val) {
+         options.thread_count = std::stoi(val);
+       }},
+      {"--reporting-interval", "how often does the benchmark reports progress",
+       [&options](std::string const& val) {
+         options.reporting_interval = ParseDuration(val);
+       }},
+      {"--running-time",
+       "stop the benchmark once this many seconds have elapsed",
+       [&options](std::string const& val) {
+         options.running_time = ParseDuration(val);
+       }},
+      {"--read-size", "number of bytes downloaded in each iteration",
+       [&options](std::string const& val) {
+         options.read_size = ParseSize(val);
+       }},
+      {"--read-buffer-size", "controls the buffer used in the downloads",
+       [&options](std::string const& val) {
+         options.read_buffer_size = ParseBufferSize(val);
+       }},
+      {"--api", "select the API (JSON, XML, or GRPC) for the benchmark",
+       [&options](std::string const& val) {
+         options.api = ParseApiName(val).value();
+       }},
+      {"--grpc-channel-count", "controls the number of gRPC channels",
+       [&options](std::string const& val) {
+         options.grpc_channel_count = std::stoi(val);
+       }},
+  };
+  auto usage = BuildUsage(desc, argv[0]);
+
+  auto unparsed = OptionsParse(desc, argv);
+  if (wants_help) {
+    std::cout << usage << "\n";
+    options.exit_after_parse = true;
+    return options;
+  }
+
+  if (wants_description) {
+    std::cout << description << "\n";
+    options.exit_after_parse = true;
+    return options;
+  }
+
+  auto make_status = [](std::ostringstream& os) {
+    auto const code = google::cloud::StatusCode::kInvalidArgument;
+    return google::cloud::Status{code, std::move(os).str()};
+  };
+
+  if (unparsed.size() != 1) {
+    std::ostringstream os;
+    os << "Unknown arguments or options\n" << usage << "\n";
+    return make_status(os);
+  }
+  if (options.bucket_name.empty()) {
+    std::ostringstream os;
+    os << "Missing --bucket option\n" << usage << "\n";
+    return make_status(os);
+  }
+  if (options.thread_count <= 0) {
+    std::ostringstream os;
+    os << "Invalid number of threads (" << options.thread_count
+       << "), check your --thread-count option\n";
+    return make_status(os);
+  }
+  if (options.grpc_channel_count < 0) {
+    std::ostringstream os;
+    os << "Invalid number of gRPC channels (" << options.grpc_channel_count
+       << "), check your --grpc-channel-count option\n";
+    return make_status(os);
+  }
+  auto const valid_apis =
+      std::set<ApiName>{ApiName::kApiGrpc, ApiName::kApiJson, ApiName::kApiXml};
+  if (valid_apis.find(options.api) == valid_apis.end()) {
+    std::ostringstream os;
+    os << "Unsupported api " << ToString(options.api) << "\n"
+       << "Choose from "
+       << absl::StrJoin(valid_apis, ", ", [](std::string* out, ApiName api) {
+            *out += ToString(api);
+          });
+    return make_status(os);
+  }
+
+  return options;
+}
+
+}  // namespace storage_benchmarks
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/storage/benchmarks/aggregate_throughput_options.h
+++ b/google/cloud/storage/benchmarks/aggregate_throughput_options.h
@@ -1,0 +1,48 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_BENCHMARKS_AGGREGATE_THROUGHPUT_OPTIONS_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_BENCHMARKS_AGGREGATE_THROUGHPUT_OPTIONS_H
+
+#include "google/cloud/storage/benchmarks/benchmark_utils.h"
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace google {
+namespace cloud {
+namespace storage_benchmarks {
+
+struct AggregateThroughputOptions {
+  std::string bucket_name;
+  std::string object_prefix;
+  int thread_count = 1;
+  std::chrono::seconds reporting_interval = std::chrono::seconds(10);
+  std::chrono::seconds running_time = std::chrono::seconds(30);
+  std::int64_t read_size = 0;  // 0 means "read the whole file"
+  std::size_t read_buffer_size = 4 * kMiB;
+  ApiName api = ApiName::kApiGrpc;
+  int grpc_channel_count = 0;
+  bool exit_after_parse = false;
+};
+
+google::cloud::StatusOr<AggregateThroughputOptions>
+ParseAggregateThroughputOptions(std::vector<std::string> const& argv,
+                                std::string const& description);
+
+}  // namespace storage_benchmarks
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_BENCHMARKS_AGGREGATE_THROUGHPUT_OPTIONS_H

--- a/google/cloud/storage/benchmarks/aggregate_throughput_options_test.cc
+++ b/google/cloud/storage/benchmarks/aggregate_throughput_options_test.cc
@@ -1,0 +1,85 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/storage/benchmarks/aggregate_throughput_options.h"
+#include "google/cloud/testing_util/status_matchers.h"
+#include <gmock/gmock.h>
+#include <thread>
+
+namespace google {
+namespace cloud {
+namespace storage_benchmarks {
+namespace {
+
+TEST(AggregateThroughputOptions, Basic) {
+  auto options = ParseAggregateThroughputOptions(
+      {
+          "self-test",
+          "--bucket-name=test-bucket-name",
+          "--object-prefix=test/object/prefix/",
+          "--thread-count=42",
+          "--reporting-interval=2m",
+          "--running-time=1h",
+          "--read-size=4MiB",
+          "--read-buffer-size=1MiB",
+          "--api=XML",
+          "--grpc-channel-count=16",
+      },
+      "");
+  ASSERT_STATUS_OK(options);
+  EXPECT_FALSE(options->exit_after_parse);
+  EXPECT_EQ("test-bucket-name", options->bucket_name);
+  EXPECT_EQ("test/object/prefix/", options->object_prefix);
+  EXPECT_EQ(42, options->thread_count);
+  EXPECT_EQ(std::chrono::minutes(2), options->reporting_interval);
+  EXPECT_EQ(std::chrono::hours(1), options->running_time);
+  EXPECT_EQ(4 * kMiB, options->read_size);
+  EXPECT_EQ(1 * kMiB, options->read_buffer_size);
+  EXPECT_EQ(ApiName::kApiXml, options->api);
+  EXPECT_EQ(16, options->grpc_channel_count);
+}
+
+TEST(AggregateThroughputOptions, Description) {
+  auto options = ParseAggregateThroughputOptions(
+      {"self-test", "--description", "fake-bucket"}, "Description for test");
+  EXPECT_STATUS_OK(options);
+  EXPECT_TRUE(options->exit_after_parse);
+}
+
+TEST(AggregateThroughputOptions, Help) {
+  auto options = ParseAggregateThroughputOptions(
+      {"self-test", "--help", "fake-bucket"}, "");
+  EXPECT_STATUS_OK(options);
+  EXPECT_TRUE(options->exit_after_parse);
+}
+
+TEST(AggregateThroughputOptions, Validate) {
+  EXPECT_FALSE(ParseAggregateThroughputOptions({"self-test"}, ""));
+  EXPECT_FALSE(ParseAggregateThroughputOptions({"self-test", "unused-1"}, ""));
+  EXPECT_FALSE(
+      ParseAggregateThroughputOptions({"self-test", "--invalid-option"}, ""));
+  EXPECT_FALSE(ParseAggregateThroughputOptions(
+      {"self-test", "--bucket-name=b", "--thread-count=0"}, ""));
+  EXPECT_FALSE(ParseAggregateThroughputOptions(
+      {"self-test", "--bucket-name=b", "--thread-count=-1"}, ""));
+  EXPECT_FALSE(ParseAggregateThroughputOptions(
+      {"self-test", "--bucket-name=b", "--api=GRPC-RAW"}, ""));
+  EXPECT_FALSE(ParseAggregateThroughputOptions(
+      {"self-test", "--bucket-name=b", "--grpc-channel-count=-1"}, ""));
+}
+
+}  // namespace
+}  // namespace storage_benchmarks
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/storage/benchmarks/storage_benchmark_programs.bzl
+++ b/google/cloud/storage/benchmarks/storage_benchmark_programs.bzl
@@ -17,6 +17,7 @@
 """Automatically generated unit tests list - DO NOT EDIT."""
 
 storage_benchmark_programs = [
+    "aggregate_throughput_benchmark.cc",
     "create_dataset.cc",
     "storage_file_transfer_benchmark.cc",
     "storage_parallel_uploads_benchmark.cc",

--- a/google/cloud/storage/benchmarks/storage_benchmarks.bzl
+++ b/google/cloud/storage/benchmarks/storage_benchmarks.bzl
@@ -17,6 +17,7 @@
 """Automatically generated source lists for storage_benchmarks - DO NOT EDIT."""
 
 storage_benchmarks_hdrs = [
+    "aggregate_throughput_options.h",
     "benchmark_utils.h",
     "bounded_queue.h",
     "create_dataset_options.h",
@@ -26,6 +27,7 @@ storage_benchmarks_hdrs = [
 ]
 
 storage_benchmarks_srcs = [
+    "aggregate_throughput_options.cc",
     "benchmark_utils.cc",
     "create_dataset_options.cc",
     "throughput_experiment.cc",

--- a/google/cloud/storage/benchmarks/storage_benchmarks_unit_tests.bzl
+++ b/google/cloud/storage/benchmarks/storage_benchmarks_unit_tests.bzl
@@ -17,6 +17,7 @@
 """Automatically generated unit tests list - DO NOT EDIT."""
 
 storage_benchmarks_unit_tests = [
+    "aggregate_throughput_options_test.cc",
     "benchmark_make_random_test.cc",
     "benchmark_parser_test.cc",
     "create_dataset_options_test.cc",


### PR DESCRIPTION
A new benchmark for aggregate download bandwidth. The existing
benchmarks perform both uploads and downloads as part of the run, which
limits the total download banwidth. Moreover, their output is per
download, which makes it hard to aggregate the results across multiple
processes. This benchmark does not suffer from those problems, but it is
more limited in that it just measures one configuration at a time.

Part of the work for #6884, I will not call it fixed yet because I would also
like to capture CPU usage.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6927)
<!-- Reviewable:end -->
