### PR TITLE
ci(checkers): trim trailing blank lines from text files

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -4,4 +4,3 @@ coverage:
   status:
     project: off
     patch: off
-

--- a/.github/ISSUE_TEMPLATE/internal-cleanup.md
+++ b/.github/ISSUE_TEMPLATE/internal-cleanup.md
@@ -6,5 +6,3 @@ labels: 'type: cleanup'
 assignees: ''
 
 ---
-
-

--- a/ci/cloudbuild/builds/checkers.sh
+++ b/ci/cloudbuild/builds/checkers.sh
@@ -141,7 +141,7 @@ time {
   # http://sed.sourceforge.net/sed1line.txt.
   expressions+=("-e" ":a" "-e" "'/^\n*$/{\$d;N;ba'" "-e" "'}'")
   git ls-files -z | grep -zv '\.gz$' |
-    xargs -P "$(nproc)" -n 50 -0 grep -ZPL "\bDO NOT EDIT\b" |
+    (xargs -P "$(nproc)" -n 50 -0 grep -ZPL "\bDO NOT EDIT\b" || true) |
     xargs -P "$(nproc)" -n 50 -0 bash -c "sed_edit ${expressions[*]} \"\$0\" \"\$@\""
 }
 

--- a/ci/cloudbuild/builds/checkers.sh
+++ b/ci/cloudbuild/builds/checkers.sh
@@ -137,8 +137,14 @@ time {
 # snippets).
 printf "%-30s" "Running whitespace fixes:" >&2
 time {
+  expressions=("-e" "'s/[[:blank:]]\+$//'")
+  # The next three expressions trim trailing blank lines, courtesy of
+  # http://sed.sourceforge.net/sed1line.txt.
+  expressions+=("-e" ":a")
+  expressions+=("-e" "'/^\n*$/{\$d;N;ba'")
+  expressions+=("-e" "'}'")
   git ls-files -z | grep -zv '\.gz$' |
-    xargs -P "$(nproc)" -n 50 -0 bash -c "sed_edit -e 's/[[:blank:]]\+$//' \"\$0\" \"\$@\""
+    xargs -P "$(nproc)" -n 50 -0 bash -c "sed_edit ${expressions[*]} \"\$0\" \"\$@\""
 }
 
 # Apply buildifier to fix the BUILD and .bzl formatting rules.

--- a/ci/cloudbuild/builds/checkers.sh
+++ b/ci/cloudbuild/builds/checkers.sh
@@ -139,7 +139,7 @@ time {
   expressions=("-e" "'s/[[:blank:]]\+$//'")
   # Trims trailing blank lines, courtesy of
   # http://sed.sourceforge.net/sed1line.txt.
-  expressions+=("-e" ":a" "-e" "'/^\n*$/{\$d;N;ba'" "-e" "'}'")
+  expressions+=("-e" "':a;/^\n*$/{\$d;N;ba;}'")
   git ls-files -z | grep -zv '\.gz$' |
     (xargs -P "$(nproc)" -n 50 -0 grep -ZPL "\bDO NOT EDIT\b" || true) |
     xargs -P "$(nproc)" -n 50 -0 bash -c "sed_edit ${expressions[*]} \"\$0\" \"\$@\""

--- a/ci/cloudbuild/builds/checkers.sh
+++ b/ci/cloudbuild/builds/checkers.sh
@@ -131,7 +131,7 @@ time {
     xargs -P "$(nproc)" -n 50 -0 bash -c "sed_edit ${expressions[*]} \"\$0\" \"\$@\""
 }
 
-# Applies the following fixes in text files that do not say "DO NOT EDIT":
+# Applies the following fixes in text files unless they say "DO NOT EDIT":
 #   - Removes trailing whitespace on lines
 #   - Removes trailing blank lines in files
 printf "%-30s" "Running whitespace fixes:" >&2

--- a/ci/cloudbuild/builds/checkers.sh
+++ b/ci/cloudbuild/builds/checkers.sh
@@ -131,17 +131,16 @@ time {
     xargs -P "$(nproc)" -n 50 -0 bash -c "sed_edit ${expressions[*]} \"\$0\" \"\$@\""
 }
 
-# Applies the following fixes in text files unless they say "DO NOT EDIT":
-#   - Removes trailing whitespace on lines
-#   - Removes trailing blank lines in files
+# Applies whitespace fixes in text files, unless they request no edits. The
+# `[D]` character class makes this file not contain the target text itself.
 printf "%-30s" "Running whitespace fixes:" >&2
 time {
+  # Removes trailing whitespace on lines
   expressions=("-e" "'s/[[:blank:]]\+$//'")
-  # Trims trailing blank lines, courtesy of
-  # http://sed.sourceforge.net/sed1line.txt.
+  # Removes trailing blank lines (see http://sed.sourceforge.net/sed1line.txt)
   expressions+=("-e" "':a;/^\n*$/{\$d;N;ba;}'")
   git ls-files -z | grep -zv '\.gz$' |
-    (xargs -P "$(nproc)" -n 50 -0 grep -ZPL "\bDO NOT EDIT\b" || true) |
+    (xargs -P "$(nproc)" -n 50 -0 grep -ZPL "\b[D]O NOT EDIT\b" || true) |
     xargs -P "$(nproc)" -n 50 -0 bash -c "sed_edit ${expressions[*]} \"\$0\" \"\$@\""
 }
 

--- a/ci/cloudbuild/builds/checkers.sh
+++ b/ci/cloudbuild/builds/checkers.sh
@@ -131,19 +131,17 @@ time {
     xargs -P "$(nproc)" -n 50 -0 bash -c "sed_edit ${expressions[*]} \"\$0\" \"\$@\""
 }
 
-# Apply transformations to fix whitespace formatting in files not handled by
-# clang-format(1) above.  For now we simply remove trailing blanks.  Note that
-# we do not expand TABs (they currently only appear in Makefiles and Makefile
-# snippets).
+# Applies the following fixes in text files that do not say "DO NOT EDIT":
+#   - Removes trailing whitespace on lines
+#   - Removes trailing blank lines in files
 printf "%-30s" "Running whitespace fixes:" >&2
 time {
   expressions=("-e" "'s/[[:blank:]]\+$//'")
-  # The next three expressions trim trailing blank lines, courtesy of
+  # Trims trailing blank lines, courtesy of
   # http://sed.sourceforge.net/sed1line.txt.
-  expressions+=("-e" ":a")
-  expressions+=("-e" "'/^\n*$/{\$d;N;ba'")
-  expressions+=("-e" "'}'")
+  expressions+=("-e" ":a" "-e" "'/^\n*$/{\$d;N;ba'" "-e" "'}'")
   git ls-files -z | grep -zv '\.gz$' |
+    xargs -P "$(nproc)" -n 50 -0 grep -ZPL "\bDO NOT EDIT\b" |
     xargs -P "$(nproc)" -n 50 -0 bash -c "sed_edit ${expressions[*]} \"\$0\" \"\$@\""
 }
 

--- a/ci/generate-markdown/generate-bigquery-readme.sh
+++ b/ci/generate-markdown/generate-bigquery-readme.sh
@@ -98,5 +98,4 @@ as well as how to properly format your code.
 ## Licensing
 
 Apache 2.0; see [`LICENSE`](../../../LICENSE) for details.
-
 _EOF_

--- a/ci/generate-markdown/generate-bigtable-readme.sh
+++ b/ci/generate-markdown/generate-bigtable-readme.sh
@@ -93,5 +93,4 @@ as well as how to properly format your code.
 ## Licensing
 
 Apache 2.0; see [`LICENSE`](../../../LICENSE) for details.
-
 _EOF_

--- a/ci/generate-markdown/generate-iam-readme.sh
+++ b/ci/generate-markdown/generate-iam-readme.sh
@@ -98,5 +98,4 @@ as well as how to properly format your code.
 ## Licensing
 
 Apache 2.0; see [`LICENSE`](../../../LICENSE) for details.
-
 _EOF_

--- a/ci/generate-markdown/generate-pubsub-readme.sh
+++ b/ci/generate-markdown/generate-pubsub-readme.sh
@@ -100,5 +100,4 @@ as well as how to properly format your code.
 ## Licensing
 
 Apache 2.0; see [`LICENSE`](../../../LICENSE) for details.
-
 _EOF_

--- a/ci/generate-markdown/generate-spanner-readme.sh
+++ b/ci/generate-markdown/generate-spanner-readme.sh
@@ -92,5 +92,4 @@ as well as how to properly format your code.
 ## Licensing
 
 Apache 2.0; see [`LICENSE`](../../../LICENSE) for details.
-
 _EOF_

--- a/ci/generate-markdown/generate-storage-readme.sh
+++ b/ci/generate-markdown/generate-storage-readme.sh
@@ -95,5 +95,4 @@ as well as how to properly format your code.
 ## Licensing
 
 Apache 2.0; see [`LICENSE`](../../../LICENSE) for details.
-
 _EOF_

--- a/doc/adr/2018-06-13-storage-always-retries.md
+++ b/doc/adr/2018-06-13-storage-always-retries.md
@@ -16,4 +16,3 @@ developers. In very rare cases the operation will result in double uploads, or
 in a new generation of the object or metadata being created. In even more
 rare cases the operation may fail, for example, an operation to create an object
 with `IfGenerationMatch(0)` would fail on the second attempt.
-

--- a/doc/adr/2019-01-04-error-reporting-with-statusor.md
+++ b/doc/adr/2019-01-04-error-reporting-with-statusor.md
@@ -34,4 +34,3 @@ timeline to change this API in a separate document.
 [gcs-link]: https://github.com/googleapis/google-cloud-cpp/tree/main/google/cloud/storage
 [bigtable-link]: https://github.com/googleapis/google-cloud-cpp/tree/main/google/cloud/bigtable
 [survey-link]: https://isocpp.org/blog/2018/03/results-summary-cpp-foundation-developer-survey-lite-2018-02
-

--- a/doc/adr/adr-template.md
+++ b/doc/adr/adr-template.md
@@ -15,4 +15,3 @@ next day during the PR review.
 **Decision**: what is the change that we're actually proposing or doing.
 
 **Consequences**: what becomes easier or more difficult to do because of this change.
-

--- a/generator/integration_tests/golden/golden_kitchen_sink_client.cc
+++ b/generator/integration_tests/golden/golden_kitchen_sink_client.cc
@@ -111,4 +111,3 @@ GoldenKitchenSinkClient::ListServiceAccountKeys(google::test::admin::database::v
 }  // namespace golden
 }  // namespace cloud
 }  // namespace google
