### PR TITLE
testing(spanner): remove the restriction on low-cost-instance location

### DIFF
--- a/google/cloud/spanner/samples/samples.cc
+++ b/google/cloud/spanner/samples/samples.cc
@@ -3460,12 +3460,9 @@ void RunAllSlowInstanceTests(
     std::cout
         << "\nRunning spanner_create_instance_with_processing_units sample"
         << std::endl;
-    // TODO(#6894): Change "regional-us-central1" to `config` when low-cost
-    // instances are generally available (well, at least in the regions that
-    // `PickConfig()` might return).
-    CreateInstanceWithProcessingUnits(
-        instance_admin_client, project_id, crud_instance_id,
-        "Test Low-Cost Instance", "regional-us-central1");
+    CreateInstanceWithProcessingUnits(instance_admin_client, project_id,
+                                      crud_instance_id,
+                                      "Test Low-Cost Instance", config);
 
     std::cout << "\nRunning delete-instance sample" << std::endl;
     DeleteInstance(instance_admin_client, project_id, crud_instance_id);


### PR DESCRIPTION
The granular instance configuration (LCI) public preview has completed
roll-out, which means we can now exercise the feature without concern
for the allow-listing process.

Fixes #6894.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7050)
<!-- Reviewable:end -->
