### PR TITLE
testing(spanner): avoid multi-region instances during CMEK testing

### DIFF
--- a/google/cloud/spanner/integration_tests/database_admin_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/database_admin_integration_test.cc
@@ -64,8 +64,8 @@ class DatabaseAdminClientTest
 
     auto generator = google::cloud::internal::MakeDefaultPRNG();
 
-    auto instance_id =
-        spanner_testing::PickRandomInstance(generator, project_id);
+    auto instance_id = spanner_testing::PickRandomInstance(
+        generator, project_id, "NOT name:/instances/test-instance-mr-");
     ASSERT_STATUS_OK(instance_id);
     instance_ = Instance(project_id, *instance_id);
 

--- a/google/cloud/spanner/samples/samples.cc
+++ b/google/cloud/spanner/samples/samples.cc
@@ -3490,10 +3490,10 @@ void RunAll(bool emulator) {
 
   auto generator = google::cloud::internal::MakeDefaultPRNG();
 
-  auto random_instance =
-      google::cloud::spanner_testing::PickRandomInstance(generator, project_id);
+  auto random_instance = google::cloud::spanner_testing::PickRandomInstance(
+      generator, project_id, "NOT name:/instances/test-instance-mr-");
   if (!random_instance) {
-    throw std::runtime_error("Cannot find an instance to run the examples: " +
+    throw std::runtime_error("Cannot find an instance to run the samples: " +
                              random_instance.status().message());
   }
   std::string instance_id = *std::move(random_instance);


### PR DESCRIPTION
Until I can determine how to provision keys in multi-region instances
and avoid "Incompatible CryptoKey location" errors, avoid randomly
selecting a "test-instance-mr-*" instance during testing of CMEKs.

[The "test-instance-mr-*" instances were recently added to start
testing multi-region features.]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7047)
<!-- Reviewable:end -->
