### PR TITLE
feat(spanner): add generated admin APIs

### DIFF
--- a/generator/generator_config.textproto
+++ b/generator/generator_config.textproto
@@ -41,3 +41,16 @@ service {
   product_path: "google/cloud/logging"
   initial_copyright_year: "2021"
 }
+
+# Spanner
+service {
+  service_proto_path: "google/spanner/admin/database/v1/spanner_database_admin.proto"
+  product_path: "google/cloud/spanner/admin"
+  initial_copyright_year: "2021"
+}
+
+service {
+  service_proto_path: "google/spanner/admin/instance/v1/spanner_instance_admin.proto"
+  product_path: "google/cloud/spanner/admin"
+  initial_copyright_year: "2021"
+}


### PR DESCRIPTION
Configure generation of the Spanner database/instance admin APIs:
- in `google::cloud::spanner_admin` namespace
- in `google/cloud/spanner/admin` include path

This will allow them to co-exist with the hand-wrought APIs until
the latter can be deprecated and eventually removed.

The actual merge of the generated code will be in followup PRs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7183)
<!-- Reviewable:end -->
