### PR TITLE
feat(common): capture thread that creates log record

### DIFF
--- a/google/cloud/internal/log_impl_test.cc
+++ b/google/cloud/internal/log_impl_test.cc
@@ -48,13 +48,7 @@ TEST(CircularBufferBackend, Basic) {
   buffer.ProcessWithOwnership(test_log_record(Severity::GCP_LS_INFO, "msg 5"));
   EXPECT_THAT(be->ExtractLines(), IsEmpty());
 
-  buffer.ProcessWithOwnership(LogRecord{Severity::GCP_LS_ERROR,
-                                        "test_error()",
-                                        "file",
-                                        1,
-                                        std::this_thread::get_id(),
-                                        {},
-                                        "msg 6"});
+  buffer.ProcessWithOwnership(test_log_record(Severity::GCP_LS_ERROR, "msg 6"));
   EXPECT_THAT(be->ExtractLines(), ElementsAre("msg 4", "msg 5", "msg 6"));
 
   buffer.ProcessWithOwnership(test_log_record(Severity::GCP_LS_INFO, "msg 7"));

--- a/google/cloud/log.cc
+++ b/google/cloud/log.cc
@@ -81,7 +81,7 @@ std::ostream& operator<<(std::ostream& os, Severity x) {
 
 std::ostream& operator<<(std::ostream& os, LogRecord const& rhs) {
   return os << Timestamp{rhs.timestamp} << " [" << rhs.severity << "]"
-            << " <" << std::this_thread::get_id() << ">"
+            << " <" << rhs.thread_id << ">"
             << " " << rhs.message << " (" << rhs.filename << ':' << rhs.lineno
             << ')';
 }

--- a/google/cloud/log.h
+++ b/google/cloud/log.h
@@ -95,6 +95,7 @@
 #include <mutex>
 #include <sstream>
 #include <string>
+#include <thread>
 
 namespace google {
 namespace cloud {
@@ -220,6 +221,7 @@ struct LogRecord {
   std::string function;
   std::string filename;
   int lineno;
+  std::thread::id thread_id;
   std::chrono::system_clock::time_point timestamp;
   std::string message;
 };
@@ -405,6 +407,7 @@ class Logger {
     record.function = function_;
     record.filename = filename_;
     record.lineno = lineno_;
+    record.thread_id = std::this_thread::get_id();
     record.timestamp = std::chrono::system_clock::now();
     record.message = stream_->str();
     sink.Log(std::move(record));

--- a/google/cloud/log_test.cc
+++ b/google/cloud/log_test.cc
@@ -42,6 +42,7 @@ TEST(LogRecordTest, Streaming) {
   lr.function = "Func";
   lr.filename = "filename.cc";
   lr.lineno = 123;
+  lr.thread_id = std::this_thread::get_id();
   lr.timestamp = std::chrono::system_clock::from_time_t(1585112316) +
                  std::chrono::microseconds(123456);
   lr.message = "message";


### PR DESCRIPTION
When using the `lastN` backend one wants the id of the thread that
created the log, not the id of the thread that is flushing the logs.
Arguably we may also want a `lastNInThread` logger, at least some of the
the time, but that is a matter for a separate PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7119)
<!-- Reviewable:end -->
