### PR TITLE
test(GCS+gRPC): verify small uploads are optimized

### DIFF
--- a/google/cloud/storage/CMakeLists.txt
+++ b/google/cloud/storage/CMakeLists.txt
@@ -586,6 +586,7 @@ if (GOOGLE_CLOUD_CPP_STORAGE_ENABLE_GRPC)
             internal/grpc_client_bucket_metadata_test.cc
             internal/grpc_client_bucket_request_test.cc
             internal/grpc_client_failures_test.cc
+            internal/grpc_client_insert_object_media_test.cc
             internal/grpc_client_object_request_test.cc
             internal/grpc_client_test.cc
             internal/grpc_object_read_source_test.cc

--- a/google/cloud/storage/internal/grpc_client.cc
+++ b/google/cloud/storage/internal/grpc_client.cc
@@ -137,11 +137,23 @@ std::shared_ptr<GrpcClient> GrpcClient::Create(Options const& opts) {
   return std::shared_ptr<GrpcClient>(new GrpcClient(opts));
 }
 
+std::shared_ptr<GrpcClient> GrpcClient::CreateMock(
+    std::shared_ptr<StorageStub> stub) {
+  return std::shared_ptr<GrpcClient>(
+      new GrpcClient(std::move(stub), DefaultOptionsGrpc({})));
+}
+
 GrpcClient::GrpcClient(Options const& opts)
     : backwards_compatibility_options_(
           MakeBackwardsCompatibleClientOptions(opts)),
       background_(opts.get<GrpcBackgroundThreadsFactoryOption>()()),
       stub_(CreateStorageStub(background_->cq(), opts)) {}
