### PR TITLE
cleanup: fix west const to east const

### DIFF
--- a/generator/generator_test.cc
+++ b/generator/generator_test.cc
@@ -40,7 +40,7 @@ class StringSourceTree : public google::protobuf::compiler::SourceTree {
       : files_(std::move(files)) {}
 
   google::protobuf::io::ZeroCopyInputStream* Open(
-      const std::string& filename) override {
+      std::string const& filename) override {
     auto iter = files_.find(filename);
     return iter == files_.end() ? nullptr
                                 : new google::protobuf::io::ArrayInputStream(
@@ -58,15 +58,15 @@ class AbortingErrorCollector : public DescriptorPool::ErrorCollector {
   AbortingErrorCollector(AbortingErrorCollector const&) = delete;
   AbortingErrorCollector& operator=(AbortingErrorCollector const&) = delete;
 
-  void AddError(const std::string& filename, const std::string& element_name,
-                const google::protobuf::Message*, ErrorLocation,
-                const std::string& error_message) override {
+  void AddError(std::string const& filename, std::string const& element_name,
+                google::protobuf::Message const*, ErrorLocation,
+                std::string const& error_message) override {
     GCP_LOG(FATAL) << "AddError() called unexpectedly: " << filename << " ["
                    << element_name << "]: " << error_message;
   }
 };
 
-const char* const kSuccessServiceProto =
+char const* const kSuccessServiceProto =
     "syntax = \"proto3\";\n"
     "package google.foo.v1;\n"
     "// Leading comments about service SuccessService.\n"
@@ -111,7 +111,7 @@ TEST_F(GeneratorTest, GenericService) {
   generic_service_file.set_name("google/generic/v1/generic.proto");
   generic_service_file.add_service()->set_name("GenericService");
   generic_service_file.mutable_options()->set_cc_generic_services(true);
-  const FileDescriptor* generic_service_file_descriptor =
+  FileDescriptor const* generic_service_file_descriptor =
       pool.BuildFile(generic_service_file);
 
   Generator generator;
@@ -128,7 +128,7 @@ TEST_F(GeneratorTest, BadCommandLineArgs) {
   service_file.set_name("google/foo/v1/service.proto");
   service_file.add_service()->set_name("Service");
   service_file.mutable_options()->set_cc_generic_services(false);
-  const FileDescriptor* service_file_descriptor = pool.BuildFile(service_file);
+  FileDescriptor const* service_file_descriptor = pool.BuildFile(service_file);
 
   Generator generator;
   std::string actual_error;
@@ -148,7 +148,7 @@ TEST_F(GeneratorTest, GenerateServicesSuccess) {
     output = absl::make_unique<generator_testing::MockZeroCopyOutputStream>();
   }
 
-  const FileDescriptor* service_file_descriptor =
+  FileDescriptor const* service_file_descriptor =
       pool_.FindFileByName("google/foo/v1/service.proto");
 
   for (auto& output : mock_outputs) {

--- a/generator/integration_tests/golden/tests/golden_kitchen_sink_stub_test.cc
+++ b/generator/integration_tests/golden/tests/golden_kitchen_sink_stub_test.cc
@@ -37,7 +37,7 @@ class MockGrpcGoldenKitchenSinkStub : public ::google::test::admin::database::
   MOCK_METHOD(
       ::grpc::Status, GenerateAccessToken,
       (::grpc::ClientContext * context,
-       const ::google::test::admin::database::v1::GenerateAccessTokenRequest&
+       ::google::test::admin::database::v1::GenerateAccessTokenRequest const&
            request,
        ::google::test::admin::database::v1::GenerateAccessTokenResponse*
            response),
@@ -45,7 +45,7 @@ class MockGrpcGoldenKitchenSinkStub : public ::google::test::admin::database::
   MOCK_METHOD(
       ::grpc::Status, GenerateIdToken,
       (::grpc::ClientContext * context,
-       const ::google::test::admin::database::v1::GenerateIdTokenRequest&
+       ::google::test::admin::database::v1::GenerateIdTokenRequest const&
            request,
        ::google::test::admin::database::v1::GenerateIdTokenResponse* response),
       (override));
@@ -54,7 +54,7 @@ class MockGrpcGoldenKitchenSinkStub : public ::google::test::admin::database::
           ::google::test::admin::database::v1::GenerateAccessTokenResponse>*,
       AsyncGenerateAccessTokenRaw,
       (::grpc::ClientContext * context,
-       const ::google::test::admin::database::v1::GenerateAccessTokenRequest&
+       ::google::test::admin::database::v1::GenerateAccessTokenRequest const&
            request,
        ::grpc::CompletionQueue* cq),
       (override));
@@ -63,7 +63,7 @@ class MockGrpcGoldenKitchenSinkStub : public ::google::test::admin::database::
           ::google::test::admin::database::v1::GenerateAccessTokenResponse>*,
       PrepareAsyncGenerateAccessTokenRaw,
       (::grpc::ClientContext * context,
-       const ::google::test::admin::database::v1::GenerateAccessTokenRequest&
+       ::google::test::admin::database::v1::GenerateAccessTokenRequest const&
            request,
        ::grpc::CompletionQueue* cq),
       (override));
@@ -72,7 +72,7 @@ class MockGrpcGoldenKitchenSinkStub : public ::google::test::admin::database::
           ::google::test::admin::database::v1::GenerateIdTokenResponse>*,
       AsyncGenerateIdTokenRaw,
       (::grpc::ClientContext * context,
-       const ::google::test::admin::database::v1::GenerateIdTokenRequest&
+       ::google::test::admin::database::v1::GenerateIdTokenRequest const&
            request,
        ::grpc::CompletionQueue* cq),
       (override));
@@ -81,14 +81,14 @@ class MockGrpcGoldenKitchenSinkStub : public ::google::test::admin::database::
           ::google::test::admin::database::v1::GenerateIdTokenResponse>*,
       PrepareAsyncGenerateIdTokenRaw,
       (::grpc::ClientContext * context,
-       const ::google::test::admin::database::v1::GenerateIdTokenRequest&
+       ::google::test::admin::database::v1::GenerateIdTokenRequest const&
            request,
        ::grpc::CompletionQueue* cq),
       (override));
   MOCK_METHOD(
       ::grpc::Status, WriteLogEntries,
       (::grpc::ClientContext * context,
-       const ::google::test::admin::database::v1::WriteLogEntriesRequest&
+       ::google::test::admin::database::v1::WriteLogEntriesRequest const&
            request,
        ::google::test::admin::database::v1::WriteLogEntriesResponse* response),
       (override));
@@ -97,7 +97,7 @@ class MockGrpcGoldenKitchenSinkStub : public ::google::test::admin::database::
           ::google::test::admin::database::v1::WriteLogEntriesResponse>*,
       AsyncWriteLogEntriesRaw,
       (::grpc::ClientContext * context,
-       const ::google::test::admin::database::v1::WriteLogEntriesRequest&
+       ::google::test::admin::database::v1::WriteLogEntriesRequest const&
            request,
        ::grpc::CompletionQueue* cq),
       (override));
@@ -106,14 +106,14 @@ class MockGrpcGoldenKitchenSinkStub : public ::google::test::admin::database::
           ::google::test::admin::database::v1::WriteLogEntriesResponse>*,
       PrepareAsyncWriteLogEntriesRaw,
       (::grpc::ClientContext * context,
-       const ::google::test::admin::database::v1::WriteLogEntriesRequest&
+       ::google::test::admin::database::v1::WriteLogEntriesRequest const&
            request,
        ::grpc::CompletionQueue* cq),
       (override));
   MOCK_METHOD(
       ::grpc::Status, ListLogs,
       (::grpc::ClientContext * context,
-       const ::google::test::admin::database::v1::ListLogsRequest& request,
+       ::google::test::admin::database::v1::ListLogsRequest const& request,
        ::google::test::admin::database::v1::ListLogsResponse* response),
       (override));
   MOCK_METHOD(
@@ -121,7 +121,7 @@ class MockGrpcGoldenKitchenSinkStub : public ::google::test::admin::database::
           ::google::test::admin::database::v1::ListLogsResponse>*,
       AsyncListLogsRaw,
       (::grpc::ClientContext * context,
-       const ::google::test::admin::database::v1::ListLogsRequest& request,
+       ::google::test::admin::database::v1::ListLogsRequest const& request,
        ::grpc::CompletionQueue* cq),
       (override));
   MOCK_METHOD(
@@ -129,21 +129,21 @@ class MockGrpcGoldenKitchenSinkStub : public ::google::test::admin::database::
           ::google::test::admin::database::v1::ListLogsResponse>*,
       PrepareAsyncListLogsRaw,
       (::grpc::ClientContext * context,
-       const ::google::test::admin::database::v1::ListLogsRequest& request,
+       ::google::test::admin::database::v1::ListLogsRequest const& request,
        ::grpc::CompletionQueue* cq),
       (override));
   MOCK_METHOD(::grpc::ClientReaderInterface<
                   ::google::test::admin::database::v1::TailLogEntriesResponse>*,
               TailLogEntriesRaw,
               (::grpc::ClientContext * context,
-               const ::google::test::admin::database::v1::TailLogEntriesRequest&
+               ::google::test::admin::database::v1::TailLogEntriesRequest const&
                    request),
               (override));
   MOCK_METHOD(::grpc::ClientAsyncReaderInterface<
                   ::google::test::admin::database::v1::TailLogEntriesResponse>*,
               AsyncTailLogEntriesRaw,
               (::grpc::ClientContext * context,
-               const ::google::test::admin::database::v1::TailLogEntriesRequest&
+               ::google::test::admin::database::v1::TailLogEntriesRequest const&
                    request,
                ::grpc::CompletionQueue* cq, void* tag),
               (override));
@@ -151,48 +151,48 @@ class MockGrpcGoldenKitchenSinkStub : public ::google::test::admin::database::
                   ::google::test::admin::database::v1::TailLogEntriesResponse>*,
               PrepareAsyncTailLogEntriesRaw,
               (::grpc::ClientContext * context,
-               const ::google::test::admin::database::v1::TailLogEntriesRequest&
+               ::google::test::admin::database::v1::TailLogEntriesRequest const&
                    request,
                ::grpc::CompletionQueue* cq),
               (override));
   MOCK_METHOD(::grpc::Status, Omitted1,
               (::grpc::ClientContext * context,
-               const ::google::protobuf::Empty& request,
+               ::google::protobuf::Empty const& request,
                ::google::protobuf::Empty* response),
               (override));
   MOCK_METHOD(
       ::grpc::ClientAsyncResponseReaderInterface< ::google::protobuf::Empty>*,
       AsyncOmitted1Raw,
       (::grpc::ClientContext * context,
-       const ::google::protobuf::Empty& request, ::grpc::CompletionQueue* cq),
+       ::google::protobuf::Empty const& request, ::grpc::CompletionQueue* cq),
       (override));
   MOCK_METHOD(
       ::grpc::ClientAsyncResponseReaderInterface< ::google::protobuf::Empty>*,
       PrepareAsyncOmitted1Raw,
       (::grpc::ClientContext * context,
-       const ::google::protobuf::Empty& request, ::grpc::CompletionQueue* cq),
+       ::google::protobuf::Empty const& request, ::grpc::CompletionQueue* cq),
       (override));
   MOCK_METHOD(::grpc::Status, Omitted2,
               (::grpc::ClientContext * context,
-               const ::google::protobuf::Empty& request,
+               ::google::protobuf::Empty const& request,
                ::google::protobuf::Empty* response),
               (override));
   MOCK_METHOD(
       ::grpc::ClientAsyncResponseReaderInterface< ::google::protobuf::Empty>*,
       AsyncOmitted2Raw,
       (::grpc::ClientContext * context,
-       const ::google::protobuf::Empty& request, ::grpc::CompletionQueue* cq),
+       ::google::protobuf::Empty const& request, ::grpc::CompletionQueue* cq),
       (override));
   MOCK_METHOD(
       ::grpc::ClientAsyncResponseReaderInterface< ::google::protobuf::Empty>*,
       PrepareAsyncOmitted2Raw,
       (::grpc::ClientContext * context,
-       const ::google::protobuf::Empty& request, ::grpc::CompletionQueue* cq),
+       ::google::protobuf::Empty const& request, ::grpc::CompletionQueue* cq),
       (override));
   MOCK_METHOD(
       ::grpc::Status, ListServiceAccountKeys,
       (::grpc::ClientContext * context,
-       const ::google::test::admin::database::v1::ListServiceAccountKeysRequest&
+       ::google::test::admin::database::v1::ListServiceAccountKeysRequest const&
            request,
        ::google::test::admin::database::v1::ListServiceAccountKeysResponse*
            response),
@@ -203,7 +203,7 @@ class MockGrpcGoldenKitchenSinkStub : public ::google::test::admin::database::
           ::google::test::admin::database::v1::ListServiceAccountKeysResponse>*,
       AsyncListServiceAccountKeysRaw,
       (::grpc::ClientContext * context,
-       const ::google::test::admin::database::v1::ListServiceAccountKeysRequest&
+       ::google::test::admin::database::v1::ListServiceAccountKeysRequest const&
            request,
        ::grpc::CompletionQueue* cq),
       (override));
