### PR TITLE
feat(common): always clog GCP_LOG(FATAL) messages

### DIFF
--- a/generator/internal/predicate_utils_test.cc
+++ b/generator/internal/predicate_utils_test.cc
@@ -508,7 +508,6 @@ TEST(PredicateUtilsTest, PaginationNoRepeatedMessageField) {
 }
 
 TEST(PredicateUtilsDeathTest, PaginationRepeatedMessageOrderMismatch) {
-  google::cloud::LogSink::EnableStdClog();
   FileDescriptorProto service_file;
   /// @cond
   auto constexpr kServiceText = R"pb(

--- a/google/cloud/internal/log_impl.cc
+++ b/google/cloud/internal/log_impl.cc
@@ -22,9 +22,11 @@ namespace internal {
 
 void StdClogBackend::Process(LogRecord const& lr) {
   std::lock_guard<std::mutex> lk(mu_);
-  std::clog << lr << "\n";
-  if (lr.severity >= Severity::GCP_LS_WARNING) {
-    std::clog << std::flush;
+  if (lr.severity >= min_severity_) {
+    std::clog << lr << "\n";
+    if (lr.severity >= Severity::GCP_LS_WARNING) {
+      std::clog << std::flush;
+    }
   }
 }
 

--- a/google/cloud/internal/log_impl_test.cc
+++ b/google/cloud/internal/log_impl_test.cc
@@ -68,62 +68,85 @@ TEST(DefaultLogBackend, CircularBuffer) {
   ScopedEnvironment config(kLogConfig, "lastN,5,WARNING");
   ScopedEnvironment clog(kEnableClog, absl::nullopt);
   auto be = DefaultLogBackend();
-  EXPECT_TRUE(!!be);
   auto const* buffer = dynamic_cast<CircularBufferBackend*>(be.get());
   ASSERT_NE(buffer, nullptr);
   EXPECT_EQ(5, buffer->size());
   EXPECT_EQ(Severity::GCP_LS_WARNING, buffer->min_flush_severity());
+  auto const* clog_be = dynamic_cast<StdClogBackend*>(buffer->backend().get());
+  ASSERT_NE(clog_be, nullptr);
+  EXPECT_EQ(Severity::GCP_LS_DEBUG, clog_be->min_severity());
 }
 
 TEST(DefaultLogBackend, CLog) {
   ScopedEnvironment config(kLogConfig, "clog");
   ScopedEnvironment clog(kEnableClog, absl::nullopt);
   auto be = DefaultLogBackend();
-  EXPECT_TRUE(!!be);
-  EXPECT_NE(dynamic_cast<StdClogBackend*>(be.get()), nullptr);
+  auto const* clog_be = dynamic_cast<StdClogBackend*>(be.get());
+  ASSERT_NE(clog_be, nullptr);
+  EXPECT_EQ(Severity::GCP_LS_DEBUG, clog_be->min_severity());
 }
 
-TEST(DefaultLogBackend, CLogBackwardsCompatibility) {
+TEST(DefaultLogBackend, BackwardsCompatibilityCLog) {
   ScopedEnvironment config(kLogConfig, absl::nullopt);
   ScopedEnvironment clog(kEnableClog, "yes");
   auto be = DefaultLogBackend();
-  EXPECT_TRUE(!!be);
-  EXPECT_NE(dynamic_cast<StdClogBackend*>(be.get()), nullptr);
+  auto const* clog_be = dynamic_cast<StdClogBackend*>(be.get());
+  ASSERT_NE(clog_be, nullptr);
+  EXPECT_EQ(Severity::GCP_LS_DEBUG, clog_be->min_severity());
 }
 
-TEST(DefaultLogBackend, Unset) {
+TEST(DefaultLogBackend, BackwardsCompatibilityCLogUnset) {
   ScopedEnvironment config(kLogConfig, absl::nullopt);
   ScopedEnvironment clog(kEnableClog, absl::nullopt);
   auto be = DefaultLogBackend();
-  EXPECT_FALSE(!!be);
+  auto const* clog_be = dynamic_cast<StdClogBackend*>(be.get());
+  ASSERT_NE(clog_be, nullptr);
+  EXPECT_EQ(Severity::GCP_LS_FATAL, clog_be->min_severity());
+}
+
+TEST(DefaultLogBackend, BackwardsCompatibilityCLogWithSeverity) {
+  ScopedEnvironment config(kLogConfig, absl::nullopt);
+  ScopedEnvironment clog(kEnableClog, "WARNING");
+  auto be = DefaultLogBackend();
+  auto const* clog_be = dynamic_cast<StdClogBackend*>(be.get());
+  ASSERT_NE(clog_be, nullptr);
+  EXPECT_EQ(Severity::GCP_LS_WARNING, clog_be->min_severity());
 }
 
 TEST(DefaultLogBackend, UnknownType) {
   ScopedEnvironment config(kLogConfig, "invalid");
   ScopedEnvironment clog(kEnableClog, absl::nullopt);
   auto be = DefaultLogBackend();
-  EXPECT_FALSE(!!be);
+  auto const* clog_be = dynamic_cast<StdClogBackend*>(be.get());
+  ASSERT_NE(clog_be, nullptr);
+  EXPECT_EQ(Severity::GCP_LS_FATAL, clog_be->min_severity());
 }
 
 TEST(DefaultLogBackend, MissingComponents) {
   ScopedEnvironment config(kLogConfig, "lastN,1");
   ScopedEnvironment clog(kEnableClog, absl::nullopt);
   auto be = DefaultLogBackend();
-  EXPECT_FALSE(!!be);
+  auto const* clog_be = dynamic_cast<StdClogBackend*>(be.get());
+  ASSERT_NE(clog_be, nullptr);
+  EXPECT_EQ(Severity::GCP_LS_FATAL, clog_be->min_severity());
 }
 
 TEST(DefaultLogBackend, InvalidSize) {
   ScopedEnvironment config(kLogConfig, "lastN,-10,WARNING");
   ScopedEnvironment clog(kEnableClog, absl::nullopt);
   auto be = DefaultLogBackend();
-  EXPECT_FALSE(!!be);
+  auto const* clog_be = dynamic_cast<StdClogBackend*>(be.get());
+  ASSERT_NE(clog_be, nullptr);
+  EXPECT_EQ(Severity::GCP_LS_FATAL, clog_be->min_severity());
 }
 
 TEST(DefaultLogBackend, InvalidSeverity) {
   ScopedEnvironment config(kLogConfig, "lastN,10,invalid");
   ScopedEnvironment clog(kEnableClog, absl::nullopt);
   auto be = DefaultLogBackend();
-  EXPECT_FALSE(!!be);
+  auto const* clog_be = dynamic_cast<StdClogBackend*>(be.get());
+  ASSERT_NE(clog_be, nullptr);
+  EXPECT_EQ(Severity::GCP_LS_FATAL, clog_be->min_severity());
 }
 
 }  // namespace

--- a/google/cloud/internal/log_impl_test.cc
+++ b/google/cloud/internal/log_impl_test.cc
@@ -27,6 +27,7 @@ using ::google::cloud::testing_util::ScopedEnvironment;
 using ::google::cloud::testing_util::ScopedLog;
 using ::testing::ElementsAre;
 using ::testing::IsEmpty;
+using ::testing::NotNull;
 
 auto constexpr kLogConfig = "GOOGLE_CLOUD_CPP_EXPERIMENTAL_LOG_CONFIG";
 auto constexpr kEnableClog = "GOOGLE_CLOUD_CPP_ENABLE_CLOG";
@@ -73,7 +74,7 @@ TEST(DefaultLogBackend, CircularBuffer) {
   EXPECT_EQ(5, buffer->size());
   EXPECT_EQ(Severity::GCP_LS_WARNING, buffer->min_flush_severity());
   auto const* clog_be = dynamic_cast<StdClogBackend*>(buffer->backend().get());
-  ASSERT_NE(clog_be, nullptr);
+  ASSERT_THAT(clog_be, NotNull());
   EXPECT_EQ(Severity::GCP_LS_DEBUG, clog_be->min_severity());
 }
 
@@ -82,7 +83,7 @@ TEST(DefaultLogBackend, CLog) {
   ScopedEnvironment clog(kEnableClog, absl::nullopt);
   auto be = DefaultLogBackend();
   auto const* clog_be = dynamic_cast<StdClogBackend*>(be.get());
-  ASSERT_NE(clog_be, nullptr);
+  ASSERT_THAT(clog_be, NotNull());
   EXPECT_EQ(Severity::GCP_LS_DEBUG, clog_be->min_severity());
 }
 
@@ -91,7 +92,7 @@ TEST(DefaultLogBackend, BackwardsCompatibilityCLog) {
   ScopedEnvironment clog(kEnableClog, "yes");
   auto be = DefaultLogBackend();
   auto const* clog_be = dynamic_cast<StdClogBackend*>(be.get());
-  ASSERT_NE(clog_be, nullptr);
+  ASSERT_THAT(clog_be, NotNull());
   EXPECT_EQ(Severity::GCP_LS_DEBUG, clog_be->min_severity());
 }
 
@@ -100,7 +101,7 @@ TEST(DefaultLogBackend, BackwardsCompatibilityCLogUnset) {
   ScopedEnvironment clog(kEnableClog, absl::nullopt);
   auto be = DefaultLogBackend();
   auto const* clog_be = dynamic_cast<StdClogBackend*>(be.get());
-  ASSERT_NE(clog_be, nullptr);
+  ASSERT_THAT(clog_be, NotNull());
   EXPECT_EQ(Severity::GCP_LS_FATAL, clog_be->min_severity());
 }
 
@@ -109,7 +110,7 @@ TEST(DefaultLogBackend, BackwardsCompatibilityCLogWithSeverity) {
   ScopedEnvironment clog(kEnableClog, "WARNING");
   auto be = DefaultLogBackend();
   auto const* clog_be = dynamic_cast<StdClogBackend*>(be.get());
-  ASSERT_NE(clog_be, nullptr);
+  ASSERT_THAT(clog_be, NotNull());
   EXPECT_EQ(Severity::GCP_LS_WARNING, clog_be->min_severity());
 }
 
@@ -118,7 +119,7 @@ TEST(DefaultLogBackend, UnknownType) {
   ScopedEnvironment clog(kEnableClog, absl::nullopt);
   auto be = DefaultLogBackend();
   auto const* clog_be = dynamic_cast<StdClogBackend*>(be.get());
-  ASSERT_NE(clog_be, nullptr);
+  ASSERT_THAT(clog_be, NotNull());
   EXPECT_EQ(Severity::GCP_LS_FATAL, clog_be->min_severity());
 }
 
@@ -127,7 +128,7 @@ TEST(DefaultLogBackend, MissingComponents) {
   ScopedEnvironment clog(kEnableClog, absl::nullopt);
   auto be = DefaultLogBackend();
   auto const* clog_be = dynamic_cast<StdClogBackend*>(be.get());
-  ASSERT_NE(clog_be, nullptr);
+  ASSERT_THAT(clog_be, NotNull());
   EXPECT_EQ(Severity::GCP_LS_FATAL, clog_be->min_severity());
 }
 
@@ -136,7 +137,7 @@ TEST(DefaultLogBackend, InvalidSize) {
   ScopedEnvironment clog(kEnableClog, absl::nullopt);
   auto be = DefaultLogBackend();
   auto const* clog_be = dynamic_cast<StdClogBackend*>(be.get());
-  ASSERT_NE(clog_be, nullptr);
+  ASSERT_THAT(clog_be, NotNull());
   EXPECT_EQ(Severity::GCP_LS_FATAL, clog_be->min_severity());
 }
 
@@ -145,7 +146,7 @@ TEST(DefaultLogBackend, InvalidSeverity) {
   ScopedEnvironment clog(kEnableClog, absl::nullopt);
   auto be = DefaultLogBackend();
   auto const* clog_be = dynamic_cast<StdClogBackend*>(be.get());
-  ASSERT_NE(clog_be, nullptr);
+  ASSERT_THAT(clog_be, NotNull());
   EXPECT_EQ(Severity::GCP_LS_FATAL, clog_be->min_severity());
 }
 

--- a/google/cloud/log.h
+++ b/google/cloud/log.h
@@ -24,8 +24,10 @@
  * The functions and macros used for logging are defined in this file. In
  * general, we abide by the following principles:
  *
- * - Logging should controlled by the application developer, unless explicitly
- *   instructed, the libraries produce no output to the console.
+ * - Logging should controlled by the application developer. Unless explicitly
+ *   instructed, the libraries produce no output to the console, except
+ *   to emit a message to `std::clog` immediately before a GCP_LOG(FATAL)
+ *   terminates the process.
  * - Logging should have very low cost:
  *   - It should be possible to disable logs at compile time, they should
  *     disappear as-if there were `#%ifdef`/`#%endif` directives around them.
@@ -323,13 +325,20 @@ class LogSink {
    * This is also enabled if the "GOOGLE_CLOUD_CPP_ENABLE_CLOG" environment
    * variable is set.
    */
-  static void EnableStdClog() { Instance().EnableStdClogImpl(); }
+  static void EnableStdClog(
+      Severity min_severity = Severity::GCP_LS_LOWEST_ENABLED) {
+    Instance().EnableStdClogImpl(min_severity);
+  }
 
-  /// Disable `std::clog` on `LogSink::Instance()`.
+  /**
+   * Disable `std::clog` on `LogSink::Instance()`.
+   *
+   * Note that this will remove the default logging backend.
+   */
   static void DisableStdClog() { Instance().DisableStdClogImpl(); }
 
  private:
-  void EnableStdClogImpl();
+  void EnableStdClogImpl(Severity min_severity);
   void DisableStdClogImpl();
   void SetDefaultBackend(std::shared_ptr<LogBackend> backend);
   BackendId AddBackendImpl(std::shared_ptr<LogBackend> backend);

--- a/google/cloud/spanner/internal/connection_impl_test.cc
+++ b/google/cloud/spanner/internal/connection_impl_test.cc
@@ -1480,7 +1480,6 @@ TEST(ConnectionImplTest, ExecuteBatchDmlNoResultSets) {
 }
 
 TEST(ConnectionImplTest, ExecutePartitionedDmlDeleteSuccess) {
-  google::cloud::LogSink::EnableStdClog();
   auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
   auto db = spanner::Database("placeholder_project", "placeholder_instance",
                               "placeholder_database_id");

--- a/google/cloud/storage/internal/curl_handle_test.cc
+++ b/google/cloud/storage/internal/curl_handle_test.cc
@@ -63,7 +63,6 @@ TEST(CurlHandleTest, AsStatus) {
 }
 
 TEST(AssertOptionSuccess, StringWithError) {
-  google::cloud::LogSink::EnableStdClog();
   EXPECT_DEATH_IF_SUPPORTED(
       AssertOptionSuccess(CURLE_NOT_BUILT_IN, CURLOPT_CAINFO, "test-function",
                           "some-path"),
@@ -71,7 +70,6 @@ TEST(AssertOptionSuccess, StringWithError) {
 }
 
 TEST(AssertOptionSuccess, IntWithError) {
-  google::cloud::LogSink::EnableStdClog();
   EXPECT_DEATH_IF_SUPPORTED(
       AssertOptionSuccess(CURLE_NOT_BUILT_IN, CURLOPT_CAINFO, "test-function",
                           1234),
@@ -79,7 +77,6 @@ TEST(AssertOptionSuccess, IntWithError) {
 }
 
 TEST(AssertOptionSuccess, NullptrWithError) {
-  google::cloud::LogSink::EnableStdClog();
   EXPECT_DEATH_IF_SUPPORTED(
       AssertOptionSuccess(CURLE_NOT_BUILT_IN, CURLOPT_CAINFO, "test-function",
                           nullptr),
@@ -89,7 +86,6 @@ TEST(AssertOptionSuccess, NullptrWithError) {
 int TestFunction() { return 42; }
 
 TEST(AssertOptionSuccess, FunctionPtrWithError) {
-  google::cloud::LogSink::EnableStdClog();
   EXPECT_EQ(42, TestFunction());
   EXPECT_DEATH_IF_SUPPORTED(
       AssertOptionSuccess(CURLE_NOT_BUILT_IN, CURLOPT_CAINFO, "test-function",

--- a/google/cloud/storage/tests/curl_request_integration_test.cc
+++ b/google/cloud/storage/tests/curl_request_integration_test.cc
@@ -490,7 +490,7 @@ class MockLogBackend : public google::cloud::LogBackend {
 TEST(CurlRequestTest, Logging) {
   // Prepare the Log subsystem to receive mock calls:
   auto mock_logger = std::make_shared<MockLogBackend>();
-  google::cloud::LogSink::Instance().AddBackend(mock_logger);
+  auto backend_id = google::cloud::LogSink::Instance().AddBackend(mock_logger);
 
   std::string log_messages;
   EXPECT_CALL(*mock_logger, ProcessWithOwnership)
@@ -516,7 +516,7 @@ TEST(CurlRequestTest, Logging) {
     EXPECT_EQ(200, response->status_code);
   }
 
-  google::cloud::LogSink::Instance().ClearBackends();
+  google::cloud::LogSink::Instance().RemoveBackend(backend_id);
 
   // Verify the URL, and headers, and payload are logged.
   EXPECT_THAT(log_messages, HasSubstr("/post?foo=bar"));
@@ -528,6 +528,7 @@ TEST(CurlRequestTest, Logging) {
   EXPECT_THAT(log_messages, HasSubstr("curl(Recv Header)"));
   EXPECT_THAT(log_messages, HasSubstr("curl(Recv Data)"));
 }
+
 }  // namespace
 }  // namespace internal
 }  // namespace STORAGE_CLIENT_NS


### PR DESCRIPTION
It is desirable that FATAL log messages are never discarded,
especially now that GCP_LOG(FATAL) calls `std::abort` (see #7058).

To that end, ...

- Don't allow FATAL logging to be compile-time disabled.

- Always instantiate a `StdClogBackend` in `DefaultLogBackend()`.

- Give that default `StdClogBackend` a "mininum log severity" from
  the first of the following conditions:
    * If `${GOOGLE_CLOUD_CPP_EXPERIMENTAL_LOG_CONFIG}` is valid,
      use the lowest enabled severity.
    * If `${GOOGLE_CLOUD_CPP_ENABLE_CLOG}` is a valid severity,
      use that.
    * If `${GOOGLE_CLOUD_CPP_ENABLE_CLOG}` is otherwise set,
      use the lowest enabled severity (backwards compatibility).
    * If `${GOOGLE_CLOUD_CPP_ENABLE_CLOG}` is unset, use FATAL.

This means that FATAL messages should always be logged. But note
that `LogSink::DisableStdClog()` and `LogSink::ClearBackends()`
can remove that `StdClogBackend`, so they should be used with care
(undoubtedly only from tests).

Also tidy up some tests so that the disposition of `LogBackend`s
is a little clearer.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7087)
<!-- Reviewable:end -->
