### PR TITLE
refactor(bigtable): replace grpc::ChannelArguments with Options

### DIFF
--- a/google/cloud/bigtable/client_options.h
+++ b/google/cloud/bigtable/client_options.h
@@ -177,13 +177,14 @@ class ClientOptions {
 
   /// Access all the channel arguments.
   grpc::ChannelArguments channel_arguments() const {
-    return channel_arguments_;
+    return ::google::cloud::internal::MakeChannelArguments(opts_);
   }
 
   /// Set all the channel arguments.
   ClientOptions& set_channel_arguments(
       grpc::ChannelArguments const& channel_arguments) {
-    channel_arguments_ = channel_arguments;
+    opts_.set<GrpcChannelArgumentsNativeOption>(channel_arguments);
+    opts_.unset<GrpcChannelArgumentsOption>();
     return *this;
   }
 
@@ -196,7 +197,8 @@ class ClientOptions {
    *
    */
   void SetCompressionAlgorithm(grpc_compression_algorithm algorithm) {
-    channel_arguments_.SetCompressionAlgorithm(algorithm);
+    opts_.lookup<GrpcChannelArgumentsNativeOption>().SetCompressionAlgorithm(
+        algorithm);
   }
 
   /**
@@ -245,7 +247,8 @@ class ClientOptions {
                                    "maximum value allowed by gRPC (INT_MAX)");
     }
     auto fallback_timeout_ms = static_cast<int>(ft_ms.count());
-    channel_arguments_.SetGrpclbFallbackTimeout(fallback_timeout_ms);
+    opts_.lookup<GrpcChannelArgumentsNativeOption>().SetGrpclbFallbackTimeout(
+        fallback_timeout_ms);
     return google::cloud::Status();
   }
 
@@ -258,7 +261,8 @@ class ClientOptions {
    *
    */
   void SetUserAgentPrefix(grpc::string const& user_agent_prefix) {
-    channel_arguments_.SetUserAgentPrefix(user_agent_prefix);
+    opts_.lookup<GrpcChannelArgumentsNativeOption>().SetUserAgentPrefix(
+        user_agent_prefix);
   }
 
   /**
@@ -270,7 +274,8 @@ class ClientOptions {
    *
    */
   void SetResourceQuota(grpc::ResourceQuota const& resource_quota) {
-    channel_arguments_.SetResourceQuota(resource_quota);
+    opts_.lookup<GrpcChannelArgumentsNativeOption>().SetResourceQuota(
+        resource_quota);
   }
 
   /**
@@ -283,7 +288,8 @@ class ClientOptions {
    *
    */
   void SetMaxReceiveMessageSize(int size) {
-    channel_arguments_.SetMaxReceiveMessageSize(size);
+    opts_.lookup<GrpcChannelArgumentsNativeOption>().SetMaxReceiveMessageSize(
+        size);
   }
 
   /**
@@ -295,7 +301,8 @@ class ClientOptions {
    *
    */
   void SetMaxSendMessageSize(int size) {
-    channel_arguments_.SetMaxSendMessageSize(size);
+    opts_.lookup<GrpcChannelArgumentsNativeOption>().SetMaxSendMessageSize(
+        size);
   }
 
   /**
@@ -308,7 +315,8 @@ class ClientOptions {
    *
    */
   void SetLoadBalancingPolicyName(grpc::string const& lb_policy_name) {
-    channel_arguments_.SetLoadBalancingPolicyName(lb_policy_name);
+    opts_.lookup<GrpcChannelArgumentsNativeOption>().SetLoadBalancingPolicyName(
+        lb_policy_name);
   }
 
   /**
@@ -320,7 +328,8 @@ class ClientOptions {
    *
    */
   void SetServiceConfigJSON(grpc::string const& service_config_json) {
-    channel_arguments_.SetServiceConfigJSON(service_config_json);
+    opts_.lookup<GrpcChannelArgumentsNativeOption>().SetServiceConfigJSON(
+        service_config_json);
   }
 
   /**
@@ -332,7 +341,8 @@ class ClientOptions {
    *
    */
   void SetSslTargetNameOverride(grpc::string const& name) {
-    channel_arguments_.SetSslTargetNameOverride(name);
+    opts_.lookup<GrpcChannelArgumentsNativeOption>().SetSslTargetNameOverride(
+        name);
   }
 
   /// Return the user agent prefix used by the library.
@@ -462,7 +472,6 @@ class ClientOptions {
     return opts_.get<InstanceAdminEndpointOption>();
   }
 
-  grpc::ChannelArguments channel_arguments_;
   std::string connection_pool_name_;
   Options opts_;
 };

--- a/google/cloud/bigtable/client_options.h
+++ b/google/cloud/bigtable/client_options.h
@@ -184,7 +184,6 @@ class ClientOptions {
   ClientOptions& set_channel_arguments(
       grpc::ChannelArguments const& channel_arguments) {
     opts_.set<GrpcChannelArgumentsNativeOption>(channel_arguments);
-    opts_.unset<GrpcChannelArgumentsOption>();
     return *this;
   }
 

--- a/google/cloud/bigtable/internal/defaults.cc
+++ b/google/cloud/bigtable/internal/defaults.cc
@@ -30,6 +30,8 @@ namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 namespace internal {
 
+namespace {
+
 // As learned from experiments, idle gRPC connections enter IDLE state after 4m.
 auto constexpr kDefaultMaxRefreshPeriod =
     std::chrono::milliseconds(std::chrono::minutes(3));
@@ -41,6 +43,23 @@ auto constexpr kDefaultMinRefreshPeriod =
 
 static_assert(kDefaultMinRefreshPeriod <= kDefaultMaxRefreshPeriod,
               "The default period range must be valid");
+
+// For background information on gRPC keepalive pings, see
+//     https://github.com/grpc/grpc/blob/master/doc/keepalive.md
+
+// The default value for GRPC_KEEPALIVE_TIME_MS, how long before a keepalive
+// ping is sent. A better name may have been "period", but consistency with the
+// gRPC naming seems valuable.
+auto constexpr kDefaultKeepaliveTime =
+    std::chrono::milliseconds(std::chrono::seconds(30));
+
+// The default value for GRPC_KEEPALIVE_TIMEOUT_MS, how long the sender (in
+// this case the Cloud Bigtable C++ client library) waits for an acknowledgement
+// for a keepalive ping.
+auto constexpr kDefaultKeepaliveTimeout =
+    std::chrono::milliseconds(std::chrono::seconds(10));
+
+}  // namespace
 
 int DefaultConnectionPoolSize() {
   // For better resource utilization and greater throughput, it is recommended
@@ -100,6 +119,29 @@ Options DefaultOptions(Options opts) {
   if (!opts.has<MaxConnectionRefreshOption>()) {
     opts.set<MaxConnectionRefreshOption>(kDefaultMaxRefreshPeriod);
   }
+
+  using ms = std::chrono::milliseconds;
+  using ::google::cloud::internal::GetIntChannelArgument;
+  using std::chrono::duration_cast;
+  auto& args = opts.lookup<GrpcChannelArgumentsNativeOption>();
+  if (!GetIntChannelArgument(args, GRPC_ARG_MAX_SEND_MESSAGE_LENGTH)) {
+    args.SetMaxSendMessageSize(BIGTABLE_CLIENT_DEFAULT_MAX_MESSAGE_LENGTH);
+  }
+  if (!GetIntChannelArgument(args, GRPC_ARG_MAX_RECEIVE_MESSAGE_LENGTH)) {
+    args.SetMaxReceiveMessageSize(BIGTABLE_CLIENT_DEFAULT_MAX_MESSAGE_LENGTH);
+  }
+  if (!GetIntChannelArgument(args, GRPC_ARG_KEEPALIVE_TIME_MS)) {
+    args.SetInt(GRPC_ARG_KEEPALIVE_TIME_MS,
+                duration_cast<ms>(kDefaultKeepaliveTime).count());
+  }
+  if (!GetIntChannelArgument(args, GRPC_ARG_KEEPALIVE_TIMEOUT_MS)) {
+    args.SetInt(GRPC_ARG_KEEPALIVE_TIMEOUT_MS,
+                duration_cast<ms>(kDefaultKeepaliveTimeout).count());
+  }
+  // Inserts our user-agent string at the front.
+  auto& products = opts.lookup<UserAgentProductsOption>();
+  products.insert(products.begin(),
+                  ::google::cloud::internal::UserAgentPrefix());
 
   return opts;
 }


### PR DESCRIPTION
Part of the work for #6307 

Note that:
1. `std::string connection_pool_name_` cannot be removed because `ClientOptions::connection_pool_name()` returns a `std::string const&`. (Well, maybe it can, but I don't know how to do it)
2. The functionality of setting a connection pool name is captured by both `GrpcChannelArgumentsOption` and `GrpcChannelArgumentsNativeOption`. (just add a string to the map, or use `SetString()` on the native object)

We could add language that tells users to avoid the `ClientOptions` setters, in favor of doing all configuring through `Options`. But I sort of think we should just wait until every use of `ClientOptions` has an `Options` alternative, and then we add language that tells users to avoid the `ClientOptions` class altogether. A second opinion on this strategy would be appreciated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7206)
<!-- Reviewable:end -->
