### PR TITLE
feat(storage): support setting HTTP version

### DIFF
--- a/google/cloud/storage/CMakeLists.txt
+++ b/google/cloud/storage/CMakeLists.txt
@@ -503,6 +503,7 @@ if (BUILD_TESTING)
         internal/curl_wrappers_locking_already_present_test.cc
         internal/curl_wrappers_locking_disabled_test.cc
         internal/curl_wrappers_locking_enabled_test.cc
+        internal/curl_wrappers_test.cc
         internal/default_object_acl_requests_test.cc
         internal/generate_message_boundary_test.cc
         internal/generic_request_test.cc

--- a/google/cloud/storage/internal/curl_download_request.cc
+++ b/google/cloud/storage/internal/curl_download_request.cc
@@ -191,6 +191,8 @@ void CurlDownloadRequest::SetOptions() {
   }
   handle_.EnableLogging(logging_enabled_);
   handle_.SetSocketCallback(socket_options_);
+  handle_.SetOptionUnchecked(CURLOPT_HTTP_VERSION,
+                             VersionToCurlCode(http_version_));
   if (download_stall_timeout_.count() != 0) {
     // Timeout if the download receives less than 1 byte/second (i.e.
     // effectively no bytes) for `download_stall_timeout_` seconds.

--- a/google/cloud/storage/internal/curl_download_request.h
+++ b/google/cloud/storage/internal/curl_download_request.h
@@ -115,6 +115,7 @@ class CurlDownloadRequest : public ObjectReadSource {
   CurlHeaders headers_;
   std::string payload_;
   std::string user_agent_;
+  std::string http_version_;
   CurlReceivedHeaders received_headers_;
   std::int32_t http_code_ = 0;
   bool logging_enabled_ = false;

--- a/google/cloud/storage/internal/curl_handle.h
+++ b/google/cloud/storage/internal/curl_handle.h
@@ -114,6 +114,18 @@ class CurlHandle {
     AssertOptionSuccess(e, option, __func__, nullptr);
   }
 
+  /**
+   * Sets an option that may fail.
+   *
+   * The common case to use this is setting an option that sometimes is disabled
+   * in libcurl at compile-time. For example, libcurl can be compiled without
+   * HTTP/2 support, requesting HTTP/2 results in a (harmless) error.
+   */
+  template <typename T>
+  void SetOptionUnchecked(CURLoption option, T&& param) {
+    (void)curl_easy_setopt(handle_.get(), option, std::forward<T>(param));
+  }
+
   Status EasyPerform() {
     auto e = curl_easy_perform(handle_.get());
     return AsStatus(e, __func__);

--- a/google/cloud/storage/internal/curl_request.cc
+++ b/google/cloud/storage/internal/curl_request.cc
@@ -104,6 +104,8 @@ StatusOr<HttpResponse> CurlRequest::MakeRequestImpl() {
   handle_.SetOption(CURLOPT_TCP_KEEPALIVE, 1L);
   handle_.EnableLogging(logging_enabled_);
   handle_.SetSocketCallback(socket_options_);
+  handle_.SetOptionUnchecked(CURLOPT_HTTP_VERSION,
+                             VersionToCurlCode(http_version_));
   handle_.SetOption(CURLOPT_WRITEFUNCTION, &CurlRequestOnWriteData);
   handle_.SetOption(CURLOPT_WRITEDATA, this);
   handle_.SetOption(CURLOPT_HEADERFUNCTION, &CurlRequestOnHeaderData);

--- a/google/cloud/storage/internal/curl_request.h
+++ b/google/cloud/storage/internal/curl_request.h
@@ -70,6 +70,7 @@ class CurlRequest {
   std::string url_;
   CurlHeaders headers_ = CurlHeaders(nullptr, &curl_slist_free_all);
   std::string user_agent_;
+  std::string http_version_;
   std::string response_payload_;
   CurlReceivedHeaders received_headers_;
   bool logging_enabled_ = false;

--- a/google/cloud/storage/internal/curl_request_builder.cc
+++ b/google/cloud/storage/internal/curl_request_builder.cc
@@ -44,6 +44,7 @@ CurlRequest CurlRequestBuilder::BuildRequest() {
   request.url_ = std::move(url_);
   request.headers_ = std::move(headers_);
   request.user_agent_ = user_agent_prefix_ + UserAgentSuffix();
+  request.http_version_ = std::move(http_version_);
   request.handle_ = std::move(handle_);
   request.factory_ = std::move(factory_);
   request.logging_enabled_ = logging_enabled_;
@@ -58,6 +59,7 @@ CurlDownloadRequest CurlRequestBuilder::BuildDownloadRequest(
   request.url_ = std::move(url_);
   request.headers_ = std::move(headers_);
   request.user_agent_ = user_agent_prefix_ + UserAgentSuffix();
+  request.http_version_ = std::move(http_version_);
   request.payload_ = std::move(payload);
   request.handle_ = std::move(handle_);
   request.multi_ = factory_->CreateMultiHandle();
@@ -81,6 +83,8 @@ CurlRequestBuilder& CurlRequestBuilder::ApplyClientOptions(
   auto agents = options.get<UserAgentProductsOption>();
   agents.push_back(user_agent_prefix_);
   user_agent_prefix_ = absl::StrJoin(agents, " ");
+  http_version_ =
+      std::move(options.get<storage_experimental::CurlHttpVersion>());
   download_stall_timeout_ = options.get<DownloadStallTimeoutOption>();
   return *this;
 }

--- a/google/cloud/storage/internal/curl_request_builder.cc
+++ b/google/cloud/storage/internal/curl_request_builder.cc
@@ -84,7 +84,7 @@ CurlRequestBuilder& CurlRequestBuilder::ApplyClientOptions(
   agents.push_back(user_agent_prefix_);
   user_agent_prefix_ = absl::StrJoin(agents, " ");
   http_version_ =
-      std::move(options.get<storage_experimental::CurlHttpVersion>());
+      std::move(options.get<storage_experimental::CurlHttpVersionOption>());
   download_stall_timeout_ = options.get<DownloadStallTimeoutOption>();
   return *this;
 }

--- a/google/cloud/storage/internal/curl_request_builder.cc
+++ b/google/cloud/storage/internal/curl_request_builder.cc
@@ -84,7 +84,7 @@ CurlRequestBuilder& CurlRequestBuilder::ApplyClientOptions(
   agents.push_back(user_agent_prefix_);
   user_agent_prefix_ = absl::StrJoin(agents, " ");
   http_version_ =
-      std::move(options.get<storage_experimental::CurlHttpVersionOption>());
+      std::move(options.get<storage_experimental::HttpVersionOption>());
   download_stall_timeout_ = options.get<DownloadStallTimeoutOption>();
   return *this;
 }

--- a/google/cloud/storage/internal/curl_request_builder.h
+++ b/google/cloud/storage/internal/curl_request_builder.h
@@ -196,6 +196,7 @@ class CurlRequestBuilder {
   bool logging_enabled_;
   CurlHandle::SocketOptions socket_options_;
   std::chrono::seconds download_stall_timeout_;
+  std::string http_version_;
 };
 
 }  // namespace internal

--- a/google/cloud/storage/internal/curl_wrappers.cc
+++ b/google/cloud/storage/internal/curl_wrappers.cc
@@ -206,6 +206,20 @@ bool SslLibraryNeedsLocking(std::string const& curl_ssl_id) {
           curl_ssl_id.rfind("LibreSSL/2", 0) == 0);
 }
 
+long VersionToCurlCode(std::string const& v) {  // NOLINT(google-runtime-int)
+  if (v == "1.0") return CURL_HTTP_VERSION_1_0;
+  if (v == "1.1") return CURL_HTTP_VERSION_1_1;
+  // CURL_HTTP_VERSION_2_0 and CURL_HTTP_VERSION_2 are aliases.
+  if (v == "2.0" || v == "2") return CURL_HTTP_VERSION_2_0;
+  if (v == "2TLS") return CURL_HTTP_VERSION_2TLS;
+#if CURL_AT_LEAST_VERSION(7, 66, 0)
+  // google-cloud-cpp requires curl >= 7.47.0. All the previous codes exist at
+  // that version, but the next one is more recent.
+  if (v == "3") return CURL_HTTP_VERSION_3;
+#endif  // CURL >= 7.66.0
+  return CURL_HTTP_VERSION_NONE;
+}
+
 bool SslLockingCallbacksInstalled() {
 #if GOOGLE_CLOUD_CPP_SSL_REQUIRES_LOCKS
   return !ssl_locks.empty();

--- a/google/cloud/storage/internal/curl_wrappers.cc
+++ b/google/cloud/storage/internal/curl_wrappers.cc
@@ -209,9 +209,13 @@ bool SslLibraryNeedsLocking(std::string const& curl_ssl_id) {
 long VersionToCurlCode(std::string const& v) {  // NOLINT(google-runtime-int)
   if (v == "1.0") return CURL_HTTP_VERSION_1_0;
   if (v == "1.1") return CURL_HTTP_VERSION_1_1;
+#if CURL_AT_LEAST_VERSION(7, 33, 0)
   // CURL_HTTP_VERSION_2_0 and CURL_HTTP_VERSION_2 are aliases.
   if (v == "2.0" || v == "2") return CURL_HTTP_VERSION_2_0;
+#endif  // CURL >= 7.33.0
+#if CURL_AT_LEAST_VERSION(7, 47, 0)
   if (v == "2TLS") return CURL_HTTP_VERSION_2TLS;
+#endif  // CURL >= 7.47.0
 #if CURL_AT_LEAST_VERSION(7, 66, 0)
   // google-cloud-cpp requires curl >= 7.47.0. All the previous codes exist at
   // that version, but the next one is more recent.

--- a/google/cloud/storage/internal/curl_wrappers.h
+++ b/google/cloud/storage/internal/curl_wrappers.h
@@ -65,6 +65,9 @@ std::string CurlSslLibraryId();
 /// Determines if the SSL library requires locking.
 bool SslLibraryNeedsLocking(std::string const& curl_ssl_id);
 
+/// Convert a HTTP version string to the CURL codes
+long VersionToCurlCode(std::string const& v);  // NOLINT(google-runtime-int)
+
 }  // namespace internal
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage

--- a/google/cloud/storage/internal/curl_wrappers_test.cc
+++ b/google/cloud/storage/internal/curl_wrappers_test.cc
@@ -1,0 +1,51 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/storage/internal/curl_wrappers.h"
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+namespace storage {
+inline namespace STORAGE_CLIENT_NS {
+namespace internal {
+namespace {
+
+TEST(CurlWrappers, VersionToCurlCode) {
+  struct Test {
+    std::string version;
+    std::int64_t expected;
+  } cases[] = {
+    {"", CURL_HTTP_VERSION_NONE},
+    {"default", CURL_HTTP_VERSION_NONE},
+    {"1.0", CURL_HTTP_VERSION_1_0},
+    {"1.1", CURL_HTTP_VERSION_1_1},
+    {"2.0", CURL_HTTP_VERSION_2_0},
+    {"2TLS", CURL_HTTP_VERSION_2TLS},
+#if CURL_AT_LEAST_VERSION(7, 66, 0)
+    {"3", CURL_HTTP_VERSION_3},
+#endif  // CURL >= 7.66.0
+  };
+  for (auto const& test : cases) {
+    SCOPED_TRACE("Testing with <" + test.version + ">");
+    EXPECT_EQ(test.expected, VersionToCurlCode(test.version));
+  }
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace STORAGE_CLIENT_NS
+}  // namespace storage
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/storage/internal/curl_wrappers_test.cc
+++ b/google/cloud/storage/internal/curl_wrappers_test.cc
@@ -31,8 +31,12 @@ TEST(CurlWrappers, VersionToCurlCode) {
     {"default", CURL_HTTP_VERSION_NONE},
     {"1.0", CURL_HTTP_VERSION_1_0},
     {"1.1", CURL_HTTP_VERSION_1_1},
+#if CURL_AT_LEAST_VERSION(7, 33, 0)
     {"2.0", CURL_HTTP_VERSION_2_0},
+#endif  // CURL >= 7.33.0
+#if CURL_AT_LEAST_VERSION(7, 47, 0)
     {"2TLS", CURL_HTTP_VERSION_2TLS},
+#endif  // CURL >= 7.47.0
 #if CURL_AT_LEAST_VERSION(7, 66, 0)
     {"3", CURL_HTTP_VERSION_3},
 #endif  // CURL >= 7.66.0

--- a/google/cloud/storage/options.h
+++ b/google/cloud/storage/options.h
@@ -44,7 +44,7 @@ inline namespace STORAGE_CLIENT_NS {
  *
  * [libcurl's default]: https://curl.se/libcurl/c/CURLOPT_HTTP_VERSION.html
  */
-struct CurlHttpVersion {
+struct CurlHttpVersionOption {
   using Type = std::string;
 };
 }  // namespace STORAGE_CLIENT_NS
@@ -236,7 +236,7 @@ using ClientOptionList = ::google::cloud::OptionList<
     MaximumCurlSocketRecvSizeOption, MaximumCurlSocketSendSizeOption,
     DownloadStallTimeoutOption, RetryPolicyOption, BackoffPolicyOption,
     IdempotencyPolicyOption, CARootsFilePathOption,
-    storage_experimental::CurlHttpVersion>;
+    storage_experimental::CurlHttpVersionOption>;
 
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage

--- a/google/cloud/storage/options.h
+++ b/google/cloud/storage/options.h
@@ -44,7 +44,7 @@ inline namespace STORAGE_CLIENT_NS {
  *
  * [libcurl's default]: https://curl.se/libcurl/c/CURLOPT_HTTP_VERSION.html
  */
-struct CurlHttpVersionOption {
+struct HttpVersionOption {
   using Type = std::string;
 };
 }  // namespace STORAGE_CLIENT_NS
@@ -236,7 +236,7 @@ using ClientOptionList = ::google::cloud::OptionList<
     MaximumCurlSocketRecvSizeOption, MaximumCurlSocketSendSizeOption,
     DownloadStallTimeoutOption, RetryPolicyOption, BackoffPolicyOption,
     IdempotencyPolicyOption, CARootsFilePathOption,
-    storage_experimental::CurlHttpVersionOption>;
+    storage_experimental::HttpVersionOption>;
 
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage

--- a/google/cloud/storage/options.h
+++ b/google/cloud/storage/options.h
@@ -28,6 +28,28 @@
 
 namespace google {
 namespace cloud {
+namespace storage_experimental {
+inline namespace STORAGE_CLIENT_NS {
+/**
+ * Set the HTTP version used by the client.
+ *
+ * If this option is not provided, or is set to `default` then the library uses
+ * [libcurl's default], typically HTTP/2 with SSL. Possible settings include:
+ * - "1.0": use HTTP/1.0, this is not recommended as would require a new
+ *   connection for each request.
+ * - "1.1": use HTTP/1.1, this may be useful when the overhead of HTTP/2 is
+ *   unacceptable. Note that this may require additional connections.
+ * - "2TLS": use HTTP/2 with TLS
+ * - "2.0": use HTTP/2 with our without TLS.
+ *
+ * [libcurl's default]: https://curl.se/libcurl/c/CURLOPT_HTTP_VERSION.html
+ */
+struct CurlHttpVersion {
+  using Type = std::string;
+};
+}  // namespace STORAGE_CLIENT_NS
+}  // namespace storage_experimental
+
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace internal {
@@ -213,7 +235,8 @@ using ClientOptionList = ::google::cloud::OptionList<
     EnableCurlSslLockingOption, EnableCurlSigpipeHandlerOption,
     MaximumCurlSocketRecvSizeOption, MaximumCurlSocketSendSizeOption,
     DownloadStallTimeoutOption, RetryPolicyOption, BackoffPolicyOption,
-    IdempotencyPolicyOption, CARootsFilePathOption>;
+    IdempotencyPolicyOption, CARootsFilePathOption,
+    storage_experimental::CurlHttpVersion>;
 
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage

--- a/google/cloud/storage/storage_client_unit_tests.bzl
+++ b/google/cloud/storage/storage_client_unit_tests.bzl
@@ -53,6 +53,7 @@ storage_client_unit_tests = [
     "internal/curl_wrappers_locking_already_present_test.cc",
     "internal/curl_wrappers_locking_disabled_test.cc",
     "internal/curl_wrappers_locking_enabled_test.cc",
+    "internal/curl_wrappers_test.cc",
     "internal/default_object_acl_requests_test.cc",
     "internal/generate_message_boundary_test.cc",
     "internal/generic_request_test.cc",

--- a/google/cloud/storage/tests/curl_request_integration_test.cc
+++ b/google/cloud/storage/tests/curl_request_integration_test.cc
@@ -344,8 +344,8 @@ TEST(CurlRequestTest, HttpVersion) {
         HttpBinEndpoint() + "/get",
         storage::internal::GetDefaultCurlHandleFactory());
     auto options =
-        google::cloud::Options{}.set<storage_experimental::CurlHttpVersion>(
-            test.version);
+        google::cloud::Options{}
+            .set<storage_experimental::CurlHttpVersionOption>(test.version);
     builder.ApplyClientOptions(options);
     builder.AddHeader("Accept: application/json");
     builder.AddHeader("charsets: utf-8");

--- a/google/cloud/storage/tests/curl_request_integration_test.cc
+++ b/google/cloud/storage/tests/curl_request_integration_test.cc
@@ -344,8 +344,8 @@ TEST(CurlRequestTest, HttpVersion) {
         HttpBinEndpoint() + "/get",
         storage::internal::GetDefaultCurlHandleFactory());
     auto options =
-        google::cloud::Options{}
-            .set<storage_experimental::CurlHttpVersionOption>(test.version);
+        google::cloud::Options{}.set<storage_experimental::HttpVersionOption>(
+            test.version);
     builder.ApplyClientOptions(options);
     builder.AddHeader("Accept: application/json");
     builder.AddHeader("charsets: utf-8");

--- a/google/cloud/storage/tests/curl_request_integration_test.cc
+++ b/google/cloud/storage/tests/curl_request_integration_test.cc
@@ -32,9 +32,12 @@ namespace internal {
 namespace {
 
 using ::google::cloud::testing_util::IsOk;
+using ::testing::Contains;
 using ::testing::ElementsAreArray;
 using ::testing::HasSubstr;
 using ::testing::Not;
+using ::testing::Pair;
+using ::testing::StartsWith;
 
 std::string HttpBinEndpoint() {
   return google::cloud::internal::GetEnv("HTTPBIN_ENDPOINT")
@@ -319,6 +322,39 @@ TEST(CurlRequestTest, UserAgent) {
   EXPECT_THAT(headers.value("User-Agent", ""),
               HasSubstr("test-user-agent-prefix"));
   EXPECT_THAT(headers.value("User-Agent", ""), HasSubstr("gcloud-cpp/"));
+}
+
+/// @test Verify the HTTP Version option.
+TEST(CurlRequestTest, HttpVersion) {
+  struct Test {
+    std::string version;
+    std::string prefix;
+  } cases[] = {
+      // The HTTP version setting is a request, libcurl may choose a slightly
+      // different version (e.g. 1.1 when 1.0 is requested).
+      {"1.1", "http/1"},
+      {"1.0", "http/1"},
+      {"2", "http/"},  // HTTP/2 may not be compiled in
+      {"", "http/"},
+  };
+
+  for (auto const& test : cases) {
+    SCOPED_TRACE("Testing with version=<" + test.version + ">");
+    CurlRequestBuilder builder(
+        HttpBinEndpoint() + "/get",
+        storage::internal::GetDefaultCurlHandleFactory());
+    auto options =
+        google::cloud::Options{}.set<storage_experimental::CurlHttpVersion>(
+            test.version);
+    builder.ApplyClientOptions(options);
+    builder.AddHeader("Accept: application/json");
+    builder.AddHeader("charsets: utf-8");
+
+    auto response = RetryMakeRequest(builder.BuildRequest());
+    ASSERT_STATUS_OK(response);
+    EXPECT_EQ(200, response->status_code);
+    EXPECT_THAT(response->headers, Contains(Pair(StartsWith(test.prefix), "")));
+  }
 }
 
 /// @test Verify that the Projection parameter is included if set.


### PR DESCRIPTION
This is an experimental feature to set the HTTP version. Disabling
HTTP/2 can result in better load balancing as load balancers are not
aware of HTTP/2 streams.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7077)
<!-- Reviewable:end -->
