### PR TITLE
feat(storage): discard handles after an error

### DIFF
--- a/google/cloud/storage/internal/curl_download_request.h
+++ b/google/cloud/storage/internal/curl_download_request.h
@@ -92,6 +92,9 @@ class CurlDownloadRequest : public ObjectReadSource {
   /// Handle a completed (even interrupted) download.
   void OnTransferDone();
 
+  /// Handle an error during a transfer
+  Status OnTransferError(Status status);
+
   /// Copy any available data from the spill buffer to `buffer_`
   void DrainSpillBuffer();
 


### PR DESCRIPTION
We keep CURL* handles in a pool, to reduce the cost of setting up TCP
connections and the SSL handshake. When there is a CURL error we
returned these handles to the pool. This is probably a bad idea,
particularly if the error is caused by timeouts or slow downloads, where
we would want to start over with a new connection.

Fixes #7079

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7088)
<!-- Reviewable:end -->
