### PR TITLE
test(storage): test all resource fields in emulator

### DIFF
--- a/google/cloud/storage/emulator/gcs/holder.py
+++ b/google/cloud/storage/emulator/gcs/holder.py
@@ -142,13 +142,13 @@ class DataHolder(types.SimpleNamespace):
         metadata = request.insert_object_spec.resource
         # Add some annotations to make it easier to write tests
         metadata.metadata["x_emulator_upload"] = "resumable"
-        if metadata.crc32c.value is not None:
+        if metadata.HasField("crc32c"):
             metadata.metadata[
                 "x_emulator_crc32c"
             ] = utils.common.rest_crc32c_from_proto(metadata.crc32c.value)
         else:
-            metadata.metadata["x_emulator_no_crc3c"] = "true"
-        if metadata.md5_hash is not None:
+            metadata.metadata["x_emulator_no_crc32c"] = "true"
+        if metadata.md5_hash is not None and metadata.md5_hash != "":
             metadata.metadata["x_emulator_md5"] = metadata.md5_hash
         else:
             metadata.metadata["x_emulator_no_md5"] = "true"

--- a/google/cloud/storage/emulator/tests/test_holder.py
+++ b/google/cloud/storage/emulator/tests/test_holder.py
@@ -198,7 +198,7 @@ class TestHolder(unittest.TestCase):
         # Verify the annotations inserted by the emulator.
         annotations = upload.metadata.metadata
         self.assertGreaterEqual(
-            set(["x_emulator_upload", "x_emulator_crc32c", "x_emulator_md5"]),
+            set(["x_emulator_upload", "x_emulator_no_crc32c", "x_emulator_no_md5"]),
             set(annotations.keys()),
         )
         # Clear any annotations created by the emulator

--- a/google/cloud/storage/emulator/tests/test_object.py
+++ b/google/cloud/storage/emulator/tests/test_object.py
@@ -53,10 +53,43 @@ class TestObject(unittest.TestCase):
         self.assertEqual(blob.metadata.metadata["key"], "value")
         self.assertEqual(blob.metadata.content_type, "image/jpeg")
 
