### PR TITLE
cleanup(storage): prevent use-after-move

### DIFF
--- a/google/cloud/storage/internal/object_write_streambuf.cc
+++ b/google/cloud/storage/internal/object_write_streambuf.cc
@@ -59,8 +59,12 @@ bool ObjectWriteStreambuf::IsOpen() const {
 }
 
 bool ObjectWriteStreambuf::ValidateHash(ObjectMetadata const& meta) {
-  hash_validator_->ProcessMetadata(meta);
-  hash_validator_result_ = std::move(*hash_validator_).Finish();
+  // This function is called once the stream is "closed" (either an explicit
+  // `Close()` call or a permanent error). After this point the validator is
+  // not usable.
+  auto validator = std::move(hash_validator_);
+  validator->ProcessMetadata(meta);
+  hash_validator_result_ = std::move(*validator).Finish();
   return !hash_validator_result_.is_mismatch;
 }
 


### PR DESCRIPTION
Part of the work for #4156 and for #4157

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6993)
<!-- Reviewable:end -->
