### PR TITLE
feat(spanner): tagging support

### DIFF
--- a/google/cloud/options.h
+++ b/google/cloud/options.h
@@ -52,7 +52,7 @@ void CheckExpectedOptionsImpl(std::set<std::type_index> const&, Options const&,
  * - `.unset<T>()`   -- Removes the option `T`
  * - `.get<T>()`     -- Gets a const-ref to the value of option `T`
  * - `.lookup<T>(x)` -- Gets a non-const-ref to option `T`'s value, initializing
- *                      it to `x` if it was no set (`x` is optional).
+ *                      it to `x` if it was not set (`x` is optional).
  *
  * @par Example:
  *

--- a/google/cloud/spanner/client.h
+++ b/google/cloud/spanner/client.h
@@ -37,6 +37,7 @@
 #include "google/cloud/spanner/version.h"
 #include "google/cloud/backoff_policy.h"
 #include "google/cloud/optional.h"
+#include "google/cloud/options.h"
 #include "google/cloud/status.h"
 #include "google/cloud/status_or.h"
 #include <google/spanner/v1/spanner.pb.h>
@@ -303,12 +304,13 @@ class Client {
    */
   RowStream ExecuteQuery(Transaction transaction, SqlStatement statement,
                          QueryOptions const& opts = {});
+
   /**
    * Executes a SQL query on a subset of rows in a database. Requires a prior
    * call to `PartitionQuery` to obtain the partition information; see the
    * documentation of that method for full details.
    *
-   * @param partition A `QueryPartition`, obtained by calling `PartitionRead`.
+   * @param partition A `QueryPartition`, obtained by calling `PartitionQuery`.
    * @param opts The `QueryOptions` to use for this call. If given, these will
    *     take precedence over the options set at the client and environment
    *     levels.

--- a/google/cloud/spanner/commit_options.h
+++ b/google/cloud/spanner/commit_options.h
@@ -18,6 +18,7 @@
 #include "google/cloud/spanner/request_priority.h"
 #include "google/cloud/spanner/version.h"
 #include "absl/types/optional.h"
+#include <string>
 
 namespace google {
 namespace cloud {
@@ -56,9 +57,27 @@ class CommitOptions {
     return request_priority_;
   }
 
+  /**
+   * Set the transaction tag for the `spanner::Client::Commit()` call.
+   * Ignored for the overload that already takes a `spanner::Transaction`.
+   */
+  CommitOptions& set_transaction_tag(
+      absl::optional<std::string> transaction_tag) {
+    transaction_tag_ = std::move(transaction_tag);
+    return *this;
+  }
+
+  /// The transaction tag for the `spanner::Client::Commit()` call.
+  absl::optional<std::string> const& transaction_tag() const {
+    return transaction_tag_;
+  }
+
  private:
+  // Note that CommitRequest.request_options.request_tag is ignored,
+  // so we do not even provide a mechanism to specify one.
   bool return_stats_ = false;
   absl::optional<RequestPriority> request_priority_;
+  absl::optional<std::string> transaction_tag_;
 };
 
 }  // namespace SPANNER_CLIENT_NS

--- a/google/cloud/spanner/commit_options_test.cc
+++ b/google/cloud/spanner/commit_options_test.cc
@@ -26,14 +26,17 @@ TEST(CommitOptionsTest, Defaults) {
   CommitOptions options;
   EXPECT_FALSE(options.return_stats());
   EXPECT_FALSE(options.request_priority().has_value());
+  EXPECT_FALSE(options.transaction_tag().has_value());
 }
 
 TEST(CommitOptionsTest, SetValues) {
   CommitOptions options;
   options.set_return_stats(true);
   options.set_request_priority(RequestPriority::kLow);
+  options.set_transaction_tag("tag");
   EXPECT_TRUE(options.return_stats());
-  EXPECT_EQ(RequestPriority::kLow, *options.request_priority());
+  EXPECT_EQ(RequestPriority::kLow, options.request_priority());
+  EXPECT_EQ("tag", options.transaction_tag());
 }
 
 }  // namespace

--- a/google/cloud/spanner/connection.h
+++ b/google/cloud/spanner/connection.h
@@ -29,6 +29,7 @@
 #include "google/cloud/spanner/transaction.h"
 #include "google/cloud/spanner/version.h"
 #include "google/cloud/optional.h"
+#include "google/cloud/options.h"
 #include "google/cloud/status_or.h"
 #include "absl/types/optional.h"
 #include <string>

--- a/google/cloud/spanner/internal/connection_impl.cc
+++ b/google/cloud/spanner/internal/connection_impl.cc
@@ -120,8 +120,8 @@ spanner::RowStream ConnectionImpl::Read(ReadParams params) {
   return Visit(std::move(params.transaction),
                [this, &params](SessionHolder& session,
                                StatusOr<spanner_proto::TransactionSelector>& s,
-                               std::int64_t) {
-                 return ReadImpl(session, s, std::move(params));
+                               std::string const& tag, std::int64_t) {
+                 return ReadImpl(session, s, tag, std::move(params));
                });
 }
 
