### PR TITLE
fix(GCS+gRPC): no hashes in Object resource

### DIFF
--- a/google/cloud/storage/internal/grpc_client.cc
+++ b/google/cloud/storage/internal/grpc_client.cc
@@ -784,14 +784,6 @@ void SetResourceOptions(google::storage::v1::Object& resource,
     resource.set_content_type(
         request.template GetOption<ContentType>().value());
   }
-
-  if (request.template HasOption<Crc32cChecksumValue>()) {
-    resource.mutable_crc32c()->set_value(GrpcClient::Crc32cToProto(
-        request.template GetOption<Crc32cChecksumValue>().value()));
-  }
-  if (request.template HasOption<MD5HashValue>()) {
-    resource.set_md5_hash(request.template GetOption<MD5HashValue>().value());
-  }
   if (request.template HasOption<KmsKeyName>()) {
     resource.set_kms_key_name(request.template GetOption<KmsKeyName>().value());
   }

--- a/google/cloud/storage/internal/grpc_client_object_request_test.cc
+++ b/google/cloud/storage/internal/grpc_client_object_request_test.cc
@@ -64,9 +64,10 @@ TEST(GrpcClientObjectRequest, InsertObjectMediaRequestAllOptions) {
             name: "test-object-name"
             content_type: "test-content-type"
             content_encoding: "test-content-encoding"
-            crc32c: { value: 576848900 }
-            # See hash_validator_test.cc for how it was obtained.
-            md5_hash: "nhB9nTcrtoJr2B01QqQZ1g=="
+            # Should not be set, the proto file says these values should
+            # not be included in the upload
+            #     crc32c:
+            #     md5_hash:
             kms_key_name: "test-kms-key-name"
           }
           predefined_acl: OBJECT_ACL_PRIVATE
@@ -90,9 +91,17 @@ TEST(GrpcClientObjectRequest, InsertObjectMediaRequestAllOptions) {
           user_project: "test-user-project"
           quota_user: "test-quota-user"
         }
-        # See hash_validator_test.cc for how these magic numbers are obtained.
         object_checksums: {
-          crc32c { value: 576848900 }
+          # Use gsutil to obtain the CRC32C checksum (in base64):
+          #    TEXT="The quick brown fox jumps over the lazy dog"
+          #    /bin/echo -n $TEXT >/tmp/fox.txt
+          #    gsutil hash /tmp/fox.txt
+          #
+          # Then convert the base64 values to hex
+          #
+          # echo "ImIEBA==" | openssl base64 -d | od -t x1
+          #
+          crc32c { value: 0x22620404 }
           md5_hash: "9e107d9d372bb6826bd81d3542a419d6"
         }
       )pb",
@@ -241,8 +250,10 @@ TEST(GrpcClientObjectRequest, ResumableUploadRequestAllFields) {
             bucket: "test-bucket"
             content_encoding: "test-content-encoding"
             content_type: "test-content-type"
-            crc32c: { value: 576848900 }
-            md5_hash: "nhB9nTcrtoJr2B01QqQZ1g=="
+            # Should not be set, the proto file says these values should
+            # not be included in the upload
+            #     crc32c:
+            #     md5_hash:
             kms_key_name: "test-kms-key-name"
           }
           predefined_acl: OBJECT_ACL_PRIVATE
@@ -259,11 +270,11 @@ TEST(GrpcClientObjectRequest, ResumableUploadRequestAllFields) {
 
       common_object_request_params: {
         encryption_algorithm: "AES256"
-# to get the key value use:
-#   /bin/echo -n "01234567" | openssl base64
-# to get the key hash use (note this command goes over two lines):
-#   /bin/echo -n "01234567" | sha256sum | awk '{printf("%s", $1);}' |
-#     xxd -r -p | openssl base64
+        # to get the key value use:
+        #   /bin/echo -n "01234567" | openssl base64
+        # to get the key hash use (note this command goes over two lines):
+        #   /bin/echo -n "01234567" | sha256sum | awk '{printf("%s", $1);}' |
+        #     xxd -r -p | openssl base64
         encryption_key: "MDEyMzQ1Njc="
         encryption_key_sha256: "kkWSubED8U+DP6r7Z/SAaR8BmIqkV8AGF2n1jNRzEbw="
       })""",

--- a/google/cloud/storage/tests/object_checksum_integration_test.cc
+++ b/google/cloud/storage/tests/object_checksum_integration_test.cc
@@ -93,6 +93,8 @@ TEST_F(ObjectChecksumIntegrationTest, XmlInsertWithCrc32c) {
 }
 
 TEST_F(ObjectChecksumIntegrationTest, InsertWithCrc32cFailure) {
+  // TODO(#4156) - use the MD5 hashes
+  if (UsingGrpc()) GTEST_SKIP();
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
@@ -108,6 +110,8 @@ TEST_F(ObjectChecksumIntegrationTest, InsertWithCrc32cFailure) {
 }
 
 TEST_F(ObjectChecksumIntegrationTest, XmlInsertWithCrc32cFailure) {
+  // TODO(#4156) - use the MD5 hashes
+  if (UsingGrpc()) GTEST_SKIP();
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 

--- a/google/cloud/storage/tests/object_hash_integration_test.cc
+++ b/google/cloud/storage/tests/object_hash_integration_test.cc
@@ -280,6 +280,8 @@ TEST_F(ObjectHashIntegrationTest, VerifyValidMD5StreamingWriteJSON) {
 
 /// @test Verify invalid MD5 hash value before upload.
 TEST_F(ObjectHashIntegrationTest, InvalidMD5StreamingWriteJSON) {
+  // TODO(#4157) - use the MD5 hashes
+  if (UsingGrpc()) GTEST_SKIP();
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
@@ -302,6 +304,8 @@ TEST_F(ObjectHashIntegrationTest, InvalidMD5StreamingWriteJSON) {
 
 /// @test Verify MD5 hashes before upload.
 TEST_F(ObjectHashIntegrationTest, InvalidMD5StreamingWriteXML) {
+  // TODO(#4157) - use the MD5 hashes
+  if (UsingGrpc()) GTEST_SKIP();
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
@@ -324,6 +328,8 @@ TEST_F(ObjectHashIntegrationTest, InvalidMD5StreamingWriteXML) {
 
 /// @test Verify that hashes and checksums can be disabled in uploads.
 TEST_F(ObjectHashIntegrationTest, DisableHashesStreamingWriteJSON) {
+  // TODO(#4157) - use the MD5 hashes
+  if (UsingGrpc()) GTEST_SKIP();
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 


### PR DESCRIPTION
The proto file says that neither the `md5_hash` nor the `crc32c` fields
should be set when uploading an `Object`:

https://github.com/googleapis/googleapis/blob/1eade8161f2ef102282869bc3eb18841807b2b46/google/storage/v1/storage_resources.proto#L691-L694
https://github.com/googleapis/googleapis/blob/1eade8161f2ef102282869bc3eb18841807b2b46/google/storage/v1/storage_resources.proto#L676-L679

Also improved the documentation on how to obtain these hashes for tests.

I disabled some tests that used to pass because the service does not ignore
the hashes in the `Object` resource. The documentation says it does (see
the links), so my tests were passing by accident and the service can change
at any time.  Once I fix #4156 and #4157 these tests can be enabled again.

Part of the work for #6946, and will eventually help with #4156 and #4157

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6963)
<!-- Reviewable:end -->
