### PR TITLE
ci: parallelize docker RUN builds whenver possible

### DIFF
--- a/ci/cloudbuild/dockerfiles/demo-centos-7.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-centos-7.Dockerfile
@@ -195,7 +195,7 @@ RUN curl -sSL https://github.com/nlohmann/json/archive/v3.9.1.tar.gz | \
       -DBUILD_SHARED_LIBS=yes \
       -DBUILD_TESTING=OFF \
       -H. -Bcmake-out/nlohmann/json && \
-    cmake --build cmake-out/nlohmann/json --target install -- -j ${NCPU} && \
+    cmake --build cmake-out/nlohmann/json --target install -- -j ${NCPU:-4} && \
     ldconfig
 # ```
 

--- a/ci/cloudbuild/dockerfiles/demo-debian-buster.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-debian-buster.Dockerfile
@@ -84,7 +84,7 @@ RUN curl -sSL https://github.com/nlohmann/json/archive/v3.9.1.tar.gz | \
       -DBUILD_SHARED_LIBS=yes \
       -DBUILD_TESTING=OFF \
       -H. -Bcmake-out/nlohmann/json && \
-    cmake --build cmake-out/nlohmann/json --target install -- -j ${NCPU} && \
+    cmake --build cmake-out/nlohmann/json --target install -- -j ${NCPU:-4} && \
     ldconfig
 # ```
 
@@ -104,7 +104,7 @@ RUN curl -sSL https://github.com/google/protobuf/archive/v3.15.8.tar.gz | \
         -DBUILD_SHARED_LIBS=yes \
         -Dprotobuf_BUILD_TESTS=OFF \
         -Hcmake -Bcmake-out && \
-    cmake --build cmake-out --target install && \
+    cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
     ldconfig
 # ```
 
@@ -128,7 +128,7 @@ RUN curl -sSL https://github.com/grpc/grpc/archive/v1.35.0.tar.gz | \
         -DgRPC_SSL_PROVIDER=package \
         -DgRPC_ZLIB_PROVIDER=package \
         -H. -Bcmake-out && \
-    cmake --build cmake-out --target install && \
+    cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
     ldconfig
 # ```
 

--- a/ci/cloudbuild/dockerfiles/demo-debian-stretch.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-debian-stretch.Dockerfile
@@ -170,7 +170,7 @@ RUN curl -sSL https://github.com/nlohmann/json/archive/v3.9.1.tar.gz | \
       -DBUILD_SHARED_LIBS=yes \
       -DBUILD_TESTING=OFF \
       -H. -Bcmake-out/nlohmann/json && \
-    cmake --build cmake-out/nlohmann/json --target install -- -j ${NCPU} && \
+    cmake --build cmake-out/nlohmann/json --target install -- -j ${NCPU:-4} && \
     ldconfig
 # ```
 

--- a/ci/cloudbuild/dockerfiles/demo-fedora.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-fedora.Dockerfile
@@ -98,7 +98,7 @@ RUN curl -sSL https://github.com/nlohmann/json/archive/v3.9.1.tar.gz | \
       -DBUILD_SHARED_LIBS=yes \
       -DBUILD_TESTING=OFF \
       -H. -Bcmake-out/nlohmann/json && \
-    cmake --build cmake-out/nlohmann/json --target install -- -j ${NCPU} && \
+    cmake --build cmake-out/nlohmann/json --target install -- -j ${NCPU:-4} && \
     ldconfig
 # ```
 
@@ -118,7 +118,7 @@ RUN curl -sSL https://github.com/google/protobuf/archive/v3.15.8.tar.gz | \
         -DBUILD_SHARED_LIBS=yes \
         -Dprotobuf_BUILD_TESTS=OFF \
         -Hcmake -Bcmake-out && \
-    cmake --build cmake-out --target install && \
+    cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
     ldconfig
 # ```
 
@@ -142,7 +142,7 @@ RUN curl -sSL https://github.com/grpc/grpc/archive/v1.35.0.tar.gz | \
         -DgRPC_SSL_PROVIDER=package \
         -DgRPC_ZLIB_PROVIDER=package \
         -H. -Bcmake-out && \
-    cmake --build cmake-out --target install && \
+    cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
     ldconfig
 # ```
 

