### PR TITLE
cleanup(storage): simplify ObjectReadStreambuf

### DIFF
--- a/google/cloud/storage/internal/hash_validator.h
+++ b/google/cloud/storage/internal/hash_validator.h
@@ -52,7 +52,11 @@ class HashValidator {
     std::string computed;
     /// A flag indicating of this is considered a mismatch based on the rules
     /// for the validator.
-    bool is_mismatch;
+    bool is_mismatch = false;
+
+    Result() = default;
+    Result(std::string r, std::string c, bool m)
+        : received(std::move(r)), computed(std::move(c)), is_mismatch(m) {}
   };
 
   /**

--- a/google/cloud/storage/internal/object_read_streambuf.cc
+++ b/google/cloud/storage/internal/object_read_streambuf.cc
@@ -113,6 +113,9 @@ void ObjectReadStreambuf::ThrowHashMismatchDelegate(const char* function_name) {
 }
 
 bool ObjectReadStreambuf::ValidateHashes(char const* function_name) {
+  // This function is called once the stream is "closed" (either an explicit
+  // `Close()` call or a permanent error). After this point the validator is
+  // not usable.
   auto validator = std::move(hash_validator_);
   hash_validator_result_ = std::move(*validator).Finish();
   if (!hash_validator_result_.is_mismatch) return true;

--- a/google/cloud/storage/internal/object_read_streambuf.h
+++ b/google/cloud/storage/internal/object_read_streambuf.h
@@ -74,9 +74,9 @@ class ObjectReadStreambuf : public std::basic_streambuf<char> {
 
  private:
   int_type ReportError(Status status);
-  void SetEmptyRegion();
-  std::string FinishValidator(char const* function_name);
-  StatusOr<int_type> Peek();
+  void ThrowHashMismatchDelegate(char const* function_name);
+  bool ValidateHashes(char const* function_name);
+  bool CheckPreconditions(char const* function_name);
 
   int_type underflow() override;
   std::streamsize xsgetn(char* s, std::streamsize count) override;


### PR DESCRIPTION
Simplify the implementation of `storage::internal::ObjectReadStreambuf`.
The class had two different paths to get more data from the underlying
`internal::ObjectReadSource`, this change makes all reads through the
`xsgetn()` function.

In addition, the class was sloppy with the hash validator, potentially
using it after it was moved-from, luckily this was harmless, but no
reason to keep doing so.

I added some integration tests to cover corner cases that were only
detected by accident in other tests.

Part of the work for #4156 and #4157

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6983)
<!-- Reviewable:end -->
