### PR TITLE
cleanup(bigtable): update MutationBatcher defaults

### DIFF
--- a/google/cloud/bigtable/mutation_batcher.cc
+++ b/google/cloud/bigtable/mutation_batcher.cc
@@ -24,6 +24,7 @@ inline namespace BIGTABLE_CLIENT_NS {
 
 // Cloud Bigtable doesn't accept more than this in a single request.
 auto constexpr kBigtableMutationLimit = 100000;
+auto constexpr kDefaultMutationLimit = 1000;
 // Maximum mutations that can be outstanding in the Cloud Bigtable front end.
 // NOTE: this is a system-wide limit, but it is only enforced per process.
 auto constexpr kBigtableOutstandingMutationLimit = 300000;
@@ -31,12 +32,12 @@ auto constexpr kBigtableOutstandingMutationLimit = 300000;
 // miscalculations don't tip us over.
 auto constexpr kDefaultMaxSizePerBatch =
     (BIGTABLE_CLIENT_DEFAULT_MAX_MESSAGE_LENGTH * 90LL) / 100LL;
-auto constexpr kDefaultMaxBatches = 8;
+auto constexpr kDefaultMaxBatches = 4;
 auto constexpr kDefaultMaxOutstandingSize =
     kDefaultMaxSizePerBatch * kDefaultMaxBatches;
 
 MutationBatcher::Options::Options()
-    : max_mutations_per_batch(kBigtableMutationLimit),
+    : max_mutations_per_batch(kDefaultMutationLimit),
       max_size_per_batch(kDefaultMaxSizePerBatch),
       max_batches(kDefaultMaxBatches),
       max_outstanding_size(kDefaultMaxOutstandingSize),

--- a/google/cloud/bigtable/mutation_batcher_test.cc
+++ b/google/cloud/bigtable/mutation_batcher_test.cc
@@ -249,6 +249,12 @@ class MutationBatcherTest : public bigtable::testing::TableTestFixture {
   std::unique_ptr<MutationBatcher> batcher_;
 };
 
+TEST(OptionsTest, Defaults) {
+  MutationBatcher::Options opt = MutationBatcher::Options();
+  ASSERT_EQ(1000, opt.max_mutations_per_batch);
+  ASSERT_EQ(4, opt.max_batches);
+}
+
 TEST(OptionsTest, Trivial) {
   MutationBatcher::Options opt = MutationBatcher::Options()
                                      .SetMaxMutationsPerBatch(1)


### PR DESCRIPTION
Fixes #7023 

The main purpose of updating these defaults is to avoid running into a queued mutations error.

Even though we have not collected a ton of data at this time, I would rather get this update into the release than not.

These values were discovered by testing a single batcher in a single threaded environment. More thorough benchmarking to pin down these values is in progress. The values are subject to change, as we learn more from our experiments.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7095)
<!-- Reviewable:end -->