--- a/ci/cloudbuild/dockerfiles/demo-opensuse-leap.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-opensuse-leap.Dockerfile
@@ -155,7 +155,7 @@ RUN curl -sSL https://github.com/nlohmann/json/archive/v3.9.1.tar.gz | \
       -DBUILD_SHARED_LIBS=yes \
       -DBUILD_TESTING=OFF \
       -H. -Bcmake-out/nlohmann/json && \
-    cmake --build cmake-out/nlohmann/json --target install -- -j ${NCPU} && \
+    cmake --build cmake-out/nlohmann/json --target install -- -j ${NCPU:-4} && \
     ldconfig
 # ```
 

--- a/ci/cloudbuild/dockerfiles/demo-rockylinux-8.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-rockylinux-8.Dockerfile
@@ -142,7 +142,7 @@ RUN curl -sSL https://github.com/nlohmann/json/archive/v3.9.1.tar.gz | \
       -DBUILD_SHARED_LIBS=yes \
       -DBUILD_TESTING=OFF \
       -H. -Bcmake-out/nlohmann/json && \
-    cmake --build cmake-out/nlohmann/json --target install -- -j ${NCPU} && \
+    cmake --build cmake-out/nlohmann/json --target install -- -j ${NCPU:-4} && \
     ldconfig
 # ```
 

--- a/ci/cloudbuild/dockerfiles/demo-ubuntu-bionic.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-ubuntu-bionic.Dockerfile
@@ -145,7 +145,7 @@ RUN curl -sSL https://github.com/nlohmann/json/archive/v3.9.1.tar.gz | \
       -DBUILD_SHARED_LIBS=yes \
       -DBUILD_TESTING=OFF \
       -H. -Bcmake-out/nlohmann/json && \
-    cmake --build cmake-out/nlohmann/json --target install -- -j ${NCPU} && \
+    cmake --build cmake-out/nlohmann/json --target install -- -j ${NCPU:-4} && \
     ldconfig
 # ```
 

--- a/ci/cloudbuild/dockerfiles/demo-ubuntu-focal.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-ubuntu-focal.Dockerfile
@@ -129,7 +129,7 @@ RUN curl -sSL https://github.com/nlohmann/json/archive/v3.9.1.tar.gz | \
       -DBUILD_SHARED_LIBS=yes \
       -DBUILD_TESTING=OFF \
       -H. -Bcmake-out/nlohmann/json && \
-    cmake --build cmake-out/nlohmann/json --target install -- -j ${NCPU} && \
+    cmake --build cmake-out/nlohmann/json --target install -- -j ${NCPU:-4} && \
     ldconfig
 # ```
 

--- a/ci/cloudbuild/dockerfiles/demo-ubuntu-xenial.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-ubuntu-xenial.Dockerfile
@@ -163,7 +163,7 @@ RUN curl -sSL https://github.com/nlohmann/json/archive/v3.9.1.tar.gz | \
       -DBUILD_SHARED_LIBS=yes \
       -DBUILD_TESTING=OFF \
       -H. -Bcmake-out/nlohmann/json && \
-    cmake --build cmake-out/nlohmann/json --target install -- -j ${NCPU} && \
+    cmake --build cmake-out/nlohmann/json --target install -- -j ${NCPU:-4} && \
     ldconfig
 # ```
 

--- a/ci/cloudbuild/dockerfiles/fedora-34.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/fedora-34.Dockerfile
@@ -133,7 +133,7 @@ RUN curl -sSL https://github.com/grpc/grpc/archive/v1.35.0.tar.gz | \
         -DgRPC_SSL_PROVIDER=package \
         -DgRPC_ZLIB_PROVIDER=package \
         -H. -Bcmake-out -GNinja && \
-    cmake --build cmake-out --target install && \
+    cmake --build cmake-out --target install -- -j ${NCPU} && \
     ldconfig && \
     cd /var/tmp && rm -fr build
 

--- a/ci/cloudbuild/dockerfiles/ubuntu-bionic-install.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/ubuntu-bionic-install.Dockerfile
@@ -66,7 +66,7 @@ RUN curl -sSL https://github.com/abseil/abseil-cpp/archive/20210324.2.tar.gz | \
       -DBUILD_SHARED_LIBS=yes \
       -DCMAKE_CXX_STANDARD=11 \
       -H. -Bcmake-out -GNinja && \
