### PR TITLE
chore: add release/changes.sh to help automate release CHANGELOG creation

### DIFF
--- a/release/README.md
+++ b/release/README.md
@@ -38,56 +38,17 @@ can, but are not required to, send a single PR to update the baseline and the
 
 ### Update CHANGELOG.md
 
-Assuming you are working on your own fork of the `google-cloud-cpp` project,
-and `upstream` points to the `googleapis/google-cloud-cpp` remote, these
-commands should be useful in identifying important changes for inclusion in the
-release notes.
-
-Update `CHANGELOG.md` based on the release notes for Bigtable, Storage,
-Spanner, and the common libraries:
+To update the top-level [`CHANGELOG.md`] file, you run the script
 
 ```bash
-# Summarize the output of this into CHANGELOG.md under the "Bigtable" header
-git log --no-merges --format="format:* %s" \
-    $(git describe --tags --abbrev=0 upstream/main)..HEAD \
-    upstream/main -- google/cloud/bigtable
+release/changes.sh
 ```
 
-```bash
-# Summarize the output of this into CHANGELOG.md under the "Pub/Sub" header
-git log --no-merges --format="format:* %s" \
-    $(git describe --tags --abbrev=0 upstream/main)..HEAD \
-    upstream/main -- google/cloud/pubsub
-```
+to output a summary of the potentially interesting changes since the previous
+release. You paste the output into the relevant section in the `CHANGELOG.md`
+file, and manually tweak as needed.
 
-```bash
-# Summarize the output of this into CHANGELOG.md under the "Storage" header
-git log --no-merges --format="format:* %s" \
-    $(git describe --tags --abbrev=0 upstream/main)..HEAD \
-    upstream/main -- google/cloud/storage
-```
-
-```bash
-# Summarize the output of this into CHANGELOG.md under the "Spanner" header
-git log --no-merges --format="format:* %s" \
-    $(git describe --tags --abbrev=0 upstream/main)..HEAD \
-    upstream/main -- google/cloud/spanner
-```
-
-```bash
-# Summarize the output of this into CHANGELOG.md under the "Common libraries" header
-git log --no-merges --format="format:* %s" \
-    $(git describe --tags --abbrev=0 upstream/main)..HEAD \
-    upstream/main -- google/cloud \
-   ':(exclude)google/cloud/firestore/' \
-   ':(exclude)google/cloud/bigtable/' \
-   ':(exclude)google/cloud/pubsub/' \
-   ':(exclude)google/cloud/spanner/' \
-   ':(exclude)google/cloud/storage/'
-```
-
-Any **chore**/**ci**/**test**-tagged PRs in the above lists should probably be
-discarded as they are uninteresting to our users.
+[`CHANGELOG.md`]: https://github.com/googleapis/google-cloud-cpp/blob/main/CHANGELOG.md
 
 ### Send a PR with all these changes
 

--- a/release/README.md
+++ b/release/README.md
@@ -48,7 +48,7 @@ to output a summary of the potentially interesting changes since the previous
 release. You paste the output into the relevant section in the `CHANGELOG.md`
 file, and manually tweak as needed.
 
-[`CHANGELOG.md`]: https://github.com/googleapis/google-cloud-cpp/blob/main/CHANGELOG.md
+[`CHANGELOG.md`]: /CHANGELOG.md
 
 ### Send a PR with all these changes
 

--- a/release/changes.sh
+++ b/release/changes.sh
@@ -90,9 +90,7 @@ sections+=("Common Libraries,google/cloud,${exclude[*]}")
 for section in "${sections[@]}"; do
   title="$(cut -f1 -d, <<<"${section}")"
   path="$(cut -f2 -d, <<<"${section}")"
-  # We want space-splitting to array here, so we need to disable
-  # shellcheck disable=SC2207
-  extra=($(cut -f3 -d, <<<"${section}"))
+  mapfile -d ' ' -t extra < <(cut -f3 -d, <<<"${section}")
   url="https://github.com/googleapis/google-cloud-cpp/blob/main/${path}/README.md"
   mapfile -t messages < <(list_changes "${last_tag}" "${path}" "${extra[@]}")
   mapfile -t changelog < <(filter_messages "${messages[@]}")

