### PR TITLE
feat(bigtable): add benchmark to measure MutationBatcher throughput

### DIFF
--- a/ci/cloudbuild/builds/lib/integration.sh
+++ b/ci/cloudbuild/builds/lib/integration.sh
@@ -164,26 +164,26 @@ function integration::bazel_with_emulators() {
     tag_filters="integration-test,-no-msan"
   fi
 
-  #  io::log_h2 "Running integration tests that require production access"
-  #  bazel "${verb}" "${args[@]}" --test_tag_filters="${tag_filters}" \
-  #    "${production_integration_tests[@]}"
-  #
-  #  io::log_h2 "Running Pub/Sub integration tests (with emulator)"
-  #  "google/cloud/pubsub/ci/${EMULATOR_SCRIPT}" \
-  #    bazel "${verb}" "${args[@]}"
-  #
-  #  io::log_h2 "Running Storage Emulator integration tests"
-  #  "google/cloud/storage/emulator/ci/run_integration_tests_bazel.sh" \
-  #    bazel "${args[@]}"
-  #
-  #  io::log_h2 "Running Storage integration tests (with emulator)"
-  #  "google/cloud/storage/ci/${EMULATOR_SCRIPT}" \
-  #    bazel "${verb}" "${args[@]}"
-  #
-  #  io::log_h2 "Running Spanner integration tests (with emulator)"
-  #  "google/cloud/spanner/ci/${EMULATOR_SCRIPT}" \
-  #    bazel "${verb}" "${args[@]}"
-  #
+  io::log_h2 "Running integration tests that require production access"
+  bazel "${verb}" "${args[@]}" --test_tag_filters="${tag_filters}" \
+    "${production_integration_tests[@]}"
+
+  io::log_h2 "Running Pub/Sub integration tests (with emulator)"
+  "google/cloud/pubsub/ci/${EMULATOR_SCRIPT}" \
+    bazel "${verb}" "${args[@]}"
+
+  io::log_h2 "Running Storage Emulator integration tests"
+  "google/cloud/storage/emulator/ci/run_integration_tests_bazel.sh" \
+    bazel "${args[@]}"
+
+  io::log_h2 "Running Storage integration tests (with emulator)"
+  "google/cloud/storage/ci/${EMULATOR_SCRIPT}" \
+    bazel "${verb}" "${args[@]}"
+
+  io::log_h2 "Running Spanner integration tests (with emulator)"
+  "google/cloud/spanner/ci/${EMULATOR_SCRIPT}" \
+    bazel "${verb}" "${args[@]}"
+
   # We retry these tests because the emulator crashes due to #441.
   io::log_h2 "Running Bigtable integration tests (with emulator)"
   ci/retry-command.sh 3 0 \
@@ -197,27 +197,27 @@ function integration::bazel_with_emulators() {
   bazel "${verb}" "${args[@]}" \
     "--test_env=GOOGLE_CLOUD_CPP_BIGTABLE_TEST_ACCESS_TOKEN=${access_token}" \
     //google/cloud/bigtable/examples:bigtable_grpc_credentials
-  #
-  #  # This test is run separately because the URL may change and that would mess
-  #  # up Bazel's test cache for all the other tests.
-  #  io::log_h2 "Running combined examples using multiple services"
-  #  hello_world_http="$(gcloud run services describe \
-  #    hello-world-http \
-  #    --project="${GOOGLE_CLOUD_PROJECT}" \
-  #    --region="us-central1" --platform="managed" \
-  #    --format='value(status.url)')"
-  #
-  #  hello_world_grpc="$(gcloud run services describe \
-  #    hello-world-grpc \
-  #    --project="${GOOGLE_CLOUD_PROJECT}" \
-  #    --region="us-central1" --platform="managed" \
-  #    --format='value(status.url)')"
-  #
-  #  bazel "${verb}" "${args[@]}" \
-  #    "--test_env=GOOGLE_CLOUD_CPP_TEST_HELLO_WORLD_HTTP_URL=${hello_world_http}" \
-  #    "--test_env=GOOGLE_CLOUD_CPP_TEST_HELLO_WORLD_GRPC_URL=${hello_world_grpc}" \
-  #    "--test_env=GOOGLE_CLOUD_CPP_TEST_HELLO_WORLD_SERVICE_ACCOUNT=${GOOGLE_CLOUD_CPP_TEST_HELLO_WORLD_SERVICE_ACCOUNT}" \
-  #    //google/cloud/examples/...
+
+  # This test is run separately because the URL may change and that would mess
+  # up Bazel's test cache for all the other tests.
+  io::log_h2 "Running combined examples using multiple services"
+  hello_world_http="$(gcloud run services describe \
+    hello-world-http \
+    --project="${GOOGLE_CLOUD_PROJECT}" \
+    --region="us-central1" --platform="managed" \
+    --format='value(status.url)')"
+
+  hello_world_grpc="$(gcloud run services describe \
+    hello-world-grpc \
+    --project="${GOOGLE_CLOUD_PROJECT}" \
+    --region="us-central1" --platform="managed" \
+    --format='value(status.url)')"
+
+  bazel "${verb}" "${args[@]}" \
+    "--test_env=GOOGLE_CLOUD_CPP_TEST_HELLO_WORLD_HTTP_URL=${hello_world_http}" \
+    "--test_env=GOOGLE_CLOUD_CPP_TEST_HELLO_WORLD_GRPC_URL=${hello_world_grpc}" \
+    "--test_env=GOOGLE_CLOUD_CPP_TEST_HELLO_WORLD_SERVICE_ACCOUNT=${GOOGLE_CLOUD_CPP_TEST_HELLO_WORLD_SERVICE_ACCOUNT}" \
+    //google/cloud/examples/...
 }
 
 # Runs integration tests with CTest using emulators. This function requires a
@@ -240,27 +240,27 @@ function integration::ctest_with_emulators() {
     "--parallel" "$(nproc)"
   )
 
-  #  io::log_h2 "Running Generator integration tests via CTest"
-  #  googleapis_abs_path="$(realpath "${cmake_out}")/external/googleapis/src/googleapis_download/"
-  #  env -C "${cmake_out}" \
-  #    GOOGLE_CLOUD_CPP_GENERATOR_RUN_INTEGRATION_TESTS="yes" \
-  #    GOOGLE_CLOUD_CPP_GENERATOR_GOOGLEAPIS_PATH="${googleapis_abs_path}" \
-  #    GOOGLE_CLOUD_CPP_GENERATOR_PROTO_PATH="/usr/include/" \
-  #    GOOGLE_CLOUD_CPP_GENERATOR_CODE_PATH="/workspace/" \
-  #    GOOGLE_CLOUD_CPP_GENERATOR_GOLDEN_PATH="/workspace/" \
-  #    ctest -R "^google_cloud_cpp_generator_integration_" "${ctest_args[@]}"
-  #
-  #  io::log_h2 "Running Pub/Sub integration tests (with emulator)"
-  #  "google/cloud/pubsub/ci/${EMULATOR_SCRIPT}" \
-  #    "${cmake_out}" "${ctest_args[@]}" -L integration-test-emulator
-  #
-  #  io::log_h2 "Running Storage integration tests (with emulator)"
-  #  "${PROJECT_ROOT}/google/cloud/storage/ci/${EMULATOR_SCRIPT}" \
-  #    "${cmake_out}" "${ctest_args[@]}" -L integration-test-emulator
-  #
-  #  io::log_h2 "Running Spanner integration tests (with emulator)"
-  #  "${PROJECT_ROOT}/google/cloud/spanner/ci/${EMULATOR_SCRIPT}" \
-  #    "${cmake_out}" "${ctest_args[@]}" -L integration-test-emulator
+  io::log_h2 "Running Generator integration tests via CTest"
+  googleapis_abs_path="$(realpath "${cmake_out}")/external/googleapis/src/googleapis_download/"
+  env -C "${cmake_out}" \
+    GOOGLE_CLOUD_CPP_GENERATOR_RUN_INTEGRATION_TESTS="yes" \
+    GOOGLE_CLOUD_CPP_GENERATOR_GOOGLEAPIS_PATH="${googleapis_abs_path}" \
+    GOOGLE_CLOUD_CPP_GENERATOR_PROTO_PATH="/usr/local/include/" \
+    GOOGLE_CLOUD_CPP_GENERATOR_CODE_PATH="/workspace/" \
+    GOOGLE_CLOUD_CPP_GENERATOR_GOLDEN_PATH="/workspace/" \
+    ctest -R "^google_cloud_cpp_generator_integration_" "${ctest_args[@]}"
+
+  io::log_h2 "Running Pub/Sub integration tests (with emulator)"
+  "google/cloud/pubsub/ci/${EMULATOR_SCRIPT}" \
+    "${cmake_out}" "${ctest_args[@]}" -L integration-test-emulator
+
+  io::log_h2 "Running Storage integration tests (with emulator)"
+  "${PROJECT_ROOT}/google/cloud/storage/ci/${EMULATOR_SCRIPT}" \
+    "${cmake_out}" "${ctest_args[@]}" -L integration-test-emulator
+
+  io::log_h2 "Running Spanner integration tests (with emulator)"
+  "${PROJECT_ROOT}/google/cloud/spanner/ci/${EMULATOR_SCRIPT}" \
+    "${cmake_out}" "${ctest_args[@]}" -L integration-test-emulator
 
   io::log_h2 "Running Bigtable integration tests (with emulator)"
   ci/retry-command.sh 3 0 \

--- a/ci/cloudbuild/builds/lib/integration.sh
+++ b/ci/cloudbuild/builds/lib/integration.sh
@@ -164,26 +164,26 @@ function integration::bazel_with_emulators() {
     tag_filters="integration-test,-no-msan"
   fi
 
-  io::log_h2 "Running integration tests that require production access"
-  bazel "${verb}" "${args[@]}" --test_tag_filters="${tag_filters}" \
-    "${production_integration_tests[@]}"
-
-  io::log_h2 "Running Pub/Sub integration tests (with emulator)"
-  "google/cloud/pubsub/ci/${EMULATOR_SCRIPT}" \
-    bazel "${verb}" "${args[@]}"
-
-  io::log_h2 "Running Storage Emulator integration tests"
-  "google/cloud/storage/emulator/ci/run_integration_tests_bazel.sh" \
-    bazel "${args[@]}"
-
-  io::log_h2 "Running Storage integration tests (with emulator)"
-  "google/cloud/storage/ci/${EMULATOR_SCRIPT}" \
-    bazel "${verb}" "${args[@]}"
-
-  io::log_h2 "Running Spanner integration tests (with emulator)"
-  "google/cloud/spanner/ci/${EMULATOR_SCRIPT}" \
-    bazel "${verb}" "${args[@]}"
-
+  #  io::log_h2 "Running integration tests that require production access"
+  #  bazel "${verb}" "${args[@]}" --test_tag_filters="${tag_filters}" \
+  #    "${production_integration_tests[@]}"
+  #
+  #  io::log_h2 "Running Pub/Sub integration tests (with emulator)"
+  #  "google/cloud/pubsub/ci/${EMULATOR_SCRIPT}" \
+  #    bazel "${verb}" "${args[@]}"
+  #
+  #  io::log_h2 "Running Storage Emulator integration tests"
+  #  "google/cloud/storage/emulator/ci/run_integration_tests_bazel.sh" \
+  #    bazel "${args[@]}"
+  #
+  #  io::log_h2 "Running Storage integration tests (with emulator)"
+  #  "google/cloud/storage/ci/${EMULATOR_SCRIPT}" \
+  #    bazel "${verb}" "${args[@]}"
+  #
+  #  io::log_h2 "Running Spanner integration tests (with emulator)"
+  #  "google/cloud/spanner/ci/${EMULATOR_SCRIPT}" \
+  #    bazel "${verb}" "${args[@]}"
+  #
   # We retry these tests because the emulator crashes due to #441.
   io::log_h2 "Running Bigtable integration tests (with emulator)"
   ci/retry-command.sh 3 0 \
@@ -197,27 +197,27 @@ function integration::bazel_with_emulators() {
   bazel "${verb}" "${args[@]}" \
     "--test_env=GOOGLE_CLOUD_CPP_BIGTABLE_TEST_ACCESS_TOKEN=${access_token}" \
     //google/cloud/bigtable/examples:bigtable_grpc_credentials
-
-  # This test is run separately because the URL may change and that would mess
-  # up Bazel's test cache for all the other tests.
-  io::log_h2 "Running combined examples using multiple services"
-  hello_world_http="$(gcloud run services describe \
-    hello-world-http \
-    --project="${GOOGLE_CLOUD_PROJECT}" \
-    --region="us-central1" --platform="managed" \
-    --format='value(status.url)')"
-
-  hello_world_grpc="$(gcloud run services describe \
-    hello-world-grpc \
-    --project="${GOOGLE_CLOUD_PROJECT}" \
-    --region="us-central1" --platform="managed" \
-    --format='value(status.url)')"
-
-  bazel "${verb}" "${args[@]}" \
-    "--test_env=GOOGLE_CLOUD_CPP_TEST_HELLO_WORLD_HTTP_URL=${hello_world_http}" \
-    "--test_env=GOOGLE_CLOUD_CPP_TEST_HELLO_WORLD_GRPC_URL=${hello_world_grpc}" \
-    "--test_env=GOOGLE_CLOUD_CPP_TEST_HELLO_WORLD_SERVICE_ACCOUNT=${GOOGLE_CLOUD_CPP_TEST_HELLO_WORLD_SERVICE_ACCOUNT}" \
-    //google/cloud/examples/...
+  #
+  #  # This test is run separately because the URL may change and that would mess
+  #  # up Bazel's test cache for all the other tests.
+  #  io::log_h2 "Running combined examples using multiple services"
+  #  hello_world_http="$(gcloud run services describe \
+  #    hello-world-http \
+  #    --project="${GOOGLE_CLOUD_PROJECT}" \
+  #    --region="us-central1" --platform="managed" \
+  #    --format='value(status.url)')"
+  #
+  #  hello_world_grpc="$(gcloud run services describe \
+  #    hello-world-grpc \
+  #    --project="${GOOGLE_CLOUD_PROJECT}" \
+  #    --region="us-central1" --platform="managed" \
+  #    --format='value(status.url)')"
+  #
+  #  bazel "${verb}" "${args[@]}" \
+  #    "--test_env=GOOGLE_CLOUD_CPP_TEST_HELLO_WORLD_HTTP_URL=${hello_world_http}" \
+  #    "--test_env=GOOGLE_CLOUD_CPP_TEST_HELLO_WORLD_GRPC_URL=${hello_world_grpc}" \
+  #    "--test_env=GOOGLE_CLOUD_CPP_TEST_HELLO_WORLD_SERVICE_ACCOUNT=${GOOGLE_CLOUD_CPP_TEST_HELLO_WORLD_SERVICE_ACCOUNT}" \
+  #    //google/cloud/examples/...
 }
 
 # Runs integration tests with CTest using emulators. This function requires a
@@ -240,27 +240,27 @@ function integration::ctest_with_emulators() {
     "--parallel" "$(nproc)"
   )
 
-  io::log_h2 "Running Generator integration tests via CTest"
-  googleapis_abs_path="$(realpath "${cmake_out}")/external/googleapis/src/googleapis_download/"
-  env -C "${cmake_out}" \
-    GOOGLE_CLOUD_CPP_GENERATOR_RUN_INTEGRATION_TESTS="yes" \
-    GOOGLE_CLOUD_CPP_GENERATOR_GOOGLEAPIS_PATH="${googleapis_abs_path}" \
-    GOOGLE_CLOUD_CPP_GENERATOR_PROTO_PATH="/usr/local/include/" \
-    GOOGLE_CLOUD_CPP_GENERATOR_CODE_PATH="/workspace/" \
-    GOOGLE_CLOUD_CPP_GENERATOR_GOLDEN_PATH="/workspace/" \
-    ctest -R "^google_cloud_cpp_generator_integration_" "${ctest_args[@]}"
-
-  io::log_h2 "Running Pub/Sub integration tests (with emulator)"
-  "google/cloud/pubsub/ci/${EMULATOR_SCRIPT}" \
-    "${cmake_out}" "${ctest_args[@]}" -L integration-test-emulator
-
-  io::log_h2 "Running Storage integration tests (with emulator)"
-  "${PROJECT_ROOT}/google/cloud/storage/ci/${EMULATOR_SCRIPT}" \
-    "${cmake_out}" "${ctest_args[@]}" -L integration-test-emulator
-
-  io::log_h2 "Running Spanner integration tests (with emulator)"
-  "${PROJECT_ROOT}/google/cloud/spanner/ci/${EMULATOR_SCRIPT}" \
-    "${cmake_out}" "${ctest_args[@]}" -L integration-test-emulator
+  #  io::log_h2 "Running Generator integration tests via CTest"
+  #  googleapis_abs_path="$(realpath "${cmake_out}")/external/googleapis/src/googleapis_download/"
+  #  env -C "${cmake_out}" \
+  #    GOOGLE_CLOUD_CPP_GENERATOR_RUN_INTEGRATION_TESTS="yes" \
+  #    GOOGLE_CLOUD_CPP_GENERATOR_GOOGLEAPIS_PATH="${googleapis_abs_path}" \
+  #    GOOGLE_CLOUD_CPP_GENERATOR_PROTO_PATH="/usr/include/" \
+  #    GOOGLE_CLOUD_CPP_GENERATOR_CODE_PATH="/workspace/" \
+  #    GOOGLE_CLOUD_CPP_GENERATOR_GOLDEN_PATH="/workspace/" \
+  #    ctest -R "^google_cloud_cpp_generator_integration_" "${ctest_args[@]}"
+  #
+  #  io::log_h2 "Running Pub/Sub integration tests (with emulator)"
+  #  "google/cloud/pubsub/ci/${EMULATOR_SCRIPT}" \
+  #    "${cmake_out}" "${ctest_args[@]}" -L integration-test-emulator
+  #
+  #  io::log_h2 "Running Storage integration tests (with emulator)"
+  #  "${PROJECT_ROOT}/google/cloud/storage/ci/${EMULATOR_SCRIPT}" \
+  #    "${cmake_out}" "${ctest_args[@]}" -L integration-test-emulator
+  #
+  #  io::log_h2 "Running Spanner integration tests (with emulator)"
+  #  "${PROJECT_ROOT}/google/cloud/spanner/ci/${EMULATOR_SCRIPT}" \
+  #    "${cmake_out}" "${ctest_args[@]}" -L integration-test-emulator
 
   io::log_h2 "Running Bigtable integration tests (with emulator)"
   ci/retry-command.sh 3 0 \

--- a/google/cloud/bigtable/benchmarks/BUILD
+++ b/google/cloud/bigtable/benchmarks/BUILD
@@ -25,6 +25,7 @@ cc_library(
     deps = [
         "//:bigtable",
         "//google/cloud:google_cloud_cpp_common",
+        "//google/cloud/bigtable:bigtable_client_testing",
         "//google/cloud/testing_util:google_cloud_cpp_testing",
     ],
 )

--- a/google/cloud/bigtable/benchmarks/BUILD
+++ b/google/cloud/bigtable/benchmarks/BUILD
@@ -25,6 +25,7 @@ cc_library(
     deps = [
         "//:bigtable",
         "//google/cloud:google_cloud_cpp_common",
+        "//google/cloud/testing_util:google_cloud_cpp_testing",
     ],
 )
 

--- a/google/cloud/bigtable/benchmarks/CMakeLists.txt
+++ b/google/cloud/bigtable/benchmarks/CMakeLists.txt
@@ -29,6 +29,7 @@ add_library(
     setup.h)
 target_link_libraries(
     bigtable_benchmark_common
+    bigtable_client_testing
     google-cloud-cpp::bigtable
     google-cloud-cpp::bigtable_protos
     google-cloud-cpp::common

--- a/google/cloud/bigtable/benchmarks/CMakeLists.txt
+++ b/google/cloud/bigtable/benchmarks/CMakeLists.txt
@@ -30,6 +30,7 @@ add_library(
 target_link_libraries(
     bigtable_benchmark_common
     bigtable_client_testing
+    google_cloud_cpp_testing_grpc
     google-cloud-cpp::bigtable
     google-cloud-cpp::bigtable_protos
     google-cloud-cpp::common

--- a/google/cloud/bigtable/benchmarks/CMakeLists.txt
+++ b/google/cloud/bigtable/benchmarks/CMakeLists.txt
@@ -21,6 +21,8 @@ add_library(
     constants.h
     embedded_server.cc
     embedded_server.h
+    mutation_batcher_throughput_options.cc
+    mutation_batcher_throughput_options.h
     random_mutation.cc
     random_mutation.h
     setup.cc
@@ -43,8 +45,12 @@ if (BUILD_TESTING)
     # List the unit tests, then setup the targets and dependencies.
     set(bigtable_benchmarks_unit_tests
         # cmake-format: sort
-        bigtable_benchmark_test.cc embedded_server_test.cc
-        format_duration_test.cc random_mutation_test.cc setup_test.cc)
+        bigtable_benchmark_test.cc
+        embedded_server_test.cc
+        format_duration_test.cc
+        mutation_batcher_throughput_options.cc
+        random_mutation_test.cc
+        setup_test.cc)
     export_list_to_bazel("bigtable_benchmarks_unit_tests.bzl"
                          "bigtable_benchmarks_unit_tests" YEAR 2020)
 
@@ -76,8 +82,11 @@ endif ()
 
 set(bigtable_benchmark_programs
     # cmake-format: sort
-    apply_read_latency_benchmark.cc endurance_benchmark.cc
-    read_sync_vs_async_benchmark.cc scan_throughput_benchmark.cc)
+    apply_read_latency_benchmark.cc
+    endurance_benchmark.cc
+    mutation_batcher_throughput_benchmark.cc
+    read_sync_vs_async_benchmark.cc
+    scan_throughput_benchmark.cc)
 export_list_to_bazel("bigtable_benchmark_programs.bzl"
                      "bigtable_benchmark_programs")
 
@@ -89,6 +98,7 @@ foreach (fname ${bigtable_benchmark_programs})
                 google-cloud-cpp::bigtable
                 google-cloud-cpp::bigtable_protos
                 google-cloud-cpp::grpc_utils
+                google_cloud_cpp_testing
                 gRPC::grpc++
                 gRPC::grpc
                 protobuf::libprotobuf)

--- a/google/cloud/bigtable/benchmarks/bigtable_benchmark_common.bzl
+++ b/google/cloud/bigtable/benchmarks/bigtable_benchmark_common.bzl
@@ -20,6 +20,7 @@ bigtable_benchmark_common_hdrs = [
     "benchmark.h",
     "constants.h",
     "embedded_server.h",
+    "mutation_batcher_throughput_options.h",
     "random_mutation.h",
     "setup.h",
 ]
@@ -27,6 +28,7 @@ bigtable_benchmark_common_hdrs = [
 bigtable_benchmark_common_srcs = [
     "benchmark.cc",
     "embedded_server.cc",
+    "mutation_batcher_throughput_options.cc",
     "random_mutation.cc",
     "setup.cc",
 ]

--- a/google/cloud/bigtable/benchmarks/bigtable_benchmark_programs.bzl
+++ b/google/cloud/bigtable/benchmarks/bigtable_benchmark_programs.bzl
@@ -19,6 +19,7 @@
 bigtable_benchmark_programs = [
     "apply_read_latency_benchmark.cc",
     "endurance_benchmark.cc",
+    "mutation_batcher_throughput_benchmark.cc",
     "read_sync_vs_async_benchmark.cc",
     "scan_throughput_benchmark.cc",
 ]

--- a/google/cloud/bigtable/benchmarks/bigtable_benchmarks_unit_tests.bzl
+++ b/google/cloud/bigtable/benchmarks/bigtable_benchmarks_unit_tests.bzl
@@ -20,6 +20,7 @@ bigtable_benchmarks_unit_tests = [
     "bigtable_benchmark_test.cc",
     "embedded_server_test.cc",
     "format_duration_test.cc",
+    "mutation_batcher_throughput_options_test.cc",
     "random_mutation_test.cc",
     "setup_test.cc",
 ]

--- a/google/cloud/bigtable/benchmarks/mutation_batcher_throughput_benchmark.cc
+++ b/google/cloud/bigtable/benchmarks/mutation_batcher_throughput_benchmark.cc
@@ -1,0 +1,274 @@
+// Copyright 2021 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/bigtable/benchmarks/mutation_batcher_throughput_options.h"
+#include "google/cloud/bigtable/mutation_batcher.h"
+#include "google/cloud/bigtable/table.h"
+#include "google/cloud/bigtable/table_admin.h"
+#include "google/cloud/internal/getenv.h"
+#include "google/cloud/status_or.h"
+#include "google/cloud/testing_util/command_line_parsing.h"
+#include "google/cloud/testing_util/timer.h"
+#include "absl/time/time.h"
+#include <chrono>
+#include <iomanip>
+#include <sstream>
+#include <string>
+#include <thread>
+
+namespace {
+
+namespace cbt = google::cloud::bigtable;
+using cbt::benchmarks::MutationBatcherThroughputOptions;
+using cbt::benchmarks::ParseMutationBatcherThroughputOptions;
+using google::cloud::Status;
+using google::cloud::StatusCode;
+using google::cloud::internal::GetEnv;
+
+char const kDescription[] =
+    R"""(A benchmark to measure the throughput of the `MutationBatcher` class.
+
+The purpose of the program is to determine effective default settings for
+`MutationBatcher::Options` that maximize throughput. The specific settings,
+which are the main inputs to this program, are maximum mutations per batch and
+maximum concurrent batches in flight.
+
+The program is designed to be run repeatedly. It has the ability to cut itself
+off (if really bad options are supplied). It also has the ability to use a
+pre-existing table instead of creating a new one then deleting it when the
+program is done.
+
+The program will:
+
+1) Conditionally create a table.
+2) Echo your configuration settings.
+3) Configure a `MutationBatcher`.
+4) Spin off some number of threads.
+5) Send mutations to a `MutationBatcher` from each thread. The `MutationBatcher`
+   will apply these mutations to the table. Progress will be logged for those
+   who are impatient.
+6) Conditionally stop batching mutations if the program exceeds a supplied deadline.
+7) Report the total time it took to apply the mutations.
+8) Report the total number of successful and failed mutations.
+9) Conditionally delete the table.
+)""";
+
+google::cloud::StatusOr<MutationBatcherThroughputOptions> ParseArgs(
+    int argc, char* argv[]) {
+  auto const auto_run =
+      GetEnv("GOOGLE_CLOUD_CPP_AUTO_RUN_EXAMPLES").value_or("") == "yes";
+  if (auto_run) {
+    for (auto const& var : {"GOOGLE_CLOUD_PROJECT",
+                            "GOOGLE_CLOUD_CPP_BIGTABLE_TEST_INSTANCE_ID"}) {
+      auto const value = GetEnv(var).value_or("");
+      if (!value.empty()) continue;
+      std::ostringstream os;
+      os << "The environment variable " << var << "is not set or empty";
+      return Status(StatusCode::kUnknown, std::move(os).str());
+    }
+    auto const project_id = GetEnv("GOOGLE_CLOUD_PROJECT").value();
+    auto const instance_id =
+        GetEnv("GOOGLE_CLOUD_CPP_BIGTABLE_TEST_INSTANCE_ID").value();
+    return ParseMutationBatcherThroughputOptions(
+        {
+            std::string(argv[0]),
+            "--project-id=" + project_id,
+            "--instance-id=" + instance_id,
+            "--mutation-count=1000",
+            "--max-batches=3",
+        },
+        kDescription);
+  }
+
+  return ParseMutationBatcherThroughputOptions({argv, argv + argc},
+                                               kDescription);
+}
+
+cbt::SingleRowMutation MakeMutation(
+    MutationBatcherThroughputOptions const& options, int key_width,
+    std::int64_t const& row_key) {
+  std::ostringstream os;
+  os << "row" << std::setw(key_width) << std::setfill('0') << row_key;
+  return cbt::SingleRowMutation(
+      std::move(os).str(),
+      {cbt::SetCell(options.column_family, options.column, "value")});
+}
+
+}  // namespace
+
+int main(int argc, char* argv[]) {
+  auto options = ParseArgs(argc, argv);
+  if (!options) {
+    std::cerr << options.status() << "\n";
+    return 1;
+  }
+  if (options->exit_after_parse) return 0;
+
+  namespace cbt = google::cloud::bigtable;
+  using google::cloud::CompletionQueue;
+  using google::cloud::future;
+  using google::cloud::Options;
+  using google::cloud::Status;
+  using google::cloud::testing_util::Timer;
+
+  cbt::TableAdmin admin(cbt::CreateDefaultAdminClient(options->project_id, {}),
+                        options->instance_id);
+
+  // Create a new table if one was not supplied
+  auto table_id = options->table_id;
+  if (table_id.empty()) {
+    using google::cloud::internal::Sample;
+    auto generator = google::cloud::internal::MakeDefaultPRNG();
+    std::string table_id_chars =
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_";
+    table_id = "table-" + Sample(generator, 8, table_id_chars);
+
+    std::cout << "# Creating Table\n";
+    auto status = admin.CreateTable(
+        table_id,
+        cbt::TableConfig(
+            {{options->column_family, cbt::GcRule::MaxNumVersions(10)}}, {}));
+    if (!status) {
+      std::cout << status.status() << std::endl;
+      return -1;
+    }
+    std::cout << "#\n";
+  } else {
+    auto status = admin.GetTable(table_id, cbt::TableAdmin::NAME_ONLY);
+    if (!status) {
+      std::cout << status.status() << std::endl;
+      return -1;
+    }
+  }
+
+  auto opts = Options{}.set<google::cloud::GrpcBackgroundThreadPoolSizeOption>(
+      options->max_batches);
+  auto table = cbt::Table(
+      cbt::CreateDefaultDataClient(options->project_id, options->instance_id,
+                                   cbt::ClientOptions(std::move(opts))),
+      table_id);
+
+  cbt::MutationBatcher batcher(
+      table, cbt::MutationBatcher::Options{}
+                 .SetMaxBatches(options->max_batches)
+                 .SetMaxMutationsPerBatch(options->batch_size));
+
+  std::cout << "# Project ID: " << options->project_id
+            << "\n# Instance ID: " << options->instance_id
+            << "\n# Table ID: " << table_id << "\n# Cutoff Time: "
+            << absl::FormatDuration(absl::FromChrono(options->max_time))
+            << "\n# Thread Count: " << options->thread_count
+            << "\n# Total Mutations: " << options->mutation_count
+            << "\n# Mutations per Batch: " << options->batch_size
+            << "\n# Concurrent Batches: " << options->max_batches << std::endl;
+
+  std::atomic<int> fails{0};
+  std::atomic<int> successes{0};
+  std::atomic<bool> timeout{false};
+
+  // Conditionally start the timeout thread
+  std::thread* timeout_thread = nullptr;
+  if (options->max_time.count() > 0) {
+    auto deadline = std::chrono::system_clock::now() + options->max_time;
+    timeout_thread = new std::thread([deadline, &timeout] {
+      while (std::chrono::system_clock::now() < deadline) {
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+      }
+      timeout = true;
+    });
+  }
+
+  // Start the MutationBatcher thread
+  CompletionQueue cq;
+  std::thread cq_runner([&cq] { cq.Run(); });
+
+  int key_width = 0;
+  for (std::int64_t i = options->mutation_count - 1; i > 0; i /= 10) ++key_width;
+  auto write = [&options, &batcher, &cq, &fails, &successes, &timeout,
+                key_width](std::int64_t const& start, std::int64_t const& end,
+                           bool const& log) {
+    // One write thread will log its progress
+    if (log) std::cout << "#\n# Writing" << std::flush;
+    auto progress_period = (std::max)(1L, (end - start) / 20);
+
+    for (std::int64_t i = start; i < end; ++i) {
+      // Stop writing if we hit the cutoff deadline
+      if (timeout) break;
+
+      auto mut = MakeMutation(*options, key_width, i);
+      auto admission_completion = batcher.AsyncApply(cq, mut);
+      auto& admission_future = admission_completion.first;
+      auto& completion_future = admission_completion.second;
+      completion_future.then([&fails, &successes](future<Status> fut) {
+        auto status = fut.get();
+        if (!status.ok())
+          ++fails;
+        else
+          ++successes;
+      });
+      admission_future.get();
+
+      if (log && (i - start) % progress_period == 0)
+        std::cout << "." << std::flush;
+    }
+    if (log) std::cout << "\n#" << std::endl;
+  };
+
+  auto timer = Timer::PerThread();
+
+  std::vector<std::future<void>> tasks;
+  std::int64_t start = 0;
+  for (int j = 0; j < options->thread_count; ++j) {
+    auto end =
+        (std::min)(options->mutation_count,
+                   start + options->mutation_count / options->thread_count);
+    tasks.emplace_back(
+        std::async(std::launch::async, write, start, end, j == 0));
+    start = end;
+  }
+
+  for (auto& t : tasks) t.get();
+
+  // Wait for all mutations to complete
+  batcher.AsyncWaitForNoPendingRequests().get();
+
+  // Join the MutationBatcher thread
+  cq.Shutdown();
+  cq_runner.join();
+
+  auto snapshot = timer.Sample();
+  std::cout << "MutationCount,BatchSize,MaxBatches,ElapsedMicroseconds,"
+               "Successes,Fails\n"
+            << options->mutation_count << "," << options->batch_size << ","
+            << options->max_batches << "," << snapshot.elapsed_time.count()
+            << "," << successes << "," << fails << "\n";
+
+  // If we created a table, delete it.
+  if (options->table_id.empty()) {
+    std::cout << "#\n# Deleting Table\n";
+    auto status = admin.DeleteTable(table_id);
+    if (!status.ok()) {
+      std::cout << status << std::endl;
+      return -1;
+    }
+  }
+
+  // Detach the timeout thread if it is running
+  if (timeout_thread) {
+    timeout_thread->detach();
+    delete timeout_thread;
+  }
+
+  return 0;
+}

--- a/google/cloud/bigtable/benchmarks/mutation_batcher_throughput_benchmark.cc
+++ b/google/cloud/bigtable/benchmarks/mutation_batcher_throughput_benchmark.cc
@@ -21,6 +21,7 @@
 #include "google/cloud/testing_util/command_line_parsing.h"
 #include "google/cloud/testing_util/timer.h"
 #include "absl/time/time.h"
+#include <algorithm>
 #include <chrono>
 #include <iomanip>
 #include <sstream>

--- a/google/cloud/bigtable/benchmarks/mutation_batcher_throughput_benchmark.cc
+++ b/google/cloud/bigtable/benchmarks/mutation_batcher_throughput_benchmark.cc
@@ -16,6 +16,8 @@
 #include "google/cloud/bigtable/mutation_batcher.h"
 #include "google/cloud/bigtable/table.h"
 #include "google/cloud/bigtable/table_admin.h"
+#include "google/cloud/bigtable/testing/random_names.h"
+#include "google/cloud/internal/background_threads_impl.h"
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/testing_util/command_line_parsing.h"
@@ -43,25 +45,41 @@ char const kDescription[] =
 The purpose of the program is to determine default settings for
 `MutationBatcher::Options` that maximize throughput. The specific settings,
 which are the main inputs to this program, are maximum mutations per batch and
-maximum concurrent batches in flight.
+maximum concurrent batches in flight. It also tests the performance that can be
+achieved by providing initial splits to the table and having multiple batchers
+send it mutations in parallel.
 
 The program is designed to be run repeatedly. It can be configured to terminate
 after a set amount of time. It can also be configured to use a pre-existing
 table instead of creating a new one then deleting it when the program is done.
 
+The mutations are all of the same size. There is exactly 1 mutation per row.
+The rows fall in the range from "row00000" to "rowNNNNN".
+
 The program will:
 
-1) Conditionally create a table.
+1) Conditionally create a table, with initial splits.
 2) Echo your configuration settings.
-3) Configure a `MutationBatcher`.
-4) Spin off some number of threads.
-5) Send mutations to a `MutationBatcher` from each thread. The `MutationBatcher`
-   will apply these mutations to the table. Progress will be logged for those
-   who are impatient.
-6) Conditionally stop batching mutations if the program exceeds a supplied deadline.
-7) Report the total time it took to apply the mutations.
-8) Report the total number of successful and failed mutations.
-9) Conditionally delete the table.
+3) Spin off some number of threads. Each thread will:
+  a) Configure a `MutationBatcher`.
+  b) Send mutations to a `MutationBatcher`. The `MutationBatcher` will apply
+     these mutations to the table.
+  c) One thread will log progress for those who are impatient.
+  d) Conditionally stop batching mutations if the program exceeds a supplied
+     deadline.
+  e) Block until all mutations have been processed.
+  f) Record the number of successful and failed mutations.
+4) Join all threads.
+5) Report the total time it took to apply the mutations.
+6) Report the total number of successful and failed mutations, across all
+   threads.
+7) Conditionally delete the table.
+
+If, for example, the program is configured to send 2000 mutations to a
+table with 4 shards using 2 write threads, the row range will be from "row0000"
+to "row1999". The initial splits provided will be at "row0000", "row0500",
+"row1000", "row1500". Two threads are created, one does the work for
+"row0000"-"row0999", the other does the work for "row1000"-"row1999".
 )""";
 
 StatusOr<MutationBatcherThroughputOptions> ParseArgs(int argc, char* argv[]) {
@@ -94,13 +112,16 @@ StatusOr<MutationBatcherThroughputOptions> ParseArgs(int argc, char* argv[]) {
                                                kDescription);
 }
 
-cbt::SingleRowMutation MakeMutation(
-    MutationBatcherThroughputOptions const& options, int key_width,
-    std::int64_t const& row_key) {
+std::string MakeRowString(int key_width, int64_t row_index) {
   std::ostringstream os;
-  os << "row" << std::setw(key_width) << std::setfill('0') << row_key;
+  os << "row" << std::setw(key_width) << std::setfill('0') << row_index;
+  return std::move(os).str();
+}
+
+cbt::SingleRowMutation MakeMutation(
+    MutationBatcherThroughputOptions const& options, std::string row_key) {
   return cbt::SingleRowMutation(
-      std::move(os).str(),
+      std::move(row_key),
       {cbt::SetCell(options.column_family, options.column, "value")});
 }
 
@@ -120,25 +141,34 @@ int main(int argc, char* argv[]) {
   using google::cloud::Options;
   using google::cloud::Status;
   using google::cloud::StatusOr;
+  using google::cloud::bigtable::testing::RandomTableId;
+  using google::cloud::internal::AutomaticallyCreatedBackgroundThreads;
   using TimerFuture = future<StatusOr<std::chrono::system_clock::time_point>>;
 
   cbt::TableAdmin admin(cbt::CreateDefaultAdminClient(options->project_id, {}),
                         options->instance_id);
 
+  int key_width = 0;
+  for (auto i = options->mutation_count - 1; i != 0; i /= 10) ++key_width;
+
   // Create a new table if one was not supplied
   auto table_id = options->table_id;
   if (table_id.empty()) {
-    using google::cloud::internal::Sample;
     auto generator = google::cloud::internal::MakeDefaultPRNG();
-    std::string table_id_chars =
-        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_";
-    table_id = "table-" + Sample(generator, 8, table_id_chars);
+    table_id = RandomTableId(generator);
+
+    // Provide initial splits to the table
+    std::vector<std::string> splits;
+    for (auto i = 0; i != options->shard_count; ++i) {
+      auto row_index = options->mutation_count * i / options->shard_count;
+      splits.emplace_back(MakeRowString(key_width, row_index));
+    }
 
     std::cout << "# Creating Table\n";
     auto status = admin.CreateTable(
-        table_id,
-        cbt::TableConfig(
-            {{options->column_family, cbt::GcRule::MaxNumVersions(10)}}, {}));
+        table_id, cbt::TableConfig({{options->column_family,
+                                     cbt::GcRule::MaxNumVersions(10)}},
+                                   splits));
     if (!status) {
       std::cout << status.status() << std::endl;
       return 1;
@@ -147,11 +177,8 @@ int main(int argc, char* argv[]) {
   } else {
     auto table = admin.GetTable(table_id, cbt::TableAdmin::NAME_ONLY);
     if (!table) {
-      if (table.status().code() == StatusCode::kNotFound) {
-        std::cout << "Table " << table_id << " does not exist\n";
-        return 1;
-      }
-      std::cout << table.status() << std::endl;
+      std::cout << "Error trying to get Table " << table_id << ":\n"
+                << table.status() << std::endl;
       return 1;
     }
   }
@@ -163,57 +190,69 @@ int main(int argc, char* argv[]) {
                                    cbt::ClientOptions(std::move(opts))),
       table_id);
 
-  cbt::MutationBatcher batcher(
-      table, cbt::MutationBatcher::Options{}
-                 .SetMaxBatches(options->max_batches)
-                 .SetMaxMutationsPerBatch(options->batch_size));
-
   std::cout << "# Project ID: " << options->project_id
             << "\n# Instance ID: " << options->instance_id
             << "\n# Table ID: " << table_id << "\n# Cutoff Time: "
             << absl::FormatDuration(absl::FromChrono(options->max_time))
-            << "\n# Thread Count: " << options->thread_count
+            << "\n# Shard Count: " << options->shard_count
+            << "\n# Write Thread Count: " << options->write_thread_count
+            << "\n# Batcher Thread Count: " << options->batcher_thread_count
             << "\n# Total Mutations: " << options->mutation_count
             << "\n# Mutations per Batch: " << options->batch_size
             << "\n# Concurrent Batches: " << options->max_batches << std::endl;
 
-  std::atomic<int> fails{0};
-  std::atomic<int> successes{0};
-  std::atomic<bool> timeout{false};
-
-  // Start the MutationBatcher thread
-  CompletionQueue cq;
-  std::thread cq_runner([&cq] { cq.Run(); });
+  // Create the batcher threads
+  AutomaticallyCreatedBackgroundThreads batcher_threads(
+      options->batcher_thread_count);
+  CompletionQueue cq = batcher_threads.cq();
 
   // Create a deadline timer
   // If there is no deadline set, the timer fires instantly and does nothing
+  std::atomic<bool> timeout{false};
   auto timer = cq.MakeRelativeTimer(options->max_time)
                    .then([&timeout, &options](TimerFuture) {
                      timeout = options->max_time.count() > 0;
                    });
 
-  int key_width = 0;
-  for (auto i = options->mutation_count - 1; i > 0; i /= 10) ++key_width;
-  auto write = [&options, &batcher, &cq, &fails, &successes, &timeout,
-                key_width](std::int64_t start, std::int64_t end, bool log) {
-    // One write thread will log its progress
+  struct BenchmarkResult {
+    std::int64_t fails = 0;
+    std::int64_t successes = 0;
+  } totals;
+
+  auto write = [&options, &table, &cq, &timeout, key_width](int write_index) {
+    auto start =
+        options->mutation_count * write_index / options->write_thread_count;
+    auto end = options->mutation_count * (write_index + 1) /
+               options->write_thread_count;
+
+    // Only one write thread will log its progress
+    bool log = write_index == 0;
     if (log) std::cout << "#\n# Writing" << std::flush;
     auto progress_period = std::max<std::int64_t>(1, (end - start) / 20);
 
-    for (auto i = start; i < end; ++i) {
-      // Stop writing if we hit the cutoff deadline
-      if (timeout) break;
+    BenchmarkResult result;
+    result.successes = end - start;
 
-      auto mut = MakeMutation(*options, key_width, i);
+    cbt::MutationBatcher batcher(
+        table, cbt::MutationBatcher::Options{}
+                   .SetMaxBatches(options->max_batches)
+                   .SetMaxMutationsPerBatch(options->batch_size));
+
+    for (auto i = start; i != end; ++i) {
+      // Stop writing if we hit the cutoff deadline
+      if (timeout) {
+        result.successes = i - start;
+        break;
+      }
+
+      auto mut = MakeMutation(*options, MakeRowString(key_width, i));
       auto admission_completion = batcher.AsyncApply(cq, std::move(mut));
       auto& admission_future = admission_completion.first;
       auto& completion_future = admission_completion.second;
-      completion_future.then([&fails, &successes](future<Status> fut) {
+      completion_future.then([&result](future<Status> fut) {
         auto status = fut.get();
         if (!status.ok()) {
-          ++fails;
-        } else {
-          ++successes;
+          ++result.fails;
         }
       });
       admission_future.get();
@@ -223,24 +262,26 @@ int main(int argc, char* argv[]) {
       }
     }
     if (log) std::cout << "\n#" << std::endl;
+
+    batcher.AsyncWaitForNoPendingRequests().get();
+
+    result.successes -= result.fails;
+    return result;
   };
 
   auto start_time = std::chrono::steady_clock::now();
 
-  std::int64_t start = 0;
-  std::vector<std::future<void>> tasks(options->thread_count);
+  auto write_index = 0;
+  std::vector<std::future<BenchmarkResult>> tasks(options->write_thread_count);
+  std::generate(tasks.begin(), tasks.end(), [write, &write_index] {
+    return std::async(std::launch::async, write, write_index++);
+  });
+
   for (auto& t : tasks) {
-    auto end = std::min<std::int64_t>(
-        options->mutation_count,
-        start + options->mutation_count / options->thread_count);
-    t = std::async(std::launch::async, write, start, end, start == 0);
-    start = end;
+    auto thread_result = t.get();
+    totals.fails += thread_result.fails;
+    totals.successes += thread_result.successes;
   }
-
-  for (auto& t : tasks) t.get();
-
-  // Wait for all mutations to complete
-  batcher.AsyncWaitForNoPendingRequests().get();
 
   auto end_time = std::chrono::steady_clock::now();
   std::chrono::duration<double> elapsed = end_time - start_time;
@@ -249,15 +290,13 @@ int main(int argc, char* argv[]) {
   timer.cancel();
   timer.get();
 
-  // Join the MutationBatcher thread
-  cq.Shutdown();
-  cq_runner.join();
-
-  std::cout << "MutationCount,BatchSize,MaxBatches,ElapsedSeconds,"
-               "Successes,Fails\n"
+  std::cout << "MutationCount,BatchSize,MaxBatches,ShardCount,WriteThreadCount,"
+               "BatcherThreadCount,ElapsedSeconds,Successes,Fails\n"
             << options->mutation_count << "," << options->batch_size << ","
-            << options->max_batches << "," << elapsed.count() << ","
-            << successes << "," << fails << "\n";
+            << options->max_batches << "," << options->shard_count << ","
+            << options->write_thread_count << ","
+            << options->batcher_thread_count << "," << elapsed.count() << ","
+            << totals.successes << "," << totals.fails << "\n";
 
   // If we created a table, delete it.
   if (options->table_id.empty()) {

--- a/google/cloud/bigtable/benchmarks/mutation_batcher_throughput_benchmark.cc
+++ b/google/cloud/bigtable/benchmarks/mutation_batcher_throughput_benchmark.cc
@@ -194,7 +194,7 @@ int main(int argc, char* argv[]) {
   std::thread cq_runner([&cq] { cq.Run(); });
 
   int key_width = 0;
-  for (std::int64_t i = options->mutation_count - 1; i > 0; i /= 10) ++key_width;
+  for (auto i = options->mutation_count - 1; i > 0; i /= 10) ++key_width;
   auto write = [&options, &batcher, &cq, &fails, &successes, &timeout,
                 key_width](std::int64_t const& start, std::int64_t const& end,
                            bool const& log) {

--- a/google/cloud/bigtable/benchmarks/mutation_batcher_throughput_options.cc
+++ b/google/cloud/bigtable/benchmarks/mutation_batcher_throughput_options.cc
@@ -1,0 +1,154 @@
+// Copyright 2021 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/bigtable/benchmarks/mutation_batcher_throughput_options.h"
+#include "google/cloud/internal/absl_str_join_quiet.h"
+#include "google/cloud/status_or.h"
+#include "google/cloud/testing_util/command_line_parsing.h"
+#include <sstream>
+
+namespace google {
+namespace cloud {
+namespace bigtable {
+namespace benchmarks {
+
+using google::cloud::testing_util::BuildUsage;
+using google::cloud::testing_util::OptionDescriptor;
+using google::cloud::testing_util::OptionsParse;
+using google::cloud::testing_util::ParseDuration;
+
+google::cloud::StatusOr<MutationBatcherThroughputOptions>
+ParseMutationBatcherThroughputOptions(std::vector<std::string> const& argv,
+                                      std::string const& description) {
+  MutationBatcherThroughputOptions options;
+  bool wants_help = false;
+  bool wants_description = false;
+
+  std::vector<OptionDescriptor> desc{
+      {"--help", "print usage information",
+       [&wants_help](std::string const&) { wants_help = true; }},
+      {"--description", "print benchmark description",
+       [&wants_description](std::string const&) { wants_description = true; }},
+      {"--project-id", "the GCP Project ID",
+       [&options](std::string const& val) { options.project_id = val; }},
+      {"--instance-id", "the Instance ID",
+       [&options](std::string const& val) { options.instance_id = val; }},
+      {"--table-id",
+       "the benchmark will be run on this table, instead of creating a new "
+       "one",
+       [&options](std::string const& val) { options.table_id = val; }},
+      {"--max-time",
+       "the benchmark will be cut off after this many seconds if it is still "
+       "running. A value of 0 means no cut off",
+       [&options](std::string const& val) {
+         options.max_time = ParseDuration(val);
+       }},
+      {"--thread-count",
+       "the number of threads sending mutations to the batcher",
+       [&options](std::string const& val) {
+         options.thread_count = std::stoi(val);
+       }},
+      {"--mutation-count", "the total number of mutations",
+       [&options](std::string const& val) {
+         options.mutation_count = std::stoll(val);
+       }},
+      {"--max-batches",
+       "the maximum batches that can be outstanding at any time",
+       [&options](std::string const& val) {
+         options.max_batches = std::stoi(val);
+       }},
+      {"--batch-size",
+       "the maximum mutations that can be packed into one batch",
+       [&options](std::string const& val) {
+         options.batch_size = std::stoi(val);
+       }},
+  };
+
+  auto usage = BuildUsage(desc, argv[0]);
+  auto unparsed = OptionsParse(desc, argv);
+
+  if (wants_help) {
+    std::cout << usage << "\n";
+    options.exit_after_parse = true;
+    return options;
+  }
+  if (wants_description) {
+    std::cout << description << "\n";
+    options.exit_after_parse = true;
+    return options;
+  }
+
+  auto make_status = [](std::ostringstream& os) {
+    auto const code = google::cloud::StatusCode::kInvalidArgument;
+    return google::cloud::Status{code, std::move(os).str()};
+  };
+
+  if (unparsed.size() != 1) {
+    std::ostringstream os;
+    os << "Unknown arguments or options: "
+       << absl::StrJoin(std::next(unparsed.begin()), unparsed.end(), ", ")
+       << "\n"
+       << usage << "\n";
+    return make_status(os);
+  }
+  if (options.project_id.empty()) {
+    std::ostringstream os;
+    os << "Missing --project-id option\n" << usage << "\n";
+    return make_status(os);
+  }
+  if (options.instance_id.empty()) {
+    std::ostringstream os;
+    os << "Missing --instance-id option\n" << usage << "\n";
+    return make_status(os);
+  }
+  if (options.max_time.count() < 0) {
+    std::ostringstream os;
+    os << "Invalid cutoff time (" << options.max_time.count()
+       << "s). Check your --max-time option\n";
+    return make_status(os);
+  }
+  if (options.thread_count <= 0) {
+    std::ostringstream os;
+    os << "Invalid number of threads (" << options.thread_count
+       << "). Check your --thread-count option\n";
+    return make_status(os);
+  }
+  if (options.mutation_count < 0) {
+    std::ostringstream os;
+    os << "Invalid number of total mutations (" << options.mutation_count
+       << "). Check your --mutation-count option\n";
+    return make_status(os);
+  }
+  if (options.max_batches <= 0) {
+    std::ostringstream os;
+    os << "Invalid maximum number of outstanding batches("
+       << options.max_batches << "). Check your --max-batches option\n";
+    return make_status(os);
+  }
+  if (options.batch_size <= 0 || options.batch_size > 100000) {
+    std::ostringstream os;
+    os << "Invalid maximum number of mutations per batch("
+       << options.max_batches
+       << "). This value must fall in the range: [1, 100000]. Check your "
+          "--batch-size option\n";
+    return make_status(os);
+  }
+
+  return options;
+}
+
+}  // namespace benchmarks
+}  // namespace bigtable
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/bigtable/benchmarks/mutation_batcher_throughput_options.h
+++ b/google/cloud/bigtable/benchmarks/mutation_batcher_throughput_options.h
@@ -1,0 +1,51 @@
+// Copyright 2021 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_BENCHMARKS_MUTATION_BATCHER_THROUGHPUT_OPTIONS_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_BENCHMARKS_MUTATION_BATCHER_THROUGHPUT_OPTIONS_H
+
+#include "google/cloud/status_or.h"
+#include <chrono>
+#include <string>
+#include <vector>
+
+namespace google {
+namespace cloud {
+namespace bigtable {
+namespace benchmarks {
+
+struct MutationBatcherThroughputOptions {
+  std::string project_id;
+  std::string instance_id;
+  std::string column_family = "cf1";
+  std::string column = "c1";
+  std::string table_id;
+  std::chrono::seconds max_time = std::chrono::seconds(0);
+  int thread_count = 1;
+  std::int64_t mutation_count = 1000000;
+  int max_batches = 10;
+  int batch_size = 1000;
+  bool exit_after_parse = false;
+};
+
+google::cloud::StatusOr<MutationBatcherThroughputOptions>
+ParseMutationBatcherThroughputOptions(std::vector<std::string> const& argv,
+                                      std::string const& description);
+
+}  // namespace benchmarks
+}  // namespace bigtable
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_BENCHMARKS_MUTATION_BATCHER_THROUGHPUT_OPTIONS_H

--- a/google/cloud/bigtable/benchmarks/mutation_batcher_throughput_options.h
+++ b/google/cloud/bigtable/benchmarks/mutation_batcher_throughput_options.h
@@ -32,7 +32,9 @@ struct MutationBatcherThroughputOptions {
   std::string column_family = "cf1";
   std::string column = "c1";
   std::chrono::seconds max_time = std::chrono::seconds(0);
-  int thread_count = 1;
+  int shard_count = 1;
+  int write_thread_count = 1;
+  int batcher_thread_count = 1;
   std::int64_t mutation_count = 1000000;
   int max_batches = 10;
   int batch_size = 1000;

--- a/google/cloud/bigtable/benchmarks/mutation_batcher_throughput_options.h
+++ b/google/cloud/bigtable/benchmarks/mutation_batcher_throughput_options.h
@@ -28,9 +28,9 @@ namespace benchmarks {
 struct MutationBatcherThroughputOptions {
   std::string project_id;
   std::string instance_id;
+  std::string table_id;
   std::string column_family = "cf1";
   std::string column = "c1";
-  std::string table_id;
   std::chrono::seconds max_time = std::chrono::seconds(0);
   int thread_count = 1;
   std::int64_t mutation_count = 1000000;

--- a/google/cloud/bigtable/benchmarks/mutation_batcher_throughput_options_test.cc
+++ b/google/cloud/bigtable/benchmarks/mutation_batcher_throughput_options_test.cc
@@ -30,7 +30,9 @@ TEST(MutationBatcherThroughputOptions, Basic) {
           "--instance-id=test-instance",
           "--table-id=test-table",
           "--max-time=200s",
-          "--thread-count=2",
+          "--shard-count=2",
+          "--write-thread-count=3",
+          "--batcher-thread-count=4",
           "--mutation-count=2000000",
           "--max-batches=20",
           "--batch-size=2000",
@@ -42,7 +44,9 @@ TEST(MutationBatcherThroughputOptions, Basic) {
   EXPECT_EQ("test-instance", options->instance_id);
   EXPECT_EQ("test-table", options->table_id);
   EXPECT_EQ(200, options->max_time.count());
-  EXPECT_EQ(2, options->thread_count);
+  EXPECT_EQ(2, options->shard_count);
+  EXPECT_EQ(3, options->write_thread_count);
+  EXPECT_EQ(4, options->batcher_thread_count);
   EXPECT_EQ(2000000, options->mutation_count);
   EXPECT_EQ(20, options->max_batches);
   EXPECT_EQ(2000, options->batch_size);
@@ -58,7 +62,9 @@ TEST(MutationBatcherThroughputOptions, Defaults) {
       "");
   EXPECT_TRUE(options->table_id.empty());
   EXPECT_EQ(0, options->max_time.count());
-  EXPECT_EQ(1, options->thread_count);
+  EXPECT_EQ(1, options->shard_count);
+  EXPECT_EQ(1, options->write_thread_count);
+  EXPECT_EQ(1, options->batcher_thread_count);
   EXPECT_EQ(1000000, options->mutation_count);
   EXPECT_EQ(10, options->max_batches);
   EXPECT_EQ(1000, options->batch_size);
@@ -92,10 +98,26 @@ TEST(MutationBatcherThroughputOptions, Validate) {
       {"self-test", "--project-id=a", "--instance-id=b", "--max-time=-1s"},
       ""));
   EXPECT_FALSE(ParseMutationBatcherThroughputOptions(
-      {"self-test", "--project-id=a", "--instance-id=b", "--thread-count=-1"},
+      {"self-test", "--project-id=a", "--instance-id=b", "--shard-count=-1"},
       ""));
   EXPECT_FALSE(ParseMutationBatcherThroughputOptions(
-      {"self-test", "--project-id=a", "--instance-id=b", "--thread-count=0"},
+      {"self-test", "--project-id=a", "--instance-id=b", "--shard-count=0"},
+      ""));
+  EXPECT_FALSE(ParseMutationBatcherThroughputOptions(
+      {"self-test", "--project-id=a", "--instance-id=b",
+       "--write-thread-count=-1"},
+      ""));
+  EXPECT_FALSE(ParseMutationBatcherThroughputOptions(
+      {"self-test", "--project-id=a", "--instance-id=b",
+       "--write-thread-count=0"},
+      ""));
+  EXPECT_FALSE(ParseMutationBatcherThroughputOptions(
+      {"self-test", "--project-id=a", "--instance-id=b",
+       "--batcher-thread-count=-1"},
+      ""));
+  EXPECT_FALSE(ParseMutationBatcherThroughputOptions(
+      {"self-test", "--project-id=a", "--instance-id=b",
+       "--batcher-thread-count=0"},
       ""));
   EXPECT_FALSE(ParseMutationBatcherThroughputOptions(
       {"self-test", "--project-id=a", "--instance-id=b", "--mutation_count=-1"},

--- a/google/cloud/bigtable/benchmarks/mutation_batcher_throughput_options_test.cc
+++ b/google/cloud/bigtable/benchmarks/mutation_batcher_throughput_options_test.cc
@@ -1,0 +1,124 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/bigtable/benchmarks/mutation_batcher_throughput_options.h"
+#include "google/cloud/testing_util/status_matchers.h"
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+namespace bigtable {
+namespace benchmarks {
+namespace {
+
+TEST(MutationBatcherThroughputOptions, Basic) {
+  auto options = ParseMutationBatcherThroughputOptions(
+      {
+          "self-test",
+          "--project-id=test-project",
+          "--instance-id=test-instance",
+          "--table-id=test-table",
+          "--max-time=200s",
+          "--thread-count=2",
+          "--mutation-count=2000000",
+          "--max-batches=20",
+          "--batch-size=2000",
+      },
+      "");
+  ASSERT_STATUS_OK(options);
+  EXPECT_FALSE(options->exit_after_parse);
+  EXPECT_EQ("test-project", options->project_id);
+  EXPECT_EQ("test-instance", options->instance_id);
+  EXPECT_EQ("test-table", options->table_id);
+  EXPECT_EQ(200, options->max_time.count());
+  EXPECT_EQ(2, options->thread_count);
+  EXPECT_EQ(2000000, options->mutation_count);
+  EXPECT_EQ(20, options->max_batches);
+  EXPECT_EQ(2000, options->batch_size);
+}
+
+TEST(MutationBatcherThroughputOptions, Defaults) {
+  auto options = ParseMutationBatcherThroughputOptions(
+      {
+          "self-test",
+          "--project-id=a",
+          "--instance-id=b",
+      },
+      "");
+  EXPECT_TRUE(options->table_id.empty());
+  EXPECT_EQ(0, options->max_time.count());
+  EXPECT_EQ(1, options->thread_count);
+  EXPECT_EQ(1000000, options->mutation_count);
+  EXPECT_EQ(10, options->max_batches);
+  EXPECT_EQ(1000, options->batch_size);
+}
+
+TEST(MutationBatcherThroughputOptions, Description) {
+  auto options = ParseMutationBatcherThroughputOptions(
+      {"self-test", "--description", "other-stuff"}, "Description for test");
+  EXPECT_STATUS_OK(options);
+  EXPECT_TRUE(options->exit_after_parse);
+}
+
+TEST(MutationBatcherThroughputOptions, Help) {
+  auto options = ParseMutationBatcherThroughputOptions(
+      {"self-test", "--help", "other-stuff"}, "");
+  EXPECT_STATUS_OK(options);
+  EXPECT_TRUE(options->exit_after_parse);
+}
+
+TEST(MutationBatcherThroughputOptions, Validate) {
+  EXPECT_FALSE(ParseMutationBatcherThroughputOptions({"self-test"}, ""));
+  EXPECT_FALSE(
+      ParseMutationBatcherThroughputOptions({"self-test", "unused-1"}, ""));
+  EXPECT_FALSE(ParseMutationBatcherThroughputOptions(
+      {"self-test", "--invalid-option"}, ""));
+  EXPECT_FALSE(ParseMutationBatcherThroughputOptions(
+      {"self-test", "--instance-id=b"}, ""));
+  EXPECT_FALSE(ParseMutationBatcherThroughputOptions(
+      {"self-test", "--project-id=a"}, ""));
+  EXPECT_FALSE(ParseMutationBatcherThroughputOptions(
+      {"self-test", "--project-id=a", "--instance-id=b", "--max-time=-1s"},
+      ""));
+  EXPECT_FALSE(ParseMutationBatcherThroughputOptions(
+      {"self-test", "--project-id=a", "--instance-id=b", "--thread-count=-1"},
+      ""));
+  EXPECT_FALSE(ParseMutationBatcherThroughputOptions(
+      {"self-test", "--project-id=a", "--instance-id=b", "--thread-count=0"},
+      ""));
+  EXPECT_FALSE(ParseMutationBatcherThroughputOptions(
+      {"self-test", "--project-id=a", "--instance-id=b", "--mutation_count=-1"},
+      ""));
+  EXPECT_FALSE(ParseMutationBatcherThroughputOptions(
+      {"self-test", "--project-id=a", "--instance-id=b", "--max-batches=-1"},
+      ""));
+  EXPECT_FALSE(ParseMutationBatcherThroughputOptions(
+      {"self-test", "--project-id=a", "--instance-id=b", "--max-batches=0"},
+      ""));
+  EXPECT_FALSE(ParseMutationBatcherThroughputOptions(
+      {"self-test", "--project-id=a", "--instance-id=b", "--batch-size=-1"},
+      ""));
+  EXPECT_FALSE(ParseMutationBatcherThroughputOptions(
+      {"self-test", "--project-id=a", "--instance-id=b", "--batch-size=0"},
+      ""));
+  EXPECT_FALSE(ParseMutationBatcherThroughputOptions(
+      {"self-test", "--project-id=a", "--instance-id=b", "--batch-size=100001"},
+      ""));
+}
+
+}  // namespace
+}  // namespace benchmarks
+}  // namespace bigtable
+}  // namespace cloud
+}  // namespace google


### PR DESCRIPTION
Fixes #7024 

A new benchmark to measure the throughput of `bigtable::MutationBatcher` given maximum number of mutations per batch and maximum number of outstanding batches.

### Design choices:

#### Shards / Splits / Row keys:

There are no initial splits provided to the table. I considered splitting based on:
* % of table - e.g. always split into 10 shards with 10% of the rows in each.
* \# of rows in split - e.g. split such that each shard will contain 1,000,000 rows
* \# of threads - e.g. launch T threads. split such that each shard contains 1/T of the data

(Our other benchmarks launch 10 threads and split the 10M rows into 10 shards. This is where my example numbers are coming from) 

But my current thinking is that it wouldn't be helpful at this time. I assume that the advantage of initial splits come when you concurrently send batches that hit different shards (where the mutations within a batch all belong to the same shard). Please correct me if I'm wrong.

The `MutationBatcher` is fed mutations from many threads. It simply [appends](https://github.com/googleapis/google-cloud-cpp/blob/1d18bca029224cab43a2e63d9a00716033cfc5df/google/cloud/bigtable/mutation_batcher.cc#L86) new mutations into the current batch. So I think the only way (presently) to guarantee mutations from a single shard make it into a single batch is to only send mutations from that shard across all threads. But then we are not getting the advantage of concurrent batches going to _different_ shards.

Initial splits might be worth adding. It would especially be worth adding if we change the guts of the `MutationBatcher` to try to batch mutations with splits in mind. I think it would come with a `--shard-count` option. And the row keys would be something like: `"row" + shard_index + mutation_index`. 

#### Cutoff deadline:

I want to be able to run the benchmark in a loop with random settings. Some of these settings are going to be very slow. I do not want to wait for them. I want to say something like "the best settings do M mutations in ~25s , so let me set a `--max-time=60s`. 

There might be a way to do this in bash with `timeout` but 1) I don't know how, 2) I want to get some sort of throughput measure if the program does get cut off.

This does complicate the code a little bit. I am obviously open to a better way to do this.

#### Logging progress:

Logging the progress of the writes also complicates the code a bit. But it's nice to know the program is doing something.

#### Things I didn't do:
* Accept an App Profile ID. Should I?
* Add ability to set maximum size in bytes of a batch (instead of maximum requests per batch). I didn't think this was necessary, as all mutations are of the same size. So I don't know if anything would be gained here.
* Make a way to compare this to using `Table::Apply` or `Table::BulkApply` directly. Our other benchmarks record throughput for manually sent batches. We can use those to get a feel for the throughput of the direct table methods.
* Make gRPC channel count configurable for the `DataClient`. It just uses the default.
* Have a setting for random row keys (instead of sequenced). I originally had this in, but I realized we are not even sending the batcher sequenced row keys, as discussed above in the initial splits section.
* Report total batches sent by the `MutationBatcher`. I think this data is valuable, but getting it is not yet native to the batcher. My plan is to first: get the benchmark done. Then second: modify `MutationBatcher` to record batches sent + update this benchmark to report the data.
* Use a version of `MutationBatcher::AsyncApply()` that uses the table's background threads. This method hasn't been made yet. Similar to the total batches, I want to first get the benchmark done before adding this feature.

#### Things that are highly questionable:
* I set the background thread pool size for the table to be equal to `max_batches`. I thought this made sense, but maybe I need to cap it. We probably don't want hundreds of threads if we set the option too high...
* I left `column_family` and `column` in the options struct... so they are essentially hard coded.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7070)
<!-- Reviewable:end -->
