### PR TITLE
refactor(storage): rename aggregate throughput bm

### DIFF
--- a/google/cloud/storage/benchmarks/CMakeLists.txt
+++ b/google/cloud/storage/benchmarks/CMakeLists.txt
@@ -19,8 +19,8 @@ if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_GRPC)
 
     add_library(
         storage_benchmarks # cmake-format: sort
-        aggregate_throughput_options.cc
-        aggregate_throughput_options.h
+        aggregate_download_throughput_options.cc
+        aggregate_download_throughput_options.h
         benchmark_utils.cc
         benchmark_utils.h
         bounded_queue.h
@@ -44,7 +44,7 @@ if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_GRPC)
 
     set(storage_benchmark_programs
         # cmake-format: sort
-        aggregate_throughput_benchmark.cc
+        aggregate_download_throughput_benchmark.cc
         create_dataset.cc
         storage_file_transfer_benchmark.cc
         storage_parallel_uploads_benchmark.cc
@@ -77,7 +77,7 @@ if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_GRPC)
     # List the unit tests, then setup the targets and dependencies.
     set(storage_benchmarks_unit_tests
         # cmake-format: sort
-        aggregate_throughput_options_test.cc
+        aggregate_download_throughput_options_test.cc
         benchmark_make_random_test.cc
         benchmark_parser_test.cc
         create_dataset_options_test.cc

--- a/google/cloud/storage/benchmarks/aggregate_download_throughput_options.cc
+++ b/google/cloud/storage/benchmarks/aggregate_download_throughput_options.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "google/cloud/storage/benchmarks/aggregate_throughput_options.h"
+#include "google/cloud/storage/benchmarks/aggregate_download_throughput_options.h"
 #include "google/cloud/internal/absl_str_join_quiet.h"
 #include <iterator>
 #include <sstream>
@@ -23,10 +23,10 @@ namespace storage_benchmarks {
 
 using ::google::cloud::testing_util::OptionDescriptor;
 
-google::cloud::StatusOr<AggregateThroughputOptions>
-ParseAggregateThroughputOptions(std::vector<std::string> const& argv,
-                                std::string const& description) {
-  AggregateThroughputOptions options;
+google::cloud::StatusOr<AggregateDownloadThroughputOptions>
+ParseAggregateDownloadThroughputOptions(std::vector<std::string> const& argv,
+                                        std::string const& description) {
+  AggregateDownloadThroughputOptions options;
   bool wants_help = false;
   bool wants_description = false;
 

--- a/google/cloud/storage/benchmarks/aggregate_download_throughput_options.h
+++ b/google/cloud/storage/benchmarks/aggregate_download_throughput_options.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_BENCHMARKS_AGGREGATE_THROUGHPUT_OPTIONS_H
-#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_BENCHMARKS_AGGREGATE_THROUGHPUT_OPTIONS_H
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_BENCHMARKS_AGGREGATE_DOWNLOAD_THROUGHPUT_OPTIONS_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_BENCHMARKS_AGGREGATE_DOWNLOAD_THROUGHPUT_OPTIONS_H
 
 #include "google/cloud/storage/benchmarks/benchmark_utils.h"
 #include <cstdint>
@@ -24,7 +24,7 @@ namespace google {
 namespace cloud {
 namespace storage_benchmarks {
 
-struct AggregateThroughputOptions {
+struct AggregateDownloadThroughputOptions {
   std::string labels;
   std::string bucket_name;
   std::string object_prefix;
@@ -42,12 +42,12 @@ struct AggregateThroughputOptions {
   bool exit_after_parse = false;
 };
 
-google::cloud::StatusOr<AggregateThroughputOptions>
-ParseAggregateThroughputOptions(std::vector<std::string> const& argv,
-                                std::string const& description);
+google::cloud::StatusOr<AggregateDownloadThroughputOptions>
+ParseAggregateDownloadThroughputOptions(std::vector<std::string> const& argv,
+                                        std::string const& description);
 
 }  // namespace storage_benchmarks
 }  // namespace cloud
 }  // namespace google
 
-#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_BENCHMARKS_AGGREGATE_THROUGHPUT_OPTIONS_H
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_BENCHMARKS_AGGREGATE_DOWNLOAD_THROUGHPUT_OPTIONS_H

--- a/google/cloud/storage/benchmarks/aggregate_download_throughput_options_test.cc
+++ b/google/cloud/storage/benchmarks/aggregate_download_throughput_options_test.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "google/cloud/storage/benchmarks/aggregate_throughput_options.h"
+#include "google/cloud/storage/benchmarks/aggregate_download_throughput_options.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
 #include <thread>
@@ -22,8 +22,8 @@ namespace cloud {
 namespace storage_benchmarks {
 namespace {
 
-TEST(AggregateThroughputOptions, Basic) {
-  auto options = ParseAggregateThroughputOptions(
+TEST(AggregateDownloadThroughputOptions, Basic) {
+  auto options = ParseAggregateDownloadThroughputOptions(
       {
           "self-test",
           "--labels=a,b,c",
@@ -60,40 +60,41 @@ TEST(AggregateThroughputOptions, Basic) {
   EXPECT_EQ(std::chrono::seconds(120), options->download_stall_timeout);
 }
 
-TEST(AggregateThroughputOptions, Description) {
-  auto options = ParseAggregateThroughputOptions(
+TEST(AggregateDownloadThroughputOptions, Description) {
+  auto options = ParseAggregateDownloadThroughputOptions(
       {"self-test", "--description", "fake-bucket"}, "Description for test");
   EXPECT_STATUS_OK(options);
   EXPECT_TRUE(options->exit_after_parse);
 }
 
-TEST(AggregateThroughputOptions, Help) {
-  auto options = ParseAggregateThroughputOptions(
+TEST(AggregateDownloadThroughputOptions, Help) {
+  auto options = ParseAggregateDownloadThroughputOptions(
       {"self-test", "--help", "fake-bucket"}, "");
   EXPECT_STATUS_OK(options);
   EXPECT_TRUE(options->exit_after_parse);
 }
 
-TEST(AggregateThroughputOptions, Validate) {
-  EXPECT_FALSE(ParseAggregateThroughputOptions({"self-test"}, ""));
-  EXPECT_FALSE(ParseAggregateThroughputOptions({"self-test", "unused-1"}, ""));
+TEST(AggregateDownloadThroughputOptions, Validate) {
+  EXPECT_FALSE(ParseAggregateDownloadThroughputOptions({"self-test"}, ""));
   EXPECT_FALSE(
-      ParseAggregateThroughputOptions({"self-test", "--invalid-option"}, ""));
-  EXPECT_FALSE(ParseAggregateThroughputOptions(
+      ParseAggregateDownloadThroughputOptions({"self-test", "unused-1"}, ""));
+  EXPECT_FALSE(ParseAggregateDownloadThroughputOptions(
+      {"self-test", "--invalid-option"}, ""));
+  EXPECT_FALSE(ParseAggregateDownloadThroughputOptions(
       {"self-test", "--bucket-name=b", "--thread-count=0"}, ""));
-  EXPECT_FALSE(ParseAggregateThroughputOptions(
+  EXPECT_FALSE(ParseAggregateDownloadThroughputOptions(
       {"self-test", "--bucket-name=b", "--thread-count=-1"}, ""));
-  EXPECT_FALSE(ParseAggregateThroughputOptions(
+  EXPECT_FALSE(ParseAggregateDownloadThroughputOptions(
       {"self-test", "--bucket-name=b", "--iteration-count=0"}, ""));
-  EXPECT_FALSE(ParseAggregateThroughputOptions(
+  EXPECT_FALSE(ParseAggregateDownloadThroughputOptions(
       {"self-test", "--bucket-name=b", "--iteration-count=-1"}, ""));
-  EXPECT_FALSE(ParseAggregateThroughputOptions(
+  EXPECT_FALSE(ParseAggregateDownloadThroughputOptions(
       {"self-test", "--bucket-name=b", "--repeats-per-iteration=0"}, ""));
-  EXPECT_FALSE(ParseAggregateThroughputOptions(
+  EXPECT_FALSE(ParseAggregateDownloadThroughputOptions(
       {"self-test", "--bucket-name=b", "--repeats-per-iteration=-1"}, ""));
-  EXPECT_FALSE(ParseAggregateThroughputOptions(
+  EXPECT_FALSE(ParseAggregateDownloadThroughputOptions(
       {"self-test", "--bucket-name=b", "--api=GRPC-RAW"}, ""));
-  EXPECT_FALSE(ParseAggregateThroughputOptions(
+  EXPECT_FALSE(ParseAggregateDownloadThroughputOptions(
       {"self-test", "--bucket-name=b", "--grpc-channel-count=-1"}, ""));
 }
 

--- a/google/cloud/storage/benchmarks/storage_benchmark_programs.bzl
+++ b/google/cloud/storage/benchmarks/storage_benchmark_programs.bzl
@@ -17,7 +17,7 @@
 """Automatically generated unit tests list - DO NOT EDIT."""
 
 storage_benchmark_programs = [
-    "aggregate_throughput_benchmark.cc",
+    "aggregate_download_throughput_benchmark.cc",
     "create_dataset.cc",
     "storage_file_transfer_benchmark.cc",
     "storage_parallel_uploads_benchmark.cc",

--- a/google/cloud/storage/benchmarks/storage_benchmarks.bzl
+++ b/google/cloud/storage/benchmarks/storage_benchmarks.bzl
@@ -17,7 +17,7 @@
 """Automatically generated source lists for storage_benchmarks - DO NOT EDIT."""
 
 storage_benchmarks_hdrs = [
-    "aggregate_throughput_options.h",
+    "aggregate_download_throughput_options.h",
     "benchmark_utils.h",
     "bounded_queue.h",
     "create_dataset_options.h",
@@ -27,7 +27,7 @@ storage_benchmarks_hdrs = [
 ]
 
 storage_benchmarks_srcs = [
-    "aggregate_throughput_options.cc",
+    "aggregate_download_throughput_options.cc",
     "benchmark_utils.cc",
     "create_dataset_options.cc",
     "throughput_experiment.cc",

--- a/google/cloud/storage/benchmarks/storage_benchmarks_unit_tests.bzl
+++ b/google/cloud/storage/benchmarks/storage_benchmarks_unit_tests.bzl
@@ -17,7 +17,7 @@
 """Automatically generated unit tests list - DO NOT EDIT."""
 
 storage_benchmarks_unit_tests = [
-    "aggregate_throughput_options_test.cc",
+    "aggregate_download_throughput_options_test.cc",
     "benchmark_make_random_test.cc",
     "benchmark_parser_test.cc",
     "create_dataset_options_test.cc",


### PR DESCRIPTION
I need to create a benchmark for aggregate upload throughput. Changing
the name of the current benchmark so the situation is clearer once I
start adding files.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7182)
<!-- Reviewable:end -->
