### PR TITLE
feat(GCS+gRPC): option to configure plugin

### DIFF
--- a/google/cloud/storage/benchmarks/aggregate_throughput_benchmark.cc
+++ b/google/cloud/storage/benchmarks/aggregate_throughput_benchmark.cc
@@ -142,8 +142,10 @@ int main(int argc, char* argv[]) {
     auto channels = options->grpc_channel_count;
     if (channels == 0) channels = (std::max)(options->thread_count / 4, 4);
     client = DefaultGrpcClient(
-        google::cloud::Options{}.set<google::cloud::GrpcNumChannelsOption>(
-            channels));
+        google::cloud::Options{}
+            .set<google::cloud::GrpcNumChannelsOption>(channels)
+            .set<google::cloud::storage_experimental::GrpcPluginOption>(
+                options->grpc_plugin_config));
   }
 #endif  // GOOGLE_CLOUD_CPP_STORAGE_HAVE_GRPC
   std::vector<gcs::ObjectMetadata> objects;

--- a/google/cloud/storage/benchmarks/aggregate_throughput_options.cc
+++ b/google/cloud/storage/benchmarks/aggregate_throughput_options.cc
@@ -68,6 +68,11 @@ ParseAggregateThroughputOptions(std::vector<std::string> const& argv,
        [&options](std::string const& val) {
          options.grpc_channel_count = std::stoi(val);
        }},
+      {"--grpc-plugin-config",
+       "low-level experimental settings for the GCS+gRPC plugin",
+       [&options](std::string const& val) {
+         options.grpc_plugin_config = val;
+       }},
   };
   auto usage = BuildUsage(desc, argv[0]);
 

--- a/google/cloud/storage/benchmarks/aggregate_throughput_options.h
+++ b/google/cloud/storage/benchmarks/aggregate_throughput_options.h
@@ -34,6 +34,7 @@ struct AggregateThroughputOptions {
   std::size_t read_buffer_size = 4 * kMiB;
   ApiName api = ApiName::kApiGrpc;
   int grpc_channel_count = 0;
+  std::string grpc_plugin_config;
   bool exit_after_parse = false;
 };
 

--- a/google/cloud/storage/benchmarks/aggregate_throughput_options_test.cc
+++ b/google/cloud/storage/benchmarks/aggregate_throughput_options_test.cc
@@ -35,6 +35,7 @@ TEST(AggregateThroughputOptions, Basic) {
           "--read-buffer-size=1MiB",
           "--api=XML",
           "--grpc-channel-count=16",
+          "--grpc-plugin-config=default",
       },
       "");
   ASSERT_STATUS_OK(options);

