### PR TITLE
feat(storage): more accurate aggregate bandwidth results

### DIFF
--- a/google/cloud/storage/benchmarks/aggregate_throughput_benchmark.cc
+++ b/google/cloud/storage/benchmarks/aggregate_throughput_benchmark.cc
@@ -214,14 +214,24 @@ int main(int argc, char* argv[]) {
     return bytes_received;
   };
 
+  using clock = std::chrono::steady_clock;
+  auto deadline = clock::now() + options->running_time;
   auto timer = Timer::PerProcess();
   auto usage = timer.Sample();
-  while (usage.elapsed_time < options->running_time) {
-    std::this_thread::sleep_for(options->reporting_interval);
+  for (auto now = clock::now(); now < deadline; now = clock::now()) {
+    std::this_thread::sleep_until(
+        (std::min)(now + options->reporting_interval, deadline));
     usage = timer.Sample();
     std::cout << current_time() << "," << accumulate_bytes_received() << ","
               << usage.cpu_time.count() << std::endl;
   }
+
+  Counters accumulated;
+  for (auto& t : tasks) {
+    auto counters = t.get();
+    for (auto const& kv : counters) accumulated[kv.first] += kv.second;
+  }
+  usage = timer.Sample();
   auto const bytes_received = accumulate_bytes_received();
   std::cout << "# Bytes Received: " << FormatSize(bytes_received)
             << "\n# Elapsed Time: " << absl::FromChrono(usage.elapsed_time)
@@ -230,12 +240,6 @@ int main(int argc, char* argv[]) {
             << "Gbit/s  "
             << FormatBandwidthGiBPerSecond(bytes_received, usage.elapsed_time)
             << "GiB/s\n";
-
-  Counters accumulated;
-  for (auto& t : tasks) {
-    auto counters = t.get();
-    for (auto const& kv : counters) accumulated[kv.first] += kv.second;
-  }
   for (auto& kv : accumulated) {
     std::cout << "# counter " << kv.first << ": " << kv.second << "\n";
   }

--- a/google/cloud/storage/benchmarks/aggregate_throughput_benchmark.cc
+++ b/google/cloud/storage/benchmarks/aggregate_throughput_benchmark.cc
@@ -217,11 +217,10 @@ int main(int argc, char* argv[]) {
   using clock = std::chrono::steady_clock;
   auto deadline = clock::now() + options->running_time;
   auto timer = Timer::PerProcess();
-  auto usage = timer.Sample();
   for (auto now = clock::now(); now < deadline; now = clock::now()) {
     std::this_thread::sleep_until(
         (std::min)(now + options->reporting_interval, deadline));
-    usage = timer.Sample();
+    auto const usage = timer.Sample();
     std::cout << current_time() << "," << accumulate_bytes_received() << ","
               << usage.cpu_time.count() << std::endl;
   }
@@ -231,10 +230,11 @@ int main(int argc, char* argv[]) {
     auto counters = t.get();
     for (auto const& kv : counters) accumulated[kv.first] += kv.second;
   }
-  usage = timer.Sample();
+  auto const usage = timer.Sample();
   auto const bytes_received = accumulate_bytes_received();
   std::cout << "# Bytes Received: " << FormatSize(bytes_received)
             << "\n# Elapsed Time: " << absl::FromChrono(usage.elapsed_time)
+            << "\n# CPU Time: " << absl::FromChrono(usage.cpu_time)
             << "\n# Bandwidth: "
             << FormatBandwidthGbPerSecond(bytes_received, usage.elapsed_time)
             << "Gbit/s  "


### PR DESCRIPTION
In the aggregate_throughput benchmark we do not want to sleep for longer
than the total running time, or the main thread would be sleeping while
no work is done by the worker threads, and the elapsed time measurement
would include time when no work was being done.

Likewise, we want to wait until all threads are done with their
downloads before reporting the aggregate bandwidth.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6953)
<!-- Reviewable:end -->
