### PR TITLE
feat(storage): use Base64 transforms

### DIFF
--- a/google/cloud/internal/base64_transforms.cc
+++ b/google/cloud/internal/base64_transforms.cc
@@ -106,7 +106,7 @@ Status Base64DecodingError(std::string const& input,
 template <typename Sink>
 Status Base64DecodeGeneric(std::string const& input, Sink const& sink) {
   auto p = input.begin();
-  for (;std::distance(p, input.end()) >= 4; p = std::next(p, 4)) {
+  for (; std::distance(p, input.end()) >= 4; p = std::next(p, 4)) {
     if (!Base64Fill(*p, *(p + 1), *(p + 2), *(p + 3), sink)) break;
   }
   if (p != input.end()) return Base64DecodingError(input, p);

--- a/google/cloud/internal/base64_transforms.h
+++ b/google/cloud/internal/base64_transforms.h
@@ -19,8 +19,10 @@
 #include "google/cloud/version.h"
 #include <array>
 #include <cstddef>
+#include <cstdint>
 #include <iterator>
 #include <string>
+#include <vector>
 
 namespace google {
 namespace cloud {
@@ -94,27 +96,10 @@ struct Base64Decoder {
   std::string const& rep_;  // encoded
 };
 
-Status Base64DecodingError(std::string const& base64,
-                           std::string::const_iterator p);
-
-std::pair<std::array<unsigned char, 3>, std::size_t> Base64Fill(
-    unsigned char p0, unsigned char p1, unsigned char p2, unsigned char p3);
-
-template <typename Sink>
-Status FromBase64(std::string const& base64, Sink const& sink) {
-  auto p = base64.begin();
-  for (; std::distance(p, base64.end()) >= 4; p = std::next(p, 4)) {
-    auto r = Base64Fill(*p, *(p + 1), *(p + 2), *(p + 3));
-    if (r.second == 0) return Base64DecodingError(base64, p);
-    for (auto* o = r.first.begin(); o != r.first.begin() + r.second; ++o) {
-      sink(*o);
-    }
-  }
-  if (p != base64.end()) return Base64DecodingError(base64, p);
-  return Status{};
-}
-
 Status ValidateBase64String(std::string const& input);
+
+StatusOr<std::vector<std::uint8_t>> Base64DecodeToBytes(
+    std::string const& input);
 
 }  // namespace internal
 }  // namespace GOOGLE_CLOUD_CPP_NS

--- a/google/cloud/storage/internal/openssl_util.cc
+++ b/google/cloud/storage/internal/openssl_util.cc
@@ -45,11 +45,7 @@ inline std::unique_ptr<EVP_MD_CTX, decltype(&EVP_MD_CTX_free)> GetDigestCtx() {
 }  // namespace
 
 std::vector<std::uint8_t> Base64Decode(std::string const& str) {
-  std::vector<std::uint8_t> result;
-  auto status = google::cloud::internal::FromBase64(
-      str, [&result](unsigned char c) { result.push_back(c); });
-  if (!status.ok()) google::cloud::internal::ThrowStatus(std::move(status));
-  return result;
+  return google::cloud::internal::Base64DecodeToBytes(str).value();
 }
 
 std::string Base64Encode(std::string const& str) {


### PR DESCRIPTION
Use the transforms in `google::cloud::internal::` to convert from and to
base64 encoding. For the moment these continue to through exceptions on
errors, a future PR will convert the remaining exception to
`StatusOr<>`.

I performed some refactoring in the base64 transforms: in spanner the
base64 decoding is always performed after the source is validated, in
storage that is not the case.

Part of the work for #6946

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6956)
<!-- Reviewable:end -->