-    cmake --build cmake-out --target install && \
+    cmake --build cmake-out --target install -- -j ${NCPU} && \
     ldconfig && \
     cd /var/tmp && rm -fr build
 
@@ -78,7 +78,7 @@ RUN curl -sSL https://github.com/google/googletest/archive/release-1.11.0.tar.gz
       -DBUILD_SHARED_LIBS=yes \
       -DCMAKE_CXX_STANDARD=11 \
       -H. -Bcmake-out/googletest && \
-    cmake --build cmake-out/googletest --target install && \
+    cmake --build cmake-out/googletest --target install -- -j ${NCPU} && \
     ldconfig && \
     cd /var/tmp && rm -fr build
 
@@ -90,7 +90,7 @@ RUN curl -sSL https://github.com/google/benchmark/archive/v1.5.5.tar.gz | \
         -DBUILD_SHARED_LIBS=yes \
         -DBENCHMARK_ENABLE_TESTING=OFF \
         -H. -Bcmake-out -GNinja && \
-    cmake --build cmake-out --target install && \
+    cmake --build cmake-out --target install -- -j ${NCPU} && \
     ldconfig && \
     cd /var/tmp && rm -fr build
 
@@ -104,7 +104,7 @@ RUN curl -sSL https://github.com/google/crc32c/archive/1.1.0.tar.gz | \
       -DCRC32C_BUILD_BENCHMARKS=OFF \
       -DCRC32C_USE_GLOG=OFF \
       -H. -Bcmake-out -GNinja && \
-    cmake --build cmake-out --target install && \
+    cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
     ldconfig && \
     cd /var/tmp && rm -fr build
 
@@ -116,7 +116,7 @@ RUN curl -sSL https://github.com/nlohmann/json/archive/v3.9.1.tar.gz | \
       -DBUILD_SHARED_LIBS=yes \
       -DBUILD_TESTING=OFF \
       -H. -Bcmake-out -GNinja && \
-    cmake --build cmake-out --target install && \
+    cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
     ldconfig && \
     cd /var/tmp && rm -fr build
 
@@ -128,7 +128,7 @@ RUN curl -sSL https://github.com/google/protobuf/archive/v3.15.8.tar.gz | \
         -DBUILD_SHARED_LIBS=yes \
         -Dprotobuf_BUILD_TESTS=OFF \
         -Hcmake -Bcmake-out -GNinja && \
-    cmake --build cmake-out --target install && \
+    cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
     ldconfig && \
     cd /var/tmp && rm -fr build
 
@@ -139,7 +139,7 @@ RUN curl -sSL https://github.com/c-ares/c-ares/archive/refs/tags/cares-1_17_1.ta
         -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=yes \
         -H. -Bcmake-out -GNinja && \
-    cmake --build cmake-out --target install && \
+    cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
     ldconfig && \
     cd /var/tmp && rm -fr build
 
@@ -150,7 +150,7 @@ RUN curl -sSL https://github.com/google/re2/archive/2020-11-01.tar.gz | \
         -DBUILD_SHARED_LIBS=ON \
         -DRE2_BUILD_TESTING=OFF \
         -H. -Bcmake-out -GNinja && \
-    cmake --build cmake-out --target install && \
+    cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
     ldconfig && \
     cd /var/tmp && rm -fr build
 
@@ -169,7 +169,7 @@ RUN curl -sSL https://github.com/grpc/grpc/archive/v1.35.0.tar.gz | \
         -DgRPC_SSL_PROVIDER=package \
         -DgRPC_ZLIB_PROVIDER=package \
         -H. -Bcmake-out -GNinja && \
-    cmake --build cmake-out --target install && \
+    cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
     ldconfig && \
     cd /var/tmp && rm -fr build
 

--- a/ci/cloudbuild/dockerfiles/ubuntu-bionic-install.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/ubuntu-bionic-install.Dockerfile
@@ -104,7 +104,7 @@ RUN curl -sSL https://github.com/google/crc32c/archive/1.1.0.tar.gz | \
       -DCRC32C_BUILD_BENCHMARKS=OFF \
       -DCRC32C_USE_GLOG=OFF \
       -H. -Bcmake-out -GNinja && \
-    cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
+    cmake --build cmake-out --target install -- -j ${NCPU} && \
     ldconfig && \
     cd /var/tmp && rm -fr build
 
