### PR TITLE
fix(common): quash "control reaches end of non-void function" error

### DIFF
--- a/generator/internal/descriptor_utils.cc
+++ b/generator/internal/descriptor_utils.cc
@@ -71,8 +71,10 @@ std::string CppTypeToString(FieldDescriptor const* field) {
     case FieldDescriptor::CPPTYPE_MESSAGE:
       return ProtoNameToCppName(field->message_type()->full_name());
   }
-  GCP_LOG(FATAL) << "FieldDescriptor " << std::string(field->cpp_type_name())
+  GCP_LOG(FATAL) << "FieldDescriptor " << field->cpp_type_name()
                  << " not handled";
+  /*NOTREACHED*/
+  return field->cpp_type_name();
 }
 
 std::string FormatDoxygenLink(google::protobuf::Descriptor const& message_type,


### PR DESCRIPTION
In #7058 we removed a `std::exit(1)` call after `GCP_LOG(FATAL)`
from `CppTypeToString()` now that the `FATAL` logging does not
return.  However, as mentioned in #7058, this obscures the flow
from the compiler, resulting in a spurious "control reaches end
of non-void function" error.

In this case there is no simple way to rework the function to avoid
that diagnosis, so we quash the error by adding an unreachable
`return`, together with a traditional `/*NOTREACHED*/` comment.

Note: Abseil has an `ABSL_INTERNAL_UNREACHABLE` attribute, which
may be exported in the future to better handle situations like this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7074)
<!-- Reviewable:end -->
