### PR TITLE
fix(spanner): fix Client::OverlayQueryOptions() to merge correctly

### DIFF
--- a/google/cloud/spanner/client.cc
+++ b/google/cloud/spanner/client.cc
@@ -301,44 +301,6 @@ StatusOr<PartitionedDmlResult> Client::ExecutePartitionedDml(
       {std::move(statement), OverlayQueryOptions(opts)});
 }
 
-// Returns a QueryOptions that has each attribute set according to the
-// preferred/fallback/environment hierarchy.
-QueryOptions Client::OverlayQueryOptions(
-    QueryOptions const& preferred, QueryOptions const& fallback,
-    absl::optional<std::string> const& optimizer_version_env,
-    absl::optional<std::string> const& optimizer_statistics_package_env) {
-  QueryOptions opts;
-
-  // Choose the `optimizer_version` option.
-  if (preferred.optimizer_version().has_value()) {
-    opts.set_optimizer_version(preferred.optimizer_version());
-  } else if (fallback.optimizer_version().has_value()) {
-    opts.set_optimizer_version(fallback.optimizer_version());
-  } else if (optimizer_version_env.has_value()) {
-    opts.set_optimizer_version(*optimizer_version_env);
-  }
-
-  // Choose the `optimizer_statistics_package` option.
-  if (preferred.optimizer_statistics_package().has_value()) {
-    opts.set_optimizer_statistics_package(
-        preferred.optimizer_statistics_package());
-  } else if (fallback.optimizer_statistics_package().has_value()) {
-    opts.set_optimizer_statistics_package(
-        fallback.optimizer_statistics_package());
-  } else if (optimizer_statistics_package_env.has_value()) {
-    opts.set_optimizer_statistics_package(*optimizer_statistics_package_env);
-  }
-
-  // Choose the `request_priority` option.
-  if (preferred.request_priority().has_value()) {
-    opts.set_request_priority(preferred.request_priority());
-  } else if (fallback.request_priority().has_value()) {
-    opts.set_request_priority(fallback.request_priority());
-  }
-
-  return opts;
-}
-
 // Returns a QueryOptions that has each attribute set according to
 // the hierarchy that options specified at the function call (i.e.,
 // `preferred`) are preferred, followed by options set at the Client
