### PR TITLE
feat(generator): customization hooks for endpoint configuration

### DIFF
--- a/generator/generator.h
+++ b/generator/generator.h
@@ -40,6 +40,8 @@ namespace generator {
  *   --cpp_codegen_out=. \
  *   --cpp_codegen_opt=product_path=google/cloud/spanner
  *   --cpp_codegen_opt=copyright_year=2020
+ *   --cpp_codegen_opt=service_endpoint_env_var=SERVICE_ENDPOINT
+ *   --cpp_codegen_opt=emulator_endpoint_env_var=SERVICE_EMULATOR_HOST
  * @endcode
  */
 class Generator : public google::protobuf::compiler::CodeGenerator {

--- a/generator/generator_config.proto
+++ b/generator/generator_config.proto
@@ -21,6 +21,8 @@ message ServiceConfiguration {
   string product_path = 2;
   string initial_copyright_year = 3;
   repeated string omitted_rpcs = 4;
+  string service_endpoint_env_var = 5;
+  string emulator_endpoint_env_var = 6;
 }
 
 message GeneratorConfiguration {

--- a/generator/generator_config.textproto
+++ b/generator/generator_config.textproto
@@ -47,10 +47,14 @@ service {
   service_proto_path: "google/spanner/admin/database/v1/spanner_database_admin.proto"
   product_path: "google/cloud/spanner/admin"
   initial_copyright_year: "2021"
+  service_endpoint_env_var: "GOOGLE_CLOUD_CPP_SPANNER_DEFAULT_ENDPOINT"
+  emulator_endpoint_env_var: "SPANNER_EMULATOR_HOST"
 }
 
 service {
   service_proto_path: "google/spanner/admin/instance/v1/spanner_instance_admin.proto"
   product_path: "google/cloud/spanner/admin"
   initial_copyright_year: "2021"
+  service_endpoint_env_var: "GOOGLE_CLOUD_CPP_SPANNER_DEFAULT_ENDPOINT"
+  emulator_endpoint_env_var: "SPANNER_EMULATOR_HOST"
 }

--- a/generator/integration_tests/generator_integration_test.cc
+++ b/generator/integration_tests/generator_integration_test.cc
@@ -101,6 +101,8 @@ class GeneratorIntegrationTest : public testing::TestWithParam<std::string> {
     copyright_year_ = CurrentCopyrightYear();
     omit_rpc1_ = "Omitted1";
     omit_rpc2_ = "Omitted2";
+    service_endpoint_env_var_ = "GOLDEN_KITCHEN_SINK_ENDPOINT";
+    emulator_endpoint_env_var_ = "GOLDEN_KITCHEN_SINK_EMULATOR_HOST";
 
     std::vector<std::string> args;
     // empty arg keeps first real arg from being ignored.
@@ -115,6 +117,10 @@ class GeneratorIntegrationTest : public testing::TestWithParam<std::string> {
     args.emplace_back("--cpp_codegen_opt=copyright_year=" + copyright_year_);
     args.emplace_back("--cpp_codegen_opt=omit_rpc=" + omit_rpc1_);
     args.emplace_back("--cpp_codegen_opt=omit_rpc=" + omit_rpc2_);
+    args.emplace_back("--cpp_codegen_opt=service_endpoint_env_var=" +
+                      service_endpoint_env_var_);
+    args.emplace_back("--cpp_codegen_opt=emulator_endpoint_env_var=" +
+                      emulator_endpoint_env_var_);
     args.emplace_back("generator/integration_tests/test.proto");
 
     std::vector<char const*> c_args;
@@ -137,6 +143,8 @@ class GeneratorIntegrationTest : public testing::TestWithParam<std::string> {
   std::string copyright_year_;
   std::string omit_rpc1_;
   std::string omit_rpc2_;
+  std::string service_endpoint_env_var_;
+  std::string emulator_endpoint_env_var_;
 };
 
 TEST_P(GeneratorIntegrationTest, CompareGeneratedToGolden) {

--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_option_defaults.cc
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_option_defaults.cc
@@ -37,8 +37,12 @@ auto constexpr kBackoffScaling = 2.0;
 
 Options GoldenKitchenSinkDefaultOptions(Options options) {
   if (!options.has<EndpointOption>()) {
-    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_GOLDEN_KITCHEN_SINK_ENDPOINT");
+    auto env = internal::GetEnv("GOLDEN_KITCHEN_SINK_ENDPOINT");
     options.set<EndpointOption>(env ? *env : "goldenkitchensink.googleapis.com");
+  }
+  if (auto emulator = internal::GetEnv("GOLDEN_KITCHEN_SINK_EMULATOR_HOST")) {
+    options.set<EndpointOption>(*emulator).set<GrpcCredentialOption>(
+        grpc::InsecureChannelCredentials());
   }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());

--- a/generator/integration_tests/golden/internal/golden_thing_admin_option_defaults.cc
+++ b/generator/integration_tests/golden/internal/golden_thing_admin_option_defaults.cc
@@ -37,8 +37,12 @@ auto constexpr kBackoffScaling = 2.0;
 
 Options GoldenThingAdminDefaultOptions(Options options) {
   if (!options.has<EndpointOption>()) {
-    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_GOLDEN_THING_ADMIN_ENDPOINT");
+    auto env = internal::GetEnv("GOLDEN_KITCHEN_SINK_ENDPOINT");
     options.set<EndpointOption>(env ? *env : "test.googleapis.com");
+  }
+  if (auto emulator = internal::GetEnv("GOLDEN_KITCHEN_SINK_EMULATOR_HOST")) {
+    options.set<EndpointOption>(*emulator).set<GrpcCredentialOption>(
+        grpc::InsecureChannelCredentials());
   }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());

--- a/generator/integration_tests/golden/tests/golden_kitchen_sink_option_defaults_test.cc
+++ b/generator/integration_tests/golden/tests/golden_kitchen_sink_option_defaults_test.cc
@@ -33,16 +33,14 @@ TEST(GoldenKitchenSinkDefaultOptions, DefaultEndpoint) {
 }
 
 TEST(GoldenKitchenSinkDefaultOptions, EnvVarEndpoint) {
-  internal::SetEnv("GOOGLE_CLOUD_CPP_GOLDEN_KITCHEN_SINK_ENDPOINT",
-                   "foo.googleapis.com");
+  internal::SetEnv("GOLDEN_KITCHEN_SINK_ENDPOINT", "foo.googleapis.com");
   Options options;
   auto updated_options = GoldenKitchenSinkDefaultOptions(options);
   EXPECT_EQ("foo.googleapis.com", updated_options.get<EndpointOption>());
 }
 
 TEST(GoldenKitchenSinkDefaultOptions, OptionEndpoint) {
-  internal::SetEnv("GOOGLE_CLOUD_CPP_GOLDEN_KITCHEN_SINK_ENDPOINT",
-                   "foo.googleapis.com");
+  internal::SetEnv("GOLDEN_KITCHEN_SINK_ENDPOINT", "foo.googleapis.com");
   Options options;
   options.set<EndpointOption>("bar.googleapis.com");
   auto updated_options = GoldenKitchenSinkDefaultOptions(options);

--- a/generator/integration_tests/golden/tests/golden_thing_admin_option_defaults_test.cc
+++ b/generator/integration_tests/golden/tests/golden_thing_admin_option_defaults_test.cc
@@ -32,16 +32,14 @@ TEST(GoldenThingAdminDefaultOptions, DefaultEndpoint) {
 }
 
 TEST(GoldenThingAdminDefaultOptions, EnvVarEndpoint) {
-  internal::SetEnv("GOOGLE_CLOUD_CPP_GOLDEN_THING_ADMIN_ENDPOINT",
-                   "foo.googleapis.com");
+  internal::SetEnv("GOLDEN_KITCHEN_SINK_ENDPOINT", "foo.googleapis.com");
   Options options;
   auto updated_options = GoldenThingAdminDefaultOptions(options);
   EXPECT_EQ("foo.googleapis.com", updated_options.get<EndpointOption>());
 }
 
 TEST(GoldenThingAdminDefaultOptions, OptionEndpoint) {
-  internal::SetEnv("GOOGLE_CLOUD_CPP_GOLDEN_THING_ADMIN_ENDPOINT",
-                   "foo.googleapis.com");
+  internal::SetEnv("GOLDEN_KITCHEN_SINK_ENDPOINT", "foo.googleapis.com");
   Options options;
   options.set<EndpointOption>("bar.googleapis.com");
   auto updated_options = GoldenThingAdminDefaultOptions(options);

--- a/generator/internal/codegen_utils.cc
+++ b/generator/internal/codegen_utils.cc
@@ -108,6 +108,30 @@ void ProcessArgOmitRpc(
   }
 }
 
+void ProcessArgServiceEndpointEnvVar(
+    std::vector<std::pair<std::string, std::string>>& command_line_args) {
+  auto service_endpoint_env_var =
+      std::find_if(command_line_args.begin(), command_line_args.end(),
+                   [](std::pair<std::string, std::string> const& p) {
+                     return p.first == "service_endpoint_env_var";
+                   });
+  if (service_endpoint_env_var == command_line_args.end()) {
+    command_line_args.emplace_back("service_endpoint_env_var", "");
+  }
+}
+
+void ProcessArgEmulatorEndpointEnvVar(
+    std::vector<std::pair<std::string, std::string>>& command_line_args) {
+  auto emulator_endpoint_env_var =
+      std::find_if(command_line_args.begin(), command_line_args.end(),
+                   [](std::pair<std::string, std::string> const& p) {
+                     return p.first == "emulator_endpoint_env_var";
+                   });
+  if (emulator_endpoint_env_var == command_line_args.end()) {
+    command_line_args.emplace_back("emulator_endpoint_env_var", "");
+  }
+}
+
 }  // namespace
 std::string CurrentCopyrightYear() {
   static std::string const kCurrentCopyrightYear =
@@ -197,6 +221,8 @@ ProcessCommandLineArgs(std::string const& parameters) {
 
   ProcessArgCopyrightYear(command_line_args);
   ProcessArgOmitRpc(command_line_args);
+  ProcessArgServiceEndpointEnvVar(command_line_args);
+  ProcessArgEmulatorEndpointEnvVar(command_line_args);
   return command_line_args;
 }
 

--- a/generator/internal/codegen_utils_test.cc
+++ b/generator/internal/codegen_utils_test.cc
@@ -25,7 +25,9 @@ namespace {
 
 using ::google::cloud::testing_util::IsOk;
 using ::google::cloud::testing_util::StatusIs;
+using ::testing::Contains;
 using ::testing::ElementsAre;
+using ::testing::Pair;
 
 TEST(LocalInclude, Success) {
   EXPECT_EQ("#include \"google/cloud/status.h\"\n",
@@ -173,15 +175,15 @@ TEST(ProcessCommandLineArgs, EmptyProductPath) {
 TEST(ProcessCommandLineArgs, ProductPathNeedsFormatting) {
   auto result = ProcessCommandLineArgs(
       "product_path=/google/cloud/pubsub,googleapis_commit_hash=foo");
-  EXPECT_THAT(result, IsOk());
-  EXPECT_EQ(result->front().second, "google/cloud/pubsub/");
+  ASSERT_THAT(result, IsOk());
+  EXPECT_THAT(*result, Contains(Pair("product_path", "google/cloud/pubsub/")));
 }
 
 TEST(ProcessCommandLineArgs, ProductPathAlreadyFormatted) {
   auto result = ProcessCommandLineArgs(
       "product_path=google/cloud/pubsub/,googleapis_commit_hash=foo");
-  EXPECT_THAT(result, IsOk());
-  EXPECT_EQ(result->front().second, "google/cloud/pubsub/");
+  ASSERT_THAT(result, IsOk());
+  EXPECT_THAT(*result, Contains(Pair("product_path", "google/cloud/pubsub/")));
 }
 
 TEST(ProcessCommandLineArgs, NoCommitHash) {
@@ -203,9 +205,8 @@ TEST(ProcessCommandLineArgs, NoCopyrightYearParameterOrValue) {
   auto result = ProcessCommandLineArgs(
       "product_path=google/cloud/pubsub/,googleapis_commit_hash=foo");
   auto expected_year = CurrentCopyrightYear();
-  EXPECT_THAT(result, IsOk());
-  EXPECT_EQ(result->back().first, "copyright_year");
-  EXPECT_EQ(result->back().second, expected_year);
+  ASSERT_THAT(result, IsOk());
+  EXPECT_THAT(*result, Contains(Pair("copyright_year", expected_year)));
 }
 
 TEST(ProcessCommandLineArgs, NoCopyrightYearValue) {
@@ -213,18 +214,37 @@ TEST(ProcessCommandLineArgs, NoCopyrightYearValue) {
       "product_path=google/cloud/pubsub/"
       ",googleapis_commit_hash=foo,copyright_year=");
   auto expected_year = CurrentCopyrightYear();
-  EXPECT_THAT(result, IsOk());
-  EXPECT_EQ(result->back().first, "copyright_year");
-  EXPECT_EQ(result->back().second, expected_year);
+  ASSERT_THAT(result, IsOk());
+  EXPECT_THAT(*result, Contains(Pair("copyright_year", expected_year)));
 }
 
 TEST(ProcessCommandLineArgs, CopyrightYearWithValue) {
   auto result = ProcessCommandLineArgs(
       "product_path=google/cloud/pubsub/"
       ",googleapis_commit_hash=foo,copyright_year=1995");
-  EXPECT_THAT(result, IsOk());
-  EXPECT_EQ(result->back().first, "copyright_year");
-  EXPECT_EQ(result->back().second, "1995");
+  ASSERT_THAT(result, IsOk());
+  EXPECT_THAT(*result, Contains(Pair("copyright_year", "1995")));
+}
+
+TEST(ProcessCommandLineArgs, ServiceEndpointEnvVar) {
+  auto result = ProcessCommandLineArgs(
+      "product_path=google/cloud/spanner/,googleapis_commit_hash=foo"
+      ",service_endpoint_env_var=GOOGLE_CLOUD_CPP_SPANNER_DEFAULT_ENDPOINT");
+  ASSERT_THAT(result, IsOk());
+  EXPECT_THAT(*result,
+              Contains(Pair("service_endpoint_env_var",
+                            "GOOGLE_CLOUD_CPP_SPANNER_DEFAULT_ENDPOINT")));
+  EXPECT_THAT(*result, Contains(Pair("emulator_endpoint_env_var", "")));
+}
+
+TEST(ProcessCommandLineArgs, EmulatorEndpointEnvVar) {
+  auto result = ProcessCommandLineArgs(
+      "product_path=google/cloud/spanner/,googleapis_commit_hash=foo"
+      ",emulator_endpoint_env_var=SPANNER_EMULATOR_HOST");
+  ASSERT_THAT(result, IsOk());
+  EXPECT_THAT(*result, Contains(Pair("emulator_endpoint_env_var",
+                                     "SPANNER_EMULATOR_HOST")));
+  EXPECT_THAT(*result, Contains(Pair("service_endpoint_env_var", "")));
 }
 
 }  // namespace

--- a/generator/internal/descriptor_utils.cc
+++ b/generator/internal/descriptor_utils.cc
@@ -488,10 +488,13 @@ VarsDictionary CreateServiceVars(
       absl::StrCat(vars["product_path"], "retry_traits", ".h");
   vars["service_endpoint"] =
       descriptor.options().GetExtension(google::api::default_host);
-  vars["service_endpoint_env_var"] = absl::StrCat(
-      "GOOGLE_CLOUD_CPP_",
-      absl::AsciiStrToUpper(CamelCaseToSnakeCase(descriptor.name())),
-      "_ENDPOINT");
+  auto& service_endpoint_env_var = vars["service_endpoint_env_var"];
+  if (service_endpoint_env_var.empty()) {
+    service_endpoint_env_var = absl::StrCat(
+        "GOOGLE_CLOUD_CPP_",
+        absl::AsciiStrToUpper(CamelCaseToSnakeCase(descriptor.name())),
+        "_ENDPOINT");
+  }
   vars["service_name"] = descriptor.name();
   vars["stub_class_name"] = absl::StrCat(descriptor.name(), "Stub");
   vars["stub_cc_path"] =

--- a/generator/internal/option_defaults_generator.cc
+++ b/generator/internal/option_defaults_generator.cc
@@ -94,8 +94,13 @@ Status OptionDefaultsGenerator::GenerateCc() {
     "  if (!options.has<EndpointOption>()) {\n"
     "    auto env = internal::GetEnv(\"$service_endpoint_env_var$\");\n"
     "    options.set<EndpointOption>(env ? *env : \"$service_endpoint$\");\n"
-    "  }\n"
-    "  if (!options.has<GrpcCredentialOption>()) {\n"
+    "  }\n"},
+   {[this]{return vars("emulator_endpoint_env_var").empty();}, "",
+    "  if (auto emulator = internal::GetEnv(\"$emulator_endpoint_env_var$\")) {\n"
+    "    options.set<EndpointOption>(*emulator).set<GrpcCredentialOption>(\n"
+    "        grpc::InsecureChannelCredentials());\n"
+    "  }\n"},
+   {"  if (!options.has<GrpcCredentialOption>()) {\n"
     "    options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());\n"
     "  }\n"
     "  auto& products = options.lookup<UserAgentProductsOption>();\n"

--- a/generator/standalone_main.cc
+++ b/generator/standalone_main.cc
@@ -106,6 +106,10 @@ int main(int argc, char** argv) {
     for (auto const& omit_rpc : service.omitted_rpcs()) {
       args.emplace_back("--cpp_codegen_opt=omit_rpc=" + omit_rpc);
     }
+    args.emplace_back("--cpp_codegen_opt=service_endpoint_env_var=" +
+                      service.service_endpoint_env_var());
+    args.emplace_back("--cpp_codegen_opt=emulator_endpoint_env_var=" +
+                      service.emulator_endpoint_env_var());
     args.emplace_back(service.service_proto_path());
     GCP_LOG(INFO) << "Generating service code using: "
                   << absl::StrJoin(args, ";") << "\n";

--- a/google/cloud/spanner/admin/internal/database_admin_option_defaults.cc
+++ b/google/cloud/spanner/admin/internal/database_admin_option_defaults.cc
@@ -37,8 +37,12 @@ auto constexpr kBackoffScaling = 2.0;
 
 Options DatabaseAdminDefaultOptions(Options options) {
   if (!options.has<EndpointOption>()) {
-    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_DATABASE_ADMIN_ENDPOINT");
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_SPANNER_DEFAULT_ENDPOINT");
     options.set<EndpointOption>(env ? *env : "spanner.googleapis.com");
+  }
+  if (auto emulator = internal::GetEnv("SPANNER_EMULATOR_HOST")) {
+    options.set<EndpointOption>(*emulator).set<GrpcCredentialOption>(
+        grpc::InsecureChannelCredentials());
   }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());

--- a/google/cloud/spanner/admin/internal/instance_admin_option_defaults.cc
+++ b/google/cloud/spanner/admin/internal/instance_admin_option_defaults.cc
@@ -37,8 +37,12 @@ auto constexpr kBackoffScaling = 2.0;
 
 Options InstanceAdminDefaultOptions(Options options) {
   if (!options.has<EndpointOption>()) {
-    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_INSTANCE_ADMIN_ENDPOINT");
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_SPANNER_DEFAULT_ENDPOINT");
     options.set<EndpointOption>(env ? *env : "spanner.googleapis.com");
+  }
+  if (auto emulator = internal::GetEnv("SPANNER_EMULATOR_HOST")) {
+    options.set<EndpointOption>(*emulator).set<GrpcCredentialOption>(
+        grpc::InsecureChannelCredentials());
   }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());


### PR DESCRIPTION
Add two ServiceConfiguration fields to customization the generation
of `<Service>DefaultOptions()`.

- `service_endpoint_env_var`: Overrides the default environment
  variable name, `GOOGLE_CLOUD_CPP_<SERVICE>_ENDPOINT`, used to
  override the default value of the `EndpointOption`.

- `emulator_endpoint_env_var`: Enables an extra override of the
  `EndpointOption` from an additional environment variable. When
  used, it also sets the `GrpcCredentialOption` with insecure
  channel credentials.

Use both of these new configuration fields for the generation of
the Spanner database/instance-admin services so that they match
the use of the existing `GOOGLE_CLOUD_CPP_SPANNER_DEFAULT_ENDPOINT`
and `SPANNER_EMULATOR_HOST` environment variables respectively.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7200)
<!-- Reviewable:end -->
