### PR TITLE
test(spanner): use text protos to test admin-connection APIs

### DIFF
--- a/google/cloud/spanner/database_admin_connection_test.cc
+++ b/google/cloud/spanner/database_admin_connection_test.cc
@@ -417,8 +417,7 @@ TEST(DatabaseAdminConnectionTest, UpdateDatabaseGetOperationError) {
 
 /// @test Verify that we can list databases in multiple pages.
 TEST(DatabaseAdminConnectionTest, ListDatabases) {
-  gcsa::Database expected_databases[5];
-  ASSERT_TRUE(TextFormat::ParseFromString(
+  constexpr char const* kDatabaseText[5] = {
       R"pb(
         name: "projects/project/instances/instance/databases/db-1"
         state: READY
@@ -439,8 +438,6 @@ TEST(DatabaseAdminConnectionTest, ListDatabases) {
         earliest_version_time { seconds: 1625696199 nanos: 111111111 }
         default_leader: "us-east1"
       )pb",
-      &expected_databases[0]));
-  ASSERT_TRUE(TextFormat::ParseFromString(
       R"pb(
         name: "projects/project/instances/instance/databases/db-2"
         state: READY
@@ -461,8 +458,6 @@ TEST(DatabaseAdminConnectionTest, ListDatabases) {
         earliest_version_time { seconds: 1625696199 nanos: 222222222 }
         default_leader: "us-east2"
       )pb",
-      &expected_databases[1]));
-  ASSERT_TRUE(TextFormat::ParseFromString(
       R"pb(
         name: "projects/project/instances/instance/databases/db-3"
         state: READY
@@ -483,8 +478,6 @@ TEST(DatabaseAdminConnectionTest, ListDatabases) {
         earliest_version_time { seconds: 1625696199 nanos: 333333333 }
         default_leader: "us-east3"
       )pb",
-      &expected_databases[2]));
-  ASSERT_TRUE(TextFormat::ParseFromString(
       R"pb(
         name: "projects/project/instances/instance/databases/db-4"
         state: READY
@@ -505,8 +498,6 @@ TEST(DatabaseAdminConnectionTest, ListDatabases) {
         earliest_version_time { seconds: 1625696199 nanos: 444444444 }
         default_leader: "us-east4"
       )pb",
-      &expected_databases[3]));
-  ASSERT_TRUE(TextFormat::ParseFromString(
       R"pb(
         name: "projects/project/instances/instance/databases/db-5"
         state: READY
@@ -527,7 +518,18 @@ TEST(DatabaseAdminConnectionTest, ListDatabases) {
         earliest_version_time { seconds: 1625696199 nanos: 555555555 }
         default_leader: "us-east5"
       )pb",
-      &expected_databases[4]));
+  };
+  gcsa::Database expected_databases[5];
+  ASSERT_TRUE(
+      TextFormat::ParseFromString(kDatabaseText[0], &expected_databases[0]));
+  ASSERT_TRUE(
+      TextFormat::ParseFromString(kDatabaseText[1], &expected_databases[1]));
+  ASSERT_TRUE(
+      TextFormat::ParseFromString(kDatabaseText[2], &expected_databases[2]));
+  ASSERT_TRUE(
+      TextFormat::ParseFromString(kDatabaseText[3], &expected_databases[3]));
+  ASSERT_TRUE(
+      TextFormat::ParseFromString(kDatabaseText[4], &expected_databases[4]));
 
   Instance in("project", "instance");
   std::string const expected_parent = in.FullName();

--- a/google/cloud/spanner/database_admin_connection_test.cc
+++ b/google/cloud/spanner/database_admin_connection_test.cc
@@ -422,7 +422,7 @@ TEST(DatabaseAdminConnectionTest, ListDatabases) {
       R"pb(
         name: "projects/project/instances/instance/databases/db-1"
         state: READY
-        create_time { seconds: 1625696199 nanos: 123456789 }
+        create_time { seconds: 1625696199 nanos: 111111111 }
         restore_info {
           source_type: BACKUP
           backup_info {
@@ -524,7 +524,7 @@ TEST(DatabaseAdminConnectionTest, ListDatabases) {
           kms_key_name: "projects/project/locations/location/keyRings/ring/cryptoKeys/key"
         }
         version_retention_period: "5d"
-        earliest_version_time { seconds: 1625696199 nanos: 123456789 }
+        earliest_version_time { seconds: 1625696199 nanos: 555555555 }
         default_leader: "us-east5"
       )pb",
       &expected_databases[4]));

--- a/google/cloud/spanner/instance_admin_connection_test.cc
+++ b/google/cloud/spanner/instance_admin_connection_test.cc
@@ -363,8 +363,7 @@ TEST(InstanceAdminConnectionTest, GetInstanceConfigTooManyTransients) {
 }
 
 TEST(InstanceAdminConnectionTest, ListInstanceConfigsSuccess) {
-  gcsa::InstanceConfig expected_instance_configs[3];
-  ASSERT_TRUE(TextFormat::ParseFromString(
+  constexpr const char* kInstanceConfigText[3] = {
       R"pb(
         name: "projects/test-project/instanceConfigs/test-instance-config-1"
         display_name: "test display name 1"
@@ -375,8 +374,6 @@ TEST(InstanceAdminConnectionTest, ListInstanceConfigsSuccess) {
         }
         leader_options: "location1"
       )pb",
-      &expected_instance_configs[0]));
-  ASSERT_TRUE(TextFormat::ParseFromString(
       R"pb(
         name: "projects/test-project/instanceConfigs/test-instance-config-2"
         display_name: "test display name 2"
@@ -387,8 +384,6 @@ TEST(InstanceAdminConnectionTest, ListInstanceConfigsSuccess) {
         }
         leader_options: "location2"
       )pb",
-      &expected_instance_configs[1]));
-  ASSERT_TRUE(TextFormat::ParseFromString(
       R"pb(
         name: "projects/test-project/instanceConfigs/test-instance-config-3"
         display_name: "test display name 3"
@@ -399,7 +394,14 @@ TEST(InstanceAdminConnectionTest, ListInstanceConfigsSuccess) {
         }
         leader_options: "location3"
       )pb",
-      &expected_instance_configs[2]));
+  };
+  gcsa::InstanceConfig expected_instance_configs[3];
+  ASSERT_TRUE(TextFormat::ParseFromString(kInstanceConfigText[0],
+                                          &expected_instance_configs[0]));
+  ASSERT_TRUE(TextFormat::ParseFromString(kInstanceConfigText[1],
+                                          &expected_instance_configs[1]));
+  ASSERT_TRUE(TextFormat::ParseFromString(kInstanceConfigText[2],
+                                          &expected_instance_configs[2]));
 
   std::string const expected_parent = "projects/test-project";
   auto mock = std::make_shared<spanner_testing::MockInstanceAdminStub>();