@@ -116,7 +116,7 @@ RUN curl -sSL https://github.com/nlohmann/json/archive/v3.9.1.tar.gz | \
       -DBUILD_SHARED_LIBS=yes \
       -DBUILD_TESTING=OFF \
       -H. -Bcmake-out -GNinja && \
-    cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
+    cmake --build cmake-out --target install -- -j ${NCPU} && \
     ldconfig && \
     cd /var/tmp && rm -fr build
 
@@ -128,7 +128,7 @@ RUN curl -sSL https://github.com/google/protobuf/archive/v3.15.8.tar.gz | \
         -DBUILD_SHARED_LIBS=yes \
         -Dprotobuf_BUILD_TESTS=OFF \
         -Hcmake -Bcmake-out -GNinja && \
-    cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
+    cmake --build cmake-out --target install -- -j ${NCPU} && \
     ldconfig && \
     cd /var/tmp && rm -fr build
 
@@ -139,7 +139,7 @@ RUN curl -sSL https://github.com/c-ares/c-ares/archive/refs/tags/cares-1_17_1.ta
         -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=yes \
         -H. -Bcmake-out -GNinja && \
-    cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
+    cmake --build cmake-out --target install -- -j ${NCPU} && \
     ldconfig && \
     cd /var/tmp && rm -fr build
 
@@ -150,7 +150,7 @@ RUN curl -sSL https://github.com/google/re2/archive/2020-11-01.tar.gz | \
         -DBUILD_SHARED_LIBS=ON \
         -DRE2_BUILD_TESTING=OFF \
         -H. -Bcmake-out -GNinja && \
-    cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
+    cmake --build cmake-out --target install -- -j ${NCPU} && \
     ldconfig && \
     cd /var/tmp && rm -fr build
 
@@ -169,7 +169,7 @@ RUN curl -sSL https://github.com/grpc/grpc/archive/v1.35.0.tar.gz | \
         -DgRPC_SSL_PROVIDER=package \
         -DgRPC_ZLIB_PROVIDER=package \
         -H. -Bcmake-out -GNinja && \
-    cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
+    cmake --build cmake-out --target install -- -j ${NCPU} && \
     ldconfig && \
     cd /var/tmp && rm -fr build
 

--- a/ci/cloudbuild/dockerfiles/ubuntu-xenial.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/ubuntu-xenial.Dockerfile
@@ -65,7 +65,7 @@ RUN curl -sSL https://github.com/abseil/abseil-cpp/archive/20210324.2.tar.gz | \
       -DBUILD_SHARED_LIBS=yes \
       -DCMAKE_CXX_STANDARD=11 \
       -H. -Bcmake-out -GNinja && \
-    cmake --build cmake-out --target install && \
+    cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
     ldconfig && \
     cd /var/tmp && rm -fr build
 
@@ -77,7 +77,7 @@ RUN curl -sSL https://github.com/google/googletest/archive/release-1.11.0.tar.gz
       -DBUILD_SHARED_LIBS=yes \
       -DCMAKE_CXX_STANDARD=11 \
       -H. -Bcmake-out/googletest && \
-    cmake --build cmake-out/googletest --target install && \
+    cmake --build cmake-out/googletest --target install -- -j ${NCPU:-4} && \
     ldconfig && \
     cd /var/tmp && rm -fr build
 
@@ -89,7 +89,7 @@ RUN curl -sSL https://github.com/google/benchmark/archive/v1.5.5.tar.gz | \
         -DBUILD_SHARED_LIBS=yes \
         -DBENCHMARK_ENABLE_TESTING=OFF \
         -H. -Bcmake-out -GNinja && \
-    cmake --build cmake-out --target install && \
+    cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
     ldconfig && \
     cd /var/tmp && rm -fr build
 
@@ -103,7 +103,7 @@ RUN curl -sSL https://github.com/google/crc32c/archive/1.1.0.tar.gz | \
       -DCRC32C_BUILD_BENCHMARKS=OFF \
       -DCRC32C_USE_GLOG=OFF \
       -H. -Bcmake-out -GNinja && \
-    cmake --build cmake-out --target install && \
+    cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
     ldconfig && \
     cd /var/tmp && rm -fr build
 
@@ -115,7 +115,7 @@ RUN curl -sSL https://github.com/nlohmann/json/archive/v3.9.1.tar.gz | \
       -DBUILD_SHARED_LIBS=yes \
       -DBUILD_TESTING=OFF \
       -H. -Bcmake-out -GNinja && \
