### PR TITLE
cleanup(bigtable): prefer `ClientOptions` constructor that uses `Options`

### DIFF
--- a/google/cloud/bigtable/benchmarks/embedded_server_test.cc
+++ b/google/cloud/bigtable/benchmarks/embedded_server_test.cc
@@ -43,8 +43,11 @@ TEST(EmbeddedServer, Admin) {
   auto server = CreateEmbeddedServer();
   std::thread wait_thread([&server]() { server->Wait(); });
 
-  ClientOptions options(grpc::InsecureChannelCredentials());
-  options.set_admin_endpoint(server->address());
+  ClientOptions options(
+      Options{}
+          .set<GrpcCredentialOption>(grpc::InsecureChannelCredentials())
+          .set<AdminEndpointOption>(server->address()));
+
   TableAdmin admin(CreateDefaultAdminClient("fake-project", options),
                    "fake-instance");
 
@@ -65,8 +68,11 @@ TEST(EmbeddedServer, TableApply) {
   auto server = CreateEmbeddedServer();
   std::thread wait_thread([&server]() { server->Wait(); });
 
-  ClientOptions options(grpc::InsecureChannelCredentials());
-  options.set_data_endpoint(server->address());
+  ClientOptions options(
+      Options{}
+          .set<GrpcCredentialOption>(grpc::InsecureChannelCredentials())
+          .set<DataEndpointOption>(server->address()));
+
   Table table(CreateDefaultDataClient("fake-project", "fake-instance", options),
               "fake-table");
 
@@ -87,8 +93,11 @@ TEST(EmbeddedServer, TableBulkApply) {
   auto server = CreateEmbeddedServer();
   std::thread wait_thread([&server]() { server->Wait(); });
 
-  ClientOptions options(grpc::InsecureChannelCredentials());
-  options.set_data_endpoint(server->address());
+  ClientOptions options(
+      Options{}
+          .set<GrpcCredentialOption>(grpc::InsecureChannelCredentials())
+          .set<DataEndpointOption>(server->address()));
+
   Table table(CreateDefaultDataClient("fake-project", "fake-instance", options),
               "fake-table");
 
@@ -111,8 +120,11 @@ TEST(EmbeddedServer, ReadRows1) {
   auto server = CreateEmbeddedServer();
   std::thread wait_thread([&server]() { server->Wait(); });
 
-  ClientOptions options(grpc::InsecureChannelCredentials());
-  options.set_data_endpoint(server->address());
+  ClientOptions options(
+      Options{}
+          .set<GrpcCredentialOption>(grpc::InsecureChannelCredentials())
+          .set<DataEndpointOption>(server->address()));
+
   Table table(CreateDefaultDataClient("fake-project", "fake-instance", options),
               "fake-table");
 
@@ -130,8 +142,11 @@ TEST(EmbeddedServer, ReadRows100) {
   auto server = CreateEmbeddedServer();
   std::thread wait_thread([&server]() { server->Wait(); });
 
-  ClientOptions options(grpc::InsecureChannelCredentials());
-  options.set_data_endpoint(server->address());
+  ClientOptions options(
+      Options{}
+          .set<GrpcCredentialOption>(grpc::InsecureChannelCredentials())
+          .set<DataEndpointOption>(server->address()));
+
   Table table(CreateDefaultDataClient("fake-project", "fake-instance", options),
               "fake-table");
 

--- a/google/cloud/bigtable/examples/bigtable_grpc_credentials.cc
+++ b/google/cloud/bigtable/examples/bigtable_grpc_credentials.cc
@@ -30,6 +30,8 @@ void AccessToken(std::vector<std::string> const& argv) {
 
   // Create a namespace alias to make the code easier to read.
   namespace cbt = google::cloud::bigtable;
+  using google::cloud::GrpcCredentialOption;
+  using google::cloud::Options;
   using google::cloud::StatusOr;
 
   //! [test access token]
@@ -40,10 +42,11 @@ void AccessToken(std::vector<std::string> const& argv) {
         grpc::SslCredentials(grpc::SslCredentialsOptions());
     auto credentials = grpc::CompositeChannelCredentials(channel_credentials,
                                                          call_credentials);
+    auto options = Options{}.set<GrpcCredentialOption>(credentials);
 
-    cbt::TableAdmin admin(cbt::CreateDefaultAdminClient(
-                              project_id, cbt::ClientOptions(credentials)),
-                          instance_id);
+    cbt::TableAdmin admin(
+        cbt::CreateDefaultAdminClient(project_id, cbt::ClientOptions(options)),
+        instance_id);
 
     auto tables = admin.ListTables(cbt::TableAdmin::NAME_ONLY);
     if (!tables) throw std::runtime_error(tables.status().message());
@@ -60,6 +63,8 @@ void JWTAccessToken(std::vector<std::string> const& argv) {
   }
   // Create a namespace alias to make the code easier to read.
   namespace cbt = google::cloud::bigtable;
+  using google::cloud::GrpcCredentialOption;
+  using google::cloud::Options;
   using google::cloud::StatusOr;
 
   //! [test jwt access token]
@@ -80,9 +85,11 @@ void JWTAccessToken(std::vector<std::string> const& argv) {
         grpc::SslCredentials(grpc::SslCredentialsOptions());
     auto credentials = grpc::CompositeChannelCredentials(channel_credentials,
                                                          call_credentials);
-    cbt::TableAdmin admin(cbt::CreateDefaultAdminClient(
-                              project_id, cbt::ClientOptions(credentials)),
-                          instance_id);
+    auto options = Options{}.set<GrpcCredentialOption>(credentials);
+
+    cbt::TableAdmin admin(
+        cbt::CreateDefaultAdminClient(project_id, cbt::ClientOptions(options)),
+        instance_id);
 
     auto tables = admin.ListTables(cbt::TableAdmin::NAME_ONLY);
     if (!tables) throw std::runtime_error(tables.status().message());
@@ -97,6 +104,8 @@ void GCECredentials(std::vector<std::string> const& argv) {
   }
   // Create a namespace alias to make the code easier to read.
   namespace cbt = google::cloud::bigtable;
+  using google::cloud::GrpcCredentialOption;
+  using google::cloud::Options;
   using google::cloud::StatusOr;
 
   //! [test gce credentials]
@@ -106,9 +115,11 @@ void GCECredentials(std::vector<std::string> const& argv) {
         grpc::SslCredentials(grpc::SslCredentialsOptions());
     auto credentials = grpc::CompositeChannelCredentials(channel_credentials,
                                                          call_credentials);
-    cbt::TableAdmin admin(cbt::CreateDefaultAdminClient(
-                              project_id, cbt::ClientOptions(credentials)),
-                          instance_id);
+    auto options = Options{}.set<GrpcCredentialOption>(credentials);
+
+    cbt::TableAdmin admin(
+        cbt::CreateDefaultAdminClient(project_id, cbt::ClientOptions(options)),
+        instance_id);
 
     auto tables = admin.ListTables(cbt::TableAdmin::NAME_ONLY);
     if (!tables) throw std::runtime_error(tables.status().message());


### PR DESCRIPTION
part of the work for #6307 

Use the preferred constructor in our benchmarks and examples. The only remaining reference to the credentials constructor is in a test for it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6992)
<!-- Reviewable:end -->
