### PR TITLE
fix(storage): avoid crashes after move

### DIFF
--- a/google/cloud/storage/object_stream_test.cc
+++ b/google/cloud/storage/object_stream_test.cc
@@ -24,68 +24,89 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace {
 
+using ::google::cloud::testing_util::IsOk;
 using ::google::cloud::testing_util::StatusIs;
+using ::testing::NotNull;
 
 TEST(ObjectStream, ReadMoveConstructor) {
   ObjectReadStream reader;
+  ASSERT_THAT(reader.rdbuf(), NotNull());
   reader.setstate(std::ios::badbit | std::ios::eofbit);
   EXPECT_TRUE(reader.bad());
   EXPECT_TRUE(reader.eof());
-  EXPECT_NE(nullptr, reader.rdbuf());
 
   ObjectReadStream copy(std::move(reader));
+  ASSERT_THAT(copy.rdbuf(), NotNull());
   EXPECT_TRUE(copy.bad());
   EXPECT_TRUE(copy.eof());
   EXPECT_THAT(copy.status(), StatusIs(StatusCode::kUnimplemented));
 
-  EXPECT_EQ(nullptr, reader.rdbuf());  // NOLINT(bugprone-use-after-move)
-  EXPECT_NE(nullptr, copy.rdbuf());
+  // NOLINTNEXTLINE(bugprone-use-after-move)
+  EXPECT_THAT(reader.status(), Not(IsOk()));
+  EXPECT_THAT(reader.rdbuf(), NotNull());
 }
 
 TEST(ObjectStream, ReadMoveAssignment) {
   ObjectReadStream reader;
+  ASSERT_THAT(reader.rdbuf(), NotNull());
   reader.setstate(std::ios::badbit | std::ios::eofbit);
-  EXPECT_NE(nullptr, reader.rdbuf());
 
   ObjectReadStream copy;
 
   copy = std::move(reader);
+  ASSERT_THAT(copy.rdbuf(), NotNull());
   EXPECT_TRUE(copy.bad());
   EXPECT_TRUE(copy.eof());
   EXPECT_THAT(copy.status(), StatusIs(StatusCode::kUnimplemented));
 
-  EXPECT_EQ(nullptr, reader.rdbuf());  // NOLINT(bugprone-use-after-move)
-  EXPECT_NE(nullptr, copy.rdbuf());
+  // NOLINTNEXTLINE(bugprone-use-after-move)
+  ASSERT_THAT(reader.rdbuf(), NotNull());
+  EXPECT_THAT(reader.status(), Not(IsOk()));
 }
 
 TEST(ObjectStream, WriteMoveConstructor) {
   ObjectWriteStream writer;
+  ASSERT_THAT(writer.rdbuf(), NotNull());
   EXPECT_THAT(writer.metadata(), StatusIs(StatusCode::kUnimplemented));
-  EXPECT_NE(nullptr, writer.rdbuf());
 
   ObjectWriteStream copy(std::move(writer));
+  ASSERT_THAT(copy.rdbuf(), NotNull());
   EXPECT_TRUE(copy.bad());
   EXPECT_TRUE(copy.eof());
   EXPECT_THAT(copy.metadata(), StatusIs(StatusCode::kUnimplemented));
 
-  EXPECT_EQ(nullptr, writer.rdbuf());  // NOLINT(bugprone-use-after-move)
-  EXPECT_NE(nullptr, copy.rdbuf());
+  // NOLINTNEXTLINE(bugprone-use-after-move)
+  ASSERT_THAT(writer.rdbuf(), NotNull());
+  EXPECT_THAT(writer.last_status(), Not(IsOk()));
 }
 
 TEST(ObjectStream, WriteMoveAssignment) {
   ObjectWriteStream writer;
+  ASSERT_THAT(writer.rdbuf(), NotNull());
   EXPECT_THAT(writer.metadata(), StatusIs(StatusCode::kUnimplemented));
-  EXPECT_NE(nullptr, writer.rdbuf());
 
   ObjectWriteStream copy;
 
   copy = std::move(writer);
+  ASSERT_THAT(copy.rdbuf(), NotNull());
   EXPECT_TRUE(copy.bad());
   EXPECT_TRUE(copy.eof());
   EXPECT_THAT(copy.metadata(), StatusIs(StatusCode::kUnimplemented));
 
-  EXPECT_EQ(nullptr, writer.rdbuf());  // NOLINT(bugprone-use-after-move)
-  EXPECT_NE(nullptr, copy.rdbuf());
+  // NOLINTNEXTLINE(bugprone-use-after-move)
+  ASSERT_THAT(writer.rdbuf(), NotNull());
+  EXPECT_THAT(writer.last_status(), Not(IsOk()));
+}
+
+TEST(ObjectStream, Suspend) {
+  ObjectWriteStream writer;
+  ASSERT_THAT(writer.rdbuf(), NotNull());
+  EXPECT_THAT(writer.metadata(), StatusIs(StatusCode::kUnimplemented));
+
+  std::move(writer).Suspend();
+  // NOLINTNEXTLINE(bugprone-use-after-move)
+  ASSERT_THAT(writer.rdbuf(), NotNull());
+  EXPECT_THAT(writer.last_status(), Not(IsOk()));
 }
 
 }  // namespace


### PR DESCRIPTION
The `storage::Object*Stream` classes should not crash when used after
moved-from. They do not guarantee what value they hold, but crashing on
functions that just query their state is unexpected. Note that we have
not defined what pre-conditions are required by each function, so we
could have decided to make it UB to call these functions. That seems too
hostile when "not crash but returns some undefined value" is less
hostile and about as easy to implement.

Fixes #7044

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7045)
<!-- Reviewable:end -->
