### PR TITLE
fix(storage): cleanup interrupted downloads

### DIFF
--- a/google/cloud/storage/internal/curl_download_request.h
+++ b/google/cloud/storage/internal/curl_download_request.h
@@ -50,13 +50,7 @@ class CurlDownloadRequest : public ObjectReadSource {
  public:
   explicit CurlDownloadRequest();
 
-  ~CurlDownloadRequest() override {
-    if (!factory_) {
-      return;
-    }
-    factory_->CleanupHandle(std::move(handle_));
-    factory_->CleanupMultiHandle(std::move(multi_));
-  }
+  ~CurlDownloadRequest() override;
 
   CurlDownloadRequest(CurlDownloadRequest&&) = default;
   CurlDownloadRequest& operator=(CurlDownloadRequest&& rhs) = default;
@@ -75,6 +69,9 @@ class CurlDownloadRequest : public ObjectReadSource {
    * @returns 100-Continue if the transfer is not yet completed.
    */
   StatusOr<ReadSourceResult> Read(char* buf, std::size_t n) override;
+
+  /// Debug and test only, help identify download handles.
+  void* id() const { return handle_.handle_.get(); }
 
  private:
   friend class CurlRequestBuilder;


### PR DESCRIPTION
Downloads can be interrupted by the application. Sometimes this results
in incomplete cleanup of the handle, which when reused would start
failing some `curl_easy_setopt()` calls.

Fixes #7051

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7064)
<!-- Reviewable:end -->