-    cmake --build cmake-out --target install && \
+    cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
     ldconfig && \
     cd /var/tmp && rm -fr build
 
@@ -127,7 +127,7 @@ RUN curl -sSL https://github.com/google/protobuf/archive/v3.15.8.tar.gz | \
         -DBUILD_SHARED_LIBS=yes \
         -Dprotobuf_BUILD_TESTS=OFF \
         -Hcmake -Bcmake-out -GNinja && \
-    cmake --build cmake-out --target install && \
+    cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
     ldconfig && \
     cd /var/tmp && rm -fr build
 
@@ -138,7 +138,7 @@ RUN curl -sSL https://github.com/c-ares/c-ares/archive/refs/tags/cares-1_17_1.ta
         -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=yes \
         -H. -Bcmake-out -GNinja && \
-    cmake --build cmake-out --target install && \
+    cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
     ldconfig && \
     cd /var/tmp && rm -fr build
 
@@ -149,7 +149,7 @@ RUN curl -sSL https://github.com/google/re2/archive/2020-11-01.tar.gz | \
         -DBUILD_SHARED_LIBS=ON \
         -DRE2_BUILD_TESTING=OFF \
         -H. -Bcmake-out -GNinja && \
-    cmake --build cmake-out --target install && \
+    cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
     ldconfig && \
     cd /var/tmp && rm -fr build
 
@@ -168,6 +168,6 @@ RUN curl -sSL https://github.com/grpc/grpc/archive/v1.35.0.tar.gz | \
         -DgRPC_SSL_PROVIDER=package \
         -DgRPC_ZLIB_PROVIDER=package \
         -H. -Bcmake-out -GNinja && \
-    cmake --build cmake-out --target install && \
+    cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
     ldconfig && \
     cd /var/tmp && rm -fr build

--- a/ci/cloudbuild/dockerfiles/ubuntu-xenial.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/ubuntu-xenial.Dockerfile
@@ -65,7 +65,7 @@ RUN curl -sSL https://github.com/abseil/abseil-cpp/archive/20210324.2.tar.gz | \
       -DBUILD_SHARED_LIBS=yes \
       -DCMAKE_CXX_STANDARD=11 \
       -H. -Bcmake-out -GNinja && \
-    cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
+    cmake --build cmake-out --target install -- -j ${NCPU} && \
     ldconfig && \
     cd /var/tmp && rm -fr build
 
@@ -77,7 +77,7 @@ RUN curl -sSL https://github.com/google/googletest/archive/release-1.11.0.tar.gz
       -DBUILD_SHARED_LIBS=yes \
       -DCMAKE_CXX_STANDARD=11 \
       -H. -Bcmake-out/googletest && \
-    cmake --build cmake-out/googletest --target install -- -j ${NCPU:-4} && \
+    cmake --build cmake-out/googletest --target install -- -j ${NCPU} && \
     ldconfig && \
     cd /var/tmp && rm -fr build
 
@@ -89,7 +89,7 @@ RUN curl -sSL https://github.com/google/benchmark/archive/v1.5.5.tar.gz | \
         -DBUILD_SHARED_LIBS=yes \
         -DBENCHMARK_ENABLE_TESTING=OFF \
         -H. -Bcmake-out -GNinja && \
-    cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
+    cmake --build cmake-out --target install -- -j ${NCPU} && \
     ldconfig && \
     cd /var/tmp && rm -fr build
 
@@ -103,7 +103,7 @@ RUN curl -sSL https://github.com/google/crc32c/archive/1.1.0.tar.gz | \
       -DCRC32C_BUILD_BENCHMARKS=OFF \
       -DCRC32C_USE_GLOG=OFF \
       -H. -Bcmake-out -GNinja && \
-    cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
+    cmake --build cmake-out --target install -- -j ${NCPU} && \
     ldconfig && \
     cd /var/tmp && rm -fr build
 
@@ -115,7 +115,7 @@ RUN curl -sSL https://github.com/nlohmann/json/archive/v3.9.1.tar.gz | \
       -DBUILD_SHARED_LIBS=yes \
       -DBUILD_TESTING=OFF \
       -H. -Bcmake-out -GNinja && \