--- a/google/cloud/storage/grpc_plugin.h
+++ b/google/cloud/storage/grpc_plugin.h
@@ -31,6 +31,30 @@ namespace storage_experimental {
 inline namespace STORAGE_CLIENT_NS {
 
 /**
+ * Low-level experimental settings for the GCS+gRPC plugin.
+ *
+ * Possible values for the string include:
+ *
+ * - "default" or "none": do not use any special settings with gRPC
+ * - "dp": equivalent to setting both "pick-first-lb" and
+ *   "enable-dns-srv-queries"
+ * - "alts": same settings as "dp", but use the experimental ALTS credentials
+ * - "enable-dns-srv-queries": set the `grpc.dns_enable_srv_queries` channel
+ *   argument to `1`, see [dns-query-arg].
+ * - "disable-dns-srv-queries": set the `grpc.dns_enable_srv_queries` channel
+ *   argument to `0`, see [dns-query-arg].
+ * - "exclusive": use a exclusive channel for each stub.
+ *
+ * Unknown values are ignored.
+ *
+ * [dns-query-arg]:
+ * https://grpc.github.io/grpc/core/group__grpc__arg__keys.html#ga247ed6771077938be12ab24790a95732
+ */
+struct GrpcPluginOption {
+  using Type = std::string;
+};
+
+/**
  * Create a `google::cloud::storage::Client` object configured to use gRPC.
  *
  * @note the Credentials parameter in the configuration is ignored. The gRPC

--- a/google/cloud/storage/grpc_plugin.h
+++ b/google/cloud/storage/grpc_plugin.h
@@ -35,15 +35,17 @@ inline namespace STORAGE_CLIENT_NS {
  *
  * Possible values for the string include:
  *
- * - "default" or "none": do not use any special settings with gRPC
- * - "dp": equivalent to setting both "pick-first-lb" and
- *   "enable-dns-srv-queries"
- * - "alts": same settings as "dp", but use the experimental ALTS credentials
+ * - "default" or "none": do not use any special settings with gRPC.
+ * - "dp": enable Google Direct Access (formerly 'Direct Path') equivalent to
+ *   setting both "pick-first-lb" and "enable-dns-srv-queries".
+ * - "alts": same settings as "dp", but use the experimental ALTS credentials.
  * - "enable-dns-srv-queries": set the `grpc.dns_enable_srv_queries` channel
  *   argument to `1`, see [dns-query-arg].
  * - "disable-dns-srv-queries": set the `grpc.dns_enable_srv_queries` channel
  *   argument to `0`, see [dns-query-arg].
- * - "exclusive": use a exclusive channel for each stub.
+ * - "pick-first-lb": configure the gRPC load balancer to use the "pick_first"
+ *   policy.
+ * - "exclusive": use an exclusive channel for each stub.
  *
  * Unknown values are ignored.
  *

--- a/google/cloud/storage/internal/grpc_client.h
+++ b/google/cloud/storage/internal/grpc_client.h
@@ -29,9 +29,11 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace internal {
 
-/// Determine if using DirectPath for GCS has been enabled through
-/// GOOGLE_CLOUD_DIRECT_PATH.
-bool DirectPathEnabled();
+/**
+ * The default options for gRPC.
+ *
+ * This adds some additional defaults to the options for REST.
+ */
 Options DefaultOptionsGrpc(Options = {});
 
 class StorageStub;

--- a/google/cloud/storage/internal/grpc_client_test.cc
+++ b/google/cloud/storage/internal/grpc_client_test.cc
@@ -31,22 +31,6 @@ namespace {
 
 namespace storage_proto = ::google::storage::v1;
 using ::google::cloud::testing_util::IsProtoEqual;
-using ::google::cloud::testing_util::ScopedEnvironment;
-
-TEST(GrpcClientDirectPath, NotSet) {
-  ScopedEnvironment env("GOOGLE_CLOUD_ENABLE_DIRECT_PATH", {});
-  EXPECT_FALSE(DirectPathEnabled());
-}
-
-TEST(GrpcClientDirectPath, Enabled) {
-  ScopedEnvironment env("GOOGLE_CLOUD_ENABLE_DIRECT_PATH", "foo,storage,bar");
-  EXPECT_TRUE(DirectPathEnabled());
-}
-
-TEST(GrpcClientDirectPath, NotEnabled) {
-  ScopedEnvironment env("GOOGLE_CLOUD_ENABLE_DIRECT_PATH", "not-quite-storage");
-  EXPECT_FALSE(DirectPathEnabled());
-}
 
 TEST(GrpcClientFromProto, ObjectSimple) {
   storage_proto::Object input;

--- a/google/cloud/storage/internal/grpc_client_test.cc
+++ b/google/cloud/storage/internal/grpc_client_test.cc
@@ -17,7 +17,6 @@
 #include "google/cloud/storage/internal/object_access_control_parser.h"
 #include "google/cloud/storage/internal/object_metadata_parser.h"
 #include "google/cloud/testing_util/is_proto_equal.h"
-#include "google/cloud/testing_util/scoped_environment.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include <google/protobuf/text_format.h>
 #include <gmock/gmock.h>


### PR DESCRIPTION
Make it easier to experiment with configuration options for the GCS+gRPC
plugin. This is useful in benchmarking, and might be useful in the final
form of the plugin.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6991)
<!-- Reviewable:end -->
