### PR TITLE
fix(storage): use hash values in InsertObject()

### DIFF
--- a/google/cloud/storage/emulator/emulator.py
+++ b/google/cloud/storage/emulator/emulator.py
@@ -48,6 +48,7 @@ def index():
 TODO(#6615): Introducing failures into uploads with return-XXX-after-YYYk
 """
 
+
 # Needs to be defined in emulator.py to keep context of flask and db global variables
 def retry_test(method):
     global supported_methods
@@ -805,7 +806,6 @@ def resumable_upload_chunk(bucket_name):
                 blob.metadata.metadata["x_emulator_transfer_encoding"] = ":".join(
                     upload.transfer
                 )
-                blob.metadata.metadata["x_emulator_upload"] = "resumable"
                 db.insert_object(upload.request, bucket_name, blob, None)
                 projection = utils.common.extract_projection(
                     upload.request, CommonEnums.Projection.NO_ACL, None
@@ -905,7 +905,6 @@ def xml_get_object(bucket_name, object_name):
 
 # Define the WSGI application to handle IAM requests
 (IAM_HANDLER_PATH, iam_app) = gcs_type.iam.get_iam_app()
-
 
 server = HandleGzipMiddleware(
     DispatcherMiddleware(

--- a/google/cloud/storage/emulator/grpc_server.py
+++ b/google/cloud/storage/emulator/grpc_server.py
@@ -253,7 +253,6 @@ class StorageServicer(storage_pb2_grpc.StorageServicer):
         upload = gcs_type.holder.DataHolder.init_resumable_grpc(
             request, bucket, context
         )
-        upload.metadata.metadata["x_emulator_upload"] = "resumable"
         db.insert_upload(upload)
         return storage_pb2.StartResumableWriteResponse(upload_id=upload.upload_id)
 

--- a/google/cloud/storage/emulator/tests/test_holder.py
+++ b/google/cloud/storage/emulator/tests/test_holder.py
@@ -195,6 +195,14 @@ class TestHolder(unittest.TestCase):
             insert_object_spec=insert_object_spec, write_offset=0
         )
         upload = gcs.holder.DataHolder.init_resumable_grpc(request, bucket, "")
+        # Verify the annotations inserted by the emulator.
+        annotations = upload.metadata.metadata
+        self.assertGreaterEqual(
+            set(["x_emulator_upload", "x_emulator_crc32c", "x_emulator_md5"]),
+            set(annotations.keys()),
+        )
+        # Clear any annotations created by the emulator
+        upload.metadata.metadata.clear()
         self.assertEqual(
             upload.metadata, resources_pb2.Object(name="object", bucket="bucket")
         )

--- a/google/cloud/storage/internal/curl_client.cc
+++ b/google/cloud/storage/internal/curl_client.cc
@@ -536,7 +536,9 @@ StatusOr<ObjectMetadata> CurlClient::InsertObjectMedia(
   // uploads. `DisableMD5Hash` and `DisableCrc32cChecksum` should not be
   // dependent on each other.
   if (!request.GetOption<DisableMD5Hash>().value() ||
-      !request.GetOption<DisableCrc32cChecksum>().value_or(false)) {
+      !request.GetOption<DisableCrc32cChecksum>().value_or(false) ||
+      request.HasOption<MD5HashValue>() ||
+      request.HasOption<Crc32cChecksumValue>()) {
     return InsertObjectMediaMultipart(request);
   }
 


### PR DESCRIPTION
If the application provides a `gcs::Crc32ChecksumValue()` or
`gcs::MD5HashValue()` to `InsertObject()` we should use those values to
create the metadata portion of the upload. Otherwise we are losing an
opportunity to validate the data integrity during the upload.

I discovered this while refactoring and restructuring the integration
tests for CRC32C checksums and MD5 hashes. Apologies for the massive
changes in the tests for what amounts to a small fix.

The tests now have 3 portions, one for `InsertObject()`, one for
`WriteObject()` and one for `ReadObject()`. Unlike before, the code for
XML and JSON tests is shared, though this required some changes in the
emulator to make it easier to detect what hash fields (if any) were
including in the upload.

For `InsertObject()` and `WriteObject()` we test 5 scenarios: (1) using
the default settings, which are enabled for CRC32C, and disabled for
MD5, (2) explicitly disabling the hash, (3) explicitly enabling the
hash, (4) setting the hash to the correct value, and (5) setting the
hash to the incorrect value.

For `WriteObject()` we also test detecting an invalid hash, both in the
case where the library computes the hash and the case where the
application provides it.

For `ReadObject()` it is simpler, because we cannot provide expected
hashes. So we only test the cases where the hash check is in its default
setting (enabled for CRC32, disabled for MD5) and that hash mistmatches
are detected when the hash is enabled.

Fixes #7014

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7025)
<!-- Reviewable:end -->
