### PR TITLE
feat(common): make GCP_LOG(FATAL) terminate execution

### DIFF
--- a/generator/generator_test.cc
+++ b/generator/generator_test.cc
@@ -62,8 +62,7 @@ class AbortingErrorCollector : public DescriptorPool::ErrorCollector {
                 const google::protobuf::Message*, ErrorLocation,
                 const std::string& error_message) override {
     GCP_LOG(FATAL) << "AddError() called unexpectedly: " << filename << " ["
-                   << element_name << "]: " << error_message << "\n";
-    std::exit(1);
+                   << element_name << "]: " << error_message;
   }
 };
 

--- a/generator/internal/descriptor_utils_test.cc
+++ b/generator/internal/descriptor_utils_test.cc
@@ -68,8 +68,7 @@ class AbortingErrorCollector : public DescriptorPool::ErrorCollector {
                 const google::protobuf::Message*, ErrorLocation,
                 const std::string& error_message) override {
     GCP_LOG(FATAL) << "AddError() called unexpectedly: " << filename << " ["
-                   << element_name << "]: " << error_message << "\n";
-    std::exit(1);
+                   << element_name << "]: " << error_message;
   }
 };
 

--- a/generator/internal/predicate_utils.cc
+++ b/generator/internal/predicate_utils.cc
@@ -82,8 +82,7 @@ DeterminePagination(google::protobuf::MethodDescriptor const& method) {
     if (min_field_number != std::get<2>(repeated_message_fields[0])) {
       GCP_LOG(FATAL) << "Repeated field in paginated response must be first "
                         "appearing and lowest field number: "
-                     << method.full_name() << std::endl;
-      std::exit(1);
+                     << method.full_name();
     }
   }
   return std::make_pair(std::get<0>(repeated_message_fields[0]),

--- a/generator/internal/predicate_utils_test.cc
+++ b/generator/internal/predicate_utils_test.cc
@@ -508,6 +508,7 @@ TEST(PredicateUtilsTest, PaginationNoRepeatedMessageField) {
 }
 
 TEST(PredicateUtilsDeathTest, PaginationRepeatedMessageOrderMismatch) {
+  google::cloud::LogSink::EnableStdClog();
   FileDescriptorProto service_file;
   /// @cond
   auto constexpr kServiceText = R"pb(
@@ -552,8 +553,9 @@ TEST(PredicateUtilsDeathTest, PaginationRepeatedMessageOrderMismatch) {
                                                             &service_file));
   DescriptorPool pool;
   FileDescriptor const* service_file_descriptor = pool.BuildFile(service_file);
-  EXPECT_DEATH(IsPaginated(*service_file_descriptor->service(0)->method(0)),
-               "");
+  EXPECT_DEATH_IF_SUPPORTED(
+      IsPaginated(*service_file_descriptor->service(0)->method(0)),
+      "Repeated field in paginated response must be first");
 }
 
 TEST(PredicateUtilsTest, PaginationExactlyOneRepatedStringResponse) {
@@ -628,8 +630,7 @@ class AbortingErrorCollector : public DescriptorPool::ErrorCollector {
                 const google::protobuf::Message*, ErrorLocation,
                 const std::string& error_message) override {
     GCP_LOG(FATAL) << "AddError() called unexpectedly: " << filename << " ["
-                   << element_name << "]: " << error_message << "\n";
-    std::exit(1);
+                   << element_name << "]: " << error_message;
   }
 };
 

--- a/generator/internal/service_code_generator_test.cc
+++ b/generator/internal/service_code_generator_test.cc
@@ -78,8 +78,7 @@ class AbortingErrorCollector : public DescriptorPool::ErrorCollector {
                 const google::protobuf::Message*, ErrorLocation,
                 const std::string& error_message) override {
     GCP_LOG(FATAL) << "AddError() called unexpectedly: " << filename << " ["
-                   << element_name << "]: " << error_message << "\n";
-    std::exit(1);
+                   << element_name << "]: " << error_message;
   }
 };
 