--- a/google/cloud/spanner/instance_admin_connection_test.cc
+++ b/google/cloud/spanner/instance_admin_connection_test.cc
@@ -33,6 +33,7 @@ using ::google::cloud::testing_util::IsProtoEqual;
 using ::google::cloud::testing_util::StatusIs;
 using ::google::protobuf::TextFormat;
 using ::testing::AtLeast;
+using ::testing::ElementsAre;
 using ::testing::Return;
 
 namespace gcsa = ::google::spanner::admin::instance::v1;
@@ -63,7 +64,7 @@ TEST(InstanceAdminConnectionTest, GetInstanceSuccess) {
   std::string const expected_name =
       "projects/test-project/instances/test-instance";
 
-  auto constexpr kText = R"pb(
+  auto constexpr kInstanceText = R"pb(
     name: "projects/test-project/instances/test-instance"
     config: "test-config"
     display_name: "test display name"
@@ -71,7 +72,7 @@ TEST(InstanceAdminConnectionTest, GetInstanceSuccess) {
     state: CREATING
   )pb";
   gcsa::Instance expected_instance;
-  ASSERT_TRUE(TextFormat::ParseFromString(kText, &expected_instance));
+  ASSERT_TRUE(TextFormat::ParseFromString(kInstanceText, &expected_instance));
 
   auto mock = std::make_shared<spanner_testing::MockInstanceAdminStub>();
   EXPECT_CALL(*mock, GetInstance)
@@ -305,12 +306,19 @@ TEST(InstanceAdminConnectionTest, DeleteInstanceTooManyTransients) {
 TEST(InstanceAdminConnectionTest, GetInstanceConfigSuccess) {
   std::string const expected_name =
       "projects/test-project/instanceConfigs/test-instance-config";
-  auto constexpr kText = R"pb(
+  auto constexpr kConfigText = R"pb(
     name: "projects/test-project/instanceConfigs/test-instance-config"
     display_name: "test display name"
+    replicas {
+      location: "location"
+      type: READ_WRITE
+      default_leader_location: true
+    }
+    leader_options: "location"
   )pb";
   gcsa::InstanceConfig expected_instance_config;
-  ASSERT_TRUE(TextFormat::ParseFromString(kText, &expected_instance_config));
+  ASSERT_TRUE(
+      TextFormat::ParseFromString(kConfigText, &expected_instance_config));
 
   auto mock = std::make_shared<spanner_testing::MockInstanceAdminStub>();
   EXPECT_CALL(*mock, GetInstanceConfig)
@@ -355,8 +363,45 @@ TEST(InstanceAdminConnectionTest, GetInstanceConfigTooManyTransients) {
 }
 
 TEST(InstanceAdminConnectionTest, ListInstanceConfigsSuccess) {
-  std::string const expected_parent = "projects/test-project";
+  gcsa::InstanceConfig expected_instance_configs[3];
+  ASSERT_TRUE(TextFormat::ParseFromString(
+      R"pb(
+        name: "projects/test-project/instanceConfigs/test-instance-config-1"
+        display_name: "test display name 1"
+        replicas {
+          location: "location1"
+          type: READ_WRITE
+          default_leader_location: true
+        }
+        leader_options: "location1"
+      )pb",
+      &expected_instance_configs[0]));
+  ASSERT_TRUE(TextFormat::ParseFromString(
+      R"pb(
+        name: "projects/test-project/instanceConfigs/test-instance-config-2"
+        display_name: "test display name 2"
+        replicas {
+          location: "location2"
+          type: READ_WRITE
+          default_leader_location: true
+        }
+        leader_options: "location2"
+      )pb",
+      &expected_instance_configs[1]));
+  ASSERT_TRUE(TextFormat::ParseFromString(
+      R"pb(
+        name: "projects/test-project/instanceConfigs/test-instance-config-3"
+        display_name: "test display name 3"
+        replicas {
+          location: "location3"
+          type: READ_WRITE
+          default_leader_location: true
+        }
+        leader_options: "location3"
+      )pb",
+      &expected_instance_configs[2]));
 
