### PR TITLE
cleanup: fix usage string

### DIFF
--- a/google/cloud/testing_util/command_line_parsing.cc
+++ b/google/cloud/testing_util/command_line_parsing.cc
@@ -108,7 +108,7 @@ std::string Basename(std::string const& path) {
 std::string BuildUsage(std::vector<OptionDescriptor> const& desc,
                        std::string const& command_path) {
   std::ostringstream os;
-  os << "Usage: " << Basename(command_path) << " [options] <region>\n";
+  os << "Usage: " << Basename(command_path) << " [options]\n";
   for (auto const& d : desc) {
     os << "    " << d.option << ": " << d.help << "\n";
   }


### PR DESCRIPTION
We missed this extra argument refactoring storage benchmarks in #2671

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7067)
<!-- Reviewable:end -->
