### PR TITLE
feat(bigtable): cap outstanding mutation number for mutation batcher

### DIFF
--- a/google/cloud/bigtable/mutation_batcher.h
+++ b/google/cloud/bigtable/mutation_batcher.h
@@ -84,10 +84,17 @@ class MutationBatcher {
       return *this;
     }
 
+    /// MutationBatcher will at most admit this many mutations.
+    Options& SetMaxOutstandingMutations(size_t max_outstanding_mutations_arg) {
+      max_outstanding_mutations = max_outstanding_mutations_arg;
+      return *this;
+    }
+
     std::size_t max_mutations_per_batch;
     std::size_t max_size_per_batch;
     std::size_t max_batches;
     std::size_t max_outstanding_size;
+    std::size_t max_outstanding_mutations;
   };
 
   explicit MutationBatcher(Table table, Options options = Options())
@@ -95,6 +102,7 @@ class MutationBatcher {
         options_(options),
         num_outstanding_batches_(),
         outstanding_size_(),
+        outstanding_mutations_(),
         num_requests_pending_(),
         cur_batch_(std::make_shared<Batch>()) {}
 
@@ -288,6 +296,8 @@ class MutationBatcher {
   size_t num_outstanding_batches_;
   /// Size of admitted but uncompleted mutations.
   size_t outstanding_size_;
+  /// Number of admitted but uncompleted mutations.
+  size_t outstanding_mutations_;
   // Number of uncompleted SingleRowMutations (including not admitted).
   size_t num_requests_pending_;
 


### PR DESCRIPTION
Fixes #6205 as our users **should not** run into that exact "queued mutations" error any more.

One thing I noticed is that we do not do any bounding for the [knobs](https://github.com/dbolduc/google-cloud-cpp/blob/feda70036bd9847a190249fd0fbef271300045c3/google/cloud/bigtable/mutation_batcher.h#L63-L67) to set the limit (they can, for example, set mutations per request to be a gajillion). This is why I said "should not" instead of "can not".

I would sleep easier if we did not let them set values above the Bigtable imposed limits.... I will fix in a later PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7028)
<!-- Reviewable:end -->