-

--- a/generator/integration_tests/golden/golden_kitchen_sink_connection.cc
+++ b/generator/integration_tests/golden/golden_kitchen_sink_connection.cc
@@ -251,4 +251,3 @@ MakeGoldenKitchenSinkConnection(
 }  // namespace golden_internal
 }  // namespace cloud
 }  // namespace google
-

--- a/generator/integration_tests/golden/golden_kitchen_sink_connection_idempotency_policy.cc
+++ b/generator/integration_tests/golden/golden_kitchen_sink_connection_idempotency_policy.cc
@@ -75,4 +75,3 @@ std::unique_ptr<GoldenKitchenSinkConnectionIdempotencyPolicy>
 }  // namespace golden
 }  // namespace cloud
 }  // namespace google
-

--- a/generator/integration_tests/golden/golden_thing_admin_client.cc
+++ b/generator/integration_tests/golden/golden_thing_admin_client.cc
@@ -244,4 +244,3 @@ GoldenThingAdminClient::ListBackupOperations(google::test::admin::database::v1::
 }  // namespace golden
 }  // namespace cloud
 }  // namespace google
-

--- a/generator/integration_tests/golden/golden_thing_admin_connection.cc
+++ b/generator/integration_tests/golden/golden_thing_admin_connection.cc
@@ -576,4 +576,3 @@ MakeGoldenThingAdminConnection(
 }  // namespace golden_internal
 }  // namespace cloud
 }  // namespace google