@@ -212,7 +212,7 @@ class MockGrpcGoldenKitchenSinkStub : public ::google::test::admin::database::
           ::google::test::admin::database::v1::ListServiceAccountKeysResponse>*,
       PrepareAsyncListServiceAccountKeysRaw,
       (::grpc::ClientContext * context,
-       const ::google::test::admin::database::v1::ListServiceAccountKeysRequest&
+       ::google::test::admin::database::v1::ListServiceAccountKeysRequest const&
            request,
        ::grpc::CompletionQueue* cq),
       (override));

--- a/generator/integration_tests/golden/tests/golden_thing_admin_stub_test.cc
+++ b/generator/integration_tests/golden/tests/golden_thing_admin_stub_test.cc
@@ -41,97 +41,97 @@ class MockGrpcGoldenThingAdminStub : public ::google::test::admin::database::
   MOCK_METHOD(
       ::grpc::Status, ListDatabases,
       (::grpc::ClientContext * context,
-       const ::google::test::admin::database::v1::ListDatabasesRequest& request,
+       ::google::test::admin::database::v1::ListDatabasesRequest const& request,
        ::google::test::admin::database::v1::ListDatabasesResponse* response),
       (override));
   MOCK_METHOD(::grpc::Status, CreateDatabase,
               (::grpc::ClientContext * context,
-               const ::google::test::admin::database::v1::CreateDatabaseRequest&
+               ::google::test::admin::database::v1::CreateDatabaseRequest const&
                    request,
                ::google::longrunning::Operation* response),
               (override));
   MOCK_METHOD(
       ::grpc::Status, GetDatabase,
       (::grpc::ClientContext * context,
-       const ::google::test::admin::database::v1::GetDatabaseRequest& request,
+       ::google::test::admin::database::v1::GetDatabaseRequest const& request,
        ::google::test::admin::database::v1::Database* response),
       (override));
   MOCK_METHOD(
       ::grpc::Status, UpdateDatabaseDdl,
       (::grpc::ClientContext * context,
-       const ::google::test::admin::database::v1::UpdateDatabaseDdlRequest&
+       ::google::test::admin::database::v1::UpdateDatabaseDdlRequest const&
            request,
        ::google::longrunning::Operation* response),
       (override));
   MOCK_METHOD(
       ::grpc::Status, DropDatabase,
       (::grpc::ClientContext * context,
-       const ::google::test::admin::database::v1::DropDatabaseRequest& request,
+       ::google::test::admin::database::v1::DropDatabaseRequest const& request,
        ::google::protobuf::Empty* response),
       (override));
   MOCK_METHOD(
       ::grpc::Status, GetDatabaseDdl,
       (::grpc::ClientContext * context,
-       const ::google::test::admin::database::v1::GetDatabaseDdlRequest&
+       ::google::test::admin::database::v1::GetDatabaseDdlRequest const&
            request,
        ::google::test::admin::database::v1::GetDatabaseDdlResponse* response),
       (override));
   MOCK_METHOD(::grpc::Status, SetIamPolicy,
               (::grpc::ClientContext * context,
-               const ::google::iam::v1::SetIamPolicyRequest& request,
+               ::google::iam::v1::SetIamPolicyRequest const& request,
                ::google::iam::v1::Policy* response),
               (override));
   MOCK_METHOD(::grpc::Status, GetIamPolicy,
               (::grpc::ClientContext * context,
-               const ::google::iam::v1::GetIamPolicyRequest& request,
+               ::google::iam::v1::GetIamPolicyRequest const& request,
                ::google::iam::v1::Policy* response),
               (override));
   MOCK_METHOD(::grpc::Status, TestIamPermissions,
               (::grpc::ClientContext * context,
-               const ::google::iam::v1::TestIamPermissionsRequest& request,
+               ::google::iam::v1::TestIamPermissionsRequest const& request,
                ::google::iam::v1::TestIamPermissionsResponse* response),
               (override));
   MOCK_METHOD(
       ::grpc::Status, CreateBackup,
       (::grpc::ClientContext * context,
-       const ::google::test::admin::database::v1::CreateBackupRequest& request,
+       ::google::test::admin::database::v1::CreateBackupRequest const& request,
        ::google::longrunning::Operation* response),
       (override));
   MOCK_METHOD(
       ::grpc::Status, GetBackup,
       (::grpc::ClientContext * context,
-       const ::google::test::admin::database::v1::GetBackupRequest& request,
+       ::google::test::admin::database::v1::GetBackupRequest const& request,
        ::google::test::admin::database::v1::Backup* response),
       (override));
   MOCK_METHOD(
       ::grpc::Status, UpdateBackup,
       (::grpc::ClientContext * context,
-       const ::google::test::admin::database::v1::UpdateBackupRequest& request,
+       ::google::test::admin::database::v1::UpdateBackupRequest const& request,
        ::google::test::admin::database::v1::Backup* response),
       (override));
   MOCK_METHOD(
       ::grpc::Status, DeleteBackup,
       (::grpc::ClientContext * context,
-       const ::google::test::admin::database::v1::DeleteBackupRequest& request,
+       ::google::test::admin::database::v1::DeleteBackupRequest const& request,
        ::google::protobuf::Empty* response),
       (override));
   MOCK_METHOD(
       ::grpc::Status, ListBackups,
       (::grpc::ClientContext * context,
-       const ::google::test::admin::database::v1::ListBackupsRequest& request,
+       ::google::test::admin::database::v1::ListBackupsRequest const& request,
        ::google::test::admin::database::v1::ListBackupsResponse* response),
       (override));
   MOCK_METHOD(
       ::grpc::Status, RestoreDatabase,
       (::grpc::ClientContext * context,
-       const ::google::test::admin::database::v1::RestoreDatabaseRequest&
+       ::google::test::admin::database::v1::RestoreDatabaseRequest const&
            request,
        ::google::longrunning::Operation* response),
       (override));
   MOCK_METHOD(
       ::grpc::Status, ListDatabaseOperations,
       (::grpc::ClientContext * context,
-       const ::google::test::admin::database::v1::ListDatabaseOperationsRequest&
+       ::google::test::admin::database::v1::ListDatabaseOperationsRequest const&
            request,
        ::google::test::admin::database::v1::ListDatabaseOperationsResponse*
            response),
@@ -139,7 +139,7 @@ class MockGrpcGoldenThingAdminStub : public ::google::test::admin::database::
   MOCK_METHOD(
       ::grpc::Status, ListBackupOperations,
       (::grpc::ClientContext * context,
-       const ::google::test::admin::database::v1::ListBackupOperationsRequest&
+       ::google::test::admin::database::v1::ListBackupOperationsRequest const&
            request,
        ::google::test::admin::database::v1::ListBackupOperationsResponse*
            response),
@@ -150,7 +150,7 @@ class MockGrpcGoldenThingAdminStub : public ::google::test::admin::database::
           ::google::test::admin::database::v1::ListDatabasesResponse>*,
       AsyncListDatabasesRaw,
       (::grpc::ClientContext * context,
-       const ::google::test::admin::database::v1::ListDatabasesRequest& request,
+       ::google::test::admin::database::v1::ListDatabasesRequest const& request,
        ::grpc::CompletionQueue* cq),
       (override));
   MOCK_METHOD(
@@ -158,14 +158,14 @@ class MockGrpcGoldenThingAdminStub : public ::google::test::admin::database::
           ::google::test::admin::database::v1::ListDatabasesResponse>*,
       PrepareAsyncListDatabasesRaw,
       (::grpc::ClientContext * context,
-       const ::google::test::admin::database::v1::ListDatabasesRequest& request,
+       ::google::test::admin::database::v1::ListDatabasesRequest const& request,
        ::grpc::CompletionQueue* cq),
       (override));
   MOCK_METHOD(::grpc::ClientAsyncResponseReaderInterface<
                   ::google::longrunning::Operation>*,
               AsyncCreateDatabaseRaw,
               (::grpc::ClientContext * context,
-               const ::google::test::admin::database::v1::CreateDatabaseRequest&
+               ::google::test::admin::database::v1::CreateDatabaseRequest const&
                    request,
                ::grpc::CompletionQueue* cq),
               (override));
@@ -173,7 +173,7 @@ class MockGrpcGoldenThingAdminStub : public ::google::test::admin::database::
                   ::google::longrunning::Operation>*,
               PrepareAsyncCreateDatabaseRaw,
               (::grpc::ClientContext * context,
-               const ::google::test::admin::database::v1::CreateDatabaseRequest&
+               ::google::test::admin::database::v1::CreateDatabaseRequest const&
                    request,
                ::grpc::CompletionQueue* cq),
               (override));
