### PR TITLE
refactor(spanner): constrain number of channels when we default options

### DIFF
--- a/google/cloud/spanner/client.cc
+++ b/google/cloud/spanner/client.cc
@@ -349,7 +349,7 @@ std::shared_ptr<spanner::Connection> MakeConnection(spanner::Database const& db,
   opts = spanner_internal::DefaultOptions(std::move(opts));
 
   std::vector<std::shared_ptr<spanner_internal::SpannerStub>> stubs(
-      (std::max)(1, opts.get<GrpcNumChannelsOption>()));
+      opts.get<GrpcNumChannelsOption>());
   int id = 0;
   std::generate(stubs.begin(), stubs.end(), [&id, db, opts] {
     return spanner_internal::CreateDefaultSpannerStub(db, opts, id++);

--- a/google/cloud/spanner/internal/defaults.cc
+++ b/google/cloud/spanner/internal/defaults.cc
@@ -93,6 +93,8 @@ Options DefaultOptions(Options opts) {
     opts.set<SessionPoolClockOption>(std::make_shared<Session::Clock>());
   }
   // Enforces some SessionPool constraints.
+  auto& num_channels = opts.lookup<GrpcNumChannelsOption>();
+  num_channels = (std::max)(num_channels, 1);
   auto& max_idle = opts.lookup<spanner::SessionPoolMaxIdleSessionsOption>();
   max_idle = (std::max)(max_idle, 0);
   auto& max_sessions_per_channel =
@@ -101,8 +103,7 @@ Options DefaultOptions(Options opts) {
   auto& min_sessions = opts.lookup<spanner::SessionPoolMinSessionsOption>();
   min_sessions = (std::max)(min_sessions, 0);
   min_sessions =
-      (std::min)(min_sessions,
-                 max_sessions_per_channel * opts.get<GrpcNumChannelsOption>());
+      (std::min)(min_sessions, max_sessions_per_channel * num_channels);
 
   return opts;
 }

--- a/google/cloud/spanner/internal/session_pool.cc
+++ b/google/cloud/spanner/internal/session_pool.cc
@@ -42,11 +42,6 @@ using google::cloud::internal::Idempotency;
 std::shared_ptr<SessionPool> MakeSessionPool(
     spanner::Database db, std::vector<std::shared_ptr<SpannerStub>> stubs,
     google::cloud::CompletionQueue cq, Options opts) {
-  auto const stub_size = static_cast<int>(stubs.size());
-  if (opts.get<GrpcNumChannelsOption>() != stub_size) {
-    opts.set<GrpcNumChannelsOption>(stub_size);
-    opts = DefaultOptions(std::move(opts));
-  }
   auto pool = std::shared_ptr<SessionPool>(new SessionPool(
       std::move(db), std::move(stubs), std::move(cq), std::move(opts)));
   pool->Initialize();


### PR DESCRIPTION
Looks like we were
1. defaulting the options
2. making at least one stub 
3. checking to see if there was a mismatch between number of stubs and `GrpcNumChannelsOption` (only happens if option is <= 0)
4. if there is a mismatch, recalculate the `SessionPoolMinSessionOption` (by calling `DefaultOptions()` again).

This can be simpler.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6973)
<!-- Reviewable:end -->
