### PR TITLE
cleanup(bigtable): unmodify the obsolete constructor

### DIFF
--- a/google/cloud/bigtable/client_options.cc
+++ b/google/cloud/bigtable/client_options.cc
@@ -78,9 +78,8 @@ ClientOptions::ClientOptions(Options opts) {
       to_arg(duration_cast<milliseconds>(kDefaultKeepaliveTimeout)));
 }
 
-ClientOptions::ClientOptions(std::shared_ptr<grpc::ChannelCredentials> creds,
-                             Options opts)
-    : ClientOptions(opts.set<GrpcCredentialOption>(std::move(creds))) {
+ClientOptions::ClientOptions(std::shared_ptr<grpc::ChannelCredentials> creds)
+    : ClientOptions(Options{}.set<GrpcCredentialOption>(std::move(creds))) {
   set_data_endpoint("bigtable.googleapis.com");
   set_admin_endpoint("bigtableadmin.googleapis.com");
 }

--- a/google/cloud/bigtable/client_options.h
+++ b/google/cloud/bigtable/client_options.h
@@ -105,10 +105,8 @@ class ClientOptions {
    *     passing in @p creds as a `GrpcCredentialOption`.
    *
    * @param creds gRPC authentication credentials
-   * @param opts (optional) configuration options
    */
-  explicit ClientOptions(std::shared_ptr<grpc::ChannelCredentials> creds,
-                         Options opts = {});
+  explicit ClientOptions(std::shared_ptr<grpc::ChannelCredentials> creds);
 
   /// Return the current endpoint for data RPCs.
   std::string const& data_endpoint() const {


### PR DESCRIPTION
@devjgm pointed out that there was no need to accept `Options` in a constructor which we do not want anyone to use.

Technically this is a breaking change since #6949, but I think it is fine to make such a change between releases.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6988)
<!-- Reviewable:end -->