@@ -182,7 +182,7 @@ class MockGrpcGoldenThingAdminStub : public ::google::test::admin::database::
           ::google::test::admin::database::v1::Database>*,
       AsyncGetDatabaseRaw,
       (::grpc::ClientContext * context,
-       const ::google::test::admin::database::v1::GetDatabaseRequest& request,
+       ::google::test::admin::database::v1::GetDatabaseRequest const& request,
        ::grpc::CompletionQueue* cq),
       (override));
   MOCK_METHOD(
@@ -190,7 +190,7 @@ class MockGrpcGoldenThingAdminStub : public ::google::test::admin::database::
           ::google::test::admin::database::v1::Database>*,
       PrepareAsyncGetDatabaseRaw,
       (::grpc::ClientContext * context,
-       const ::google::test::admin::database::v1::GetDatabaseRequest& request,
+       ::google::test::admin::database::v1::GetDatabaseRequest const& request,
        ::grpc::CompletionQueue* cq),
       (override));
   MOCK_METHOD(
@@ -198,7 +198,7 @@ class MockGrpcGoldenThingAdminStub : public ::google::test::admin::database::
           ::google::longrunning::Operation>*,
       AsyncUpdateDatabaseDdlRaw,
       (::grpc::ClientContext * context,
-       const ::google::test::admin::database::v1::UpdateDatabaseDdlRequest&
+       ::google::test::admin::database::v1::UpdateDatabaseDdlRequest const&
            request,
        ::grpc::CompletionQueue* cq),
       (override));
@@ -207,7 +207,7 @@ class MockGrpcGoldenThingAdminStub : public ::google::test::admin::database::
           ::google::longrunning::Operation>*,
       PrepareAsyncUpdateDatabaseDdlRaw,
       (::grpc::ClientContext * context,
-       const ::google::test::admin::database::v1::UpdateDatabaseDdlRequest&
+       ::google::test::admin::database::v1::UpdateDatabaseDdlRequest const&
            request,
        ::grpc::CompletionQueue* cq),
       (override));
@@ -215,21 +215,21 @@ class MockGrpcGoldenThingAdminStub : public ::google::test::admin::database::
       ::grpc::ClientAsyncResponseReaderInterface<::google::protobuf::Empty>*,
       AsyncDropDatabaseRaw,
       (::grpc::ClientContext * context,
-       const ::google::test::admin::database::v1::DropDatabaseRequest& request,
+       ::google::test::admin::database::v1::DropDatabaseRequest const& request,
        ::grpc::CompletionQueue* cq),
       (override));
   MOCK_METHOD(
       ::grpc::ClientAsyncResponseReaderInterface<::google::protobuf::Empty>*,
       PrepareAsyncDropDatabaseRaw,
       (::grpc::ClientContext * context,
-       const ::google::test::admin::database::v1::DropDatabaseRequest& request,
+       ::google::test::admin::database::v1::DropDatabaseRequest const& request,
        ::grpc::CompletionQueue* cq),
       (override));
   MOCK_METHOD(::grpc::ClientAsyncResponseReaderInterface<
                   ::google::test::admin::database::v1::GetDatabaseDdlResponse>*,
               AsyncGetDatabaseDdlRaw,
               (::grpc::ClientContext * context,
-               const ::google::test::admin::database::v1::GetDatabaseDdlRequest&
+               ::google::test::admin::database::v1::GetDatabaseDdlRequest const&
                    request,
                ::grpc::CompletionQueue* cq),
               (override));
@@ -237,7 +237,7 @@ class MockGrpcGoldenThingAdminStub : public ::google::test::admin::database::
                   ::google::test::admin::database::v1::GetDatabaseDdlResponse>*,
               PrepareAsyncGetDatabaseDdlRaw,
               (::grpc::ClientContext * context,
-               const ::google::test::admin::database::v1::GetDatabaseDdlRequest&
+               ::google::test::admin::database::v1::GetDatabaseDdlRequest const&
                    request,
                ::grpc::CompletionQueue* cq),
               (override));
