### PR TITLE
cleanup(bigtable): strictly enforce bigtable limits in mutation batcher

### DIFF
--- a/google/cloud/bigtable/mutation_batcher.h
+++ b/google/cloud/bigtable/mutation_batcher.h
@@ -155,6 +155,7 @@ class MutationBatcher {
    */
   std::pair<future<void>, future<Status>> AsyncApply(CompletionQueue& cq,
                                                      SingleRowMutation mut);
+
   /**
    * Asynchronously wait until all submitted mutations complete.
    *

--- a/google/cloud/bigtable/mutation_batcher.h
+++ b/google/cloud/bigtable/mutation_batcher.h
@@ -61,10 +61,7 @@ class MutationBatcher {
     Options();
 
     /// A single RPC will not have more mutations than this.
-    Options& SetMaxMutationsPerBatch(size_t max_mutations_per_batch_arg) {
-      max_mutations_per_batch = max_mutations_per_batch_arg;
-      return *this;
-    }
+    Options& SetMaxMutationsPerBatch(size_t max_mutations_per_batch_arg);
 
     /// Sum of mutations' sizes in a single RPC will not be larger than this.
     Options& SetMaxSizePerBatch(size_t max_size_per_batch_arg) {
@@ -85,10 +82,7 @@ class MutationBatcher {
     }
 
     /// MutationBatcher will at most admit this many mutations.
-    Options& SetMaxOutstandingMutations(size_t max_outstanding_mutations_arg) {
-      max_outstanding_mutations = max_outstanding_mutations_arg;
-      return *this;
-    }
+    Options& SetMaxOutstandingMutations(size_t max_outstanding_mutations_arg);
 
     std::size_t max_mutations_per_batch;
     std::size_t max_size_per_batch;
@@ -161,7 +155,6 @@ class MutationBatcher {
    */
   std::pair<future<void>, future<Status>> AsyncApply(CompletionQueue& cq,
                                                      SingleRowMutation mut);
-
   /**
    * Asynchronously wait until all submitted mutations complete.
    *

--- a/google/cloud/bigtable/mutation_batcher_test.cc
+++ b/google/cloud/bigtable/mutation_batcher_test.cc
@@ -254,11 +254,23 @@ TEST(OptionsTest, Trivial) {
                                      .SetMaxMutationsPerBatch(1)
                                      .SetMaxSizePerBatch(2)
                                      .SetMaxBatches(3)
-                                     .SetMaxOutstandingSize(4);
+                                     .SetMaxOutstandingSize(4)
+                                     .SetMaxOutstandingMutations(5);
   ASSERT_EQ(1, opt.max_mutations_per_batch);
   ASSERT_EQ(2, opt.max_size_per_batch);
   ASSERT_EQ(3, opt.max_batches);
   ASSERT_EQ(4, opt.max_outstanding_size);
+  ASSERT_EQ(5, opt.max_outstanding_mutations);
+}
+
+TEST(OptionsTest, StrictLimits) {
+  MutationBatcher::Options opt = MutationBatcher::Options()
+                                     .SetMaxMutationsPerBatch(200000)
+                                     .SetMaxOutstandingMutations(400000);
+  // See `kBigtableMutationLimit`
+  ASSERT_EQ(100000, opt.max_mutations_per_batch);
+  // See `kBigtableOutstandingMutationLimit`
+  ASSERT_EQ(300000, opt.max_outstanding_mutations);
 }
 
 TEST_F(MutationBatcherTest, TrivialTest) {


### PR DESCRIPTION
Fixes #7030

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7036)
<!-- Reviewable:end -->