-

--- a/generator/integration_tests/golden/golden_thing_admin_connection_idempotency_policy.cc
+++ b/generator/integration_tests/golden/golden_thing_admin_connection_idempotency_policy.cc
@@ -135,4 +135,3 @@ std::unique_ptr<GoldenThingAdminConnectionIdempotencyPolicy>
 }  // namespace golden
 }  // namespace cloud
 }  // namespace google
-

--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_auth_decorator.cc
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_auth_decorator.cc
@@ -86,4 +86,3 @@ StatusOr<google::test::admin::database::v1::ListServiceAccountKeysResponse> Gold
 }  // namespace golden_internal
 }  // namespace cloud
 }  // namespace google
-

--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_logging_decorator.cc
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_logging_decorator.cc
@@ -119,4 +119,3 @@ GoldenKitchenSinkLogging::ListServiceAccountKeys(
 }  // namespace golden_internal
 }  // namespace cloud
 }  // namespace google
-

--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_metadata_decorator.cc
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_metadata_decorator.cc
@@ -89,4 +89,3 @@ void GoldenKitchenSinkMetadata::SetMetadata(grpc::ClientContext& context,
 }  // namespace golden_internal
 }  // namespace cloud
 }  // namespace google
-

--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_option_defaults.cc
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_option_defaults.cc
@@ -70,4 +70,3 @@ Options GoldenKitchenSinkDefaultOptions(Options options) {
 }  // namespace golden_internal
 }  // namespace cloud
 }  // namespace google
