### PR TITLE
ci(kokoro): remove GCS P12 keyfile test from mac+win

### DIFF
--- a/ci/kokoro/macos/builds/bazel.sh
+++ b/ci/kokoro/macos/builds/bazel.sh
@@ -41,7 +41,6 @@ bazel_args=(
 
 readonly CONFIG_DIR="${KOKORO_GFILE_DIR:-/private/var/tmp}"
 readonly TEST_KEY_FILE_JSON="${CONFIG_DIR}/kokoro-run-key.json"
-readonly TEST_KEY_FILE_P12="${CONFIG_DIR}/kokoro-run-key.p12"
 readonly BAZEL_CACHE="https://storage.googleapis.com/cloud-cpp-bazel-cache"
 
 # If we have the right credentials, tell bazel to cache build results in a GCS
@@ -84,8 +83,7 @@ bazelisk build "${bazel_args[@]}" ...
 
 should_run_integration_tests() {
   if [[ -r "${GOOGLE_APPLICATION_CREDENTIALS}" && -r \
-    "${TEST_KEY_FILE_JSON}" && -r \
-    "${TEST_KEY_FILE_P12}" ]]; then
+    "${TEST_KEY_FILE_JSON}" ]]; then
     return 0
   fi
   return 1
@@ -124,7 +122,6 @@ if should_run_integration_tests; then
     "--test_env=GOOGLE_CLOUD_CPP_STORAGE_TEST_SIGNING_KEYFILE=${PROJECT_ROOT}/google/cloud/storage/tests/test_service_account.not-a-test.json"
     "--test_env=GOOGLE_CLOUD_CPP_STORAGE_TEST_SIGNING_CONFORMANCE_FILENAME=${PROJECT_ROOT}/google/cloud/storage/tests/v4_signatures.json"
     "--test_env=GOOGLE_CLOUD_CPP_STORAGE_TEST_KEY_FILE_JSON=${TEST_KEY_FILE_JSON}"
-    "--test_env=GOOGLE_CLOUD_CPP_STORAGE_TEST_KEY_FILE_P12=${TEST_KEY_FILE_P12}"
     "--test_env=GOOGLE_CLOUD_CPP_STORAGE_TEST_ROOTS_PEM=${GRPC_DEFAULT_SSL_ROOTS_FILE_PATH}"
 
     # Spanner

--- a/ci/kokoro/macos/builds/cmake-vcpkg.sh
+++ b/ci/kokoro/macos/builds/cmake-vcpkg.sh
@@ -77,12 +77,10 @@ io::log_h2 "Running unit tests"
 
 readonly CONFIG_DIR="${KOKORO_GFILE_DIR:-/private/var/tmp}"
 readonly TEST_KEY_FILE_JSON="${CONFIG_DIR}/kokoro-run-key.json"
-readonly TEST_KEY_FILE_P12="${CONFIG_DIR}/kokoro-run-key.p12"
 
 should_run_integration_tests() {
   if [[ -r "${GOOGLE_APPLICATION_CREDENTIALS}" && -r \
-    "${TEST_KEY_FILE_JSON}" && -r \
-    "${TEST_KEY_FILE_P12}" ]]; then
+    "${TEST_KEY_FILE_JSON}" ]]; then
     return 0
   fi
   return 1