--- a/google/cloud/log.h
+++ b/google/cloud/log.h
@@ -85,6 +85,7 @@
 #include "google/cloud/version.h"
 #include <atomic>
 #include <chrono>
+#include <cstdlib>
 #include <functional>
 #include <iostream>
 #include <map>
@@ -139,14 +140,14 @@ inline namespace GOOGLE_CLOUD_CPP_NS {
  * is to prevent problems if anybody uses this macro in a context where `Logger`
  * is defined by the enclosing namespaces.
  */
-#define GOOGLE_CLOUD_CPP_LOG_I(level, sink)                                \
-  for (auto GOOGLE_CLOUD_CPP_LOGGER_IDENTIFIER = ::google::cloud::Logger<  \
-           ::google::cloud::LogSink::CompileTimeEnabled(                   \
-               ::google::cloud::Severity::level)>(                         \
-           ::google::cloud::Severity::level, __func__, __FILE__, __LINE__, \
-           sink);                                                          \
-       GOOGLE_CLOUD_CPP_LOGGER_IDENTIFIER.enabled();                       \
-       GOOGLE_CLOUD_CPP_LOGGER_IDENTIFIER.LogTo(sink))                     \
+#define GOOGLE_CLOUD_CPP_LOG_I(level, sink)                                    \
+  for (::google::cloud::Logger<::google::cloud::LogSink::CompileTimeEnabled(   \
+           ::google::cloud::Severity::level)>                                  \
+           GOOGLE_CLOUD_CPP_LOGGER_IDENTIFIER(                                 \
+               ::google::cloud::Severity::level, __func__, __FILE__, __LINE__, \
+               sink);                                                          \
+       GOOGLE_CLOUD_CPP_LOGGER_IDENTIFIER.enabled();                           \
+       GOOGLE_CLOUD_CPP_LOGGER_IDENTIFIER.LogTo(sink))                         \
   GOOGLE_CLOUD_CPP_LOGGER_IDENTIFIER.Stream()
 
 // Note that we do not use `GOOGLE_CLOUD_CPP_PP_CONCAT` here: we actually want
@@ -195,7 +196,7 @@ enum class Severity : int {
   GCP_LS_CRITICAL,  // NOLINT(readability-identifier-naming)
   /// The system is at risk of immediate failure.
   GCP_LS_ALERT,  // NOLINT(readability-identifier-naming)
-  /// The system is about to crash or terminate.
+  /// The system is unusable.  GCP_LOG(FATAL) will call std::abort().
   GCP_LS_FATAL,  // NOLINT(readability-identifier-naming)
   /// The highest possible severity level.
   GCP_LS_HIGHEST = int(GCP_LS_FATAL),  // NOLINT(readability-identifier-naming)
@@ -372,11 +373,14 @@ class Logger {
  public:
   Logger(Severity severity, char const* function, char const* filename,
          int lineno, LogSink& sink)
-      : severity_(severity),
+      : enabled_(!sink.empty() && sink.is_enabled(severity)),
+        severity_(severity),
         function_(function),
         filename_(filename),
-        lineno_(lineno) {
-    enabled_ = !sink.empty() && sink.is_enabled(severity);
+        lineno_(lineno) {}
+
+  ~Logger() {
+    if (severity_ >= Severity::GCP_LS_FATAL) std::abort();
   }
 
   bool enabled() const { return enabled_; }
@@ -420,8 +424,12 @@ class Logger {
 template <>
 class Logger<false> {
  public:
-  Logger<false>() = default;
-  Logger<false>(Severity, char const*, char const*, int, LogSink&) {}
+  Logger<false>(Severity severity, char const*, char const*, int, LogSink&)
+      : severity_(severity) {}
+
+  ~Logger() {
+    if (severity_ >= Severity::GCP_LS_FATAL) std::abort();
+  }
 
   //@{
   /**
@@ -434,6 +442,9 @@ class Logger<false> {
   // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
   NullStream Stream() { return NullStream(); }
   //@}
+
+ private:
+  Severity severity_;
 };
 
 namespace internal {

--- a/google/cloud/log.h
+++ b/google/cloud/log.h
@@ -437,7 +437,7 @@ class Logger<false> {
    * interface.
    */
   // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
-  constexpr bool enabled() const { return false; }
+  bool enabled() const { return false; }
   void LogTo(LogSink&) {}
   // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
   NullStream Stream() { return NullStream(); }

--- a/google/cloud/log_test.cc
+++ b/google/cloud/log_test.cc
@@ -229,7 +229,7 @@ TEST(LogSinkTest, LogCheckCounter) {
   EXPECT_CALL(*backend, ProcessWithOwnership).Times(2);
   sink.AddBackend(backend);
   GOOGLE_CLOUD_CPP_LOG_I(GCP_LS_ALERT, sink) << "count is " << counter;
-  GOOGLE_CLOUD_CPP_LOG_I(GCP_LS_FATAL, sink) << "count is " << counter;
+  GOOGLE_CLOUD_CPP_LOG_I(GCP_LS_CRITICAL, sink) << "count is " << counter;
   EXPECT_EQ(2, counter.count);
 }
 
@@ -290,6 +290,11 @@ TEST(LogSinkTest, DisabledLogsMakeNoCalls) {
   GOOGLE_CLOUD_CPP_LOG_I(GCP_LS_WARNING, sink) << "count is " << caller();
   // With no backends, we expect no calls to the expressions in the log line.
   EXPECT_EQ(0, counter);
+}
+
+TEST(LogFatalTest, NoReturn) {
+  LogSink::EnableStdClog();
+  EXPECT_DEATH_IF_SUPPORTED(GCP_LOG(FATAL) << "fatal message", "fatal message");
 }
 
 }  // namespace

--- a/google/cloud/storage/internal/curl_handle.cc
+++ b/google/cloud/storage/internal/curl_handle.cc
@@ -130,12 +130,10 @@ extern "C" int CurlSetSocketOptions(void* userdata, curl_socket_t curlfd,
 void AssertOptionSuccessImpl(
     CURLcode e, CURLoption opt, char const* where,
     absl::FunctionRef<std::string()> const& format_parameter) {
-  std::ostringstream os;
-  os << where << "() - error [" << e << "] while setting curl option [" << opt
-     << "] to [" << format_parameter()
-     << "], error description=" << curl_easy_strerror(e);
-  // TODO(#5693) - replace with GCP_LOG(FATAL).
-  google::cloud::internal::ThrowLogicError(std::move(os).str());
+  GCP_LOG(FATAL) << where << "() - error [" << e
+                 << "] while setting curl option [" << opt << "] to ["
+                 << format_parameter()
+                 << "], error description=" << curl_easy_strerror(e);
 }
 
 CurlHandle::CurlHandle() : handle_(curl_easy_init(), &curl_easy_cleanup) {

--- a/google/cloud/storage/internal/curl_handle_test.cc
+++ b/google/cloud/storage/internal/curl_handle_test.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/storage/internal/curl_handle.h"
+#include "google/cloud/log.h"
 #include <gmock/gmock.h>
 
 namespace google {
@@ -62,86 +63,38 @@ TEST(CurlHandleTest, AsStatus) {
 }
 
 TEST(AssertOptionSuccess, StringWithError) {
-#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
-  EXPECT_THROW(
-      try {
-        AssertOptionSuccess(CURLE_NOT_BUILT_IN, CURLOPT_CAINFO, "test-function",
-                            "some-path");
-      } catch (std::exception const& ex) {
-        EXPECT_THAT(ex.what(), HasSubstr("test-function"));
-        EXPECT_THAT(ex.what(), HasSubstr("some-path"));
-        throw;
-      },
-      std::logic_error);
-#else
+  google::cloud::LogSink::EnableStdClog();
   EXPECT_DEATH_IF_SUPPORTED(
       AssertOptionSuccess(CURLE_NOT_BUILT_IN, CURLOPT_CAINFO, "test-function",
                           "some-path"),
       "test-function");
-#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 }
 
 TEST(AssertOptionSuccess, IntWithError) {
-#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
-  EXPECT_THROW(
-      try {
-        AssertOptionSuccess(CURLE_NOT_BUILT_IN, CURLOPT_CAINFO, "test-function",
-                            1234);
-      } catch (std::exception const& ex) {
-        EXPECT_THAT(ex.what(), HasSubstr("test-function"));
-        EXPECT_THAT(ex.what(), HasSubstr("1234"));
-        throw;
-      },
-      std::logic_error);
-#else
+  google::cloud::LogSink::EnableStdClog();
   EXPECT_DEATH_IF_SUPPORTED(
       AssertOptionSuccess(CURLE_NOT_BUILT_IN, CURLOPT_CAINFO, "test-function",
                           1234),
       "test-function");
-#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 }
 
 TEST(AssertOptionSuccess, NullptrWithError) {
-#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
-  EXPECT_THROW(
-      try {
-        AssertOptionSuccess(CURLE_NOT_BUILT_IN, CURLOPT_CAINFO, "test-function",
-                            nullptr);
-      } catch (std::exception const& ex) {
-        EXPECT_THAT(ex.what(), HasSubstr("test-function"));
-        EXPECT_THAT(ex.what(), HasSubstr("nullptr"));
-        throw;
-      },
-      std::logic_error);
-#else
+  google::cloud::LogSink::EnableStdClog();
   EXPECT_DEATH_IF_SUPPORTED(
       AssertOptionSuccess(CURLE_NOT_BUILT_IN, CURLOPT_CAINFO, "test-function",
                           nullptr),
       "test-function");
-#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 }
 
 int TestFunction() { return 42; }
 
 TEST(AssertOptionSuccess, FunctionPtrWithError) {
+  google::cloud::LogSink::EnableStdClog();
   EXPECT_EQ(42, TestFunction());
-#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
-  EXPECT_THROW(
-      try {
-        AssertOptionSuccess(CURLE_NOT_BUILT_IN, CURLOPT_CAINFO, "test-function",
-                            &TestFunction);
-      } catch (std::exception const& ex) {
-        EXPECT_THAT(ex.what(), HasSubstr("test-function"));
-        EXPECT_THAT(ex.what(), HasSubstr("a value of type="));
-        throw;
-      },
-      std::logic_error);
-#else
   EXPECT_DEATH_IF_SUPPORTED(
       AssertOptionSuccess(CURLE_NOT_BUILT_IN, CURLOPT_CAINFO, "test-function",
                           &TestFunction),
       "test-function");
-#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 }
 
 }  // namespace


### PR DESCRIPTION
`GCP_LOG(FATAL)` now calls `std::abort()` during destruction
of its `Logger`, so control will never return to the caller.
This makes it more closely resemble the behavior of Abseil
logging, which eliminates some confusion between authors and
code readers, and which may also be a feature down the line.

This required some refactoring in a few places because the
control flow is more hidden, and `[[unreachable]]` isn't a
standard attribute yet.

Some, but not all, existing `GCP_LOG(FATAL)` invocations
were immediately followed by calls to `std::exit(1)`. These
were removed. The streaming arguments were also purged of
any trailing newlines and flushes, which `GCP_LOG()` already
handles.

Finally, `storage::AssertOptionSuccess()` was changed to
use `GCP_LOG(FATAL)` instead of `ThrowLogicError()`,
because (as implied in the `TODO`) an assertion failure
is not really something that should be caught.

Fixes #5693.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7058)
<!-- Reviewable:end -->
