### PR TITLE
feat(storage): capture peer addres for REST

### DIFF
--- a/google/cloud/storage/internal/curl_download_request.cc
+++ b/google/cloud/storage/internal/curl_download_request.cc
@@ -124,6 +124,7 @@ StatusOr<HttpResponse> CurlDownloadRequest::Close() {
   }
   TRACE_STATE() << ", http_code.status=" << http_code.status()
                 << ", http_code=" << *http_code;
+  received_headers_.emplace(":curl-peer", handle_.GetPeer());
   return HttpResponse{http_code.value(), std::string{},
                       std::move(received_headers_)};
 }
@@ -186,6 +187,7 @@ StatusOr<ReadSourceResult> CurlDownloadRequest::Read(char* buf, std::size_t n) {
     //   if not.
     // if the option is not supported then we cannot use HTTP at all in libcurl
     // and the whole class would fail.
+    received_headers_.emplace(":curl-peer", handle_.GetPeer());
     HttpResponse response{handle_.GetResponseCode().value(), std::string{},
                           std::move(received_headers_)};
     TRACE_STATE() << ", code=" << response.status_code;
@@ -197,6 +199,7 @@ StatusOr<ReadSourceResult> CurlDownloadRequest::Read(char* buf, std::size_t n) {
     return ReadSourceResult{bytes_read, std::move(response)};
   }
   TRACE_STATE() << ", code=100";
+  received_headers_.emplace(":curl-peer", handle_.GetPeer());
   return ReadSourceResult{
       bytes_read,
       HttpResponse{

--- a/google/cloud/storage/internal/curl_handle.cc
+++ b/google/cloud/storage/internal/curl_handle.cc
@@ -160,9 +160,9 @@ StatusOr<std::int32_t> CurlHandle::GetResponseCode() {
 }
 
 std::string CurlHandle::GetPeer() {
-  char* ip;
+  char* ip = nullptr;
   auto e = curl_easy_getinfo(handle_.get(), CURLINFO_PRIMARY_IP, &ip);
-  if (e == CURLE_OK) return ip;
+  if (e == CURLE_OK && ip != nullptr) return ip;
   return std::string{"[error-fetching-peer]"};
 }
 

--- a/google/cloud/storage/internal/curl_handle.cc
+++ b/google/cloud/storage/internal/curl_handle.cc
@@ -152,6 +152,20 @@ void CurlHandle::SetSocketCallback(SocketOptions const& options) {
   SetOption(CURLOPT_SOCKOPTFUNCTION, &CurlSetSocketOptions);
 }
 
+StatusOr<std::int32_t> CurlHandle::GetResponseCode() {
+  long code;  // NOLINT(google-runtime-int)
+  auto e = curl_easy_getinfo(handle_.get(), CURLINFO_RESPONSE_CODE, &code);
+  if (e == CURLE_OK) return static_cast<std::int32_t>(code);
+  return AsStatus(e, __func__);
+}
+
+std::string CurlHandle::GetPeer() {
+  char* ip;
+  auto e = curl_easy_getinfo(handle_.get(), CURLINFO_PRIMARY_IP, &ip);
+  if (e == CURLE_OK) return ip;
+  return std::string{"[error-fetching-peer]"};
+}
+
 void CurlHandle::EnableLogging(bool enabled) {
   if (enabled) {
     debug_info_ = std::make_shared<DebugInfo>();

--- a/google/cloud/storage/internal/curl_handle.h
+++ b/google/cloud/storage/internal/curl_handle.h
@@ -119,14 +119,11 @@ class CurlHandle {
     return AsStatus(e, __func__);
   }
 
-  StatusOr<long> GetResponseCode() {  // NOLINT(google-runtime-int)
-    long code;                        // NOLINT(google-runtime-int)
-    auto e = curl_easy_getinfo(handle_.get(), CURLINFO_RESPONSE_CODE, &code);
-    if (e == CURLE_OK) {
-      return code;
-    }
-    return AsStatus(e, __func__);
-  }
+  /// Get the HTTP response code, or an error.
+  StatusOr<std::int32_t> GetResponseCode();
+
+  /// Get the peer, or just "unknown".
+  std::string GetPeer();
 
   Status EasyPause(int bitmask) {
     auto e = curl_easy_pause(handle_.get(), bitmask);

--- a/google/cloud/storage/internal/curl_handle.h
+++ b/google/cloud/storage/internal/curl_handle.h
@@ -119,10 +119,15 @@ class CurlHandle {
     return AsStatus(e, __func__);
   }
 
-  /// Get the HTTP response code, or an error.
+  /// Gets the HTTP response code, or an error.
   StatusOr<std::int32_t> GetResponseCode();
 
-  /// Get the peer, or just "unknown".
+  /**
+   * Gets a string identifying the peer.
+   *
+   * It always returns a non-empty string, even if there is an error. The
+   * contents of the string if there was an error are otherwise unspecified.
+   */
   std::string GetPeer();
 
   Status EasyPause(int bitmask) {


### PR DESCRIPTION
This is most useful in benchmarks, but could be handy
when troubleshooting connection problems. Specially
if proxies or VPC-SC are involved.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6994)
<!-- Reviewable:end -->