-    cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
+    cmake --build cmake-out --target install -- -j ${NCPU} && \
     ldconfig && \
     cd /var/tmp && rm -fr build
 
@@ -127,7 +127,7 @@ RUN curl -sSL https://github.com/google/protobuf/archive/v3.15.8.tar.gz | \
         -DBUILD_SHARED_LIBS=yes \
         -Dprotobuf_BUILD_TESTS=OFF \
         -Hcmake -Bcmake-out -GNinja && \
-    cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
+    cmake --build cmake-out --target install -- -j ${NCPU} && \
     ldconfig && \
     cd /var/tmp && rm -fr build
 
@@ -138,7 +138,7 @@ RUN curl -sSL https://github.com/c-ares/c-ares/archive/refs/tags/cares-1_17_1.ta
         -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=yes \
         -H. -Bcmake-out -GNinja && \
-    cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
+    cmake --build cmake-out --target install -- -j ${NCPU} && \
     ldconfig && \
     cd /var/tmp && rm -fr build
 
@@ -149,7 +149,7 @@ RUN curl -sSL https://github.com/google/re2/archive/2020-11-01.tar.gz | \
         -DBUILD_SHARED_LIBS=ON \
         -DRE2_BUILD_TESTING=OFF \
         -H. -Bcmake-out -GNinja && \
-    cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
+    cmake --build cmake-out --target install -- -j ${NCPU} && \
     ldconfig && \
     cd /var/tmp && rm -fr build
 
@@ -168,6 +168,6 @@ RUN curl -sSL https://github.com/grpc/grpc/archive/v1.35.0.tar.gz | \
         -DgRPC_SSL_PROVIDER=package \
         -DgRPC_ZLIB_PROVIDER=package \
         -H. -Bcmake-out -GNinja && \
-    cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
+    cmake --build cmake-out --target install -- -j ${NCPU} && \
     ldconfig && \
     cd /var/tmp && rm -fr build

--- a/doc/packaging.md
+++ b/doc/packaging.md
@@ -288,7 +288,7 @@ curl -sSL https://github.com/nlohmann/json/archive/v3.9.1.tar.gz | \
       -DBUILD_SHARED_LIBS=yes \
       -DBUILD_TESTING=OFF \
       -H. -Bcmake-out/nlohmann/json && \
-sudo cmake --build cmake-out/nlohmann/json --target install -- -j ${NCPU} && \
+sudo cmake --build cmake-out/nlohmann/json --target install -- -j ${NCPU:-4} && \
 sudo ldconfig
 ```
 
@@ -308,7 +308,7 @@ curl -sSL https://github.com/google/protobuf/archive/v3.15.8.tar.gz | \
         -DBUILD_SHARED_LIBS=yes \
         -Dprotobuf_BUILD_TESTS=OFF \
         -Hcmake -Bcmake-out && \
-sudo cmake --build cmake-out --target install && \
+sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
 sudo ldconfig
 ```
 
@@ -332,7 +332,7 @@ curl -sSL https://github.com/grpc/grpc/archive/v1.35.0.tar.gz | \
         -DgRPC_SSL_PROVIDER=package \
         -DgRPC_ZLIB_PROVIDER=package \
         -H. -Bcmake-out && \
-sudo cmake --build cmake-out --target install && \
+sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
 sudo ldconfig
 ```
 
@@ -495,7 +495,7 @@ curl -sSL https://github.com/nlohmann/json/archive/v3.9.1.tar.gz | \
       -DBUILD_SHARED_LIBS=yes \
       -DBUILD_TESTING=OFF \
       -H. -Bcmake-out/nlohmann/json && \
-sudo cmake --build cmake-out/nlohmann/json --target install -- -j ${NCPU} && \
+sudo cmake --build cmake-out/nlohmann/json --target install -- -j ${NCPU:-4} && \
 sudo ldconfig
 ```
 
@@ -632,7 +632,7 @@ curl -sSL https://github.com/nlohmann/json/archive/v3.9.1.tar.gz | \
       -DBUILD_SHARED_LIBS=yes \
       -DBUILD_TESTING=OFF \
       -H. -Bcmake-out/nlohmann/json && \
