### PR TITLE
test(storage): deflake integration tests

### DIFF
--- a/google/cloud/storage/tests/object_plenty_clients_serially_integration_test.cc
+++ b/google/cloud/storage/tests/object_plenty_clients_serially_integration_test.cc
@@ -38,6 +38,11 @@ using ObjectPlentyClientsSeriallyIntegrationTest =
     ::google::cloud::storage::testing::ObjectIntegrationTest;
 
 TEST_F(ObjectPlentyClientsSeriallyIntegrationTest, PlentyClientsSerially) {
+  // The main purpose of this test is to search for file description leaks in
+  // the REST-based client. We do not need such tests with gRPC, they have their
+  // own tests.
+  if (UsingGrpc()) GTEST_SKIP();
+
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
@@ -50,7 +55,7 @@ TEST_F(ObjectPlentyClientsSeriallyIntegrationTest, PlentyClientsSerially) {
   ASSERT_STATUS_OK(meta);
   ScheduleForDelete(*meta);
 
-  // Create a iostream to read the object back.
+  // Create an iostream to read the object back.
 
   // Track the number of open files to ensure every client creates the same
   // number of file descriptors and none are leaked.

--- a/google/cloud/storage/tests/object_plenty_clients_simultaneously_integration_test.cc
+++ b/google/cloud/storage/tests/object_plenty_clients_simultaneously_integration_test.cc
@@ -39,6 +39,11 @@ using ObjectPlentyClientsSimultaneouslyIntegrationTest =
 
 TEST_F(ObjectPlentyClientsSimultaneouslyIntegrationTest,
        PlentyClientsSimultaneously) {
+  // The main purpose of this test is to search for file description leaks in
+  // the REST-based client. We do not need such tests with gRPC, they have their
+  // own tests.
+  if (UsingGrpc()) GTEST_SKIP();
+
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
@@ -52,7 +57,7 @@ TEST_F(ObjectPlentyClientsSimultaneouslyIntegrationTest,
   ASSERT_STATUS_OK(meta);
   ScheduleForDelete(*meta);
 
-  // Create a iostream to read the object back.
+  // Create an iostream to read the object back.
   auto num_fds_before_test = GetNumOpenFiles();
   std::vector<Client> read_clients;
   std::vector<ObjectReadStream> read_streams;


### PR DESCRIPTION
These integration tests are designed to detect file descriptor leaks in
the REST implementation of the storage library. They do not work
reliably with the GCS+gRPC plugin because gRPC is less predictable in
how it releases resources. It does not matter to us, gRPC has its own
tests for resource leaks, we do not need to duplicate that work.

Fixes #7059

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7180)
<!-- Reviewable:end -->
