### PR TITLE
refactor: move gRPC Channel Argument helpers to common

### DIFF
--- a/google/cloud/bigtable/client_options_test.cc
+++ b/google/cloud/bigtable/client_options_test.cc
@@ -35,6 +35,12 @@ struct ClientOptionsTestTraits {
   }
 };
 
+namespace {
+using ::google::cloud::internal::GetIntChannelArgument;
+using ::google::cloud::internal::GetStringChannelArgument;
+using ::testing::HasSubstr;
+}  // namespace
+
 TEST(ClientOptionsTest, ClientOptionsDefaultSettings) {
   bigtable::ClientOptions client_options_object = bigtable::ClientOptions();
   EXPECT_EQ("bigtable.googleapis.com", client_options_object.data_endpoint());
@@ -278,9 +284,9 @@ TEST(ClientOptionsTest, SetGrpclbFallbackTimeoutMS) {
   bigtable::ClientOptions client_options_object = bigtable::ClientOptions();
   ASSERT_STATUS_OK(client_options_object.SetGrpclbFallbackTimeout(
       std::chrono::milliseconds(5)));
-  auto const actual = ::google::cloud::internal::GetIntChannelArgument(
-      client_options_object.channel_arguments(),
-      GRPC_ARG_GRPCLB_FALLBACK_TIMEOUT_MS);
+  auto const actual =
+      GetIntChannelArgument(client_options_object.channel_arguments(),
+                            GRPC_ARG_GRPCLB_FALLBACK_TIMEOUT_MS);
   ASSERT_TRUE(actual.has_value());
   EXPECT_EQ(*actual, 5);
 }
@@ -291,9 +297,9 @@ TEST(ClientOptionsTest, SetGrpclbFallbackTimeoutSec) {
       bigtable::ClientOptions();
   ASSERT_STATUS_OK(client_options_object_second.SetGrpclbFallbackTimeout(
       std::chrono::seconds(5)));
-  auto const actual = ::google::cloud::internal::GetIntChannelArgument(
-      client_options_object_second.channel_arguments(),
-      GRPC_ARG_GRPCLB_FALLBACK_TIMEOUT_MS);
+  auto const actual =
+      GetIntChannelArgument(client_options_object_second.channel_arguments(),
+                            GRPC_ARG_GRPCLB_FALLBACK_TIMEOUT_MS);
   ASSERT_TRUE(actual.has_value());
   EXPECT_EQ(*actual, 5000);
 }
@@ -312,9 +318,9 @@ TEST(ClientOptionsTest, SetGrpclbFallbackTimeoutException) {
 TEST(ClientOptionsTest, SetCompressionAlgorithm) {
   bigtable::ClientOptions client_options_object = bigtable::ClientOptions();
   client_options_object.SetCompressionAlgorithm(GRPC_COMPRESS_NONE);
-  auto const actual = ::google::cloud::internal::GetIntChannelArgument(
-      client_options_object.channel_arguments(),
-      GRPC_COMPRESSION_CHANNEL_DEFAULT_ALGORITHM);
+  auto const actual =
+      GetIntChannelArgument(client_options_object.channel_arguments(),
+                            GRPC_COMPRESSION_CHANNEL_DEFAULT_ALGORITHM);
   ASSERT_TRUE(actual.has_value());
   EXPECT_EQ(*actual, GRPC_COMPRESS_NONE);
 }
@@ -323,9 +329,9 @@ TEST(ClientOptionsTest, SetMaxReceiveMessageSize) {
   bigtable::ClientOptions client_options_object = bigtable::ClientOptions();
   auto constexpr kExpected = 256 * 1024L * 1024L;
   client_options_object.SetMaxReceiveMessageSize(kExpected);
-  auto const actual = ::google::cloud::internal::GetIntChannelArgument(
-      client_options_object.channel_arguments(),
-      GRPC_ARG_MAX_RECEIVE_MESSAGE_LENGTH);
+  auto const actual =
+      GetIntChannelArgument(client_options_object.channel_arguments(),
+                            GRPC_ARG_MAX_RECEIVE_MESSAGE_LENGTH);
   ASSERT_TRUE(actual.has_value());
   EXPECT_EQ(*actual, kExpected);
 }
@@ -335,9 +341,9 @@ TEST(ClientOptionsTest, SetMaxSendMessageSize) {
   auto constexpr kExpected = 256 * 1024L * 1024L;
   client_options_object.SetMaxSendMessageSize(kExpected);
   grpc::ChannelArguments c_args = client_options_object.channel_arguments();
-  auto const actual = ::google::cloud::internal::GetIntChannelArgument(
-      client_options_object.channel_arguments(),
-      GRPC_ARG_MAX_SEND_MESSAGE_LENGTH);
+  auto const actual =
+      GetIntChannelArgument(client_options_object.channel_arguments(),
+                            GRPC_ARG_MAX_SEND_MESSAGE_LENGTH);
   ASSERT_TRUE(actual.has_value());
   EXPECT_EQ(*actual, kExpected);
 }
@@ -346,7 +352,7 @@ TEST(ClientOptionsTest, SetLoadBalancingPolicyName) {
   bigtable::ClientOptions client_options_object = bigtable::ClientOptions();
   client_options_object.SetLoadBalancingPolicyName("test-policy-name");
   grpc::ChannelArguments c_args = client_options_object.channel_arguments();
-  auto const actual = ::google::cloud::internal::GetStringChannelArgument(
+  auto const actual = GetStringChannelArgument(
       client_options_object.channel_arguments(), GRPC_ARG_LB_POLICY_NAME);
   ASSERT_TRUE(actual.has_value());
   EXPECT_EQ(*actual, "test-policy-name");
@@ -356,7 +362,7 @@ TEST(ClientOptionsTest, SetServiceConfigJSON) {
   bigtable::ClientOptions client_options_object = bigtable::ClientOptions();
   client_options_object.SetServiceConfigJSON("test-config");
   grpc::ChannelArguments c_args = client_options_object.channel_arguments();
-  auto const actual = ::google::cloud::internal::GetStringChannelArgument(
+  auto const actual = GetStringChannelArgument(
       client_options_object.channel_arguments(), GRPC_ARG_SERVICE_CONFIG);
   ASSERT_TRUE(actual.has_value());
   EXPECT_EQ(*actual, "test-config");
@@ -365,19 +371,19 @@ TEST(ClientOptionsTest, SetServiceConfigJSON) {
 TEST(ClientOptionsTest, SetUserAgentPrefix) {
   bigtable::ClientOptions client_options_object = bigtable::ClientOptions();
   client_options_object.SetUserAgentPrefix("test_prefix");
-  auto const actual = ::google::cloud::internal::GetStringChannelArgument(
-      client_options_object.channel_arguments(),
-      GRPC_ARG_PRIMARY_USER_AGENT_STRING);
+  auto const actual =
+      GetStringChannelArgument(client_options_object.channel_arguments(),
+                               GRPC_ARG_PRIMARY_USER_AGENT_STRING);
   ASSERT_TRUE(actual.has_value());
-  EXPECT_THAT(*actual, ::testing::HasSubstr("test_prefix"));
+  EXPECT_THAT(*actual, HasSubstr("test_prefix"));
 }
 
 TEST(ClientOptionsTest, SetSslTargetNameOverride) {
   bigtable::ClientOptions client_options_object = bigtable::ClientOptions();
   client_options_object.SetSslTargetNameOverride("test-name");
-  auto const actual = ::google::cloud::internal::GetStringChannelArgument(
-      client_options_object.channel_arguments(),
-      GRPC_SSL_TARGET_NAME_OVERRIDE_ARG);
+  auto const actual =
+      GetStringChannelArgument(client_options_object.channel_arguments(),
+                               GRPC_SSL_TARGET_NAME_OVERRIDE_ARG);
   ASSERT_TRUE(actual.has_value());
   EXPECT_EQ(*actual, "test-name");
 }
@@ -385,7 +391,7 @@ TEST(ClientOptionsTest, SetSslTargetNameOverride) {
 TEST(ClientOptionsTest, UserAgentPrefix) {
   std::string const actual = bigtable::ClientOptions::UserAgentPrefix();
 
-  EXPECT_THAT(actual, ::testing::HasSubstr("gcloud-cpp/"));
+  EXPECT_THAT(actual, HasSubstr("gcloud-cpp/"));
 }
 
 TEST(ClientOptionsTest, RefreshPeriod) {

--- a/google/cloud/bigtable/client_options_test.cc
+++ b/google/cloud/bigtable/client_options_test.cc
@@ -37,32 +37,12 @@ struct ClientOptionsTestTraits {
 namespace {
 
 using ::testing::HasSubstr;
+// NOLINTNEXTLINE(readability-identifier-naming)
+auto const GetInt = ::google::cloud::internal::GetIntChannelArgument;
+// NOLINTNEXTLINE(readability-identifier-naming)
+auto const GetString = ::google::cloud::internal::GetStringChannelArgument;
 
-absl::optional<int> GetInt(grpc::ChannelArguments const& args,
-                           std::string const& key) {
-  auto c_args = args.c_channel_args();
-  // Just do a linear search for the key; the data structure is not organized
-  // in any other useful way.
-  for (auto const* a = c_args.args; a != c_args.args + c_args.num_args; ++a) {
-    if (key != a->key) continue;
-    if (a->type != GRPC_ARG_INTEGER) return absl::nullopt;
-    return a->value.integer;
-  }
-  return absl::nullopt;
-}
-
-absl::optional<std::string> GetString(grpc::ChannelArguments const& args,
-                                      std::string const& key) {
-  auto c_args = args.c_channel_args();
-  // Just do a linear search for the key; the data structure is not organized
-  // in any other useful way.
-  for (auto const* a = c_args.args; a != c_args.args + c_args.num_args; ++a) {
-    if (key != a->key) continue;
-    if (a->type != GRPC_ARG_STRING) return absl::nullopt;
-    return a->value.string;
-  }
-  return absl::nullopt;
-}
+}  // namespace
 
 TEST(ClientOptionsTest, ClientOptionsDefaultSettings) {
   bigtable::ClientOptions client_options_object = bigtable::ClientOptions();
@@ -516,7 +496,6 @@ TEST(ClientOptionsTest, CustomBackgroundThreads) {
   t.join();
 }
 
-}  // namespace
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable
 }  // namespace cloud

--- a/google/cloud/bigtable/client_options_test.cc
+++ b/google/cloud/bigtable/client_options_test.cc
@@ -14,6 +14,7 @@
 
 #include "google/cloud/bigtable/client_options.h"
 #include "google/cloud/bigtable/internal/client_options_defaults.h"
+#include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/background_threads_impl.h"
 #include "google/cloud/status.h"
 #include "google/cloud/testing_util/scoped_environment.h"
@@ -33,16 +34,6 @@ struct ClientOptionsTestTraits {
     return options.instance_admin_endpoint();
   }
 };
-
-namespace {
-
-using ::testing::HasSubstr;
-// NOLINTNEXTLINE(readability-identifier-naming)
-auto const GetInt = ::google::cloud::internal::GetIntChannelArgument;
-// NOLINTNEXTLINE(readability-identifier-naming)
-auto const GetString = ::google::cloud::internal::GetStringChannelArgument;
-
-}  // namespace
 
 TEST(ClientOptionsTest, ClientOptionsDefaultSettings) {
   bigtable::ClientOptions client_options_object = bigtable::ClientOptions();
@@ -287,8 +278,9 @@ TEST(ClientOptionsTest, SetGrpclbFallbackTimeoutMS) {
   bigtable::ClientOptions client_options_object = bigtable::ClientOptions();
   ASSERT_STATUS_OK(client_options_object.SetGrpclbFallbackTimeout(
       std::chrono::milliseconds(5)));
-  auto const actual = GetInt(client_options_object.channel_arguments(),
-                             GRPC_ARG_GRPCLB_FALLBACK_TIMEOUT_MS);
+  auto const actual = ::google::cloud::internal::GetIntChannelArgument(
+      client_options_object.channel_arguments(),
+      GRPC_ARG_GRPCLB_FALLBACK_TIMEOUT_MS);
   ASSERT_TRUE(actual.has_value());
   EXPECT_EQ(*actual, 5);
 }
@@ -299,8 +291,9 @@ TEST(ClientOptionsTest, SetGrpclbFallbackTimeoutSec) {
       bigtable::ClientOptions();
   ASSERT_STATUS_OK(client_options_object_second.SetGrpclbFallbackTimeout(
       std::chrono::seconds(5)));
-  auto const actual = GetInt(client_options_object_second.channel_arguments(),
-                             GRPC_ARG_GRPCLB_FALLBACK_TIMEOUT_MS);
+  auto const actual = ::google::cloud::internal::GetIntChannelArgument(
+      client_options_object_second.channel_arguments(),
+      GRPC_ARG_GRPCLB_FALLBACK_TIMEOUT_MS);
   ASSERT_TRUE(actual.has_value());
   EXPECT_EQ(*actual, 5000);
 }
@@ -319,8 +312,9 @@ TEST(ClientOptionsTest, SetGrpclbFallbackTimeoutException) {
 TEST(ClientOptionsTest, SetCompressionAlgorithm) {
   bigtable::ClientOptions client_options_object = bigtable::ClientOptions();
   client_options_object.SetCompressionAlgorithm(GRPC_COMPRESS_NONE);
-  auto const actual = GetInt(client_options_object.channel_arguments(),
-                             GRPC_COMPRESSION_CHANNEL_DEFAULT_ALGORITHM);
+  auto const actual = ::google::cloud::internal::GetIntChannelArgument(
+      client_options_object.channel_arguments(),
+      GRPC_COMPRESSION_CHANNEL_DEFAULT_ALGORITHM);
   ASSERT_TRUE(actual.has_value());
   EXPECT_EQ(*actual, GRPC_COMPRESS_NONE);
 }
@@ -329,8 +323,9 @@ TEST(ClientOptionsTest, SetMaxReceiveMessageSize) {
   bigtable::ClientOptions client_options_object = bigtable::ClientOptions();
   auto constexpr kExpected = 256 * 1024L * 1024L;
   client_options_object.SetMaxReceiveMessageSize(kExpected);
-  auto const actual = GetInt(client_options_object.channel_arguments(),
-                             GRPC_ARG_MAX_RECEIVE_MESSAGE_LENGTH);
+  auto const actual = ::google::cloud::internal::GetIntChannelArgument(
+      client_options_object.channel_arguments(),
+      GRPC_ARG_MAX_RECEIVE_MESSAGE_LENGTH);
   ASSERT_TRUE(actual.has_value());
   EXPECT_EQ(*actual, kExpected);
 }
@@ -340,8 +335,9 @@ TEST(ClientOptionsTest, SetMaxSendMessageSize) {
   auto constexpr kExpected = 256 * 1024L * 1024L;
   client_options_object.SetMaxSendMessageSize(kExpected);
   grpc::ChannelArguments c_args = client_options_object.channel_arguments();
-  auto const actual = GetInt(client_options_object.channel_arguments(),
-                             GRPC_ARG_MAX_SEND_MESSAGE_LENGTH);
+  auto const actual = ::google::cloud::internal::GetIntChannelArgument(
+      client_options_object.channel_arguments(),
+      GRPC_ARG_MAX_SEND_MESSAGE_LENGTH);
   ASSERT_TRUE(actual.has_value());
   EXPECT_EQ(*actual, kExpected);
 }
@@ -350,8 +346,8 @@ TEST(ClientOptionsTest, SetLoadBalancingPolicyName) {
   bigtable::ClientOptions client_options_object = bigtable::ClientOptions();
   client_options_object.SetLoadBalancingPolicyName("test-policy-name");
   grpc::ChannelArguments c_args = client_options_object.channel_arguments();
-  auto const actual = GetString(client_options_object.channel_arguments(),
-                                GRPC_ARG_LB_POLICY_NAME);
+  auto const actual = ::google::cloud::internal::GetStringChannelArgument(
+      client_options_object.channel_arguments(), GRPC_ARG_LB_POLICY_NAME);
   ASSERT_TRUE(actual.has_value());
   EXPECT_EQ(*actual, "test-policy-name");
 }
@@ -360,8 +356,8 @@ TEST(ClientOptionsTest, SetServiceConfigJSON) {
   bigtable::ClientOptions client_options_object = bigtable::ClientOptions();
   client_options_object.SetServiceConfigJSON("test-config");
   grpc::ChannelArguments c_args = client_options_object.channel_arguments();
-  auto const actual = GetString(client_options_object.channel_arguments(),
-                                GRPC_ARG_SERVICE_CONFIG);
+  auto const actual = ::google::cloud::internal::GetStringChannelArgument(
+      client_options_object.channel_arguments(), GRPC_ARG_SERVICE_CONFIG);
   ASSERT_TRUE(actual.has_value());
   EXPECT_EQ(*actual, "test-config");
 }
@@ -369,17 +365,19 @@ TEST(ClientOptionsTest, SetServiceConfigJSON) {
 TEST(ClientOptionsTest, SetUserAgentPrefix) {
   bigtable::ClientOptions client_options_object = bigtable::ClientOptions();
   client_options_object.SetUserAgentPrefix("test_prefix");
-  auto const actual = GetString(client_options_object.channel_arguments(),
-                                GRPC_ARG_PRIMARY_USER_AGENT_STRING);
+  auto const actual = ::google::cloud::internal::GetStringChannelArgument(
+      client_options_object.channel_arguments(),
+      GRPC_ARG_PRIMARY_USER_AGENT_STRING);
   ASSERT_TRUE(actual.has_value());
-  EXPECT_THAT(*actual, HasSubstr("test_prefix"));
+  EXPECT_THAT(*actual, ::testing::HasSubstr("test_prefix"));
 }
 
 TEST(ClientOptionsTest, SetSslTargetNameOverride) {
   bigtable::ClientOptions client_options_object = bigtable::ClientOptions();
   client_options_object.SetSslTargetNameOverride("test-name");
-  auto const actual = GetString(client_options_object.channel_arguments(),
-                                GRPC_SSL_TARGET_NAME_OVERRIDE_ARG);
+  auto const actual = ::google::cloud::internal::GetStringChannelArgument(
+      client_options_object.channel_arguments(),
+      GRPC_SSL_TARGET_NAME_OVERRIDE_ARG);
   ASSERT_TRUE(actual.has_value());
   EXPECT_EQ(*actual, "test-name");
 }
@@ -387,7 +385,7 @@ TEST(ClientOptionsTest, SetSslTargetNameOverride) {
 TEST(ClientOptionsTest, UserAgentPrefix) {
   std::string const actual = bigtable::ClientOptions::UserAgentPrefix();
 
-  EXPECT_THAT(actual, HasSubstr("gcloud-cpp/"));
+  EXPECT_THAT(actual, ::testing::HasSubstr("gcloud-cpp/"));
 }
 
 TEST(ClientOptionsTest, RefreshPeriod) {

--- a/google/cloud/grpc_options.cc
+++ b/google/cloud/grpc_options.cc
@@ -35,6 +35,32 @@ grpc::ChannelArguments MakeChannelArguments(Options const& opts) {
   return channel_arguments;
 }
 
+absl::optional<int> GetIntChannelArgument(grpc::ChannelArguments const& args,
+                                          std::string const& key) {
+  auto c_args = args.c_channel_args();
+  // Just do a linear search for the key; the data structure is not organized
+  // in any other useful way.
+  for (auto const* a = c_args.args; a != c_args.args + c_args.num_args; ++a) {
+    if (key != a->key) continue;
+    if (a->type != GRPC_ARG_INTEGER) return absl::nullopt;
+    return a->value.integer;
+  }
+  return absl::nullopt;
+}
+
+absl::optional<std::string> GetStringChannelArgument(
+    grpc::ChannelArguments const& args, std::string const& key) {
+  auto c_args = args.c_channel_args();
+  // Just do a linear search for the key; the data structure is not organized
+  // in any other useful way.
+  for (auto const* a = c_args.args; a != c_args.args + c_args.num_args; ++a) {
+    if (key != a->key) continue;
+    if (a->type != GRPC_ARG_STRING) return absl::nullopt;
+    return a->value.string;
+  }
+  return absl::nullopt;
+}
+
 BackgroundThreadsFactory MakeBackgroundThreadsFactory(Options const& opts) {
   if (opts.has<GrpcBackgroundThreadsFactoryOption>())
     return opts.get<GrpcBackgroundThreadsFactoryOption>();

--- a/google/cloud/grpc_options.h
+++ b/google/cloud/grpc_options.h
@@ -131,6 +131,14 @@ namespace internal {
 /// Creates a new `grpc::ChannelArguments` configured with @p opts.
 grpc::ChannelArguments MakeChannelArguments(Options const& opts);
 
+/// Helper function to extract the first instance of an integer channel argument
+absl::optional<int> GetIntChannelArgument(grpc::ChannelArguments const& args,
+                                          std::string const& key);
+
+/// Helper function to extract the first instance of a string channel argument
+absl::optional<std::string> GetStringChannelArgument(
+    grpc::ChannelArguments const& args, std::string const& key);
+
 /**
  * Returns a factory for generating `BackgroundThreads`. If
  * `GrpcBackgroundThreadsFactoryOption` is unset, it will return a thread pool

--- a/google/cloud/grpc_options_test.cc
+++ b/google/cloud/grpc_options_test.cc
@@ -90,7 +90,7 @@ TEST(GrpcOptionList, RegularOptions) {
   TestGrpcOption<GrpcTracingOptionsOption>(TracingOptions{});
 }
 
-TEST(GrpcOptionList, MakeChannelArguments) {
+TEST(GrpcChannelArguments, MakeChannelArguments) {
   // This test will just set all 3 options related to channel arguments and
   // ensure that `MakeChannelArguments` combines them in the correct order.
   grpc::ChannelArguments native;
@@ -109,7 +109,7 @@ TEST(GrpcOptionList, MakeChannelArguments) {
   CheckGrpcChannelArguments(expected, internal::MakeChannelArguments(opts));
 }
 
-TEST(GrpcOptionList, GetIntChannelArgument) {
+TEST(GrpcChannelArguments, GetIntChannelArgument) {
   grpc::ChannelArguments args;
   args.SetInt("key", 1);
   args.SetInt("key", 2);
@@ -120,7 +120,7 @@ TEST(GrpcOptionList, GetIntChannelArgument) {
   EXPECT_EQ(1, value.value());
 }
 
-TEST(GrpcOptionList, GetStringChannelArgument) {
+TEST(GrpcChannelArguments, GetStringChannelArgument) {
   grpc::ChannelArguments args;
   args.SetString("key", "first-value");
   args.SetString("key", "last-value");

--- a/google/cloud/grpc_options_test.cc
+++ b/google/cloud/grpc_options_test.cc
@@ -109,6 +109,28 @@ TEST(GrpcOptionList, MakeChannelArguments) {
   CheckGrpcChannelArguments(expected, internal::MakeChannelArguments(opts));
 }
 
+TEST(GrpcOptionList, GetIntChannelArgument) {
+  grpc::ChannelArguments args;
+  args.SetInt("key", 1);
+  args.SetInt("key", 2);
+  EXPECT_FALSE(internal::GetIntChannelArgument(args, "key-not-present"));
+  auto value = internal::GetIntChannelArgument(args, "key");
+  ASSERT_TRUE(value.has_value());
+  // Check that the value is extracted, and that the first value is used.
+  EXPECT_EQ(1, value.value());
+}
+
+TEST(GrpcOptionList, GetStringChannelArgument) {
+  grpc::ChannelArguments args;
+  args.SetString("key", "first-value");
+  args.SetString("key", "last-value");
+  EXPECT_FALSE(internal::GetStringChannelArgument(args, "key-not-present"));
+  auto value = internal::GetStringChannelArgument(args, "key");
+  ASSERT_TRUE(value.has_value());
+  // Check that the value is extracted, and that the first value is used.
+  EXPECT_EQ("first-value", value.value());
+}
+
 TEST(GrpcOptionList, GrpcBackgroundThreadsFactoryOption) {
   struct Fake : BackgroundThreads {
     CompletionQueue cq() const override { return {}; }


### PR DESCRIPTION
If a library wants to default a gRPC channel argument, it will need to check if the user has set it. Move the functions that do this into common.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7199)
<!-- Reviewable:end -->
