### PR TITLE
refactor(storage): isolate header parsing to REST

### DIFF
--- a/google/cloud/storage/CMakeLists.txt
+++ b/google/cloud/storage/CMakeLists.txt
@@ -495,6 +495,7 @@ if (BUILD_TESTING)
         internal/compute_engine_util_test.cc
         internal/const_buffer_test.cc
         internal/curl_client_test.cc
+        internal/curl_download_request_test.cc
         internal/curl_handle_factory_test.cc
         internal/curl_handle_test.cc
         internal/curl_resumable_upload_session_test.cc

--- a/google/cloud/storage/internal/curl_download_request.h
+++ b/google/cloud/storage/internal/curl_download_request.h
@@ -29,6 +29,14 @@ namespace cloud {
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace internal {
+/// Parse the `x-goog-hash` header and get one of the hashes.
+std::string ExtractHashValue(std::string const& hash_header,
+                             std::string const& hash_key);
+
+/// Parse the headers in a response and decorate the ReadSourceResult.
+ReadSourceResult MakeReadResult(std::size_t bytes_received,
+                                HttpResponse response);
+
 extern "C" std::size_t CurlDownloadRequestWrite(char* ptr, size_t size,
                                                 size_t nmemb, void* userdata);
 extern "C" std::size_t CurlDownloadRequestHeader(char* contents,

--- a/google/cloud/storage/internal/curl_download_request_test.cc
+++ b/google/cloud/storage/internal/curl_download_request_test.cc
@@ -1,0 +1,92 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/storage/internal/curl_download_request.h"
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+namespace storage {
+inline namespace STORAGE_CLIENT_NS {
+namespace internal {
+namespace {
+
+TEST(CurlDownloadRequest, ExtractHashValue) {
+  struct Test {
+    std::string value;
+    std::string key;
+    std::string expected;
+  } cases[] = {
+      {"", "", ""},
+      {"crc32c=123", "crc32c=", "123"},
+      {"crc32c=123,", "crc32c=", "123"},
+      {"crc32c=", "crc32c=", ""},
+      {"crc32c=,", "crc32c=", ""},
+      {"crc32c=123, md4=abc", "crc32c=", "123"},
+      {"md5=abc, crc32c=123", "crc32c=", "123"},
+  };
+
+  for (auto const& test : cases) {
+    SCOPED_TRACE("Testing with " + test.value + " and " + test.key);
+    auto const actual = ExtractHashValue(test.value, test.key);
+    EXPECT_EQ(test.expected, actual);
+  }
+}
+
+TEST(CurlDownloadRequest, MakeReadResult) {
+  struct Test {
+    std::string name;
+    std::multimap<std::string, std::string> headers;
+    HashValues expected_hashes;
+    absl::optional<std::int64_t> expected_generation;
+  } cases[] = {
+      {"empty", {}, {}, absl::nullopt},
+      {"irrelevant headers",
+       {{"x-generation", "123"},
+        {"x-goog-stuff", "thing"},
+        {"x-hashes", "crc32c=123"}},
+       {},
+       absl::nullopt},
+      {"generation", {{"x-goog-generation", "123"}}, {}, 123},
+      {"hashes",
+       {{"x-goog-hash", "md5=123, crc32c=abc"}},
+       {"abc", "123"},
+       absl::nullopt},
+      {"split hashes",
+       {{"x-goog-hash", "md5=123"}, {"x-goog-hash", "crc32c=abc"}},
+       {"abc", "123"},
+       absl::nullopt},
+      {"hashes and generation",
+       {{"x-goog-hash", "md5=123, crc32c=abc"}, {"x-goog-generation", "456"}},
+       {"abc", "123"},
+       456},
+  };
+
+  for (auto const& test : cases) {
+    SCOPED_TRACE("Test case: " + test.name);
+    auto const actual = MakeReadResult(42, HttpResponse{200, {}, test.headers});
+    EXPECT_EQ(42, actual.bytes_received);
+    EXPECT_EQ(200, actual.response.status_code);
+    EXPECT_EQ(test.expected_generation, actual.generation);
+    EXPECT_EQ(test.expected_hashes.crc32c, actual.hashes.crc32c);
+    EXPECT_EQ(test.expected_hashes.md5, actual.hashes.md5);
+  }
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace STORAGE_CLIENT_NS
+}  // namespace storage
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/storage/internal/grpc_object_read_source.h
+++ b/google/cloud/storage/internal/grpc_object_read_source.h
@@ -65,10 +65,6 @@ class GrpcObjectReadSource : public ObjectReadSource {
 
   // The status of the request.
   google::cloud::Status status_;
-
-  // If set the checksums for the object are known and `Read()` does not need
-  // to return them, even if present in the response.
-  bool checksums_known_ = false;
 };
 
 }  // namespace internal

--- a/google/cloud/storage/internal/hash_validator.h
+++ b/google/cloud/storage/internal/hash_validator.h
@@ -40,8 +40,7 @@ class HashValidator {
   virtual void ProcessMetadata(ObjectMetadata const& meta) = 0;
 
   /// Update the received hash value based on a response header.
-  virtual void ProcessHeader(std::string const& key,
-                             std::string const& value) = 0;
+  virtual void ProcessHashValues(HashValues const& hashes) = 0;
 
   struct Result {
     /// The value reported by the server, based on the calls to ProcessHeader().

--- a/google/cloud/storage/internal/hash_validator_impl.cc
+++ b/google/cloud/storage/internal/hash_validator_impl.cc
@@ -30,10 +30,9 @@ void CompositeValidator::ProcessMetadata(ObjectMetadata const& meta) {
   b_->ProcessMetadata(meta);
 }
 
-void CompositeValidator::ProcessHeader(std::string const& key,
-                                       std::string const& value) {
-  a_->ProcessHeader(key, value);
-  b_->ProcessHeader(key, value);
+void CompositeValidator::ProcessHashValues(HashValues const& values) {
+  a_->ProcessHashValues(values);
+  b_->ProcessHashValues(values);
 }
 
 HashValidator::Result CompositeValidator::Finish(HashValues computed) && {
@@ -56,19 +55,8 @@ void MD5HashValidator::ProcessMetadata(ObjectMetadata const& meta) {
   received_hash_ = meta.md5_hash();
 }
 
-void MD5HashValidator::ProcessHeader(std::string const& key,
-                                     std::string const& value) {
-  if (key != "x-goog-hash") return;
-  char const prefix[] = "md5=";
-  auto constexpr kPrefixLen = sizeof(prefix) - 1;
-  auto pos = value.find(prefix);
-  if (pos == std::string::npos) return;
-  auto end = value.find(',', pos);
-  if (end == std::string::npos) {
-    received_hash_ = value.substr(pos + kPrefixLen);
-    return;
-  }
-  received_hash_ = value.substr(pos + kPrefixLen, end - pos - kPrefixLen);
+void MD5HashValidator::ProcessHashValues(HashValues const& values) {
+  if (!values.md5.empty()) received_hash_ = values.md5;
 }
 
 HashValidator::Result MD5HashValidator::Finish(HashValues computed) && {
@@ -88,20 +76,8 @@ void Crc32cHashValidator::ProcessMetadata(ObjectMetadata const& meta) {
   received_hash_ = meta.crc32c();
 }
 
-void Crc32cHashValidator::ProcessHeader(std::string const& key,
-                                        std::string const& value) {
-  if (key != "x-goog-hash") return;
-
-  char const prefix[] = "crc32c=";
-  auto constexpr kPrefixLen = sizeof(prefix) - 1;
-  auto pos = value.find(prefix);
-  if (pos == std::string::npos) return;
-  auto end = value.find(',', pos);
-  if (end == std::string::npos) {
-    received_hash_ = value.substr(pos + kPrefixLen);
-    return;
-  }
-  received_hash_ = value.substr(pos + kPrefixLen, end - pos - kPrefixLen);
+void Crc32cHashValidator::ProcessHashValues(HashValues const& values) {
+  if (!values.crc32c.empty()) received_hash_ = values.crc32c;
 }
 
 HashValidator::Result Crc32cHashValidator::Finish(HashValues computed) && {

--- a/google/cloud/storage/internal/hash_validator_impl.h
+++ b/google/cloud/storage/internal/hash_validator_impl.h
@@ -34,7 +34,7 @@ class NullHashValidator : public HashValidator {
 
   std::string Name() const override { return "null"; }
   void ProcessMetadata(ObjectMetadata const&) override {}
-  void ProcessHeader(std::string const&, std::string const&) override {}
+  void ProcessHashValues(HashValues const&) override {}
   Result Finish(HashValues computed) && override;
 };
 
@@ -49,7 +49,7 @@ class CompositeValidator : public HashValidator {
 
   std::string Name() const override { return "composite"; }
   void ProcessMetadata(ObjectMetadata const& meta) override;
-  void ProcessHeader(std::string const& key, std::string const& value) override;
+  void ProcessHashValues(HashValues const& values) override;
   Result Finish(HashValues computed) && override;
 
  private:
@@ -69,7 +69,7 @@ class MD5HashValidator : public HashValidator {
 
   std::string Name() const override { return "md5"; }
   void ProcessMetadata(ObjectMetadata const& meta) override;
-  void ProcessHeader(std::string const& key, std::string const& value) override;
+  void ProcessHashValues(HashValues const& values) override;
   Result Finish(HashValues computed) && override;
 
  private:
@@ -88,7 +88,7 @@ class Crc32cHashValidator : public HashValidator {
 
   std::string Name() const override { return "crc32c"; }
   void ProcessMetadata(ObjectMetadata const& meta) override;
-  void ProcessHeader(std::string const& key, std::string const& value) override;
+  void ProcessHashValues(HashValues const& values) override;
   Result Finish(HashValues computed) && override;
 
  private:

--- a/google/cloud/storage/internal/object_read_source.h
+++ b/google/cloud/storage/internal/object_read_source.h
@@ -54,12 +54,6 @@ struct ReadSourceResult {
   ReadSourceResult() = default;
   ReadSourceResult(std::size_t b, HttpResponse r)
       : bytes_received(std::move(b)), response(std::move(r)) {}
-
-  // This makes it easier to write some unit tests
-  ReadSourceResult&& set_generation(std::int64_t v) && {
-    generation = v;
-    return std::move(*this);
-  }
 };
 
 /**

--- a/google/cloud/storage/internal/object_read_source.h
+++ b/google/cloud/storage/internal/object_read_source.h
@@ -15,9 +15,11 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_OBJECT_READ_SOURCE_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_OBJECT_READ_SOURCE_H
 
+#include "google/cloud/storage/internal/hash_values.h"
 #include "google/cloud/storage/internal/http_response.h"
 #include "google/cloud/storage/version.h"
 #include "google/cloud/status_or.h"
+#include "absl/types/optional.h"
 
 namespace google {
 namespace cloud {
@@ -46,6 +48,18 @@ namespace internal {
 struct ReadSourceResult {
   std::size_t bytes_received;
   HttpResponse response;
+  HashValues hashes;
+  absl::optional<std::int64_t> generation;
+
+  ReadSourceResult() = default;
+  ReadSourceResult(std::size_t b, HttpResponse r)
+      : bytes_received(std::move(b)), response(std::move(r)) {}
+
+  // This makes it easier to write some unit tests
+  ReadSourceResult&& set_generation(std::int64_t v) && {
+    generation = v;
+    return std::move(*this);
+  }
 };
 
 /**

--- a/google/cloud/storage/internal/object_read_streambuf.cc
+++ b/google/cloud/storage/internal/object_read_streambuf.cc
@@ -190,11 +190,10 @@ std::streamsize ObjectReadStreambuf::xsgetn(char* s, std::streamsize count) {
   if (!read) return run_validator_if_closed(std::move(read).status());
 
   hash_function_->Update(s + offset, read->bytes_received);
+  hash_validator_->ProcessHashValues(read->hashes);
   offset += static_cast<std::streamsize>(read->bytes_received);
   source_pos_ += static_cast<std::streamoff>(read->bytes_received);
-
   for (auto const& kv : read->response.headers) {
-    hash_validator_->ProcessHeader(kv.first, kv.second);
     headers_.emplace(kv.first, kv.second);
   }
   return run_validator_if_closed(Status());

--- a/google/cloud/storage/internal/retry_object_read_source.cc
+++ b/google/cloud/storage/internal/retry_object_read_source.cc
@@ -56,10 +56,7 @@ StatusOr<ReadSourceResult> RetryObjectReadSource::Read(char* buf,
                     << ", status=" << r.status();
       return false;
     }
-    auto g = r->response.headers.find("x-goog-generation");
-    if (g != r->response.headers.end()) {
-      generation_ = std::stoll(g->second);
-    }
+    if (r->generation) generation_ = *r->generation;
     if (offset_direction_ == kFromEnd) {
       current_offset_ -= r->bytes_received;
     } else {

--- a/google/cloud/storage/internal/retry_object_read_source_test.cc
+++ b/google/cloud/storage/internal/retry_object_read_source_test.cc
@@ -304,10 +304,8 @@ TEST(RetryObjectReadSourceTest, TransientFailureWithGeneration) {
         EXPECT_FALSE(req.HasOption<ReadRange>());
         EXPECT_FALSE(req.HasOption<Generation>());
         auto source = absl::make_unique<MockObjectReadSource>();
-        auto result = ReadSourceResult{
-          static_cast<std::size_t>(1024),
-          HttpResponse{
-            200, "", {}}};
+        auto result = ReadSourceResult{static_cast<std::size_t>(1024),
+                                       HttpResponse{200, "", {}}};
         result.generation = 23456;
         EXPECT_CALL(*source, Read)
             .WillOnce(Return(result))

--- a/google/cloud/storage/internal/retry_object_read_source_test.cc
+++ b/google/cloud/storage/internal/retry_object_read_source_test.cc
@@ -304,11 +304,13 @@ TEST(RetryObjectReadSourceTest, TransientFailureWithGeneration) {
         EXPECT_FALSE(req.HasOption<ReadRange>());
         EXPECT_FALSE(req.HasOption<Generation>());
         auto source = absl::make_unique<MockObjectReadSource>();
+        auto result = ReadSourceResult{
+          static_cast<std::size_t>(1024),
+          HttpResponse{
+            200, "", {}}};
+        result.generation = 23456;
         EXPECT_CALL(*source, Read)
-            .WillOnce(Return(ReadSourceResult{
-                static_cast<std::size_t>(1024),
-                HttpResponse{
-                    200, "", {}}}.set_generation(23456)))
+            .WillOnce(Return(result))
             .WillOnce(Return(TransientError()));
         return std::unique_ptr<ObjectReadSource>(std::move(source));
       })

--- a/google/cloud/storage/internal/retry_object_read_source_test.cc
+++ b/google/cloud/storage/internal/retry_object_read_source_test.cc
@@ -292,6 +292,42 @@ TEST(RetryObjectReadSourceTest, TransientFailureWithReadLastOption) {
   auto res = (*source)->Read(nullptr, 1024);
   ASSERT_TRUE(res);
 }
+
+/// @test The generation is captured such that we resume from the same version
+TEST(RetryObjectReadSourceTest, TransientFailureWithGeneration) {
+  auto raw_client = std::make_shared<testing::MockClient>();
+  auto client = std::make_shared<RetryClient>(
+      std::shared_ptr<internal::RawClient>(raw_client), BasicTestPolicies());
+
+  EXPECT_CALL(*raw_client, ReadObject)
+      .WillOnce([](ReadObjectRangeRequest const& req) {
+        EXPECT_FALSE(req.HasOption<ReadRange>());
+        EXPECT_FALSE(req.HasOption<Generation>());
+        auto source = absl::make_unique<MockObjectReadSource>();
+        EXPECT_CALL(*source, Read)
+            .WillOnce(Return(ReadSourceResult{
+                static_cast<std::size_t>(1024),
+                HttpResponse{
+                    200, "", {}}}.set_generation(23456)))
+            .WillOnce(Return(TransientError()));
+        return std::unique_ptr<ObjectReadSource>(std::move(source));
+      })
+      .WillOnce([](ReadObjectRangeRequest const& req) {
+        EXPECT_EQ(1024, req.GetOption<ReadFromOffset>().value_or(0));
+        EXPECT_EQ(23456, req.GetOption<Generation>().value_or(0));
+        auto source = absl::make_unique<MockObjectReadSource>();
+        EXPECT_CALL(*source, Read).WillOnce(Return(ReadSourceResult{}));
+        return std::unique_ptr<ObjectReadSource>(std::move(source));
+      });
+
+  ReadObjectRangeRequest req("test_bucket", "test_object");
+  auto source = client->ReadObject(req);
+  ASSERT_STATUS_OK(source);
+  ASSERT_STATUS_OK((*source)->Read(nullptr, 1024));
+  auto res = (*source)->Read(nullptr, 1024);
+  ASSERT_TRUE(res);
+}
+
 }  // namespace
 }  // namespace internal
 }  // namespace STORAGE_CLIENT_NS

--- a/google/cloud/storage/storage_client_unit_tests.bzl
+++ b/google/cloud/storage/storage_client_unit_tests.bzl
@@ -45,6 +45,7 @@ storage_client_unit_tests = [
     "internal/compute_engine_util_test.cc",
     "internal/const_buffer_test.cc",
     "internal/curl_client_test.cc",
+    "internal/curl_download_request_test.cc",
     "internal/curl_handle_factory_test.cc",
     "internal/curl_handle_test.cc",
     "internal/curl_resumable_upload_session_test.cc",

--- a/google/cloud/storage/tests/curl_download_request_integration_test.cc
+++ b/google/cloud/storage/tests/curl_download_request_integration_test.cc
@@ -40,7 +40,7 @@ std::string HttpBinEndpoint() {
       .value_or("https://nghttp2.org/httpbin");
 }
 
-Status Make3Attemps(std::function<Status()> const& attempt) {
+Status Make3Attempts(std::function<Status()> const& attempt) {
   Status status;
   auto backoff = std::chrono::seconds(1);
   for (int i = 0; i != 3; ++i) {
@@ -109,7 +109,7 @@ TEST(CurlDownloadRequestTest, HashHeaders) {
     return Status{};
   };
 
-  auto status = Make3Attemps(attempt);
+  auto status = Make3Attempts(attempt);
   ASSERT_STATUS_OK(status);
   EXPECT_EQ(hashes.crc32c, "123");
   EXPECT_EQ(hashes.md5, "234");
@@ -137,7 +137,7 @@ TEST(CurlDownloadRequestTest, Generation) {
     return Status{};
   };
 
-  auto status = Make3Attemps(attempt);
+  auto status = Make3Attempts(attempt);
   ASSERT_STATUS_OK(status);
   EXPECT_EQ(received_generation.value_or(0), 123456);
 }
@@ -172,7 +172,7 @@ TEST(CurlDownloadRequestTest, HandlesReleasedOnRead) {
     return Status{};
   };
 
-  auto status = Make3Attemps(download);
+  auto status = Make3Attempts(download);
   ASSERT_STATUS_OK(status);
   EXPECT_EQ(1, factory->CurrentHandleCount());
   EXPECT_EQ(1, factory->CurrentMultiHandleCount());
@@ -210,7 +210,7 @@ TEST(CurlDownloadRequestTest, HandlesReleasedOnClose) {
     return Status{};
   };
 
-  auto status = Make3Attemps(download);
+  auto status = Make3Attempts(download);
   ASSERT_STATUS_OK(status);
   EXPECT_EQ(1, factory->CurrentHandleCount());
   EXPECT_EQ(1, factory->CurrentMultiHandleCount());
@@ -343,7 +343,7 @@ Status AttemptRegression7051() {
 
 /// @test Prevent regressions of #7051: re-using a stream after a partial read.
 TEST(CurlDownloadRequestTest, Regression7051) {
-  auto status = Make3Attemps(AttemptRegression7051);
+  auto status = Make3Attempts(AttemptRegression7051);
   ASSERT_STATUS_OK(status);
 }
 

--- a/google/cloud/storage/tests/object_read_headers_integration_test.cc
+++ b/google/cloud/storage/tests/object_read_headers_integration_test.cc
@@ -29,6 +29,7 @@ namespace {
 
 using ::google::cloud::internal::GetEnv;
 using ::google::cloud::testing_util::IsOk;
+using ::testing::Contains;
 using ::testing::IsSupersetOf;
 
 class ObjectReadHeadersIntegrationTest
@@ -77,14 +78,13 @@ TEST_F(ObjectReadHeadersIntegrationTest, SmokeTest) {
     return keys;
   };
   if (UsingGrpc()) {
-    EXPECT_THAT(keys(is.headers()),
-                IsSupersetOf({":grpc-context-peer", "x-goog-hash"}));
+    EXPECT_THAT(keys(is.headers()), Contains(":grpc-context-peer"));
   } else if (UsingEmulator()) {
-    EXPECT_THAT(keys(is.headers()), IsSupersetOf({"x-goog-hash"}));
+    EXPECT_THAT(keys(is.headers()), Contains("x-goog-hash"));
   } else {
     EXPECT_THAT(keys(is.headers()),
                 IsSupersetOf({"x-guploader-uploadid", "x-goog-hash",
-                              "x-goog-generation"}));
+                              "x-goog-generation", ":curl-peer"}));
   }
 }
 


### PR DESCRIPTION
REST uses HTTP headers to return some information. We are mainly
interseted in the the object generation (to resume downloads for the
same object), and the data hashes (for data integrity). Previously the
GCS+gRPC implementation attempted to inject these headers into the
results to keep the changes to the library smaller. This proved messy.

Now we return these values in member variables of the
`internal::ReadSourceResult` struct. Each protocol knows how to parse
its messages and put the right information into these new member
variables. The struct gained a couple of constructors for backwards
compatibility, though in `storage::internal::` it is used for mocking
:disappointed:

Fixes #7124

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7137)
<!-- Reviewable:end -->
