### PR TITLE
test(spanner): configurable leader placement support

### DIFF
--- a/google/cloud/spanner/samples/samples.cc
+++ b/google/cloud/spanner/samples/samples.cc
@@ -3095,6 +3095,9 @@ void PartitionQuery(google::cloud::spanner::Client client) {
 void QueryInformationSchemaDatabaseOptions(
     google::cloud::spanner::Client client) {
   namespace spanner = ::google::cloud::spanner;
+  // clang-format misinterprets the namespace alias followed by a block as
+  // introducing a sub-namespace and so adds a misleading namespace-closing
+  // comment at the end. This separating comment defeats that.
   {
     auto rows = client.ExecuteQuery(spanner::SqlStatement(R"""(
         SELECT s.OPTION_NAME, s.OPTION_VALUE

--- a/google/cloud/spanner/samples/samples.cc
+++ b/google/cloud/spanner/samples/samples.cc
@@ -3106,7 +3106,7 @@ void QueryInformationSchemaDatabaseOptions(
       if (!row) throw std::runtime_error(row.status().message());
       std::cout << std::get<0>(*row) << "=" << std::get<1>(*row) << "\n";
     }
-  }  // namespace =::google::cloud::spanner;
+  }
   {
     auto rows = client.ExecuteQuery(spanner::SqlStatement(R"""(
         SELECT s.OPTION_NAME, s.OPTION_VALUE


### PR DESCRIPTION
Test support to:
- read leader options via `GetInstanceConfig()` and `ListInstanceConfigs()`,
- set a default leader via `CreateDatabase()` and `UpdateDatabase()`, and
- read the default leader via `GetDatabase()`, `GetDatabaseDdl()`,
  `ListDatabases()`, and the `INFORMATION_SCHEMA` table.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7148)
<!-- Reviewable:end -->