+    __REST_FIELDS_KEY_ONLY = [
+        "owner",
+        "timeCreated",
+        "timeDeleted",
+        "timeStorageClassUpdated",
+        "updated",
+    ]
+
     def test_grpc_to_rest(self):
         # Make sure that object created by `gRPC` works with `REST`'s request.
         spec = storage_pb2.InsertObjectSpec(
-            resource={"name": "object", "bucket": "bucket"}
+            resource=resources_pb2.Object(
+                name="test-object-name",
+                bucket="bucket",
+                metadata={"label0": "value0"},
+                cache_control="no-cache",
+                content_disposition="test-value",
+                content_encoding="test-value",
+                content_language="test-value",
+                content_type="octet-stream",
+                storage_class="regional",
+                customer_encryption=resources_pb2.Object.CustomerEncryption(
+                    encryption_algorithm="AES", key_sha256="123456"
+                ),
+                # TODO(#6982) - add these fields when moving to storage/v2
+                #   custom_time=utils.common.rest_rfc3339_to_proto("2021-08-01T12:00:00Z"),
+                event_based_hold={"value": True},
+                kms_key_name="test-value",
+                retention_expiration_time=utils.common.rest_rfc3339_to_proto(
+                    "2022-01-01T00:00:00Z"
+                ),
+                temporary_hold=True,
+                time_deleted=utils.common.rest_rfc3339_to_proto("2021-06-01T00:00:00Z"),
+                time_storage_class_updated=utils.common.rest_rfc3339_to_proto(
+                    "2021-07-01T00:00:00Z"
+                ),
+            )
         )
         request = storage_pb2.StartResumableWriteRequest(insert_object_spec=spec)
         upload = gcs.holder.DataHolder.init_resumable_grpc(
@@ -65,18 +98,88 @@ class TestObject(unittest.TestCase):
         blob, _ = gcs.object.Object.init(
             upload.request, upload.metadata, b"123456789", upload.bucket, False, ""
         )
-
         self.assertDictEqual(blob.rest_only, {})
         self.assertEqual(blob.metadata.bucket, "bucket")
-        self.assertEqual(blob.metadata.name, "object")
+        self.assertEqual(blob.metadata.name, "test-object-name")
         self.assertEqual(blob.media, b"123456789")
 
         # `REST` GET
 
         rest_metadata = blob.rest_metadata()
         self.assertEqual(rest_metadata["bucket"], "bucket")
-        self.assertEqual(rest_metadata["name"], "object")
+        self.assertEqual(rest_metadata["name"], "test-object-name")
         self.assertIsNone(blob.metadata.metadata.get("method"))
+        # Verify the ObjectAccessControl entries have the desired fields
+        acl = rest_metadata.pop("acl", None)
+        self.assertIsNotNone(acl)
+        for entry in acl:
+            self.assertEqual(entry.pop("kind", None), "storage#objectAccessControl")
+            self.assertEqual(entry.pop("bucket", None), "bucket")
+            self.assertEqual(entry.pop("object", None), "test-object-name")
+            self.assertIsNotNone(entry.pop("entity", None))
+            self.assertIsNotNone(entry.pop("role", None))
+            # Verify the remaining keys are a subset of the expected keys
+            self.assertLessEqual(
+                set(entry.keys()),
+                set(
+                    [
+                        "id",
+                        "selfLink",
+                        "generation",
+                        "email",
+                        "entityId",
+                        "domain",
+                        "projectTeam",
+                        "etag",
+                    ]
+                ),
+            )
+        # Some fields we only care that they exist.
+        for key in self.__REST_FIELDS_KEY_ONLY:
+            self.assertIsNotNone(rest_metadata.pop(key, None), msg="key=%s" % key)
+        # Some fields we need to manually extract to check their values
+        generation = rest_metadata.pop("generation", None)
+        self.assertIsNotNone(generation)
+        self.assertEqual(
+            "bucket/o/test-object-name#" + generation, rest_metadata.pop("id")
+        )
+        self.maxDiff = None
+        self.assertDictEqual(
+            rest_metadata,
+            {
+                "kind": "storage#object",
+                "bucket": "bucket",
+                "name": "test-object-name",
+                "cacheControl": "no-cache",
+                "contentDisposition": "test-value",
+                "contentEncoding": "test-value",
+                "contentLanguage": "test-value",
+                "contentType": "octet-stream",
+                "eventBasedHold": True,
+                "crc32c": "4waSgw==",
+                "customerEncryption": {
+                    "encryptionAlgorithm": "AES",
+                    "keySha256": "123456",
+                },
+                "kmsKeyName": "test-value",
+                "md5Hash": "JfnnlDI7RTiF9RgfG2JNCw==",
+                "metadata": {
+                    "label0": "value0",
+                    # The emulator adds useful annotations
+                    "x_emulator_upload": "resumable",
+                    "x_emulator_no_crc32c": "true",
+                    "x_emulator_no_md5": "true",
+                    "x_testbench_upload": "resumable",
+                    "x_testbench_no_crc32c": "true",
+                    "x_testbench_no_md5": "true",
+                },
+                "metageneration": "1",
+                "retentionExpirationTime": "2022-01-01T00:00:00Z",
+                "size": "9",
+                "storageClass": "regional",
+                "temporaryHold": True,
+            },
+        )
 
         # `REST` PATCH
 
@@ -88,17 +191,135 @@ class TestObject(unittest.TestCase):
 
     def test_rest_to_grpc(self):
         # Make sure that object created by `REST` works with `gRPC`'s request.
+        metadata = {
+            "bucket": "bucket",
+            "name": "test-object-name",
+            "metadata": {"method": "rest", "label0": "value0"},
+            "cacheControl": "no-cache",
+            "contentDisposition": "test-value",
+            "contentEncoding": "test-value",
+            "contentLanguage": "test-value",
+            "contentType": "application/octet-stream",
+            "eventBasedHold": True,
+            "customerEncryption": {"encryptionAlgorithm": "AES", "keySha256": "123456"},
+            "kmsKeyName": "test-value",
+            "retentionExpirationTime": "2022-01-01T00:00:00Z",
+            "temporaryHold": True,
+            # These are a bit artificial, but good to test the
+            # emulator preserves valid fields.
+            "timeDeleted": "2021-07-01T01:02:03Z",
+            "timeStorageClassUpdated": "2021-07-01T02:03:04Z",
+            "storageClass": "regional",
+        }
+        boundary = "test_separator_deadbeef"
+        payload = (
+            ("--" + boundary + "\r\n").join(
+                [
+                    "",
+                    # object metadata "part"
+                    "\r\n".join(
+                        [
+                            "Content-Type: application/json; charset=UTF-8",
+                            "",
+                            json.dumps(metadata),
+                            "",
+                        ]
+                    ),
+                    # object media "part"
+                    "\r\n".join(
+                        [
+                            "Content-Type: application/octet-stream",
+                            "Content-Length: 9",
+                            "",
+                            "123456789",
+                            "",
+                        ]
+                    ),
+                ]
+            )
+            + "--"
+            + boundary
+            + "--\r\n"
+        )
         request = utils.common.FakeRequest(
             args={},
-            headers={"content-type": "multipart/related; boundary=foo_bar_baz"},
-            data=b'--foo_bar_baz\r\nContent-Type: application/json; charset=UTF-8\r\n\r\n{"name": "object", "metadata": {"method": "rest"}}\r\n--foo_bar_baz\r\nContent-Type: image/jpeg\r\n\r\n123456789\r\n--foo_bar_baz--\r\n',
+            headers={"content-type": "multipart/related; boundary=" + boundary},
+            data=payload.encode("UTF-8"),
             environ={},
         )
         blob, _ = gcs.object.Object.init_multipart(request, self.bucket.metadata)
         self.assertEqual(blob.metadata.bucket, "bucket")
-        self.assertEqual(blob.metadata.name, "object")
+        self.assertEqual(blob.metadata.name, "test-object-name")
         self.assertEqual(blob.media, b"123456789")
         self.assertEqual(blob.metadata.metadata["method"], "rest")
+        rest_metadata = blob.rest_metadata()
+        # Verify the ObjectAccessControl entries have the desired fields
+        acl = rest_metadata.pop("acl", None)
+        self.assertIsNotNone(acl)
+        for entry in acl:
+            self.assertEqual(entry.pop("kind", None), "storage#objectAccessControl")
+            self.assertEqual(entry.pop("bucket", None), "bucket")
+            self.assertEqual(entry.pop("object", None), "test-object-name")
+            self.assertIsNotNone(entry.pop("entity", None))
+            self.assertIsNotNone(entry.pop("role", None))
+            # Verify the remaining keys are a subset of the expected keys
+            self.assertLessEqual(
+                set(entry.keys()),
+                set(
+                    [
+                        "id",
+                        "selfLink",
+                        "generation",
+                        "email",
+                        "entityId",
+                        "domain",
+                        "projectTeam",
+                        "etag",
+                    ]
+                ),
+            )
+        # Some fields we only care that they exist.
+        for key in self.__REST_FIELDS_KEY_ONLY:
+            self.assertIsNotNone(rest_metadata.pop(key, None), msg="key=%s" % key)
+        # Some fields we need to manually extract to check their values
+        generation = rest_metadata.pop("generation", None)
+        self.assertIsNotNone(generation)
+        self.assertEqual(
+            "bucket/o/test-object-name#" + generation, rest_metadata.pop("id")
+        )
+        self.maxDiff = None
+        self.assertDictEqual(
+            rest_metadata,
+            {
+                "kind": "storage#object",
+                "bucket": "bucket",
+                "name": "test-object-name",
+                "cacheControl": "no-cache",
+                "contentDisposition": "test-value",
+                "contentEncoding": "test-value",
+                "contentLanguage": "test-value",
+                "contentType": "application/octet-stream",
+                "eventBasedHold": True,
+                "crc32c": "4waSgw==",
+                "customerEncryption": {
+                    "encryptionAlgorithm": "AES",
+                    "keySha256": "123456",
+                },
+                "kmsKeyName": "test-value",
+                "md5Hash": "JfnnlDI7RTiF9RgfG2JNCw==",
+                "metadata": {
+                    "label0": "value0",
+                    "method": "rest",
+                    "x_emulator_upload": "multipart",
+                    "x_testbench_upload": "multipart",
+                },
+                "metageneration": "1",
+                "retentionExpirationTime": "2022-01-01T00:00:00Z",
+                "size": "9",
+                "storageClass": "regional",
+                "temporaryHold": True,
+            },
+        )
 
         # `grpc` PATCH
 
@@ -110,7 +331,7 @@ class TestObject(unittest.TestCase):
         )
         blob.patch(request, "")
         self.assertEqual(blob.metadata.bucket, "bucket")
