### PR TITLE
cleanup(storage): error handling in base64 decoding

### DIFF
--- a/google/cloud/storage/client.cc
+++ b/google/cloud/storage/client.cc
@@ -356,11 +356,10 @@ StatusOr<Client::SignBlobResponseRaw> Client::SignBlobImpl(
   internal::SignBlobRequest sign_request(
       signing_account_email, internal::Base64Encode(string_to_sign), {});
   auto response = raw_client_->SignBlob(sign_request);
-  if (!response) {
-    return response.status();
-  }
-  return SignBlobResponseRaw{response->key_id,
-                             internal::Base64Decode(response->signed_blob)};
+  if (!response) return response.status();
+  auto decoded = internal::Base64Decode(response->signed_blob);
+  if (!decoded) return std::move(decoded).status();
+  return SignBlobResponseRaw{response->key_id, *std::move(decoded)};
 }
 
 StatusOr<std::string> Client::SignUrlV2(

--- a/google/cloud/storage/client_sign_policy_document_test.cc
+++ b/google/cloud/storage/client_sign_policy_document_test.cc
@@ -53,7 +53,7 @@ constexpr char kJsonKeyfileContents[] = R"""({
  * base64.
  */
 std::string Dec64(std::string const& s) {
-  auto res = internal::Base64Decode(s);
+  auto res = internal::Base64Decode(s).value();
   return std::string(res.begin(), res.end());
 };
 

--- a/google/cloud/storage/internal/grpc_client.cc
+++ b/google/cloud/storage/internal/grpc_client.cc
@@ -1850,11 +1850,11 @@ std::string GrpcClient::Crc32cFromProto(
   return Base64Encode(endian_encoded);
 }
 
-std::uint32_t GrpcClient::Crc32cToProto(std::string const& v) {
+StatusOr<std::uint32_t> GrpcClient::Crc32cToProto(std::string const& v) {
   auto decoded = Base64Decode(v);
+  if (!decoded) return std::move(decoded).status();
   return google::cloud::internal::DecodeBigEndian<std::uint32_t>(
-             std::string(decoded.begin(), decoded.end()))
-      .value();
+      std::string(decoded->begin(), decoded->end()));
 }
 
 std::string GrpcClient::MD5FromProto(std::string const& v) {
@@ -1863,10 +1863,11 @@ std::string GrpcClient::MD5FromProto(std::string const& v) {
   return internal::Base64Encode(binary);
 }
 
-std::string GrpcClient::MD5ToProto(std::string const& v) {
+StatusOr<std::string> GrpcClient::MD5ToProto(std::string const& v) {
   if (v.empty()) return {};
   auto binary = internal::Base64Decode(v);
-  return internal::HexEncode(binary);
+  if (!binary) return std::move(binary).status();
+  return internal::HexEncode(*binary);
 }
 
 std::string GrpcClient::ComputeMD5Hash(const std::string& payload) {

--- a/google/cloud/storage/internal/grpc_client.h
+++ b/google/cloud/storage/internal/grpc_client.h
@@ -320,9 +320,9 @@ class GrpcClient : public RawClient,
       ReadObjectRangeRequest const& request);
 
   static std::string Crc32cFromProto(google::protobuf::UInt32Value const&);
-  static std::uint32_t Crc32cToProto(std::string const&);
+  static StatusOr<std::uint32_t> Crc32cToProto(std::string const&);
   static std::string MD5FromProto(std::string const&);
-  static std::string MD5ToProto(std::string const&);
+  static StatusOr<std::string> MD5ToProto(std::string const&);
   static std::string ComputeMD5Hash(std::string const& payload);
 
  protected:

--- a/google/cloud/storage/internal/grpc_client_test.cc
+++ b/google/cloud/storage/internal/grpc_client_test.cc
@@ -201,7 +201,7 @@ TEST(GrpcClientFromProto, Crc32cRoundtrip) {
   };
   for (auto const& start : values) {
     google::protobuf::UInt32Value v;
-    v.set_value(GrpcClient::Crc32cToProto(start));
+    v.set_value(GrpcClient::Crc32cToProto(start).value());
     auto end = GrpcClient::Crc32cFromProto(v);
     EXPECT_EQ(start, end) << " value=" << v.value();
   }
@@ -222,7 +222,7 @@ TEST(GrpcClientFromProto, MD5Roundtrip) {
   };
   for (auto const& test : cases) {
     EXPECT_EQ(GrpcClient::MD5FromProto(test.proto), test.rest);
-    EXPECT_EQ(GrpcClient::MD5ToProto(test.rest), test.proto);
+    EXPECT_EQ(GrpcClient::MD5ToProto(test.rest).value(), test.proto);
   }
 }
 

--- a/google/cloud/storage/internal/grpc_object_read_source_test.cc
+++ b/google/cloud/storage/internal/grpc_object_read_source_test.cc
@@ -209,9 +209,9 @@ TEST(GrpcObjectReadSource, PreserveChecksums) {
         storage_proto::GetObjectMediaResponse response;
         response.mutable_checksummed_data()->set_content("The quick brown");
         response.mutable_object_checksums()->set_md5_hash(
-            GrpcClient::MD5ToProto(expected_md5));
+            GrpcClient::MD5ToProto(expected_md5).value());
         response.mutable_object_checksums()->mutable_crc32c()->set_value(
-            GrpcClient::Crc32cToProto(expected_crc32c));
+            GrpcClient::Crc32cToProto(expected_crc32c).value());
         return response;
       })
       .WillOnce([&] {
@@ -221,9 +221,9 @@ TEST(GrpcObjectReadSource, PreserveChecksums) {
         // The headers may be included more than once in the stream,
         // `GrpcObjectReadSource` should return them only once.
         response.mutable_object_checksums()->set_md5_hash(
-            GrpcClient::MD5ToProto(expected_md5));
+            GrpcClient::MD5ToProto(expected_md5).value());
         response.mutable_object_checksums()->mutable_crc32c()->set_value(
-            GrpcClient::Crc32cToProto(expected_crc32c));
+            GrpcClient::Crc32cToProto(expected_crc32c).value());
         return response;
       })
       .WillOnce(Return(Status{}));

--- a/google/cloud/storage/internal/grpc_resumable_upload_session_url.cc
+++ b/google/cloud/storage/internal/grpc_resumable_upload_session_url.cc
@@ -49,8 +49,9 @@ StatusOr<ResumableUploadSessionGrpcParams> DecodeGrpcResumableUploadSessionUrl(
         "configuration");
   }
   auto const payload = upload_session_url.substr(std::strlen(kUriScheme));
-  auto const decoded_vec = UrlsafeBase64Decode(payload);
-  std::string decoded(decoded_vec.begin(), decoded_vec.end());
+  auto decoded_vec = UrlsafeBase64Decode(payload);
+  if (!decoded_vec) return std::move(decoded_vec).status();
+  std::string decoded(decoded_vec->begin(), decoded_vec->end());
 
   GrpcResumableUploadSessionUrl proto;
   if (!proto.ParseFromString(decoded)) {

--- a/google/cloud/storage/internal/openssl_util.cc
+++ b/google/cloud/storage/internal/openssl_util.cc
@@ -44,8 +44,8 @@ inline std::unique_ptr<EVP_MD_CTX, decltype(&EVP_MD_CTX_free)> GetDigestCtx() {
 #endif
 }  // namespace
 
-std::vector<std::uint8_t> Base64Decode(std::string const& str) {
-  return google::cloud::internal::Base64DecodeToBytes(str).value();
+StatusOr<std::vector<std::uint8_t>> Base64Decode(std::string const& str) {
+  return google::cloud::internal::Base64DecodeToBytes(str);
 }
 
 std::string Base64Encode(std::string const& str) {
@@ -155,10 +155,9 @@ StatusOr<std::vector<std::uint8_t>> SignStringWithPem(
       {signed_str.begin(), signed_str.end()});
 }
 
-std::vector<std::uint8_t> UrlsafeBase64Decode(std::string const& str) {
-  if (str.empty()) {
-    return {};
-  }
+StatusOr<std::vector<std::uint8_t>> UrlsafeBase64Decode(
+    std::string const& str) {
+  if (str.empty()) return std::vector<std::uint8_t>{};
   std::string b64str = str;
   std::replace(b64str.begin(), b64str.end(), '-', '+');
   std::replace(b64str.begin(), b64str.end(), '_', '/');

--- a/google/cloud/storage/internal/openssl_util.h
+++ b/google/cloud/storage/internal/openssl_util.h
@@ -31,7 +31,7 @@ namespace internal {
 /**
  * Decodes a Base64-encoded string.
  */
-std::vector<std::uint8_t> Base64Decode(std::string const& str);
+StatusOr<std::vector<std::uint8_t>> Base64Decode(std::string const& str);
 
 /**
  * Encodes a string using Base64.
@@ -76,7 +76,7 @@ inline std::string UrlsafeBase64Encode(Collection const& bytes) {
 /**
  * Decodes a Url-safe Base64-encoded string.
  */
-std::vector<std::uint8_t> UrlsafeBase64Decode(std::string const& str);
+StatusOr<std::vector<std::uint8_t>> UrlsafeBase64Decode(std::string const& str);
 
 /// Compute the MD5 hash of @p payload
 std::vector<std::uint8_t> MD5Hash(std::string const& payload);

--- a/google/cloud/storage/internal/self_signing_service_account_credentials_test.cc
+++ b/google/cloud/storage/internal/self_signing_service_account_credentials_test.cc
@@ -47,7 +47,7 @@ TEST(SelfSigningServiceAccountCredentials, CreateBearerToken) {
   std::vector<std::string> decoded(components.size());
   std::transform(components.begin(), components.end(), decoded.begin(),
                  [](std::string const& e) {
-                   auto v = UrlsafeBase64Decode(e);
+                   auto v = UrlsafeBase64Decode(e).value();
                    return std::string{v.begin(), v.end()};
                  });
   ASSERT_THAT(3, decoded.size());

--- a/google/cloud/storage/oauth2/service_account_credentials_test.cc
+++ b/google/cloud/storage/oauth2/service_account_credentials_test.cc
@@ -380,9 +380,10 @@ TEST_F(ServiceAccountCredentialsTest, RefreshingUpdatesTimestamps) {
       std::string const& encoded_header = tokens[0];
       std::string const& encoded_payload = tokens[1];
 
-      auto header_bytes = internal::UrlsafeBase64Decode(encoded_header);
+      auto header_bytes = internal::UrlsafeBase64Decode(encoded_header).value();
       std::string header_str{header_bytes.begin(), header_bytes.end()};
-      auto payload_bytes = internal::UrlsafeBase64Decode(encoded_payload);
+      auto payload_bytes =
+          internal::UrlsafeBase64Decode(encoded_payload).value();
       std::string payload_str{payload_bytes.begin(), payload_bytes.end()};
 
       auto header = nlohmann::json::parse(header_str);

--- a/google/cloud/storage/testing/write_base64.cc
+++ b/google/cloud/storage/testing/write_base64.cc
@@ -23,7 +23,7 @@ namespace testing {
 void WriteBase64AsBinary(std::string const& filename, char const* data) {
   std::ofstream os(filename, std::ios::binary);
   os.exceptions(std::ios::badbit);
-  auto bytes = internal::Base64Decode(data);
+  auto bytes = internal::Base64Decode(data).value();
   for (unsigned char c : bytes) {
     os << c;
   }

--- a/google/cloud/storage/tests/curl_sign_blob_integration_test.cc
+++ b/google/cloud/storage/tests/curl_sign_blob_integration_test.cc
@@ -55,7 +55,7 @@ TEST_F(CurlSignBlobIntegrationTest, Simple) {
   EXPECT_FALSE(response->key_id.empty());
   EXPECT_FALSE(response->signed_blob.empty());
 
-  auto decoded = Base64Decode(response->signed_blob);
+  auto decoded = Base64Decode(response->signed_blob).value();
   EXPECT_FALSE(decoded.empty());
 }
 

--- a/google/cloud/storage/tests/signed_url_conformance_test.cc
+++ b/google/cloud/storage/tests/signed_url_conformance_test.cc
@@ -250,7 +250,9 @@ TEST_P(V4PostPolicyConformanceTest, V4PostPolicy) {
   ASSERT_STATUS_OK(doc_res);
   EXPECT_EQ(expected_policy, doc_res->policy);
   auto actual_policy_vec = internal::Base64Decode(doc_res->policy);
-  std::string actual_policy(actual_policy_vec.begin(), actual_policy_vec.end());
+  ASSERT_STATUS_OK(actual_policy_vec);
+  std::string actual_policy(actual_policy_vec->begin(),
+                            actual_policy_vec->end());
   EXPECT_EQ(expected_decoded_policy, actual_policy);
   EXPECT_EQ(expected_url, doc_res->url);
   EXPECT_EQ(expected_credential, doc_res->access_id);

--- a/google/cloud/storage/well_known_headers.cc
+++ b/google/cloud/storage/well_known_headers.cc
@@ -36,7 +36,7 @@ EncryptionKeyData EncryptionDataFromBinaryKey(std::string const& key) {
 }
 
 EncryptionKeyData EncryptionDataFromBase64Key(std::string const& key) {
-  auto binary_key = internal::Base64Decode(key);
+  auto binary_key = internal::Base64Decode(key).value();
   return EncryptionKeyData{
       "AES256", key, internal::Base64Encode(internal::Sha256Hash(binary_key))};
 }


### PR DESCRIPTION
Use StatusOr<> to signal errors when decoding base64 strings. This
required changes at the call sites, which I generally handled as
follows:

- In tests, where the decoding is known to work, I just call `.value()`.
- In functions ready to return `StatusOr<>` I just propagate the
  failure.
- In other functions, I changed the chain of calls until all of them had
  a `Status` or `StatusOr<>`.

Fixes #6946

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6961)
<!-- Reviewable:end -->