-sudo cmake --build cmake-out/nlohmann/json --target install -- -j ${NCPU} && \
+sudo cmake --build cmake-out/nlohmann/json --target install -- -j ${NCPU:-4} && \
 sudo ldconfig
 ```
 
@@ -785,7 +785,7 @@ curl -sSL https://github.com/nlohmann/json/archive/v3.9.1.tar.gz | \
       -DBUILD_SHARED_LIBS=yes \
       -DBUILD_TESTING=OFF \
       -H. -Bcmake-out/nlohmann/json && \
-sudo cmake --build cmake-out/nlohmann/json --target install -- -j ${NCPU} && \
+sudo cmake --build cmake-out/nlohmann/json --target install -- -j ${NCPU:-4} && \
 sudo ldconfig
 ```
 
@@ -956,7 +956,7 @@ curl -sSL https://github.com/nlohmann/json/archive/v3.9.1.tar.gz | \
       -DBUILD_SHARED_LIBS=yes \
       -DBUILD_TESTING=OFF \
       -H. -Bcmake-out/nlohmann/json && \
-sudo cmake --build cmake-out/nlohmann/json --target install -- -j ${NCPU} && \
+sudo cmake --build cmake-out/nlohmann/json --target install -- -j ${NCPU:-4} && \
 sudo ldconfig
 ```
 
@@ -1048,7 +1048,7 @@ curl -sSL https://github.com/nlohmann/json/archive/v3.9.1.tar.gz | \
       -DBUILD_SHARED_LIBS=yes \
       -DBUILD_TESTING=OFF \
       -H. -Bcmake-out/nlohmann/json && \
-sudo cmake --build cmake-out/nlohmann/json --target install -- -j ${NCPU} && \
+sudo cmake --build cmake-out/nlohmann/json --target install -- -j ${NCPU:-4} && \
 sudo ldconfig
 ```
 
@@ -1068,7 +1068,7 @@ curl -sSL https://github.com/google/protobuf/archive/v3.15.8.tar.gz | \
         -DBUILD_SHARED_LIBS=yes \
         -Dprotobuf_BUILD_TESTS=OFF \
         -Hcmake -Bcmake-out && \
-sudo cmake --build cmake-out --target install && \
+sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
 sudo ldconfig
 ```
 
@@ -1092,7 +1092,7 @@ curl -sSL https://github.com/grpc/grpc/archive/v1.35.0.tar.gz | \
         -DgRPC_SSL_PROVIDER=package \
         -DgRPC_ZLIB_PROVIDER=package \
         -H. -Bcmake-out && \
-sudo cmake --build cmake-out --target install && \
+sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
 sudo ldconfig
 ```
 
@@ -1270,7 +1270,7 @@ curl -sSL https://github.com/nlohmann/json/archive/v3.9.1.tar.gz | \
       -DBUILD_SHARED_LIBS=yes \
       -DBUILD_TESTING=OFF \
       -H. -Bcmake-out/nlohmann/json && \
-sudo cmake --build cmake-out/nlohmann/json --target install -- -j ${NCPU} && \
+sudo cmake --build cmake-out/nlohmann/json --target install -- -j ${NCPU:-4} && \
 sudo ldconfig
 ```
 
@@ -1420,7 +1420,7 @@ curl -sSL https://github.com/nlohmann/json/archive/v3.9.1.tar.gz | \
       -DBUILD_SHARED_LIBS=yes \
       -DBUILD_TESTING=OFF \
       -H. -Bcmake-out/nlohmann/json && \
-sudo cmake --build cmake-out/nlohmann/json --target install -- -j ${NCPU} && \
+sudo cmake --build cmake-out/nlohmann/json --target install -- -j ${NCPU:-4} && \
 sudo ldconfig
 ```
 
@@ -1610,7 +1610,7 @@ curl -sSL https://github.com/nlohmann/json/archive/v3.9.1.tar.gz | \
       -DBUILD_SHARED_LIBS=yes \
       -DBUILD_TESTING=OFF \
       -H. -Bcmake-out/nlohmann/json && \
-sudo cmake --build cmake-out/nlohmann/json --target install -- -j ${NCPU} && \
+sudo cmake --build cmake-out/nlohmann/json --target install -- -j ${NCPU:-4} && \
 sudo ldconfig
 ```
 


### PR DESCRIPTION
I used `${NCPU:-4}` (with a default value) in all the `demo-*` files. I used `${NCPU}` in the non-demo files, because its always set in our builds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7060)
<!-- Reviewable:end -->
