### PR TITLE
fix(GCS+gRPC): return status on stream closure

### DIFF
--- a/google/cloud/storage/internal/grpc_object_read_source.cc
+++ b/google/cloud/storage/internal/grpc_object_read_source.cc
@@ -100,19 +100,9 @@ StatusOr<ReadSourceResult> GrpcObjectReadSource::Read(char* buf,
     headers.insert(h.begin(), h.end());
   }
 
-  if (offset != 0) {
-    return ReadSourceResult{
-        offset,
-        HttpResponse{HttpStatusCode::kContinue, {}, std::move(headers)}};
-  }
-  if (status_.ok()) {
-    // The stream was closed successfully, but there is no more data, cannot
-    // return a "OK" Status via a `StatusOr` need to provide some value.
-    return ReadSourceResult{
-        0, HttpResponse{HttpStatusCode::kOk, {}, std::move(headers)}};
-  }
-
-  return status_;
+  if (!status_.ok()) return status_;
+  return ReadSourceResult{
+      offset, HttpResponse{HttpStatusCode::kContinue, {}, std::move(headers)}};
 }
 
 }  // namespace internal

--- a/google/cloud/storage/internal/grpc_object_read_source_test.cc
+++ b/google/cloud/storage/internal/grpc_object_read_source_test.cc
@@ -108,12 +108,8 @@ TEST(GrpcObjectReadSource, DataWithError) {
   std::string expected = "0123456789";
   std::vector<char> buffer(1024);
   auto response = tested.Read(buffer.data(), buffer.size());
-  ASSERT_STATUS_OK(response);
-  EXPECT_EQ(expected.size(), response->bytes_received);
-  std::string actual(buffer.data(), response->bytes_received);
-  EXPECT_EQ(expected, actual);
-
-  EXPECT_THAT(tested.Read(buffer.data(), buffer.size()),
+  EXPECT_FALSE(tested.IsOpen());
+  EXPECT_THAT(response,
               StatusIs(StatusCode::kPermissionDenied, HasSubstr("uh-oh")));
 
   EXPECT_THAT(tested.Close(),
@@ -319,7 +315,7 @@ TEST(GrpcObjectReadSource, HandleExtraRead) {
   response = tested.Read(buffer.data(), buffer.size());
   ASSERT_STATUS_OK(response);
   EXPECT_EQ(0, response->bytes_received);
-  EXPECT_EQ(200, response->response.status_code);
+  EXPECT_EQ(100, response->response.status_code);
 
   auto status = tested.Close();
   EXPECT_STATUS_OK(status);


### PR DESCRIPTION
The GCS+gRPC version of `ObjectReadSource` was behaving differently from
the REST version. It was returning the last bytes received before the
stream closed, which sets `IsOpen()` to return `false`. The caller
checks `IsOpen` and assumes the last returned status indicates whether
there was an error.

It is possible we want the return type to be `StatusAnd`, but that would
require changing all kinds of APIs that we expose for mocking. Better to
have GCS+gRPC and REST behave consistently, if a bit weirdly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7128)
<!-- Reviewable:end -->
