### PR TITLE
ci: gcc-3.8 and gcc-5.4 do not need super builds

### DIFF
--- a/ci/cloudbuild/builds/clang-38.sh
+++ b/ci/cloudbuild/builds/clang-38.sh
@@ -25,5 +25,9 @@ export CC=clang
 export CXX=clang++
 
 cmake -GNinja -DBUILD_SHARED_LIBS=yes -DGOOGLE_CLOUD_CPP_ENABLE_CCACHE=ON \
-  -Hsuper -Bcmake-out
+  -H. -Bcmake-out
 cmake --build cmake-out
+(
+  cd cmake-out
+  ctest --output-on-failure -LE "integration-test" -j "$(nproc)"
+)

--- a/ci/cloudbuild/builds/gcc-54.sh
+++ b/ci/cloudbuild/builds/gcc-54.sh
@@ -25,5 +25,9 @@ export CC=gcc
 export CXX=g++
 
 cmake -GNinja -DBUILD_SHARED_LIBS=yes -DGOOGLE_CLOUD_CPP_ENABLE_CCACHE=ON \
-  -Hsuper -Bcmake-out
+  -H. -Bcmake-out
 cmake --build cmake-out
+(
+  cd cmake-out
+  ctest --output-on-failure -LE "integration-test" -j "$(nproc)"
+)

--- a/google/cloud/storage/benchmarks/throughput_experiment.cc
+++ b/google/cloud/storage/benchmarks/throughput_experiment.cc
@@ -205,9 +205,8 @@ class DownloadObjectLibcurl : public ThroughputExperiment {
     }
     curl_easy_setopt(hnd, CURLOPT_URL, url.c_str());
     curl_easy_setopt(hnd, CURLOPT_HTTPHEADER, slist1);
-    curl_easy_setopt(hnd, CURLOPT_USERAGENT, "curl/7.65.3");
+    curl_easy_setopt(hnd, CURLOPT_USERAGENT, curl_version());
     curl_easy_setopt(hnd, CURLOPT_MAXREDIRS, 50L);
-    curl_easy_setopt(hnd, CURLOPT_HTTP09_ALLOWED, 1L);
     curl_easy_setopt(hnd, CURLOPT_TCP_KEEPALIVE, 1L);
 
     std::vector<char> buffer(CURL_MAX_WRITE_SIZE);

--- a/google/cloud/storage/tests/curl_request_integration_test.cc
+++ b/google/cloud/storage/tests/curl_request_integration_test.cc
@@ -21,7 +21,6 @@
 #include <gmock/gmock.h>
 #include <nlohmann/json.hpp>
 #include <chrono>
-#include <cstdlib>
 #include <thread>
 #include <vector>
 
@@ -219,7 +218,11 @@ TEST(CurlRequestTest, MultiBufferLargePUT) {
   auto constexpr kLineSize = 1024;
   // libcurl's CURLOPT_READFUNCTION provides at most CURL_MAX_READ_SIZE bytes,
   // use enough buffers to ensure we get more than one read callback.
+#if CURL_AT_LEAST_VERSION(7, 53, 0)
   auto constexpr kLineCount = (2 * CURL_MAX_READ_SIZE) / kLineSize;
+#else
+  auto constexpr kLineCount = 512 * 1024 / kLineSize;
+#endif  // CURL_AT_LEAST_VERSION >= 7.53.0
   for (int i = 0; i != kLineCount; ++i) {
     std::string line = std::to_string(i);
     line += ": ";


### PR DESCRIPTION
Part of the work for #6424

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6971)
<!-- Reviewable:end -->
