### PR TITLE
chore: update google-cloud-sdk

### DIFF
--- a/ci/cloudbuild/build.sh
+++ b/ci/cloudbuild/build.sh
@@ -326,5 +326,7 @@ args=(
   "--config=ci/cloudbuild/cloudbuild.yaml"
   "--substitutions=$(printf "%s," "${subs[@]}")"
   "--project=${project}"
+  # This value must match the workerPool configured in cloudbuild.yaml
+  "--region=us-east1"
 )
 io::run gcloud builds submit "${args[@]}" .

--- a/ci/install-cloud-sdk.sh
+++ b/ci/install-cloud-sdk.sh
@@ -16,8 +16,8 @@
 
 set -eu
 
-readonly GOOGLE_CLOUD_CPP_CLOUD_SDK_VERSION="328.0.0"
-readonly GOOGLE_CLOUD_CPP_SDK_SHA256="31f95d4e82bb65f756662667235a8a235a3f752894732b31cd491360c559e6ee"
+readonly GOOGLE_CLOUD_CPP_CLOUD_SDK_VERSION="348.0.0"
+readonly GOOGLE_CLOUD_CPP_SDK_SHA256="8341a9b21088fd382522be247c7e51c61d8ea4ff86e6ededfa601afd5223e153"
 
 readonly SITE="https://dl.google.com/dl/cloudsdk/channels/rapid/downloads"
 readonly TARBALL="google-cloud-sdk-${GOOGLE_CLOUD_CPP_CLOUD_SDK_VERSION}-linux-x86_64.tar.gz"


### PR DESCRIPTION
The latest version should include fixes for the Cloud Bigtable emulator.

Part of the fixes for #441

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6981)
<!-- Reviewable:end -->