@@ -353,9 +315,9 @@ QueryOptions Client::OverlayQueryOptions(QueryOptions const& preferred) {
   static auto const* const kOptimizerStatisticsPackageEnvValue = new auto(
       google::cloud::internal::GetEnv("SPANNER_OPTIMIZER_STATISTICS_PACKAGE"));
 
-  return OverlayQueryOptions(preferred, opts_.query_options(),
-                             *kOptimizerVersionEnvValue,
-                             *kOptimizerStatisticsPackageEnvValue);
+  return spanner_internal::OverlayQueryOptions(
+      preferred, opts_.query_options(), *kOptimizerVersionEnvValue,
+      *kOptimizerStatisticsPackageEnvValue);
 }
 
 std::shared_ptr<spanner::Connection> MakeConnection(spanner::Database const& db,
@@ -400,5 +362,50 @@ std::shared_ptr<Connection> MakeConnection(
 
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner
+
+namespace spanner_internal {
+inline namespace SPANNER_CLIENT_NS {
+
+// Returns a QueryOptions that has each attribute set according to the
+// preferred/fallback/environment hierarchy.
+spanner::QueryOptions OverlayQueryOptions(
+    spanner::QueryOptions const& preferred,
+    spanner::QueryOptions const& fallback,
+    absl::optional<std::string> const& optimizer_version_env,
+    absl::optional<std::string> const& optimizer_statistics_package_env) {
+  spanner::QueryOptions opts;
+
+  // Choose the `optimizer_version` option.
+  if (preferred.optimizer_version().has_value()) {
+    opts.set_optimizer_version(preferred.optimizer_version());
+  } else if (fallback.optimizer_version().has_value()) {
+    opts.set_optimizer_version(fallback.optimizer_version());
+  } else if (optimizer_version_env.has_value()) {
+    opts.set_optimizer_version(*optimizer_version_env);
+  }
+
+  // Choose the `optimizer_statistics_package` option.
+  if (preferred.optimizer_statistics_package().has_value()) {
+    opts.set_optimizer_statistics_package(
+        preferred.optimizer_statistics_package());
+  } else if (fallback.optimizer_statistics_package().has_value()) {
+    opts.set_optimizer_statistics_package(
+        fallback.optimizer_statistics_package());
+  } else if (optimizer_statistics_package_env.has_value()) {
+    opts.set_optimizer_statistics_package(*optimizer_statistics_package_env);
+  }
+
+  // Choose the `request_priority` option.
+  if (preferred.request_priority().has_value()) {
+    opts.set_request_priority(preferred.request_priority());
+  } else if (fallback.request_priority().has_value()) {
+    opts.set_request_priority(fallback.request_priority());
+  }
+
+  return opts;
+}
+
+}  // namespace SPANNER_CLIENT_NS
+}  // namespace spanner_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/spanner/client.h
+++ b/google/cloud/spanner/client.h
@@ -643,6 +643,11 @@ class Client {
       SqlStatement statement, QueryOptions const& opts = {});
 
  private:
+  friend class OverlayQueryOptionsTester;
+  static QueryOptions OverlayQueryOptions(
+      QueryOptions const& preferred, QueryOptions const& fallback,
+      absl::optional<std::string> const& optimizer_version_env,
+      absl::optional<std::string> const& optimizer_statistics_package_env);
   QueryOptions OverlayQueryOptions(QueryOptions const&);
 
   std::shared_ptr<Connection> conn_;

--- a/google/cloud/spanner/client.h
+++ b/google/cloud/spanner/client.h
@@ -643,11 +643,6 @@ class Client {
       SqlStatement statement, QueryOptions const& opts = {});
 
  private:
-  friend class OverlayQueryOptionsTester;
-  static QueryOptions OverlayQueryOptions(
-      QueryOptions const& preferred, QueryOptions const& fallback,
-      absl::optional<std::string> const& optimizer_version_env,
-      absl::optional<std::string> const& optimizer_statistics_package_env);
   QueryOptions OverlayQueryOptions(QueryOptions const&);
 
   std::shared_ptr<Connection> conn_;
@@ -727,6 +722,18 @@ std::shared_ptr<Connection> MakeConnection(
 
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner
+
+namespace spanner_internal {
+inline namespace SPANNER_CLIENT_NS {
+
+spanner::QueryOptions OverlayQueryOptions(
+    spanner::QueryOptions const& preferred,
+    spanner::QueryOptions const& fallback,
+    absl::optional<std::string> const& optimizer_version_env,
+    absl::optional<std::string> const& optimizer_statistics_package_env);
+
+}  // namespace SPANNER_CLIENT_NS
+}  // namespace spanner_internal
 }  // namespace cloud
 }  // namespace google
 

--- a/google/cloud/spanner/client_test.cc
+++ b/google/cloud/spanner/client_test.cc
@@ -34,19 +34,6 @@ namespace google {
 namespace cloud {
 namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
-
-class OverlayQueryOptionsTester {
- public:
-  static QueryOptions OverlayQueryOptions(
-      QueryOptions const& preferred, QueryOptions const& fallback,
-      absl::optional<std::string> const& optimizer_version_env,
-      absl::optional<std::string> const& optimizer_statistics_package_env) {
-    return Client::OverlayQueryOptions(preferred, fallback,
-                                       optimizer_version_env,
-                                       optimizer_statistics_package_env);
-  }
-};
-
 namespace {
 
 namespace spanner_proto = ::google::spanner::v1;
@@ -1034,9 +1021,6 @@ TEST(ClientTest, ProfileQueryWithOptionsSuccess) {
 }
 
 TEST(ClientTest, QueryOptionsOverlayPrecedence) {
-  constexpr auto OverlayQueryOptions =  // NOLINT(readability-identifier-naming)
-      OverlayQueryOptionsTester::OverlayQueryOptions;
-
   // Check optimizer_version.
   {
     QueryOptions preferred;
@@ -1044,23 +1028,23 @@ TEST(ClientTest, QueryOptionsOverlayPrecedence) {
     QueryOptions fallback;
     fallback.set_optimizer_version("fallback");
     absl::optional<std::string> optimizer_version_env = "environment";
-    EXPECT_EQ(OverlayQueryOptions(preferred, fallback, optimizer_version_env,
-                                  absl::nullopt)
+    EXPECT_EQ(spanner_internal::OverlayQueryOptions(
+                  preferred, fallback, optimizer_version_env, absl::nullopt)
                   .optimizer_version(),
               "preferred");
     preferred.set_optimizer_version(absl::nullopt);
-    EXPECT_EQ(OverlayQueryOptions(preferred, fallback, optimizer_version_env,
-                                  absl::nullopt)
+    EXPECT_EQ(spanner_internal::OverlayQueryOptions(
+                  preferred, fallback, optimizer_version_env, absl::nullopt)
                   .optimizer_version(),
               "fallback");
     fallback.set_optimizer_version(absl::nullopt);
-    EXPECT_EQ(OverlayQueryOptions(preferred, fallback, optimizer_version_env,
-                                  absl::nullopt)
+    EXPECT_EQ(spanner_internal::OverlayQueryOptions(
+                  preferred, fallback, optimizer_version_env, absl::nullopt)
                   .optimizer_version(),
               "environment");
     optimizer_version_env = absl::nullopt;
-    EXPECT_EQ(OverlayQueryOptions(preferred, fallback, optimizer_version_env,
-                                  absl::nullopt)
+    EXPECT_EQ(spanner_internal::OverlayQueryOptions(
+                  preferred, fallback, optimizer_version_env, absl::nullopt)
                   .optimizer_version(),
               absl::nullopt);
   }
@@ -1073,23 +1057,27 @@ TEST(ClientTest, QueryOptionsOverlayPrecedence) {
     fallback.set_optimizer_statistics_package("fallback");
     absl::optional<std::string> optimizer_statistics_package_env =
         "environment";
-    EXPECT_EQ(OverlayQueryOptions(preferred, fallback, absl::nullopt,
-                                  optimizer_statistics_package_env)
+    EXPECT_EQ(spanner_internal::OverlayQueryOptions(
+                  preferred, fallback, absl::nullopt,
+                  optimizer_statistics_package_env)
                   .optimizer_statistics_package(),
               "preferred");
     preferred.set_optimizer_statistics_package(absl::nullopt);
-    EXPECT_EQ(OverlayQueryOptions(preferred, fallback, absl::nullopt,
-                                  optimizer_statistics_package_env)
+    EXPECT_EQ(spanner_internal::OverlayQueryOptions(
+                  preferred, fallback, absl::nullopt,
+                  optimizer_statistics_package_env)
                   .optimizer_statistics_package(),
               "fallback");
     fallback.set_optimizer_statistics_package(absl::nullopt);
-    EXPECT_EQ(OverlayQueryOptions(preferred, fallback, absl::nullopt,
-                                  optimizer_statistics_package_env)
+    EXPECT_EQ(spanner_internal::OverlayQueryOptions(
+                  preferred, fallback, absl::nullopt,
+                  optimizer_statistics_package_env)
                   .optimizer_statistics_package(),
               "environment");
     optimizer_statistics_package_env = absl::nullopt;
-    EXPECT_EQ(OverlayQueryOptions(preferred, fallback, absl::nullopt,
-                                  optimizer_statistics_package_env)
+    EXPECT_EQ(spanner_internal::OverlayQueryOptions(
+                  preferred, fallback, absl::nullopt,
+                  optimizer_statistics_package_env)
                   .optimizer_statistics_package(),
               absl::nullopt);
   }
@@ -1100,20 +1088,20 @@ TEST(ClientTest, QueryOptionsOverlayPrecedence) {
     preferred.set_request_priority(RequestPriority::kHigh);
     QueryOptions fallback;
     fallback.set_request_priority(RequestPriority::kLow);
-    EXPECT_EQ(
-        OverlayQueryOptions(preferred, fallback, absl::nullopt, absl::nullopt)
-            .request_priority(),
-        RequestPriority::kHigh);
+    EXPECT_EQ(spanner_internal::OverlayQueryOptions(
+                  preferred, fallback, absl::nullopt, absl::nullopt)
+                  .request_priority(),
+              RequestPriority::kHigh);
     preferred.set_request_priority(absl::nullopt);
-    EXPECT_EQ(
-        OverlayQueryOptions(preferred, fallback, absl::nullopt, absl::nullopt)
-            .request_priority(),
-        RequestPriority::kLow);
+    EXPECT_EQ(spanner_internal::OverlayQueryOptions(
+                  preferred, fallback, absl::nullopt, absl::nullopt)
+                  .request_priority(),
+              RequestPriority::kLow);
     fallback.set_request_priority(absl::nullopt);
-    EXPECT_EQ(
-        OverlayQueryOptions(preferred, fallback, absl::nullopt, absl::nullopt)
-            .request_priority(),
-        absl::nullopt);
+    EXPECT_EQ(spanner_internal::OverlayQueryOptions(
+                  preferred, fallback, absl::nullopt, absl::nullopt)
+                  .request_priority(),
+              absl::nullopt);
   }
 }
 

--- a/google/cloud/spanner/doc/spanner-main.dox
+++ b/google/cloud/spanner/doc/spanner-main.dox
@@ -89,6 +89,9 @@ behaviors in the library.
 - `SPANNER_OPTIMIZER_VERSION=n` sets the default query optimizer version to use
   in `Client::ExecuteQuery()` calls.
 
+- `SPANNER_OPTIMIZER_STATISTICS_PACKAGE=...` specifies a statistics package
+  for the query optimizer to use when compiling a SQL query.
+
 - `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` turns on logging in the library, basically
   the library always "logs" but the logging infrastructure has no backend to
   actually print anything until the application sets a backend or they set this

--- a/google/cloud/spanner/query_options.h
+++ b/google/cloud/spanner/query_options.h
@@ -30,6 +30,9 @@ inline namespace SPANNER_CLIENT_NS {
  * These QueryOptions allow users to configure features about how their SQL
  * queries executes on the server.
  *
+ * Note: If you add an attribute here, remember to update the implementation
+ * of Client::OverlayQueryOptions().
+ *
  * @see https://cloud.google.com/spanner/docs/reference/rest/v1/QueryOptions
  * @see http://cloud/spanner/docs/query-optimizer/manage-query-optimizer
  */

--- a/google/cloud/spanner/query_options.h
+++ b/google/cloud/spanner/query_options.h
@@ -30,9 +30,6 @@ inline namespace SPANNER_CLIENT_NS {
  * These QueryOptions allow users to configure features about how their SQL
  * queries executes on the server.
  *
- * Note: If you add an attribute here, remember to update the implementation
- * of Client::OverlayQueryOptions().
- *
  * @see https://cloud.google.com/spanner/docs/reference/rest/v1/QueryOptions
  * @see http://cloud/spanner/docs/query-optimizer/manage-query-optimizer
  */
@@ -96,6 +93,8 @@ class QueryOptions {
   }
 
  private:
+  // Note: If you add an attribute here, remember to update the implementation
+  // of Client::OverlayQueryOptions().
   absl::optional<std::string> optimizer_version_;
   absl::optional<std::string> optimizer_statistics_package_;
   absl::optional<RequestPriority> request_priority_;


### PR DESCRIPTION
`Client::OverlayQueryOptions()` was misbehaving on two fronts:
- The environment option for `optimizer_statistics_package` was
  using the value of `${SPANNER_OPTIMIZER_VERSION}` instead of
  `${SPANNER_OPTIMIZER_STATISTICS_PACKAGE}`.
- It was not setting an output value for `request_priority` at all.

At least part of the reason for these errors was that the test:
- assumed the behavior could be changed by modifying the environment
  whereas the implementation only read the environment once, and
- only a single `MockConnection`, with accumulated parameter matches,
  was used across all test cases.

So, fix the implementation, and revamp the test to be more direct
(which eliminates the mocking) and to exercise RequestPriority.

Also add a note to `query_options.h` to update `OverlayQueryOptions()`
whenever new options are added.

Finally, add documentation for `${SPANNER_OPTIMIZER_STATISTICS_PACKAGE}`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7118)
<!-- Reviewable:end -->