-

--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_stub.cc
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_stub.cc
@@ -109,4 +109,3 @@ DefaultGoldenKitchenSinkStub::ListServiceAccountKeys(
 }  // namespace golden_internal
 }  // namespace cloud
 }  // namespace google
-

--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_stub_factory.cc
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_stub_factory.cc
@@ -71,4 +71,3 @@ CreateDefaultGoldenKitchenSinkStub(
 }  // namespace golden_internal
 }  // namespace cloud
 }  // namespace google
-

--- a/generator/integration_tests/golden/internal/golden_thing_admin_auth_decorator.cc
+++ b/generator/integration_tests/golden/internal/golden_thing_admin_auth_decorator.cc
@@ -243,4 +243,3 @@ future<Status> GoldenThingAdminAuth::AsyncCancelOperation(
 }  // namespace golden_internal
 }  // namespace cloud
 }  // namespace google
-

--- a/generator/integration_tests/golden/internal/golden_thing_admin_logging_decorator.cc
+++ b/generator/integration_tests/golden/internal/golden_thing_admin_logging_decorator.cc
@@ -276,4 +276,3 @@ future<Status> GoldenThingAdminLogging::AsyncCancelOperation(
 }  // namespace golden_internal
 }  // namespace cloud
 }  // namespace google
-

--- a/generator/integration_tests/golden/internal/golden_thing_admin_metadata_decorator.cc
+++ b/generator/integration_tests/golden/internal/golden_thing_admin_metadata_decorator.cc
@@ -194,4 +194,3 @@ void GoldenThingAdminMetadata::SetMetadata(grpc::ClientContext& context,
 }  // namespace golden_internal
 }  // namespace cloud
 }  // namespace google
-

--- a/generator/integration_tests/golden/internal/golden_thing_admin_option_defaults.cc
+++ b/generator/integration_tests/golden/internal/golden_thing_admin_option_defaults.cc
@@ -80,4 +80,3 @@ Options GoldenThingAdminDefaultOptions(Options options) {
 }  // namespace golden_internal
 }  // namespace cloud
 }  // namespace google
-

--- a/generator/integration_tests/golden/internal/golden_thing_admin_stub.cc
+++ b/generator/integration_tests/golden/internal/golden_thing_admin_stub.cc
@@ -289,4 +289,3 @@ future<Status> DefaultGoldenThingAdminStub::AsyncCancelOperation(
 }  // namespace golden_internal
 }  // namespace cloud
 }  // namespace google