@@ -245,42 +245,42 @@ class MockGrpcGoldenThingAdminStub : public ::google::test::admin::database::
       ::grpc::ClientAsyncResponseReaderInterface<::google::iam::v1::Policy>*,
       AsyncSetIamPolicyRaw,
       (::grpc::ClientContext * context,
-       const ::google::iam::v1::SetIamPolicyRequest& request,
+       ::google::iam::v1::SetIamPolicyRequest const& request,
        ::grpc::CompletionQueue* cq),
       (override));
   MOCK_METHOD(
       ::grpc::ClientAsyncResponseReaderInterface<::google::iam::v1::Policy>*,
       PrepareAsyncSetIamPolicyRaw,
       (::grpc::ClientContext * context,
-       const ::google::iam::v1::SetIamPolicyRequest& request,
+       ::google::iam::v1::SetIamPolicyRequest const& request,
        ::grpc::CompletionQueue* cq),
       (override));
   MOCK_METHOD(
       ::grpc::ClientAsyncResponseReaderInterface<::google::iam::v1::Policy>*,
       AsyncGetIamPolicyRaw,
       (::grpc::ClientContext * context,
-       const ::google::iam::v1::GetIamPolicyRequest& request,
+       ::google::iam::v1::GetIamPolicyRequest const& request,
        ::grpc::CompletionQueue* cq),
       (override));
   MOCK_METHOD(
       ::grpc::ClientAsyncResponseReaderInterface<::google::iam::v1::Policy>*,
       PrepareAsyncGetIamPolicyRaw,
       (::grpc::ClientContext * context,
-       const ::google::iam::v1::GetIamPolicyRequest& request,
+       ::google::iam::v1::GetIamPolicyRequest const& request,
        ::grpc::CompletionQueue* cq),
       (override));
   MOCK_METHOD(::grpc::ClientAsyncResponseReaderInterface<
                   ::google::iam::v1::TestIamPermissionsResponse>*,
               AsyncTestIamPermissionsRaw,
               (::grpc::ClientContext * context,
-               const ::google::iam::v1::TestIamPermissionsRequest& request,
+               ::google::iam::v1::TestIamPermissionsRequest const& request,
                ::grpc::CompletionQueue* cq),
               (override));
   MOCK_METHOD(::grpc::ClientAsyncResponseReaderInterface<
                   ::google::iam::v1::TestIamPermissionsResponse>*,
               PrepareAsyncTestIamPermissionsRaw,
               (::grpc::ClientContext * context,
-               const ::google::iam::v1::TestIamPermissionsRequest& request,
+               ::google::iam::v1::TestIamPermissionsRequest const& request,
                ::grpc::CompletionQueue* cq),
               (override));
   MOCK_METHOD(
@@ -288,7 +288,7 @@ class MockGrpcGoldenThingAdminStub : public ::google::test::admin::database::
           ::google::longrunning::Operation>*,
       AsyncCreateBackupRaw,
       (::grpc::ClientContext * context,
-       const ::google::test::admin::database::v1::CreateBackupRequest& request,
+       ::google::test::admin::database::v1::CreateBackupRequest const& request,
        ::grpc::CompletionQueue* cq),
       (override));
   MOCK_METHOD(
@@ -296,7 +296,7 @@ class MockGrpcGoldenThingAdminStub : public ::google::test::admin::database::
           ::google::longrunning::Operation>*,
       PrepareAsyncCreateBackupRaw,
       (::grpc::ClientContext * context,
-       const ::google::test::admin::database::v1::CreateBackupRequest& request,
+       ::google::test::admin::database::v1::CreateBackupRequest const& request,
        ::grpc::CompletionQueue* cq),
       (override));
   MOCK_METHOD(
@@ -304,7 +304,7 @@ class MockGrpcGoldenThingAdminStub : public ::google::test::admin::database::
           ::google::test::admin::database::v1::Backup>*,
       AsyncGetBackupRaw,
       (::grpc::ClientContext * context,
-       const ::google::test::admin::database::v1::GetBackupRequest& request,
+       ::google::test::admin::database::v1::GetBackupRequest const& request,
        ::grpc::CompletionQueue* cq),
       (override));
   MOCK_METHOD(
@@ -312,7 +312,7 @@ class MockGrpcGoldenThingAdminStub : public ::google::test::admin::database::
           ::google::test::admin::database::v1::Backup>*,
       PrepareAsyncGetBackupRaw,
       (::grpc::ClientContext * context,
-       const ::google::test::admin::database::v1::GetBackupRequest& request,
+       ::google::test::admin::database::v1::GetBackupRequest const& request,
        ::grpc::CompletionQueue* cq),
       (override));
   MOCK_METHOD(
@@ -320,7 +320,7 @@ class MockGrpcGoldenThingAdminStub : public ::google::test::admin::database::
           ::google::test::admin::database::v1::Backup>*,
       AsyncUpdateBackupRaw,
       (::grpc::ClientContext * context,
-       const ::google::test::admin::database::v1::UpdateBackupRequest& request,
+       ::google::test::admin::database::v1::UpdateBackupRequest const& request,
        ::grpc::CompletionQueue* cq),
       (override));
   MOCK_METHOD(
@@ -328,21 +328,21 @@ class MockGrpcGoldenThingAdminStub : public ::google::test::admin::database::
           ::google::test::admin::database::v1::Backup>*,
       PrepareAsyncUpdateBackupRaw,
       (::grpc::ClientContext * context,
-       const ::google::test::admin::database::v1::UpdateBackupRequest& request,
+       ::google::test::admin::database::v1::UpdateBackupRequest const& request,
        ::grpc::CompletionQueue* cq),
       (override));
   MOCK_METHOD(
       ::grpc::ClientAsyncResponseReaderInterface<::google::protobuf::Empty>*,
       AsyncDeleteBackupRaw,
       (::grpc::ClientContext * context,
-       const ::google::test::admin::database::v1::DeleteBackupRequest& request,
+       ::google::test::admin::database::v1::DeleteBackupRequest const& request,
        ::grpc::CompletionQueue* cq),
       (override));
   MOCK_METHOD(
       ::grpc::ClientAsyncResponseReaderInterface<::google::protobuf::Empty>*,
       PrepareAsyncDeleteBackupRaw,
       (::grpc::ClientContext * context,
-       const ::google::test::admin::database::v1::DeleteBackupRequest& request,
+       ::google::test::admin::database::v1::DeleteBackupRequest const& request,
        ::grpc::CompletionQueue* cq),
       (override));
   MOCK_METHOD(
@@ -350,7 +350,7 @@ class MockGrpcGoldenThingAdminStub : public ::google::test::admin::database::
           ::google::test::admin::database::v1::ListBackupsResponse>*,
       AsyncListBackupsRaw,
       (::grpc::ClientContext * context,
-       const ::google::test::admin::database::v1::ListBackupsRequest& request,
+       ::google::test::admin::database::v1::ListBackupsRequest const& request,
        ::grpc::CompletionQueue* cq),
       (override));
   MOCK_METHOD(
@@ -358,7 +358,7 @@ class MockGrpcGoldenThingAdminStub : public ::google::test::admin::database::
           ::google::test::admin::database::v1::ListBackupsResponse>*,
       PrepareAsyncListBackupsRaw,
       (::grpc::ClientContext * context,
-       const ::google::test::admin::database::v1::ListBackupsRequest& request,
+       ::google::test::admin::database::v1::ListBackupsRequest const& request,
        ::grpc::CompletionQueue* cq),
       (override));
   MOCK_METHOD(
@@ -366,7 +366,7 @@ class MockGrpcGoldenThingAdminStub : public ::google::test::admin::database::
           ::google::longrunning::Operation>*,
       AsyncRestoreDatabaseRaw,
       (::grpc::ClientContext * context,
-       const ::google::test::admin::database::v1::RestoreDatabaseRequest&
+       ::google::test::admin::database::v1::RestoreDatabaseRequest const&
            request,
        ::grpc::CompletionQueue* cq),
       (override));
@@ -375,7 +375,7 @@ class MockGrpcGoldenThingAdminStub : public ::google::test::admin::database::
           ::google::longrunning::Operation>*,
       PrepareAsyncRestoreDatabaseRaw,
       (::grpc::ClientContext * context,
-       const ::google::test::admin::database::v1::RestoreDatabaseRequest&
+       ::google::test::admin::database::v1::RestoreDatabaseRequest const&
            request,
        ::grpc::CompletionQueue* cq),
       (override));
@@ -384,7 +384,7 @@ class MockGrpcGoldenThingAdminStub : public ::google::test::admin::database::
           ::google::test::admin::database::v1::ListDatabaseOperationsResponse>*,
       AsyncListDatabaseOperationsRaw,
       (::grpc::ClientContext * context,
-       const ::google::test::admin::database::v1::ListDatabaseOperationsRequest&
+       ::google::test::admin::database::v1::ListDatabaseOperationsRequest const&
            request,
        ::grpc::CompletionQueue* cq),
       (override));
@@ -393,7 +393,7 @@ class MockGrpcGoldenThingAdminStub : public ::google::test::admin::database::
           ::google::test::admin::database::v1::ListDatabaseOperationsResponse>*,
       PrepareAsyncListDatabaseOperationsRaw,
       (::grpc::ClientContext * context,
-       const ::google::test::admin::database::v1::ListDatabaseOperationsRequest&
+       ::google::test::admin::database::v1::ListDatabaseOperationsRequest const&
            request,
        ::grpc::CompletionQueue* cq),
       (override));
@@ -402,7 +402,7 @@ class MockGrpcGoldenThingAdminStub : public ::google::test::admin::database::
           ::google::test::admin::database::v1::ListBackupOperationsResponse>*,
       AsyncListBackupOperationsRaw,
       (::grpc::ClientContext * context,
-       const ::google::test::admin::database::v1::ListBackupOperationsRequest&
+       ::google::test::admin::database::v1::ListBackupOperationsRequest const&
            request,
        ::grpc::CompletionQueue* cq),
       (override));
