### PR TITLE
test(pubsub): deflake pubsub default batching test

### DIFF
--- a/google/cloud/pubsub/internal/batching_publisher_connection_test.cc
+++ b/google/cloud/pubsub/internal/batching_publisher_connection_test.cc
@@ -85,11 +85,7 @@ TEST(BatchingPublisherConnectionTest, DefaultMakesProgress) {
   google::cloud::internal::AutomaticallyCreatedBackgroundThreads background;
   auto const ordering_key = std::string{};
   auto publisher = BatchingPublisherConnection::Create(
-      topic,
-      pubsub::PublisherOptions{}
-          .set_maximum_batch_message_count(4)
-          .set_maximum_hold_time(std::chrono::milliseconds(50)),
-      ordering_key, mock, background.cq());
+      topic, pubsub::PublisherOptions{}, ordering_key, mock, background.cq());
 
   // We expect the responses to be satisfied in the context of the completion
   // queue threads. This is an important property, the processing of any

--- a/google/cloud/pubsub/internal/batching_publisher_connection_test.cc
+++ b/google/cloud/pubsub/internal/batching_publisher_connection_test.cc
@@ -64,7 +64,7 @@ TEST(BatchingPublisherConnectionTest, DefaultMakesProgress) {
   pubsub::Topic const topic("test-project", "test-topic");
 
   AsyncSequencer<void> async;
-  auto publish_count = 0;
+  std::atomic<int> publish_count{0};
   EXPECT_CALL(*mock, AsyncPublish)
       .Times(AtLeast(1))
       .WillRepeatedly([&](google::pubsub::v1::PublishRequest const& request) {
@@ -113,7 +113,7 @@ TEST(BatchingPublisherConnectionTest, DefaultMakesProgress) {
   publisher->Flush({});
   // Use the CQ threads to satisfy the AsyncPull future, like we do in the
   // normal code.
-  background.cq().RunAsync([&async, publish_count] {
+  background.cq().RunAsync([&async, &publish_count] {
     for (auto i = 0; i != publish_count; ++i) {
       async.PopFront().set_value();
     }


### PR DESCRIPTION
Fixes #7021 

Basically the same as #7008, the problem was that super rarely the two messages would be sent in two batches instead of one, due to the hold timer. And, previously, we would only get the future for one batch.

I considered using a CQ that is manually started after the messages are ready, instead of the `AutomaticallyCreatedBackgroundThreads`. I decided against this because I'd rather have no reliance on timers at all.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7146)
<!-- Reviewable:end -->
