### PR TITLE
feat(GCS+gRPC): initial support for download timeouts

### DIFF
--- a/google/cloud/storage/CMakeLists.txt
+++ b/google/cloud/storage/CMakeLists.txt
@@ -602,6 +602,7 @@ if (GOOGLE_CLOUD_CPP_STORAGE_ENABLE_GRPC)
             internal/grpc_client_failures_test.cc
             internal/grpc_client_insert_object_media_test.cc
             internal/grpc_client_object_request_test.cc
+            internal/grpc_client_read_object_test.cc
             internal/grpc_client_test.cc
             internal/grpc_object_read_source_test.cc
             internal/grpc_resumable_upload_session_test.cc

--- a/google/cloud/storage/internal/grpc_client.h
+++ b/google/cloud/storage/internal/grpc_client.h
@@ -45,7 +45,7 @@ class GrpcClient : public RawClient,
 
   // This is used to create a client from a mocked StorageStub.
   static std::shared_ptr<GrpcClient> CreateMock(
-      std::shared_ptr<StorageStub> stub);
+      std::shared_ptr<StorageStub> stub, Options opts = {});
 
   ~GrpcClient() override = default;
 

--- a/google/cloud/storage/internal/grpc_client_read_object_test.cc
+++ b/google/cloud/storage/internal/grpc_client_read_object_test.cc
@@ -1,0 +1,103 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/storage/internal/grpc_client.h"
+#include "google/cloud/storage/testing/mock_storage_stub.h"
+#include "google/cloud/grpc_options.h"
+#include "google/cloud/options.h"
+#include "google/cloud/testing_util/is_proto_equal.h"
+#include "google/cloud/testing_util/status_matchers.h"
+#include "absl/memory/memory.h"
+#include <google/protobuf/text_format.h>
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+namespace storage {
+inline namespace STORAGE_CLIENT_NS {
+namespace internal {
+namespace {
+
+using ::google::cloud::storage::testing::MockObjectMediaStream;
+using ::google::cloud::storage::testing::MockStorageStub;
+using ::google::cloud::testing_util::IsProtoEqual;
+using ::google::protobuf::TextFormat;
+using ::google::storage::v1::GetObjectMediaRequest;
+using ::testing::NotNull;
+
+/// @test Verify downloads have a default timeout.
+TEST(GrpcClientReadObjectTest, WithDefaultTimeout) {
+  auto constexpr kExpectedRequestText = R"pb(bucket: "test-bucket"
+                                             object: "test-object")pb";
+  google::storage::v1::GetObjectMediaRequest expected_request;
+  ASSERT_TRUE(
+      TextFormat::ParseFromString(kExpectedRequestText, &expected_request));
+
+  auto mock = std::make_shared<MockStorageStub>();
+  EXPECT_CALL(*mock, GetObjectMedia)
+      .WillOnce([&](std::unique_ptr<grpc::ClientContext> context,
+                    GetObjectMediaRequest const& request) {
+        EXPECT_THAT(request, IsProtoEqual(expected_request));
+        auto const timeout =
+            context->deadline() - std::chrono::system_clock::now();
+        // The default stall timeout is 2 minutes, but let's be generous to
+        // avoid flakiness.
+        EXPECT_LT(timeout, std::chrono::minutes(5))
+            << ", timeout=" << absl::FromChrono(timeout);
+        return absl::make_unique<MockObjectMediaStream>();
+      });
+
+  auto client = GrpcClient::CreateMock(mock);
+  auto stream =
+      client->ReadObject(ReadObjectRangeRequest("test-bucket", "test-object"));
+  ASSERT_STATUS_OK(stream);
+  ASSERT_THAT(stream->get(), NotNull());
+}
+
+/// @test Verify options can configured a non-default timeout.
+TEST(GrpcClientReadObjectTest, WithExplicitTimeout) {
+  auto constexpr kExpectedRequestText = R"pb(bucket: "test-bucket"
+                                             object: "test-object")pb";
+  google::storage::v1::GetObjectMediaRequest expected_request;
+  ASSERT_TRUE(
+      TextFormat::ParseFromString(kExpectedRequestText, &expected_request));
+
+  auto const configured_timeout = std::chrono::seconds(3);
+
+  auto mock = std::make_shared<MockStorageStub>();
+  EXPECT_CALL(*mock, GetObjectMedia)
+      .WillOnce([&](std::unique_ptr<grpc::ClientContext> context,
+                    GetObjectMediaRequest const& request) {
+        EXPECT_THAT(request, IsProtoEqual(expected_request));
+        auto const timeout =
+            context->deadline() - std::chrono::system_clock::now();
+        EXPECT_LE(timeout, configured_timeout)
+            << ", timeout=" << absl::FromChrono(timeout);
+        return absl::make_unique<MockObjectMediaStream>();
+      });
+
+  auto client = GrpcClient::CreateMock(
+      mock, Options{}.set<DownloadStallTimeoutOption>(configured_timeout));
+  auto stream =
+      client->ReadObject(ReadObjectRangeRequest("test-bucket", "test-object"));
+  ASSERT_STATUS_OK(stream);
+  ASSERT_THAT(stream->get(), NotNull());
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace STORAGE_CLIENT_NS
+}  // namespace storage
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/storage/storage_client_grpc_unit_tests.bzl
+++ b/google/cloud/storage/storage_client_grpc_unit_tests.bzl
@@ -20,6 +20,7 @@ storage_client_grpc_unit_tests = [
     "internal/grpc_client_failures_test.cc",
     "internal/grpc_client_insert_object_media_test.cc",
     "internal/grpc_client_object_request_test.cc",
+    "internal/grpc_client_read_object_test.cc",
     "internal/grpc_client_test.cc",
     "internal/grpc_object_read_source_test.cc",
     "internal/grpc_resumable_upload_session_test.cc",

--- a/google/cloud/storage/testing/mock_storage_stub.h
+++ b/google/cloud/storage/testing/mock_storage_stub.h
@@ -53,6 +53,16 @@ class MockInsertStream : public internal::StorageStub::InsertStream {
   MOCK_METHOD(StatusOr<google::storage::v1::Object>, Close, (), (override));
 };
 
+class MockObjectMediaStream : public internal::StorageStub::ObjectMediaStream {
+ public:
+  MOCK_METHOD(void, Cancel, (), (override));
+  using ReadResultType =
+      absl::variant<Status, google::storage::v1::GetObjectMediaResponse>;
+  MOCK_METHOD(ReadResultType, Read, (), (override));
+  MOCK_METHOD(google::cloud::internal::StreamingRpcMetadata, GetRequestMetadata,
+              (), (const, override));
+};
+
 }  // namespace testing
 }  // namespace storage
 }  // namespace cloud


### PR DESCRIPTION
Timeouts for downloads (or any streaming operation) are tricky. A
download can take anywhere from a few milliseconds, to tens of thousands
of seconds. For the REST-based implementation we do not use timeouts for
the full operation, we use a "minimum observed bandwidth" requirement.
There does not seem to a an easy way to implement this in gRPC. While I
work in an implementation setting a timeout (of any kind) is a good
start: at least the programs won't hang forever waiting for stalled
downloads.

Part of the work for #4216

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7108)
<!-- Reviewable:end -->