@@ -411,7 +411,7 @@ class MockGrpcGoldenThingAdminStub : public ::google::test::admin::database::
           ::google::test::admin::database::v1::ListBackupOperationsResponse>*,
       PrepareAsyncListBackupOperationsRaw,
       (::grpc::ClientContext * context,
-       const ::google::test::admin::database::v1::ListBackupOperationsRequest&
+       ::google::test::admin::database::v1::ListBackupOperationsRequest const&
            request,
        ::grpc::CompletionQueue* cq),
       (override));
@@ -423,97 +423,97 @@ class MockLongrunningOperationsStub
   ~MockLongrunningOperationsStub() override = default;
   MOCK_METHOD(::grpc::Status, ListOperations,
               (::grpc::ClientContext * context,
-               const ::google::longrunning::ListOperationsRequest& request,
+               ::google::longrunning::ListOperationsRequest const& request,
                ::google::longrunning::ListOperationsResponse* response),
               (override));
   MOCK_METHOD(::grpc::Status, GetOperation,
               (::grpc::ClientContext * context,
-               const ::google::longrunning::GetOperationRequest& request,
+               ::google::longrunning::GetOperationRequest const& request,
                ::google::longrunning::Operation* response),
               (override));
   MOCK_METHOD(::grpc::Status, DeleteOperation,
               (::grpc::ClientContext * context,
-               const ::google::longrunning::DeleteOperationRequest& request,
+               ::google::longrunning::DeleteOperationRequest const& request,
                ::google::protobuf::Empty* response),
               (override));
   MOCK_METHOD(::grpc::Status, CancelOperation,
               (::grpc::ClientContext * context,
-               const ::google::longrunning::CancelOperationRequest& request,
+               ::google::longrunning::CancelOperationRequest const& request,
                ::google::protobuf::Empty* response),
               (override));
   MOCK_METHOD(::grpc::Status, WaitOperation,
               (::grpc::ClientContext * context,
-               const ::google::longrunning::WaitOperationRequest& request,
+               ::google::longrunning::WaitOperationRequest const& request,
                ::google::longrunning::Operation* response),
               (override));
   MOCK_METHOD(::grpc::ClientAsyncResponseReaderInterface<
                   ::google::longrunning::ListOperationsResponse>*,
               AsyncListOperationsRaw,
               (::grpc::ClientContext * context,
-               const ::google::longrunning::ListOperationsRequest& request,
+               ::google::longrunning::ListOperationsRequest const& request,
                ::grpc::CompletionQueue* cq),
               (override));
   MOCK_METHOD(::grpc::ClientAsyncResponseReaderInterface<
                   ::google::longrunning::ListOperationsResponse>*,
               PrepareAsyncListOperationsRaw,
               (::grpc::ClientContext * context,
-               const ::google::longrunning::ListOperationsRequest& request,
+               ::google::longrunning::ListOperationsRequest const& request,
                ::grpc::CompletionQueue* cq),
               (override));
   MOCK_METHOD(::grpc::ClientAsyncResponseReaderInterface<
                   ::google::longrunning::Operation>*,
               AsyncGetOperationRaw,
               (::grpc::ClientContext * context,
-               const ::google::longrunning::GetOperationRequest& request,
+               ::google::longrunning::GetOperationRequest const& request,
                ::grpc::CompletionQueue* cq),
               (override));
   MOCK_METHOD(::grpc::ClientAsyncResponseReaderInterface<
                   ::google::longrunning::Operation>*,
               PrepareAsyncGetOperationRaw,
               (::grpc::ClientContext * context,
-               const ::google::longrunning::GetOperationRequest& request,
+               ::google::longrunning::GetOperationRequest const& request,
                ::grpc::CompletionQueue* cq),
               (override));
   MOCK_METHOD(
       ::grpc::ClientAsyncResponseReaderInterface<::google::protobuf::Empty>*,
       AsyncDeleteOperationRaw,
       (::grpc::ClientContext * context,
-       const ::google::longrunning::DeleteOperationRequest& request,
+       ::google::longrunning::DeleteOperationRequest const& request,
        ::grpc::CompletionQueue* cq),
       (override));
   MOCK_METHOD(
       ::grpc::ClientAsyncResponseReaderInterface<::google::protobuf::Empty>*,
       PrepareAsyncDeleteOperationRaw,
       (::grpc::ClientContext * context,
-       const ::google::longrunning::DeleteOperationRequest& request,
+       ::google::longrunning::DeleteOperationRequest const& request,
        ::grpc::CompletionQueue* cq),
       (override));
   MOCK_METHOD(
       ::grpc::ClientAsyncResponseReaderInterface<::google::protobuf::Empty>*,
       AsyncCancelOperationRaw,
       (::grpc::ClientContext * context,
-       const ::google::longrunning::CancelOperationRequest& request,
+       ::google::longrunning::CancelOperationRequest const& request,
        ::grpc::CompletionQueue* cq),
       (override));
   MOCK_METHOD(
       ::grpc::ClientAsyncResponseReaderInterface<::google::protobuf::Empty>*,
       PrepareAsyncCancelOperationRaw,
       (::grpc::ClientContext * context,
-       const ::google::longrunning::CancelOperationRequest& request,
+       ::google::longrunning::CancelOperationRequest const& request,
        ::grpc::CompletionQueue* cq),
       (override));
   MOCK_METHOD(::grpc::ClientAsyncResponseReaderInterface<
                   ::google::longrunning::Operation>*,
               AsyncWaitOperationRaw,
               (::grpc::ClientContext * context,
-               const ::google::longrunning::WaitOperationRequest& request,
+               ::google::longrunning::WaitOperationRequest const& request,
                ::grpc::CompletionQueue* cq),
               (override));
   MOCK_METHOD(::grpc::ClientAsyncResponseReaderInterface<
                   ::google::longrunning::Operation>*,
               PrepareAsyncWaitOperationRaw,
               (::grpc::ClientContext * context,
-               const ::google::longrunning::WaitOperationRequest& request,
+               ::google::longrunning::WaitOperationRequest const& request,
                ::grpc::CompletionQueue* cq),
               (override));
 };

