### PR TITLE
ci: avoid fedora's `pkgconf` which is slow

### DIFF
--- a/ci/cloudbuild/builds/cmake-install.sh
+++ b/ci/cloudbuild/builds/cmake-install.sh
@@ -149,6 +149,7 @@ done < <(find "${INSTALL_PREFIX}" -type f -print0)
 
 for repo_root in "ci/verify_current_targets" "ci/verify_deprecated_targets"; do
   out_dir="cmake-out/$(basename "${repo_root}")-out"
+  rm -f "${out_dir}/CMakeCache.txt"
   io::log_h2 "Verifying CMake targets in repo root: ${repo_root}"
   cmake -GNinja -DCMAKE_PREFIX_PATH="${INSTALL_PREFIX}" \
     -S "${repo_root}" -B "${out_dir}" -Wno-dev

--- a/ci/cloudbuild/dockerfiles/demo-fedora.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-fedora.Dockerfile
@@ -21,8 +21,8 @@ ARG NCPU=4
 
 # ```bash
 RUN dnf makecache && \
-    dnf install -y ccache cmake curl gcc-c++ git make ninja-build \
-        openssl-devel patch pkgconfig unzip tar wget zip zlib-devel
+    dnf install -y ccache cmake curl findutils gcc-c++ git make ninja-build \
+        openssl-devel patch unzip tar wget zip zlib-devel
 # ```
 
 # Fedora 34 includes packages for gRPC and Protobuf, but they are not
@@ -34,11 +34,27 @@ RUN dnf makecache && \
     dnf install -y c-ares-devel re2-devel libcurl-devel
 # ```
 
+# Fedora's version of `pkg-config` (https://github.com/pkgconf/pkgconf) is slow
+# when handling `.pc` files with lots of `Requires:` deps, which happens with
+# Abseil. If you plan to use `pkg-config` with any of the installed artifacts,
+# you may want to use a recent version of the standard `pkg-config` binary. If
+# not, `dnf install pkgconfig` should work.
+
+# ```bash
+WORKDIR /var/tmp/build/pkg-config-cpp
+RUN curl -sSL https://pkgconfig.freedesktop.org/releases/pkg-config-0.29.2.tar.gz | \
+    tar -xzf - --strip-components=1 && \
+    ./configure --with-internal-glib && \
+    make -j ${NCPU:-4} && \
+    make install && \
+    ldconfig
+# ```
+
 # The following steps will install libraries and tools in `/usr/local`. By
 # default pkg-config does not search in these directories.
 
 # ```bash
-ENV PKG_CONFIG_PATH=/usr/local/lib64/pkgconfig:/usr/local/lib/pkgconfig
+ENV PKG_CONFIG_PATH=/usr/local/lib64/pkgconfig:/usr/local/lib/pkgconfig:/usr/lib64/pkgconfig
 # ```
 
 # #### Abseil

--- a/doc/packaging.md
+++ b/doc/packaging.md
@@ -211,8 +211,8 @@ Install the minimal development tools:
 
 ```bash
 sudo dnf makecache && \
-sudo dnf install -y ccache cmake curl gcc-c++ git make ninja-build \
-        openssl-devel patch pkgconfig unzip tar wget zip zlib-devel
+sudo dnf install -y ccache cmake curl findutils gcc-c++ git make ninja-build \
+        openssl-devel patch unzip tar wget zip zlib-devel
 ```
 
 Fedora 34 includes packages for gRPC and Protobuf, but they are not
@@ -224,11 +224,27 @@ sudo dnf makecache && \
 sudo dnf install -y c-ares-devel re2-devel libcurl-devel
 ```
 
+Fedora's version of `pkg-config` (https://github.com/pkgconf/pkgconf) is slow
+when handling `.pc` files with lots of `Requires:` deps, which happens with
+Abseil. If you plan to use `pkg-config` with any of the installed artifacts,
+you may want to use a recent version of the standard `pkg-config` binary. If
+not, `sudo dnf install pkgconfig` should work.
+
+```bash
+mkdir -p $HOME/Downloads/pkg-config-cpp && cd $HOME/Downloads/pkg-config-cpp
+curl -sSL https://pkgconfig.freedesktop.org/releases/pkg-config-0.29.2.tar.gz | \
+    tar -xzf - --strip-components=1 && \
+    ./configure --with-internal-glib && \
+    make -j ${NCPU:-4} && \
+sudo make install && \
+sudo ldconfig
+```
+
 The following steps will install libraries and tools in `/usr/local`. By
 default pkg-config does not search in these directories.
 
 ```bash
-export PKG_CONFIG_PATH=/usr/local/lib64/pkgconfig:/usr/local/lib/pkgconfig
+export PKG_CONFIG_PATH=/usr/local/lib64/pkgconfig:/usr/local/lib/pkgconfig:/usr/lib64/pkgconfig
 ```
 
 #### Abseil


### PR DESCRIPTION
Fixes: #7052

This avoids Fedora's `pkgconf` (a drop-in replacement for `pkg-config`)
because it's too slow when dealing with `.pc` files with lots of
`Requires:` deps, which we have with Abseil. Instead, we use the normal
`pkg-config` binary, which seems to work better.

After this PR, we should be able to upgrade to gRPC 1.39.0 (`git revert
ba41d5a99818922b09eee5da148786c1d68c17f5`)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7061)
<!-- Reviewable:end -->
