### PR TITLE
refactor(stream_range): remove unnecessary noexcept spec

### DIFF
--- a/google/cloud/stream_range.h
+++ b/google/cloud/stream_range.h
@@ -86,14 +86,6 @@ StreamRange<T> MakeStreamRange(StreamReader<T>);
  */
 template <typename T>
 class StreamRange {
-  // Helper that returns true if StreamRange's move constructor and assignment
-  // operator should be declared noexcept.
-  template <typename U>
-  static constexpr bool IsMoveNoexcept() {
-    return noexcept(StatusOr<U>(std::declval<U>()))&& noexcept(
-        internal::StreamReader<U>(std::declval<internal::StreamReader<U>>()));
-  }
-
  public:
   /**
    * An input iterator for a `StreamRange<T>` -- DO NOT USE DIRECTLY.
@@ -165,9 +157,9 @@ class StreamRange {
   StreamRange(StreamRange const&) = delete;
   StreamRange& operator=(StreamRange const&) = delete;
   // NOLINTNEXTLINE(performance-noexcept-move-constructor)
-  StreamRange(StreamRange&&) noexcept(IsMoveNoexcept<T>()) = default;
+  StreamRange(StreamRange&&) = default;
   // NOLINTNEXTLINE(performance-noexcept-move-constructor)
-  StreamRange& operator=(StreamRange&&) noexcept(IsMoveNoexcept<T>()) = default;
+  StreamRange& operator=(StreamRange&&) = default;
   //@}
 
   iterator begin() { return iterator(this); }


### PR DESCRIPTION
`=default` will implicitly set an appropriate noexcept specification, so the `IsMoveNoexcept()` function is unnecessary and possibly even subtly wrong. The clang-tidy warning `performance-noexcept-move-constructor` incorrectly triggers on this case, so the NOLINTs are still needed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7134)
<!-- Reviewable:end -->
