### PR TITLE
doc: fix cmake instructions in top-level README

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ colleagues.
 From the top-level directory of `google-cloud-cpp` run these commands:
 
 ```shell
-git clone -C $HOME https://github.com/microsoft/vcpkg.git
+git -C $HOME clone https://github.com/microsoft/vcpkg.git
 $HOME/vcpkg/bootstrap-vcpkg.sh
 cmake -H. -Bcmake-out/ -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
 cmake --build cmake-out -- -j $(nproc)

--- a/ci/generate-markdown/generate-readme.sh
+++ b/ci/generate-markdown/generate-readme.sh
@@ -104,7 +104,7 @@ colleagues.
 From the top-level directory of `google-cloud-cpp` run these commands:
 
 ```shell
-git clone -C $HOME https://github.com/microsoft/vcpkg.git
+git -C $HOME clone https://github.com/microsoft/vcpkg.git
 $HOME/vcpkg/bootstrap-vcpkg.sh
 cmake -H. -Bcmake-out/ -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
 cmake --build cmake-out -- -j $(nproc)


### PR DESCRIPTION
Reordered command line options, "-C" option is part of the git's general options.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7057)
<!-- Reviewable:end -->
