### PR TITLE
cleanup(storage): correct return value for WriteCallback

### DIFF
--- a/google/cloud/storage/internal/curl_download_request.cc
+++ b/google/cloud/storage/internal/curl_download_request.cc
@@ -243,7 +243,7 @@ std::size_t CurlDownloadRequest::WriteCallback(void* ptr, std::size_t size,
   if (buffer_offset_ >= buffer_size_) {
     TRACE_STATE() << " *** PAUSING HANDLE ***";
     paused_ = true;
-    return CURL_READFUNC_PAUSE;
+    return CURL_WRITEFUNC_PAUSE;
   }
 
   // Use the spill buffer first, if there is any...
@@ -252,7 +252,7 @@ std::size_t CurlDownloadRequest::WriteCallback(void* ptr, std::size_t size,
   if (free == 0) {
     TRACE_STATE() << " *** PAUSING HANDLE ***";
     paused_ = true;
-    return CURL_READFUNC_PAUSE;
+    return CURL_WRITEFUNC_PAUSE;
   }
   TRACE_STATE() << ", n=" << size * nmemb << ", free=" << free;
 


### PR DESCRIPTION
In libcurl the callback to receive data is called the "write callback",
I believe because this is the callback where you (the application
developer) write data to the destination file. I always found this
confusing: I am reading data from GCS and use the "write callback" for
it.

In this particular case my confusion manifested as returning
`CURL_READFUNC_PAUSE` from the write callback, when one is supposed to
use `CURL_WRITEFUNC_PAUSE`. Both are macros that expand to the same
value, so the confusion was harmless, but let's fix it anyway.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7066)
<!-- Reviewable:end -->