+  std::string const expected_parent = "projects/test-project";
   auto mock = std::make_shared<spanner_testing::MockInstanceAdminStub>();
   EXPECT_CALL(*mock, ListInstanceConfigs)
       .WillOnce([&](grpc::ClientContext&,
@@ -372,8 +417,8 @@ TEST(InstanceAdminConnectionTest, ListInstanceConfigsSuccess) {
 
         gcsa::ListInstanceConfigsResponse response;
         response.set_next_page_token("p1");
-        response.add_instance_configs()->set_name("c1");
-        response.add_instance_configs()->set_name("c2");
+        *response.add_instance_configs() = expected_instance_configs[0];
+        *response.add_instance_configs() = expected_instance_configs[1];
         return response;
       })
       .WillOnce([&](grpc::ClientContext&,
@@ -383,18 +428,21 @@ TEST(InstanceAdminConnectionTest, ListInstanceConfigsSuccess) {
 
         gcsa::ListInstanceConfigsResponse response;
         response.clear_next_page_token();
-        response.add_instance_configs()->set_name("c3");
+        *response.add_instance_configs() = expected_instance_configs[2];
         return response;
       });
 
   auto conn = MakeLimitedRetryConnection(mock);
-  std::vector<std::string> actual_names;
+  std::vector<gcsa::InstanceConfig> actual_instance_configs;
   for (auto const& instance_config :
        conn->ListInstanceConfigs({"test-project"})) {
     ASSERT_STATUS_OK(instance_config);
-    actual_names.push_back(instance_config->name());
+    actual_instance_configs.push_back(*instance_config);
   }
-  EXPECT_THAT(actual_names, ::testing::ElementsAre("c1", "c2", "c3"));
+  EXPECT_THAT(actual_instance_configs,
+              ElementsAre(IsProtoEqual(expected_instance_configs[0]),
+                          IsProtoEqual(expected_instance_configs[1]),
+                          IsProtoEqual(expected_instance_configs[2])));
 }
 
 TEST(InstanceAdminConnectionTest, ListInstanceConfigsPermanentFailure) {
@@ -465,7 +513,7 @@ TEST(InstanceAdminConnectionTest, ListInstancesSuccess) {
     ASSERT_STATUS_OK(instance);
     actual_names.push_back(instance->name());
   }
-  EXPECT_THAT(actual_names, ::testing::ElementsAre("i1", "i2", "i3"));
+  EXPECT_THAT(actual_names, ElementsAre("i1", "i2", "i3"));
 }
 
 TEST(InstanceAdminConnectionTest, ListInstancesPermanentFailure) {
@@ -546,7 +594,7 @@ TEST(InstanceAdminConnectionTest, SetIamPolicySuccess) {
   std::string const expected_name =
       "projects/test-project/instances/test-instance";
 
-  auto constexpr kText = R"pb(
+  auto constexpr kPolicyText = R"pb(
     etag: "request-etag"
     bindings {
       role: "roles/spanner.databaseReader"
@@ -555,7 +603,7 @@ TEST(InstanceAdminConnectionTest, SetIamPolicySuccess) {
     }
   )pb";
   giam::Policy expected_policy;
-  ASSERT_TRUE(TextFormat::ParseFromString(kText, &expected_policy));
+  ASSERT_TRUE(TextFormat::ParseFromString(kPolicyText, &expected_policy));
 
   auto mock = std::make_shared<spanner_testing::MockInstanceAdminStub>();
   EXPECT_CALL(*mock, SetIamPolicy)


### PR DESCRIPTION
Use full text protos, which set every field, to test the Spanner
GetDatabase/ListDatabases and GetInstanceConfig/ListInstanceConfigs
admin-connection APIs, rather than only individually assigning and
checking certain fields.  While these APIs are quite thin, this
gives us a little more confidence that we're not missing anything.

It also allows us to add new fields without changing the control
flow in the test.  That was the primary goal in this case, so as
to get coverage for the new "configurable leader placement" fields
`google.spanner.admin.database.v1.Database.default_leader` and
`google.spanner.admin.instance.v1.InstanceConfig.leader_options`.

In addition, the `GetDatabaseWithEncryption` test becomes redundant.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6958)
<!-- Reviewable:end -->
