### PR TITLE
feat(GCS+gRPC): upload checksums with last chunk

### DIFF
--- a/google/cloud/storage/client_write_object_test.cc
+++ b/google/cloud/storage/client_write_object_test.cc
@@ -223,7 +223,7 @@ TEST_F(WriteObjectTest, UploadStreamResumable) {
         EXPECT_CALL(*mock, UploadFinalChunk)
             .WillOnce([expected, &bytes_written](
                           internal::ConstBufferSequence const& data,
-                          std::uint64_t size) {
+                          std::uint64_t size, internal::HashValues const&) {
               bytes_written += internal::TotalBytes(data);
               EXPECT_EQ(bytes_written, size);
               return make_status_or(ResumableUploadResponse{
@@ -356,7 +356,7 @@ TEST_F(WriteObjectTest, UploadFile) {
         EXPECT_CALL(*mock, UploadFinalChunk)
             .WillOnce([expected, &bytes_written](
                           internal::ConstBufferSequence const& data,
-                          std::uint64_t size) {
+                          std::uint64_t size, internal::HashValues const&) {
               bytes_written += internal::TotalBytes(data);
               EXPECT_EQ(bytes_written, size);
               return make_status_or(ResumableUploadResponse{

--- a/google/cloud/storage/internal/curl_resumable_upload_session.cc
+++ b/google/cloud/storage/internal/curl_resumable_upload_session.cc
@@ -30,7 +30,8 @@ StatusOr<ResumableUploadResponse> CurlResumableUploadSession::UploadChunk(
 }
 
 StatusOr<ResumableUploadResponse> CurlResumableUploadSession::UploadFinalChunk(
-    ConstBufferSequence const& buffers, std::uint64_t upload_size) {
+    ConstBufferSequence const& buffers, std::uint64_t upload_size,
+    HashValues const& /*full_object_hashes*/) {
   UploadChunkRequest request(session_id_, next_expected_, buffers, upload_size);
   request.set_option(custom_header());
   auto result = client_->UploadChunk(request);

--- a/google/cloud/storage/internal/curl_resumable_upload_session.h
+++ b/google/cloud/storage/internal/curl_resumable_upload_session.h
@@ -41,7 +41,8 @@ class CurlResumableUploadSession : public ResumableUploadSession {
       ConstBufferSequence const& buffers) override;
 
   StatusOr<ResumableUploadResponse> UploadFinalChunk(
-      ConstBufferSequence const& buffers, std::uint64_t upload_size) override;
+      ConstBufferSequence const& buffers, std::uint64_t upload_size,
+      HashValues const& full_object_hashes) override;
 
   StatusOr<ResumableUploadResponse> ResetSession() override;
 

--- a/google/cloud/storage/internal/curl_resumable_upload_session_test.cc
+++ b/google/cloud/storage/internal/curl_resumable_upload_session_test.cc
@@ -87,7 +87,7 @@ TEST(CurlResumableUploadSessionTest, Simple) {
   EXPECT_EQ(size, session.next_expected_byte());
   EXPECT_FALSE(session.done());
 
-  upload = session.UploadFinalChunk({{payload}}, 2 * size);
+  upload = session.UploadFinalChunk({{payload}}, 2 * size, {});
   EXPECT_STATUS_OK(upload);
   EXPECT_EQ(2 * size - 1, upload->last_committed_byte);
   EXPECT_EQ(2 * size, session.next_expected_byte());
@@ -189,7 +189,7 @@ TEST(CurlResumableUploadSessionTest, Empty) {
             "", size, {}, ResumableUploadResponse::kDone, {}});
       });
 
-  auto upload = session.UploadFinalChunk({{payload}}, size);
+  auto upload = session.UploadFinalChunk({{payload}}, size, {});
   EXPECT_STATUS_OK(upload);
   EXPECT_EQ(size, upload->last_committed_byte);
   EXPECT_EQ(size, session.next_expected_byte());

--- a/google/cloud/storage/internal/grpc_resumable_upload_session.h
+++ b/google/cloud/storage/internal/grpc_resumable_upload_session.h
@@ -37,7 +37,8 @@ class GrpcResumableUploadSession : public ResumableUploadSession {
       ConstBufferSequence const& payload) override;
 
   StatusOr<ResumableUploadResponse> UploadFinalChunk(
-      ConstBufferSequence const& payload, std::uint64_t upload_size) override;
+      ConstBufferSequence const& payload, std::uint64_t upload_size,
+      HashValues const& full_object_hashes) override;
 
   StatusOr<ResumableUploadResponse> ResetSession() override;
 
@@ -56,7 +57,8 @@ class GrpcResumableUploadSession : public ResumableUploadSession {
    * This function is used by both UploadChunk() and UploadFinalChunk()
    */
   StatusOr<ResumableUploadResponse> UploadGeneric(ConstBufferSequence buffers,
-                                                  bool final_chunk);
+                                                  bool final_chunk,
+                                                  HashValues const& hashes);
 
   std::shared_ptr<GrpcClient> client_;
   ResumableUploadSessionGrpcParams session_id_params_;

--- a/google/cloud/storage/internal/hash_function.cc
+++ b/google/cloud/storage/internal/hash_function.cc
@@ -50,6 +50,11 @@ std::unique_ptr<HashFunction> CreateHashFunction(
 
 std::unique_ptr<HashFunction> CreateHashFunction(
     ResumableUploadRequest const& request) {
+  if (!request.GetOption<UseResumableUploadSession>().value_or("").empty()) {
+    // Resumed sessions cannot include a hash function because the hash state
+    // for previous values is lost.
+    return CreateNullHashFunction();
+  }
   // A non-empty Crc32cChecksumValue implies that the application provided a
   // hash, and we should not compute our own.
   return CreateHashFunction(

--- a/google/cloud/storage/internal/hash_function_impl_test.cc
+++ b/google/cloud/storage/internal/hash_function_impl_test.cc
@@ -203,6 +203,18 @@ TEST(HasFunctionImplTest, CreateHashFunctionUpload) {
   }
 }
 
+TEST(HasFunctionImplTest, CreateHashFunctionUploadResumedSession) {
+  auto function = CreateHashFunction(
+      ResumableUploadRequest("test-bucket", "test-object")
+          .set_multiple_options(UseResumableUploadSession("test-session-id"),
+                                DisableCrc32cChecksum(false),
+                                DisableMD5Hash(false)));
+  Update(*function, "The quick brown fox jumps over the lazy dog");
+  auto const actual = std::move(*function).Finish();
+  EXPECT_THAT(actual.crc32c, IsEmpty());
+  EXPECT_THAT(actual.crc32c, IsEmpty());
+}
+
 }  // namespace
 }  // namespace internal
 }  // namespace STORAGE_CLIENT_NS

--- a/google/cloud/storage/internal/logging_resumable_upload_session.cc
+++ b/google/cloud/storage/internal/logging_resumable_upload_session.cc
@@ -37,10 +37,14 @@ StatusOr<ResumableUploadResponse> LoggingResumableUploadSession::UploadChunk(
 
 StatusOr<ResumableUploadResponse>
 LoggingResumableUploadSession::UploadFinalChunk(
-    ConstBufferSequence const& buffers, std::uint64_t upload_size) {
+    ConstBufferSequence const& buffers, std::uint64_t upload_size,
+    HashValues const& full_object_hashes) {
   GCP_LOG(INFO) << __func__ << "() << upload_size=" << upload_size
-                << ", buffer.size=" << TotalBytes(buffers);
-  auto response = session_->UploadFinalChunk(buffers, upload_size);
+                << ", buffer.size=" << TotalBytes(buffers) << ", crc32c=<"
+                << full_object_hashes.crc32c << ">, md5=<"
+                << full_object_hashes.md5 << ">";
+  auto response =
+      session_->UploadFinalChunk(buffers, upload_size, full_object_hashes);
   if (response.ok()) {
     GCP_LOG(INFO) << __func__ << "() >> payload={" << response.value() << "}";
   } else {

--- a/google/cloud/storage/internal/logging_resumable_upload_session.h
+++ b/google/cloud/storage/internal/logging_resumable_upload_session.h
@@ -37,7 +37,8 @@ class LoggingResumableUploadSession : public ResumableUploadSession {
   StatusOr<ResumableUploadResponse> UploadChunk(
       ConstBufferSequence const& buffers) override;
   StatusOr<ResumableUploadResponse> UploadFinalChunk(
-      ConstBufferSequence const& buffers, std::uint64_t upload_size) override;
+      ConstBufferSequence const& buffers, std::uint64_t upload_size,
+      HashValues const& full_object_hashes) override;
   StatusOr<ResumableUploadResponse> ResetSession() override;
   std::uint64_t next_expected_byte() const override;
   std::string const& session_id() const override;

--- a/google/cloud/storage/internal/logging_resumable_upload_session_test.cc
+++ b/google/cloud/storage/internal/logging_resumable_upload_session_test.cc
@@ -63,7 +63,8 @@ TEST_F(LoggingResumableUploadSessionTest, UploadFinalChunk) {
 
   std::string const payload = "test-payload-data";
   EXPECT_CALL(*mock, UploadFinalChunk)
-      .WillOnce([&](ConstBufferSequence const& p, std::uint64_t s) {
+      .WillOnce([&](ConstBufferSequence const& p, std::uint64_t s,
+                    HashValues const&) {
         EXPECT_THAT(p, ElementsAre(ConstBuffer{payload}));
         EXPECT_EQ(513 * 1024, s);
         return StatusOr<ResumableUploadResponse>(
@@ -72,7 +73,7 @@ TEST_F(LoggingResumableUploadSessionTest, UploadFinalChunk) {
 
   LoggingResumableUploadSession session(std::move(mock));
 
-  auto result = session.UploadFinalChunk({{payload}}, 513 * 1024);
+  auto result = session.UploadFinalChunk({{payload}}, 513 * 1024, {});
   EXPECT_THAT(result, StatusIs(StatusCode::kUnavailable, "uh oh"));
 
   auto const log_lines = log_backend_.ExtractLines();

--- a/google/cloud/storage/internal/object_write_streambuf.h
+++ b/google/cloud/storage/internal/object_write_streambuf.h
@@ -44,6 +44,7 @@ class ObjectWriteStreambuf : public std::basic_streambuf<char> {
   ObjectWriteStreambuf(std::unique_ptr<ResumableUploadSession> upload_session,
                        std::size_t max_buffer_size,
                        std::unique_ptr<HashFunction> hash_function,
+                       HashValues known_hashes,
                        std::unique_ptr<HashValidator> hash_validator,
                        AutoFinalizeConfig auto_finalize);
 
@@ -109,6 +110,8 @@ class ObjectWriteStreambuf : public std::basic_streambuf<char> {
   std::size_t max_buffer_size_;
 
   std::unique_ptr<HashFunction> hash_function_;
+  HashValues hash_values_;
+  HashValues known_hashes_;
   std::unique_ptr<HashValidator> hash_validator_;
   AutoFinalizeConfig auto_finalize_ = AutoFinalizeConfig::kDisabled;
 

--- a/google/cloud/storage/internal/resumable_upload_session.h
+++ b/google/cloud/storage/internal/resumable_upload_session.h
@@ -16,6 +16,7 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_RESUMABLE_UPLOAD_SESSION_H
 
 #include "google/cloud/storage/internal/const_buffer.h"
+#include "google/cloud/storage/internal/hash_values.h"
 #include "google/cloud/storage/internal/http_response.h"
 #include "google/cloud/storage/object_metadata.h"
 #include "google/cloud/storage/version.h"
@@ -57,7 +58,8 @@ class ResumableUploadSession {
    * @return The final result of the upload, including the object metadata.
    */
   virtual StatusOr<ResumableUploadResponse> UploadFinalChunk(
-      ConstBufferSequence const& buffers, std::uint64_t upload_size) = 0;
+      ConstBufferSequence const& buffers, std::uint64_t upload_size,
+      HashValues const& full_object_hashes) = 0;
 
   /// Resets the session by querying its current state.
   virtual StatusOr<ResumableUploadResponse> ResetSession() = 0;
@@ -130,8 +132,8 @@ class ResumableUploadSessionError : public ResumableUploadSession {
     return last_response_;
   }
 
-  StatusOr<ResumableUploadResponse> UploadFinalChunk(ConstBufferSequence const&,
-                                                     std::uint64_t) override {
+  StatusOr<ResumableUploadResponse> UploadFinalChunk(
+      ConstBufferSequence const&, std::uint64_t, HashValues const&) override {
     return last_response_;
   }
 

--- a/google/cloud/storage/object_write_stream.cc
+++ b/google/cloud/storage/object_write_stream.cc
@@ -31,8 +31,8 @@ ObjectWriteStream::ObjectWriteStream()
           absl::make_unique<internal::ResumableUploadSessionError>(
               Status(StatusCode::kUnimplemented, "null stream")),
           /*max_buffer_size=*/0, internal::CreateNullHashFunction(),
-          internal::CreateNullHashValidator(), AutoFinalizeConfig::kDisabled)) {
-}
+          internal::HashValues{}, internal::CreateNullHashValidator(),
+          AutoFinalizeConfig::kDisabled)) {}
 
 ObjectWriteStream::ObjectWriteStream(
     std::unique_ptr<internal::ObjectWriteStreambuf> buf)

--- a/google/cloud/storage/parallel_uploads_test.cc
+++ b/google/cloud/storage/parallel_uploads_test.cc
@@ -199,7 +199,8 @@ class ParallelUploadTest
       EXPECT_CALL(res, UploadFinalChunk)
           .WillOnce([expected_content, object_name, generation](
                         ConstBufferSequence const& content,
-                        std::uint64_t /*size*/) {
+                        std::uint64_t /*size*/,
+                        HashValues const& /*full_object_hashes*/) {
             EXPECT_THAT(content, ElementsAre(ConstBuffer(*expected_content)));
             return make_status_or(
                 ResumableUploadResponse{"fake-url",

--- a/google/cloud/storage/testing/mock_client.h
+++ b/google/cloud/storage/testing/mock_client.h
@@ -165,10 +165,10 @@ class MockResumableUploadSession
     : public google::cloud::storage::internal::ResumableUploadSession {
  public:
   MOCK_METHOD(StatusOr<internal::ResumableUploadResponse>, UploadChunk,
-              (internal::ConstBufferSequence const& buffer), (override));
+              (internal::ConstBufferSequence const&), (override));
   MOCK_METHOD(StatusOr<internal::ResumableUploadResponse>, UploadFinalChunk,
-              (internal::ConstBufferSequence const& buffer,
-               std::uint64_t upload_size),
+              (internal::ConstBufferSequence const&, std::uint64_t,
+               internal::HashValues const&),
               (override));
   MOCK_METHOD(StatusOr<internal::ResumableUploadResponse>, ResetSession, (),
               (override));

--- a/google/cloud/storage/tests/curl_resumable_upload_session_integration_test.cc
+++ b/google/cloud/storage/tests/curl_resumable_upload_session_integration_test.cc
@@ -58,7 +58,7 @@ TEST_F(CurlResumableUploadIntegrationTest, Simple) {
 
   std::string const contents = LoremIpsum();
   StatusOr<ResumableUploadResponse> response =
-      (*session)->UploadFinalChunk({{contents}}, contents.size());
+      (*session)->UploadFinalChunk({{contents}}, contents.size(), HashValues{});
 
   ASSERT_STATUS_OK(response);
   EXPECT_TRUE(response->payload.has_value());
@@ -91,7 +91,8 @@ TEST_F(CurlResumableUploadIntegrationTest, WithReset) {
   response = (*session)->ResetSession();
   ASSERT_STATUS_OK(response);
 
-  response = (*session)->UploadFinalChunk({{contents}}, 2 * contents.size());
+  response = (*session)->UploadFinalChunk({{contents}}, 2 * contents.size(),
+                                          HashValues{});
   ASSERT_STATUS_OK(response);
 
   EXPECT_TRUE(response->payload.has_value());
@@ -130,7 +131,8 @@ TEST_F(CurlResumableUploadIntegrationTest, Restore) {
   response = (*session)->UploadChunk({{contents}});
   ASSERT_STATUS_OK(response);
 
-  response = (*session)->UploadFinalChunk({{contents}}, 3 * contents.size());
+  response = (*session)->UploadFinalChunk({{contents}}, 3 * contents.size(),
+                                          HashValues{});
   ASSERT_STATUS_OK(response);
 
   EXPECT_TRUE(response->payload.has_value());
@@ -169,7 +171,8 @@ TEST_F(CurlResumableUploadIntegrationTest, EmptyTrailer) {
   // upload quantum. In this case the stream is terminated by sending an empty
   // chunk at the end, with the size of the previous chunks as an indication
   // of "done".
-  response = (*session)->UploadFinalChunk({}, 2 * contents.size());
+  response =
+      (*session)->UploadFinalChunk({}, 2 * contents.size(), HashValues{});
   ASSERT_STATUS_OK(response.status());
 
   EXPECT_TRUE(response->payload.has_value());
@@ -194,7 +197,7 @@ TEST_F(CurlResumableUploadIntegrationTest, Empty) {
 
   ASSERT_STATUS_OK(session);
 
-  auto response = (*session)->UploadFinalChunk({}, 0);
+  auto response = (*session)->UploadFinalChunk({}, 0, HashValues{});
   ASSERT_STATUS_OK(response.status());
 
   EXPECT_TRUE(response->payload.has_value());
@@ -250,7 +253,8 @@ TEST_F(CurlResumableUploadIntegrationTest, ResetWithParameters) {
   response = (*session)->ResetSession();
   ASSERT_STATUS_OK(response);
 
-  response = (*session)->UploadFinalChunk({{contents}}, 2 * contents.size());
+  response = (*session)->UploadFinalChunk({{contents}}, 2 * contents.size(),
+                                          HashValues{});
   ASSERT_STATUS_OK(response);
   ASSERT_TRUE(response->payload.has_value());
   auto metadata = *response->payload;

--- a/google/cloud/storage/tests/object_checksum_integration_test.cc
+++ b/google/cloud/storage/tests/object_checksum_integration_test.cc
@@ -228,8 +228,6 @@ TEST_F(ObjectChecksumIntegrationTest, WriteObjectWithValueSuccess) {
 
 /// @test Verify that incorrect CRC32C checksums values work in WriteObject().
 TEST_F(ObjectChecksumIntegrationTest, WriteObjectWithValueFailure) {
-  // TODO(#4157) - add supports for hashes in gRPC
-  if (UsingGrpc()) GTEST_SKIP();
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
   auto object_name = MakeRandomObjectName();
@@ -268,8 +266,6 @@ TEST_F(ObjectChecksumIntegrationTest, WriteObjectReceiveBadChecksum) {
 
 /// @test Verify that CRC32C checksum mismatches are reported by default.
 TEST_F(ObjectChecksumIntegrationTest, WriteObjectUploadBadChecksum) {
-  // TODO(#4156) - enable test when checksums are implemented.
-  if (UsingGrpc()) GTEST_SKIP();
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 

--- a/google/cloud/storage/tests/object_hash_integration_test.cc
+++ b/google/cloud/storage/tests/object_hash_integration_test.cc
@@ -222,8 +222,6 @@ TEST_F(ObjectHashIntegrationTest, WriteObjectWithValueSuccess) {
 
 /// @test Verify that incorrect MD5 hash values work in WriteObject().
 TEST_F(ObjectHashIntegrationTest, WriteObjectWithValueFailure) {
-  // TODO(#4157) - add supports for hashes in gRPC
-  if (UsingGrpc()) GTEST_SKIP();
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
   auto object_name = MakeRandomObjectName();
@@ -263,8 +261,6 @@ TEST_F(ObjectHashIntegrationTest, WriteObjectReceiveBadChecksum) {
 
 /// @test Verify that MD5 hash mismatches are reported by default.
 TEST_F(ObjectHashIntegrationTest, WriteObjectUploadBadChecksum) {
-  // TODO(#4156) - enable test when checksums are implemented.
-  if (UsingGrpc()) GTEST_SKIP();
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 

--- a/google/cloud/storage/tests/object_resumable_write_integration_test.cc
+++ b/google/cloud/storage/tests/object_resumable_write_integration_test.cc
@@ -25,6 +25,7 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace {
 
+using ::google::cloud::testing_util::IsOk;
 using ::testing::AnyOf;
 using ::testing::Eq;
 using ::testing::HasSubstr;
@@ -318,8 +319,9 @@ TEST_F(ObjectResumableWriteIntegrationTest, WithXUploadContentLength) {
     os.Close();
     ASSERT_STATUS_OK(os.metadata());
     ScheduleForDelete(*os.metadata());
-    EXPECT_FALSE(os.bad());
+    EXPECT_FALSE(os.bad()) << *os.metadata();
     EXPECT_EQ(desired_size, os.metadata()->size());
+    EXPECT_EQ(desired_size, offset);
   }
 }
 

--- a/google/cloud/storage/tests/object_write_streambuf_integration_test.cc
+++ b/google/cloud/storage/tests/object_write_streambuf_integration_test.cc
@@ -56,7 +56,7 @@ class ObjectWriteStreambufIntegrationTest
         internal::ClientImplDetails::GetRawClient(*client)
             ->client_options()
             .upload_buffer_size(),
-        CreateNullHashFunction(), CreateNullHashValidator(),
+        CreateNullHashFunction(), HashValues{}, CreateNullHashValidator(),
         AutoFinalizeConfig::kEnabled));
 
     std::ostringstream expected_stream;


### PR DESCRIPTION
gRPC supports sending the object checksums in the last chunk of a
resumable upload. This changes the `internal::ResumableUploadSession`
class to receive these checksums, and weaves them through all the
decorators and tests. I also changed `internal::ObjectWriteStream` to
compute and store the checksums, and only validate them later.

Fixes #4156 and fixes #4157

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7031)
<!-- Reviewable:end -->