@@ -130,8 +130,8 @@ StatusOr<std::vector<spanner::ReadPartition>> ConnectionImpl::PartitionRead(
   return Visit(std::move(params.read_params.transaction),
                [this, &params](SessionHolder& session,
                                StatusOr<spanner_proto::TransactionSelector>& s,
-                               std::int64_t) {
-                 return PartitionReadImpl(session, s, params.read_params,
+                               std::string const& tag, std::int64_t) {
+                 return PartitionReadImpl(session, s, tag, params.read_params,
                                           params.partition_options);
                });
 }
@@ -140,8 +140,9 @@ spanner::RowStream ConnectionImpl::ExecuteQuery(SqlParams params) {
   return Visit(std::move(params.transaction),
                [this, &params](SessionHolder& session,
                                StatusOr<spanner_proto::TransactionSelector>& s,
-                               std::int64_t seqno) {
-                 return ExecuteQueryImpl(session, s, seqno, std::move(params));
+                               std::string const& tag, std::int64_t seqno) {
+                 return ExecuteQueryImpl(session, s, tag, seqno,
+                                         std::move(params));
                });
 }
 
@@ -149,8 +150,9 @@ StatusOr<spanner::DmlResult> ConnectionImpl::ExecuteDml(SqlParams params) {
   return Visit(std::move(params.transaction),
                [this, &params](SessionHolder& session,
                                StatusOr<spanner_proto::TransactionSelector>& s,
-                               std::int64_t seqno) {
-                 return ExecuteDmlImpl(session, s, seqno, std::move(params));
+                               std::string const& tag, std::int64_t seqno) {
+                 return ExecuteDmlImpl(session, s, tag, seqno,
+                                       std::move(params));
                });
 }
 
@@ -158,8 +160,9 @@ spanner::ProfileQueryResult ConnectionImpl::ProfileQuery(SqlParams params) {
   return Visit(std::move(params.transaction),
                [this, &params](SessionHolder& session,
                                StatusOr<spanner_proto::TransactionSelector>& s,
-                               std::int64_t seqno) {
-                 return ProfileQueryImpl(session, s, seqno, std::move(params));
+                               std::string const& tag, std::int64_t seqno) {
+                 return ProfileQueryImpl(session, s, tag, seqno,
+                                         std::move(params));
                });
 }
 
@@ -168,8 +171,9 @@ StatusOr<spanner::ProfileDmlResult> ConnectionImpl::ProfileDml(
   return Visit(std::move(params.transaction),
                [this, &params](SessionHolder& session,
                                StatusOr<spanner_proto::TransactionSelector>& s,
-                               std::int64_t seqno) {
-                 return ProfileDmlImpl(session, s, seqno, std::move(params));
+                               std::string const& tag, std::int64_t seqno) {
+                 return ProfileDmlImpl(session, s, tag, seqno,
+                                       std::move(params));
                });
 }
 
@@ -177,20 +181,21 @@ StatusOr<spanner::ExecutionPlan> ConnectionImpl::AnalyzeSql(SqlParams params) {
   return Visit(std::move(params.transaction),
                [this, &params](SessionHolder& session,
                                StatusOr<spanner_proto::TransactionSelector>& s,
-                               std::int64_t seqno) {
-                 return AnalyzeSqlImpl(session, s, seqno, std::move(params));
+                               std::string const& tag, std::int64_t seqno) {
+                 return AnalyzeSqlImpl(session, s, tag, seqno,
+                                       std::move(params));
                });
 }
 
 StatusOr<spanner::PartitionedDmlResult> ConnectionImpl::ExecutePartitionedDml(
     ExecutePartitionedDmlParams params) {
-  auto txn = spanner::MakeReadOnlyTransaction();
-  return Visit(
-      txn, [this, &params](SessionHolder& session,
-                           StatusOr<spanner_proto::TransactionSelector>& s,
-                           std::int64_t seqno) {
-        return ExecutePartitionedDmlImpl(session, s, seqno, std::move(params));
-      });
+  auto txn = spanner::MakeReadOnlyTransaction();  // becomes partitioned DML
+  return Visit(txn, [this, &params](
+                        SessionHolder& session,
+                        StatusOr<spanner_proto::TransactionSelector>& s,
+                        std::string const& tag, std::int64_t seqno) {
+    return ExecutePartitionedDmlImpl(session, s, tag, seqno, std::move(params));
+  });
 }
 
 StatusOr<std::vector<spanner::QueryPartition>> ConnectionImpl::PartitionQuery(
@@ -198,8 +203,8 @@ StatusOr<std::vector<spanner::QueryPartition>> ConnectionImpl::PartitionQuery(
   return Visit(std::move(params.transaction),
                [this, &params](SessionHolder& session,
                                StatusOr<spanner_proto::TransactionSelector>& s,
-                               std::int64_t) {
-                 return PartitionQueryImpl(session, s, params);
+                               std::string const& tag, std::int64_t) {
+                 return PartitionQueryImpl(session, s, tag, params);
                });
 }
 
@@ -208,8 +213,8 @@ StatusOr<spanner::BatchDmlResult> ConnectionImpl::ExecuteBatchDml(
   return Visit(std::move(params.transaction),
                [this, &params](SessionHolder& session,
                                StatusOr<spanner_proto::TransactionSelector>& s,
-                               std::int64_t seqno) {
-                 return ExecuteBatchDmlImpl(session, s, seqno,
+                               std::string const& tag, std::int64_t seqno) {
+                 return ExecuteBatchDmlImpl(session, s, tag, seqno,
                                             std::move(params));
                });
 }
@@ -218,8 +223,8 @@ StatusOr<spanner::CommitResult> ConnectionImpl::Commit(CommitParams params) {
   return Visit(std::move(params.transaction),
                [this, &params](SessionHolder& session,
                                StatusOr<spanner_proto::TransactionSelector>& s,
-                               std::int64_t) {
-                 return this->CommitImpl(session, s, std::move(params));
+                               std::string const& tag, std::int64_t) {
+                 return this->CommitImpl(session, s, tag, std::move(params));
                });
 }
 
@@ -227,7 +232,9 @@ Status ConnectionImpl::Rollback(RollbackParams params) {
   return Visit(std::move(params.transaction),
                [this](SessionHolder& session,
                       StatusOr<spanner_proto::TransactionSelector>& s,
-                      std::int64_t) { return this->RollbackImpl(session, s); });
+                      std::string const& tag, std::int64_t) {
+                 return this->RollbackImpl(session, s, tag);
+               });
 }
 
 class StatusOnlyResultSetSource : public ResultSourceInterface {
@@ -346,6 +353,7 @@ Status ConnectionImpl::PrepareSession(SessionHolder& session,
  */
 StatusOr<spanner_proto::Transaction> ConnectionImpl::BeginTransaction(
     SessionHolder& session, spanner_proto::TransactionOptions options,
+    std::string request_tag, std::string const& transaction_tag,
     char const* func) {
   spanner_proto::BeginTransactionRequest begin;
   begin.set_session(session->session_name());
@@ -353,6 +361,12 @@ StatusOr<spanner_proto::Transaction> ConnectionImpl::BeginTransaction(
   // `begin.request_options.priority` is ignored. To set the priority
   // for a transaction, set it on the reads and writes that are part of
   // the transaction instead.
+  if (!request_tag.empty()) {
+    begin.mutable_request_options()->set_request_tag(request_tag);
+  }
+  if (!transaction_tag.empty()) {
+    begin.mutable_request_options()->set_transaction_tag(transaction_tag);
+  }
 
   auto stub = session_pool_->GetStub(*session);
   auto response = RetryLoop(
@@ -373,7 +387,7 @@ StatusOr<spanner_proto::Transaction> ConnectionImpl::BeginTransaction(
 
 spanner::RowStream ConnectionImpl::ReadImpl(
     SessionHolder& session, StatusOr<spanner_proto::TransactionSelector>& s,
-    ReadParams params) {
+    std::string const& transaction_tag, ReadParams params) {
   if (!s.ok()) {
     return MakeStatusOnlyResult<spanner::RowStream>(s.status());
   }
@@ -398,6 +412,14 @@ spanner::RowStream ConnectionImpl::ReadImpl(
   }
   request.mutable_request_options()->set_priority(
       ProtoRequestPriority(params.read_options.request_priority));
+  if (params.read_options.request_tag.has_value() &&
+      !params.read_options.request_tag->empty()) {
+    request.mutable_request_options()->set_request_tag(
+        *std::move(params.read_options.request_tag));
+  }
+  if (!transaction_tag.empty()) {
+    request.mutable_request_options()->set_transaction_tag(transaction_tag);
+  }
 
   // Capture a copy of `stub` to ensure the `shared_ptr<>` remains valid through
   // the lifetime of the lambda.
@@ -431,7 +453,9 @@ spanner::RowStream ConnectionImpl::ReadImpl(
         }
         s->set_id(metadata->transaction().id());
       } else {
-        auto begin = BeginTransaction(session, s->begin(), __func__);
+        auto begin = BeginTransaction(session, s->begin(),
+                                      request.request_options().request_tag(),
+                                      transaction_tag, __func__);
         if (begin.ok()) {
           s->set_id(begin->id());
           *request.mutable_transaction() = *s;
@@ -452,7 +476,7 @@ spanner::RowStream ConnectionImpl::ReadImpl(
 
 StatusOr<std::vector<spanner::ReadPartition>> ConnectionImpl::PartitionReadImpl(
     SessionHolder& session, StatusOr<spanner_proto::TransactionSelector>& s,
-    ReadParams const& params,
+    std::string const& transaction_tag, ReadParams const& params,
     spanner::PartitionOptions const& partition_options) {
   if (!s.ok()) {
     return s.status();
@@ -494,7 +518,8 @@ StatusOr<std::vector<spanner::ReadPartition>> ConnectionImpl::PartitionReadImpl(
         }
         s->set_id(response->transaction().id());
       } else {
-        auto begin = BeginTransaction(session, s->begin(), __func__);
+        auto begin = BeginTransaction(session, s->begin(), std::string(),
+                                      transaction_tag, __func__);
         if (begin.ok()) {
           s->set_id(begin->id());
           *request.mutable_transaction() = *s;
@@ -513,9 +538,9 @@ StatusOr<std::vector<spanner::ReadPartition>> ConnectionImpl::PartitionReadImpl(
     std::vector<spanner::ReadPartition> read_partitions;
     for (auto const& partition : response->partitions()) {
       read_partitions.push_back(MakeReadPartition(
-          response->transaction().id(), session->session_name(),
-          partition.partition_token(), params.table, params.keys,
-          params.columns, params.read_options));
+          response->transaction().id(), transaction_tag,
+          session->session_name(), partition.partition_token(), params.table,
+          params.keys, params.columns, params.read_options));
     }
 
     return read_partitions;
@@ -525,7 +550,7 @@ StatusOr<std::vector<spanner::ReadPartition>> ConnectionImpl::PartitionReadImpl(
 template <typename ResultType>
 StatusOr<ResultType> ConnectionImpl::ExecuteSqlImpl(
     SessionHolder& session, StatusOr<spanner_proto::TransactionSelector>& s,
-    std::int64_t seqno, SqlParams params,
+    std::string const& transaction_tag, std::int64_t seqno, SqlParams params,
     google::spanner::v1::ExecuteSqlRequest::QueryMode query_mode,
     std::function<StatusOr<std::unique_ptr<ResultSourceInterface>>(
         google::spanner::v1::ExecuteSqlRequest& request)> const&
@@ -557,6 +582,14 @@ StatusOr<ResultType> ConnectionImpl::ExecuteSqlImpl(
   }
   request.mutable_request_options()->set_priority(
       ProtoRequestPriority(params.query_options.request_priority()));
+  if (params.query_options.request_tag().has_value() &&
+      !params.query_options.request_tag()->empty()) {
+    request.mutable_request_options()->set_request_tag(
+        *params.query_options.request_tag());
+  }
+  if (!transaction_tag.empty()) {
+    request.mutable_request_options()->set_transaction_tag(transaction_tag);
+  }
 
   for (;;) {
     auto reader = retry_resume_fn(request);
@@ -569,7 +602,9 @@ StatusOr<ResultType> ConnectionImpl::ExecuteSqlImpl(
         }
         s->set_id(metadata->transaction().id());
       } else {
-        auto begin = BeginTransaction(session, s->begin(), __func__);
+        auto begin = BeginTransaction(session, s->begin(),
+                                      request.request_options().request_tag(),
+                                      transaction_tag, __func__);
         if (begin.ok()) {
           s->set_id(begin->id());
           *request.mutable_transaction() = *s;
@@ -588,7 +623,7 @@ StatusOr<ResultType> ConnectionImpl::ExecuteSqlImpl(
 template <typename ResultType>
 ResultType ConnectionImpl::CommonQueryImpl(
     SessionHolder& session, StatusOr<spanner_proto::TransactionSelector>& s,
-    std::int64_t seqno, SqlParams params,
+    std::string const& transaction_tag, std::int64_t seqno, SqlParams params,
     google::spanner::v1::ExecuteSqlRequest::QueryMode query_mode) {
   if (!s.ok()) {
     return MakeStatusOnlyResult<ResultType>(s.status());
@@ -630,9 +665,9 @@ ResultType ConnectionImpl::CommonQueryImpl(
     return PartialResultSetSource::Create(std::move(rpc));
   };
 
-  StatusOr<ResultType> response =
-      ExecuteSqlImpl<ResultType>(session, s, seqno, std::move(params),
-                                 query_mode, std::move(retry_resume_fn));
+  StatusOr<ResultType> response = ExecuteSqlImpl<ResultType>(
+      session, s, transaction_tag, seqno, std::move(params), query_mode,
+      std::move(retry_resume_fn));
   if (!response) {
     auto status = std::move(response).status();
     if (IsSessionNotFound(status)) session->set_bad();
@@ -643,24 +678,24 @@ ResultType ConnectionImpl::CommonQueryImpl(
 
 spanner::RowStream ConnectionImpl::ExecuteQueryImpl(
     SessionHolder& session, StatusOr<spanner_proto::TransactionSelector>& s,
-    std::int64_t seqno, SqlParams params) {
+    std::string const& transaction_tag, std::int64_t seqno, SqlParams params) {
   return CommonQueryImpl<spanner::RowStream>(
-      session, s, seqno, std::move(params),
+      session, s, transaction_tag, seqno, std::move(params),
       spanner_proto::ExecuteSqlRequest::NORMAL);
 }
 
 spanner::ProfileQueryResult ConnectionImpl::ProfileQueryImpl(
     SessionHolder& session, StatusOr<spanner_proto::TransactionSelector>& s,
-    std::int64_t seqno, SqlParams params) {
+    std::string const& transaction_tag, std::int64_t seqno, SqlParams params) {
   return CommonQueryImpl<spanner::ProfileQueryResult>(
-      session, s, seqno, std::move(params),
+      session, s, transaction_tag, seqno, std::move(params),
       spanner_proto::ExecuteSqlRequest::PROFILE);
 }
 
 template <typename ResultType>
 StatusOr<ResultType> ConnectionImpl::CommonDmlImpl(
     SessionHolder& session, StatusOr<spanner_proto::TransactionSelector>& s,
-    std::int64_t seqno, SqlParams params,
+    std::string const& transaction_tag, std::int64_t seqno, SqlParams params,
     google::spanner::v1::ExecuteSqlRequest::QueryMode query_mode) {
   if (!s.ok()) {
     return s.status();
@@ -696,31 +731,32 @@ StatusOr<ResultType> ConnectionImpl::CommonDmlImpl(
     }
     return DmlResultSetSource::Create(std::move(*response));
   };
-  return ExecuteSqlImpl<ResultType>(session, s, seqno, std::move(params),
-                                    query_mode, std::move(retry_resume_fn));
+  return ExecuteSqlImpl<ResultType>(session, s, transaction_tag, seqno,
+                                    std::move(params), query_mode,
+                                    std::move(retry_resume_fn));
 }
 
 StatusOr<spanner::DmlResult> ConnectionImpl::ExecuteDmlImpl(
     SessionHolder& session, StatusOr<spanner_proto::TransactionSelector>& s,
-    std::int64_t seqno, SqlParams params) {
+    std::string const& transaction_tag, std::int64_t seqno, SqlParams params) {
   return CommonDmlImpl<spanner::DmlResult>(
-      session, s, seqno, std::move(params),
+      session, s, transaction_tag, seqno, std::move(params),
       spanner_proto::ExecuteSqlRequest::NORMAL);
 }
 
 StatusOr<spanner::ProfileDmlResult> ConnectionImpl::ProfileDmlImpl(
     SessionHolder& session, StatusOr<spanner_proto::TransactionSelector>& s,
-    std::int64_t seqno, SqlParams params) {
+    std::string const& transaction_tag, std::int64_t seqno, SqlParams params) {
   return CommonDmlImpl<spanner::ProfileDmlResult>(
-      session, s, seqno, std::move(params),
+      session, s, transaction_tag, seqno, std::move(params),
       spanner_proto::ExecuteSqlRequest::PROFILE);
 }
 
 StatusOr<spanner::ExecutionPlan> ConnectionImpl::AnalyzeSqlImpl(
     SessionHolder& session, StatusOr<spanner_proto::TransactionSelector>& s,
-    std::int64_t seqno, SqlParams params) {
+    std::string const& transaction_tag, std::int64_t seqno, SqlParams params) {
   auto result = CommonDmlImpl<spanner::ProfileDmlResult>(
-      session, s, seqno, std::move(params),
+      session, s, transaction_tag, seqno, std::move(params),
       spanner_proto::ExecuteSqlRequest::PLAN);
   if (result.status().ok()) {
     return *result->ExecutionPlan();
@@ -731,7 +767,7 @@ StatusOr<spanner::ExecutionPlan> ConnectionImpl::AnalyzeSqlImpl(
 StatusOr<std::vector<spanner::QueryPartition>>
 ConnectionImpl::PartitionQueryImpl(
     SessionHolder& session, StatusOr<spanner_proto::TransactionSelector>& s,
-    PartitionQueryParams const& params) {
+    std::string const& transaction_tag, PartitionQueryParams const& params) {
   if (!s.ok()) {
     return s.status();
   }
@@ -772,7 +808,8 @@ ConnectionImpl::PartitionQueryImpl(
         }
         s->set_id(response->transaction().id());
       } else {
-        auto begin = BeginTransaction(session, s->begin(), __func__);
+        auto begin = BeginTransaction(session, s->begin(), std::string(),
+                                      transaction_tag, __func__);
         if (begin.ok()) {
           s->set_id(begin->id());
           *request.mutable_transaction() = *s;
@@ -789,9 +826,10 @@ ConnectionImpl::PartitionQueryImpl(
 
     std::vector<spanner::QueryPartition> query_partitions;
     for (auto const& partition : response->partitions()) {
-      query_partitions.push_back(MakeQueryPartition(
-          response->transaction().id(), session->session_name(),
-          partition.partition_token(), params.statement));
+      query_partitions.push_back(
+          MakeQueryPartition(response->transaction().id(), transaction_tag,
+                             session->session_name(),
+                             partition.partition_token(), params.statement));
     }
     return query_partitions;
   }
@@ -799,7 +837,8 @@ ConnectionImpl::PartitionQueryImpl(
 
 StatusOr<spanner::BatchDmlResult> ConnectionImpl::ExecuteBatchDmlImpl(
     SessionHolder& session, StatusOr<spanner_proto::TransactionSelector>& s,
-    std::int64_t seqno, ExecuteBatchDmlParams params) {
+    std::string const& transaction_tag, std::int64_t seqno,
+    ExecuteBatchDmlParams params) {
   if (!s.ok()) {
     return s.status();
   }
@@ -819,8 +858,15 @@ StatusOr<spanner::BatchDmlResult> ConnectionImpl::ExecuteBatchDmlImpl(
   request.mutable_request_options()->set_priority(
       params.options.has<spanner::RequestPriorityOption>()
           ? ProtoRequestPriority(
-                params.options.lookup<spanner::RequestPriorityOption>())
+                params.options.get<spanner::RequestPriorityOption>())
           : spanner_proto::RequestOptions::PRIORITY_UNSPECIFIED);
+  auto const& request_tag = params.options.get<spanner::RequestTagOption>();
+  if (!request_tag.empty()) {
+    request.mutable_request_options()->set_request_tag(request_tag);
+  }
+  if (!transaction_tag.empty()) {
+    request.mutable_request_options()->set_transaction_tag(transaction_tag);
+  }
 
   auto stub = session_pool_->GetStub(*session);
   for (;;) {
@@ -840,7 +886,8 @@ StatusOr<spanner::BatchDmlResult> ConnectionImpl::ExecuteBatchDmlImpl(
         }
         s->set_id(response->result_sets(0).metadata().transaction().id());
       } else {
-        auto begin = BeginTransaction(session, s->begin(), __func__);
+        auto begin = BeginTransaction(session, s->begin(), request_tag,
+                                      transaction_tag, __func__);
         if (begin.ok()) {
           s->set_id(begin->id());
           *request.mutable_transaction() = *s;
@@ -866,7 +913,8 @@ StatusOr<spanner::BatchDmlResult> ConnectionImpl::ExecuteBatchDmlImpl(
 StatusOr<spanner::PartitionedDmlResult>
 ConnectionImpl::ExecutePartitionedDmlImpl(
     SessionHolder& session, StatusOr<spanner_proto::TransactionSelector>& s,
-    std::int64_t seqno, ExecutePartitionedDmlParams params) {
+    std::string const& transaction_tag, std::int64_t seqno,
+    ExecutePartitionedDmlParams params) {
   if (!s.ok()) {
     return s.status();
   }
@@ -875,20 +923,23 @@ ConnectionImpl::ExecutePartitionedDmlImpl(
   if (!prepare_status.ok()) {
     return prepare_status;
   }
-  auto begin =
-      BeginTransaction(session, PartitionedDmlTransactionOptions(), __func__);
+  auto begin = BeginTransaction(
+      session, PartitionedDmlTransactionOptions(),
+      params.query_options.request_tag().value_or(std::string()),
+      transaction_tag, __func__);
   if (!begin.ok()) {
     s = begin.status();  // invalidate the transaction
     return begin.status();
   }
   s->set_id(begin->id());
 
-  SqlParams sql_params(
-      {MakeTransactionFromIds(session->session_name(), begin->id()),
-       std::move(params.statement), std::move(params.query_options),
-       /*partition_token=*/{}});
+  SqlParams sql_params({MakeTransactionFromIds(session->session_name(),
+                                               begin->id(), transaction_tag),
+                        std::move(params.statement),
+                        std::move(params.query_options),
+                        /*partition_token=*/{}});
   auto dml_result = CommonQueryImpl<StreamingPartitionedDmlResult>(
-      session, s, seqno, std::move(sql_params),
+      session, s, transaction_tag, seqno, std::move(sql_params),
       spanner_proto::ExecuteSqlRequest::NORMAL);
   auto rows_modified = dml_result.RowsModifiedLowerBound();
   if (!rows_modified.ok()) {
@@ -903,7 +954,7 @@ ConnectionImpl::ExecutePartitionedDmlImpl(
 
 StatusOr<spanner::CommitResult> ConnectionImpl::CommitImpl(
     SessionHolder& session, StatusOr<spanner_proto::TransactionSelector>& s,
-    CommitParams params) {
+    std::string const& transaction_tag, CommitParams params) {
   if (!s.ok()) {
     // Fail the commit if the transaction has been invalidated.
     return s.status();
@@ -922,10 +973,17 @@ StatusOr<spanner::CommitResult> ConnectionImpl::CommitImpl(
   request.set_return_commit_stats(params.options.return_stats());
   request.mutable_request_options()->set_priority(
       ProtoRequestPriority(params.options.request_priority()));
+  if (!transaction_tag.empty()) {
+    // params.options.transaction_tag() was either already used to set
+    // transaction_tag (for a library-generated transaction), or it is
+    // ignored (for a user-supplied transaction).
+    request.mutable_request_options()->set_transaction_tag(transaction_tag);
+  }
 
   if (s->selector_case() != spanner_proto::TransactionSelector::kId) {
-    auto begin = BeginTransaction(
-        session, s->has_begin() ? s->begin() : s->single_use(), __func__);
+    auto begin =
+        BeginTransaction(session, s->has_begin() ? s->begin() : s->single_use(),
+                         std::string(), transaction_tag, __func__);
     if (!begin.ok()) {
       s = begin.status();  // invalidate the transaction
       return begin.status();
@@ -968,7 +1026,8 @@ StatusOr<spanner::CommitResult> ConnectionImpl::CommitImpl(
 }
 
 Status ConnectionImpl::RollbackImpl(
-    SessionHolder& session, StatusOr<spanner_proto::TransactionSelector>& s) {
+    SessionHolder& session, StatusOr<spanner_proto::TransactionSelector>& s,
+    std::string const& transaction_tag) {
   if (!s.ok()) {
     return s.status();
   }
@@ -983,7 +1042,8 @@ Status ConnectionImpl::RollbackImpl(
   }
 
   if (s->has_begin()) {
-    auto begin = BeginTransaction(session, s->begin(), __func__);
+    auto begin = BeginTransaction(session, s->begin(), std::string(),
+                                  transaction_tag, __func__);
     if (!begin.ok()) {
       s = begin.status();  // invalidate the transaction
       return begin.status();

--- a/google/cloud/spanner/internal/connection_impl.h
+++ b/google/cloud/spanner/internal/connection_impl.h
@@ -32,6 +32,7 @@
 #include <cstdint>
 #include <memory>
 #include <mutex>
+#include <string>
 #include <vector>
 
 namespace google {
@@ -72,71 +73,76 @@ class ConnectionImpl : public spanner::Connection {
 
   StatusOr<google::spanner::v1::Transaction> BeginTransaction(
       SessionHolder& session, google::spanner::v1::TransactionOptions options,
+      std::string request_tag, std::string const& transaction_tag,
       char const* func);
 
   spanner::RowStream ReadImpl(
       SessionHolder& session,
-      StatusOr<google::spanner::v1::TransactionSelector>& s, ReadParams params);
+      StatusOr<google::spanner::v1::TransactionSelector>& s,
+      std::string const& transaction_tag, ReadParams params);
 
   StatusOr<std::vector<spanner::ReadPartition>> PartitionReadImpl(
       SessionHolder& session,
       StatusOr<google::spanner::v1::TransactionSelector>& s,
-      ReadParams const& params,
+      std::string const& transaction_tag, ReadParams const& params,
       spanner::PartitionOptions const& partition_options);
 
   spanner::RowStream ExecuteQueryImpl(
       SessionHolder& session,
-      StatusOr<google::spanner::v1::TransactionSelector>& s, std::int64_t seqno,
-      SqlParams params);
+      StatusOr<google::spanner::v1::TransactionSelector>& s,
+      std::string const& transaction_tag, std::int64_t seqno, SqlParams params);
 
   StatusOr<spanner::DmlResult> ExecuteDmlImpl(
       SessionHolder& session,
-      StatusOr<google::spanner::v1::TransactionSelector>& s, std::int64_t seqno,
-      SqlParams params);
+      StatusOr<google::spanner::v1::TransactionSelector>& s,
+      std::string const& transaction_tag, std::int64_t seqno, SqlParams params);
 
   spanner::ProfileQueryResult ProfileQueryImpl(
       SessionHolder& session,
-      StatusOr<google::spanner::v1::TransactionSelector>& s, std::int64_t seqno,
-      SqlParams params);
+      StatusOr<google::spanner::v1::TransactionSelector>& s,
+      std::string const& transaction_tag, std::int64_t seqno, SqlParams params);
 
   StatusOr<spanner::ProfileDmlResult> ProfileDmlImpl(
       SessionHolder& session,
-      StatusOr<google::spanner::v1::TransactionSelector>& s, std::int64_t seqno,
-      SqlParams params);
+      StatusOr<google::spanner::v1::TransactionSelector>& s,
+      std::string const& transaction_tag, std::int64_t seqno, SqlParams params);
 
   StatusOr<spanner::ExecutionPlan> AnalyzeSqlImpl(
       SessionHolder& session,
-      StatusOr<google::spanner::v1::TransactionSelector>& s, std::int64_t seqno,
-      SqlParams params);
+      StatusOr<google::spanner::v1::TransactionSelector>& s,
+      std::string const& transaction_tag, std::int64_t seqno, SqlParams params);
 
   StatusOr<spanner::PartitionedDmlResult> ExecutePartitionedDmlImpl(
       SessionHolder& session,
-      StatusOr<google::spanner::v1::TransactionSelector>& s, std::int64_t seqno,
+      StatusOr<google::spanner::v1::TransactionSelector>& s,
+      std::string const& transaction_tag, std::int64_t seqno,
       ExecutePartitionedDmlParams params);
 
   StatusOr<std::vector<spanner::QueryPartition>> PartitionQueryImpl(
       SessionHolder& session,
       StatusOr<google::spanner::v1::TransactionSelector>& s,
-      PartitionQueryParams const& params);
+      std::string const& transaction_tag, PartitionQueryParams const& params);
 
   StatusOr<spanner::BatchDmlResult> ExecuteBatchDmlImpl(
       SessionHolder& session,
-      StatusOr<google::spanner::v1::TransactionSelector>& s, std::int64_t seqno,
+      StatusOr<google::spanner::v1::TransactionSelector>& s,
+      std::string const& transaction_tag, std::int64_t seqno,
       ExecuteBatchDmlParams params);
 
   StatusOr<spanner::CommitResult> CommitImpl(
       SessionHolder& session,
       StatusOr<google::spanner::v1::TransactionSelector>& s,
-      CommitParams params);
+      std::string const& transaction_tag, CommitParams params);
 
   Status RollbackImpl(SessionHolder& session,
-                      StatusOr<google::spanner::v1::TransactionSelector>& s);
+                      StatusOr<google::spanner::v1::TransactionSelector>& s,
+                      std::string const& transaction_tag);
 
   template <typename ResultType>
   StatusOr<ResultType> ExecuteSqlImpl(
       SessionHolder& session,
-      StatusOr<google::spanner::v1::TransactionSelector>& s, std::int64_t seqno,
-      SqlParams params,
+      StatusOr<google::spanner::v1::TransactionSelector>& s,
+      std::string const& transaction_tag, std::int64_t seqno, SqlParams params,
       google::spanner::v1::ExecuteSqlRequest::QueryMode query_mode,
       std::function<StatusOr<std::unique_ptr<ResultSourceInterface>>(
           google::spanner::v1::ExecuteSqlRequest& request)> const&
@@ -145,14 +151,14 @@ class ConnectionImpl : public spanner::Connection {
   template <typename ResultType>
   ResultType CommonQueryImpl(
       SessionHolder& session,
-      StatusOr<google::spanner::v1::TransactionSelector>& s, std::int64_t seqno,
-      SqlParams params,
+      StatusOr<google::spanner::v1::TransactionSelector>& s,
+      std::string const& transaction_tag, std::int64_t seqno, SqlParams params,
       google::spanner::v1::ExecuteSqlRequest::QueryMode query_mode);
   template <typename ResultType>
   StatusOr<ResultType> CommonDmlImpl(
       SessionHolder& session,
-      StatusOr<google::spanner::v1::TransactionSelector>& s, std::int64_t seqno,
-      SqlParams params,
+      StatusOr<google::spanner::v1::TransactionSelector>& s,
+      std::string const& transaction_tag, std::int64_t seqno, SqlParams params,
       google::spanner::v1::ExecuteSqlRequest::QueryMode query_mode);
 
   spanner::Database db_;

--- a/google/cloud/spanner/internal/transaction_impl.h
+++ b/google/cloud/spanner/internal/transaction_impl.h
@@ -25,6 +25,7 @@
 #include <cstdint>
 #include <memory>
 #include <mutex>
+#include <string>
 
 namespace google {
 namespace cloud {
@@ -34,24 +35,29 @@ inline namespace SPANNER_CLIENT_NS {
 template <typename Functor>
 using VisitInvokeResult = ::google::cloud::internal::invoke_result_t<
     Functor, SessionHolder&,
-    StatusOr<google::spanner::v1::TransactionSelector>&, std::int64_t>;
+    StatusOr<google::spanner::v1::TransactionSelector>&, std::string const&,
+    std::int64_t>;
 
 /**
  * The internal representation of a google::cloud::spanner::Transaction.
  */
 class TransactionImpl {
  public:
-  explicit TransactionImpl(google::spanner::v1::TransactionSelector selector)
-      : TransactionImpl(/*session=*/{}, std::move(selector)) {}
+  TransactionImpl(google::spanner::v1::TransactionSelector selector,
+                  std::string tag)
+      : TransactionImpl(/*session=*/{}, std::move(selector), std::move(tag)) {}
 
   TransactionImpl(TransactionImpl const& impl,
-                  google::spanner::v1::TransactionSelector selector)
-      : TransactionImpl(impl.session_, std::move(selector)) {}
+                  google::spanner::v1::TransactionSelector selector,
+                  std::string tag)
+      : TransactionImpl(impl.session_, std::move(selector), std::move(tag)) {}
 
   TransactionImpl(SessionHolder session,
-                  google::spanner::v1::TransactionSelector selector)
+                  google::spanner::v1::TransactionSelector selector,
+                  std::string tag)
       : session_(std::move(session)),
         selector_(std::move(selector)),
+        tag_(std::move(tag)),
         seqno_(0) {
     state_ = selector_->has_begin() ? State::kBegin : State::kDone;
   }
@@ -75,13 +81,14 @@ class TransactionImpl {
   // must not modify it. Rather it should use either the transaction ID or
   // the error state in a manner appropriate for the operation.
   //
-  // A monotonically-increasing sequence number is also passed to the functor.
+  // A tag string and a monotonically-increasing sequence number are also
+  // passed to the functor.
   template <typename Functor>
   VisitInvokeResult<Functor> Visit(Functor&& f) {
     static_assert(google::cloud::internal::is_invocable<
                       Functor, SessionHolder&,
                       StatusOr<google::spanner::v1::TransactionSelector>&,
-                      std::int64_t>::value,
+                      std::string const&, std::int64_t>::value,
                   "TransactionImpl::Visit() functor has incompatible type.");
     std::int64_t seqno;
     {
@@ -90,7 +97,7 @@ class TransactionImpl {
       cond_.wait(lock, [this] { return state_ != State::kPending; });
       if (state_ == State::kDone) {
         lock.unlock();
-        return f(session_, selector_, seqno);
+        return f(session_, selector_, tag_, seqno);
       }
       state_ = State::kPending;
     }
@@ -98,7 +105,7 @@ class TransactionImpl {
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
     try {
 #endif
-      auto r = f(session_, selector_, seqno);
+      auto r = f(session_, selector_, tag_, seqno);
       bool done = false;
       {
         std::lock_guard<std::mutex> lock(mu_);
@@ -136,6 +143,7 @@ class TransactionImpl {
   std::condition_variable cond_;
   SessionHolder session_;
   StatusOr<google::spanner::v1::TransactionSelector> selector_;
+  std::string tag_;  // would be nicer as a selector_.begin.read_write.tag
   std::int64_t seqno_;
 };
 

--- a/google/cloud/spanner/options.h
+++ b/google/cloud/spanner/options.h
@@ -164,9 +164,16 @@ struct RequestPriorityOption {
 };
 
 /**
+ * Option for `google::cloud::Options` to set a per-request tag.
+ */
+struct RequestTagOption {
+  using Type = std::string;
+};
+
+/**
  * List of all Request options.
  */
-using RequestOptionList = OptionList<RequestPriorityOption>;
+using RequestOptionList = OptionList<RequestPriorityOption, RequestTagOption>;
 
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner

--- a/google/cloud/spanner/query_options.h
+++ b/google/cloud/spanner/query_options.h
@@ -82,8 +82,20 @@ class QueryOptions {
     return *this;
   }
 
+  /// Returns the request tag.
+  absl::optional<std::string> const& request_tag() const {
+    return request_tag_;
+  }
+
+  /// Sets the request tag.
+  QueryOptions& set_request_tag(absl::optional<std::string> tag) {
+    request_tag_ = std::move(tag);
+    return *this;
+  }
+
   friend bool operator==(QueryOptions const& a, QueryOptions const& b) {
     return a.request_priority_ == b.request_priority_ &&
+           a.request_tag_ == b.request_tag_ &&
            a.optimizer_version_ == b.optimizer_version_ &&
            a.optimizer_statistics_package_ == b.optimizer_statistics_package_;
   }
@@ -98,6 +110,7 @@ class QueryOptions {
   absl::optional<std::string> optimizer_version_;
   absl::optional<std::string> optimizer_statistics_package_;
   absl::optional<RequestPriority> request_priority_;
+  absl::optional<std::string> request_tag_;
 };
 
 }  // namespace SPANNER_CLIENT_NS

--- a/google/cloud/spanner/query_options_test.cc
+++ b/google/cloud/spanner/query_options_test.cc
@@ -30,6 +30,28 @@ TEST(QueryOptionsTest, Values) {
   auto copy = default_constructed;
   EXPECT_EQ(copy, default_constructed);
 
+  copy.set_request_priority(RequestPriority::kLow);
+  EXPECT_NE(copy, default_constructed);
+  copy.set_request_priority(RequestPriority::kHigh);
+  EXPECT_NE(copy, default_constructed);
+
+  copy.set_request_priority(absl::optional<RequestPriority>{});
+  EXPECT_EQ(copy, default_constructed);
+
+  copy.set_request_tag("foo");
+  EXPECT_NE(copy, default_constructed);
+
+  copy.set_request_tag(absl::optional<std::string>{});
+  EXPECT_EQ(copy, default_constructed);
+}
+
+TEST(QueryOptionsTest, OptimizerVersion) {
+  QueryOptions const default_constructed{};
+  EXPECT_FALSE(default_constructed.optimizer_statistics_package().has_value());
+
+  auto copy = default_constructed;
+  EXPECT_EQ(copy, default_constructed);
+
   copy.set_optimizer_version("");
   EXPECT_NE(copy, default_constructed);
   EXPECT_EQ("", copy.optimizer_version().value());
@@ -58,14 +80,6 @@ TEST(QueryOptionsTest, OptimizerStatisticsPackage) {
   EXPECT_EQ("foo", copy.optimizer_statistics_package().value());
 
   copy.set_optimizer_statistics_package(absl::nullopt);
-  EXPECT_EQ(copy, default_constructed);
-
-  copy.set_request_priority(RequestPriority::kLow);
-  EXPECT_NE(copy, default_constructed);
-  copy.set_request_priority(RequestPriority::kHigh);
-  EXPECT_NE(copy, default_constructed);
-
-  copy.set_request_priority(absl::optional<RequestPriority>{});
   EXPECT_EQ(copy, default_constructed);
 }
 

--- a/google/cloud/spanner/read_options.h
+++ b/google/cloud/spanner/read_options.h
@@ -45,12 +45,17 @@ struct ReadOptions {
    * Priority for the read request.
    */
   absl::optional<RequestPriority> request_priority;
+
+  /**
+   * Tag for the read request.
+   */
+  absl::optional<std::string> request_tag;
 };
 
 inline bool operator==(ReadOptions const& lhs, ReadOptions const& rhs) {
   return lhs.limit == rhs.limit &&
          lhs.request_priority == rhs.request_priority &&
-         lhs.index_name == rhs.index_name;
+         lhs.request_tag == rhs.request_tag && lhs.index_name == rhs.index_name;
 }
 
 inline bool operator!=(ReadOptions const& lhs, ReadOptions const& rhs) {

--- a/google/cloud/spanner/read_options_test.cc
+++ b/google/cloud/spanner/read_options_test.cc
@@ -41,6 +41,11 @@ TEST(ReadOptionsTest, Equality) {
   test_options_1.request_priority = RequestPriority::kLow;
   EXPECT_EQ(test_options_0, test_options_1);
 
+  test_options_0.request_tag = "tag";
+  EXPECT_NE(test_options_0, test_options_1);
+  test_options_1.request_tag = "tag";
+  EXPECT_EQ(test_options_0, test_options_1);
+
   ReadOptions test_options_2 = test_options_0;
   EXPECT_EQ(test_options_0, test_options_2);
 }

--- a/google/cloud/spanner/read_partition.cc
+++ b/google/cloud/spanner/read_partition.cc
@@ -20,7 +20,9 @@ namespace cloud {
 namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
 
-ReadPartition::ReadPartition(std::string transaction_id, std::string session_id,
+ReadPartition::ReadPartition(std::string transaction_id,
+                             std::string transaction_tag,
+                             std::string session_id,
                              std::string partition_token,
                              std::string table_name,
                              google::cloud::spanner::KeySet key_set,
@@ -53,6 +55,15 @@ ReadPartition::ReadPartition(std::string transaction_id, std::string session_id,
         break;
     }
   }
+  if (read_options.request_tag.has_value() &&
+      !read_options.request_tag->empty()) {
+    proto_.mutable_request_options()->set_request_tag(
+        *std::move(read_options.request_tag));
+  }
+  if (!transaction_tag.empty()) {
+    proto_.mutable_request_options()->set_transaction_tag(
+        std::move(transaction_tag));
+  }
 }
 
 google::cloud::spanner::ReadOptions ReadPartition::ReadOptions() const {
@@ -72,6 +83,9 @@ google::cloud::spanner::ReadOptions ReadPartition::ReadOptions() const {
         break;
       default:
         break;
+    }
+    if (!proto_.request_options().request_tag().empty()) {
+      options.request_tag = proto_.request_options().request_tag();
     }
   }
   return options;

--- a/google/cloud/spanner/testing/matchers.h
+++ b/google/cloud/spanner/testing/matchers.h
@@ -28,14 +28,14 @@ namespace cloud {
 namespace spanner_testing {
 inline namespace SPANNER_CLIENT_NS {
 
-/// Verifies a `Transaction` has the expected Session and Transaction IDs
-MATCHER_P2(
-    HasSessionAndTransactionId, session_id, transaction_id,
+/// Verifies a `Transaction` has the expected Session and ID/tag.
+MATCHER_P3(
+    HasSessionAndTransaction, session_id, transaction_id, transaction_tag,
     "Verifies a Transaction has the expected Session and Transaction IDs") {
   return google::cloud::spanner_internal::Visit(
-      arg,
-      [&](google::cloud::spanner_internal::SessionHolder& session,
-          StatusOr<google::spanner::v1::TransactionSelector>& s, std::int64_t) {
+      arg, [&](google::cloud::spanner_internal::SessionHolder& session,
+               StatusOr<google::spanner::v1::TransactionSelector>& s,
+               std::string const& tag, std::int64_t) {
         bool result = true;
         if (!session) {
           *result_listener << "Session ID missing (expected " << session_id
@@ -55,6 +55,11 @@ MATCHER_P2(
         } else if (s->id() != transaction_id) {
           *result_listener << "Transaction ID mismatch: " << s->id()
                            << " != " << transaction_id;
+          result = false;
+        }
+        if (tag != transaction_tag) {
+          *result_listener << "Transaction tag mismatch: " << tag
+                           << " != " << transaction_tag;
           result = false;
         }
         return result;


### PR DESCRIPTION
Add support for setting string tags on database operations that have
stored statistics, such as reads, queries and transactions. The tags
allow the statistics to be grouped, making them easily searchable and
more useful.

Specifically, ...
- `ReadOptions` and `QueryOptions` now include a request tag,
- `ExecuteBatchDml()` options now includes a `RequestTagOption`,
- `Transaction::ReadWriteOptions` can have a transaction tag, and
- `CommitOptions` now includes a transaction tag.

Add the `spanner_set_transaction_tag` and `spanner_set_request_tag`
samples.

Fixes #5258.