### PR TITLE
test: simplify helpers to track usage

### DIFF
--- a/google/cloud/storage/benchmarks/aggregate_throughput_benchmark.cc
+++ b/google/cloud/storage/benchmarks/aggregate_throughput_benchmark.cc
@@ -184,7 +184,7 @@ int main(int argc, char* argv[]) {
             << "\n# gRPC Channel Count: " << options->grpc_channel_count
             << "\n# Build Info: " << notes
             << "\n# Object Count: " << objects.size()
-            << "\n# Dataset size: " << dataset_size << std::endl;
+            << "\n# Dataset size: " << FormatSize(dataset_size) << std::endl;
 
   auto configs = [](std::size_t count) {
     std::random_device rd;

--- a/google/cloud/storage/benchmarks/throughput_options.cc
+++ b/google/cloud/storage/benchmarks/throughput_options.cc
@@ -209,7 +209,7 @@ google::cloud::StatusOr<ThroughputOptions> ParseThroughputOptions(
     return make_status(os);
   }
 
-  if (!Timer::SupportPerThreadUsage() && options.thread_count > 1) {
+  if (!Timer::SupportsPerThreadUsage() && options.thread_count > 1) {
     std::cerr <<
         R"""(
 # WARNING

--- a/google/cloud/testing_util/timer.h
+++ b/google/cloud/testing_util/timer.h
@@ -29,32 +29,20 @@ namespace testing_util {
 
 class Timer {
  public:
-  Timer() = default;
+  struct Snapshot {
+    std::chrono::microseconds elapsed_time;
+    std::chrono::microseconds cpu_time;
+  };
 
-  /// Start the timer, call before the code being measured.
-  void Start();
+  Timer();
 
-  /// Stop the timer, call after the code being measured.
-  void Stop();
+  Snapshot Sample() const;
+  std::string Annotations() const;
 
-  //@{
-  /**
-   * @name Measurement results.
-   *
-   * @note The values are only valid after calling Start() and Stop().
-   */
-  std::chrono::microseconds elapsed_time() const { return elapsed_time_; }
-  std::chrono::microseconds cpu_time() const { return cpu_time_; }
-  std::string const& annotations() const { return annotations_; }
-  //@}
-
-  static bool SupportPerThreadUsage();
+  static bool SupportsPerThreadUsage();
 
  private:
   std::chrono::steady_clock::time_point start_;
-  std::chrono::microseconds elapsed_time_;
-  std::chrono::microseconds cpu_time_;
-  std::string annotations_;
 #if GOOGLE_CLOUD_CPP_HAVE_GETRUSAGE
   struct rusage start_usage_;
 #endif  // GOOGLE_CLOUD_CPP_HAVE_GETRUSAGE


### PR DESCRIPTION
This is some slight refactoring / reorganization to make the
`testing_util::Timer` class more friendly towards tracking cumulative
usage. I will need this for storage's aggregate throughput benchmark,
and I think it is easier to use anyway.

Part of the work for #6884

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6932)
<!-- Reviewable:end -->