--- a/generator/internal/descriptor_utils.cc
+++ b/generator/internal/descriptor_utils.cc
@@ -47,7 +47,7 @@ namespace google {
 namespace cloud {
 namespace generator_internal {
 namespace {
-const char* const kGoogleapisProtoFileLinkPrefix =
+char const* const kGoogleapisProtoFileLinkPrefix =
     "https://github.com/googleapis/googleapis/blob/";
 
 std::string CppTypeToString(FieldDescriptor const* field) {

--- a/generator/internal/descriptor_utils_test.cc
+++ b/generator/internal/descriptor_utils_test.cc
@@ -46,7 +46,7 @@ class StringSourceTree : public google::protobuf::compiler::SourceTree {
       : files_(std::move(files)) {}
 
   google::protobuf::io::ZeroCopyInputStream* Open(
-      const std::string& filename) override {
+      std::string const& filename) override {
     auto iter = files_.find(filename);
     return iter == files_.end() ? nullptr
                                 : new google::protobuf::io::ArrayInputStream(
@@ -64,15 +64,15 @@ class AbortingErrorCollector : public DescriptorPool::ErrorCollector {
   AbortingErrorCollector(AbortingErrorCollector const&) = delete;
   AbortingErrorCollector& operator=(AbortingErrorCollector const&) = delete;
 
-  void AddError(const std::string& filename, const std::string& element_name,
-                const google::protobuf::Message*, ErrorLocation,
-                const std::string& error_message) override {
+  void AddError(std::string const& filename, std::string const& element_name,
+                google::protobuf::Message const*, ErrorLocation,
+                std::string const& error_message) override {
     GCP_LOG(FATAL) << "AddError() called unexpectedly: " << filename << " ["
                    << element_name << "]: " << error_message;
   }
 };
 
-const char* const kHttpProto =
+char const* const kHttpProto =
     "syntax = \"proto3\";\n"
     "package google.api;\n"
     "option cc_enable_arenas = true;\n"
@@ -99,7 +99,7 @@ const char* const kHttpProto =
     "  string path = 2;\n"
     "}\n";
 
-const char* const kAnnotationsProto =
+char const* const kAnnotationsProto =
     "syntax = \"proto3\";\n"
     "package google.api;\n"
     "import \"google/api/http.proto\";\n"
@@ -109,7 +109,7 @@ const char* const kAnnotationsProto =
     "  HttpRule http = 72295728;\n"
     "}\n";
 
-const char* const kFrobberServiceProto =
+char const* const kFrobberServiceProto =
     "syntax = \"proto3\";\n"
     "package google.cloud.frobber.v1;\n"
     "import \"google/api/annotations.proto\";\n"
@@ -171,7 +171,7 @@ TEST_F(CreateServiceVarsTest, FilesParseSuccessfully) {
 }
 
 TEST_P(CreateServiceVarsTest, KeySetCorrectly) {
-  const FileDescriptor* service_file_descriptor =
+  FileDescriptor const* service_file_descriptor =
       pool_.FindFileByName("google/cloud/frobber/v1/frobber.proto");
   service_vars_ = CreateServiceVars(
       *service_file_descriptor->service(0),
@@ -269,11 +269,11 @@ INSTANTIATE_TEST_SUITE_P(
                        "google/cloud/frobber/internal/frobber_stub_factory.cc"),
         std::make_pair("stub_factory_header_path",
                        "google/cloud/frobber/internal/frobber_stub_factory.h")),
-    [](const testing::TestParamInfo<CreateServiceVarsTest::ParamType>& info) {
+    [](testing::TestParamInfo<CreateServiceVarsTest::ParamType> const& info) {
       return std::get<0>(info.param);
     });
 
-const char* const kClientProto =
+char const* const kClientProto =
     "syntax = \"proto3\";\n"
     "package google.api;\n"
     "import \"google/protobuf/descriptor.proto\";\n"
@@ -285,7 +285,7 @@ const char* const kClientProto =
     "  string oauth_scopes = 1050;\n"
     "}\n";
 
-const char* const kLongrunningOperationsProto =
+char const* const kLongrunningOperationsProto =
     "syntax = \"proto3\";\n"
     "package google.longrunning;\n"
     "import \"google/protobuf/descriptor.proto\";\n"
@@ -300,7 +300,7 @@ const char* const kLongrunningOperationsProto =
     "  string metadata_type = 2;\n"
     "}\n";
 
-const char* const kSourceLocationTestInput =
+char const* const kSourceLocationTestInput =
     "syntax = \"proto3\";\n"
     "import \"google/api/annotations.proto\";\n"
     "message A {\n"
@@ -322,7 +322,7 @@ const char* const kSourceLocationTestInput =
     "  }\n"
     "}\n";
 
-const char* const kServiceProto =
+char const* const kServiceProto =
     "syntax = \"proto3\";\n"
     "package google.protobuf;\n"
     "import \"google/api/annotations.proto\";\n"
@@ -489,7 +489,7 @@ TEST_F(CreateMethodVarsTest, FilesParseSuccessfully) {
 
 TEST_F(CreateMethodVarsTest,
        FormatMethodCommentsFromRpcCommentsProtobufRequest) {
-  const FileDescriptor* service_file_descriptor =
+  FileDescriptor const* service_file_descriptor =
       pool_.FindFileByName("google/foo/v1/service.proto");
   EXPECT_EQ(
       FormatMethodCommentsFromRpcComments(
@@ -503,7 +503,7 @@ TEST_F(CreateMethodVarsTest,
 
 TEST_F(CreateMethodVarsTest,
        FormatMethodCommentsFromRpcCommentsApiMethodSignature) {
-  const FileDescriptor* service_file_descriptor =
+  FileDescriptor const* service_file_descriptor =
       pool_.FindFileByName("google/foo/v1/service.proto");
   EXPECT_EQ(FormatMethodCommentsFromRpcComments(
                 *service_file_descriptor->service(0)->method(6),
@@ -513,7 +513,7 @@ TEST_F(CreateMethodVarsTest,
 }
 
 TEST_P(CreateMethodVarsTest, KeySetCorrectly) {
-  const FileDescriptor* service_file_descriptor =
+  FileDescriptor const* service_file_descriptor =
       pool_.FindFileByName("google/foo/v1/service.proto");
   vars_ = CreateMethodVars(*service_file_descriptor->service(0), service_vars_);
   auto method_iter = vars_.find(GetParam().method);
@@ -703,7 +703,7 @@ INSTANTIATE_TEST_SUITE_P(
             "method_longrunning_deduced_return_doxygen_link",
             "[google::protobuf::Bar](https://github.com/googleapis/"
             "googleapis/blob/foo/google/foo/v1/service.proto#L14)")),
-    [](const testing::TestParamInfo<CreateMethodVarsTest::ParamType>& info) {
+    [](testing::TestParamInfo<CreateMethodVarsTest::ParamType> const& info) {
       std::vector<std::string> pieces = absl::StrSplit(info.param.method, '.');
       return pieces.back() + "_" + info.param.vars_key;
     });

--- a/generator/internal/predicate_utils_test.cc
+++ b/generator/internal/predicate_utils_test.cc
@@ -607,7 +607,7 @@ class StringSourceTree : public google::protobuf::compiler::SourceTree {
       : files_(std::move(files)) {}
 
   google::protobuf::io::ZeroCopyInputStream* Open(
-      const std::string& filename) override {
+      std::string const& filename) override {
     auto iter = files_.find(filename);
     return iter == files_.end() ? nullptr
                                 : new google::protobuf::io::ArrayInputStream(
@@ -625,15 +625,15 @@ class AbortingErrorCollector : public DescriptorPool::ErrorCollector {
   AbortingErrorCollector(AbortingErrorCollector const&) = delete;
   AbortingErrorCollector& operator=(AbortingErrorCollector const&) = delete;
 
-  void AddError(const std::string& filename, const std::string& element_name,
-                const google::protobuf::Message*, ErrorLocation,
-                const std::string& error_message) override {
+  void AddError(std::string const& filename, std::string const& element_name,
+                google::protobuf::Message const*, ErrorLocation,
+                std::string const& error_message) override {
     GCP_LOG(FATAL) << "AddError() called unexpectedly: " << filename << " ["
                    << element_name << "]: " << error_message;
   }
 };
 
-const char* const kStreamingServiceProto =
+char const* const kStreamingServiceProto =
     "syntax = \"proto3\";\n"
     "package google.protobuf;\n"
     "// Leading comments about message Foo.\n"
@@ -700,7 +700,7 @@ class StreamingReadTest : public testing::Test {
 };
 
 TEST_F(StreamingReadTest, IsStreamingRead) {
-  const FileDescriptor* service_file_descriptor =
+  FileDescriptor const* service_file_descriptor =
       pool_.FindFileByName("google/cloud/foo/streaming.proto");
   EXPECT_TRUE(IsStreamingRead(*service_file_descriptor->service(0)->method(0)));
   EXPECT_FALSE(

--- a/generator/internal/service_code_generator.cc
+++ b/generator/internal/service_code_generator.cc
@@ -35,7 +35,7 @@ absl::optional<std::string> IncludePathForWellKnownProtobufType(
     google::protobuf::FieldDescriptor const& parameter) {
   // This hash is not intended to be comprehensive. Problematic types and their
   // includes should be added as needed.
-  static const auto* const kTypeIncludeMap =
+  static auto const* const kTypeIncludeMap =
       new absl::flat_hash_map<std::string, std::string>(
           {{"google.protobuf.Duration", "google/protobuf/duration.pb.h"}});
   if (parameter.type() == google::protobuf::FieldDescriptor::TYPE_MESSAGE) {
@@ -118,8 +118,8 @@ bool ServiceCodeGenerator::HasPaginatedMethod() const {
 
 bool ServiceCodeGenerator::HasMessageWithMapField() const {
   for (auto method : methods_) {
-    const auto* const request = method.get().input_type();
-    const auto* const response = method.get().output_type();
+    auto const* const request = method.get().input_type();
+    auto const* const response = method.get().output_type();
     for (int j = 0; j < request->field_count(); ++j) {
       if (request->field(j)->is_map()) {
         return true;

--- a/generator/internal/service_code_generator_test.cc
+++ b/generator/internal/service_code_generator_test.cc
@@ -58,7 +58,7 @@ class StringSourceTree : public google::protobuf::compiler::SourceTree {
       : files_(std::move(files)) {}
 
   google::protobuf::io::ZeroCopyInputStream* Open(
-      const std::string& filename) override {
+      std::string const& filename) override {
     auto iter = files_.find(filename);
     return iter == files_.end() ? nullptr
                                 : new google::protobuf::io::ArrayInputStream(
@@ -76,9 +76,9 @@ class AbortingErrorCollector : public DescriptorPool::ErrorCollector {
   AbortingErrorCollector(AbortingErrorCollector const&) = delete;
   AbortingErrorCollector& operator=(AbortingErrorCollector const&) = delete;
 
-  void AddError(const std::string& filename, const std::string& element_name,
-                const google::protobuf::Message*, ErrorLocation,
-                const std::string& error_message) override {
+  void AddError(std::string const& filename, std::string const& element_name,
+                google::protobuf::Message const*, ErrorLocation,
+                std::string const& error_message) override {
     GCP_LOG(FATAL) << "AddError() called unexpectedly: " << filename << " ["
                    << element_name << "]: " << error_message;
   }
@@ -325,7 +325,7 @@ TEST(PredicateUtilsTest, HasPaginatedMethodFalse) {
   EXPECT_FALSE(g.HasPaginatedMethod());
 }
 
-const char* const kFooServiceProto =
+char const* const kFooServiceProto =
     "syntax = \"proto3\";\n"
     "package google.protobuf;\n"
     "// Leading comments about message Foo.\n"
@@ -381,7 +381,7 @@ class HasMessageWithMapFieldTest : public testing::Test {
 };
 
 TEST_F(HasMessageWithMapFieldTest, HasRequestMessageWithMapField) {
-  const FileDescriptor* service_file_descriptor =
+  FileDescriptor const* service_file_descriptor =
       pool_.FindFileByName("google/cloud/foo/service.proto");
   auto generator_context = absl::make_unique<MockGeneratorContext>();
   auto output = absl::make_unique<MockZeroCopyOutputStream>();
@@ -392,7 +392,7 @@ TEST_F(HasMessageWithMapFieldTest, HasRequestMessageWithMapField) {
 }
 
 TEST_F(HasMessageWithMapFieldTest, HasResponseMessageWithMapField) {
-  const FileDescriptor* service_file_descriptor =
+  FileDescriptor const* service_file_descriptor =
       pool_.FindFileByName("google/cloud/foo/service.proto");
   auto generator_context = absl::make_unique<MockGeneratorContext>();
   auto output = absl::make_unique<MockZeroCopyOutputStream>();
@@ -403,7 +403,7 @@ TEST_F(HasMessageWithMapFieldTest, HasResponseMessageWithMapField) {
 }
 
 TEST_F(HasMessageWithMapFieldTest, HasNoMessageWithMapField) {
-  const FileDescriptor* service_file_descriptor =
+  FileDescriptor const* service_file_descriptor =
       pool_.FindFileByName("google/cloud/foo/service.proto");
   auto generator_context = absl::make_unique<MockGeneratorContext>();
   auto output = absl::make_unique<MockZeroCopyOutputStream>();
@@ -413,7 +413,7 @@ TEST_F(HasMessageWithMapFieldTest, HasNoMessageWithMapField) {
   EXPECT_FALSE(g.HasMessageWithMapField());
 }
 
-const char* const kClientProto =
+char const* const kClientProto =
     "syntax = \"proto3\";\n"
     "package google.api;\n"
     "import \"google/protobuf/descriptor.proto\";\n"
@@ -425,7 +425,7 @@ const char* const kClientProto =
     "  string oauth_scopes = 1050;\n"
     "}\n";
 
-const char* const kDurationProto =
+char const* const kDurationProto =
     "syntax = \"proto3\";\n"
     "package google.protobuf;\n"
     "message Duration {\n"
@@ -433,7 +433,7 @@ const char* const kDurationProto =
     "  int32 nanos = 2;\n"
     "}\n";
 
-const char* const kMethodSignatureServiceProto =
+char const* const kMethodSignatureServiceProto =
     "syntax = \"proto3\";\n"
     "package google.protobuf;\n"
     "import \"google/api/client.proto\";\n"
@@ -495,7 +495,7 @@ class MethodSignatureWellKnownProtobufTypeIncludesTest : public testing::Test {
 
 TEST_F(MethodSignatureWellKnownProtobufTypeIncludesTest,
        HasSignatureWithDurationField) {
-  const FileDescriptor* service_file_descriptor =
+  FileDescriptor const* service_file_descriptor =
       pool_.FindFileByName("google/cloud/foo/service.proto");
   auto generator_context = absl::make_unique<MockGeneratorContext>();
   auto output = absl::make_unique<MockZeroCopyOutputStream>();
@@ -508,7 +508,7 @@ TEST_F(MethodSignatureWellKnownProtobufTypeIncludesTest,
 
 TEST_F(MethodSignatureWellKnownProtobufTypeIncludesTest,
        HasSignatureWithoutWellKnownTypeField) {
-  const FileDescriptor* service_file_descriptor =
+  FileDescriptor const* service_file_descriptor =
       pool_.FindFileByName("google/cloud/foo/service.proto");
   auto generator_context = absl::make_unique<MockGeneratorContext>();
   auto output = absl::make_unique<MockZeroCopyOutputStream>();
@@ -519,7 +519,7 @@ TEST_F(MethodSignatureWellKnownProtobufTypeIncludesTest,
   EXPECT_THAT(includes, IsEmpty());
 }
 
-const char* const kStreamingServiceProto =
+char const* const kStreamingServiceProto =
     "syntax = \"proto3\";\n"
     "package google.protobuf;\n"
     "// Leading comments about message Foo.\n"
@@ -586,7 +586,7 @@ class StreamingReadTest : public testing::Test {
 };
 
 TEST_F(StreamingReadTest, HasStreamingReadTrue) {
-  const FileDescriptor* service_file_descriptor =
+  FileDescriptor const* service_file_descriptor =
       pool_.FindFileByName("google/cloud/foo/streaming.proto");
   auto generator_context = absl::make_unique<MockGeneratorContext>();
   auto output = absl::make_unique<MockZeroCopyOutputStream>();
@@ -597,7 +597,7 @@ TEST_F(StreamingReadTest, HasStreamingReadTrue) {
 }
 
 TEST_F(StreamingReadTest, HasStreamingReadFalse) {
-  const FileDescriptor* service_file_descriptor =
+  FileDescriptor const* service_file_descriptor =
       pool_.FindFileByName("google/cloud/foo/streaming.proto");
   auto generator_context = absl::make_unique<MockGeneratorContext>();
   auto output = absl::make_unique<MockZeroCopyOutputStream>();

--- a/google/cloud/firestore/field_path.h
+++ b/google/cloud/firestore/field_path.h
@@ -98,7 +98,7 @@ class FieldPath {
    * @return The ostream written to.
    */
   friend std::ostream& operator<<(std::ostream& os,
-                                  const FieldPath& field_path);
+                                  FieldPath const& field_path);
 
   // This is a friend because it accesses parts_ directly.
   friend bool operator<(FieldPath const& lhs, FieldPath const& rhs);

--- a/google/cloud/internal/async_rpc_details.h
+++ b/google/cloud/internal/async_rpc_details.h
@@ -109,7 +109,7 @@ using CheckUnaryRpcCallback =
  */
 template <typename Functor, typename Response>
 using CheckUnaryStreamRpcDataCallback = google::cloud::internal::is_invocable<
-    Functor, CompletionQueue&, const grpc::ClientContext&, Response&>;
+    Functor, CompletionQueue&, grpc::ClientContext const&, Response&>;
 
 /**
  * Verify that @p Functor meets the requirements for an AsyncUnaryStreamRpc

--- a/google/cloud/pubsub/internal/session_shutdown_manager.cc
+++ b/google/cloud/pubsub/internal/session_shutdown_manager.cc
@@ -39,7 +39,7 @@ SessionShutdownManager::~SessionShutdownManager() {
   done_.set_value(std::move(result_));
 }
 
-void SessionShutdownManager::LogStart(const char* caller, const char* name) {
+void SessionShutdownManager::LogStart(char const* caller, char const* name) {
   auto increase_count = [&] { return ++ops_[name]; };
   GCP_LOG(TRACE) << "operation <" << name << "> starting from " << caller
                  << ", shutdown=" << shutdown_ << ", signaled=" << signaled_

--- a/google/cloud/spanner/instance_admin_connection_test.cc
+++ b/google/cloud/spanner/instance_admin_connection_test.cc
@@ -363,7 +363,7 @@ TEST(InstanceAdminConnectionTest, GetInstanceConfigTooManyTransients) {
 }
 
 TEST(InstanceAdminConnectionTest, ListInstanceConfigsSuccess) {
-  constexpr const char* kInstanceConfigText[3] = {
+  constexpr char const* kInstanceConfigText[3] = {
       R"pb(
         name: "projects/test-project/instanceConfigs/test-instance-config-1"
         display_name: "test display name 1"

--- a/google/cloud/spanner/internal/partial_result_set_source_test.cc
+++ b/google/cloud/spanner/internal/partial_result_set_source_test.cc
@@ -438,7 +438,7 @@ TEST(PartialResultSetSourceTest, ChunkedStringValueWellFormed) {
   EXPECT_STATUS_OK(reader.status());
 
   // Verify the returned values are correct.
-  for (const auto& value :
+  for (auto const& value :
        {"not_chunked", "first_chunksecond_chunkthird_chunk",
         "second group first_chunk second group second_chunk",
         "also not_chunked", "still not_chunked"}) {

--- a/google/cloud/spanner/row_test.cc
+++ b/google/cloud/spanner/row_test.cc
@@ -229,7 +229,7 @@ TEST(RowStreamIterator, Basics) {
   EXPECT_STATUS_OK(*it);
   EXPECT_EQ(rows[2], **it);
 
-  // Tests const op*() and op->()
+  // Tests op*() const and op->() const
   auto const copy = it;
   EXPECT_EQ(copy, it);
   EXPECT_NE(copy, end);
@@ -350,7 +350,7 @@ TEST(TupleStreamIterator, Basics) {
   EXPECT_STATUS_OK(*it);
   EXPECT_EQ(std::make_tuple(3, "baz", true), **it);
 
-  // Tests const op*() and op->()
+  // Tests op*() const and op->() const
   auto const copy = it;
   EXPECT_EQ(copy, it);
   EXPECT_NE(copy, end);

--- a/google/cloud/spanner/sql_statement_test.cc
+++ b/google/cloud/spanner/sql_statement_test.cc
@@ -32,7 +32,7 @@ using ::testing::Eq;
 using ::testing::UnorderedPointwise;
 
 TEST(SqlStatementTest, SqlAccessor) {
-  const char* statement = "select * from foo";
+  char const* statement = "select * from foo";
   SqlStatement stmt(statement);
   EXPECT_EQ(statement, stmt.sql());
 }

--- a/google/cloud/spanner/value.cc
+++ b/google/cloud/spanner/value.cc
@@ -150,7 +150,7 @@ std::ostream& StreamHelper(std::ostream& os,  // NOLINT(misc-no-recursion)
              << spanner_internal::FromProto(t, v).get<absl::CivilDay>().value();
 
     case google::spanner::v1::TypeCode::ARRAY: {
-      const char* delimiter = "";
+      char const* delimiter = "";
       os << '[';
       for (auto const& e : v.list_value().values()) {
         os << delimiter;
@@ -161,7 +161,7 @@ std::ostream& StreamHelper(std::ostream& os,  // NOLINT(misc-no-recursion)
     }
 
     case google::spanner::v1::TypeCode::STRUCT: {
-      const char* delimiter = "";
+      char const* delimiter = "";
       os << '(';
       for (int i = 0; i < v.list_value().values_size(); ++i) {
         os << delimiter;

--- a/google/cloud/storage/examples/storage_bucket_acl_samples.cc
+++ b/google/cloud/storage/examples/storage_bucket_acl_samples.cc
@@ -200,7 +200,7 @@ void RemoveBucketOwner(google::cloud::storage::Client client,
     std::vector<gcs::BucketAccessControl> original_acl =
         original_metadata->acl();
     auto it = std::find_if(original_acl.begin(), original_acl.end(),
-                           [entity](const gcs::BucketAccessControl& entry) {
+                           [entity](gcs::BucketAccessControl const& entry) {
                              return entry.entity() == entity &&
                                     entry.role() ==
                                         gcs::BucketAccessControl::ROLE_OWNER();

--- a/google/cloud/storage/examples/storage_object_acl_samples.cc
+++ b/google/cloud/storage/examples/storage_object_acl_samples.cc
@@ -212,7 +212,7 @@ void RemoveObjectOwner(google::cloud::storage::Client client,
     std::vector<gcs::ObjectAccessControl> original_acl =
         original_metadata->acl();
     auto it = std::find_if(original_acl.begin(), original_acl.end(),
-                           [entity](const gcs::ObjectAccessControl& entry) {
+                           [entity](gcs::ObjectAccessControl const& entry) {
                              return entry.entity() == entity &&
                                     entry.role() ==
                                         gcs::ObjectAccessControl::ROLE_OWNER();

--- a/google/cloud/storage/internal/curl_handle_factory_test.cc
+++ b/google/cloud/storage/internal/curl_handle_factory_test.cc
@@ -35,7 +35,7 @@ class OverriddenDefaultCurlHandleFactory : public DefaultCurlHandleFactory {
 
  protected:
   void SetCurlStringOption(CURL* handle, CURLoption option_tag,
-                           const char* value) override {
+                           char const* value) override {
     set_options_[option_tag] = value;
     DefaultCurlHandleFactory::SetCurlStringOption(handle, option_tag, value);
   }
@@ -56,7 +56,7 @@ class OverriddenPooledCurlHandleFactory : public PooledCurlHandleFactory {
 
  protected:
   void SetCurlStringOption(CURL* handle, CURLoption option_tag,
-                           const char* value) override {
+                           char const* value) override {
     set_options_[option_tag] = value;
     PooledCurlHandleFactory::SetCurlStringOption(handle, option_tag, value);
   }

--- a/google/cloud/storage/internal/grpc_client.cc
+++ b/google/cloud/storage/internal/grpc_client.cc
@@ -1012,7 +1012,7 @@ StatusOr<std::string> GrpcClient::MD5ToProto(std::string const& v) {
   return internal::HexEncode(*binary);
 }
 
-std::string GrpcClient::ComputeMD5Hash(const std::string& payload) {
+std::string GrpcClient::ComputeMD5Hash(std::string const& payload) {
   return internal::HexEncode(internal::MD5Hash(payload));
 }
 

--- a/google/cloud/storage/internal/object_read_streambuf.cc
+++ b/google/cloud/storage/internal/object_read_streambuf.cc
@@ -87,7 +87,7 @@ ObjectReadStreambuf::int_type ObjectReadStreambuf::ReportError(Status status) {
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 }
 
-void ObjectReadStreambuf::ThrowHashMismatchDelegate(const char* function_name) {
+void ObjectReadStreambuf::ThrowHashMismatchDelegate(char const* function_name) {
   std::string msg;
   msg += function_name;
   msg += "(): mismatched hashes in download";

--- a/google/cloud/terminate_handler.cc
+++ b/google/cloud/terminate_handler.cc
@@ -42,7 +42,7 @@ class TerminateFunction {
 };
 
 TerminateFunction& GetTerminateHolder() {
-  static TerminateFunction f([](const char* msg) {
+  static TerminateFunction f([](char const* msg) {
     std::cerr << "Aborting because exceptions are disabled: " << msg << "\n";
     std::abort();
   });
@@ -57,7 +57,7 @@ TerminateHandler SetTerminateHandler(TerminateHandler f) {
 
 TerminateHandler GetTerminateHandler() { return GetTerminateHolder().Get(); }
 
-[[noreturn]] void Terminate(const char* msg) {
+[[noreturn]] void Terminate(char const* msg) {
   GetTerminateHolder().Get()(msg);
   std::cerr << "Aborting because the installed terminate handler returned. "
                "Error details: "

--- a/google/cloud/terminate_handler.h
+++ b/google/cloud/terminate_handler.h
@@ -38,7 +38,7 @@ inline namespace GOOGLE_CLOUD_CPP_NS {
  * It should handle the error, whose description are given in *msg* and should
  * never return.
  */
-using TerminateHandler = std::function<void(const char* msg)>;
+using TerminateHandler = std::function<void(char const* msg)>;
 
 /**
  * Install terminate handler and get the old one atomically.
@@ -65,7 +65,7 @@ TerminateHandler GetTerminateHandler();
  * This function should never return.
  *
  */
-[[noreturn]] void Terminate(const char* msg);
+[[noreturn]] void Terminate(char const* msg);
 
 //@}
 

--- a/google/cloud/terminate_handler_test.cc
+++ b/google/cloud/terminate_handler_test.cc
@@ -24,12 +24,12 @@ using ::google::cloud::TerminateHandler;
 namespace {
 const std::string kHandlerMsg = "Custom handler invoked. Extra description: ";
 
-void CustomHandler(const char* msg) {
+void CustomHandler(char const* msg) {
   std::cerr << kHandlerMsg << msg << "\n";
   abort();
 }
 
-void CustomHandlerOld(const char*) { abort(); }
+void CustomHandlerOld(char const*) { abort(); }
 }  // namespace
 
 TEST(TerminateHandler, UnsetTerminates) {
@@ -41,14 +41,14 @@ TEST(TerminateHandler, UnsetTerminates) {
 TEST(TerminateHandler, SettingGettingWorks) {
   SetTerminateHandler(&CustomHandler);
   TerminateHandler set_handler = GetTerminateHandler();
-  ASSERT_TRUE(CustomHandler == *set_handler.target<void (*)(const char*)>())
+  ASSERT_TRUE(CustomHandler == *set_handler.target<void (*)(char const*)>())
       << "The handler objects should be equal.";
 }
 
 TEST(TerminateHandler, OldHandlerIsReturned) {
   SetTerminateHandler(&CustomHandlerOld);
   TerminateHandler old_handler = SetTerminateHandler(CustomHandler);
-  ASSERT_TRUE(CustomHandlerOld == *old_handler.target<void (*)(const char*)>())
+  ASSERT_TRUE(CustomHandlerOld == *old_handler.target<void (*)(char const*)>())
       << "The handler objects should be equal.";
 }
 
@@ -58,7 +58,7 @@ TEST(TerminateHandler, TerminateTerminates) {
 }
 
 TEST(TerminateHandler, NoAbortAborts) {
-  SetTerminateHandler([](const char*) {});
+  SetTerminateHandler([](char const*) {});
   const std::string expected =
       "Aborting because the installed terminate "
       "handler returned. Error details: details";


### PR DESCRIPTION
This may not be all of them, but it's the ones that I could find with a relatively simple PCRE of `\bconst\s[\w\d:_<>]+\s?[&*]`

No semantic changes, just const moving.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7163)
<!-- Reviewable:end -->