@@ -92,7 +90,6 @@ if should_run_integration_tests; then
   io::log_h2 "Running integration tests"
   (
     export GOOGLE_CLOUD_CPP_STORAGE_TEST_KEY_FILE_JSON="${TEST_KEY_FILE_JSON}"
-    export GOOGLE_CLOUD_CPP_STORAGE_TEST_KEY_FILE_P12="${TEST_KEY_FILE_P12}"
     export GOOGLE_CLOUD_CPP_STORAGE_TEST_ROOTS_PEM="${GRPC_DEFAULT_SSL_ROOTS_FILE_PATH}"
     export GOOGLE_CLOUD_CPP_STORAGE_TEST_SIGNING_KEYFILE="${PROJECT_ROOT}/google/cloud/storage/tests/test_service_account.not-a-test.json"
     export GOOGLE_CLOUD_CPP_STORAGE_TEST_SIGNING_CONFORMANCE_FILENAME="${PROJECT_ROOT}/google/cloud/storage/tests/v4_signatures.json"

--- a/ci/kokoro/macos/common.cfg
+++ b/ci/kokoro/macos/common.cfg
@@ -17,4 +17,3 @@ timeout_mins: 60
 
 gfile_resources: "/bigstore/cloud-cpp-integration-secrets/build-results-service-account.json"
 gfile_resources: "/bigstore/cloud-cpp-integration-secrets/kokoro-run-key.json"
-gfile_resources: "/bigstore/cloud-cpp-integration-secrets/kokoro-run-key.p12"

--- a/ci/kokoro/windows/build-bazel.ps1
+++ b/ci/kokoro/windows/build-bazel.ps1
@@ -140,8 +140,7 @@ if ($LastExitCode) {
 
 function Integration-Tests-Enabled {
     if ((Test-Path env:KOKORO_GFILE_DIR) -and
-        (Test-Path "${env:KOKORO_GFILE_DIR}/kokoro-run-key.json") -and
-        (Test-Path "${env:KOKORO_GFILE_DIR}/kokoro-run-key.p12")) {
+        (Test-Path "${env:KOKORO_GFILE_DIR}/kokoro-run-key.json")) {
         return $True
     }
     return $False
@@ -202,7 +201,6 @@ if (Integration-Tests-Enabled) {
         "--test_env=GOOGLE_CLOUD_CPP_STORAGE_TEST_SIGNING_KEYFILE=${PROJECT_ROOT}/google/cloud/storage/tests/test_service_account.not-a-test.json",
         "--test_env=GOOGLE_CLOUD_CPP_STORAGE_TEST_SIGNING_CONFORMANCE_FILENAME=${PROJECT_ROOT}/google/cloud/storage/tests/v4_signatures.json",
         "--test_env=GOOGLE_CLOUD_CPP_STORAGE_TEST_KEY_FILE_JSON=${env:KOKORO_GFILE_DIR}/kokoro-run-key.json",
-        "--test_env=GOOGLE_CLOUD_CPP_STORAGE_TEST_KEY_FILE_P12=${env:KOKORO_GFILE_DIR}/kokoro-run-key.p12",
         # Spanner
         "--test_env=GOOGLE_CLOUD_CPP_SPANNER_TEST_INSTANCE_ID=${env:GOOGLE_CLOUD_CPP_SPANNER_TEST_INSTANCE_ID}",
         "--test_env=GOOGLE_CLOUD_CPP_SPANNER_TEST_SERVICE_ACCOUNT=${env:GOOGLE_CLOUD_CPP_SPANNER_TEST_SERVICE_ACCOUNT}",

--- a/ci/kokoro/windows/build-cmake.ps1
+++ b/ci/kokoro/windows/build-cmake.ps1
@@ -106,8 +106,7 @@ if ((Test-Path env:RUN_INTEGRATION_TESTS) -and ($env:RUN_INTEGRATION_TESTS -eq "
 
 function Integration-Tests-Enabled {
     if ((Test-Path env:KOKORO_GFILE_DIR) -and
-        (Test-Path "${env:KOKORO_GFILE_DIR}/kokoro-run-key.json") -and
-        (Test-Path "${env:KOKORO_GFILE_DIR}/kokoro-run-key.p12")) {
+        (Test-Path "${env:KOKORO_GFILE_DIR}/kokoro-run-key.json")) {
         return $True
     }
     return $False
@@ -136,7 +135,6 @@ if (Integration-Tests-Enabled) {
     ${env:GOOGLE_APPLICATION_CREDENTIALS}="${env:KOKORO_GFILE_DIR}/kokoro-run-key.json"
     ${env:GOOGLE_CLOUD_CPP_AUTO_RUN_EXAMPLES}="yes"
     ${env:GOOGLE_CLOUD_CPP_STORAGE_TEST_KEY_FILE_JSON}="${env:KOKORO_GFILE_DIR}/kokoro-run-key.json"
-    ${env:GOOGLE_CLOUD_CPP_STORAGE_TEST_KEY_FILE_P12}="${env:KOKORO_GFILE_DIR}/kokoro-run-key.p12"
     ${env:GOOGLE_CLOUD_CPP_STORAGE_TEST_ROOTS_PEM}="${env:GRPC_DEFAULT_SSL_ROOTS_FILE_PATH}"
     ${env:GOOGLE_CLOUD_CPP_STORAGE_TEST_SIGNING_KEYFILE}="${PROJECT_ROOT}/google/cloud/storage/tests/test_service_account.not-a-test.json"
     ${env:GOOGLE_CLOUD_CPP_STORAGE_TEST_SIGNING_CONFORMANCE_FILENAME}="${PROJECT_ROOT}/google/cloud/storage/tests/v4_signatures.json"

--- a/ci/kokoro/windows/build-quickstart-bazel.ps1
+++ b/ci/kokoro/windows/build-quickstart-bazel.ps1
@@ -79,10 +79,8 @@ if (-not (Test-Path env:KOKORO_GFILE_DIR)) {
 } else {
     $integration_tests_config="${project_root}/ci/etc/integration-tests-config.ps1"
     $test_key_file_json="${env:KOKORO_GFILE_DIR}/kokoro-run-key.json"
-    $test_key_file_p12="${env:KOKORO_GFILE_DIR}/kokoro-run-key.p12"
     if ((Test-Path "${integration_tests_config}") -and
-        (Test-Path "${test_key_file_json}") -and
-        (Test-Path "${test_key_file_p12}")) {
+        (Test-Path "${test_key_file_json}")) {
         Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) Loading integration tests config"
         . "${integration_tests_config}"
         ${env:GOOGLE_APPLICATION_CREDENTIALS}="${test_key_file_json}"

--- a/ci/kokoro/windows/build-quickstart-cmake.ps1
+++ b/ci/kokoro/windows/build-quickstart-cmake.ps1
@@ -38,10 +38,8 @@ if (-not (Test-Path env:KOKORO_GFILE_DIR)) {
 } else {
     $integration_tests_config="${project_root}/ci/etc/integration-tests-config.ps1"
     $test_key_file_json="${env:KOKORO_GFILE_DIR}/kokoro-run-key.json"
-    $test_key_file_p12="${env:KOKORO_GFILE_DIR}/kokoro-run-key.p12"
     if ((Test-Path "${integration_tests_config}") -and
-        (Test-Path "${test_key_file_json}") -and
-        (Test-Path "${test_key_file_p12}")) {
+        (Test-Path "${test_key_file_json}")) {
         Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) Loading integration tests config"
         . "${integration_tests_config}"
         ${env:GOOGLE_APPLICATION_CREDENTIALS}="${test_key_file_json}"

--- a/ci/kokoro/windows/common.cfg
+++ b/ci/kokoro/windows/common.cfg
@@ -18,7 +18,6 @@ timeout_mins: 180
 
 gfile_resources: "/bigstore/cloud-cpp-integration-secrets/build-results-service-account.json"
 gfile_resources: "/bigstore/cloud-cpp-integration-secrets/kokoro-run-key.json"
-gfile_resources: "/bigstore/cloud-cpp-integration-secrets/kokoro-run-key.p12"
 
 env_vars {
     key: "MSVC_VERSION"

--- a/google/cloud/storage/tests/key_file_integration_test.cc
+++ b/google/cloud/storage/tests/key_file_integration_test.cc
@@ -35,16 +35,16 @@ class KeyFileIntegrationTest
     // The emulator does not implement signed URLs.
     if (UsingEmulator()) GTEST_SKIP();
 
-    std::string const key_file_envvar = GetParam();
+    std::string const env = GetParam();
+    key_filename_ = google::cloud::internal::GetEnv(env.c_str()).value_or("");
+    if (key_filename_.empty()) {
+      GTEST_SKIP() << "Skipping because " << env << " is not set";
+    }
 
     bucket_name_ = google::cloud::internal::GetEnv(
                        "GOOGLE_CLOUD_CPP_STORAGE_TEST_BUCKET_NAME")
                        .value_or("");
     ASSERT_FALSE(bucket_name_.empty());
-    key_filename_ =
-        google::cloud::internal::GetEnv(key_file_envvar.c_str()).value_or("");
-    ASSERT_FALSE(key_filename_.empty())
-        << " expected non-empty value for ${" << key_file_envvar << "}";
     service_account_ =
         google::cloud::internal::GetEnv(
             "GOOGLE_CLOUD_CPP_STORAGE_TEST_SIGNING_SERVICE_ACCOUNT")


### PR DESCRIPTION
Testing GCS with P12 keys is still being run on Linux with GCB, but we
probably don't need to duplicate that test on macos and windows, which
requires us to maintain and rotate separate keys.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7114)
<!-- Reviewable:end -->
