### PR TITLE
feat(storage): more tuning parameters for benchmark

### DIFF
--- a/google/cloud/storage/benchmarks/aggregate_throughput_options.cc
+++ b/google/cloud/storage/benchmarks/aggregate_throughput_options.cc
@@ -75,6 +75,14 @@ ParseAggregateThroughputOptions(std::vector<std::string> const& argv,
        [&options](std::string const& val) {
          options.grpc_plugin_config = val;
        }},
+      {"--rest-http-version", "change the preferred HTTP version",
+       [&options](std::string const& val) { options.rest_http_version = val; }},
+      {"--client-per-thread",
+       "use a different storage::Client object in each thread",
+       [&options](std::string const& val) {
+         options.client_per_thread =
+             testing_util::ParseBoolean(val).value_or("false");
+       }},
   };
   auto usage = BuildUsage(desc, argv[0]);
 

--- a/google/cloud/storage/benchmarks/aggregate_throughput_options.cc
+++ b/google/cloud/storage/benchmarks/aggregate_throughput_options.cc
@@ -81,7 +81,7 @@ ParseAggregateThroughputOptions(std::vector<std::string> const& argv,
        "use a different storage::Client object in each thread",
        [&options](std::string const& val) {
          options.client_per_thread =
-             testing_util::ParseBoolean(val).value_or("false");
+             testing_util::ParseBoolean(val).value_or("true");
        }},
   };
   auto usage = BuildUsage(desc, argv[0]);

--- a/google/cloud/storage/benchmarks/aggregate_throughput_options.h
+++ b/google/cloud/storage/benchmarks/aggregate_throughput_options.h
@@ -36,6 +36,8 @@ struct AggregateThroughputOptions {
   ApiName api = ApiName::kApiGrpc;
   int grpc_channel_count = 0;
   std::string grpc_plugin_config;
+  std::string rest_http_version;
+  bool client_per_thread = false;
   bool exit_after_parse = false;
 };
 

--- a/google/cloud/storage/benchmarks/aggregate_throughput_options_test.cc
+++ b/google/cloud/storage/benchmarks/aggregate_throughput_options_test.cc
@@ -37,6 +37,8 @@ TEST(AggregateThroughputOptions, Basic) {
           "--api=XML",
           "--grpc-channel-count=16",
           "--grpc-plugin-config=default",
+          "--rest-http-version=1.1",
+          "--client-per-thread=true",
       },
       "");
   ASSERT_STATUS_OK(options);
@@ -51,6 +53,9 @@ TEST(AggregateThroughputOptions, Basic) {
   EXPECT_EQ(1 * kMiB, options->read_buffer_size);
   EXPECT_EQ(ApiName::kApiXml, options->api);
   EXPECT_EQ(16, options->grpc_channel_count);
+  EXPECT_EQ("default", options->grpc_plugin_config);
+  EXPECT_EQ("1.1", options->rest_http_version);
+  EXPECT_EQ(true, options->client_per_thread);
 }
 
 TEST(AggregateThroughputOptions, Description) {

--- a/google/cloud/storage/benchmarks/aggregate_throughput_options_test.cc
+++ b/google/cloud/storage/benchmarks/aggregate_throughput_options_test.cc
@@ -38,7 +38,7 @@ TEST(AggregateThroughputOptions, Basic) {
           "--grpc-channel-count=16",
           "--grpc-plugin-config=default",
           "--rest-http-version=1.1",
-          "--client-per-thread=true",
+          "--client-per-thread",
       },
       "");
   ASSERT_STATUS_OK(options);


### PR DESCRIPTION
Add options to prefer HTTP/1.1 over HTTP/2 when using REST, and to use a
different `gcs::Client` when using either gRPC or REST.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7091)
<!-- Reviewable:end -->