+
+GrpcClient::GrpcClient(std::shared_ptr<StorageStub> stub, Options const& opts)
+    : backwards_compatibility_options_(
+          MakeBackwardsCompatibleClientOptions(opts)),
+      background_(opts.get<GrpcBackgroundThreadsFactoryOption>()()),
+      stub_(std::move(stub)) {}
 
 std::unique_ptr<GrpcClient::InsertStream> GrpcClient::CreateUploadWriter(
     std::unique_ptr<grpc::ClientContext> context) {

--- a/google/cloud/storage/internal/grpc_client.h
+++ b/google/cloud/storage/internal/grpc_client.h
@@ -40,6 +40,11 @@ class GrpcClient : public RawClient,
                    public std::enable_shared_from_this<GrpcClient> {
  public:
   static std::shared_ptr<GrpcClient> Create(Options const& opts);
+
+  // This is used to create a client from a mocked StorageStub.
+  static std::shared_ptr<GrpcClient> CreateMock(
+      std::shared_ptr<StorageStub> stub);
+
   ~GrpcClient() override = default;
 
   //@{
@@ -321,6 +326,7 @@ class GrpcClient : public RawClient,
 
  protected:
   explicit GrpcClient(Options const& opts);
+  explicit GrpcClient(std::shared_ptr<StorageStub> stub, Options const& opts);
 
  private:
   ClientOptions backwards_compatibility_options_;

--- a/google/cloud/storage/internal/grpc_client_insert_object_media_test.cc
+++ b/google/cloud/storage/internal/grpc_client_insert_object_media_test.cc
@@ -1,0 +1,89 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/storage/internal/grpc_client.h"
+#include "google/cloud/storage/internal/grpc_resumable_upload_session_url.h"
+#include "google/cloud/storage/internal/hybrid_client.h"
+#include "google/cloud/storage/oauth2/google_credentials.h"
+#include "google/cloud/storage/testing/mock_storage_stub.h"
+#include "google/cloud/grpc_options.h"
+#include "google/cloud/testing_util/is_proto_equal.h"
+#include "google/cloud/testing_util/status_matchers.h"
+#include "absl/memory/memory.h"
+#include <google/protobuf/text_format.h>
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+namespace storage {
+inline namespace STORAGE_CLIENT_NS {
+namespace internal {
+namespace {
+
+using ::google::cloud::storage::testing::MockInsertStream;
+using ::google::cloud::storage::testing::MockStorageStub;
+using ::google::cloud::testing_util::IsProtoEqual;
+using ::google::protobuf::TextFormat;
+using ::testing::_;
+using ::testing::Return;
+
+/// @verify that small objects are inserted with a single Write() call.
+TEST(GrpcClientInsertObjectMediaTest, Small) {
+  auto constexpr kResponseText =
+      R"pb(bucket: "test-bucket" name: "test-object" generation: 12345)pb";
+  google::storage::v1::Object response;
+  ASSERT_TRUE(TextFormat::ParseFromString(kResponseText, &response));
+
+  auto constexpr kWriteRequestText = R"pb(
+    insert_object_spec {
+      resource: { bucket: "test-bucket" name: "test-object" }
+    }
+    checksummed_data {
+      content: "The quick brown fox jumps over the lazy dog"
+      crc32c { value: 576848900 }
+    }
+    object_checksums {
+      crc32c { value: 576848900 }
+      md5_hash: "9e107d9d372bb6826bd81d3542a419d6"
+    }
+    finish_write: true
+  )pb";
+  google::storage::v1::InsertObjectRequest write_request;
+  ASSERT_TRUE(TextFormat::ParseFromString(kWriteRequestText, &write_request));
+
+  auto mock = std::make_shared<MockStorageStub>();
+  EXPECT_CALL(*mock, InsertObjectMedia)
+      .WillOnce([&](std::unique_ptr<grpc::ClientContext>) {
+        auto stream = absl::make_unique<MockInsertStream>();
+        EXPECT_CALL(*stream, Write(IsProtoEqual(write_request), _))
+            .WillOnce(Return(true));
+        EXPECT_CALL(*stream, Close).WillOnce(Return(make_status_or(response)));
+        return stream;
+      });
+  auto client = GrpcClient::CreateMock(mock);
+  auto metadata = client->InsertObjectMedia(
+      InsertObjectMediaRequest("test-bucket", "test-object",
+                               "The quick brown fox jumps over the lazy dog"));
+  ASSERT_STATUS_OK(metadata);
+  EXPECT_EQ(metadata->bucket(), "test-bucket");
+  EXPECT_EQ(metadata->name(), "test-object");
+  EXPECT_EQ(metadata->generation(), 12345);
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace STORAGE_CLIENT_NS
+}  // namespace storage
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/storage/storage_client_grpc_unit_tests.bzl
+++ b/google/cloud/storage/storage_client_grpc_unit_tests.bzl
@@ -20,6 +20,7 @@ storage_client_grpc_unit_tests = [
     "internal/grpc_client_bucket_metadata_test.cc",
     "internal/grpc_client_bucket_request_test.cc",
     "internal/grpc_client_failures_test.cc",
+    "internal/grpc_client_insert_object_media_test.cc",
     "internal/grpc_client_object_request_test.cc",
     "internal/grpc_client_test.cc",
     "internal/grpc_object_read_source_test.cc",

--- a/google/cloud/storage/testing/mock_storage_stub.h
+++ b/google/cloud/storage/testing/mock_storage_stub.h
@@ -150,6 +150,16 @@ class MockStorageStub : public internal::StorageStub {
               (override));
 };
 
+class MockInsertStream : public internal::StorageStub::InsertStream {
+ public:
+  MOCK_METHOD(void, Cancel, (), (override));
+  MOCK_METHOD(bool, Write,
+              (google::storage::v1::InsertObjectRequest const&,
+               grpc::WriteOptions),
+              (override));
+  MOCK_METHOD(StatusOr<google::storage::v1::Object>, Close, (), (override));
+};
+
 }  // namespace testing
 }  // namespace storage
 }  // namespace cloud


### PR DESCRIPTION
Small uploads can include the metadata, the data, and the checksums in a
single `Write()` call. This adds a test to verify the plugin actually
does so.

Fixes #4383

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6951)
<!-- Reviewable:end -->
