### PR TITLE
fix(statusor)!: remove status() accessor returning non-const lvalue 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,16 @@
 
 ## v1.31.0 - TBD
 
+## [Common Libraries](https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/README.md)
+
+**BREAKING CHANGES**:
+
+* `google::cloud::StatusOr<T>` had an accessor that returned an lvalue
+  reference to non-const `Status`, which could allow callers to modify the
+  contained `Status` and thus break invariants of the `StatusOr` class. This
+  function was removed. If your code previously relied on `sor.status() =
+  new_status` you should change it to `sor = new_status`.
+
 ## v1.30.0 - 2021-08
 
 ### New GA Libraries

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,7 @@
   reference to non-const `Status`, which could allow callers to modify the
   contained `Status` and thus break invariants of the `StatusOr` class. This
   function was removed. If your code previously relied on `sor.status() =
-  new_status` you should change it to `sor = new_status`.
+  new_status` you should change it to `sor = new_status`. ([#7150](https://github.com/googleapis/google-cloud-cpp/pull/7150))
 
 ## v1.30.0 - 2021-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,10 +59,10 @@
 **BREAKING CHANGES**:
 
 * `google::cloud::StatusOr<T>` had an accessor that returned an lvalue
-  reference to non-const `Status`, which could allow callers to modify the
-  contained `Status` and thus break invariants of the `StatusOr` class. This
-  function was removed. If your code previously relied on `sor.status() =
-  new_status` you should change it to `sor = new_status`. ([#7150](https://github.com/googleapis/google-cloud-cpp/pull/7150))
+  reference to non-const `Status`, this allowed callers to modify the contained
+  `Status` and break invariants of the `StatusOr` class. This function was
+  removed. If your code previously relied on `sor.status() = new_status` you
+  should change it to `sor = new_status`. ([#7150](https://github.com/googleapis/google-cloud-cpp/pull/7150))
 
 ## v1.30.0 - 2021-08
 

--- a/google/cloud/bigtable/benchmarks/read_sync_vs_async_benchmark.cc
+++ b/google/cloud/bigtable/benchmarks/read_sync_vs_async_benchmark.cc
@@ -279,7 +279,7 @@ void AsyncBenchmark::OnReadRow(
 
   std::unique_lock<std::mutex> lk(mu_);
   outstanding_requests_--;
-  results_.operations.push_back({row.status(), usecs});
+  results_.operations.push_back({std::move(row).status(), usecs});
   ++results_.row_count;
   if (now < deadline_) {
     lk.unlock();

--- a/google/cloud/spanner/internal/connection_impl_test.cc
+++ b/google/cloud/spanner/internal/connection_impl_test.cc
@@ -1888,7 +1888,7 @@ TEST(ConnectionImplTest, CommitBeginTransactionSessionNotFound) {
   auto txn = spanner::MakeReadWriteTransaction();
   auto commit = conn->Commit({txn});
   EXPECT_THAT(commit, Not(IsOk()));
-  auto status = commit.status();
+  auto const& status = commit.status();
   EXPECT_TRUE(IsSessionNotFound(status)) << status;
   EXPECT_THAT(txn, HasBadSession());
 }
@@ -1970,7 +1970,6 @@ TEST(ConnectionImplTest, CommitCommitInvalidatedTransaction) {
 
   auto commit = conn->Commit({txn});
   EXPECT_THAT(commit, Not(IsOk()));
-  auto status = commit.status();
   EXPECT_THAT(commit, StatusIs(StatusCode::kAlreadyExists,
                                HasSubstr("constraint error")));
 }
@@ -2613,7 +2612,7 @@ TEST(ConnectionImplTest, ReadSessionNotFound) {
   auto params = spanner::Connection::ReadParams{txn};
   auto response = GetSingularRow(conn->Read(std::move(params)));
   EXPECT_THAT(response, Not(IsOk()));
-  auto status = response.status();
+  auto const& status = response.status();
   EXPECT_TRUE(IsSessionNotFound(status)) << status;
   EXPECT_THAT(txn, HasBadSession());
 }
@@ -2632,7 +2631,7 @@ TEST(ConnectionImplTest, PartitionReadSessionNotFound) {
   auto params = spanner::Connection::ReadParams{txn};
   auto response = conn->PartitionRead({params});
   EXPECT_THAT(response, Not(IsOk()));
-  auto status = response.status();
+  auto const& status = response.status();
   EXPECT_TRUE(IsSessionNotFound(status)) << status;
   EXPECT_THAT(txn, HasBadSession());
 }
@@ -2651,7 +2650,7 @@ TEST(ConnectionImplTest, ExecuteQuerySessionNotFound) {
   SetTransactionId(txn, "test-txn-id");
   auto response = GetSingularRow(conn->ExecuteQuery({txn}));
   EXPECT_THAT(response, Not(IsOk()));
-  auto status = response.status();
+  auto const& status = response.status();
   EXPECT_TRUE(IsSessionNotFound(status)) << status;
   EXPECT_THAT(txn, HasBadSession());
 }
@@ -2670,7 +2669,7 @@ TEST(ConnectionImplTest, ProfileQuerySessionNotFound) {
   SetTransactionId(txn, "test-txn-id");
   auto response = GetSingularRow(conn->ProfileQuery({txn}));
   EXPECT_THAT(response, Not(IsOk()));
-  auto status = response.status();
+  auto const& status = response.status();
   EXPECT_TRUE(IsSessionNotFound(status)) << status;
   EXPECT_THAT(txn, HasBadSession());
 }
@@ -2688,7 +2687,7 @@ TEST(ConnectionImplTest, ExecuteDmlSessionNotFound) {
   SetTransactionId(txn, "test-txn-id");
   auto response = conn->ExecuteDml({txn});
   EXPECT_THAT(response, Not(IsOk()));
-  auto status = response.status();
+  auto const& status = response.status();
   EXPECT_TRUE(IsSessionNotFound(status)) << status;
   EXPECT_THAT(txn, HasBadSession());
 }
@@ -2706,7 +2705,7 @@ TEST(ConnectionImplTest, ProfileDmlSessionNotFound) {
   SetTransactionId(txn, "test-txn-id");
   auto response = conn->ProfileDml({txn});
   EXPECT_THAT(response, Not(IsOk()));
-  auto status = response.status();
+  auto const& status = response.status();
   EXPECT_TRUE(IsSessionNotFound(status)) << status;
   EXPECT_THAT(txn, HasBadSession());
 }
@@ -2724,7 +2723,7 @@ TEST(ConnectionImplTest, AnalyzeSqlSessionNotFound) {
   SetTransactionId(txn, "test-txn-id");
   auto response = conn->AnalyzeSql({txn});
   EXPECT_THAT(response, Not(IsOk()));
-  auto status = response.status();
+  auto const& status = response.status();
   EXPECT_TRUE(IsSessionNotFound(status)) << status;
   EXPECT_THAT(txn, HasBadSession());
 }
@@ -2742,7 +2741,7 @@ TEST(ConnectionImplTest, PartitionQuerySessionNotFound) {
   SetTransactionId(txn, "test-txn-id");
   auto response = conn->PartitionQuery({txn});
   EXPECT_THAT(response, Not(IsOk()));
-  auto status = response.status();
+  auto const& status = response.status();
   EXPECT_TRUE(IsSessionNotFound(status)) << status;
   EXPECT_THAT(txn, HasBadSession());
 }
@@ -2760,7 +2759,7 @@ TEST(ConnectionImplTest, ExecuteBatchDmlSessionNotFound) {
   SetTransactionId(txn, "test-txn-id");
   auto response = conn->ExecuteBatchDml({txn});
   EXPECT_THAT(response, Not(IsOk()));
-  auto status = response.status();
+  auto const& status = response.status();
   EXPECT_TRUE(IsSessionNotFound(status)) << status;
   EXPECT_THAT(txn, HasBadSession());
 }
@@ -2785,7 +2784,7 @@ TEST(ConnectionImplTest, CommitSessionNotFound) {
   SetTransactionId(txn, "test-txn-id");
   auto response = conn->Commit({txn});
   EXPECT_THAT(response, Not(IsOk()));
-  auto status = response.status();
+  auto const& status = response.status();
   EXPECT_TRUE(IsSessionNotFound(status)) << status;
   EXPECT_THAT(txn, HasBadSession());
 }
@@ -2801,7 +2800,7 @@ TEST(ConnectionImplTest, RollbackSessionNotFound) {
   auto conn = MakeLimitedRetryConnection(db, mock);
   auto txn = spanner::MakeReadWriteTransaction();
   SetTransactionId(txn, "test-txn-id");
-  auto status = conn->Rollback({txn});
+  auto const& status = conn->Rollback({txn});
   EXPECT_TRUE(IsSessionNotFound(status)) << status;
   EXPECT_THAT(txn, HasBadSession());
 }

--- a/google/cloud/status_or.h
+++ b/google/cloud/status_or.h
@@ -239,14 +239,10 @@ class StatusOr final {
   /**
    * @name Status accessors.
    *
-   * @return All these member functions return the (properly ref and
-   *     const-qualified) status. If the object contains a value then
-   *     `status().ok() == true`.
+   * @return A reference to the contained `Status`.
    */
-  Status& status() & { return status_; }
   Status const& status() const& { return status_; }
   Status&& status() && { return std::move(status_); }
-  Status const&& status() const&& { return std::move(status_); }
   //@}
 
  private:


### PR DESCRIPTION
This function would allow callers to assign to the contained `Status`
and potentially violate class invariants. For example:

```cc
StatusOr<Foo> sor;  // constructed with kUnknown and no Foo
sor.status() = Status{};  // BUG
auto v = sor.value();  // :-|
```

This PR fixes the above API bug by removing the `status()` accessor that
returns the lvalue to non-const T.

I also remove the `status()` overload that returns the rvalue-ref to
const-T, because I don't think it adds any new functionality to the
class, and a "move" isn't actually happening behind the scenes. Also,
the two access that remain (`const &` and `&&`) are the same two that
`absl::StatusOr` [1] has, so we match there.

[1]: https://github.com/abseil/abseil-cpp/blob/bf31a10b65d945665cecfb9d8807702ae4a7fde1/absl/status/statusor.h#L492-L493

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7150)
<!-- Reviewable:end -->
