### PR TITLE
feat(storage): release download handles sooner

### DIFF
--- a/google/cloud/storage/internal/curl_download_request.cc
+++ b/google/cloud/storage/internal/curl_download_request.cc
@@ -341,7 +341,7 @@ StatusOr<int> CurlDownloadRequest::PerformWork() {
     result = curl_multi_perform(multi_.get(), &running_handles);
   } while (result == CURLM_CALL_MULTI_PERFORM);
 
-  // Throw an exception if the result is unexpected, otherwise return.
+  // Return an error if the result is unexpected, otherwise return.
   auto status = AsStatus(result, __func__);
   if (!status.ok()) {
     TRACE_STATE() << ", status=" << status;

--- a/google/cloud/storage/internal/curl_download_request.cc
+++ b/google/cloud/storage/internal/curl_download_request.cc
@@ -104,17 +104,22 @@ StatusOr<ReadSourceResult> CurlDownloadRequest::Read(char* buf, std::size_t n) {
   if (n == 0) {
     return Status(StatusCode::kInvalidArgument, "Empty buffer for Read()");
   }
-  handle_.SetOption(CURLOPT_WRITEFUNCTION, &CurlDownloadRequestWrite);
-  handle_.SetOption(CURLOPT_WRITEDATA, this);
-  handle_.SetOption(CURLOPT_HEADERFUNCTION, &CurlDownloadRequestHeader);
-  handle_.SetOption(CURLOPT_HEADERDATA, this);
-
   // Before calling `Wait()` copy any data from the spill buffer into the
   // application buffer. It is possible that `Wait()` will never call
   // `WriteCallback()`, for example, because the Read() or Peek() closed the
   // connection, but if there is any data left in the spill buffer we need
   // to return it.
   DrainSpillBuffer();
+  if (curl_closed_) {
+    return ReadSourceResult{
+        buffer_offset_,
+        HttpResponse{http_code_, std::string{}, std::move(received_headers_)}};
+  }
+
+  handle_.SetOption(CURLOPT_WRITEFUNCTION, &CurlDownloadRequestWrite);
+  handle_.SetOption(CURLOPT_WRITEDATA, this);
+  handle_.SetOption(CURLOPT_HEADERFUNCTION, &CurlDownloadRequestHeader);
+  handle_.SetOption(CURLOPT_HEADERDATA, this);
 
   handle_.FlushDebug(__func__);
   TRACE_STATE();
@@ -223,12 +228,19 @@ void CurlDownloadRequest::OnTransferDone() {
   //   Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION
   //   if not.
   // if the option is not supported then we cannot use HTTP at all in libcurl
-  // and the whole class would fail.
+  // and the whole library would be unusable.
   http_code_ = handle_.GetResponseCode().value();
 
   // Capture the peer (the HTTP server), used for troubleshooting.
   received_headers_.emplace(":curl-peer", handle_.GetPeer());
   TRACE_STATE();
+
+  // Release the handles back to the factory as soon as possible, so they can be
+  // reused for any other requests.
+  if (factory_) {
+    factory_->CleanupHandle(std::move(handle_));
+    factory_->CleanupMultiHandle(std::move(multi_));
+  }
 }
 
 void CurlDownloadRequest::DrainSpillBuffer() {

--- a/google/cloud/storage/internal/curl_download_request.h
+++ b/google/cloud/storage/internal/curl_download_request.h
@@ -90,6 +90,9 @@ class CurlDownloadRequest : public ObjectReadSource {
   /// Handle a completed (even interrupted) download.
   void OnTransferDone();
 
+  /// Release the handles back to the pool.
+  void ReleaseHandles();
+
   /// Copy any available data from the spill buffer to `buffer_`.
   void DrainSpillBuffer();
 

--- a/google/cloud/storage/internal/curl_download_request.h
+++ b/google/cloud/storage/internal/curl_download_request.h
@@ -90,7 +90,7 @@ class CurlDownloadRequest : public ObjectReadSource {
   /// Handle a completed (even interrupted) download.
   void OnTransferDone();
 
-  /// Copy any available data from the spill buffer to `buffer_`
+  /// Copy any available data from the spill buffer to `buffer_`.
   void DrainSpillBuffer();
 
   /// Called by libcurl to show that more data is available in the download.

--- a/google/cloud/storage/internal/curl_handle.h
+++ b/google/cloud/storage/internal/curl_handle.h
@@ -88,6 +88,8 @@ class CurlHandle {
   CurlHandle(CurlHandle&&) = default;
   CurlHandle& operator=(CurlHandle&&) = default;
 
+  operator bool() const { return static_cast<bool>(handle_); }
+
   /// Set the callback to initialize each socket.
   struct SocketOptions {
     std::size_t recv_buffer_size_ = 0;

--- a/google/cloud/storage/internal/curl_handle_factory.cc
+++ b/google/cloud/storage/internal/curl_handle_factory.cc
@@ -54,7 +54,7 @@ CurlPtr DefaultCurlHandleFactory::CreateHandle() {
 }
 
 void DefaultCurlHandleFactory::CleanupHandle(CurlHandle&& h) {
-  if (GetHandle(h) == nullptr) return;
+  if (!h) return;
   char* ip;
   auto res = curl_easy_getinfo(GetHandle(h), CURLINFO_LOCAL_IP, &ip);
   if (res == CURLE_OK && ip != nullptr) {
@@ -112,7 +112,7 @@ CurlPtr PooledCurlHandleFactory::CreateHandle() {
 }
 
 void PooledCurlHandleFactory::CleanupHandle(CurlHandle&& h) {
-  if (GetHandle(h) == nullptr) return;
+  if (!h) return;
   std::unique_lock<std::mutex> lk(mu_);
   char* ip;
   auto res = curl_easy_getinfo(GetHandle(h), CURLINFO_LOCAL_IP, &ip);

--- a/google/cloud/storage/internal/curl_handle_factory.cc
+++ b/google/cloud/storage/internal/curl_handle_factory.cc
@@ -54,6 +54,7 @@ CurlPtr DefaultCurlHandleFactory::CreateHandle() {
 }
 
 void DefaultCurlHandleFactory::CleanupHandle(CurlHandle&& h) {
+  if (GetHandle(h) == nullptr) return;
   char* ip;
   auto res = curl_easy_getinfo(GetHandle(h), CURLINFO_LOCAL_IP, &ip);
   if (res == CURLE_OK && ip != nullptr) {
@@ -111,6 +112,7 @@ CurlPtr PooledCurlHandleFactory::CreateHandle() {
 }
 
 void PooledCurlHandleFactory::CleanupHandle(CurlHandle&& h) {
+  if (GetHandle(h) == nullptr) return;
   std::unique_lock<std::mutex> lk(mu_);
   char* ip;
   auto res = curl_easy_getinfo(GetHandle(h), CURLINFO_LOCAL_IP, &ip);
@@ -138,6 +140,7 @@ CurlMulti PooledCurlHandleFactory::CreateMultiHandle() {
 }
 
 void PooledCurlHandleFactory::CleanupMultiHandle(CurlMulti&& m) {
+  if (!m) return;
   std::unique_lock<std::mutex> lk(mu_);
   while (multi_handles_.size() >= maximum_size_) {
     auto* tmp = multi_handles_.front();

--- a/google/cloud/storage/internal/curl_handle_factory.h
+++ b/google/cloud/storage/internal/curl_handle_factory.h
@@ -113,6 +113,17 @@ class PooledCurlHandleFactory : public CurlHandleFactory {
     return last_client_ip_address_;
   }
 
+  // Test only
+  std::size_t CurrentHandleCount() const {
+    std::lock_guard<std::mutex> lk(mu_);
+    return handles_.size();
+  }
+  // Test only
+  std::size_t CurrentMultiHandleCount() const {
+    std::lock_guard<std::mutex> lk(mu_);
+    return multi_handles_.size();
+  }
+
  private:
   void SetCurlOptions(CURL* handle);
 

--- a/google/cloud/storage/tests/object_read_preconditions_integration_test.cc
+++ b/google/cloud/storage/tests/object_read_preconditions_integration_test.cc
@@ -15,6 +15,7 @@
 #include "google/cloud/storage/client.h"
 #include "google/cloud/storage/testing/storage_integration_test.h"
 #include "google/cloud/internal/getenv.h"
+#include "google/cloud/log.h"
 #include "google/cloud/testing_util/scoped_environment.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include "absl/types/optional.h"
@@ -75,6 +76,8 @@ TEST_P(ObjectReadPreconditionsIntegrationTest, IfGenerationMatchSuccess) {
                                    IfGenerationMatch(meta->generation()));
   reader.Close();
   EXPECT_THAT(reader.status(), IsOk());
+  // TODO(coryan) - do not merge, troubleshooting on Windows.
+  google::cloud::LogSink::Instance().Flush();
 }
 
 TEST_P(ObjectReadPreconditionsIntegrationTest, IfGenerationMatchFailure) {
@@ -92,6 +95,8 @@ TEST_P(ObjectReadPreconditionsIntegrationTest, IfGenerationMatchFailure) {
                                    IfGenerationMatch(meta->generation() + 1));
   reader.Close();
   EXPECT_THAT(reader.status(), StatusIs(StatusCode::kFailedPrecondition));
+  // TODO(coryan) - do not merge, troubleshooting on Windows.
+  google::cloud::LogSink::Instance().Flush();
 }
 
 TEST_P(ObjectReadPreconditionsIntegrationTest, IfGenerationNotMatchSuccess) {


### PR DESCRIPTION
Release the CURL* handles as soon as we are done using them. The
downloads used to hold on to these until the `CurlDownloadRequest`
object was deleted, which in turn could live until the
`storage::ObjectReadStream` was deleted.

Fixes #6160

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7081)
<!-- Reviewable:end -->
