### PR TITLE
feat(common): add GrpcChannelArgumentsNativeOption

### DIFF
--- a/google/cloud/grpc_options.cc
+++ b/google/cloud/grpc_options.cc
@@ -24,7 +24,7 @@ inline namespace GOOGLE_CLOUD_CPP_NS {
 namespace internal {
 
 grpc::ChannelArguments MakeChannelArguments(Options const& opts) {
-  grpc::ChannelArguments channel_arguments;
+  auto channel_arguments = opts.get<GrpcChannelArgumentsNativeOption>();
   for (auto const& p : opts.get<GrpcChannelArgumentsOption>()) {
     channel_arguments.SetString(p.first, p.second);
   }

--- a/google/cloud/grpc_options.h
+++ b/google/cloud/grpc_options.h
@@ -50,13 +50,40 @@ struct GrpcNumChannelsOption {
  *
  * This option gives users the ability to set various arguments for the
  * underlying `grpc::ChannelArguments` objects that will be created. See the
- * gRPC documentation for more details about available options.
+ * gRPC documentation for more details about available channel arguments.
+ *
+ * Our library will always start with the native object from
+ * `GrpcChannelArgumentsNativeOption`, then add the channel arguments from this
+ * option. Users are cautioned not to set the same channel argument to different
+ * values in different options as gRPC will use the first value set for some
+ * channel arguments, and the last value set for others.
  *
  * @see https://grpc.github.io/grpc/cpp/classgrpc_1_1_channel_arguments.html
  * @see https://grpc.github.io/grpc/core/group__grpc__arg__keys.html
  */
 struct GrpcChannelArgumentsOption {
   using Type = std::map<std::string, std::string>;
+};
+
+/**
+ * The native `grpc::ChannelArguments` object.
+ *
+ * This option gives users full control over the `grpc::ChannelArguments`
+ * objects that will be created. See the gRPC documentation for more details
+ * about available channel arguments.
+ *
+ * Our library will always start with the native object, then add in the channel
+ * arguments from `GrpcChannelArgumentsOption`, then add the user agent prefix
+ * from `UserAgentProductsOption`. Users are cautioned not to set the same
+ * channel argument to different values in different options as gRPC will use
+ * the first value set for some channel arguments, and the last value set for
+ * others.
+ *
+ * @see https://grpc.github.io/grpc/cpp/classgrpc_1_1_channel_arguments.html
+ * @see https://grpc.github.io/grpc/core/group__grpc__arg__keys.html
+ */
+struct GrpcChannelArgumentsNativeOption {
+  using Type = grpc::ChannelArguments;
 };
 
 /**
@@ -96,8 +123,8 @@ struct GrpcBackgroundThreadsFactoryOption {
  */
 using GrpcOptionList =
     OptionList<GrpcCredentialOption, GrpcNumChannelsOption,
-               GrpcChannelArgumentsOption, GrpcTracingOptionsOption,
-               GrpcBackgroundThreadsFactoryOption>;
+               GrpcChannelArgumentsOption, GrpcChannelArgumentsNativeOption,
+               GrpcTracingOptionsOption, GrpcBackgroundThreadsFactoryOption>;
 
 namespace internal {
 

--- a/google/cloud/grpc_options.h
+++ b/google/cloud/grpc_options.h
@@ -52,7 +52,7 @@ struct GrpcNumChannelsOption {
  * underlying `grpc::ChannelArguments` objects that will be created. See the
  * gRPC documentation for more details about available channel arguments.
  *
- * Our library will always start with the native object from
+ * @note Our library will always start with the native object from
  * `GrpcChannelArgumentsNativeOption`, then add the channel arguments from this
  * option. Users are cautioned not to set the same channel argument to different
  * values in different options as gRPC will use the first value set for some
@@ -72,12 +72,12 @@ struct GrpcChannelArgumentsOption {
  * objects that will be created. See the gRPC documentation for more details
  * about available channel arguments.
  *
- * Our library will always start with the native object, then add in the channel
- * arguments from `GrpcChannelArgumentsOption`, then add the user agent prefix
- * from `UserAgentProductsOption`. Users are cautioned not to set the same
- * channel argument to different values in different options as gRPC will use
- * the first value set for some channel arguments, and the last value set for
- * others.
+ * @note Our library will always start with the native object, then add in the
+ * channel arguments from `GrpcChannelArgumentsOption`, then add the user agent
+ * prefix from `UserAgentProductsOption`. Users are cautioned not to set the
+ * same channel argument to different values in different options as gRPC will
+ * use the first value set for some channel arguments, and the last value set
+ * for others.
  *
  * @see https://grpc.github.io/grpc/cpp/classgrpc_1_1_channel_arguments.html
  * @see https://grpc.github.io/grpc/core/group__grpc__arg__keys.html


### PR DESCRIPTION
Part of the work for #6307 

Add a common option to give users full control over their gRPC channel configuration.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7194)
<!-- Reviewable:end -->