--- a/release/changes.sh
+++ b/release/changes.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+#
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Usage:
+#   $ changes.sh
+#
+# Prints a summary of changes since the last release in Markdown. PRs that seem
+# uninteresting to customers are omitted. The output should be pasted into the
+# `CHANGELOG.md` file during a release and manually tweaked as needed.
+
+set -eu
+
+function filter_messages() {
+  pr_url="https://github.com/googleapis/google-cloud-cpp/pull"
+  for message in "$@"; do
+    # Linkify "(#NNNN)" PR numbers.
+    message="$(sed -e "s,(#\([0-9]\+\)),([#\1][${pr_url}/\1]),g" <<<"${message}")"
+    # Include any PR message that says it's a breaking change.
+    if grep -qP "!:" <<<"${message}"; then
+      echo "${message}"
+      continue
+    fi
+    # Skip PRs that likely won't interest our customers.
+    if grep -qP "^\* (ci|chore|test|testing|cleanup)\b" <<<"${message}"; then
+      continue
+    fi
+    echo "${message}"
+  done
+}
+
+# We'll look for changes between this tag (likely the last release) and HEAD.
+last_tag="$(git describe --tags --abbrev=0 upstream/main)"
+
+# The list of libraries to include in the CHANGELOG.md. The format is:
+#   <section title>:<repo path>
+libraries=(
+  "BigQuery:google/cloud/bigquery"
+  "Bigtable:google/cloud/bigtable"
+  "Firestore:google/cloud/firestore"
+  "IAM:google/cloud/iam"
+  "Pub/Sub:google/cloud/pubsub"
+  "Storage:google/cloud/storage"
+  "Spanner:google/cloud/spanner"
+)
+
+# We'll add an entry to this array for each library path above.
+git_exclude=()
+
+for lib in "${libraries[@]}"; do
+  title="$(cut -f1 -d: <<<"${lib}")"
+  path="$(cut -f2 -d: <<<"${lib}")"
+  url="https://github.com/googleapis/google-cloud-cpp/blob/main/${path}/README.md"
+  mapfile -t messages < <(git log --no-merges --format="format:* %s" \
+    "${last_tag}"..HEAD upstream/main -- "${path}")
+  mapfile -t changelog < <(filter_messages "${messages[@]}")
+  if [[ ${#changelog[@]} > 0 ]]; then
+    printf "\n### [%s][%s]\n\n" "${title}" "${url}"
+    printf "%s\n" "${changelog[@]}"
+  fi
+  git_exclude+=(":(exclude)${path}")
+done
+
+# Prints the changelog for the "common" library by excluding changes for all
+# the libraries above.
+mapfile -t messages < <(git log --no-merges --format="format:* %s" \
+  "${last_tag}"..HEAD upstream/main -- "google/cloud" "${git_exclude[@]}")
+mapfile -t changelog < <(filter_messages "${messages[@]}")
+if [[ ${#changelog[@]} > 0 ]]; then
+  url="https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/README.md"
+  printf "\n### [%s][%s]\n\n" "Common Libraries" "${url}"
+  printf "%s\n" "${changelog[@]}"
+fi
+

--- a/release/changes.sh
+++ b/release/changes.sh
@@ -27,14 +27,15 @@ function filter_messages() {
   pr_url="https://github.com/googleapis/google-cloud-cpp/pull"
   for message in "$@"; do
     # Linkify "(#NNNN)" PR numbers.
+    # shellcheck disable=SC2001
     message="$(sed -e "s,(#\([0-9]\+\)),([#\1][${pr_url}/\1]),g" <<<"${message}")"
-    # Include any PR message that says it's a breaking change.
+    # Include any message that says it's a breaking change, like "feat!: foo"
     if grep -qP "!:" <<<"${message}"; then
       echo "${message}"
       continue
     fi
     # Skip PRs that likely won't interest our customers.
-    if grep -qP "^\* (ci|chore|test|testing|cleanup)\b" <<<"${message}"; then
+    if grep -qP "^\*\s(ci|chore|test|testing|cleanup)\b" <<<"${message}"; then
       continue
     fi
     echo "${message}"
@@ -66,7 +67,7 @@ for lib in "${libraries[@]}"; do
   mapfile -t messages < <(git log --no-merges --format="format:* %s" \
     "${last_tag}"..HEAD upstream/main -- "${path}")
   mapfile -t changelog < <(filter_messages "${messages[@]}")
-  if [[ ${#changelog[@]} > 0 ]]; then
+  if [[ ${#changelog[@]} -gt 0 ]]; then
     printf "\n### [%s][%s]\n\n" "${title}" "${url}"
     printf "%s\n" "${changelog[@]}"
   fi
@@ -78,9 +79,8 @@ done
 mapfile -t messages < <(git log --no-merges --format="format:* %s" \
   "${last_tag}"..HEAD upstream/main -- "google/cloud" "${git_exclude[@]}")
 mapfile -t changelog < <(filter_messages "${messages[@]}")
-if [[ ${#changelog[@]} > 0 ]]; then
+if [[ ${#changelog[@]} -gt 0 ]]; then
   url="https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/README.md"
   printf "\n### [%s][%s]\n\n" "Common Libraries" "${url}"
   printf "%s\n" "${changelog[@]}"
 fi
-

--- a/release/changes.sh
+++ b/release/changes.sh
@@ -63,7 +63,7 @@ function print_changelog() {
   local url=$2
   shift 2
   if [[ $# -gt 0 ]]; then
-    printf "\n### [%s][%s]\n\n" "${title}" "${url}"
+    printf "\n### [%s](%s)\n\n" "${title}" "${url}"
     printf "* %s\n" "${changelog[@]}"
   fi
 }

--- a/release/changes.sh
+++ b/release/changes.sh
@@ -23,64 +23,72 @@
 
 set -eu
 
+# Lists all the changes between the given tag and HEAD.
+function list_changes() {
+  local since_tag="$1"
+  shift
+  git log --no-merges --format="format:%s" \
+    "${since_tag}"..HEAD upstream/main -- "$@"
+}
+
+# Removes changes that are likely uninteresting to customers. Changes that
+# indicate they're breaking with a `!:` are always kept. Pull request numbers
+# of the form `(#NNNN)` are turned into links.
 function filter_messages() {
   pr_url="https://github.com/googleapis/google-cloud-cpp/pull"
   for message in "$@"; do
     # Linkify "(#NNNN)" PR numbers.
     # shellcheck disable=SC2001
     message="$(sed -e "s,(#\([0-9]\+\)),([#\1][${pr_url}/\1]),g" <<<"${message}")"
-    # Include any message that says it's a breaking change, like "feat!: foo"
     if grep -qP "!:" <<<"${message}"; then
       echo "${message}"
       continue
     fi
-    # Skip PRs that likely won't interest our customers.
-    if grep -qP "^\*\s(ci|chore|test|testing|cleanup)\b" <<<"${message}"; then
+    # Likely uninteresting changes.
+    if grep -qP "^(ci|chore|test|testing|cleanup)\b" <<<"${message}"; then
       continue
     fi
     echo "${message}"
   done
 }
 
+# Prints the given changelog IFF it's not empty. The first argument is the
+# title for the section, the second argument is the URL to link the title to,
+# and the remaining arguments are the changelog messages to be bulleted after.
+function print_changelog() {
+  local title=$1
+  local url=$2
+  shift 2
+  if [[ $# -gt 0 ]]; then
+    printf "\n### [%s][%s]\n\n" "${title}" "${url}"
+    printf "* %s\n" "${changelog[@]}"
+  fi
+}
+
 # We'll look for changes between this tag (likely the last release) and HEAD.
 last_tag="$(git describe --tags --abbrev=0 upstream/main)"
 
-# The list of libraries to include in the CHANGELOG.md. The format is:
-#   <section title>:<repo path>
-libraries=(
-  "BigQuery:google/cloud/bigquery"
-  "Bigtable:google/cloud/bigtable"
-  "Firestore:google/cloud/firestore"
-  "IAM:google/cloud/iam"
-  "Pub/Sub:google/cloud/pubsub"
-  "Storage:google/cloud/storage"
-  "Spanner:google/cloud/spanner"
+# The format is: <title>,<path>[,<extra path> ...]
+sections=(
+  "BigQuery,google/cloud/bigquery"
+  "Bigtable,google/cloud/bigtable"
+  "Firestore,google/cloud/firestore"
+  "IAM,google/cloud/iam"
+  "Pub/Sub,google/cloud/pubsub"
+  "Storage,google/cloud/storage"
+  "Spanner,google/cloud/spanner"
 )
 
-# We'll add an entry to this array for each library path above.
-git_exclude=()
+# Adds a section for "Common Libraries", which excludes the previous sections.
+exclude=($(printf "%s\n" "${sections[@]}" | cut -f2 -d, | sed -e 's/^/:(exclude)/'))
+sections+=("Common Libraries,google/cloud,${exclude[*]}")
 
-for lib in "${libraries[@]}"; do
-  title="$(cut -f1 -d: <<<"${lib}")"
-  path="$(cut -f2 -d: <<<"${lib}")"
+for section in "${sections[@]}"; do
+  title="$(cut -f1 -d, <<<"${section}")"
+  path="$(cut -f2 -d, <<<"${section}")"
+  extra=($(cut -f3 -d, <<<"${section}"))
   url="https://github.com/googleapis/google-cloud-cpp/blob/main/${path}/README.md"
-  mapfile -t messages < <(git log --no-merges --format="format:* %s" \
-    "${last_tag}"..HEAD upstream/main -- "${path}")
+  mapfile -t messages < <(list_changes "${last_tag}" "${path}" "${extra[@]}")
   mapfile -t changelog < <(filter_messages "${messages[@]}")
-  if [[ ${#changelog[@]} -gt 0 ]]; then
-    printf "\n### [%s][%s]\n\n" "${title}" "${url}"
-    printf "%s\n" "${changelog[@]}"
-  fi
-  git_exclude+=(":(exclude)${path}")
+  print_changelog "${title}" "${url}" "${changelog[@]}"
 done
-
-# Prints the changelog for the "common" library by excluding changes for all
-# the libraries above.
-mapfile -t messages < <(git log --no-merges --format="format:* %s" \
-  "${last_tag}"..HEAD upstream/main -- "google/cloud" "${git_exclude[@]}")
-mapfile -t changelog < <(filter_messages "${messages[@]}")
-if [[ ${#changelog[@]} -gt 0 ]]; then
-  url="https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/README.md"
-  printf "\n### [%s][%s]\n\n" "Common Libraries" "${url}"
-  printf "%s\n" "${changelog[@]}"
-fi

--- a/release/changes.sh
+++ b/release/changes.sh
@@ -42,7 +42,7 @@ function filter_messages() {
   for message in "$@"; do
     # Linkify "(#NNNN)" PR numbers.
     # shellcheck disable=SC2001
-    message="$(sed -e "s,(#\([0-9]\+\)),([#\1][${pr_url}/\1]),g" <<<"${message}")"
+    message="$(sed -e "s,(#\([0-9]\+\)),([#\1](${pr_url}/\1)),g" <<<"${message}")"
     if grep -qP "!:" <<<"${message}"; then
       echo "${message}"
       continue


### PR DESCRIPTION
This script generates copy-n-pasteable markdown that can serve as the starting point for a human creating the release notes for our releases. It removes "uninteresting" PRs, and outputs markdown with properly linked section headings and PR numbers. A human will then need to manually tweak the output a bit, but this will helpful be a helpful starting point.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7102)
<!-- Reviewable:end -->
