### PR TITLE
feat(storage): CPU usage in throughput benchmark

### DIFF
--- a/google/cloud/pubsub/benchmarks/throughput.cc
+++ b/google/cloud/pubsub/benchmarks/throughput.cc
@@ -370,7 +370,7 @@ void PublisherTask(Config const& config) {
   auto const start = std::chrono::steady_clock::now();
   for (int i = 0; !Done(config, i, start); ++i) {
     using std::chrono::steady_clock;
-    Timer timer;
+    auto timer = Timer::PerThread();
     auto const start_send_count = send_count.load();
     auto const start_send_bytes = send_bytes.load();
     auto const start_ack_count = ack_count.load();
@@ -451,7 +451,7 @@ void SubscriberTask(Config const& config) {
   auto const start = std::chrono::steady_clock::now();
   for (int i = 0; !Done(config, i, start); ++i) {
     using std::chrono::steady_clock;
-    Timer timer;
+    auto timer = Timer::PerThread();
     auto const start_count = received_count.load();
     auto const start_bytes = received_bytes.load();
     std::this_thread::sleep_for(config.iteration_duration);

--- a/google/cloud/spanner/benchmarks/multiple_rows_cpu_benchmark.cc
+++ b/google/cloud/spanner/benchmarks/multiple_rows_cpu_benchmark.cc
@@ -440,7 +440,7 @@ class BasicExperiment : public Experiment {
     auto stubs = impl_.MakeStubs(config, database);
 
     // Capture some overall getrusage() statistics as comments.
-    Timer overall;
+    auto overall = Timer::PerProcess();
     for (int i = 0; i != config.samples; ++i) {
       auto const use_stubs = impl_.UseStub(config);
       auto const thread_count = impl_.ThreadCount(config);
@@ -568,7 +568,7 @@ class ReadExperiment : public BasicExperiment<Traits> {
          start < deadline; start = std::chrono::steady_clock::now()) {
       auto key = this->impl_.RandomKeySet(config);
 
-      Timer timer;
+      auto timer = Timer::PerThread();
 
       google::spanner::v1::ReadRequest request{};
       request.set_session(*session);
@@ -631,7 +631,7 @@ class ReadExperiment : public BasicExperiment<Traits> {
          start < deadline; start = std::chrono::steady_clock::now()) {
       auto key = this->impl_.RandomKeySet(config);
 
-      Timer timer;
+      auto timer = Timer::PerThread();
       auto rows = client.Read(this->table_name_, key, column_names);
       int row_count = 0;
       Status status;
@@ -705,7 +705,7 @@ class SelectExperiment : public BasicExperiment<Traits> {
          start < deadline; start = std::chrono::steady_clock::now()) {
       auto key = this->impl_.RandomKeySetBegin(config);
 
-      Timer timer;
+      auto timer = Timer::PerThread();
 
       google::spanner::v1::ExecuteSqlRequest request{};
       request.set_session(*session);
@@ -772,7 +772,7 @@ class SelectExperiment : public BasicExperiment<Traits> {
          start < deadline; start = std::chrono::steady_clock::now()) {
       auto key = this->impl_.RandomKeySetBegin(config);
 
-      Timer timer;
+      auto timer = Timer::PerThread();
       auto rows = client.ExecuteQuery(spanner::SqlStatement(
           statement, {{"begin", spanner::Value(key)},
                       {"end", spanner::Value(key + config.query_size)}}));
@@ -872,7 +872,7 @@ class UpdateExperiment : public BasicExperiment<Traits> {
           this->impl_.GenerateRandomValue(), this->impl_.GenerateRandomValue(),
       };
 
-      Timer timer;
+      auto timer = Timer::PerThread();
 
       google::spanner::v1::ExecuteSqlRequest request{};
       request.set_session(*session);
@@ -950,7 +950,7 @@ class UpdateExperiment : public BasicExperiment<Traits> {
           this->impl_.GenerateRandomValue(), this->impl_.GenerateRandomValue(),
       };
 
-      Timer timer;
+      auto timer = Timer::PerThread();
       std::unordered_map<std::string, spanner::Value> const params{
           {"key", spanner::Value(key)},      {"v0", spanner::Value(values[0])},
           {"v1", spanner::Value(values[1])}, {"v2", spanner::Value(values[2])},
@@ -1065,7 +1065,7 @@ class MutationExperiment : public BasicExperiment<Traits> {
           this->impl_.GenerateRandomValue(), this->impl_.GenerateRandomValue(),
       };
 
-      Timer timer;
+      auto timer = Timer::PerThread();
 
       grpc::ClientContext context;
       google::spanner::v1::CommitRequest commit_request;
@@ -1129,7 +1129,7 @@ class MutationExperiment : public BasicExperiment<Traits> {
           this->impl_.GenerateRandomValue(), this->impl_.GenerateRandomValue(),
       };
 
-      Timer timer;
+      auto timer = Timer::PerThread();
 
       int row_count = 0;
       auto commit_result =

--- a/google/cloud/storage/benchmarks/storage_throughput_vs_cpu_benchmark.cc
+++ b/google/cloud/storage/benchmarks/storage_throughput_vs_cpu_benchmark.cc
@@ -289,7 +289,6 @@ TestResults RunThread(ThroughputOptions const& options, gcs::Client rest_client,
 
   auto deadline = std::chrono::steady_clock::now() + options.duration;
 
-  gcs_bm::Timer timer;
   TestResults results;
 
   std::int32_t iteration_count = 0;

--- a/google/cloud/storage/benchmarks/throughput_experiment.cc
+++ b/google/cloud/storage/benchmarks/throughput_experiment.cc
@@ -63,7 +63,7 @@ class UploadObject : public ThroughputExperiment {
     // ObjectInsert()
     if (static_cast<std::size_t>(config.object_size) < random_data_.size() &&
         prefer_insert_) {
-      Timer timer;
+      auto timer = Timer::PerThread();
       std::string data =
           random_data_.substr(0, static_cast<std::size_t>(config.object_size));
       auto object_metadata = client_.InsertObject(
@@ -82,7 +82,7 @@ class UploadObject : public ThroughputExperiment {
                               usage.cpu_time,
                               object_metadata.status()};
     }
-    Timer timer;
+    auto timer = Timer::PerThread();
     auto writer = client_.WriteObject(
         bucket_name, object_name,
         gcs::DisableCrc32cChecksum(!config.enable_crc32c),
@@ -138,7 +138,7 @@ class DownloadObject : public ThroughputExperiment {
 
     std::vector<char> buffer(config.app_buffer_size);
 
-    Timer timer;
+    auto timer = Timer::PerThread();
     auto reader = client_.ReadObject(
         bucket_name, object_name,
         gcs::DisableCrc32cChecksum(!config.enable_crc32c),
@@ -189,7 +189,7 @@ class DownloadObjectLibcurl : public ThroughputExperiment {
     auto header = creds_->AuthorizationHeader();
     if (!header) return {};
 
-    Timer timer;
+    auto timer = Timer::PerThread();
     struct curl_slist* slist1 = nullptr;
     slist1 = curl_slist_append(slist1, header->c_str());
 
@@ -283,7 +283,7 @@ class DownloadObjectRawGrpc : public ThroughputExperiment {
   ThroughputResult Run(std::string const& bucket_name,
                        std::string const& object_name,
                        ThroughputExperimentConfig const& config) override {
-    Timer timer;
+    auto timer = Timer::PerThread();
     google::storage::v1::GetObjectMediaRequest request;
     request.set_bucket(bucket_name);
     request.set_object(object_name);

--- a/google/cloud/testing_util/timer.cc
+++ b/google/cloud/testing_util/timer.cc
@@ -79,15 +79,11 @@ std::string Timer::Annotations() const {
 #if GOOGLE_CLOUD_CPP_HAVE_RUSAGE_THREAD
   std::string accounting =
       accounting_ == CpuAccounting::kPerThread ? "per-thread" : "per-process";
-#elif GOOGLE_CLOUD_CPP_HAVE_GETRUSAGE
-  std::string accounting = accounting_ == CpuAccounting::kPerThread
-                               ? "per-thread (but unsupported)"
-                               : "per-process";
 #else
   std::string accounting = accounting_ == CpuAccounting::kPerThread
                                ? "per-thread (but unsupported)"
-                               : "per-process (but unsupported)";
-#endif
+                               : "per-process";
+#endif  //  GOOGLE_CLOUD_CPP_HAVE_RUSAGE_THREAD
 
   std::ostringstream os;
   os << "# accounting                   =" << accounting

--- a/google/cloud/testing_util/timer.cc
+++ b/google/cloud/testing_util/timer.cc
@@ -76,9 +76,22 @@ std::string Timer::Annotations() const {
   now.ru_nsignals -= start_usage_.ru_nsignals;
   now.ru_nvcsw -= start_usage_.ru_nvcsw;
   now.ru_nivcsw -= start_usage_.ru_nivcsw;
+#if GOOGLE_CLOUD_CPP_HAVE_RUSAGE_THREAD
+  std::string accounting =
+      accounting_ == CpuAccounting::kPerThread ? "per-thread" : "per-process";
+#elif GOOGLE_CLOUD_CPP_HAVE_GETRUSAGE
+  std::string accounting = accounting_ == CpuAccounting::kPerThread
+                               ? "per-thread (but unsupported)"
+                               : "per-process";
+#else
+  std::string accounting = accounting_ == CpuAccounting::kPerThread
+                               ? "per-thread (but unsupported)"
+                               : "per-process (but unsupported)";
+#endif
 
   std::ostringstream os;
-  os << "# user time                    =" << utime.count() << " us\n"
+  os << "# Accounting                   =" << accounting
+     << "# user time                    =" << utime.count() << " us\n"
      << "# system time                  =" << stime.count() << " us\n"
      << "# CPU fraction                 =" << cpu_fraction << "\n"
      << "# maximum resident set size    =" << now.ru_maxrss << " KiB\n"

--- a/google/cloud/testing_util/timer.cc
+++ b/google/cloud/testing_util/timer.cc
@@ -23,12 +23,13 @@ namespace testing_util {
 #if GOOGLE_CLOUD_CPP_HAVE_GETRUSAGE
 namespace {
 int rusage_who(CpuAccounting accounting) {
-#if GOOGLE_CLOUD_CPP_HAVE_RUSAGE_THREAD
-  return accounting == CpuAccounting::kPerThread ? RUSAGE_THREAD : RUSAGE_SELF;
-#else
-  (void)accounting;
+  switch (accounting) {
+    case CpuAccounting::kPerThread:
+      return RUSAGE_THREAD;
+    case CpuAccounting::kPerProcess:
+      break;
+  }
   return RUSAGE_SELF;
-#endif  // GOOGLE_CLOUD_CPP_HAVE_RUSAGE_THREAD
 }
 }  // namespace
 #endif  // GOOGLE_CLOUD_CPP_HAVE_GETRUSAGE

--- a/google/cloud/testing_util/timer.cc
+++ b/google/cloud/testing_util/timer.cc
@@ -42,7 +42,7 @@ Timer::Snapshot Timer::Sample() const {
   (void)getrusage(RUsageWho(), &now);
   auto const utime = as_usec(now.ru_utime) - as_usec(start_usage_.ru_utime);
   auto const stime = as_usec(now.ru_stime) - as_usec(start_usage_.ru_stime);
-  return Snapshot{std::move(elapsed), utime + stime};
+  return Snapshot{elapsed, utime + stime};
 #endif  // GOOGLE_CLOUD_CPP_HAVE_GETRUSAGE
 }
 

--- a/google/cloud/testing_util/timer.cc
+++ b/google/cloud/testing_util/timer.cc
@@ -90,7 +90,7 @@ std::string Timer::Annotations() const {
 #endif
 
   std::ostringstream os;
-  os << "# Accounting                   =" << accounting
+  os << "# accounting                   =" << accounting
      << "# user time                    =" << utime.count() << " us\n"
      << "# system time                  =" << stime.count() << " us\n"
      << "# CPU fraction                 =" << cpu_fraction << "\n"

--- a/google/cloud/testing_util/timer.h
+++ b/google/cloud/testing_util/timer.h
@@ -27,6 +27,11 @@ namespace cloud {
 inline namespace GOOGLE_CLOUD_CPP_NS {
 namespace testing_util {
 
+enum class CpuAccounting {
+  kPerThread,
+  kPerProcess,
+};
+
 class Timer {
  public:
   struct Snapshot {
@@ -34,7 +39,8 @@ class Timer {
     std::chrono::microseconds cpu_time;
   };
 
-  Timer();
+  Timer() : Timer(CpuAccounting::kPerThread) {}
+  explicit Timer(CpuAccounting cpu_accounting);
 
   Snapshot Sample() const;
   std::string Annotations() const;
@@ -42,6 +48,7 @@ class Timer {
   static bool SupportsPerThreadUsage();
 
  private:
+  CpuAccounting accounting_;
   std::chrono::steady_clock::time_point start_;
 #if GOOGLE_CLOUD_CPP_HAVE_GETRUSAGE
   struct rusage start_usage_;

--- a/google/cloud/testing_util/timer.h
+++ b/google/cloud/testing_util/timer.h
@@ -38,9 +38,8 @@ class Timer {
     std::chrono::microseconds elapsed_time;
     std::chrono::microseconds cpu_time;
   };
-
-  Timer() : Timer(CpuAccounting::kPerThread) {}
-  explicit Timer(CpuAccounting cpu_accounting);
+  static Timer PerThread() { return Timer(CpuAccounting::kPerThread); }
+  static Timer PerProcess() { return Timer(CpuAccounting::kPerProcess); }
 
   Snapshot Sample() const;
   std::string Annotations() const;
@@ -48,6 +47,8 @@ class Timer {
   static bool SupportsPerThreadUsage();
 
  private:
+  explicit Timer(CpuAccounting cpu_accounting);
+
   CpuAccounting accounting_;
   std::chrono::steady_clock::time_point start_;
 #if GOOGLE_CLOUD_CPP_HAVE_GETRUSAGE

--- a/google/cloud/testing_util/timer.h
+++ b/google/cloud/testing_util/timer.h
@@ -27,11 +27,6 @@ namespace cloud {
 inline namespace GOOGLE_CLOUD_CPP_NS {
 namespace testing_util {
 
-enum class CpuAccounting {
-  kPerThread,
-  kPerProcess,
-};
-
 class Timer {
  public:
   struct Snapshot {
@@ -47,7 +42,14 @@ class Timer {
   static bool SupportsPerThreadUsage();
 
  private:
+  enum class CpuAccounting {
+    kPerThread,
+    kPerProcess,
+  };
+
   explicit Timer(CpuAccounting cpu_accounting);
+
+  int RUsageWho() const;
 
   CpuAccounting accounting_;
   std::chrono::steady_clock::time_point start_;


### PR DESCRIPTION
Capture CPU usage in the `aggregate_throughput_benchmark`. This is
useful when trying to compare the costs of different protocols.

Fixes #6884

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6941)
<!-- Reviewable:end -->
