### PR TITLE
cleanup: define inline ns to be GOOGLE_CLOUD_CPP_NS

### DIFF
--- a/google/cloud/bigtable/version.h
+++ b/google/cloud/bigtable/version.h
@@ -27,9 +27,7 @@
       " instead. The function will be removed on 2022-04-01 or shortly "       \
       "after. See GitHub issue #5929 for more information.")
 
-#define BIGTABLE_CLIENT_NS                              \
-  GOOGLE_CLOUD_CPP_VEVAL(BIGTABLE_CLIENT_VERSION_MAJOR, \
-                         BIGTABLE_CLIENT_VERSION_MINOR)
+#define BIGTABLE_CLIENT_NS GOOGLE_CLOUD_CPP_NS
 
 namespace google {
 namespace cloud {
@@ -55,32 +53,24 @@ inline namespace BIGTABLE_CLIENT_NS {
  *
  * @see https://semver.org/spec/v2.0.0.html for details.
  */
-int constexpr version_major() { return BIGTABLE_CLIENT_VERSION_MAJOR; }
+int constexpr version_major() { return google::cloud::version_major(); }
 
 /**
  * The Cloud Bigtable C++ Client minor version.
  *
  * @see https://semver.org/spec/v2.0.0.html for details.
  */
-int constexpr version_minor() { return BIGTABLE_CLIENT_VERSION_MINOR; }
+int constexpr version_minor() { return google::cloud::version_minor(); }
 
 /**
  * The Cloud Bigtable C++ Client patch version.
  *
  * @see https://semver.org/spec/v2.0.0.html for details.
  */
-int constexpr version_patch() { return BIGTABLE_CLIENT_VERSION_PATCH; }
+int constexpr version_patch() { return google::cloud::version_patch(); }
 
 /// A single integer representing the Major/Minor/Patch version.
-int constexpr version() {
-  static_assert(::google::cloud::version_major() == version_major(),
-                "Mismatched major version");
-  static_assert(::google::cloud::version_minor() == version_minor(),
-                "Mismatched minor version");
-  static_assert(::google::cloud::version_patch() == version_patch(),
-                "Mismatched patch version");
-  return ::google::cloud::version();
-}
+int constexpr version() { return google::cloud::version(); }
 
 /// The version as a string, in MAJOR.MINOR.PATCH+gitrev format.
 std::string version_string();

--- a/google/cloud/pubsub/version.h
+++ b/google/cloud/pubsub/version.h
@@ -18,32 +18,6 @@
 #include "google/cloud/pubsub/version_info.h"
 #include "google/cloud/version.h"
 
-#define GOOGLE_CLOUD_CPP_PUBSUB_NS                                     \
-  GOOGLE_CLOUD_CPP_VEVAL(GOOGLE_CLOUD_CPP_PUBSUB_CLIENT_VERSION_MAJOR, \
-                         GOOGLE_CLOUD_CPP_PUBSUB_CLIENT_VERSION_MINOR)
-
-namespace google {
-/**
- * The namespace Google Cloud Platform C++ client libraries.
- */
-namespace cloud {
-/**
- * Contains all the Cloud Pubsub C++ client types and functions.
- */
-namespace pubsub {
-/**
- * The inlined, versioned namespace for the Cloud Pubsub C++ client APIs.
- *
- * Applications may need to link multiple versions of the Cloud pubsub C++
- * client, for example, if they link a library that uses an older version of
- * the client than they do.  This namespace is inlined, so applications can use
- * `pubsub::Foo` in their source, but the symbols are versioned, i.e., the
- * symbol becomes `pubsub::v1::Foo`.
- */
-inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
-}  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS
-}  // namespace pubsub
-}  // namespace cloud
-}  // namespace google
+#define GOOGLE_CLOUD_CPP_PUBSUB_NS GOOGLE_CLOUD_CPP_NS
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PUBSUB_VERSION_H

--- a/google/cloud/pubsub/version.h
+++ b/google/cloud/pubsub/version.h
@@ -20,4 +20,28 @@
 
 #define GOOGLE_CLOUD_CPP_PUBSUB_NS GOOGLE_CLOUD_CPP_NS
 
+namespace google {
+/**
+ * The namespace Google Cloud Platform C++ client libraries.
+ */
+namespace cloud {
+/**
+ * Contains all the Cloud Pubsub C++ client types and functions.
+ */
+namespace pubsub {
+/**
+ * The inlined, versioned namespace for the Cloud Pubsub C++ client APIs.
+ *
+ * Applications may need to link multiple versions of the Cloud pubsub C++
+ * client, for example, if they link a library that uses an older version of
+ * the client than they do.  This namespace is inlined, so applications can use
+ * `pubsub::Foo` in their source, but the symbols are versioned, i.e., the
+ * symbol becomes `pubsub::v1::Foo`.
+ */
+inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
+}  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS
+}  // namespace pubsub
+}  // namespace cloud
+}  // namespace google
+
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PUBSUB_VERSION_H

--- a/google/cloud/spanner/version.h
+++ b/google/cloud/spanner/version.h
@@ -19,9 +19,7 @@
 #include "google/cloud/version.h"
 #include <string>
 
-#define SPANNER_CLIENT_NS                              \
-  GOOGLE_CLOUD_CPP_VEVAL(SPANNER_CLIENT_VERSION_MAJOR, \
-                         SPANNER_CLIENT_VERSION_MINOR)
+#define SPANNER_CLIENT_NS GOOGLE_CLOUD_CPP_NS
 
 namespace google {
 /**
@@ -45,28 +43,20 @@ inline namespace SPANNER_CLIENT_NS {
 /**
  * The Cloud spanner C++ Client major version.
  */
-int constexpr VersionMajor() { return SPANNER_CLIENT_VERSION_MAJOR; }
+int constexpr VersionMajor() { return google::cloud::version_major(); }
 
 /**
  * The Cloud spanner C++ Client minor version.
  */
-int constexpr VersionMinor() { return SPANNER_CLIENT_VERSION_MINOR; }
+int constexpr VersionMinor() { return google::cloud::version_minor(); }
 
 /**
  * The Cloud spanner C++ Client patch version.
  */
-int constexpr VersionPatch() { return SPANNER_CLIENT_VERSION_PATCH; }
+int constexpr VersionPatch() { return google::cloud::version_patch(); }
 
 /// A single integer representing the Major/Minor/Patch version.
-int constexpr Version() {
-  static_assert(::google::cloud::version_major() == VersionMajor(),
-                "Mismatched major version");
-  static_assert(::google::cloud::version_minor() == VersionMinor(),
-                "Mismatched minor version");
-  static_assert(::google::cloud::version_patch() == VersionPatch(),
-                "Mismatched patch version");
-  return ::google::cloud::version();
-}
+int constexpr Version() { return google::cloud::version(); }
 
 /// The version as a string, in MAJOR.MINOR.PATCH+gitrev format.
 std::string VersionString();

--- a/google/cloud/storage/version.h
+++ b/google/cloud/storage/version.h
@@ -27,9 +27,7 @@
       " instead. The function will be removed on 2022-04-01 or shortly "       \
       "after. See GitHub issue #5929 for more information.")
 
-#define STORAGE_CLIENT_NS                              \
-  GOOGLE_CLOUD_CPP_VEVAL(STORAGE_CLIENT_VERSION_MAJOR, \
-                         STORAGE_CLIENT_VERSION_MINOR)
+#define STORAGE_CLIENT_NS GOOGLE_CLOUD_CPP_NS
 
 namespace google {
 namespace cloud {
@@ -55,32 +53,24 @@ inline namespace STORAGE_CLIENT_NS {
  *
  * @see https://semver.org/spec/v2.0.0.html for details.
  */
-int constexpr version_major() { return STORAGE_CLIENT_VERSION_MAJOR; }
+int constexpr version_major() { return google::cloud::version_major(); }
 
 /**
  * Returns the Google Cloud Storage C++ Client minor version.
  *
  * @see https://semver.org/spec/v2.0.0.html for details.
  */
-int constexpr version_minor() { return STORAGE_CLIENT_VERSION_MINOR; }
+int constexpr version_minor() { return google::cloud::version_minor(); }
 
 /**
  * Returns the Google Cloud Storage C++ Client patch version.
  *
  * @see https://semver.org/spec/v2.0.0.html for details.
  */
-int constexpr version_patch() { return STORAGE_CLIENT_VERSION_PATCH; }
+int constexpr version_patch() { return google::cloud::version_patch(); }
 
 /// Returns a single integer representing the Major/Minor/Patch version.
-int constexpr version() {
-  static_assert(::google::cloud::version_major() == version_major(),
-                "Mismatched major version");
-  static_assert(::google::cloud::version_minor() == version_minor(),
-                "Mismatched minor version");
-  static_assert(::google::cloud::version_patch() == version_patch(),
-                "Mismatched patch version");
-  return ::google::cloud::version();
-}
+int constexpr version() { return google::cloud::version(); }
 
 /// Returns the version as a string, in MAJOR.MINOR.PATCH+gitrev format.
 std::string version_string();


### PR DESCRIPTION
This is a cleanup related to #5976

There's no semantic change here.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7204)
<!-- Reviewable:end -->
