### PR TITLE
cleanup(storage): simplify CurlDownloadRequest shutdown

### DIFF
--- a/google/cloud/storage/internal/curl_download_request.cc
+++ b/google/cloud/storage/internal/curl_download_request.cc
@@ -72,7 +72,6 @@ StatusOr<HttpResponse> CurlDownloadRequest::Close() {
   if (curl_closed_) return HttpResponse{http_code_, {}, received_headers_};
   TRACE_STATE();
   // Set the the closing_ flag to trigger a return 0 from the next read
-
   // callback, see the comments in the header file for more details.
   closing_ = true;
   TRACE_STATE();

--- a/google/cloud/storage/internal/curl_download_request.h
+++ b/google/cloud/storage/internal/curl_download_request.h
@@ -75,14 +75,20 @@ class CurlDownloadRequest : public ObjectReadSource {
 
  private:
   friend class CurlRequestBuilder;
-  /// Set the underlying CurlHandle options on a new CurlDownloadRequest.
-  void SetOptions();
-
   friend std::size_t CurlDownloadRequestWrite(char* ptr, size_t size,
                                               size_t nmemb, void* userdata);
   friend std::size_t CurlDownloadRequestHeader(char* contents, std::size_t size,
                                                std::size_t nitems,
                                                void* userdata);
+
+  /// Cleanup the CURL handles, leaving them ready for reuse.
+  void CleanupHandles();
+
+  /// Set the underlying CurlHandle options on a new CurlDownloadRequest.
+  void SetOptions();
+
+  /// Handle a completed (even interrupted) download.
+  void OnTransferDone();
 
   /// Copy any available data from the spill buffer to `buffer_`
   void DrainSpillBuffer();
@@ -110,6 +116,7 @@ class CurlDownloadRequest : public ObjectReadSource {
   std::string payload_;
   std::string user_agent_;
   CurlReceivedHeaders received_headers_;
+  std::int32_t http_code_ = 0;
   bool logging_enabled_ = false;
   CurlHandle::SocketOptions socket_options_;
   std::chrono::seconds download_stall_timeout_;


### PR DESCRIPTION
With this change there is a single place where the status of the HTTP
download is captured, and a single place where we cleanup the CURL* and
CURLM* handles.

Part of the work for #6160

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7073)
<!-- Reviewable:end -->
