### PR TITLE
refactor(build.sh): make build.sh --docker the default

### DIFF
--- a/ci/cloudbuild/cloudbuild.yaml
+++ b/ci/cloudbuild/cloudbuild.yaml
@@ -95,7 +95,7 @@ steps:
   # Runs the specified build in the image that was created in the first step.
 - name: 'gcr.io/${PROJECT_ID}/${_IMAGE}:${BUILD_ID}'
   entrypoint: 'ci/cloudbuild/build.sh'
-  args: [ '--local', '${_BUILD_NAME}' ]
+  args: [ '--local', '--build', '${_BUILD_NAME}' ]
   secretEnv: ['CODECOV_TOKEN', 'LOG_LINKER_PAT']
   env: [
     'BAZEL_REMOTE_CACHE=https://storage.googleapis.com/${_CACHE_BUCKET}/bazel-cache/${_DISTRO}-${_BUILD_NAME}',


### PR DESCRIPTION
I did some cleanup and refactoring to `ci/cloudbuild/build.sh` to make
it a little nicer to use in the common case. Changes:

1. `--docker` mode is now **the default build mode**, and may be
specified but does not need to be. So now the following are equivalent
```shell
$ build.sh -t asan-pr  # assumes --docker
$ build.sh -t asan-pr --docker
```

2. `--cloud=project` is **a new flag** to run the build on GCB in the
named project.

3. The `--project=name` flag **has been removed**. If you were using
this flag, use `--cloud=name` instead. I suspect this was rarely used.

4. The build script name may now be specified using the `--build` flag.
Previously this script was specified as a non-flag `$1` to the script.
This was inconsistent.

5. Documentation simplified and clarified. Examples now show common use
cases.

Note: I did not invest much effort to make this change _non-breaking_,
becuase it only affects us and not our users. And the only "breaking"
part of this PR may be for those of us who use the script to trigger
builds on on GCB, which _I think_ is not too common. And for this we
only need to start using the `--cloud=project` flag.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7139)
<!-- Reviewable:end -->