-        self.assertEqual(blob.metadata.name, "object")
+        self.assertEqual(blob.metadata.name, "test-object-name")
         self.assertEqual(blob.media, b"123456789")
         self.assertEqual(blob.metadata.metadata["method"], "grpc")
 

--- a/google/cloud/storage/emulator/utils/common.py
+++ b/google/cloud/storage/emulator/utils/common.py
@@ -27,7 +27,7 @@ from flask import Response as FlaskResponse
 import scalpl
 import utils
 
-
+from google.protobuf import timestamp_pb2
 from requests_toolbelt import MultipartDecoder
 from requests_toolbelt.multipart.decoder import ImproperBodyPartContentException
 
@@ -438,6 +438,13 @@ def rest_crc32c_from_proto(crc32c):
     REST uses base64 encoded 32-bit big endian integers, while protos use just `int32`.
     """
     return base64.b64encode(struct.pack(">I", crc32c)).decode("utf-8")
+
+
+def rest_rfc3339_to_proto(rfc3339):
+    """Convert a RFC3339 timestamp to the google.protobuf.Timestamp format."""
+    ts = timestamp_pb2.Timestamp()
+    ts.FromJsonString(rfc3339)
+    return ts
 
 
 def rest_adjust(data, adjustments):


### PR DESCRIPTION
Before moving to the storage v2/ protos it would be good to have tests
verifying that all resource (`Object`, `Bucket`, `BucketAccessControl`,
etc.) fields are preserved as the are received from REST, stored in
protos, and returned as REST.

Part of the work for #6982

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7032)
<!-- Reviewable:end -->
