### PR TITLE
test(spanner): extend timeouts for "slow" database operations

### DIFF
--- a/ci/cloudbuild/builds/integration-daily.sh
+++ b/ci/cloudbuild/builds/integration-daily.sh
@@ -47,4 +47,5 @@ integration::bazel_with_emulators test "${args[@]}" "${integration_args[@]}"
 
 io::log_h2 "Running Spanner integration tests (against prod)"
 bazel test "${args[@]}" "${integration_args[@]}" \
-  --test_tag_filters="integration-test" google/cloud/spanner/...
+  --test_tag_filters="integration-test" --test_timeout=-1,-1,-1,7200 \
+  google/cloud/spanner/...

--- a/google/cloud/spanner/testing/policies.h
+++ b/google/cloud/spanner/testing/policies.h
@@ -26,7 +26,7 @@ namespace cloud {
 namespace spanner_testing {
 inline namespace SPANNER_CLIENT_NS {
 
-auto constexpr kMaximumWaitTimeMinutes = 30;  // test timeout notwithstanding
+auto constexpr kMaximumWaitTimeMinutes = 60;  // test timeout notwithstanding
 auto constexpr kBackoffScaling = 2.0;
 
 inline std::unique_ptr<spanner::RetryPolicy> TestRetryPolicy() {


### PR DESCRIPTION
Creating/restoring backups are not only long-running operations,
but their service time is variable (apparently because they are
batch-scheduled in the backend).

So:
- Extend the timeout for "eternal" integration tests in the
  `integration-daily` build (where they run against prod) from
  1h (the default) to 2h.  This now matches the GCB timeout.
- Extend the per-operation polling timeout from 30m to 60m.

Fixes #4306.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7195)
<!-- Reviewable:end -->
