### PR TITLE
feat(spanner): send session-refresh request at low priority

### DIFF
--- a/google/cloud/spanner/internal/session_pool.cc
+++ b/google/cloud/spanner/internal/session_pool.cc
@@ -448,7 +448,10 @@ future<StatusOr<spanner_proto::ResultSet>> SessionPool::AsyncRefreshSession(
     std::string session_name) {
   spanner_proto::ExecuteSqlRequest request;
   request.set_session(std::move(session_name));
+  // Single-use transaction with strong concurrency.
   request.set_sql("SELECT 1;");
+  request.mutable_request_options()->set_priority(
+      spanner_proto::RequestOptions::PRIORITY_LOW);
   return google::cloud::internal::StartRetryAsyncUnaryRpc(
       cq, __func__, retry_policy_prototype_->clone(),
       backoff_policy_prototype_->clone(), Idempotency::kIdempotent,


### PR DESCRIPTION
Use low refresh priority for the "SELECT 1" "send and forget"
session-refresh query.

Also add a note about the default transaction mode used for
that query.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7140)
<!-- Reviewable:end -->