-

--- a/generator/integration_tests/golden/internal/golden_thing_admin_stub_factory.cc
+++ b/generator/integration_tests/golden/internal/golden_thing_admin_stub_factory.cc
@@ -73,4 +73,3 @@ CreateDefaultGoldenThingAdminStub(
 }  // namespace golden_internal
 }  // namespace cloud
 }  // namespace google
-

--- a/generator/internal/connection_generator.cc
+++ b/generator/internal/connection_generator.cc
@@ -487,6 +487,7 @@ std::shared_ptr<$connection_class_name$> Make$connection_class_name$(
 )""");
 
   CcCloseNamespaces();
+  CcPrint("\n");
   CcOpenNamespaces(NamespaceType::kInternal);
 
   CcPrint(

--- a/generator/internal/service_code_generator.cc
+++ b/generator/internal/service_code_generator.cc
@@ -171,7 +171,10 @@ Status ServiceCodeGenerator::HeaderOpenNamespaces(NamespaceType ns_type) {
   return OpenNamespaces(header_, ns_type);
 }
 
-void ServiceCodeGenerator::HeaderCloseNamespaces() { CloseNamespaces(header_); }
+void ServiceCodeGenerator::HeaderCloseNamespaces() {
+  CloseNamespaces(header_);
+  HeaderPrint("\n");
+}
 
 Status ServiceCodeGenerator::CcOpenNamespaces(NamespaceType ns_type) {
   return OpenNamespaces(cc_, ns_type);
@@ -256,7 +259,6 @@ void ServiceCodeGenerator::CloseNamespaces(Printer& p) {
   for (auto iter = namespaces_.rbegin(); iter != namespaces_.rend(); ++iter) {
     p.Print("}  // namespace $namespace$\n", "namespace", *iter);
   }
-  p.Print("\n");
 }
 
 Status ServiceCodeGenerator::Generate() {

--- a/google/cloud/bigquery/README.md
+++ b/google/cloud/bigquery/README.md
@@ -124,4 +124,3 @@ as well as how to properly format your code.
 ## Licensing
 
 Apache 2.0; see [`LICENSE`](../../../LICENSE) for details.
-

--- a/google/cloud/bigtable/README.md
+++ b/google/cloud/bigtable/README.md
@@ -106,4 +106,3 @@ as well as how to properly format your code.
 ## Licensing
 
 Apache 2.0; see [`LICENSE`](../../../LICENSE) for details.
-

--- a/google/cloud/iam/README.md
+++ b/google/cloud/iam/README.md
@@ -98,4 +98,3 @@ as well as how to properly format your code.
 ## Licensing
 
 Apache 2.0; see [`LICENSE`](../../../LICENSE) for details.
-

--- a/google/cloud/pubsub/README.md
+++ b/google/cloud/pubsub/README.md
@@ -97,4 +97,3 @@ as well as how to properly format your code.
 ## Licensing
 
 Apache 2.0; see [`LICENSE`](../../../LICENSE) for details.
-

--- a/google/cloud/spanner/README.md
+++ b/google/cloud/spanner/README.md
@@ -88,4 +88,3 @@ as well as how to properly format your code.
 ## Licensing
 
 Apache 2.0; see [`LICENSE`](../../../LICENSE) for details.
-

--- a/google/cloud/storage/README.md
+++ b/google/cloud/storage/README.md
@@ -109,4 +109,3 @@ as well as how to properly format your code.
 ## Licensing
 
 Apache 2.0; see [`LICENSE`](../../../LICENSE) for details.
-


### PR DESCRIPTION
This PR
* Updates the `ci/cloudbuild/builds/checkers.sh` script to trim trailing blank lines from text files
* Fixes all the files in the repo that had trailing blank lines
* Updates the generator so that it doesn't generate files w/ trailing blank lines

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7116)
<!-- Reviewable:end -->
