### PR TITLE
feat(GCS+gRPC): checksums on ObjectInsert

### DIFF
--- a/google/cloud/storage/internal/grpc_client.cc
+++ b/google/cloud/storage/internal/grpc_client.cc
@@ -1755,7 +1755,7 @@ StatusOr<google::storage::v1::InsertObjectRequest> GrpcClient::ToProto(
     // REST APIs (base64-encoded big-endian, 32-bit integers). We need to
     // convert this to the format expected by proto, which is just a 32-bit
     // integer. But the value received by the application might be incorrect, so
-    // we need to validated it.
+    // we need to validate it.
     auto as_proto =
         Crc32cToProto(request.GetOption<Crc32cChecksumValue>().value());
     if (!as_proto.ok()) return std::move(as_proto).status();

--- a/google/cloud/storage/internal/grpc_client.h
+++ b/google/cloud/storage/internal/grpc_client.h
@@ -305,7 +305,7 @@ class GrpcClient : public RawClient,
   static google::storage::v1::DeleteNotificationRequest ToProto(
       DeleteNotificationRequest const& request);
 
-  static google::storage::v1::InsertObjectRequest ToProto(
+  static StatusOr<google::storage::v1::InsertObjectRequest> ToProto(
       InsertObjectMediaRequest const& request);
   static google::storage::v1::DeleteObjectRequest ToProto(
       DeleteObjectRequest const& request);

--- a/google/cloud/storage/internal/grpc_client_insert_object_media_test.cc
+++ b/google/cloud/storage/internal/grpc_client_insert_object_media_test.cc
@@ -51,11 +51,13 @@ TEST(GrpcClientInsertObjectMediaTest, Small) {
     }
     checksummed_data {
       content: "The quick brown fox jumps over the lazy dog"
-      crc32c { value: 576848900 }
+      # grpc_client_object_request_test.cc documents on this magic value
+      crc32c { value: 0x22620404 }
+      # MD5 is disabled by default
     }
     object_checksums {
-      crc32c { value: 576848900 }
-      md5_hash: "9e107d9d372bb6826bd81d3542a419d6"
+      crc32c { value: 0x22620404 }
+      # MD5 is disabled by default
     }
     finish_write: true
   )pb";

--- a/google/cloud/storage/internal/grpc_client_insert_object_media_test.cc
+++ b/google/cloud/storage/internal/grpc_client_insert_object_media_test.cc
@@ -51,7 +51,7 @@ TEST(GrpcClientInsertObjectMediaTest, Small) {
     }
     checksummed_data {
       content: "The quick brown fox jumps over the lazy dog"
-      # grpc_client_object_request_test.cc documents on this magic value
+      # grpc_client_object_request_test.cc documents this magic value
       crc32c { value: 0x22620404 }
       # MD5 is disabled by default
     }

--- a/google/cloud/storage/internal/grpc_client_object_request_test.cc
+++ b/google/cloud/storage/internal/grpc_client_object_request_test.cc
@@ -34,11 +34,11 @@ using ::google::cloud::testing_util::StatusIs;
 
 // Use gsutil to obtain the CRC32C checksum (in base64):
 //    TEXT="The quick brown fox jumps over the lazy dog"
-//    /bin/echo -n $TEXT >/tmp/fox.txt
+//    /bin/echo -n $TEXT > /tmp/fox.txt
 //    gsutil hash /tmp/fox.txt
 // Hashes [base64] for /tmp/fox.txt:
-//	Hash (crc32c):		ImIEBA==
-//	Hash (md5):		nhB9nTcrtoJr2B01QqQZ1g==
+//    Hash (crc32c): ImIEBA==
+//    Hash (md5)   : nhB9nTcrtoJr2B01QqQZ1g==
 //
 // Then convert the base64 values to hex
 //
@@ -47,17 +47,17 @@ using ::google::cloud::testing_util::StatusIs;
 //
 // Which yields (in proto format):
 //
-//     CRC32C: 0x22620404
-//     MD5   : 9e107d9d372bb6826bd81d3542a419d6
+//     CRC32C      : 0x22620404
+//     MD5         : 9e107d9d372bb6826bd81d3542a419d6
 auto constexpr kText = "The quick brown fox jumps over the lazy dog";
 
 // Doing something similar for an alternative text yields:
 // Hashes [base64] for /tmp/alt.txt:
-//	Hash (crc32c):		StZ/gA==
-//	Hash (md5):		StEvo2V/qoDCuaktZSw3IQ==
+//    Hash (crc32c): StZ/gA==
+//    Hash (md5)   : StEvo2V/qoDCuaktZSw3IQ==
 // In proto format
-//     CRC32C: 0x4ad67f80
-//     MD5   : 4ad12fa3657faa80c2b9a92d652c3721
+//     CRC32C      : 0x4ad67f80
+//     MD5         : 4ad12fa3657faa80c2b9a92d652c3721
 auto constexpr kAlt = "How vexingly quick daft zebras jump!";
 
 TEST(GrpcClientObjectRequest, InsertObjectMediaRequestSimple) {
@@ -89,11 +89,11 @@ TEST(GrpcClientObjectRequest, InsertObjectMediaRequestHashOptions) {
     std::function<void(InsertObjectMediaRequest&)> apply_options;
     std::string expected_checksums;
   } cases[] = {
-      // These tests provide the "wrong" hashes, this is what would happen if
+      // These tests provide the "wrong" hashes. This is what would happen if
       // one was (for example) reading a GCS file, obtained the expected hashes
       // from GCS, and then uploaded to another GCS destination *but*
-      // the data was somehow corrupted locally (say a bad disk), we don't want
-      // to recompute the hashes in the upload.
+      // the data was somehow corrupted locally (say a bad disk). In that case,
+      // we don't want to recompute the hashes in the upload.
       {
           [](InsertObjectMediaRequest& r) {
             r.set_option(MD5HashValue(ComputeMD5Hash(kText)));
@@ -107,8 +107,9 @@ TEST(GrpcClientObjectRequest, InsertObjectMediaRequestHashOptions) {
             r.set_option(MD5HashValue(ComputeMD5Hash(kText)));
             r.set_option(DisableCrc32cChecksum(false));
           },
-          R"pb(md5_hash: "9e107d9d372bb6826bd81d3542a419d6"
-               crc32c { value: 0x4ad67f80 })pb",
+          R"pb(
+            md5_hash: "9e107d9d372bb6826bd81d3542a419d6"
+            crc32c { value: 0x4ad67f80 })pb",
       },
       {
           [](InsertObjectMediaRequest& r) {
@@ -152,7 +153,8 @@ TEST(GrpcClientObjectRequest, InsertObjectMediaRequestHashOptions) {
             r.set_option(DisableMD5Hash(true));
             r.set_option(DisableCrc32cChecksum(true));
           },
-          R"pb()pb",
+          R"pb(
+          )pb",
       },
       {
           [](InsertObjectMediaRequest& r) {

--- a/google/cloud/storage/tests/object_checksum_integration_test.cc
+++ b/google/cloud/storage/tests/object_checksum_integration_test.cc
@@ -93,8 +93,6 @@ TEST_F(ObjectChecksumIntegrationTest, XmlInsertWithCrc32c) {
 }
 
 TEST_F(ObjectChecksumIntegrationTest, InsertWithCrc32cFailure) {
-  // TODO(#4156) - use the MD5 hashes
-  if (UsingGrpc()) GTEST_SKIP();
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
@@ -110,8 +108,6 @@ TEST_F(ObjectChecksumIntegrationTest, InsertWithCrc32cFailure) {
 }
 
 TEST_F(ObjectChecksumIntegrationTest, XmlInsertWithCrc32cFailure) {
-  // TODO(#4156) - use the MD5 hashes
-  if (UsingGrpc()) GTEST_SKIP();
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 


### PR DESCRIPTION
With this change `ObjectInsert()` uses all the checksum options,
allowing applications to provide checksums (when known in advance),
disabling some checksums, or letting the library compute them.

Part of the work for #4156 and for #4157

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6967)
<!-- Reviewable:end -->
