### PR TITLE
ci: add DISTRO to bash prompt in build.sh --docker

### DIFF
--- a/ci/cloudbuild/build.sh
+++ b/ci/cloudbuild/build.sh
@@ -248,6 +248,7 @@ if [[ "${DOCKER_FLAG}" = "true" ]]; then
     "--rm"
     "--network=host"
     "--user=$(id -u):$(id -g)"
+    "--env=PS1=docker:${DISTRO_FLAG}\$ "
     "--env=USER=$(id -un)"
     "--env=TERM=$([[ -t 0 ]] && echo "${TERM:-dumb}" || echo dumb)"
     "--env=TZ=UTC0"
@@ -281,7 +282,7 @@ if [[ "${DOCKER_FLAG}" = "true" ]]; then
     printf "To run the build manually:\n  "
     printf " %q" "${cmd[@]}"
     printf "\n\n"
-    cmd=("bash")
+    cmd=("bash" "--norc") # some distros have rc files that override our PS1
   fi
   io::run docker run "${run_flags[@]}" "${image}" "${cmd[@]}"
   exit


### PR DESCRIPTION
This gives all of our `build.sh -s ...` sessions a consistent prompt
that shows the name of the distro that we're running in which can be
useful, because sometimes we need to know `apt` vs `dnf` etc.

For example, with this I get
```console
$ build.sh -t asan-pr -s
...
docker:fedora-34$ 
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6997)
<!-- Reviewable:end -->
