### PR TITLE
ci: change to docker "bridge" network driver

### DIFF
--- a/ci/cloudbuild/build.sh
+++ b/ci/cloudbuild/build.sh
@@ -246,7 +246,7 @@ if [[ "${DOCKER_FLAG}" = "true" ]]; then
     "--interactive"
     "--tty=$([[ -t 0 ]] && echo true || echo false)"
     "--rm"
-    "--network=host"
+    "--network=bridge"
     "--user=$(id -u):$(id -g)"
     "--env=PS1=docker:${DISTRO_FLAG}\$ "
     "--env=USER=$(id -un)"


### PR DESCRIPTION
This restores network isolation between the container and the docker
host, which should allow for using fixed ports from concurrent
containers without interference. The DNS cache problems alluded to
from #4288 appear to be a thing of the past.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7003)
<!-- Reviewable:end -->
