### PR TITLE
cleanup: use a blank comment line between shebang and copyright

### DIFF
--- a/ci/etc/integration-tests-config.sh
+++ b/ci/etc/integration-tests-config.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+#
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/ci/etc/quickstart-config.sh
+++ b/ci/etc/quickstart-config.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+#
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/ci/etc/repo-config.sh
+++ b/ci/etc/repo-config.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+#
 # Copyright 2019 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/ci/kokoro/lib/cache.sh
+++ b/ci/kokoro/lib/cache.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+#
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/ci/kokoro/lib/gcloud.sh
+++ b/ci/kokoro/lib/gcloud.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+#
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/ci/kokoro/macos/builds/bazel.sh
+++ b/ci/kokoro/macos/builds/bazel.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+#
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/ci/kokoro/macos/builds/cmake-vcpkg.sh
+++ b/ci/kokoro/macos/builds/cmake-vcpkg.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+#
 # Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/ci/kokoro/macos/builds/quickstart-bazel.sh
+++ b/ci/kokoro/macos/builds/quickstart-bazel.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+#
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/ci/kokoro/macos/builds/quickstart-cmake.sh
+++ b/ci/kokoro/macos/builds/quickstart-cmake.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+#
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/ci/kokoro/macos/download-cache.sh
+++ b/ci/kokoro/macos/download-cache.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+#
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/ci/kokoro/macos/upload-cache.sh
+++ b/ci/kokoro/macos/upload-cache.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+#
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/ci/kokoro/windows/build-bazel-dependencies.ps1
+++ b/ci/kokoro/windows/build-bazel-dependencies.ps1
@@ -1,4 +1,5 @@
 # !/usr/bin/env powershell
+#
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/ci/kokoro/windows/build-bazel.ps1
+++ b/ci/kokoro/windows/build-bazel.ps1
@@ -1,4 +1,5 @@
 # !/usr/bin/env powershell
+#
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/ci/kokoro/windows/build-cmake-dependencies.ps1
+++ b/ci/kokoro/windows/build-cmake-dependencies.ps1
@@ -1,4 +1,5 @@
 # !/usr/bin/env powershell
+#
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/ci/kokoro/windows/build-cmake.ps1
+++ b/ci/kokoro/windows/build-cmake.ps1
@@ -1,4 +1,5 @@
 # !/usr/bin/env powershell
+#
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/ci/kokoro/windows/build-quickstart-bazel.ps1
+++ b/ci/kokoro/windows/build-quickstart-bazel.ps1
@@ -1,4 +1,5 @@
 # !/usr/bin/env powershell
+#
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/ci/kokoro/windows/build-quickstart-cmake.ps1
+++ b/ci/kokoro/windows/build-quickstart-cmake.ps1
@@ -1,4 +1,5 @@
 # !/usr/bin/env powershell
+#
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/ci/kokoro/windows/build.ps1
+++ b/ci/kokoro/windows/build.ps1
@@ -1,4 +1,5 @@
 # !/usr/bin/env powershell
+#
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/ci/lib/init.sh
+++ b/ci/lib/init.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+#
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/ci/lib/io.sh
+++ b/ci/lib/io.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+#
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/ci/lib/module
+++ b/ci/lib/module
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+#
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/google/cloud/bigtable/ci/run_integration_tests_emulator_bazel.sh
+++ b/google/cloud/bigtable/ci/run_integration_tests_emulator_bazel.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+#
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/google/cloud/bigtable/ci/run_integration_tests_emulator_cmake.sh
+++ b/google/cloud/bigtable/ci/run_integration_tests_emulator_cmake.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+#
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/google/cloud/bigtable/tools/run_emulator_utils.sh
+++ b/google/cloud/bigtable/tools/run_emulator_utils.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+#
 # Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/google/cloud/pubsub/ci/lib/pubsub_emulator.sh
+++ b/google/cloud/pubsub/ci/lib/pubsub_emulator.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+#
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/google/cloud/pubsub/ci/run_integration_tests_emulator_bazel.sh
+++ b/google/cloud/pubsub/ci/run_integration_tests_emulator_bazel.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+#
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/google/cloud/pubsub/ci/run_integration_tests_emulator_cmake.sh
+++ b/google/cloud/pubsub/ci/run_integration_tests_emulator_cmake.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+#
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/google/cloud/spanner/benchmarks/single_row_throughput_plots.py
+++ b/google/cloud/spanner/benchmarks/single_row_throughput_plots.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+#
 # Copyright 2019 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/google/cloud/spanner/ci/lib/spanner_emulator.sh
+++ b/google/cloud/spanner/ci/lib/spanner_emulator.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+#
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/google/cloud/spanner/ci/run_integration_tests_emulator_bazel.sh
+++ b/google/cloud/spanner/ci/run_integration_tests_emulator_bazel.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+#
 # Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/google/cloud/spanner/ci/run_integration_tests_emulator_cmake.sh
+++ b/google/cloud/spanner/ci/run_integration_tests_emulator_cmake.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+#
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/google/cloud/storage/benchmarks/storage_parallel_uploads_plots.py
+++ b/google/cloud/storage/benchmarks/storage_parallel_uploads_plots.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+#
 # Copyright 2019 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/google/cloud/storage/benchmarks/storage_throughput_vs_cpu_plots.py
+++ b/google/cloud/storage/benchmarks/storage_throughput_vs_cpu_plots.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+#
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/google/cloud/storage/ci/run_integration_tests_emulator_bazel.sh
+++ b/google/cloud/storage/ci/run_integration_tests_emulator_bazel.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+#
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/google/cloud/storage/ci/run_integration_tests_emulator_cmake.sh
+++ b/google/cloud/storage/ci/run_integration_tests_emulator_cmake.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+#
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/google/cloud/storage/emulator/ci/run_integration_tests_bazel.sh
+++ b/google/cloud/storage/emulator/ci/run_integration_tests_bazel.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+#
 # Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/google/cloud/storage/emulator/tests/test_bucket.py
+++ b/google/cloud/storage/emulator/tests/test_bucket.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+#
 # Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/google/cloud/storage/emulator/tests/test_holder.py
+++ b/google/cloud/storage/emulator/tests/test_holder.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+#
 # Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/google/cloud/storage/emulator/tests/test_object.py
+++ b/google/cloud/storage/emulator/tests/test_object.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+#
 # Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/google/cloud/storage/emulator/tests/test_utils.py
+++ b/google/cloud/storage/emulator/tests/test_utils.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+#
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/google/cloud/storage/tools/make_jwt_assertion_for_test_data.py
+++ b/google/cloud/storage/tools/make_jwt_assertion_for_test_data.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+#
 # Copyright 2018 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
This fixes all files that start w/ a `#!`. 

Context: https://github.com/googleapis/google-cloud-cpp/pull/7071#discussion_r677835834

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7075)
<!-- Reviewable:end -->
