### PR TITLE
cleanup(GCS+gRPC): compute MD5 hashes directly

### DIFF
--- a/google/cloud/storage/hashing_options.cc
+++ b/google/cloud/storage/hashing_options.cc
@@ -16,21 +16,14 @@
 #include "google/cloud/storage/internal/openssl_util.h"
 #include "google/cloud/internal/big_endian.h"
 #include <crc32c/crc32c.h>
-#include <openssl/md5.h>
-#include <cstring>
 
 namespace google {
 namespace cloud {
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
-std::string ComputeMD5Hash(std::string const& payload) {
-  MD5_CTX md5;
-  MD5_Init(&md5);
-  MD5_Update(&md5, payload.c_str(), payload.size());
 
-  std::string hash(MD5_DIGEST_LENGTH, ' ');
-  MD5_Final(reinterpret_cast<unsigned char*>(&hash[0]), &md5);
-  return internal::Base64Encode(hash);
+std::string ComputeMD5Hash(std::string const& payload) {
+  return internal::Base64Encode(internal::MD5Hash(payload));
 }
 
 std::string ComputeCrc32cChecksum(std::string const& payload) {

--- a/google/cloud/storage/internal/grpc_client.cc
+++ b/google/cloud/storage/internal/grpc_client.cc
@@ -1762,7 +1762,7 @@ google::storage::v1::InsertObjectRequest GrpcClient::ToProto(
   // TODO(#4156) - use the crc32c value in the request options.
   checksums.mutable_crc32c()->set_value(crc32c::Crc32c(request.contents()));
   // TODO(#4157) - use the MD5 hash value in the request options.
-  checksums.set_md5_hash(MD5ToProto(ComputeMD5Hash(request.contents())));
+  checksums.set_md5_hash(ComputeMD5Hash(request.contents()));
 
   return r;
 }
@@ -1871,10 +1871,8 @@ std::string GrpcClient::MD5FromProto(std::string const& v) {
   return internal::Base64Encode(binary);
 }
 
-std::string GrpcClient::MD5ToProto(std::string const& v) {
-  if (v.empty()) return {};
-  auto binary = internal::Base64Decode(v);
-  return internal::HexEncode(binary);
+std::string GrpcClient::ComputeMD5Hash(const std::string& payload) {
+  return internal::HexEncode(internal::MD5Hash(payload));
 }
 
 }  // namespace internal

--- a/google/cloud/storage/internal/grpc_client.cc
+++ b/google/cloud/storage/internal/grpc_client.cc
@@ -1871,6 +1871,12 @@ std::string GrpcClient::MD5FromProto(std::string const& v) {
   return internal::Base64Encode(binary);
 }
 
+std::string GrpcClient::MD5ToProto(std::string const& v) {
+  if (v.empty()) return {};
+  auto binary = internal::Base64Decode(v);
+  return internal::HexEncode(binary);
+}
+
 std::string GrpcClient::ComputeMD5Hash(const std::string& payload) {
   return internal::HexEncode(internal::MD5Hash(payload));
 }

--- a/google/cloud/storage/internal/grpc_client.h
+++ b/google/cloud/storage/internal/grpc_client.h
@@ -322,7 +322,7 @@ class GrpcClient : public RawClient,
   static std::string Crc32cFromProto(google::protobuf::UInt32Value const&);
   static std::uint32_t Crc32cToProto(std::string const&);
   static std::string MD5FromProto(std::string const&);
-  static std::string MD5ToProto(std::string const&);
+  static std::string ComputeMD5Hash(std::string const& payload);
 
  protected:
   explicit GrpcClient(Options const& opts);

--- a/google/cloud/storage/internal/grpc_client.h
+++ b/google/cloud/storage/internal/grpc_client.h
@@ -322,6 +322,7 @@ class GrpcClient : public RawClient,
   static std::string Crc32cFromProto(google::protobuf::UInt32Value const&);
   static std::uint32_t Crc32cToProto(std::string const&);
   static std::string MD5FromProto(std::string const&);
+  static std::string MD5ToProto(std::string const&);
   static std::string ComputeMD5Hash(std::string const& payload);
 
  protected:

--- a/google/cloud/storage/internal/grpc_client_test.cc
+++ b/google/cloud/storage/internal/grpc_client_test.cc
@@ -208,15 +208,21 @@ TEST(GrpcClientFromProto, Crc32cRoundtrip) {
 }
 
 TEST(GrpcClientFromProto, MD5Roundtrip) {
-  std::string const values[] = {
-      "1B2M2Y8AsgTpgAmY7PhCfg==",
-      "nhB9nTcrtoJr2B01QqQZ1g==",
-      "96HF9K981B+JfoQuTVnyCg==",
+  // As usual, get the values using openssl, e.g.,
+  //  TEXT="The quick brown fox jumps over the lazy dog"
+  //  /bin/echo -n $TEXT | openssl md5 -binary | openssl base64
+  //  /bin/echo -n $TEXT | openssl md5
+  struct Test {
+    std::string rest;
+    std::string proto;
+  } cases[] = {
+      {"1B2M2Y8AsgTpgAmY7PhCfg==", "d41d8cd98f00b204e9800998ecf8427e"},
+      {"nhB9nTcrtoJr2B01QqQZ1g==", "9e107d9d372bb6826bd81d3542a419d6"},
+      {"96HF9K981B+JfoQuTVnyCg==", "f7a1c5f4af7cd41f897e842e4d59f20a"},
   };
-  for (auto const& start : values) {
-    auto proto_form = GrpcClient::MD5ToProto(start);
-    auto end = GrpcClient::MD5FromProto(proto_form);
-    EXPECT_EQ(start, end) << " proto_form=" << proto_form;
+  for (auto const& test : cases) {
+    auto actual = GrpcClient::MD5FromProto(test.proto);
+    EXPECT_EQ(actual, test.rest);
   }
 }
 

--- a/google/cloud/storage/internal/grpc_client_test.cc
+++ b/google/cloud/storage/internal/grpc_client_test.cc
@@ -221,8 +221,8 @@ TEST(GrpcClientFromProto, MD5Roundtrip) {
       {"96HF9K981B+JfoQuTVnyCg==", "f7a1c5f4af7cd41f897e842e4d59f20a"},
   };
   for (auto const& test : cases) {
-    auto actual = GrpcClient::MD5FromProto(test.proto);
-    EXPECT_EQ(actual, test.rest);
+    EXPECT_EQ(GrpcClient::MD5FromProto(test.proto), test.rest);
+    EXPECT_EQ(GrpcClient::MD5ToProto(test.rest), test.proto);
   }
 }
 

--- a/google/cloud/storage/internal/openssl_util.cc
+++ b/google/cloud/storage/internal/openssl_util.cc
@@ -14,10 +14,10 @@
 
 #include "google/cloud/storage/internal/openssl_util.h"
 #include "google/cloud/internal/base64_transforms.h"
-#include "google/cloud/internal/throw_delegate.h"
 #include <openssl/bio.h>
 #include <openssl/buffer.h>
 #include <openssl/evp.h>
+#include <openssl/md5.h>
 #include <openssl/opensslv.h>
 #include <openssl/pem.h>
 #include <memory>
@@ -170,6 +170,20 @@ std::vector<std::uint8_t> UrlsafeBase64Decode(std::string const& str) {
     b64str.append("=");
   }
   return Base64Decode(b64str);
+}
+
+std::vector<std::uint8_t> MD5Hash(std::string const& payload) {
+  MD5_CTX md5;
+  MD5_Init(&md5);
+  MD5_Update(&md5, payload.c_str(), payload.size());
+
+  std::vector<std::uint8_t> hash(MD5_DIGEST_LENGTH, 0);
+  // Note: MD5_Final consumes a `unsigned char*` in its first parameter, on some
+  // platforms (PowerPC and ARM I read), the default `char` is unsigned. In
+  // those platforms it is possible that `std::uint8_t != unsigned char` and
+  // the `reinterpret_cast<>` is not trivial (but still safe I think).
+  MD5_Final(reinterpret_cast<unsigned char*>(hash.data()), &md5);
+  return hash;
 }
 
 }  // namespace internal

--- a/google/cloud/storage/internal/openssl_util.h
+++ b/google/cloud/storage/internal/openssl_util.h
@@ -78,6 +78,9 @@ inline std::string UrlsafeBase64Encode(Collection const& bytes) {
  */
 std::vector<std::uint8_t> UrlsafeBase64Decode(std::string const& str);
 
+/// Compute the MD5 hash of @p payload
+std::vector<std::uint8_t> MD5Hash(std::string const& payload);
+
 }  // namespace internal
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage

--- a/google/cloud/storage/internal/openssl_util_test.cc
+++ b/google/cloud/storage/internal/openssl_util_test.cc
@@ -68,6 +68,27 @@ TEST(OpensslUtilTest, Base64DecodePadding) {
   EXPECT_THAT(UrlsafeBase64Decode("QUJDRA=="), ElementsAre('A', 'B', 'C', 'D'));
 }
 
+TEST(OpensslUtilTest, MD5HashEmpty) {
+  auto const actual = MD5Hash("");
+  // I used this command to get the expected value:
+  // /bin/echo -n "" | openssl md5
+  auto const expected =
+      std::vector<std::uint8_t>{0xd4, 0x1d, 0x8c, 0xd9, 0x8f, 0x00, 0xb2, 0x04,
+                                0xe9, 0x80, 0x09, 0x98, 0xec, 0xf8, 0x42, 0x7e};
+  EXPECT_THAT(actual, ElementsAreArray(expected));
+}
+
+TEST(OpensslUtilTest, MD5HashSimple) {
+  auto const actual = MD5Hash("The quick brown fox jumps over the lazy dog");
+  // I used this command to get the expected value:
+  // /bin/echo -n "The quick brown fox jumps over the lazy dog" |
+  //     openssl md5 -binary | openssl base64
+  auto const expected =
+      std::vector<std::uint8_t>{0x9e, 0x10, 0x7d, 0x9d, 0x37, 0x2b, 0xb6, 0x82,
+                                0x6b, 0xd8, 0x1d, 0x35, 0x42, 0xa4, 0x19, 0xd6};
+  EXPECT_THAT(actual, ElementsAreArray(expected));
+}
+
 }  // namespace
 }  // namespace internal
 }  // namespace STORAGE_CLIENT_NS


### PR DESCRIPTION
Avoid going through the base64 representation used in the REST protocol,
as this requires weaving error handling through many layers.

Part of the work for #6946

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6959)
<!-- Reviewable:end -->
