### PR TITLE
test: avoid using old emulator logs in startup

### DIFF
--- a/google/cloud/bigtable/tools/run_emulator_utils.sh
+++ b/google/cloud/bigtable/tools/run_emulator_utils.sh
@@ -82,12 +82,10 @@ function start_emulators() {
   trap kill_emulators EXIT
 
   local -r CBT_EMULATOR_CMD="/usr/local/google-cloud-sdk/platform/bigtable-emulator/cbtemulator"
-  rm -f emulator.log
   "${CBT_EMULATOR_CMD}" -port "${emulator_port}" >emulator.log 2>&1 </dev/null &
   EMULATOR_PID=$!
 
   # The path to this command must be set by the caller.
-  rm -f instance-admin-emulator.log
   "${CBT_INSTANCE_ADMIN_EMULATOR_CMD}" "${instance_admin_emulator_port}" >instance-admin-emulator.log 2>&1 </dev/null &
   INSTANCE_ADMIN_EMULATOR_PID=$!
 

--- a/google/cloud/bigtable/tools/run_emulator_utils.sh
+++ b/google/cloud/bigtable/tools/run_emulator_utils.sh
@@ -82,10 +82,12 @@ function start_emulators() {
   trap kill_emulators EXIT
 
   local -r CBT_EMULATOR_CMD="/usr/local/google-cloud-sdk/platform/bigtable-emulator/cbtemulator"
+  rm -f emulator.log
   "${CBT_EMULATOR_CMD}" -port "${emulator_port}" >emulator.log 2>&1 </dev/null &
   EMULATOR_PID=$!
 
   # The path to this command must be set by the caller.
+  rm -f instance-admin-emulator.log
   "${CBT_INSTANCE_ADMIN_EMULATOR_CMD}" "${instance_admin_emulator_port}" >instance-admin-emulator.log 2>&1 </dev/null &
   INSTANCE_ADMIN_EMULATOR_PID=$!
 

--- a/google/cloud/pubsub/ci/lib/pubsub_emulator.sh
+++ b/google/cloud/pubsub/ci/lib/pubsub_emulator.sh
@@ -32,7 +32,7 @@ function pubsub_emulator::internal::read_emulator_port() {
 
   local emulator_port="0"
   local -r expected=": Server started, listening on "
-  for attempt in $(seq 1 12); do
+  for _ in $(seq 1 12); do
     if grep -q "${expected}" "${logfile}"; then
       # The port number is whatever is after 'listening on'.
       emulator_port=$(grep "${expected}" "${logfile}" | awk -F' ' '{print $NF}')
@@ -59,6 +59,7 @@ function pubsub_emulator::start() {
   readonly PUBSUB_EMULATOR_ARGS=(
     "beta" "emulators" "pubsub" "start"
     "--project=${GOOGLE_CLOUD_PROJECT:-fake-project}")
+  rm -f emulator.log
   if [[ ! -x "${PUBSUB_EMULATOR_CMD}" ]]; then
     echo 1>&2 "The Cloud Pub/Sub emulator does not seem to be installed, aborting"
     cat emulator.log >&2

--- a/google/cloud/pubsub/ci/lib/pubsub_emulator.sh
+++ b/google/cloud/pubsub/ci/lib/pubsub_emulator.sh
@@ -59,15 +59,14 @@ function pubsub_emulator::start() {
   readonly PUBSUB_EMULATOR_ARGS=(
     "beta" "emulators" "pubsub" "start"
     "--project=${GOOGLE_CLOUD_PROJECT:-fake-project}")
-  rm -f emulator.log
   if [[ ! -x "${PUBSUB_EMULATOR_CMD}" ]]; then
     echo 1>&2 "The Cloud Pub/Sub emulator does not seem to be installed, aborting"
-    cat emulator.log >&2
     return 1
   fi
 
   # The tests typically run in a Docker container, where the ports are largely
   # free; when using in manual tests, you can set EMULATOR_PORT.
+  rm -f emulator.log
   "${PUBSUB_EMULATOR_CMD}" "${PUBSUB_EMULATOR_ARGS[@]}" >emulator.log 2>&1 </dev/null &
   PUBSUB_EMULATOR_PID=$!
 

--- a/google/cloud/spanner/ci/lib/spanner_emulator.sh
+++ b/google/cloud/spanner/ci/lib/spanner_emulator.sh
@@ -32,7 +32,7 @@ function spanner_emulator::internal::read_emulator_port() {
 
   local emulator_port="0"
   local -r expected=" : Server address: "
-  for attempt in $(seq 1 8); do
+  for _ in $(seq 1 8); do
     if grep -q "${expected}" "${logfile}"; then
       # The port number is whatever is after the last ':'.
       emulator_port=$(grep "${expected}" "${logfile}" | awk -F: '{print $NF}')
@@ -68,6 +68,7 @@ function spanner_emulator::start() {
 
   # The tests typically run in a Docker container, where the ports are largely
   # free; when using in manual tests, you can set EMULATOR_PORT.
+  rm -f emulator.log
   "${SPANNER_EMULATOR_CMD}" --host_port "localhost:${emulator_port}" >emulator.log 2>&1 </dev/null &
   SPANNER_EMULATOR_PID=$!
 

--- a/google/cloud/storage/tools/run_emulator_utils.sh
+++ b/google/cloud/storage/tools/run_emulator_utils.sh
@@ -55,6 +55,7 @@ start_emulator() {
   io::log "Launching Cloud Storage emulator on port ${port}"
   trap kill_emulator EXIT
 
+  rm -f gcs_emulator.log
   gunicorn --bind "0.0.0.0:${port}" \
     --worker-class sync \
     --threads "$(nproc)" \


### PR DESCRIPTION
I think this will deflake the storage builds.  Consider this:

- The script to startup the emulator uses the log file to discover the
  port where it is running.
- The script launches the emulator in the background and then
  immediately tries to read its log
- The script fails with "cannot connect", which it is only attempted
  after the port is found.
- The script then prints an empty emulator log, which could not happen
  if the port was found!

But really what is going on is that the shell calls `fork(2)` to start
the emulator, but before it gets to call `exec(2)`, or before it even
redirects `stdout` the parent process reads the file, finds the *old*
ports, then tries to connect. That fails, of course, then it prints the
log file, but that might be empty, or incomplete, or completely
different.

I got paranoid and fixed all the other scripts to start emulators.

Here is a log showing this:

```
2021-07-16T00:00:13Z (+362s)
---------------------------------------------------------
|   Running Storage integration tests (with emulator)   |
---------------------------------------------------------
2021-07-16T00:00:13Z (+362s): Launching Cloud Storage emulator on port 0
2021-07-16T00:00:13Z (+362s): Cannot connect to emulator; aborting test.
2021-07-16T00:00:13Z (+362s): curl connection test result.
curl: (7) Failed to connect to localhost port 39413: Connection refused
Killing emulator server [25990] ... 2021-07-16T00:00:13Z (+362s): ===> ccache stats
```

Part of the work for #6832

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7002)
<!-- Reviewable:end -->
