### PR TITLE
cleanup(storage): simplify CurlDownloadRequest creation

### DIFF
--- a/google/cloud/storage/internal/curl_client.cc
+++ b/google/cloud/storage/internal/curl_client.cc
@@ -608,7 +608,7 @@ StatusOr<std::unique_ptr<ObjectReadSource>> CurlClient::ReadObject(
   }
 
   return std::unique_ptr<ObjectReadSource>(
-      new CurlDownloadRequest(builder.BuildDownloadRequest(std::string{})));
+      std::move(builder).BuildDownloadRequest());
 }
 
 StatusOr<ListObjectsResponse> CurlClient::ListObjects(
@@ -1316,7 +1316,7 @@ StatusOr<std::unique_ptr<ObjectReadSource>> CurlClient::ReadObjectXml(
   }
 
   return std::unique_ptr<ObjectReadSource>(
-      new CurlDownloadRequest(builder.BuildDownloadRequest(std::string{})));
+      std::move(builder).BuildDownloadRequest());
 }
 
 StatusOr<ObjectMetadata> CurlClient::InsertObjectMediaMultipart(

--- a/google/cloud/storage/internal/curl_download_request.cc
+++ b/google/cloud/storage/internal/curl_download_request.cc
@@ -54,10 +54,12 @@ extern "C" std::size_t CurlDownloadRequestHeader(char* contents,
                  << ", closing=" << closing_ << ", closed=" << curl_closed_ \
                  << ", paused=" << paused_ << ", in_multi=" << in_multi_
 
-CurlDownloadRequest::CurlDownloadRequest()
-    : headers_(nullptr, &curl_slist_free_all),
+CurlDownloadRequest::CurlDownloadRequest(CurlHeaders headers, CurlHandle handle,
+                                         CurlMulti multi)
+    : headers_(std::move(headers)),
       download_stall_timeout_(0),
-      multi_(nullptr, &curl_multi_cleanup),
+      handle_(std::move(handle)),
+      multi_(std::move(multi)),
       spill_(CURL_MAX_WRITE_SIZE) {}
 
 CurlDownloadRequest::~CurlDownloadRequest() {

--- a/google/cloud/storage/internal/curl_download_request.h
+++ b/google/cloud/storage/internal/curl_download_request.h
@@ -48,12 +48,14 @@ extern "C" std::size_t CurlDownloadRequestHeader(char* contents,
  */
 class CurlDownloadRequest : public ObjectReadSource {
  public:
-  explicit CurlDownloadRequest();
+  CurlDownloadRequest(CurlHeaders headers, CurlHandle handle, CurlMulti multi);
 
   ~CurlDownloadRequest() override;
 
-  CurlDownloadRequest(CurlDownloadRequest&&) = default;
-  CurlDownloadRequest& operator=(CurlDownloadRequest&& rhs) = default;
+  CurlDownloadRequest(CurlDownloadRequest&&) = delete;
+  CurlDownloadRequest& operator=(CurlDownloadRequest&&) = delete;
+  CurlDownloadRequest(CurlDownloadRequest const&) = delete;
+  CurlDownloadRequest& operator=(CurlDownloadRequest const&) = delete;
 
   bool IsOpen() const override { return !(curl_closed_ && spill_offset_ == 0); }
   StatusOr<HttpResponse> Close() override;

--- a/google/cloud/storage/internal/curl_request_builder.cc
+++ b/google/cloud/storage/internal/curl_request_builder.cc
@@ -52,22 +52,20 @@ CurlRequest CurlRequestBuilder::BuildRequest() {
   return request;
 }
 
-CurlDownloadRequest CurlRequestBuilder::BuildDownloadRequest(
-    std::string payload) {
+std::unique_ptr<CurlDownloadRequest>
+CurlRequestBuilder::BuildDownloadRequest() && {
   ValidateBuilderState(__func__);
-  CurlDownloadRequest request;
-  request.url_ = std::move(url_);
-  request.headers_ = std::move(headers_);
-  request.user_agent_ = user_agent_prefix_ + UserAgentSuffix();
-  request.http_version_ = std::move(http_version_);
-  request.payload_ = std::move(payload);
-  request.handle_ = std::move(handle_);
-  request.multi_ = factory_->CreateMultiHandle();
-  request.factory_ = factory_;
-  request.logging_enabled_ = logging_enabled_;
-  request.socket_options_ = socket_options_;
-  request.download_stall_timeout_ = download_stall_timeout_;
-  request.SetOptions();
+  auto agent = user_agent_prefix_ + UserAgentSuffix();
+  auto request = absl::make_unique<CurlDownloadRequest>(
+      std::move(headers_), std::move(handle_), factory_->CreateMultiHandle());
+  request->url_ = std::move(url_);
+  request->user_agent_ = std::move(agent);
+  request->http_version_ = std::move(http_version_);
+  request->factory_ = factory_;
+  request->logging_enabled_ = logging_enabled_;
+  request->socket_options_ = socket_options_;
+  request->download_stall_timeout_ = download_stall_timeout_;
+  request->SetOptions();
   return request;
 }
 

--- a/google/cloud/storage/internal/curl_request_builder.h
+++ b/google/cloud/storage/internal/curl_request_builder.h
@@ -53,7 +53,7 @@ class CurlRequestBuilder {
    * This function invalidates the builder. The application should not use this
    * builder once this function is called.
    */
-  CurlDownloadRequest BuildDownloadRequest(std::string payload);
+  std::unique_ptr<CurlDownloadRequest> BuildDownloadRequest() &&;
 
   /// Adds one of the well-known parameters as a query parameter
   template <typename P>


### PR DESCRIPTION
Other than in tests, we always used the class in a `std::unique_ptr<>`.
We can make the class non-copyable and non-moveable, and simply return a
`std::unique_ptr<CurlDownloadRequest>` from the `CurlRequestBuilder`.
This will also workaround some bugs in MSVC (or at least I believe they
are bugs).

This is part of the work for #6160

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7082)
<!-- Reviewable:end -->
