### PR TITLE
fix(GCS+gRPC): quickstart build with Bazel+Windows

### DIFF
--- a/google/cloud/storage/BUILD
+++ b/google/cloud/storage/BUILD
@@ -27,15 +27,15 @@ load(":google_cloud_cpp_storage.bzl", "google_cloud_cpp_storage_hdrs", "google_c
 load(":google_cloud_cpp_storage_grpc.bzl", "google_cloud_cpp_storage_grpc_hdrs", "google_cloud_cpp_storage_grpc_srcs")
 
 proto_library(
-    name = "google_cloud_cpp_storage_internal_grpc_resumable_session_url_proto",
+    name = "grpc_resumable_session_url_proto",
     srcs = [
         "internal/grpc_resumable_upload_session_url.proto",
     ],
 )
 
 cc_proto_library(
-    name = "google_cloud_cpp_storage_internal_grpc_resumable_session_url_cc_proto",
-    deps = [":google_cloud_cpp_storage_internal_grpc_resumable_session_url_proto"],
+    name = "grpc_resumable_session_url_cc_proto",
+    deps = [":grpc_resumable_session_url_proto"],
 )
 
 cc_library(
@@ -49,7 +49,7 @@ cc_library(
     defines = ["GOOGLE_CLOUD_CPP_STORAGE_HAVE_GRPC"],
     deps = [
         ":google_cloud_cpp_storage",
-        ":google_cloud_cpp_storage_internal_grpc_resumable_session_url_cc_proto",
+        ":grpc_resumable_session_url_cc_proto",
         "//google/cloud:google_cloud_cpp_grpc_utils",
         "@boringssl//:crypto",
         "@boringssl//:ssl",

--- a/google/cloud/storage/quickstart/grpc/BUILD
+++ b/google/cloud/storage/quickstart/grpc/BUILD
@@ -22,6 +22,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:storage",
+        "@com_github_googleapis_google_cloud_cpp//:experimental-storage-grpc",
     ],
 )


### PR DESCRIPTION
One of the (internal) library names was too long for Windows, that broke
the build. In addition, the GCS+gRPC quickstart was linking the wrong
library.

Part of the work for #6467

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7147)
<!-- Reviewable:end -->
