### PR TITLE
feat(storage): release download handles sooner

### DIFF
--- a/google/cloud/storage/internal/curl_handle_factory.cc
+++ b/google/cloud/storage/internal/curl_handle_factory.cc
@@ -54,6 +54,7 @@ CurlPtr DefaultCurlHandleFactory::CreateHandle() {
 }
 
 void DefaultCurlHandleFactory::CleanupHandle(CurlHandle&& h) {
+  if (GetHandle(h) == nullptr) return;
   char* ip;
   auto res = curl_easy_getinfo(GetHandle(h), CURLINFO_LOCAL_IP, &ip);
   if (res == CURLE_OK && ip != nullptr) {
@@ -111,6 +112,7 @@ CurlPtr PooledCurlHandleFactory::CreateHandle() {
 }
 
 void PooledCurlHandleFactory::CleanupHandle(CurlHandle&& h) {
+  if (GetHandle(h) == nullptr) return;
   std::unique_lock<std::mutex> lk(mu_);
   char* ip;
   auto res = curl_easy_getinfo(GetHandle(h), CURLINFO_LOCAL_IP, &ip);
@@ -138,6 +140,7 @@ CurlMulti PooledCurlHandleFactory::CreateMultiHandle() {
 }
 
 void PooledCurlHandleFactory::CleanupMultiHandle(CurlMulti&& m) {
+  if (!m) return;
   std::unique_lock<std::mutex> lk(mu_);
   while (multi_handles_.size() >= maximum_size_) {
     auto* tmp = multi_handles_.front();

--- a/google/cloud/storage/internal/curl_handle_factory.h
+++ b/google/cloud/storage/internal/curl_handle_factory.h
@@ -113,6 +113,17 @@ class PooledCurlHandleFactory : public CurlHandleFactory {
     return last_client_ip_address_;
   }
 
+  // Test only
+  std::size_t CurrentHandleCount() const {
+    std::lock_guard<std::mutex> lk(mu_);
+    return handles_.size();
+  }
+  // Test only
+  std::size_t CurrentMultiHandleCount() const {
+    std::lock_guard<std::mutex> lk(mu_);
+    return multi_handles_.size();
+  }
+
  private:
   void SetCurlOptions(CURL* handle);
 

--- a/google/cloud/storage/tests/curl_download_request_integration_test.cc
+++ b/google/cloud/storage/tests/curl_download_request_integration_test.cc
@@ -16,7 +16,9 @@
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/log.h"
 #include "google/cloud/testing_util/status_matchers.h"
+#include "absl/strings/str_split.h"
 #include <gmock/gmock.h>
+#include <nlohmann/json.hpp>
 #include <chrono>
 #include <thread>
 #include <vector>
@@ -73,6 +75,134 @@ TEST(CurlDownloadRequestTest, SimpleStream) {
     delay *= 2;
   }
   EXPECT_EQ(kDownloadedLines, count);
+}
+
+TEST(CurlDownloadRequestTest, HandlesReleasedOnRead) {
+  auto constexpr kLineCount = 10;
+  auto constexpr kTestPoolSize = 8;
+  auto factory =
+      std::make_shared<PooledCurlHandleFactory>(kTestPoolSize, Options{});
+  ASSERT_EQ(0, factory->CurrentHandleCount());
+  ASSERT_EQ(0, factory->CurrentMultiHandleCount());
+
+  auto download = [&]() -> Status {
+    CurlRequestBuilder builder(
+        HttpBinEndpoint() + "/stream/" + std::to_string(kLineCount), factory);
+    auto download = std::move(builder).BuildDownloadRequest();
+
+    char buffer[4096];
+    auto read = download->Read(buffer, sizeof(buffer));
+    if (!read) return std::move(read).status();
+    // The data is 10 lines of about 200 bytes each, it all fits in the buffer.
+    EXPECT_LT(read->bytes_received, sizeof(buffer));
+    // This means the transfers completes during the Read() call, and the
+    // handles are immediately returned to the pool.
+    EXPECT_EQ(1, factory->CurrentHandleCount());
+    EXPECT_EQ(1, factory->CurrentMultiHandleCount());
+
+    auto close = download->Close();
+    if (!close) return std::move(close).status();
+    EXPECT_EQ(1, factory->CurrentHandleCount());
+    EXPECT_EQ(1, factory->CurrentMultiHandleCount());
+    return Status{};
+  };
+
+  auto delay = std::chrono::seconds(1);
+  Status status;
+  for (int i = 0; i != 3; ++i) {
+    status = download();
+    if (status.ok()) break;
+    std::this_thread::sleep_for(delay);
+    delay *= 2;
+  }
+  EXPECT_EQ(1, factory->CurrentHandleCount());
+  EXPECT_EQ(1, factory->CurrentMultiHandleCount());
+  ASSERT_STATUS_OK(status);
+}
+
+TEST(CurlDownloadRequestTest, HandlesReleasedOnClose) {
+  auto constexpr kLineCount = 10;
+  auto constexpr kTestPoolSize = 8;
+  auto factory =
+      std::make_shared<PooledCurlHandleFactory>(kTestPoolSize, Options{});
+  ASSERT_EQ(0, factory->CurrentHandleCount());
+  ASSERT_EQ(0, factory->CurrentMultiHandleCount());
+
+  auto download = [&]() -> Status {
+    CurlRequestBuilder builder(
+        HttpBinEndpoint() + "/stream/" + std::to_string(kLineCount), factory);
+    auto download = std::move(builder).BuildDownloadRequest();
+
+    char buffer[4];
+    auto read = download->Read(buffer, sizeof(buffer));
+    if (!read) return std::move(read).status();
+    // The data is 10 lines of about 200 bytes each, it will not fit in the
+    // buffer:
+    EXPECT_EQ(read->bytes_received, sizeof(buffer));
+    EXPECT_EQ(read->response.status_code, HttpStatusCode::kContinue);
+    // This means the transfer is still active, and the handles would not have
+    // been returned to the pool.
+    EXPECT_EQ(0, factory->CurrentHandleCount());
+    EXPECT_EQ(0, factory->CurrentMultiHandleCount());
+
+    auto close = download->Close();
+    if (!close) return std::move(close).status();
+    EXPECT_EQ(1, factory->CurrentHandleCount());
+    EXPECT_EQ(1, factory->CurrentMultiHandleCount());
+    return Status{};
+  };
+
+  auto delay = std::chrono::seconds(1);
+  Status status;
+  for (int i = 0; i != 3; ++i) {
+    status = download();
+    if (status.ok()) break;
+    std::this_thread::sleep_for(delay);
+    delay *= 2;
+  }
+  EXPECT_EQ(1, factory->CurrentHandleCount());
+  EXPECT_EQ(1, factory->CurrentMultiHandleCount());
+  ASSERT_STATUS_OK(status);
+}
+
+TEST(CurlDownloadRequestTest, SimpleStreamReadAfterClosed) {
+  auto constexpr kLineCount = 10;
+  auto download = [&]() -> StatusOr<std::string> {
+    std::string contents;
+    CurlRequestBuilder builder(
+        HttpBinEndpoint() + "/stream/" + std::to_string(kLineCount),
+        storage::internal::GetDefaultCurlHandleFactory());
+    auto download = std::move(builder).BuildDownloadRequest();
+    // Perform a series of very small `.Read()` calls. This will force the
+    char buffer[4];
+    do {
+      auto result = download->Read(buffer, sizeof(buffer));
+      if (!result) return std::move(result).status();
+      if (result->bytes_received == 0) break;
+      contents += std::string{buffer, result->bytes_received};
+    } while (true);
+    return contents;
+  };
+
+  auto delay = std::chrono::seconds(1);
+  StatusOr<std::string> received;
+  for (int i = 0; i != 3; ++i) {
+    received = download();
+    if (received) break;
+    std::this_thread::sleep_for(delay);
+    delay *= 2;
+  }
+  ASSERT_STATUS_OK(received);
+  std::vector<std::string> lines = absl::StrSplit(*received, "\n");
+  auto p = std::remove(lines.begin(), lines.end(), std::string{});
+  lines.erase(p, lines.end());
+  EXPECT_EQ(kLineCount, lines.size());
+  int count = 0;
+  for (auto const& line : lines) {
+    auto parsed = nlohmann::json::parse(line);
+    ASSERT_TRUE(parsed.contains("id"));
+    EXPECT_EQ(count++, parsed["id"].get<std::int64_t>());
+  }
 }
 
 // Run one attempt of the Regression7051 test. This is wrapped in a retry loop,


### PR DESCRIPTION
Release the CURL* handles as soon as we are done using them. The
downloads used to hold on to these until the `CurlDownloadRequest`
object was deleted, which in turn could live until the
`storage::ObjectReadStream` was deleted.

Fixes #6160 