### PR TITLE
fix(storage): parsing timestamps should return status

### DIFF
--- a/google/cloud/storage/internal/common_metadata_parser.h
+++ b/google/cloud/storage/internal/common_metadata_parser.h
@@ -47,8 +47,12 @@ struct CommonMetadataParser {
     }
     result.self_link_ = json.value("selfLink", "");
     result.storage_class_ = json.value("storageClass", "");
-    result.time_created_ = ParseTimestampField(json, "timeCreated");
-    result.updated_ = ParseTimestampField(json, "updated");
+    auto time_created = ParseTimestampField(json, "timeCreated");
+    if (!time_created) return std::move(time_created).status();
+    result.time_created_ = *time_created;
+    auto updated = ParseTimestampField(json, "updated");
+    if (!updated) return std::move(updated).status();
+    result.updated_ = *updated;
     return Status();
   }
   static StatusOr<CommonMetadata<Derived>> FromString(

--- a/google/cloud/storage/internal/metadata_parser.cc
+++ b/google/cloud/storage/internal/metadata_parser.cc
@@ -51,7 +51,7 @@ StatusOr<std::int32_t> ParseIntField(nlohmann::json const& json,
   }
   std::ostringstream os;
   os << "Error parsing field <" << field_name
-     << "> as an std::int32_t, json=" << json;
+     << "> as a std::int32_t, json=" << json;
   return Status(StatusCode::kInvalidArgument, std::move(os).str());
 }
 
@@ -66,7 +66,7 @@ StatusOr<std::uint32_t> ParseUnsignedIntField(nlohmann::json const& json,
   }
   std::ostringstream os;
   os << "Error parsing field <" << field_name
-     << "> as an std::uint32_t, json=" << json;
+     << "> as a std::uint32_t, json=" << json;
   return Status(StatusCode::kInvalidArgument, std::move(os).str());
 }
 
@@ -81,7 +81,7 @@ StatusOr<std::int64_t> ParseLongField(nlohmann::json const& json,
   }
   std::ostringstream os;
   os << "Error parsing field <" << field_name
-     << "> as an std::int64_t, json=" << json;
+     << "> as a std::int64_t, json=" << json;
   return Status(StatusCode::kInvalidArgument, std::move(os).str());
 }
 
@@ -96,16 +96,21 @@ StatusOr<std::uint64_t> ParseUnsignedLongField(nlohmann::json const& json,
   }
   std::ostringstream os;
   os << "Error parsing field <" << field_name
-     << "> as an std::uint64_t, json=" << json;
+     << "> as a std::uint64_t, json=" << json;
   return Status(StatusCode::kInvalidArgument, std::move(os).str());
 }
 
-std::chrono::system_clock::time_point ParseTimestampField(
+StatusOr<std::chrono::system_clock::time_point> ParseTimestampField(
     nlohmann::json const& json, char const* field_name) {
   if (json.count(field_name) == 0) {
     return std::chrono::system_clock::time_point{};
   }
-  return google::cloud::internal::ParseRfc3339(json[field_name]);
+  auto const& f = json[field_name];
+  if (f.is_string()) return google::cloud::internal::ParseRfc3339(f);
+  std::ostringstream os;
+  os << "Error parsing field <" << field_name
+     << "> as a timestamp, json=" << json;
+  return Status(StatusCode::kInvalidArgument, std::move(os).str());
 }
 
 }  // namespace internal

--- a/google/cloud/storage/internal/metadata_parser.h
+++ b/google/cloud/storage/internal/metadata_parser.h
@@ -75,7 +75,7 @@ StatusOr<std::uint64_t> ParseUnsignedLongField(nlohmann::json const& json,
  * @return the value of @p field_name in @p json, or the epoch if the field is
  * not present.
  */
-std::chrono::system_clock::time_point ParseTimestampField(
+StatusOr<std::chrono::system_clock::time_point> ParseTimestampField(
     nlohmann::json const& json, char const* field_name);
 
 }  // namespace internal

--- a/google/cloud/storage/internal/object_metadata_parser.cc
+++ b/google/cloud/storage/internal/object_metadata_parser.cc
@@ -89,21 +89,30 @@ StatusOr<ObjectMetadata> ObjectMetadataParser::FromJson(
       result.metadata_.emplace(kv.key(), kv.value().get<std::string>());
     }
   }
-  result.retention_expiration_time_ =
+  auto expiration_time =
       internal::ParseTimestampField(json, "retentionExpirationTime");
+  if (!expiration_time) return std::move(expiration_time).status();
+  result.retention_expiration_time_ = *expiration_time;
   auto size = internal::ParseUnsignedLongField(json, "size");
   if (!size) return std::move(size).status();
   result.size_ = *size;
   auto temporary_hold = internal::ParseBoolField(json, "temporaryHold");
   if (!temporary_hold) return std::move(temporary_hold).status();
   result.temporary_hold_ = *temporary_hold;
-  result.time_deleted_ = internal::ParseTimestampField(json, "timeDeleted");
-  result.time_storage_class_updated_ =
+  auto time_deleted = internal::ParseTimestampField(json, "timeDeleted");
+  if (!time_deleted) return std::move(time_deleted).status();
+  result.time_deleted_ = *time_deleted;
+  auto time_storage_class_updated =
       internal::ParseTimestampField(json, "timeStorageClassUpdated");
+  if (!time_storage_class_updated)
+    return std::move(time_storage_class_updated).status();
+  result.time_storage_class_updated_ = *time_storage_class_updated;
   if (json.count("customTime") == 0) {
     result.custom_time_.reset();
   } else {
-    result.custom_time_ = internal::ParseTimestampField(json, "customTime");
+    auto v = internal::ParseTimestampField(json, "customTime");
+    if (!v) return std::move(v).status();
+    result.custom_time_ = *v;
   }
   return result;
 }


### PR DESCRIPTION
Part of the work for #6935.  I will fix `ParseRfc3339()` in a followup PR, I did not want to make changes across services in the same PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6939)
<!-- Reviewable:end -->
