### PR TITLE
feat(storage): control data hotness in benchmark

### DIFF
--- a/google/cloud/storage/benchmarks/aggregate_throughput_options.cc
+++ b/google/cloud/storage/benchmarks/aggregate_throughput_options.cc
@@ -35,6 +35,8 @@ ParseAggregateThroughputOptions(std::vector<std::string> const& argv,
        [&wants_help](std::string const&) { wants_help = true; }},
       {"--description", "print benchmark description",
        [&wants_description](std::string const&) { wants_description = true; }},
+      {"--labels", "user-defined labels to tag the results",
+       [&options](std::string const& val) { options.labels = val; }},
       {"--bucket-name", "the bucket where the dataset is located",
        [&options](std::string const& val) { options.bucket_name = val; }},
       {"--object-prefix", "the dataset prefix",
@@ -46,6 +48,11 @@ ParseAggregateThroughputOptions(std::vector<std::string> const& argv,
       {"--iteration-count", "set the number of iterations",
        [&options](std::string const& val) {
          options.iteration_count = std::stoi(val);
+       }},
+      {"--repeats-per-iteration",
+       "each iteration downloads the dataset this many times",
+       [&options](std::string const& val) {
+         options.repeats_per_iteration = std::stoi(val);
        }},
       {"--read-size", "number of bytes downloaded in each iteration",
        [&options](std::string const& val) {
@@ -112,6 +119,13 @@ ParseAggregateThroughputOptions(std::vector<std::string> const& argv,
     std::ostringstream os;
     os << "Invalid number of iterations (" << options.iteration_count
        << "), check your --iteration-count option\n";
+    return make_status(os);
+  }
+  if (options.repeats_per_iteration <= 0) {
+    std::ostringstream os;
+    os << "Invalid number of repeats per iteration ("
+       << options.repeats_per_iteration
+       << "), check your --repeats-per-iteration option\n";
     return make_status(os);
   }
   if (options.grpc_channel_count < 0) {

--- a/google/cloud/storage/benchmarks/aggregate_throughput_options.h
+++ b/google/cloud/storage/benchmarks/aggregate_throughput_options.h
@@ -25,10 +25,12 @@ namespace cloud {
 namespace storage_benchmarks {
 
 struct AggregateThroughputOptions {
+  std::string labels;
   std::string bucket_name;
   std::string object_prefix;
   int thread_count = 1;
   int iteration_count = 1;
+  int repeats_per_iteration = 1;
   std::int64_t read_size = 0;  // 0 means "read the whole file"
   std::size_t read_buffer_size = 4 * kMiB;
   ApiName api = ApiName::kApiGrpc;

--- a/google/cloud/storage/benchmarks/aggregate_throughput_options_test.cc
+++ b/google/cloud/storage/benchmarks/aggregate_throughput_options_test.cc
@@ -26,10 +26,12 @@ TEST(AggregateThroughputOptions, Basic) {
   auto options = ParseAggregateThroughputOptions(
       {
           "self-test",
+          "--labels=a,b,c",
           "--bucket-name=test-bucket-name",
           "--object-prefix=test/object/prefix/",
           "--thread-count=42",
           "--iteration-count=10",
+          "--repeats-per-iteration=2",
           "--read-size=4MiB",
           "--read-buffer-size=1MiB",
           "--api=XML",
@@ -39,10 +41,12 @@ TEST(AggregateThroughputOptions, Basic) {
       "");
   ASSERT_STATUS_OK(options);
   EXPECT_FALSE(options->exit_after_parse);
+  EXPECT_EQ("a,b,c", options->labels);
   EXPECT_EQ("test-bucket-name", options->bucket_name);
   EXPECT_EQ("test/object/prefix/", options->object_prefix);
   EXPECT_EQ(42, options->thread_count);
   EXPECT_EQ(10, options->iteration_count);
+  EXPECT_EQ(2, options->repeats_per_iteration);
   EXPECT_EQ(4 * kMiB, options->read_size);
   EXPECT_EQ(1 * kMiB, options->read_buffer_size);
   EXPECT_EQ(ApiName::kApiXml, options->api);
@@ -76,6 +80,10 @@ TEST(AggregateThroughputOptions, Validate) {
       {"self-test", "--bucket-name=b", "--iteration-count=0"}, ""));
   EXPECT_FALSE(ParseAggregateThroughputOptions(
       {"self-test", "--bucket-name=b", "--iteration-count=-1"}, ""));
+  EXPECT_FALSE(ParseAggregateThroughputOptions(
+      {"self-test", "--bucket-name=b", "--repeats-per-iteration=0"}, ""));
+  EXPECT_FALSE(ParseAggregateThroughputOptions(
+      {"self-test", "--bucket-name=b", "--repeats-per-iteration=-1"}, ""));
   EXPECT_FALSE(ParseAggregateThroughputOptions(
       {"self-test", "--bucket-name=b", "--api=GRPC-RAW"}, ""));
   EXPECT_FALSE(ParseAggregateThroughputOptions(


### PR DESCRIPTION
Add an option to control how "hot" is the data in the aggregate
throughput benchmark. Recall that the aggregate throughput benchmark
runs in iterations, during which a full dataset is downloaded. With this
option the same dataset can be downloaded multiple times. This can be
used, for example, to configured the benchmark to read a single file of
1GiB a thousand times in each iteration, which approximates a workload
reading "hot" data. In contrast, configuring the benchmark to read a
dataset of 1024 files of 1GiB each just once approximates an application
reading "cold" data.

Also introduced an option to label the data, so it is easier to load
multiple benchmark results into analysis tools (coLab, Python pandas, R,
etc.) without having to parse the output filenames to annonate the
different runs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7090)
<!-- Reviewable:end -->
