### PR TITLE
chore(bigtable): move to bigtable_internal; clean up namespace qualifiers

### DIFF
--- a/ci/cloudbuild/builds/check-api.sh
+++ b/ci/cloudbuild/builds/check-api.sh
@@ -84,7 +84,7 @@ for lib in "${libraries[@]}"; do
     # namespace. See: https://en.wikipedia.org/wiki/Name_mangling
     report="cmake-out/compat_reports/${lib}/expected_to_actual/src_compat_report.html"
     if ! abi-compliance-checker \
-      -skip-internal-symbols "(8internal|17bigquery_internal|12iam_internal|15pubsub_internal|16spanner_internal)\d" \
+      -skip-internal-symbols "(8internal|17bigtable_internal|17bigquery_internal|12iam_internal|15pubsub_internal|16spanner_internal)\d" \
       -report-path "${report}" \
       -src -l "${lib}" \
       -old "cmake-out/${expected_dump_file}" \

--- a/google/cloud/bigtable/CMakeLists.txt
+++ b/google/cloud/bigtable/CMakeLists.txt
@@ -31,7 +31,7 @@ set(DOXYGEN_EXCLUDE_PATTERNS
     "*/google/cloud/bigtable/tests/*"
     "*/google/cloud/bigtable/tools/*"
     "*/google/cloud/bigtable/*_test.cc")
-set(DOXYGEN_EXCLUDE_SYMBOLS "internal")
+set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "bigtable_internal")
 
 include(GoogleCloudCppCommon)
 

--- a/google/cloud/bigtable/admin_client.cc
+++ b/google/cloud/bigtable/admin_client.cc
@@ -131,25 +131,25 @@ namespace btadmin = ::google::bigtable::admin::v2;
  * should only reconnect on those errors that indicate the credentials or
  * connections need refreshing.
  */
-class DefaultAdminClient : public google::cloud::bigtable::AdminClient {
+class DefaultAdminClient : public AdminClient {
  private:
   // Introduce an early `private:` section because this type is used to define
   // the public interface, it should not be part of the public interface.
   struct AdminTraits {
     static std::string const& Endpoint(
-        google::cloud::bigtable::ClientOptions& options) {
+        ClientOptions& options) {
       return options.admin_endpoint();
     }
   };
 
-  using Impl = ::google::cloud::bigtable::internal::CommonClient<
-      AdminTraits, btadmin::BigtableTableAdmin>;
+  using Impl =
+      bigtable_internal::CommonClient<AdminTraits, btadmin::BigtableTableAdmin>;
 
  public:
   using AdminStubPtr = Impl::StubPtr;
 
   DefaultAdminClient(std::string project,
-                     google::cloud::bigtable::ClientOptions options)
+                     ClientOptions options)
       : project_(std::move(project)), impl_(std::move(options)) {}
 
   std::string const& project() const override { return project_; }
@@ -452,7 +452,7 @@ std::shared_ptr<AdminClient> CreateDefaultAdminClient(
       std::make_shared<DefaultAdminClient>(std::move(project), options);
   if (options.tracing_enabled("rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
-    client = std::make_shared<internal::LoggingAdminClient>(
+    client = std::make_shared<bigtable_internal::LoggingAdminClient>(
         std::move(client), options.tracing_options());
   }
   return client;

--- a/google/cloud/bigtable/admin_client.cc
+++ b/google/cloud/bigtable/admin_client.cc
@@ -136,8 +136,7 @@ class DefaultAdminClient : public AdminClient {
   // Introduce an early `private:` section because this type is used to define
   // the public interface, it should not be part of the public interface.
   struct AdminTraits {
-    static std::string const& Endpoint(
-        ClientOptions& options) {
+    static std::string const& Endpoint(ClientOptions& options) {
       return options.admin_endpoint();
     }
   };
@@ -148,8 +147,7 @@ class DefaultAdminClient : public AdminClient {
  public:
   using AdminStubPtr = Impl::StubPtr;
 
-  DefaultAdminClient(std::string project,
-                     ClientOptions options)
+  DefaultAdminClient(std::string project, ClientOptions options)
       : project_(std::move(project)), impl_(std::move(options)) {}
 
   std::string const& project() const override { return project_; }

--- a/google/cloud/bigtable/admin_client.h
+++ b/google/cloud/bigtable/admin_client.h
@@ -23,15 +23,17 @@
 
 namespace google {
 namespace cloud {
-namespace bigtable {
+namespace bigtable_internal {
 inline namespace BIGTABLE_CLIENT_NS {
 // Forward declare some classes so we can be friends.
-class TableAdmin;
-namespace internal {
 template <typename Client, typename Response>
 class AsyncLongrunningOperation;
 class LoggingAdminClient;
-}  // namespace internal
+}  // namespace BIGTABLE_CLIENT_NS
+}  // namespace bigtable_internal
+namespace bigtable {
+inline namespace BIGTABLE_CLIENT_NS {
+class TableAdmin;
 
 /**
  * Connects to Cloud Bigtable's table administration APIs.
@@ -89,8 +91,8 @@ class AdminClient {
  protected:
   friend class TableAdmin;
   template <typename Client, typename Response>
-  friend class internal::AsyncLongrunningOperation;
-  friend class internal::LoggingAdminClient;
+  friend class bigtable_internal::AsyncLongrunningOperation;
+  friend class bigtable_internal::LoggingAdminClient;
 
   //@{
   /// @name The `google.bigtable.admin.v2.TableAdmin` operations.

--- a/google/cloud/bigtable/app_profile_config.cc
+++ b/google/cloud/bigtable/app_profile_config.cc
@@ -41,8 +41,7 @@ AppProfileConfig AppProfileConfig::SingleClusterRouting(
 }
 
 void AppProfileUpdateConfig::AddPathIfNotPresent(std::string field_name) {
-  if (!google::cloud::internal::Contains(proto_.update_mask().paths(),
-                                         field_name)) {
+  if (!internal::Contains(proto_.update_mask().paths(), field_name)) {
     proto_.mutable_update_mask()->add_paths(std::move(field_name));
   }
 }

--- a/google/cloud/bigtable/async_read_stream_test.cc
+++ b/google/cloud/bigtable/async_read_stream_test.cc
@@ -160,7 +160,7 @@ TEST_F(AsyncReadStreamTest, MetaFunctions) {
   static_assert(
       std::is_same<
           btproto::MutateRowsResponse,
-          google::cloud::internal::AsyncStreamingReadResponseType<
+          internal::AsyncStreamingReadResponseType<
               decltype(async_call), btproto::MutateRowsRequest>::type>::value,
       "Unexpected type for AsyncStreamingReadResponseType<>");
 }

--- a/google/cloud/bigtable/async_row_reader.h
+++ b/google/cloud/bigtable/async_row_reader.h
@@ -73,7 +73,8 @@ class AsyncRowReader : public std::enable_shared_from_this<
       Filter filter, std::unique_ptr<RPCRetryPolicy> rpc_retry_policy,
       std::unique_ptr<RPCBackoffPolicy> rpc_backoff_policy,
       MetadataUpdatePolicy metadata_update_policy,
-      std::unique_ptr<bigtable_internal::ReadRowsParserFactory> parser_factory) {
+      std::unique_ptr<bigtable_internal::ReadRowsParserFactory>
+          parser_factory) {
     std::shared_ptr<AsyncRowReader> res(new AsyncRowReader(
         std::move(cq), std::move(client), std::move(app_profile_id),
         std::move(table_name), std::move(on_row), std::move(on_finish),

--- a/google/cloud/bigtable/async_row_reader.h
+++ b/google/cloud/bigtable/async_row_reader.h
@@ -56,15 +56,13 @@ class AsyncRowReader : public std::enable_shared_from_this<
   AsyncRowReader(AsyncRowReader const&) = delete;
 
  private:
-  static_assert(google::cloud::internal::is_invocable<RowFunctor, Row>::value,
+  static_assert(internal::is_invocable<RowFunctor, Row>::value,
                 "RowFunctor must be invocable with Row.");
-  static_assert(
-      google::cloud::internal::is_invocable<FinishFunctor, Status>::value,
-      "RowFunctor must be invocable with Status.");
-  static_assert(
-      std::is_same<google::cloud::internal::invoke_result_t<RowFunctor, Row>,
-                   future<bool>>::value,
-      "RowFunctor should return a future<bool>.");
+  static_assert(internal::is_invocable<FinishFunctor, Status>::value,
+                "RowFunctor must be invocable with Status.");
+  static_assert(std::is_same<internal::invoke_result_t<RowFunctor, Row>,
+                             future<bool>>::value,
+                "RowFunctor should return a future<bool>.");
 
   static std::shared_ptr<AsyncRowReader> Create(
       CompletionQueue cq, std::shared_ptr<DataClient> client,

--- a/google/cloud/bigtable/async_row_reader.h
+++ b/google/cloud/bigtable/async_row_reader.h
@@ -73,7 +73,7 @@ class AsyncRowReader : public std::enable_shared_from_this<
       Filter filter, std::unique_ptr<RPCRetryPolicy> rpc_retry_policy,
       std::unique_ptr<RPCBackoffPolicy> rpc_backoff_policy,
       MetadataUpdatePolicy metadata_update_policy,
-      std::unique_ptr<internal::ReadRowsParserFactory> parser_factory) {
+      std::unique_ptr<bigtable_internal::ReadRowsParserFactory> parser_factory) {
     std::shared_ptr<AsyncRowReader> res(new AsyncRowReader(
         std::move(cq), std::move(client), std::move(app_profile_id),
         std::move(table_name), std::move(on_row), std::move(on_finish),
@@ -91,7 +91,7 @@ class AsyncRowReader : public std::enable_shared_from_this<
       Filter filter, std::unique_ptr<RPCRetryPolicy> rpc_retry_policy,
       std::unique_ptr<RPCBackoffPolicy> rpc_backoff_policy,
       MetadataUpdatePolicy metadata_update_policy,
-      std::unique_ptr<internal::ReadRowsParserFactory> parser_factory)
+      std::unique_ptr<bigtable_internal::ReadRowsParserFactory> parser_factory)
       : cq_(std::move(cq)),
         client_(std::move(client)),
         app_profile_id_(std::move(app_profile_id)),
@@ -392,8 +392,8 @@ class AsyncRowReader : public std::enable_shared_from_this<
   std::unique_ptr<RPCRetryPolicy> rpc_retry_policy_;
   std::unique_ptr<RPCBackoffPolicy> rpc_backoff_policy_;
   MetadataUpdatePolicy metadata_update_policy_;
-  std::unique_ptr<internal::ReadRowsParserFactory> parser_factory_;
-  std::unique_ptr<internal::ReadRowsParser> parser_;
+  std::unique_ptr<bigtable_internal::ReadRowsParserFactory> parser_factory_;
+  std::unique_ptr<bigtable_internal::ReadRowsParser> parser_;
   /// Number of rows read so far, used to set row_limit in retries.
   std::int64_t rows_count_;
   /// Holds the last read row key, for retries.

--- a/google/cloud/bigtable/async_row_reader_test.cc
+++ b/google/cloud/bigtable/async_row_reader_test.cc
@@ -75,7 +75,7 @@ class TableAsyncReadRowsTest : public bigtable::testing::TableTestFixture {
                       grpc::CompletionQueue*) {
           EXPECT_STATUS_OK(
               IsContextMDValid(*context, "google.bigtable.v2.Bigtable.ReadRows",
-                               google::cloud::internal::ApiClientHeader()));
+                               internal::ApiClientHeader()));
           (*request_expectations_ptr)(r);
           return std::unique_ptr<
               MockClientAsyncReaderInterface<btproto::ReadRowsResponse>>(

--- a/google/cloud/bigtable/bigtable_version_test.cc
+++ b/google/cloud/bigtable/bigtable_version_test.cc
@@ -42,9 +42,8 @@ TEST(StorageVersionTest, Format) {
 
 /// @test Verify the version contains build metadata only if defined.
 TEST(StorageVersionTest, HasMetadataWhenDefined) {
-  if (!google::cloud::internal::build_metadata().empty()) {
-    EXPECT_THAT(version_string(),
-                HasSubstr("+" + google::cloud::internal::build_metadata()));
+  if (!internal::build_metadata().empty()) {
+    EXPECT_THAT(version_string(), HasSubstr("+" + internal::build_metadata()));
     return;
   }
   EXPECT_THAT(version_string(), Not(HasSubstr("+")));

--- a/google/cloud/bigtable/cell.h
+++ b/google/cloud/bigtable/cell.h
@@ -114,8 +114,7 @@ class Cell {
        std::int64_t value, std::vector<std::string> labels)
       : Cell(std::forward<KeyType>(row_key), std::move(family_name),
              std::forward<ColumnType>(column_qualifier), timestamp,
-             google::cloud::internal::EncodeBigEndian(value),
-             std::move(labels)) {}
+             internal::EncodeBigEndian(value), std::move(labels)) {}
 
   /// Create a cell and fill it with data, but with empty labels.
   template <typename KeyType, typename ColumnType, typename ValueType>

--- a/google/cloud/bigtable/cell.h
+++ b/google/cloud/bigtable/cell.h
@@ -160,7 +160,7 @@ class Cell {
    */
   template <typename T>
   StatusOr<T> decode_big_endian_integer() const {
-    return internal::DecodeBigEndianCellValue<T>(value_);
+    return bigtable_internal::DecodeBigEndianCellValue<T>(value_);
   }
 
   /// Return the labels applied to this cell by label transformer read filters.

--- a/google/cloud/bigtable/client_options.cc
+++ b/google/cloud/bigtable/client_options.cc
@@ -29,9 +29,9 @@ inline namespace BIGTABLE_CLIENT_NS {
 ClientOptions::ClientOptions() : ClientOptions(Options{}) {}
 
 ClientOptions::ClientOptions(Options opts) {
-  ::google::cloud::internal::CheckExpectedOptions<
-      ClientOptionList, CommonOptionList, GrpcOptionList>(opts, __func__);
-  opts_ = internal::DefaultOptions(std::move(opts));
+  internal::CheckExpectedOptions<ClientOptionList, CommonOptionList,
+                                 GrpcOptionList>(opts, __func__);
+  opts_ = bigtable_internal::DefaultOptions(std::move(opts));
 }
 
 ClientOptions::ClientOptions(std::shared_ptr<grpc::ChannelCredentials> creds)
@@ -43,25 +43,24 @@ ClientOptions::ClientOptions(std::shared_ptr<grpc::ChannelCredentials> creds)
 // NOLINTNEXTLINE(readability-identifier-naming)
 ClientOptions& ClientOptions::set_connection_pool_size(std::size_t size) {
   opts_.set<GrpcNumChannelsOption>(
-      size == 0 ? internal::DefaultConnectionPoolSize() : int(size));
+      size == 0 ? bigtable_internal::DefaultConnectionPoolSize() : int(size));
   return *this;
 }
 
 std::string ClientOptions::UserAgentPrefix() {
-  return google::cloud::internal::UserAgentPrefix();
+  return internal::UserAgentPrefix();
 }
 
 ClientOptions& ClientOptions::DisableBackgroundThreads(
     google::cloud::CompletionQueue const& cq) {
   opts_.set<GrpcBackgroundThreadsFactoryOption>([cq] {
-    return absl::make_unique<
-        google::cloud::internal::CustomerSuppliedBackgroundThreads>(cq);
+    return absl::make_unique<internal::CustomerSuppliedBackgroundThreads>(cq);
   });
   return *this;
 }
 
 BackgroundThreadsFactory ClientOptions::background_threads_factory() const {
-  return google::cloud::internal::MakeBackgroundThreadsFactory(opts_);
+  return internal::MakeBackgroundThreadsFactory(opts_);
 }
 
 }  // namespace BIGTABLE_CLIENT_NS

--- a/google/cloud/bigtable/client_options.cc
+++ b/google/cloud/bigtable/client_options.cc
@@ -52,7 +52,7 @@ std::string ClientOptions::UserAgentPrefix() {
 }
 
 ClientOptions& ClientOptions::DisableBackgroundThreads(
-    google::cloud::CompletionQueue const& cq) {
+    CompletionQueue const& cq) {
   opts_.set<GrpcBackgroundThreadsFactoryOption>([cq] {
     return absl::make_unique<internal::CustomerSuppliedBackgroundThreads>(cq);
   });

--- a/google/cloud/bigtable/client_options.h
+++ b/google/cloud/bigtable/client_options.h
@@ -34,11 +34,13 @@
 
 namespace google {
 namespace cloud {
+namespace bigtable_internal {
+inline namespace BIGTABLE_CLIENT_NS {
+struct InstanceAdminTraits;
+}  // namespace BIGTABLE_CLIENT_NS
+}  // namespace bigtable_internal
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
-namespace internal {
-struct InstanceAdminTraits;
-}  // namespace internal
 
 /**
  * Configuration options for the Bigtable Client.
@@ -235,20 +237,20 @@ class ClientOptions {
    *
    */
   template <typename Rep, typename Period>
-  google::cloud::Status SetGrpclbFallbackTimeout(
+  Status SetGrpclbFallbackTimeout(
       std::chrono::duration<Rep, Period> fallback_timeout) {
     std::chrono::milliseconds ft_ms =
         std::chrono::duration_cast<std::chrono::milliseconds>(fallback_timeout);
 
     if (ft_ms.count() > std::numeric_limits<int>::max()) {
-      return google::cloud::Status(google::cloud::StatusCode::kOutOfRange,
+      return Status(StatusCode::kOutOfRange,
                                    "The supplied duration is larger than the "
                                    "maximum value allowed by gRPC (INT_MAX)");
     }
     auto fallback_timeout_ms = static_cast<int>(ft_ms.count());
     opts_.lookup<GrpcChannelArgumentsNativeOption>().SetGrpclbFallbackTimeout(
         fallback_timeout_ms);
-    return google::cloud::Status();
+    return Status();
   }
 
   /**
@@ -355,7 +357,7 @@ class ClientOptions {
    * be enabled by clients configured with this option.
    */
   bool tracing_enabled(std::string const& component) const {
-    return google::cloud::internal::Contains(
+    return internal::Contains(
         opts_.get<TracingComponentsOption>(), component);
   }
 
@@ -451,7 +453,7 @@ class ClientOptions {
    * `CompletionQueue::Run()`.
    */
   ClientOptions& DisableBackgroundThreads(
-      google::cloud::CompletionQueue const& cq);
+      CompletionQueue const& cq);
 
   /**
    * Backwards compatibility alias
@@ -463,7 +465,7 @@ class ClientOptions {
   BackgroundThreadsFactory background_threads_factory() const;
 
  private:
-  friend struct internal::InstanceAdminTraits;
+  friend struct bigtable_internal::InstanceAdminTraits;
   friend struct ClientOptionsTestTraits;
 
   /// Return the current endpoint for instance admin RPCs.

--- a/google/cloud/bigtable/client_options.h
+++ b/google/cloud/bigtable/client_options.h
@@ -179,7 +179,7 @@ class ClientOptions {
 
   /// Access all the channel arguments.
   grpc::ChannelArguments channel_arguments() const {
-    return ::google::cloud::internal::MakeChannelArguments(opts_);
+    return internal::MakeChannelArguments(opts_);
   }
 
   /// Set all the channel arguments.

--- a/google/cloud/bigtable/client_options.h
+++ b/google/cloud/bigtable/client_options.h
@@ -244,8 +244,8 @@ class ClientOptions {
 
     if (ft_ms.count() > std::numeric_limits<int>::max()) {
       return Status(StatusCode::kOutOfRange,
-                                   "The supplied duration is larger than the "
-                                   "maximum value allowed by gRPC (INT_MAX)");
+                    "The supplied duration is larger than the "
+                    "maximum value allowed by gRPC (INT_MAX)");
     }
     auto fallback_timeout_ms = static_cast<int>(ft_ms.count());
     opts_.lookup<GrpcChannelArgumentsNativeOption>().SetGrpclbFallbackTimeout(
@@ -357,8 +357,7 @@ class ClientOptions {
    * be enabled by clients configured with this option.
    */
   bool tracing_enabled(std::string const& component) const {
-    return internal::Contains(
-        opts_.get<TracingComponentsOption>(), component);
+    return internal::Contains(opts_.get<TracingComponentsOption>(), component);
   }
 
   /// Enable tracing for @p component in clients configured with this object.
@@ -452,8 +451,7 @@ class ClientOptions {
    * it assumes responsibility for creating one or more threads blocked on
    * `CompletionQueue::Run()`.
    */
-  ClientOptions& DisableBackgroundThreads(
-      CompletionQueue const& cq);
+  ClientOptions& DisableBackgroundThreads(CompletionQueue const& cq);
 
   /**
    * Backwards compatibility alias

--- a/google/cloud/bigtable/client_options_test.cc
+++ b/google/cloud/bigtable/client_options_test.cc
@@ -316,7 +316,7 @@ TEST(ClientOptionsTest, SetGrpclbFallbackTimeoutException) {
   ClientOptions client_options;
   EXPECT_EQ(
       client_options.SetGrpclbFallbackTimeout(std::chrono::hours(999)).code(),
-      google::cloud::StatusCode::kOutOfRange);
+      StatusCode::kOutOfRange);
 }
 
 TEST(ClientOptionsTest, SetCompressionAlgorithm) {

--- a/google/cloud/bigtable/data_client.cc
+++ b/google/cloud/bigtable/data_client.cc
@@ -50,7 +50,7 @@ class DefaultDataClient : public DataClient {
     }
   };
 
-  using Impl = bigtable::internal::CommonClient<DataTraits, btproto::Bigtable>;
+  using Impl = bigtable_internal::CommonClient<DataTraits, btproto::Bigtable>;
 
  public:
   DefaultDataClient(std::string project, std::string instance,
@@ -205,7 +205,7 @@ std::shared_ptr<DataClient> CreateDefaultDataClient(
       std::move(project_id), std::move(instance_id), options);
   if (options.tracing_enabled("rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
-    client = std::make_shared<internal::LoggingDataClient>(
+    client = std::make_shared<bigtable_internal::LoggingDataClient>(
         std::move(client), options.tracing_options());
   }
   return client;

--- a/google/cloud/bigtable/data_client.cc
+++ b/google/cloud/bigtable/data_client.cc
@@ -45,7 +45,7 @@ class DefaultDataClient : public DataClient {
   // Introduce an early `private:` section because this type is used to define
   // the public interface, it should not be part of the public interface.
   struct DataTraits {
-    static std::string const& Endpoint(bigtable::ClientOptions& options) {
+    static std::string const& Endpoint(ClientOptions& options) {
       return options.data_endpoint();
     }
   };

--- a/google/cloud/bigtable/data_client.h
+++ b/google/cloud/bigtable/data_client.h
@@ -24,16 +24,18 @@
 
 namespace google {
 namespace cloud {
-namespace bigtable {
+namespace bigtable_internal {
 inline namespace BIGTABLE_CLIENT_NS {
 // Forward declare some classes so we can be friends.
-class Table;
-namespace internal {
 class AsyncRetryBulkApply;
 class AsyncRowSampler;
 class BulkMutator;
 class LoggingDataClient;
-}  // namespace internal
+}  // namespace BIGTABLE_CLIENT_NS
+}  // namespace bigtable_internal
+namespace bigtable {
+inline namespace BIGTABLE_CLIENT_NS {
+class Table;
 
 /**
  * Connects to Cloud Bigtable's data manipulation APIs.
@@ -89,13 +91,13 @@ class DataClient {
   // classes that do use them friends.
  protected:
   friend class Table;
-  friend class internal::AsyncRetryBulkApply;
-  friend class internal::AsyncRowSampler;
-  friend class internal::BulkMutator;
+  friend class bigtable_internal::AsyncRetryBulkApply;
+  friend class bigtable_internal::AsyncRowSampler;
+  friend class bigtable_internal::BulkMutator;
   friend class RowReader;
   template <typename RowFunctor, typename FinishFunctor>
   friend class AsyncRowReader;
-  friend class internal::LoggingDataClient;
+  friend class bigtable_internal::LoggingDataClient;
 
   //@{
   /// @name the `google.bigtable.v2.Bigtable` wrappers.

--- a/google/cloud/bigtable/examples/bigtable_examples_common.cc
+++ b/google/cloud/bigtable/examples/bigtable_examples_common.cc
@@ -25,9 +25,7 @@ namespace bigtable {
 namespace examples {
 
 bool UsingEmulator() {
-  return !internal::GetEnv("BIGTABLE_EMULATOR_HOST")
-              .value_or("")
-              .empty();
+  return !internal::GetEnv("BIGTABLE_EMULATOR_HOST").value_or("").empty();
 }
 
 bool RunAdminIntegrationTests() {
@@ -37,14 +35,13 @@ bool RunAdminIntegrationTests() {
   // In production, we run the admin integration tests only on the nightly
   // builds to stay below the quota limits. Only this build should set the
   // following environment variable.
-  return internal::GetEnv(
-             "ENABLE_BIGTABLE_ADMIN_INTEGRATION_TESTS")
+  return internal::GetEnv("ENABLE_BIGTABLE_ADMIN_INTEGRATION_TESTS")
              .value_or("") == "yes";
 }
 
-Commands::value_type MakeCommandEntry(
-    std::string const& name, std::vector<std::string> const& args,
-    TableCommandType const& function) {
+Commands::value_type MakeCommandEntry(std::string const& name,
+                                      std::vector<std::string> const& args,
+                                      TableCommandType const& function) {
   auto command = [=](std::vector<std::string> argv) {
     if ((argv.size() == 1 && argv[0] == "--help") ||
         argv.size() != 3 + args.size()) {
@@ -53,10 +50,8 @@ Commands::value_type MakeCommandEntry(
       if (!args.empty()) os << " " << absl::StrJoin(args, " ");
       throw Usage{std::move(os).str()};
     }
-    Table table(
-        CreateDefaultDataClient(
-            argv[0], argv[1], ClientOptions()),
-        argv[2]);
+    Table table(CreateDefaultDataClient(argv[0], argv[1], ClientOptions()),
+                argv[2]);
     argv.erase(argv.begin(), argv.begin() + 3);
     function(table, argv);
   };
@@ -75,10 +70,8 @@ Commands::value_type MakeCommandEntry(std::string const& name,
       if (!args.empty()) os << " " << absl::StrJoin(args, " ");
       throw Usage{std::move(os).str()};
     }
-    TableAdmin table(
-        CreateDefaultAdminClient(
-            argv[0], ClientOptions()),
-        argv[1]);
+    TableAdmin table(CreateDefaultAdminClient(argv[0], ClientOptions()),
+                     argv[1]);
     argv.erase(argv.begin(), argv.begin() + kFixedArguments);
     function(table, argv);
   };
@@ -98,8 +91,7 @@ Commands::value_type MakeCommandEntry(
       throw Usage{std::move(os).str()};
     }
     InstanceAdmin instance(
-        CreateDefaultInstanceAdminClient(
-            argv[0], ClientOptions()));
+        CreateDefaultInstanceAdminClient(argv[0], ClientOptions()));
     argv.erase(argv.begin(), argv.begin() + kFixedArguments);
     function(instance, argv);
   };
@@ -124,10 +116,8 @@ Commands::value_type MakeCommandEntry(std::string const& name,
       }
       throw Usage{std::move(os).str()};
     }
-    Table table(
-        CreateDefaultDataClient(
-            argv[0], argv[1], ClientOptions()),
-        argv[2]);
+    Table table(CreateDefaultDataClient(argv[0], argv[1], ClientOptions()),
+                argv[2]);
     CompletionQueue cq;
     std::thread t([&cq] { cq.Run(); });
     AutoShutdownCQ shutdown(cq, std::move(t));

--- a/google/cloud/bigtable/examples/bigtable_examples_common.cc
+++ b/google/cloud/bigtable/examples/bigtable_examples_common.cc
@@ -25,7 +25,7 @@ namespace bigtable {
 namespace examples {
 
 bool UsingEmulator() {
-  return !google::cloud::internal::GetEnv("BIGTABLE_EMULATOR_HOST")
+  return !internal::GetEnv("BIGTABLE_EMULATOR_HOST")
               .value_or("")
               .empty();
 }
@@ -37,12 +37,12 @@ bool RunAdminIntegrationTests() {
   // In production, we run the admin integration tests only on the nightly
   // builds to stay below the quota limits. Only this build should set the
   // following environment variable.
-  return google::cloud::internal::GetEnv(
+  return internal::GetEnv(
              "ENABLE_BIGTABLE_ADMIN_INTEGRATION_TESTS")
              .value_or("") == "yes";
 }
 
-google::cloud::bigtable::examples::Commands::value_type MakeCommandEntry(
+Commands::value_type MakeCommandEntry(
     std::string const& name, std::vector<std::string> const& args,
     TableCommandType const& function) {
   auto command = [=](std::vector<std::string> argv) {
@@ -53,9 +53,9 @@ google::cloud::bigtable::examples::Commands::value_type MakeCommandEntry(
       if (!args.empty()) os << " " << absl::StrJoin(args, " ");
       throw Usage{std::move(os).str()};
     }
-    google::cloud::bigtable::Table table(
-        google::cloud::bigtable::CreateDefaultDataClient(
-            argv[0], argv[1], google::cloud::bigtable::ClientOptions()),
+    Table table(
+        CreateDefaultDataClient(
+            argv[0], argv[1], ClientOptions()),
         argv[2]);
     argv.erase(argv.begin(), argv.begin() + 3);
     function(table, argv);
@@ -75,9 +75,9 @@ Commands::value_type MakeCommandEntry(std::string const& name,
       if (!args.empty()) os << " " << absl::StrJoin(args, " ");
       throw Usage{std::move(os).str()};
     }
-    google::cloud::bigtable::TableAdmin table(
-        google::cloud::bigtable::CreateDefaultAdminClient(
-            argv[0], google::cloud::bigtable::ClientOptions()),
+    TableAdmin table(
+        CreateDefaultAdminClient(
+            argv[0], ClientOptions()),
         argv[1]);
     argv.erase(argv.begin(), argv.begin() + kFixedArguments);
     function(table, argv);
@@ -97,9 +97,9 @@ Commands::value_type MakeCommandEntry(
       if (!args.empty()) os << " " << absl::StrJoin(args, " ");
       throw Usage{std::move(os).str()};
     }
-    google::cloud::bigtable::InstanceAdmin instance(
-        google::cloud::bigtable::CreateDefaultInstanceAdminClient(
-            argv[0], google::cloud::bigtable::ClientOptions()));
+    InstanceAdmin instance(
+        CreateDefaultInstanceAdminClient(
+            argv[0], ClientOptions()));
     argv.erase(argv.begin(), argv.begin() + kFixedArguments);
     function(instance, argv);
   };
@@ -124,11 +124,11 @@ Commands::value_type MakeCommandEntry(std::string const& name,
       }
       throw Usage{std::move(os).str()};
     }
-    google::cloud::bigtable::Table table(
-        google::cloud::bigtable::CreateDefaultDataClient(
-            argv[0], argv[1], google::cloud::bigtable::ClientOptions()),
+    Table table(
+        CreateDefaultDataClient(
+            argv[0], argv[1], ClientOptions()),
         argv[2]);
-    google::cloud::CompletionQueue cq;
+    CompletionQueue cq;
     std::thread t([&cq] { cq.Run(); });
     AutoShutdownCQ shutdown(cq, std::move(t));
     argv.erase(argv.begin(), argv.begin() + common.size());

--- a/google/cloud/bigtable/examples/bigtable_examples_common.h
+++ b/google/cloud/bigtable/examples/bigtable_examples_common.h
@@ -55,30 +55,28 @@ class AutoShutdownCQ {
   std::thread th_;
 };
 
-using TableCommandType = std::function<void(Table,
-                                            std::vector<std::string>)>;
+using TableCommandType = std::function<void(Table, std::vector<std::string>)>;
 
-Commands::value_type MakeCommandEntry(
-    std::string const& name, std::vector<std::string> const& args,
-    TableCommandType const& function);
+Commands::value_type MakeCommandEntry(std::string const& name,
+                                      std::vector<std::string> const& args,
+                                      TableCommandType const& function);
 
-using TableAdminCommandType = std::function<void(
-    TableAdmin, std::vector<std::string>)>;
+using TableAdminCommandType =
+    std::function<void(TableAdmin, std::vector<std::string>)>;
 
 Commands::value_type MakeCommandEntry(std::string const& name,
                                       std::vector<std::string> const& args,
                                       TableAdminCommandType const& function);
 
-using InstanceAdminCommandType = std::function<void(
-    InstanceAdmin, std::vector<std::string>)>;
+using InstanceAdminCommandType =
+    std::function<void(InstanceAdmin, std::vector<std::string>)>;
 
 Commands::value_type MakeCommandEntry(std::string const& name,
                                       std::vector<std::string> const& args,
                                       InstanceAdminCommandType const& function);
 
-using TableAsyncCommandType = std::function<void(Table,
-                                                 CompletionQueue,
-                                                 std::vector<std::string>)>;
+using TableAsyncCommandType =
+    std::function<void(Table, CompletionQueue, std::vector<std::string>)>;
 
 Commands::value_type MakeCommandEntry(std::string const& name,
                                       std::vector<std::string> const& args,

--- a/google/cloud/bigtable/examples/bigtable_examples_common.h
+++ b/google/cloud/bigtable/examples/bigtable_examples_common.h
@@ -40,7 +40,7 @@ bool RunAdminIntegrationTests();
 
 class AutoShutdownCQ {
  public:
-  AutoShutdownCQ(google::cloud::CompletionQueue cq, std::thread th)
+  AutoShutdownCQ(CompletionQueue cq, std::thread th)
       : cq_(std::move(cq)), th_(std::move(th)) {}
   ~AutoShutdownCQ() {
     cq_.Shutdown();
@@ -51,33 +51,33 @@ class AutoShutdownCQ {
   AutoShutdownCQ& operator=(AutoShutdownCQ&&) = delete;
 
  private:
-  google::cloud::CompletionQueue cq_;
+  CompletionQueue cq_;
   std::thread th_;
 };
 
-using TableCommandType = std::function<void(google::cloud::bigtable::Table,
+using TableCommandType = std::function<void(Table,
                                             std::vector<std::string>)>;
 
-google::cloud::bigtable::examples::Commands::value_type MakeCommandEntry(
+Commands::value_type MakeCommandEntry(
     std::string const& name, std::vector<std::string> const& args,
     TableCommandType const& function);
 
 using TableAdminCommandType = std::function<void(
-    google::cloud::bigtable::TableAdmin, std::vector<std::string>)>;
+    TableAdmin, std::vector<std::string>)>;
 
 Commands::value_type MakeCommandEntry(std::string const& name,
                                       std::vector<std::string> const& args,
                                       TableAdminCommandType const& function);
 
 using InstanceAdminCommandType = std::function<void(
-    google::cloud::bigtable::InstanceAdmin, std::vector<std::string>)>;
+    InstanceAdmin, std::vector<std::string>)>;
 
 Commands::value_type MakeCommandEntry(std::string const& name,
                                       std::vector<std::string> const& args,
                                       InstanceAdminCommandType const& function);
 
-using TableAsyncCommandType = std::function<void(google::cloud::bigtable::Table,
-                                                 google::cloud::CompletionQueue,
+using TableAsyncCommandType = std::function<void(Table,
+                                                 CompletionQueue,
                                                  std::vector<std::string>)>;
 
 Commands::value_type MakeCommandEntry(std::string const& name,

--- a/google/cloud/bigtable/instance_admin.cc
+++ b/google/cloud/bigtable/instance_admin.cc
@@ -465,9 +465,7 @@ StatusOr<google::cloud::IamPolicy> InstanceAdmin::GetIamPolicy(
       &InstanceAdminClient::GetIamPolicy, request,
       "InstanceAdmin::GetIamPolicy", status, Idempotency::kIdempotent);
 
-  if (!status.ok()) {
-    return MakeStatusFromRpcError(status);
-  }
+  if (!status.ok()) return MakeStatusFromRpcError(status);
 
   return ProtoToWrapper(std::move(proto));
 }
@@ -498,8 +496,8 @@ StatusOr<google::iam::v1::Policy> InstanceAdmin::GetNativeIamPolicy(
 }
 
 StatusOr<google::cloud::IamPolicy> InstanceAdmin::SetIamPolicy(
-    std::string const& instance_id,
-    google::cloud::IamBindings const& iam_bindings, std::string const& etag) {
+    std::string const& instance_id, IamBindings const& iam_bindings,
+    std::string const& etag) {
   grpc::Status status;
   auto rpc_policy = clone_rpc_retry_policy();
   auto backoff_policy = clone_rpc_backoff_policy();

--- a/google/cloud/bigtable/instance_admin.cc
+++ b/google/cloud/bigtable/instance_admin.cc
@@ -37,7 +37,7 @@ inline namespace BIGTABLE_CLIENT_NS {
 static_assert(std::is_copy_assignable<bigtable::InstanceAdmin>::value,
               "bigtable::InstanceAdmin must be CopyAssignable");
 
-using ClientUtils = bigtable::internal::UnaryClientUtils<InstanceAdminClient>;
+using ClientUtils = bigtable_internal::UnaryClientUtils<InstanceAdminClient>;
 using ::google::cloud::internal::Idempotency;
 
 StatusOr<InstanceList> InstanceAdmin::ListInstances() {
@@ -100,11 +100,11 @@ InstanceAdmin::AsyncCreateInstanceImpl(
                            kv.second.location());
   }
   std::shared_ptr<InstanceAdminClient> client(client_);
-  return internal::AsyncStartPollAfterRetryUnaryRpc<
+  return bigtable_internal::AsyncStartPollAfterRetryUnaryRpc<
       google::bigtable::admin::v2::Instance>(
       __func__, clone_polling_policy(), clone_rpc_retry_policy(),
       clone_rpc_backoff_policy(),
-      internal::ConstantIdempotencyPolicy(Idempotency::kNonIdempotent),
+      bigtable_internal::ConstantIdempotencyPolicy(Idempotency::kNonIdempotent),
       MetadataUpdatePolicy(project_name(), MetadataParamTypes::PARENT), client,
       [client](
           grpc::ClientContext* context,
@@ -137,11 +137,11 @@ InstanceAdmin::AsyncCreateClusterImpl(CompletionQueue& cq,
   request.set_cluster_id(cluster_id);
 
   std::shared_ptr<InstanceAdminClient> client(client_);
-  return internal::AsyncStartPollAfterRetryUnaryRpc<
+  return bigtable_internal::AsyncStartPollAfterRetryUnaryRpc<
       google::bigtable::admin::v2::Cluster>(
       __func__, clone_polling_policy(), clone_rpc_retry_policy(),
       clone_rpc_backoff_policy(),
-      internal::ConstantIdempotencyPolicy(Idempotency::kNonIdempotent),
+      bigtable_internal::ConstantIdempotencyPolicy(Idempotency::kNonIdempotent),
       MetadataUpdatePolicy(parent, MetadataParamTypes::PARENT), client,
       [client](grpc::ClientContext* context,
                google::bigtable::admin::v2::CreateClusterRequest const& request,
@@ -164,11 +164,11 @@ InstanceAdmin::AsyncUpdateInstanceImpl(
   auto request = std::move(instance_update_config).as_proto();
 
   std::shared_ptr<InstanceAdminClient> client(client_);
-  return internal::AsyncStartPollAfterRetryUnaryRpc<
+  return bigtable_internal::AsyncStartPollAfterRetryUnaryRpc<
       google::bigtable::admin::v2::Instance>(
       __func__, clone_polling_policy(), clone_rpc_retry_policy(),
       clone_rpc_backoff_policy(),
-      internal::ConstantIdempotencyPolicy(Idempotency::kNonIdempotent),
+      bigtable_internal::ConstantIdempotencyPolicy(Idempotency::kNonIdempotent),
       MetadataUpdatePolicy(name, MetadataParamTypes::INSTANCE_NAME), client,
       [client](grpc::ClientContext* context,
                google::bigtable::admin::v2::PartialUpdateInstanceRequest const&
@@ -302,11 +302,11 @@ InstanceAdmin::AsyncUpdateClusterImpl(CompletionQueue& cq,
   auto name = request.name();
 
   std::shared_ptr<InstanceAdminClient> client(client_);
-  return internal::AsyncStartPollAfterRetryUnaryRpc<
+  return bigtable_internal::AsyncStartPollAfterRetryUnaryRpc<
       google::bigtable::admin::v2::Cluster>(
       __func__, clone_polling_policy(), clone_rpc_retry_policy(),
       clone_rpc_backoff_policy(),
-      internal::ConstantIdempotencyPolicy(Idempotency::kNonIdempotent),
+      bigtable_internal::ConstantIdempotencyPolicy(Idempotency::kNonIdempotent),
       MetadataUpdatePolicy(name, MetadataParamTypes::NAME), client,
       [client](grpc::ClientContext* context,
                google::bigtable::admin::v2::Cluster const& request,
@@ -392,11 +392,11 @@ InstanceAdmin::AsyncUpdateAppProfileImpl(CompletionQueue& cq,
   request.mutable_app_profile()->set_name(name);
 
   std::shared_ptr<InstanceAdminClient> client(client_);
-  return internal::AsyncStartPollAfterRetryUnaryRpc<
+  return bigtable_internal::AsyncStartPollAfterRetryUnaryRpc<
       google::bigtable::admin::v2::AppProfile>(
       __func__, clone_polling_policy(), clone_rpc_retry_policy(),
       clone_rpc_backoff_policy(),
-      internal::ConstantIdempotencyPolicy(Idempotency::kNonIdempotent),
+      bigtable_internal::ConstantIdempotencyPolicy(Idempotency::kNonIdempotent),
       MetadataUpdatePolicy(name, MetadataParamTypes::APP_PROFILE_NAME), client,
       [client](
           grpc::ClientContext* context,

--- a/google/cloud/bigtable/instance_admin.cc
+++ b/google/cloud/bigtable/instance_admin.cc
@@ -34,7 +34,7 @@ namespace google {
 namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
-static_assert(std::is_copy_assignable<bigtable::InstanceAdmin>::value,
+static_assert(std::is_copy_assignable<InstanceAdmin>::value,
               "bigtable::InstanceAdmin must be CopyAssignable");
 
 using ClientUtils = bigtable_internal::UnaryClientUtils<InstanceAdminClient>;
@@ -90,9 +90,8 @@ future<StatusOr<btadmin::Instance>> InstanceAdmin::CreateInstance(
   return AsyncCreateInstanceImpl(cq, std::move(instance_config));
 }
 
-future<StatusOr<google::bigtable::admin::v2::Instance>>
-InstanceAdmin::AsyncCreateInstanceImpl(
-    CompletionQueue& cq, bigtable::InstanceConfig instance_config) {
+future<StatusOr<btadmin::Instance>> InstanceAdmin::AsyncCreateInstanceImpl(
+    CompletionQueue& cq, InstanceConfig instance_config) {
   auto request = std::move(instance_config).as_proto();
   request.set_parent(project_name());
   for (auto& kv : *request.mutable_clusters()) {
@@ -100,16 +99,14 @@ InstanceAdmin::AsyncCreateInstanceImpl(
                            kv.second.location());
   }
   std::shared_ptr<InstanceAdminClient> client(client_);
-  return bigtable_internal::AsyncStartPollAfterRetryUnaryRpc<
-      google::bigtable::admin::v2::Instance>(
+  return bigtable_internal::AsyncStartPollAfterRetryUnaryRpc<btadmin::Instance>(
       __func__, clone_polling_policy(), clone_rpc_retry_policy(),
       clone_rpc_backoff_policy(),
       bigtable_internal::ConstantIdempotencyPolicy(Idempotency::kNonIdempotent),
       MetadataUpdatePolicy(project_name(), MetadataParamTypes::PARENT), client,
-      [client](
-          grpc::ClientContext* context,
-          google::bigtable::admin::v2::CreateInstanceRequest const& request,
-          grpc::CompletionQueue* cq) {
+      [client](grpc::ClientContext* context,
+               btadmin::CreateInstanceRequest const& request,
+               grpc::CompletionQueue* cq) {
         return client->AsyncCreateInstance(context, request, cq);
       },
       std::move(request), cq);
@@ -123,11 +120,9 @@ future<StatusOr<btadmin::Cluster>> InstanceAdmin::CreateCluster(
                                 cluster_id);
 }
 
-future<StatusOr<google::bigtable::admin::v2::Cluster>>
-InstanceAdmin::AsyncCreateClusterImpl(CompletionQueue& cq,
-                                      ClusterConfig cluster_config,
-                                      std::string const& instance_id,
-                                      std::string const& cluster_id) {
+future<StatusOr<btadmin::Cluster>> InstanceAdmin::AsyncCreateClusterImpl(
+    CompletionQueue& cq, ClusterConfig cluster_config,
+    std::string const& instance_id, std::string const& cluster_id) {
   auto cluster = std::move(cluster_config).as_proto();
   cluster.set_location(project_name() + "/locations/" + cluster.location());
   btadmin::CreateClusterRequest request;
@@ -137,42 +132,38 @@ InstanceAdmin::AsyncCreateClusterImpl(CompletionQueue& cq,
   request.set_cluster_id(cluster_id);
 
   std::shared_ptr<InstanceAdminClient> client(client_);
-  return bigtable_internal::AsyncStartPollAfterRetryUnaryRpc<
-      google::bigtable::admin::v2::Cluster>(
+  return bigtable_internal::AsyncStartPollAfterRetryUnaryRpc<btadmin::Cluster>(
       __func__, clone_polling_policy(), clone_rpc_retry_policy(),
       clone_rpc_backoff_policy(),
       bigtable_internal::ConstantIdempotencyPolicy(Idempotency::kNonIdempotent),
       MetadataUpdatePolicy(parent, MetadataParamTypes::PARENT), client,
       [client](grpc::ClientContext* context,
-               google::bigtable::admin::v2::CreateClusterRequest const& request,
+               btadmin::CreateClusterRequest const& request,
                grpc::CompletionQueue* cq) {
         return client->AsyncCreateCluster(context, request, cq);
       },
       std::move(request), cq);
 }
 
-future<StatusOr<google::bigtable::admin::v2::Instance>>
-InstanceAdmin::UpdateInstance(InstanceUpdateConfig instance_update_config) {
+future<StatusOr<btadmin::Instance>> InstanceAdmin::UpdateInstance(
+    InstanceUpdateConfig instance_update_config) {
   auto cq = background_threads_->cq();
   return AsyncUpdateInstanceImpl(cq, std::move(instance_update_config));
 }
 
-future<StatusOr<google::bigtable::admin::v2::Instance>>
-InstanceAdmin::AsyncUpdateInstanceImpl(
+future<StatusOr<btadmin::Instance>> InstanceAdmin::AsyncUpdateInstanceImpl(
     CompletionQueue& cq, InstanceUpdateConfig instance_update_config) {
   auto name = instance_update_config.GetName();
   auto request = std::move(instance_update_config).as_proto();
 
   std::shared_ptr<InstanceAdminClient> client(client_);
-  return bigtable_internal::AsyncStartPollAfterRetryUnaryRpc<
-      google::bigtable::admin::v2::Instance>(
+  return bigtable_internal::AsyncStartPollAfterRetryUnaryRpc<btadmin::Instance>(
       __func__, clone_polling_policy(), clone_rpc_retry_policy(),
       clone_rpc_backoff_policy(),
       bigtable_internal::ConstantIdempotencyPolicy(Idempotency::kNonIdempotent),
       MetadataUpdatePolicy(name, MetadataParamTypes::INSTANCE_NAME), client,
       [client](grpc::ClientContext* context,
-               google::bigtable::admin::v2::PartialUpdateInstanceRequest const&
-                   request,
+               btadmin::PartialUpdateInstanceRequest const& request,
                grpc::CompletionQueue* cq) {
         return client->AsyncUpdateInstance(context, request, cq);
       },
@@ -289,27 +280,24 @@ StatusOr<ClusterList> InstanceAdmin::ListClusters(
   return result;
 }
 
-future<StatusOr<google::bigtable::admin::v2::Cluster>>
-InstanceAdmin::UpdateCluster(ClusterConfig cluster_config) {
+future<StatusOr<btadmin::Cluster>> InstanceAdmin::UpdateCluster(
+    ClusterConfig cluster_config) {
   auto cq = background_threads_->cq();
   return AsyncUpdateClusterImpl(cq, std::move(cluster_config));
 }
 
-future<StatusOr<google::bigtable::admin::v2::Cluster>>
-InstanceAdmin::AsyncUpdateClusterImpl(CompletionQueue& cq,
-                                      ClusterConfig cluster_config) {
+future<StatusOr<btadmin::Cluster>> InstanceAdmin::AsyncUpdateClusterImpl(
+    CompletionQueue& cq, ClusterConfig cluster_config) {
   auto request = std::move(cluster_config).as_proto();
   auto name = request.name();
 
   std::shared_ptr<InstanceAdminClient> client(client_);
-  return bigtable_internal::AsyncStartPollAfterRetryUnaryRpc<
-      google::bigtable::admin::v2::Cluster>(
+  return bigtable_internal::AsyncStartPollAfterRetryUnaryRpc<btadmin::Cluster>(
       __func__, clone_polling_policy(), clone_rpc_retry_policy(),
       clone_rpc_backoff_policy(),
       bigtable_internal::ConstantIdempotencyPolicy(Idempotency::kNonIdempotent),
       MetadataUpdatePolicy(name, MetadataParamTypes::NAME), client,
-      [client](grpc::ClientContext* context,
-               google::bigtable::admin::v2::Cluster const& request,
+      [client](grpc::ClientContext* context, btadmin::Cluster const& request,
                grpc::CompletionQueue* cq) {
         return client->AsyncUpdateCluster(context, request, cq);
       },
@@ -382,26 +370,23 @@ future<StatusOr<btadmin::AppProfile>> InstanceAdmin::UpdateAppProfile(
                                    std::move(config));
 }
 
-future<StatusOr<google::bigtable::admin::v2::AppProfile>>
-InstanceAdmin::AsyncUpdateAppProfileImpl(CompletionQueue& cq,
-                                         std::string const& instance_id,
-                                         std::string const& profile_id,
-                                         AppProfileUpdateConfig config) {
+future<StatusOr<btadmin::AppProfile>> InstanceAdmin::AsyncUpdateAppProfileImpl(
+    CompletionQueue& cq, std::string const& instance_id,
+    std::string const& profile_id, AppProfileUpdateConfig config) {
   auto request = std::move(config).as_proto();
   auto name = AppProfileName(instance_id, profile_id);
   request.mutable_app_profile()->set_name(name);
 
   std::shared_ptr<InstanceAdminClient> client(client_);
   return bigtable_internal::AsyncStartPollAfterRetryUnaryRpc<
-      google::bigtable::admin::v2::AppProfile>(
+      btadmin::AppProfile>(
       __func__, clone_polling_policy(), clone_rpc_retry_policy(),
       clone_rpc_backoff_policy(),
       bigtable_internal::ConstantIdempotencyPolicy(Idempotency::kNonIdempotent),
       MetadataUpdatePolicy(name, MetadataParamTypes::APP_PROFILE_NAME), client,
-      [client](
-          grpc::ClientContext* context,
-          google::bigtable::admin::v2::UpdateAppProfileRequest const& request,
-          grpc::CompletionQueue* cq) {
+      [client](grpc::ClientContext* context,
+               btadmin::UpdateAppProfileRequest const& request,
+               grpc::CompletionQueue* cq) {
         return client->AsyncUpdateAppProfile(context, request, cq);
       },
       std::move(request), cq);

--- a/google/cloud/bigtable/instance_admin.h
+++ b/google/cloud/bigtable/instance_admin.h
@@ -129,12 +129,12 @@ class InstanceAdmin {
   explicit InstanceAdmin(std::shared_ptr<InstanceAdminClient> client)
       : client_(std::move(client)),
         project_name_("projects/" + project_id()),
-        rpc_retry_policy_prototype_(
-            DefaultRPCRetryPolicy(bigtable_internal::kBigtableInstanceAdminLimits)),
-        rpc_backoff_policy_prototype_(
-            DefaultRPCBackoffPolicy(bigtable_internal::kBigtableInstanceAdminLimits)),
-        polling_policy_prototype_(
-            DefaultPollingPolicy(bigtable_internal::kBigtableInstanceAdminLimits)),
+        rpc_retry_policy_prototype_(DefaultRPCRetryPolicy(
+            bigtable_internal::kBigtableInstanceAdminLimits)),
+        rpc_backoff_policy_prototype_(DefaultRPCBackoffPolicy(
+            bigtable_internal::kBigtableInstanceAdminLimits)),
+        polling_policy_prototype_(DefaultPollingPolicy(
+            bigtable_internal::kBigtableInstanceAdminLimits)),
         background_threads_(client_->BackgroundThreadsFactory()()) {}
 
   /**

--- a/google/cloud/bigtable/instance_admin.h
+++ b/google/cloud/bigtable/instance_admin.h
@@ -130,11 +130,11 @@ class InstanceAdmin {
       : client_(std::move(client)),
         project_name_("projects/" + project_id()),
         rpc_retry_policy_prototype_(
-            DefaultRPCRetryPolicy(internal::kBigtableInstanceAdminLimits)),
+            DefaultRPCRetryPolicy(bigtable_internal::kBigtableInstanceAdminLimits)),
         rpc_backoff_policy_prototype_(
-            DefaultRPCBackoffPolicy(internal::kBigtableInstanceAdminLimits)),
+            DefaultRPCBackoffPolicy(bigtable_internal::kBigtableInstanceAdminLimits)),
         polling_policy_prototype_(
-            DefaultPollingPolicy(internal::kBigtableInstanceAdminLimits)),
+            DefaultPollingPolicy(bigtable_internal::kBigtableInstanceAdminLimits)),
         background_threads_(client_->BackgroundThreadsFactory()()) {}
 
   /**

--- a/google/cloud/bigtable/instance_admin.h
+++ b/google/cloud/bigtable/instance_admin.h
@@ -174,21 +174,19 @@ class InstanceAdmin {
 
   /// Return the fully qualified name of the given instance_id.
   std::string InstanceName(std::string const& instance_id) const {
-    return google::cloud::bigtable::InstanceName(project_id(), instance_id);
+    return bigtable::InstanceName(project_id(), instance_id);
   }
 
   /// Return the fully qualified name of the given cluster_id in give
   /// instance_id.
   std::string ClusterName(std::string const& instance_id,
                           std::string const& cluster_id) const {
-    return google::cloud::bigtable::ClusterName(project_id(), instance_id,
-                                                cluster_id);
+    return bigtable::ClusterName(project_id(), instance_id, cluster_id);
   }
 
   std::string AppProfileName(std::string const& instance_id,
                              std::string const& profile_id) const {
-    return google::cloud::bigtable::AppProfileName(project_id(), instance_id,
-                                                   profile_id);
+    return bigtable::AppProfileName(project_id(), instance_id, profile_id);
   }
 
   /**

--- a/google/cloud/bigtable/instance_admin.h
+++ b/google/cloud/bigtable/instance_admin.h
@@ -654,8 +654,7 @@ class InstanceAdmin {
   GOOGLE_CLOUD_CPP_BIGTABLE_IAM_DEPRECATED(
       "SetIamPolicy(std::string const&, google::iam::v1::Policy const&)")
   StatusOr<google::cloud::IamPolicy> SetIamPolicy(
-      std::string const& instance_id,
-      google::cloud::IamBindings const& iam_bindings,
+      std::string const& instance_id, IamBindings const& iam_bindings,
       std::string const& etag = std::string{});
 
   /**

--- a/google/cloud/bigtable/instance_admin_client.cc
+++ b/google/cloud/bigtable/instance_admin_client.cc
@@ -13,22 +13,25 @@
 // limitations under the License.
 
 #include "google/cloud/bigtable/instance_admin_client.h"
+#include "google/cloud/bigtable/client_options.h"
 #include "google/cloud/bigtable/internal/common_client.h"
 #include "google/cloud/bigtable/internal/logging_instance_admin_client.h"
 #include <google/longrunning/operations.grpc.pb.h>
 
 namespace google {
 namespace cloud {
-namespace bigtable {
+namespace bigtable_internal {
 inline namespace BIGTABLE_CLIENT_NS {
-namespace internal {
 /// Define what endpoint in ClientOptions is used for the InstanceAdminClient.
 struct InstanceAdminTraits {
-  static std::string const& Endpoint(ClientOptions& options) {
+  static std::string const& Endpoint(bigtable::ClientOptions& options) {
     return options.instance_admin_endpoint();
   }
 };
-}  // namespace internal
+}  // namespace BIGTABLE_CLIENT_NS
+}  // namespace bigtable_internal
+namespace bigtable {
+inline namespace BIGTABLE_CLIENT_NS {
 
 namespace {
 /**
@@ -48,8 +51,8 @@ class DefaultInstanceAdminClient : public InstanceAdminClient {
  private:
   // Introduce an early `private:` section because this type is used to define
   // the public interface, it should not be part of the public interface.
-  using Impl = internal::CommonClient<
-      internal::InstanceAdminTraits,
+  using Impl = bigtable_internal::CommonClient<
+      bigtable_internal::InstanceAdminTraits,
       ::google::bigtable::admin::v2::BigtableInstanceAdmin>;
 
  public:
@@ -384,7 +387,7 @@ std::shared_ptr<InstanceAdminClient> CreateDefaultInstanceAdminClient(
       std::make_shared<DefaultInstanceAdminClient>(std::move(project), options);
   if (options.tracing_enabled("rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
-    client = std::make_shared<internal::LoggingInstanceAdminClient>(
+    client = std::make_shared<bigtable_internal::LoggingInstanceAdminClient>(
         std::move(client), options.tracing_options());
   }
   return client;

--- a/google/cloud/bigtable/instance_admin_client.h
+++ b/google/cloud/bigtable/instance_admin_client.h
@@ -23,15 +23,17 @@
 
 namespace google {
 namespace cloud {
+namespace bigtable_internal {
+inline namespace BIGTABLE_CLIENT_NS {
+template <typename Client, typename Response>
+class AsyncLongrunningOperation;
+class LoggingInstanceAdminClient;
+}  // namespace BIGTABLE_CLIENT_NS
+}  // namespace bigtable_internal
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 // Forward declare some classes so we can be friends.
 class InstanceAdmin;
-namespace internal {
-template <typename Client, typename Response>
-class AsyncLongrunningOperation;
-class LoggingInstanceAdminClient;
-}  // namespace internal
 
 /**
  * Connects to Cloud Bigtable's instance administration APIs.
@@ -89,8 +91,8 @@ class InstanceAdminClient {
  protected:
   friend class InstanceAdmin;
   template <typename Client, typename Response>
-  friend class internal::AsyncLongrunningOperation;
-  friend class internal::LoggingInstanceAdminClient;
+  friend class bigtable_internal::AsyncLongrunningOperation;
+  friend class bigtable_internal::LoggingInstanceAdminClient;
   //@{
   /// @name The `google.bigtable.v2.InstanceAdmin` wrappers.
   virtual grpc::Status ListInstances(

--- a/google/cloud/bigtable/instance_admin_test.cc
+++ b/google/cloud/bigtable/instance_admin_test.cc
@@ -75,7 +75,7 @@ auto create_list_instances_lambda =
         EXPECT_STATUS_OK(IsContextMDValid(
             *context,
             "google.bigtable.admin.v2.BigtableInstanceAdmin.ListInstances",
-            google::cloud::internal::ApiClientHeader()));
+            internal::ApiClientHeader()));
         auto const project_name = "projects/" + kProjectId;
         EXPECT_EQ(project_name, request.parent());
         EXPECT_EQ(expected_token, request.page_token());
@@ -100,7 +100,7 @@ auto create_get_cluster_mock = []() {
             btadmin::Cluster* response) {
     EXPECT_STATUS_OK(IsContextMDValid(
         *context, "google.bigtable.admin.v2.BigtableInstanceAdmin.GetCluster",
-        google::cloud::internal::ApiClientHeader()));
+        internal::ApiClientHeader()));
     EXPECT_NE(nullptr, response);
     response->set_name(request.name());
     return grpc::Status::OK;
@@ -113,7 +113,7 @@ auto create_get_policy_mock = []() {
             ::google::iam::v1::Policy* response) {
     EXPECT_STATUS_OK(IsContextMDValid(
         *context, "google.bigtable.admin.v2.BigtableInstanceAdmin.GetIamPolicy",
-        google::cloud::internal::ApiClientHeader()));
+        internal::ApiClientHeader()));
     EXPECT_NE(nullptr, response);
     response->set_version(3);
     response->set_etag("random-tag");
@@ -127,7 +127,7 @@ auto create_policy_with_params = []() {
             ::google::iam::v1::Policy* response) {
     EXPECT_STATUS_OK(IsContextMDValid(
         *context, "google.bigtable.admin.v2.BigtableInstanceAdmin.SetIamPolicy",
-        google::cloud::internal::ApiClientHeader()));
+        internal::ApiClientHeader()));
     EXPECT_NE(nullptr, response);
     *response = request.policy();
     return grpc::Status::OK;
@@ -147,7 +147,7 @@ auto create_list_clusters_lambda =
         EXPECT_STATUS_OK(IsContextMDValid(
             *context,
             "google.bigtable.admin.v2.BigtableInstanceAdmin.ListClusters",
-            google::cloud::internal::ApiClientHeader()));
+            internal::ApiClientHeader()));
         auto const instance_name =
             "projects/" + kProjectId + "/instances/" + instance_id;
         EXPECT_EQ(instance_name, request.parent());
@@ -187,8 +187,8 @@ struct MockRpcFactory {
         [expected_request, method](grpc::ClientContext* context,
                                    RequestType const& request,
                                    ResponseType* response) {
-          EXPECT_STATUS_OK(IsContextMDValid(
-              *context, method, google::cloud::internal::ApiClientHeader()));
+          EXPECT_STATUS_OK(
+              IsContextMDValid(*context, method, internal::ApiClientHeader()));
           RequestType expected;
           // Cannot use ASSERT_TRUE() here, it has an embedded "return;"
           EXPECT_TRUE(google::protobuf::TextFormat::ParseFromString(
@@ -278,7 +278,7 @@ TEST_F(InstanceAdminTest, ListInstancesRecoverableFailures) {
     EXPECT_STATUS_OK(IsContextMDValid(
         *context,
         "google.bigtable.admin.v2.BigtableInstanceAdmin.ListInstances",
-        google::cloud::internal::ApiClientHeader()));
+        internal::ApiClientHeader()));
     return grpc::Status(grpc::StatusCode::UNAVAILABLE, "try-again");
   };
   auto batch0 = create_list_instances_lambda("", "token-001", {"t0", "t1"});
@@ -396,7 +396,7 @@ TEST_F(InstanceAdminTest, ListClustersRecoverableFailures) {
                                      btadmin::ListClustersResponse*) {
     EXPECT_STATUS_OK(IsContextMDValid(
         *context, "google.bigtable.admin.v2.BigtableInstanceAdmin.ListClusters",
-        google::cloud::internal::ApiClientHeader()));
+        internal::ApiClientHeader()));
     return grpc::Status(grpc::StatusCode::UNAVAILABLE, "try-again");
   };
   std::string const& instance_id = "the-instance";
@@ -467,7 +467,7 @@ TEST_F(InstanceAdminTest, GetClusterRecoverableError) {
                                      btadmin::Cluster*) {
     EXPECT_STATUS_OK(IsContextMDValid(
         *context, "google.bigtable.admin.v2.BigtableInstanceAdmin.GetCluster",
-        google::cloud::internal::ApiClientHeader()));
+        internal::ApiClientHeader()));
     return grpc::Status(grpc::StatusCode::UNAVAILABLE, "try-again");
   };
 
@@ -542,7 +542,7 @@ TEST_F(InstanceAdminTest, GetIamPolicyWithConditionsFails) {
         EXPECT_STATUS_OK(IsContextMDValid(
             *context,
             "google.bigtable.admin.v2.BigtableInstanceAdmin.GetIamPolicy",
-            google::cloud::internal::ApiClientHeader()));
+            internal::ApiClientHeader()));
         EXPECT_NE(nullptr, response);
         response->set_version(3);
         response->set_etag("random-tag");
@@ -584,7 +584,7 @@ TEST_F(InstanceAdminTest, GetIamPolicyRecoverableError) {
                                      iamproto::Policy*) {
     EXPECT_STATUS_OK(IsContextMDValid(
         *context, "google.bigtable.admin.v2.BigtableInstanceAdmin.GetIamPolicy",
-        google::cloud::internal::ApiClientHeader()));
+        internal::ApiClientHeader()));
     return grpc::Status(grpc::StatusCode::UNAVAILABLE, "try-again");
   };
   auto mock_policy = create_get_policy_mock();
@@ -634,7 +634,7 @@ TEST_F(InstanceAdminTest, GetNativeIamPolicyRecoverableError) {
                                      iamproto::Policy*) {
     EXPECT_STATUS_OK(IsContextMDValid(
         *context, "google.bigtable.admin.v2.BigtableInstanceAdmin.GetIamPolicy",
-        google::cloud::internal::ApiClientHeader()));
+        internal::ApiClientHeader()));
     return grpc::Status(grpc::StatusCode::UNAVAILABLE, "try-again");
   };
   auto mock_policy = create_get_policy_mock();
@@ -657,8 +657,8 @@ TEST_F(InstanceAdminTest, SetIamPolicy) {
   EXPECT_CALL(*client_, SetIamPolicy).WillOnce(mock_policy);
 
   std::string resource = "test-resource";
-  google::cloud::IamBindings iam_bindings =
-      google::cloud::IamBindings("writer", {"abc@gmail.com", "xyz@gmail.com"});
+  IamBindings iam_bindings =
+      IamBindings("writer", {"abc@gmail.com", "xyz@gmail.com"});
   auto policy = tested.SetIamPolicy(resource, iam_bindings, "test-tag");
   ASSERT_STATUS_OK(policy);
 
@@ -675,8 +675,8 @@ TEST_F(InstanceAdminTest, SetIamPolicyUnrecoverableError) {
           Return(grpc::Status(grpc::StatusCode::PERMISSION_DENIED, "err!")));
 
   std::string resource = "test-resource";
-  google::cloud::IamBindings iam_bindings =
-      google::cloud::IamBindings("writer", {"abc@gmail.com", "xyz@gmail.com"});
+  IamBindings iam_bindings =
+      IamBindings("writer", {"abc@gmail.com", "xyz@gmail.com"});
   EXPECT_FALSE(tested.SetIamPolicy(resource, iam_bindings, "test-tag"));
 }
 
@@ -691,7 +691,7 @@ TEST_F(InstanceAdminTest, SetIamPolicyRecoverableError) {
                                      iamproto::Policy*) {
     EXPECT_STATUS_OK(IsContextMDValid(
         *context, "google.bigtable.admin.v2.BigtableInstanceAdmin.SetIamPolicy",
-        google::cloud::internal::ApiClientHeader()));
+        internal::ApiClientHeader()));
     return grpc::Status(grpc::StatusCode::UNAVAILABLE, "try-again");
   };
   auto mock_policy = create_policy_with_params();
@@ -701,8 +701,8 @@ TEST_F(InstanceAdminTest, SetIamPolicyRecoverableError) {
       .WillOnce(mock_policy);
 
   std::string resource = "test-resource";
-  google::cloud::IamBindings iam_bindings =
-      google::cloud::IamBindings("writer", {"abc@gmail.com", "xyz@gmail.com"});
+  IamBindings iam_bindings =
+      IamBindings("writer", {"abc@gmail.com", "xyz@gmail.com"});
   auto policy = tested.SetIamPolicy(resource, iam_bindings, "test-tag");
   ASSERT_STATUS_OK(policy);
 
@@ -753,7 +753,7 @@ TEST_F(InstanceAdminTest, SetNativeIamPolicyRecoverableError) {
                                      iamproto::Policy*) {
     EXPECT_STATUS_OK(IsContextMDValid(
         *context, "google.bigtable.admin.v2.BigtableInstanceAdmin.SetIamPolicy",
-        google::cloud::internal::ApiClientHeader()));
+        internal::ApiClientHeader()));
     return grpc::Status(grpc::StatusCode::UNAVAILABLE, "try-again");
   };
   auto mock_policy = create_policy_with_params();
@@ -784,7 +784,7 @@ TEST_F(InstanceAdminTest, TestIamPermissions) {
         EXPECT_STATUS_OK(IsContextMDValid(
             *context,
             "google.bigtable.admin.v2.BigtableInstanceAdmin.TestIamPermissions",
-            google::cloud::internal::ApiClientHeader()));
+            internal::ApiClientHeader()));
         EXPECT_NE(nullptr, response);
         std::vector<std::string> permissions = {"writer", "reader"};
         response->add_permissions(permissions[0]);
@@ -827,7 +827,7 @@ TEST_F(InstanceAdminTest, TestIamPermissionsRecoverableError) {
     EXPECT_STATUS_OK(IsContextMDValid(
         *context,
         "google.bigtable.admin.v2.BigtableInstanceAdmin.TestIamPermissions",
-        google::cloud::internal::ApiClientHeader()));
+        internal::ApiClientHeader()));
     return grpc::Status(grpc::StatusCode::UNAVAILABLE, "try-again");
   };
 
@@ -838,7 +838,7 @@ TEST_F(InstanceAdminTest, TestIamPermissionsRecoverableError) {
         EXPECT_STATUS_OK(IsContextMDValid(
             *context,
             "google.bigtable.admin.v2.BigtableInstanceAdmin.TestIamPermissions",
-            google::cloud::internal::ApiClientHeader()));
+            internal::ApiClientHeader()));
         EXPECT_NE(nullptr, response);
         std::vector<std::string> permissions = {"writer", "reader"};
         response->add_permissions(permissions[0]);
@@ -887,8 +887,8 @@ class ValidContextMdAsyncTest : public ::testing::Test {
 };
 
 TEST_F(ValidContextMdAsyncTest, CreateCluster) {
-  ::google::cloud::bigtable::testing::MockAsyncFailingRpcFactory<
-      btadmin::CreateClusterRequest, google::longrunning::Operation>
+  bigtable::testing::MockAsyncFailingRpcFactory<btadmin::CreateClusterRequest,
+                                                google::longrunning::Operation>
       rpc_factory;
   EXPECT_CALL(*client_, AsyncCreateCluster)
       .WillOnce(rpc_factory.Create(
@@ -908,8 +908,8 @@ TEST_F(ValidContextMdAsyncTest, CreateCluster) {
 }
 
 TEST_F(ValidContextMdAsyncTest, CreateInstance) {
-  ::google::cloud::bigtable::testing::MockAsyncFailingRpcFactory<
-      btadmin::CreateInstanceRequest, google::longrunning::Operation>
+  bigtable::testing::MockAsyncFailingRpcFactory<btadmin::CreateInstanceRequest,
+                                                google::longrunning::Operation>
       rpc_factory;
   EXPECT_CALL(*client_, AsyncCreateInstance)
       .WillOnce(rpc_factory.Create(
@@ -924,7 +924,7 @@ TEST_F(ValidContextMdAsyncTest, CreateInstance) {
 }
 
 TEST_F(ValidContextMdAsyncTest, UpdateAppProfile) {
-  ::google::cloud::bigtable::testing::MockAsyncFailingRpcFactory<
+  bigtable::testing::MockAsyncFailingRpcFactory<
       btadmin::UpdateAppProfileRequest, google::longrunning::Operation>
       rpc_factory;
   EXPECT_CALL(*client_, AsyncUpdateAppProfile)
@@ -940,8 +940,8 @@ TEST_F(ValidContextMdAsyncTest, UpdateAppProfile) {
 }
 
 TEST_F(ValidContextMdAsyncTest, UpdateCluster) {
-  ::google::cloud::bigtable::testing::MockAsyncFailingRpcFactory<
-      btadmin::Cluster, google::longrunning::Operation>
+  bigtable::testing::MockAsyncFailingRpcFactory<btadmin::Cluster,
+                                                google::longrunning::Operation>
       rpc_factory;
   EXPECT_CALL(*client_, AsyncUpdateCluster)
       .WillOnce(rpc_factory.Create(
@@ -959,7 +959,7 @@ TEST_F(ValidContextMdAsyncTest, UpdateCluster) {
 }
 
 TEST_F(ValidContextMdAsyncTest, UpdateInstance) {
-  ::google::cloud::bigtable::testing::MockAsyncFailingRpcFactory<
+  bigtable::testing::MockAsyncFailingRpcFactory<
       btadmin::PartialUpdateInstanceRequest, google::longrunning::Operation>
       rpc_factory;
   EXPECT_CALL(*client_, AsyncUpdateInstance)

--- a/google/cloud/bigtable/instance_update_config.h
+++ b/google/cloud/bigtable/instance_update_config.h
@@ -118,8 +118,7 @@ class InstanceUpdateConfig {
 
  private:
   void AddPathIfNotPresent(std::string const& field_name) {
-    if (!google::cloud::internal::Contains(proto_.update_mask().paths(),
-                                           field_name)) {
+    if (!internal::Contains(proto_.update_mask().paths(), field_name)) {
       proto_.mutable_update_mask()->add_paths(field_name);
     }
   }

--- a/google/cloud/bigtable/internal/async_bulk_apply.cc
+++ b/google/cloud/bigtable/internal/async_bulk_apply.cc
@@ -29,8 +29,9 @@ future<std::vector<bigtable::FailedMutation>> AsyncRetryBulkApply::Create(
     std::shared_ptr<bigtable::DataClient> client,
     std::string const& app_profile_id, std::string const& table_name,
     bigtable::BulkMutation mut) {
-  if (mut.empty())
+  if (mut.empty()) {
     return make_ready_future(std::vector<bigtable::FailedMutation>{});
+  }
 
   std::shared_ptr<AsyncRetryBulkApply> bulk_apply(new AsyncRetryBulkApply(
       std::move(rpc_retry_policy), std::move(rpc_backoff_policy),

--- a/google/cloud/bigtable/internal/async_bulk_apply.cc
+++ b/google/cloud/bigtable/internal/async_bulk_apply.cc
@@ -21,14 +21,16 @@ namespace bigtable_internal {
 inline namespace BIGTABLE_CLIENT_NS {
 
 future<std::vector<bigtable::FailedMutation>> AsyncRetryBulkApply::Create(
-    CompletionQueue cq, std::unique_ptr<bigtable::RPCRetryPolicy> rpc_retry_policy,
+    CompletionQueue cq,
+    std::unique_ptr<bigtable::RPCRetryPolicy> rpc_retry_policy,
     std::unique_ptr<bigtable::RPCBackoffPolicy> rpc_backoff_policy,
     bigtable::IdempotentMutationPolicy& idempotent_policy,
     bigtable::MetadataUpdatePolicy metadata_update_policy,
     std::shared_ptr<bigtable::DataClient> client,
     std::string const& app_profile_id, std::string const& table_name,
     bigtable::BulkMutation mut) {
-  if (mut.empty()) return make_ready_future(std::vector<bigtable::FailedMutation>{});
+  if (mut.empty())
+    return make_ready_future(std::vector<bigtable::FailedMutation>{});
 
   std::shared_ptr<AsyncRetryBulkApply> bulk_apply(new AsyncRetryBulkApply(
       std::move(rpc_retry_policy), std::move(rpc_backoff_policy),

--- a/google/cloud/bigtable/internal/async_bulk_apply.cc
+++ b/google/cloud/bigtable/internal/async_bulk_apply.cc
@@ -17,19 +17,18 @@
 
 namespace google {
 namespace cloud {
-namespace bigtable {
+namespace bigtable_internal {
 inline namespace BIGTABLE_CLIENT_NS {
-namespace internal {
 
-future<std::vector<FailedMutation>> AsyncRetryBulkApply::Create(
-    CompletionQueue cq, std::unique_ptr<RPCRetryPolicy> rpc_retry_policy,
-    std::unique_ptr<RPCBackoffPolicy> rpc_backoff_policy,
-    IdempotentMutationPolicy& idempotent_policy,
-    MetadataUpdatePolicy metadata_update_policy,
+future<std::vector<bigtable::FailedMutation>> AsyncRetryBulkApply::Create(
+    CompletionQueue cq, std::unique_ptr<bigtable::RPCRetryPolicy> rpc_retry_policy,
+    std::unique_ptr<bigtable::RPCBackoffPolicy> rpc_backoff_policy,
+    bigtable::IdempotentMutationPolicy& idempotent_policy,
+    bigtable::MetadataUpdatePolicy metadata_update_policy,
     std::shared_ptr<bigtable::DataClient> client,
     std::string const& app_profile_id, std::string const& table_name,
-    BulkMutation mut) {
-  if (mut.empty()) return make_ready_future(std::vector<FailedMutation>{});
+    bigtable::BulkMutation mut) {
+  if (mut.empty()) return make_ready_future(std::vector<bigtable::FailedMutation>{});
 
   std::shared_ptr<AsyncRetryBulkApply> bulk_apply(new AsyncRetryBulkApply(
       std::move(rpc_retry_policy), std::move(rpc_backoff_policy),
@@ -40,13 +39,13 @@ future<std::vector<FailedMutation>> AsyncRetryBulkApply::Create(
 }
 
 AsyncRetryBulkApply::AsyncRetryBulkApply(
-    std::unique_ptr<RPCRetryPolicy> rpc_retry_policy,
-    std::unique_ptr<RPCBackoffPolicy> rpc_backoff_policy,
-    IdempotentMutationPolicy& idempotent_policy,
-    MetadataUpdatePolicy metadata_update_policy,
+    std::unique_ptr<bigtable::RPCRetryPolicy> rpc_retry_policy,
+    std::unique_ptr<bigtable::RPCBackoffPolicy> rpc_backoff_policy,
+    bigtable::IdempotentMutationPolicy& idempotent_policy,
+    bigtable::MetadataUpdatePolicy metadata_update_policy,
     std::shared_ptr<bigtable::DataClient> client,
     std::string const& app_profile_id, std::string const& table_name,
-    BulkMutation mut)
+    bigtable::BulkMutation mut)
     : rpc_retry_policy_(std::move(rpc_retry_policy)),
       rpc_backoff_policy_(std::move(rpc_backoff_policy)),
       metadata_update_policy_(std::move(metadata_update_policy)),
@@ -104,8 +103,7 @@ void AsyncRetryBulkApply::SetPromise() {
   promise_.set_value(std::move(state_).OnRetryDone());
 }
 
-}  // namespace internal
 }  // namespace BIGTABLE_CLIENT_NS
-}  // namespace bigtable
+}  // namespace bigtable_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/bigtable/internal/async_bulk_apply.h
+++ b/google/cloud/bigtable/internal/async_bulk_apply.h
@@ -28,9 +28,8 @@
 
 namespace google {
 namespace cloud {
-namespace bigtable {
+namespace bigtable_internal {
 inline namespace BIGTABLE_CLIENT_NS {
-namespace internal {
 /**
  * Implement the retry loop for AsyncBulkApply.
  *
@@ -42,40 +41,39 @@ namespace internal {
 class AsyncRetryBulkApply
     : public std::enable_shared_from_this<AsyncRetryBulkApply> {
  public:
-  static future<std::vector<FailedMutation>> Create(
-      CompletionQueue cq, std::unique_ptr<RPCRetryPolicy> rpc_retry_policy,
-      std::unique_ptr<RPCBackoffPolicy> rpc_backoff_policy,
-      IdempotentMutationPolicy& idempotent_policy,
-      MetadataUpdatePolicy metadata_update_policy,
+  static future<std::vector<bigtable::FailedMutation>> Create(
+      CompletionQueue cq, std::unique_ptr<bigtable::RPCRetryPolicy> rpc_retry_policy,
+      std::unique_ptr<bigtable::RPCBackoffPolicy> rpc_backoff_policy,
+      bigtable::IdempotentMutationPolicy& idempotent_policy,
+      bigtable::MetadataUpdatePolicy metadata_update_policy,
       std::shared_ptr<bigtable::DataClient> client,
       std::string const& app_profile_id, std::string const& table_name,
-      BulkMutation mut);
+      bigtable::BulkMutation mut);
 
  private:
-  AsyncRetryBulkApply(std::unique_ptr<RPCRetryPolicy> rpc_retry_policy,
-                      std::unique_ptr<RPCBackoffPolicy> rpc_backoff_policy,
-                      IdempotentMutationPolicy& idempotent_policy,
-                      MetadataUpdatePolicy metadata_update_policy,
+  AsyncRetryBulkApply(std::unique_ptr<bigtable::RPCRetryPolicy> rpc_retry_policy,
+                      std::unique_ptr<bigtable::RPCBackoffPolicy> rpc_backoff_policy,
+                      bigtable::IdempotentMutationPolicy& idempotent_policy,
+                      bigtable::MetadataUpdatePolicy metadata_update_policy,
                       std::shared_ptr<bigtable::DataClient> client,
                       std::string const& app_profile_id,
-                      std::string const& table_name, BulkMutation mut);
+                      std::string const& table_name, bigtable::BulkMutation mut);
 
   void StartIteration(CompletionQueue cq);
   void OnRead(google::bigtable::v2::MutateRowsResponse response);
   void OnFinish(CompletionQueue cq, google::cloud::Status const& status);
   void SetPromise();
 
-  std::unique_ptr<RPCRetryPolicy> rpc_retry_policy_;
-  std::unique_ptr<RPCBackoffPolicy> rpc_backoff_policy_;
-  MetadataUpdatePolicy metadata_update_policy_;
+  std::unique_ptr<bigtable::RPCRetryPolicy> rpc_retry_policy_;
+  std::unique_ptr<bigtable::RPCBackoffPolicy> rpc_backoff_policy_;
+  bigtable::MetadataUpdatePolicy metadata_update_policy_;
   std::shared_ptr<bigtable::DataClient> client_;
   BulkMutatorState state_;
-  promise<std::vector<FailedMutation>> promise_;
+  promise<std::vector<bigtable::FailedMutation>> promise_;
 };
 
-}  // namespace internal
 }  // namespace BIGTABLE_CLIENT_NS
-}  // namespace bigtable
+}  // namespace bigtable_internal
 }  // namespace cloud
 }  // namespace google
 

--- a/google/cloud/bigtable/internal/async_bulk_apply.h
+++ b/google/cloud/bigtable/internal/async_bulk_apply.h
@@ -42,7 +42,8 @@ class AsyncRetryBulkApply
     : public std::enable_shared_from_this<AsyncRetryBulkApply> {
  public:
   static future<std::vector<bigtable::FailedMutation>> Create(
-      CompletionQueue cq, std::unique_ptr<bigtable::RPCRetryPolicy> rpc_retry_policy,
+      CompletionQueue cq,
+      std::unique_ptr<bigtable::RPCRetryPolicy> rpc_retry_policy,
       std::unique_ptr<bigtable::RPCBackoffPolicy> rpc_backoff_policy,
       bigtable::IdempotentMutationPolicy& idempotent_policy,
       bigtable::MetadataUpdatePolicy metadata_update_policy,
@@ -51,13 +52,14 @@ class AsyncRetryBulkApply
       bigtable::BulkMutation mut);
 
  private:
-  AsyncRetryBulkApply(std::unique_ptr<bigtable::RPCRetryPolicy> rpc_retry_policy,
-                      std::unique_ptr<bigtable::RPCBackoffPolicy> rpc_backoff_policy,
-                      bigtable::IdempotentMutationPolicy& idempotent_policy,
-                      bigtable::MetadataUpdatePolicy metadata_update_policy,
-                      std::shared_ptr<bigtable::DataClient> client,
-                      std::string const& app_profile_id,
-                      std::string const& table_name, bigtable::BulkMutation mut);
+  AsyncRetryBulkApply(
+      std::unique_ptr<bigtable::RPCRetryPolicy> rpc_retry_policy,
+      std::unique_ptr<bigtable::RPCBackoffPolicy> rpc_backoff_policy,
+      bigtable::IdempotentMutationPolicy& idempotent_policy,
+      bigtable::MetadataUpdatePolicy metadata_update_policy,
+      std::shared_ptr<bigtable::DataClient> client,
+      std::string const& app_profile_id, std::string const& table_name,
+      bigtable::BulkMutation mut);
 
   void StartIteration(CompletionQueue cq);
   void OnRead(google::bigtable::v2::MutateRowsResponse response);

--- a/google/cloud/bigtable/internal/async_bulk_apply_test.cc
+++ b/google/cloud/bigtable/internal/async_bulk_apply_test.cc
@@ -49,8 +49,7 @@ class AsyncBulkApplyTest : public bigtable::testing::TableTestFixture {
             DefaultRPCRetryPolicy(bigtable_internal::kBigtableLimits)),
         rpc_backoff_policy_(DefaultRPCBackoffPolicy(
             bigtable_internal::kBigtableTableAdminLimits)),
-        idempotent_mutation_policy_(
-            DefaultIdempotentMutationPolicy()),
+        idempotent_mutation_policy_(DefaultIdempotentMutationPolicy()),
         metadata_update_policy_("my_table", MetadataParamTypes::NAME) {}
 
   void SimulateIteration() {
@@ -89,10 +88,8 @@ TEST_F(AsyncBulkApplyTest, NoMutations) {
 
 TEST_F(AsyncBulkApplyTest, Success) {
   BulkMutation mut{
-      SingleRowMutation("foo2",
-                                  {SetCell("f", "c", 0_ms, "v2")}),
-      SingleRowMutation("foo3",
-                                  {SetCell("f", "c", 0_ms, "v3")}),
+      SingleRowMutation("foo2", {SetCell("f", "c", 0_ms, "v2")}),
+      SingleRowMutation("foo3", {SetCell("f", "c", 0_ms, "v3")}),
   };
 
   auto* reader =
@@ -142,10 +139,8 @@ TEST_F(AsyncBulkApplyTest, Success) {
 
 TEST_F(AsyncBulkApplyTest, PartialSuccessRetry) {
   BulkMutation mut{
-      SingleRowMutation("foo2",
-                                  {SetCell("f", "c", 0_ms, "v2")}),
-      SingleRowMutation("foo3",
-                                  {SetCell("f", "c", 0_ms, "v3")}),
+      SingleRowMutation("foo2", {SetCell("f", "c", 0_ms, "v2")}),
+      SingleRowMutation("foo3", {SetCell("f", "c", 0_ms, "v3")}),
   };
 
   auto* reader0 =
@@ -217,10 +212,8 @@ TEST_F(AsyncBulkApplyTest, PartialSuccessRetry) {
 
 TEST_F(AsyncBulkApplyTest, DefaultFailureRetry) {
   BulkMutation mut{
-      SingleRowMutation("foo2",
-                                  {SetCell("f", "c", 0_ms, "v2")}),
-      SingleRowMutation("foo3",
-                                  {SetCell("f", "c", 0_ms, "v3")}),
+      SingleRowMutation("foo2", {SetCell("f", "c", 0_ms, "v2")}),
+      SingleRowMutation("foo3", {SetCell("f", "c", 0_ms, "v3")}),
   };
 
   auto* reader0 =
@@ -297,10 +290,8 @@ TEST_F(AsyncBulkApplyTest, DefaultFailureRetry) {
 
 TEST_F(AsyncBulkApplyTest, TooManyFailures) {
   BulkMutation mut{
-      SingleRowMutation("foo2",
-                                  {SetCell("f", "c", 0_ms, "v2")}),
-      SingleRowMutation("foo3",
-                                  {SetCell("f", "c", 0_ms, "v3")}),
+      SingleRowMutation("foo2", {SetCell("f", "c", 0_ms, "v2")}),
+      SingleRowMutation("foo3", {SetCell("f", "c", 0_ms, "v3")}),
   };
 
   // We give up on the 3rd error.
@@ -346,10 +337,8 @@ TEST_F(AsyncBulkApplyTest, TooManyFailures) {
 
 TEST_F(AsyncBulkApplyTest, UsesBackoffPolicy) {
   BulkMutation mut{
-      SingleRowMutation("foo2",
-                                  {SetCell("f", "c", 0_ms, "v2")}),
-      SingleRowMutation("foo3",
-                                  {SetCell("f", "c", 0_ms, "v3")}),
+      SingleRowMutation("foo2", {SetCell("f", "c", 0_ms, "v2")}),
+      SingleRowMutation("foo3", {SetCell("f", "c", 0_ms, "v3")}),
   };
 
   auto grpc_error = grpc::Status(grpc::StatusCode::UNAVAILABLE, "try again");
@@ -415,10 +404,8 @@ TEST_F(AsyncBulkApplyTest, UsesBackoffPolicy) {
 
 TEST_F(AsyncBulkApplyTest, CancelDuringBackoff) {
   BulkMutation mut{
-      SingleRowMutation("foo2",
-                                  {SetCell("f", "c", 0_ms, "v2")}),
-      SingleRowMutation("foo3",
-                                  {SetCell("f", "c", 0_ms, "v3")}),
+      SingleRowMutation("foo2", {SetCell("f", "c", 0_ms, "v2")}),
+      SingleRowMutation("foo3", {SetCell("f", "c", 0_ms, "v3")}),
   };
 
   auto grpc_error = grpc::Status(grpc::StatusCode::UNAVAILABLE, "try again");

--- a/google/cloud/bigtable/internal/async_longrunning_op.h
+++ b/google/cloud/bigtable/internal/async_longrunning_op.h
@@ -133,9 +133,11 @@ class AsyncLongrunningOperation {
  */
 template <typename Client, typename Response>
 future<StatusOr<Response>> StartAsyncLongrunningOp(
-    char const* location, std::unique_ptr<bigtable::PollingPolicy> polling_policy,
-    bigtable::MetadataUpdatePolicy metadata_update_policy, std::shared_ptr<Client> client,
-    CompletionQueue cq, google::longrunning::Operation operation) {
+    char const* location,
+    std::unique_ptr<bigtable::PollingPolicy> polling_policy,
+    bigtable::MetadataUpdatePolicy metadata_update_policy,
+    std::shared_ptr<Client> client, CompletionQueue cq,
+    google::longrunning::Operation operation) {
   return StartAsyncPollOp(location, std::move(polling_policy),
                           std::move(metadata_update_policy), std::move(cq),
                           AsyncLongrunningOperation<Client, Response>(

--- a/google/cloud/bigtable/internal/async_longrunning_op.h
+++ b/google/cloud/bigtable/internal/async_longrunning_op.h
@@ -26,9 +26,8 @@
 
 namespace google {
 namespace cloud {
-namespace bigtable {
+namespace bigtable_internal {
 inline namespace BIGTABLE_CLIENT_NS {
-namespace internal {
 
 /**
  * The operation passed to StartAsyncPollOp to implement longrunning operations.
@@ -134,8 +133,8 @@ class AsyncLongrunningOperation {
  */
 template <typename Client, typename Response>
 future<StatusOr<Response>> StartAsyncLongrunningOp(
-    char const* location, std::unique_ptr<PollingPolicy> polling_policy,
-    MetadataUpdatePolicy metadata_update_policy, std::shared_ptr<Client> client,
+    char const* location, std::unique_ptr<bigtable::PollingPolicy> polling_policy,
+    bigtable::MetadataUpdatePolicy metadata_update_policy, std::shared_ptr<Client> client,
     CompletionQueue cq, google::longrunning::Operation operation) {
   return StartAsyncPollOp(location, std::move(polling_policy),
                           std::move(metadata_update_policy), std::move(cq),
@@ -152,9 +151,8 @@ future<StatusOr<Response>> StartAsyncLongrunningOp(
       });
 }
 
-}  // namespace internal
 }  // namespace BIGTABLE_CLIENT_NS
-}  // namespace bigtable
+}  // namespace bigtable_internal
 }  // namespace cloud
 }  // namespace google
 

--- a/google/cloud/bigtable/internal/async_longrunning_op_test.cc
+++ b/google/cloud/bigtable/internal/async_longrunning_op_test.cc
@@ -90,11 +90,11 @@ TEST_P(AsyncLongrunningOpFutureTest, EndToEnd) {
   google::longrunning::Operation op_arg;
   op_arg.set_name("test_operation_id");
   auto polling_policy =
-      bigtable::DefaultPollingPolicy(internal::kBigtableLimits);
+      DefaultPollingPolicy(bigtable_internal::kBigtableLimits);
   auto metadata_update_policy =
       MetadataUpdatePolicy(op_arg.name(), MetadataParamTypes::NAME);
 
-  auto fut = internal::StartAsyncLongrunningOp<
+  auto fut = bigtable_internal::StartAsyncLongrunningOp<
       AdminClient, google::bigtable::v2::SampleRowKeysResponse>(
       __func__, polling_policy->clone(), metadata_update_policy, client, cq_,
       std::move(op_arg));
@@ -160,7 +160,7 @@ class AsyncLongrunningOperationTest : public ::testing::Test {
               return std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<
                   google::longrunning::Operation>>(longrunning_reader_.get());
             });
-    internal::AsyncLongrunningOperation<testing::MockAdminClient,
+    bigtable_internal::AsyncLongrunningOperation<testing::MockAdminClient,
                                         SampleRowKeysResponse>
         operation(client_, std::move(op));
     auto fut = operation(cq_, std::move(context_));
@@ -176,7 +176,7 @@ class AsyncLongrunningOperationTest : public ::testing::Test {
 
   std::shared_ptr<testing::MockAdminClient> client_;
   std::shared_ptr<FakeCompletionQueueImpl> cq_impl_;
-  bigtable::CompletionQueue cq_;
+  CompletionQueue cq_;
   std::unique_ptr<MockAsyncLongrunningOpReader> longrunning_reader_;
   std::unique_ptr<grpc::ClientContext> context_;
 };
@@ -251,7 +251,7 @@ TEST_F(AsyncLongrunningOperationTest, ImmediateSuccess) {
   grpc::Status placeholder_status;
   OperationFinishedSuccessfully(op, placeholder_status);
 
-  internal::AsyncLongrunningOperation<testing::MockAdminClient,
+  bigtable_internal::AsyncLongrunningOperation<testing::MockAdminClient,
                                       SampleRowKeysResponse>
       operation(client_, std::move(op));
   auto fut = operation(cq_, std::move(context_));

--- a/google/cloud/bigtable/internal/async_longrunning_op_test.cc
+++ b/google/cloud/bigtable/internal/async_longrunning_op_test.cc
@@ -161,7 +161,7 @@ class AsyncLongrunningOperationTest : public ::testing::Test {
                   google::longrunning::Operation>>(longrunning_reader_.get());
             });
     bigtable_internal::AsyncLongrunningOperation<testing::MockAdminClient,
-                                        SampleRowKeysResponse>
+                                                 SampleRowKeysResponse>
         operation(client_, std::move(op));
     auto fut = operation(cq_, std::move(context_));
 
@@ -252,7 +252,7 @@ TEST_F(AsyncLongrunningOperationTest, ImmediateSuccess) {
   OperationFinishedSuccessfully(op, placeholder_status);
 
   bigtable_internal::AsyncLongrunningOperation<testing::MockAdminClient,
-                                      SampleRowKeysResponse>
+                                               SampleRowKeysResponse>
       operation(client_, std::move(op));
   auto fut = operation(cq_, std::move(context_));
   EXPECT_TRUE(cq_impl_->empty());

--- a/google/cloud/bigtable/internal/async_poll_op.h
+++ b/google/cloud/bigtable/internal/async_poll_op.h
@@ -26,9 +26,8 @@
 
 namespace google {
 namespace cloud {
-namespace bigtable {
+namespace bigtable_internal {
 inline namespace BIGTABLE_CLIENT_NS {
-namespace internal {
 
 /// SFINAE matcher for `future<StatusOr<absl::optional<T>>>`, false branch.
 template <typename Future>
@@ -82,8 +81,8 @@ template <typename Operation>
 future<
     StatusOr<typename PollableOperationRequestTraits<Operation>::ResponseType>>
 StartAsyncPollOp(char const* location,
-                 std::unique_ptr<PollingPolicy> polling_policy,
-                 MetadataUpdatePolicy metadata_update_policy,
+                 std::unique_ptr<bigtable::PollingPolicy> polling_policy,
+                 bigtable::MetadataUpdatePolicy metadata_update_policy,
                  CompletionQueue cq, Operation operation);
 
 /**
@@ -100,8 +99,8 @@ class PollAsyncOpFuture {
   // a shared pointer. The lifetime is controlled by any pending operations in
   // the CompletionQueue.
   PollAsyncOpFuture(char const* location,
-                    std::unique_ptr<PollingPolicy> polling_policy,
-                    MetadataUpdatePolicy metadata_update_policy,
+                    std::unique_ptr<bigtable::PollingPolicy> polling_policy,
+                    bigtable::MetadataUpdatePolicy metadata_update_policy,
                     CompletionQueue cq, Operation operation)
       : location_(location),
         polling_policy_(std::move(polling_policy)),
@@ -173,8 +172,8 @@ class PollAsyncOpFuture {
   }
 
   char const* location_;
-  std::unique_ptr<PollingPolicy> polling_policy_;
-  MetadataUpdatePolicy metadata_update_policy_;
+  std::unique_ptr<bigtable::PollingPolicy> polling_policy_;
+  bigtable::MetadataUpdatePolicy metadata_update_policy_;
   CompletionQueue cq_;
   Operation operation_;
   promise<StatusOr<Response>> final_result_;
@@ -182,8 +181,8 @@ class PollAsyncOpFuture {
   friend future<StatusOr<
       typename PollableOperationRequestTraits<Operation>::ResponseType>>
   StartAsyncPollOp<Operation>(char const* location,
-                              std::unique_ptr<PollingPolicy> polling_policy,
-                              MetadataUpdatePolicy metadata_update_policy,
+                              std::unique_ptr<bigtable::PollingPolicy> polling_policy,
+                              bigtable::MetadataUpdatePolicy metadata_update_policy,
                               CompletionQueue cq, Operation operation);
 };
 
@@ -206,8 +205,8 @@ template <typename Operation>
 future<
     StatusOr<typename PollableOperationRequestTraits<Operation>::ResponseType>>
 StartAsyncPollOp(char const* location,
-                 std::unique_ptr<PollingPolicy> polling_policy,
-                 MetadataUpdatePolicy metadata_update_policy,
+                 std::unique_ptr<bigtable::PollingPolicy> polling_policy,
+                 bigtable::MetadataUpdatePolicy metadata_update_policy,
                  CompletionQueue cq, Operation operation) {
   auto req = std::shared_ptr<PollAsyncOpFuture<Operation>>(
       new PollAsyncOpFuture<Operation>(location, std::move(polling_policy),
@@ -217,9 +216,8 @@ StartAsyncPollOp(char const* location,
   return req->final_result_.get_future();
 }
 
-}  // namespace internal
 }  // namespace BIGTABLE_CLIENT_NS
-}  // namespace bigtable
+}  // namespace bigtable_internal
 }  // namespace cloud
 }  // namespace google
 

--- a/google/cloud/bigtable/internal/async_poll_op.h
+++ b/google/cloud/bigtable/internal/async_poll_op.h
@@ -180,10 +180,11 @@ class PollAsyncOpFuture {
 
   friend future<StatusOr<
       typename PollableOperationRequestTraits<Operation>::ResponseType>>
-  StartAsyncPollOp<Operation>(char const* location,
-                              std::unique_ptr<bigtable::PollingPolicy> polling_policy,
-                              bigtable::MetadataUpdatePolicy metadata_update_policy,
-                              CompletionQueue cq, Operation operation);
+  StartAsyncPollOp<Operation>(
+      char const* location,
+      std::unique_ptr<bigtable::PollingPolicy> polling_policy,
+      bigtable::MetadataUpdatePolicy metadata_update_policy, CompletionQueue cq,
+      Operation operation);
 };
 
 /**

--- a/google/cloud/bigtable/internal/async_poll_op_test.cc
+++ b/google/cloud/bigtable/internal/async_poll_op_test.cc
@@ -57,7 +57,7 @@ class AsyncPollOpTest : public bigtable::testing::TableTestFixture {
       : TableTestFixture(
             CompletionQueue(std::make_shared<FakeCompletionQueueImpl>())),
         polling_policy_(
-            bigtable::DefaultPollingPolicy(internal::kBigtableLimits)),
+            DefaultPollingPolicy(bigtable_internal::kBigtableLimits)),
         metadata_update_policy_("test_operation_id", MetadataParamTypes::NAME),
         client_(new testing::MockAdminClient(
             ClientOptions().DisableBackgroundThreads(cq_))) {}
@@ -88,9 +88,9 @@ TEST_F(AsyncPollOpTest, AsyncPollOpTestSuccess) {
   google::longrunning::Operation op_arg;
   op_arg.set_name("test_operation_id");
 
-  auto poll_op_future = internal::StartAsyncPollOp(
+  auto poll_op_future = bigtable_internal::StartAsyncPollOp(
       __func__, polling_policy_->clone(), metadata_update_policy_, cq_,
-      internal::AsyncLongrunningOperation<
+      bigtable_internal::AsyncLongrunningOperation<
           AdminClient, google::bigtable::v2::SampleRowKeysResponse>(
           client_, std::move(op_arg)));
 
@@ -126,9 +126,9 @@ TEST_F(AsyncPollOpTest, AsyncPollOpTestPermanentFailure) {
   google::longrunning::Operation op_arg;
   op_arg.set_name("test_operation_id");
 
-  auto poll_op_future = internal::StartAsyncPollOp(
+  auto poll_op_future = bigtable_internal::StartAsyncPollOp(
       __func__, polling_policy_->clone(), metadata_update_policy_, cq_,
-      internal::AsyncLongrunningOperation<
+      bigtable_internal::AsyncLongrunningOperation<
           AdminClient, google::bigtable::v2::SampleRowKeysResponse>(
           client_, std::move(op_arg)));
 
@@ -170,9 +170,9 @@ TEST_F(AsyncPollOpTest, AsyncPollOpTestPolicyExhausted) {
   google::longrunning::Operation op_arg;
   op_arg.set_name("test_operation_id");
 
-  auto poll_op_future = internal::StartAsyncPollOp(
+  auto poll_op_future = bigtable_internal::StartAsyncPollOp(
       __func__, polling.clone(), metadata_update_policy_, cq_,
-      internal::AsyncLongrunningOperation<
+      bigtable_internal::AsyncLongrunningOperation<
           AdminClient, google::bigtable::v2::SampleRowKeysResponse>(
           client_, std::move(op_arg)));
 

--- a/google/cloud/bigtable/internal/async_retry_multi_page.h
+++ b/google/cloud/bigtable/internal/async_retry_multi_page.h
@@ -26,16 +26,15 @@
 
 namespace google {
 namespace cloud {
-namespace bigtable {
+namespace bigtable_internal {
 inline namespace BIGTABLE_CLIENT_NS {
-namespace internal {
 
 template <typename AsyncCallType, typename Request, typename Accumulator,
           typename CombiningFunction>
 future<StatusOr<Accumulator>> StartAsyncRetryMultiPage(
-    char const* location, std::unique_ptr<RPCRetryPolicy> rpc_retry_policy,
-    std::unique_ptr<RPCBackoffPolicy> rpc_backoff_policy,
-    MetadataUpdatePolicy metadata_update_policy, AsyncCallType async_call,
+    char const* location, std::unique_ptr<bigtable::RPCRetryPolicy> rpc_retry_policy,
+    std::unique_ptr<bigtable::RPCBackoffPolicy> rpc_backoff_policy,
+    bigtable::MetadataUpdatePolicy metadata_update_policy, AsyncCallType async_call,
     Request request, Accumulator accumulator,
     CombiningFunction combining_function, CompletionQueue cq);
 
@@ -78,9 +77,9 @@ class AsyncRetryMultiPageFuture {
   // a shared pointer. The lifetime is controlled by any pending operations in
   // the CompletionQueue.
   AsyncRetryMultiPageFuture(
-      char const* location, std::unique_ptr<RPCRetryPolicy> rpc_retry_policy,
-      std::unique_ptr<RPCBackoffPolicy> rpc_backoff_policy,
-      MetadataUpdatePolicy metadata_update_policy, AsyncCallType async_call,
+      char const* location, std::unique_ptr<bigtable::RPCRetryPolicy> rpc_retry_policy,
+      std::unique_ptr<bigtable::RPCBackoffPolicy> rpc_backoff_policy,
+      bigtable::MetadataUpdatePolicy metadata_update_policy, AsyncCallType async_call,
       Request request, Accumulator accumulator,
       CombiningFunction combining_function, CompletionQueue cq)
       : location_(location),
@@ -112,7 +111,7 @@ class AsyncRetryMultiPageFuture {
       return;
     }
     if (!self->rpc_retry_policy_->OnFailure(result.status())) {
-      char const* context = RPCRetryPolicy::IsPermanentFailure(result.status())
+      char const* context = bigtable::RPCRetryPolicy::IsPermanentFailure(result.status())
                                 ? "permanent error"
                                 : "too many transient errors";
       self->final_result_.set_value(
@@ -159,10 +158,10 @@ class AsyncRetryMultiPageFuture {
   }
 
   char const* location_;
-  std::unique_ptr<RPCRetryPolicy> rpc_retry_policy_;
-  std::unique_ptr<RPCBackoffPolicy> rpc_backoff_policy_;
-  std::unique_ptr<RPCBackoffPolicy> rpc_backoff_policy_prototype_;
-  MetadataUpdatePolicy metadata_update_policy_;
+  std::unique_ptr<bigtable::RPCRetryPolicy> rpc_retry_policy_;
+  std::unique_ptr<bigtable::RPCBackoffPolicy> rpc_backoff_policy_;
+  std::unique_ptr<bigtable::RPCBackoffPolicy> rpc_backoff_policy_prototype_;
+  bigtable::MetadataUpdatePolicy metadata_update_policy_;
   AsyncCallType async_call_;
   Request request_;
   Accumulator accumulator_;
@@ -173,9 +172,9 @@ class AsyncRetryMultiPageFuture {
 
   friend future<StatusOr<Accumulator>> StartAsyncRetryMultiPage<
       AsyncCallType, Request, Accumulator, CombiningFunction>(
-      char const* location, std::unique_ptr<RPCRetryPolicy> rpc_retry_policy,
-      std::unique_ptr<RPCBackoffPolicy> rpc_backoff_policy,
-      MetadataUpdatePolicy metadata_update_policy, AsyncCallType async_call,
+      char const* location, std::unique_ptr<bigtable::RPCRetryPolicy> rpc_retry_policy,
+      std::unique_ptr<bigtable::RPCBackoffPolicy> rpc_backoff_policy,
+      bigtable::MetadataUpdatePolicy metadata_update_policy, AsyncCallType async_call,
       Request request, Accumulator accumulator,
       CombiningFunction combining_function, CompletionQueue cq);
 };
@@ -205,9 +204,9 @@ class AsyncRetryMultiPageFuture {
 template <typename AsyncCallType, typename Request, typename Accumulator,
           typename CombiningFunction>
 future<StatusOr<Accumulator>> StartAsyncRetryMultiPage(
-    char const* location, std::unique_ptr<RPCRetryPolicy> rpc_retry_policy,
-    std::unique_ptr<RPCBackoffPolicy> rpc_backoff_policy,
-    MetadataUpdatePolicy metadata_update_policy, AsyncCallType async_call,
+    char const* location, std::unique_ptr<bigtable::RPCRetryPolicy> rpc_retry_policy,
+    std::unique_ptr<bigtable::RPCBackoffPolicy> rpc_backoff_policy,
+    bigtable::MetadataUpdatePolicy metadata_update_policy, AsyncCallType async_call,
     Request request, Accumulator accumulator,
     CombiningFunction combining_function, CompletionQueue cq) {
   std::shared_ptr<AsyncRetryMultiPageFuture<AsyncCallType, Request, Accumulator,
@@ -223,9 +222,8 @@ future<StatusOr<Accumulator>> StartAsyncRetryMultiPage(
   return future;
 }
 
-}  // namespace internal
 }  // namespace BIGTABLE_CLIENT_NS
-}  // namespace bigtable
+}  // namespace bigtable_internal
 }  // namespace cloud
 }  // namespace google
 

--- a/google/cloud/bigtable/internal/async_retry_multi_page.h
+++ b/google/cloud/bigtable/internal/async_retry_multi_page.h
@@ -32,10 +32,11 @@ inline namespace BIGTABLE_CLIENT_NS {
 template <typename AsyncCallType, typename Request, typename Accumulator,
           typename CombiningFunction>
 future<StatusOr<Accumulator>> StartAsyncRetryMultiPage(
-    char const* location, std::unique_ptr<bigtable::RPCRetryPolicy> rpc_retry_policy,
+    char const* location,
+    std::unique_ptr<bigtable::RPCRetryPolicy> rpc_retry_policy,
     std::unique_ptr<bigtable::RPCBackoffPolicy> rpc_backoff_policy,
-    bigtable::MetadataUpdatePolicy metadata_update_policy, AsyncCallType async_call,
-    Request request, Accumulator accumulator,
+    bigtable::MetadataUpdatePolicy metadata_update_policy,
+    AsyncCallType async_call, Request request, Accumulator accumulator,
     CombiningFunction combining_function, CompletionQueue cq);
 
 /**
@@ -77,10 +78,11 @@ class AsyncRetryMultiPageFuture {
   // a shared pointer. The lifetime is controlled by any pending operations in
   // the CompletionQueue.
   AsyncRetryMultiPageFuture(
-      char const* location, std::unique_ptr<bigtable::RPCRetryPolicy> rpc_retry_policy,
+      char const* location,
+      std::unique_ptr<bigtable::RPCRetryPolicy> rpc_retry_policy,
       std::unique_ptr<bigtable::RPCBackoffPolicy> rpc_backoff_policy,
-      bigtable::MetadataUpdatePolicy metadata_update_policy, AsyncCallType async_call,
-      Request request, Accumulator accumulator,
+      bigtable::MetadataUpdatePolicy metadata_update_policy,
+      AsyncCallType async_call, Request request, Accumulator accumulator,
       CombiningFunction combining_function, CompletionQueue cq)
       : location_(location),
         rpc_retry_policy_(std::move(rpc_retry_policy)),
@@ -111,9 +113,10 @@ class AsyncRetryMultiPageFuture {
       return;
     }
     if (!self->rpc_retry_policy_->OnFailure(result.status())) {
-      char const* context = bigtable::RPCRetryPolicy::IsPermanentFailure(result.status())
-                                ? "permanent error"
-                                : "too many transient errors";
+      char const* context =
+          bigtable::RPCRetryPolicy::IsPermanentFailure(result.status())
+              ? "permanent error"
+              : "too many transient errors";
       self->final_result_.set_value(
           self->DetailedStatus(context, result.status()));
       return;
@@ -172,10 +175,11 @@ class AsyncRetryMultiPageFuture {
 
   friend future<StatusOr<Accumulator>> StartAsyncRetryMultiPage<
       AsyncCallType, Request, Accumulator, CombiningFunction>(
-      char const* location, std::unique_ptr<bigtable::RPCRetryPolicy> rpc_retry_policy,
+      char const* location,
+      std::unique_ptr<bigtable::RPCRetryPolicy> rpc_retry_policy,
       std::unique_ptr<bigtable::RPCBackoffPolicy> rpc_backoff_policy,
-      bigtable::MetadataUpdatePolicy metadata_update_policy, AsyncCallType async_call,
-      Request request, Accumulator accumulator,
+      bigtable::MetadataUpdatePolicy metadata_update_policy,
+      AsyncCallType async_call, Request request, Accumulator accumulator,
       CombiningFunction combining_function, CompletionQueue cq);
 };
 
@@ -204,10 +208,11 @@ class AsyncRetryMultiPageFuture {
 template <typename AsyncCallType, typename Request, typename Accumulator,
           typename CombiningFunction>
 future<StatusOr<Accumulator>> StartAsyncRetryMultiPage(
-    char const* location, std::unique_ptr<bigtable::RPCRetryPolicy> rpc_retry_policy,
+    char const* location,
+    std::unique_ptr<bigtable::RPCRetryPolicy> rpc_retry_policy,
     std::unique_ptr<bigtable::RPCBackoffPolicy> rpc_backoff_policy,
-    bigtable::MetadataUpdatePolicy metadata_update_policy, AsyncCallType async_call,
-    Request request, Accumulator accumulator,
+    bigtable::MetadataUpdatePolicy metadata_update_policy,
+    AsyncCallType async_call, Request request, Accumulator accumulator,
     CombiningFunction combining_function, CompletionQueue cq) {
   std::shared_ptr<AsyncRetryMultiPageFuture<AsyncCallType, Request, Accumulator,
                                             CombiningFunction>>

--- a/google/cloud/bigtable/internal/async_retry_multi_page_test.cc
+++ b/google/cloud/bigtable/internal/async_retry_multi_page_test.cc
@@ -25,9 +25,8 @@
 
 namespace google {
 namespace cloud {
-namespace bigtable {
+namespace bigtable_internal {
 inline namespace BIGTABLE_CLIENT_NS {
-namespace internal {
 
 using ::google::cloud::testing_util::chrono_literals::operator"" _ms;
 using ::google::cloud::testing_util::FakeCompletionQueueImpl;
@@ -93,13 +92,13 @@ class AsyncMultipageFutureTest : public ::testing::Test {
  public:
   AsyncMultipageFutureTest()
       : rpc_retry_policy_(
-            bigtable::DefaultRPCRetryPolicy(internal::kBigtableLimits)),
+            bigtable::DefaultRPCRetryPolicy(bigtable_internal::kBigtableLimits)),
         shared_backoff_policy_mock_(
             absl::make_unique<SharedBackoffPolicyMock>()),
         cq_impl_(new google::cloud::testing_util::FakeCompletionQueueImpl),
         cq_(cq_impl_),
-        client_(new testing::MockInstanceAdminClient),
-        metadata_update_policy_("my_instance", MetadataParamTypes::NAME) {}
+        client_(new bigtable::testing::MockInstanceAdminClient),
+        metadata_update_policy_("my_instance", bigtable::MetadataParamTypes::NAME) {}
 
   // Description of a single expected RPC exchange.
   struct Exchange {
@@ -178,13 +177,13 @@ class AsyncMultipageFutureTest : public ::testing::Test {
   }
 
  protected:
-  std::unique_ptr<RPCRetryPolicy> rpc_retry_policy_;
+  std::unique_ptr<bigtable::RPCRetryPolicy> rpc_retry_policy_;
   std::unique_ptr<SharedBackoffPolicyMock> shared_backoff_policy_mock_;
   std::shared_ptr<google::cloud::testing_util::FakeCompletionQueueImpl>
       cq_impl_;
   CompletionQueue cq_;
-  std::shared_ptr<testing::MockInstanceAdminClient> client_;
-  MetadataUpdatePolicy metadata_update_policy_;
+  std::shared_ptr<bigtable::testing::MockInstanceAdminClient> client_;
+  bigtable::MetadataUpdatePolicy metadata_update_policy_;
   std::vector<std::unique_ptr<MockAsyncListClustersReader>> readers_to_delete_;
 };
 
@@ -350,8 +349,7 @@ TEST_F(AsyncMultipageFutureTest, PermanentErrorsAreNotRetried) {
   EXPECT_EQ(StatusCode::kPermissionDenied, clusters.status().code());
 }
 
-}  // namespace internal
 }  // namespace BIGTABLE_CLIENT_NS
-}  // namespace bigtable
+}  // namespace bigtable_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/bigtable/internal/async_retry_multi_page_test.cc
+++ b/google/cloud/bigtable/internal/async_retry_multi_page_test.cc
@@ -91,8 +91,7 @@ using ::google::bigtable::admin::v2::ListClustersResponse;
 class AsyncMultipageFutureTest : public ::testing::Test {
  public:
   AsyncMultipageFutureTest()
-      : rpc_retry_policy_(bigtable::DefaultRPCRetryPolicy(
-            bigtable_internal::kBigtableLimits)),
+      : rpc_retry_policy_(bigtable::DefaultRPCRetryPolicy(kBigtableLimits)),
         shared_backoff_policy_mock_(
             absl::make_unique<SharedBackoffPolicyMock>()),
         cq_impl_(new google::cloud::testing_util::FakeCompletionQueueImpl),

--- a/google/cloud/bigtable/internal/async_retry_multi_page_test.cc
+++ b/google/cloud/bigtable/internal/async_retry_multi_page_test.cc
@@ -91,14 +91,15 @@ using ::google::bigtable::admin::v2::ListClustersResponse;
 class AsyncMultipageFutureTest : public ::testing::Test {
  public:
   AsyncMultipageFutureTest()
-      : rpc_retry_policy_(
-            bigtable::DefaultRPCRetryPolicy(bigtable_internal::kBigtableLimits)),
+      : rpc_retry_policy_(bigtable::DefaultRPCRetryPolicy(
+            bigtable_internal::kBigtableLimits)),
         shared_backoff_policy_mock_(
             absl::make_unique<SharedBackoffPolicyMock>()),
         cq_impl_(new google::cloud::testing_util::FakeCompletionQueueImpl),
         cq_(cq_impl_),
         client_(new bigtable::testing::MockInstanceAdminClient),
-        metadata_update_policy_("my_instance", bigtable::MetadataParamTypes::NAME) {}
+        metadata_update_policy_("my_instance",
+                                bigtable::MetadataParamTypes::NAME) {}
 
   // Description of a single expected RPC exchange.
   struct Exchange {

--- a/google/cloud/bigtable/internal/async_retry_op.h
+++ b/google/cloud/bigtable/internal/async_retry_op.h
@@ -26,9 +26,8 @@
 
 namespace google {
 namespace cloud {
-namespace bigtable {
+namespace bigtable_internal {
 inline namespace BIGTABLE_CLIENT_NS {
-namespace internal {
 
 /**
  * An idempotent policy for `AsyncRetryOp` based on a pre-computed value.
@@ -56,9 +55,8 @@ class ConstantIdempotencyPolicy {
   google::cloud::internal::Idempotency idempotency_;
 };
 
-}  // namespace internal
 }  // namespace BIGTABLE_CLIENT_NS
-}  // namespace bigtable
+}  // namespace bigtable_internal
 }  // namespace cloud
 }  // namespace google
 

--- a/google/cloud/bigtable/internal/async_retry_unary_rpc_and_poll.h
+++ b/google/cloud/bigtable/internal/async_retry_unary_rpc_and_poll.h
@@ -27,9 +27,8 @@
 
 namespace google {
 namespace cloud {
-namespace bigtable {
+namespace bigtable_internal {
 inline namespace BIGTABLE_CLIENT_NS {
-namespace internal {
 
 /**
  * Asynchronously start a longrunning operation (with retries) and poll its
@@ -58,11 +57,11 @@ namespace internal {
 template <typename Response, typename AsyncCallType, typename RequestType,
           typename IdempotencyPolicy, typename Client>
 future<StatusOr<Response>> AsyncStartPollAfterRetryUnaryRpc(
-    char const* location, std::unique_ptr<PollingPolicy> polling_policy,
-    std::unique_ptr<RPCRetryPolicy> rpc_retry_policy,
-    std::unique_ptr<RPCBackoffPolicy> rpc_backoff_policy,
+    char const* location, std::unique_ptr<bigtable::PollingPolicy> polling_policy,
+    std::unique_ptr<bigtable::RPCRetryPolicy> rpc_retry_policy,
+    std::unique_ptr<bigtable::RPCBackoffPolicy> rpc_backoff_policy,
     IdempotencyPolicy idempotent_policy,
-    MetadataUpdatePolicy metadata_update_policy, std::shared_ptr<Client> client,
+    bigtable::MetadataUpdatePolicy metadata_update_policy, std::shared_ptr<Client> client,
     AsyncCallType async_call, RequestType request, CompletionQueue cq) {
   static_assert(
       std::is_same<typename google::cloud::internal::AsyncCallResponseType<
@@ -70,7 +69,7 @@ future<StatusOr<Response>> AsyncStartPollAfterRetryUnaryRpc(
                    google::longrunning::Operation>::value,
       "async_call should return a google::longrunning::Operation");
   struct CallWrapper {
-    MetadataUpdatePolicy metadata_update_policy;
+    bigtable::MetadataUpdatePolicy metadata_update_policy;
     AsyncCallType async_call;
 
     google::cloud::internal::invoke_result_t<
@@ -99,12 +98,12 @@ future<StatusOr<Response>> AsyncStartPollAfterRetryUnaryRpc(
       std::string const policy_id = "operations/" + maybe_op->name();
       return StartAsyncLongrunningOp<Client, Response>(
           location, std::move(polling_policy),
-          MetadataUpdatePolicy(policy_id, MetadataParamTypes::NAME), client, cq,
+          bigtable::MetadataUpdatePolicy(policy_id, bigtable::MetadataParamTypes::NAME), client, cq,
           *std::move(maybe_op));
     }
 
     char const* location;
-    std::unique_ptr<PollingPolicy> polling_policy;
+    std::unique_ptr<bigtable::PollingPolicy> polling_policy;
     std::shared_ptr<Client> client;
     CompletionQueue cq;
   };
@@ -112,9 +111,8 @@ future<StatusOr<Response>> AsyncStartPollAfterRetryUnaryRpc(
                                             std::move(client), std::move(cq)});
 }
 
-}  // namespace internal
 }  // namespace BIGTABLE_CLIENT_NS
-}  // namespace bigtable
+}  // namespace bigtable_internal
 }  // namespace cloud
 }  // namespace google
 

--- a/google/cloud/bigtable/internal/async_retry_unary_rpc_and_poll.h
+++ b/google/cloud/bigtable/internal/async_retry_unary_rpc_and_poll.h
@@ -57,12 +57,14 @@ inline namespace BIGTABLE_CLIENT_NS {
 template <typename Response, typename AsyncCallType, typename RequestType,
           typename IdempotencyPolicy, typename Client>
 future<StatusOr<Response>> AsyncStartPollAfterRetryUnaryRpc(
-    char const* location, std::unique_ptr<bigtable::PollingPolicy> polling_policy,
+    char const* location,
+    std::unique_ptr<bigtable::PollingPolicy> polling_policy,
     std::unique_ptr<bigtable::RPCRetryPolicy> rpc_retry_policy,
     std::unique_ptr<bigtable::RPCBackoffPolicy> rpc_backoff_policy,
     IdempotencyPolicy idempotent_policy,
-    bigtable::MetadataUpdatePolicy metadata_update_policy, std::shared_ptr<Client> client,
-    AsyncCallType async_call, RequestType request, CompletionQueue cq) {
+    bigtable::MetadataUpdatePolicy metadata_update_policy,
+    std::shared_ptr<Client> client, AsyncCallType async_call,
+    RequestType request, CompletionQueue cq) {
   static_assert(
       std::is_same<typename google::cloud::internal::AsyncCallResponseType<
                        AsyncCallType, RequestType>::type,
@@ -98,8 +100,9 @@ future<StatusOr<Response>> AsyncStartPollAfterRetryUnaryRpc(
       std::string const policy_id = "operations/" + maybe_op->name();
       return StartAsyncLongrunningOp<Client, Response>(
           location, std::move(polling_policy),
-          bigtable::MetadataUpdatePolicy(policy_id, bigtable::MetadataParamTypes::NAME), client, cq,
-          *std::move(maybe_op));
+          bigtable::MetadataUpdatePolicy(policy_id,
+                                         bigtable::MetadataParamTypes::NAME),
+          client, cq, *std::move(maybe_op));
     }
 
     char const* location;

--- a/google/cloud/bigtable/internal/async_retry_unary_rpc_and_poll_test.cc
+++ b/google/cloud/bigtable/internal/async_retry_unary_rpc_and_poll_test.cc
@@ -57,10 +57,8 @@ class AsyncStartPollAfterRetryUnaryRpcTest
             std::chrono::hours(0),
         },
         polling_policy(bigtable::DefaultPollingPolicy(no_retries)),
-        rpc_retry_policy(
-            bigtable::DefaultRPCRetryPolicy(kBigtableLimits)),
-        rpc_backoff_policy(
-            bigtable::DefaultRPCBackoffPolicy(kBigtableLimits)),
+        rpc_retry_policy(bigtable::DefaultRPCRetryPolicy(kBigtableLimits)),
+        rpc_backoff_policy(bigtable::DefaultRPCBackoffPolicy(kBigtableLimits)),
         metadata_update_policy(
             "projects/" + k_project_id + "/instances/" + k_instance_id,
             bigtable::MetadataParamTypes::PARENT),

--- a/google/cloud/bigtable/internal/async_retry_unary_rpc_and_poll_test.cc
+++ b/google/cloud/bigtable/internal/async_retry_unary_rpc_and_poll_test.cc
@@ -29,9 +29,8 @@
 
 namespace google {
 namespace cloud {
-namespace bigtable {
+namespace bigtable_internal {
 inline namespace BIGTABLE_CLIENT_NS {
-namespace internal {
 namespace {
 
 namespace btproto = ::google::bigtable::admin::v2;
@@ -59,14 +58,14 @@ class AsyncStartPollAfterRetryUnaryRpcTest
         },
         polling_policy(bigtable::DefaultPollingPolicy(no_retries)),
         rpc_retry_policy(
-            bigtable::DefaultRPCRetryPolicy(internal::kBigtableLimits)),
+            bigtable::DefaultRPCRetryPolicy(kBigtableLimits)),
         rpc_backoff_policy(
-            bigtable::DefaultRPCBackoffPolicy(internal::kBigtableLimits)),
+            bigtable::DefaultRPCBackoffPolicy(kBigtableLimits)),
         metadata_update_policy(
             "projects/" + k_project_id + "/instances/" + k_instance_id,
-            MetadataParamTypes::PARENT),
-        client(std::make_shared<testing::MockInstanceAdminClient>(
-            ClientOptions().DisableBackgroundThreads(cq_))),
+            bigtable::MetadataParamTypes::PARENT),
+        client(std::make_shared<bigtable::testing::MockInstanceAdminClient>(
+            bigtable::ClientOptions().DisableBackgroundThreads(cq_))),
         create_cluster_reader(
             absl::make_unique<MockAsyncLongrunningOpReader>()),
         get_operation_reader(
@@ -143,10 +142,10 @@ class AsyncStartPollAfterRetryUnaryRpcTest
   future<StatusOr<btproto::Cluster>> SimulateCreateCluster() {
     btproto::CreateClusterRequest request;
     request.set_cluster_id("my_newly_created_cluster");
-    auto fut = internal::AsyncStartPollAfterRetryUnaryRpc<btproto::Cluster>(
+    auto fut = AsyncStartPollAfterRetryUnaryRpc<btproto::Cluster>(
         __func__, std::move(polling_policy), std::move(rpc_retry_policy),
         std::move(rpc_backoff_policy),
-        internal::ConstantIdempotencyPolicy(
+        ConstantIdempotencyPolicy(
             google::cloud::internal::Idempotency::kNonIdempotent),
         std::move(metadata_update_policy), client,
         [this](grpc::ClientContext* context,
@@ -166,12 +165,12 @@ class AsyncStartPollAfterRetryUnaryRpcTest
   std::string const k_instance_id;
   std::string const k_cluster_id;
   std::string const k_table_id;
-  internal::RPCPolicyParameters const no_retries;
-  std::unique_ptr<PollingPolicy> polling_policy;
-  std::unique_ptr<RPCRetryPolicy> rpc_retry_policy;
-  std::unique_ptr<RPCBackoffPolicy> rpc_backoff_policy;
-  MetadataUpdatePolicy metadata_update_policy;
-  std::shared_ptr<testing::MockInstanceAdminClient> client;
+  RPCPolicyParameters const no_retries;
+  std::unique_ptr<bigtable::PollingPolicy> polling_policy;
+  std::unique_ptr<bigtable::RPCRetryPolicy> rpc_retry_policy;
+  std::unique_ptr<bigtable::RPCBackoffPolicy> rpc_backoff_policy;
+  bigtable::MetadataUpdatePolicy metadata_update_policy;
+  std::shared_ptr<bigtable::testing::MockInstanceAdminClient> client;
   std::unique_ptr<MockAsyncLongrunningOpReader> create_cluster_reader;
   std::unique_ptr<MockAsyncLongrunningOpReader> get_operation_reader;
 };
@@ -257,8 +256,7 @@ TEST_F(AsyncStartPollAfterRetryUnaryRpcTest, FinalErrorIsPassedOn) {
 }
 
 }  // namespace
-}  // namespace internal
 }  // namespace BIGTABLE_CLIENT_NS
-}  // namespace bigtable
+}  // namespace bigtable_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/bigtable/internal/async_row_sampler.cc
+++ b/google/cloud/bigtable/internal/async_row_sampler.cc
@@ -30,8 +30,8 @@ future<StatusOr<std::vector<bigtable::RowKeySample>>> AsyncRowSampler::Create(
     CompletionQueue cq, std::shared_ptr<bigtable::DataClient> client,
     std::unique_ptr<bigtable::RPCRetryPolicy> rpc_retry_policy,
     std::unique_ptr<bigtable::RPCBackoffPolicy> rpc_backoff_policy,
-    bigtable::MetadataUpdatePolicy metadata_update_policy, std::string app_profile_id,
-    std::string table_name) {
+    bigtable::MetadataUpdatePolicy metadata_update_policy,
+    std::string app_profile_id, std::string table_name) {
   std::shared_ptr<AsyncRowSampler> sampler(new AsyncRowSampler(
       std::move(cq), std::move(client), std::move(rpc_retry_policy),
       std::move(rpc_backoff_policy), std::move(metadata_update_policy),
@@ -44,8 +44,8 @@ AsyncRowSampler::AsyncRowSampler(
     CompletionQueue cq, std::shared_ptr<bigtable::DataClient> client,
     std::unique_ptr<bigtable::RPCRetryPolicy> rpc_retry_policy,
     std::unique_ptr<bigtable::RPCBackoffPolicy> rpc_backoff_policy,
-    bigtable::MetadataUpdatePolicy metadata_update_policy, std::string app_profile_id,
-    std::string table_name)
+    bigtable::MetadataUpdatePolicy metadata_update_policy,
+    std::string app_profile_id, std::string table_name)
     : cq_(std::move(cq)),
       client_(std::move(client)),
       rpc_retry_policy_(std::move(rpc_retry_policy)),

--- a/google/cloud/bigtable/internal/async_row_sampler.cc
+++ b/google/cloud/bigtable/internal/async_row_sampler.cc
@@ -21,17 +21,16 @@
 
 namespace google {
 namespace cloud {
-namespace bigtable {
+namespace bigtable_internal {
 inline namespace BIGTABLE_CLIENT_NS {
-namespace internal {
 
 namespace btproto = ::google::bigtable::v2;
 
-future<StatusOr<std::vector<RowKeySample>>> AsyncRowSampler::Create(
-    CompletionQueue cq, std::shared_ptr<DataClient> client,
-    std::unique_ptr<RPCRetryPolicy> rpc_retry_policy,
-    std::unique_ptr<RPCBackoffPolicy> rpc_backoff_policy,
-    MetadataUpdatePolicy metadata_update_policy, std::string app_profile_id,
+future<StatusOr<std::vector<bigtable::RowKeySample>>> AsyncRowSampler::Create(
+    CompletionQueue cq, std::shared_ptr<bigtable::DataClient> client,
+    std::unique_ptr<bigtable::RPCRetryPolicy> rpc_retry_policy,
+    std::unique_ptr<bigtable::RPCBackoffPolicy> rpc_backoff_policy,
+    bigtable::MetadataUpdatePolicy metadata_update_policy, std::string app_profile_id,
     std::string table_name) {
   std::shared_ptr<AsyncRowSampler> sampler(new AsyncRowSampler(
       std::move(cq), std::move(client), std::move(rpc_retry_policy),
@@ -42,10 +41,10 @@ future<StatusOr<std::vector<RowKeySample>>> AsyncRowSampler::Create(
 }
 
 AsyncRowSampler::AsyncRowSampler(
-    CompletionQueue cq, std::shared_ptr<DataClient> client,
-    std::unique_ptr<RPCRetryPolicy> rpc_retry_policy,
-    std::unique_ptr<RPCBackoffPolicy> rpc_backoff_policy,
-    MetadataUpdatePolicy metadata_update_policy, std::string app_profile_id,
+    CompletionQueue cq, std::shared_ptr<bigtable::DataClient> client,
+    std::unique_ptr<bigtable::RPCRetryPolicy> rpc_retry_policy,
+    std::unique_ptr<bigtable::RPCBackoffPolicy> rpc_backoff_policy,
+    bigtable::MetadataUpdatePolicy metadata_update_policy, std::string app_profile_id,
     std::string table_name)
     : cq_(std::move(cq)),
       client_(std::move(client)),
@@ -85,7 +84,7 @@ void AsyncRowSampler::StartIteration() {
 future<bool> AsyncRowSampler::OnRead(btproto::SampleRowKeysResponse response) {
   if (stream_cancelled_) return make_ready_future(false);
 
-  RowKeySample row_sample;
+  bigtable::RowKeySample row_sample;
   row_sample.offset_bytes = response.offset_bytes();
   row_sample.row_key = std::move(*response.mutable_row_key());
   samples_.emplace_back(std::move(row_sample));
@@ -117,8 +116,7 @@ void AsyncRowSampler::OnFinish(Status const& status) {
   });
 }
 
-}  // namespace internal
 }  // namespace BIGTABLE_CLIENT_NS
-}  // namespace bigtable
+}  // namespace bigtable_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/bigtable/internal/async_row_sampler.h
+++ b/google/cloud/bigtable/internal/async_row_sampler.h
@@ -44,15 +44,16 @@ class AsyncRowSampler : public std::enable_shared_from_this<AsyncRowSampler> {
       CompletionQueue cq, std::shared_ptr<bigtable::DataClient> client,
       std::unique_ptr<bigtable::RPCRetryPolicy> rpc_retry_policy,
       std::unique_ptr<bigtable::RPCBackoffPolicy> rpc_backoff_policy,
-      bigtable::MetadataUpdatePolicy metadata_update_policy, std::string app_profile_id,
-      std::string table_name);
+      bigtable::MetadataUpdatePolicy metadata_update_policy,
+      std::string app_profile_id, std::string table_name);
 
  private:
-  AsyncRowSampler(CompletionQueue cq, std::shared_ptr<bigtable::DataClient> client,
-                  std::unique_ptr<bigtable::RPCRetryPolicy> rpc_retry_policy,
-                  std::unique_ptr<bigtable::RPCBackoffPolicy> rpc_backoff_policy,
-                  bigtable::MetadataUpdatePolicy metadata_update_policy,
-                  std::string app_profile_id, std::string table_name);
+  AsyncRowSampler(
+      CompletionQueue cq, std::shared_ptr<bigtable::DataClient> client,
+      std::unique_ptr<bigtable::RPCRetryPolicy> rpc_retry_policy,
+      std::unique_ptr<bigtable::RPCBackoffPolicy> rpc_backoff_policy,
+      bigtable::MetadataUpdatePolicy metadata_update_policy,
+      std::string app_profile_id, std::string table_name);
 
   void StartIteration();
   future<bool> OnRead(google::bigtable::v2::SampleRowKeysResponse response);

--- a/google/cloud/bigtable/internal/async_row_sampler.h
+++ b/google/cloud/bigtable/internal/async_row_sampler.h
@@ -32,27 +32,26 @@
 
 namespace google {
 namespace cloud {
-namespace bigtable {
+namespace bigtable_internal {
 inline namespace BIGTABLE_CLIENT_NS {
-namespace internal {
 /**
  * Objects of this class represent the state of receiving row keys via
  * AsyncSampleRows.
  */
 class AsyncRowSampler : public std::enable_shared_from_this<AsyncRowSampler> {
  public:
-  static future<StatusOr<std::vector<RowKeySample>>> Create(
-      CompletionQueue cq, std::shared_ptr<DataClient> client,
-      std::unique_ptr<RPCRetryPolicy> rpc_retry_policy,
-      std::unique_ptr<RPCBackoffPolicy> rpc_backoff_policy,
-      MetadataUpdatePolicy metadata_update_policy, std::string app_profile_id,
+  static future<StatusOr<std::vector<bigtable::RowKeySample>>> Create(
+      CompletionQueue cq, std::shared_ptr<bigtable::DataClient> client,
+      std::unique_ptr<bigtable::RPCRetryPolicy> rpc_retry_policy,
+      std::unique_ptr<bigtable::RPCBackoffPolicy> rpc_backoff_policy,
+      bigtable::MetadataUpdatePolicy metadata_update_policy, std::string app_profile_id,
       std::string table_name);
 
  private:
-  AsyncRowSampler(CompletionQueue cq, std::shared_ptr<DataClient> client,
-                  std::unique_ptr<RPCRetryPolicy> rpc_retry_policy,
-                  std::unique_ptr<RPCBackoffPolicy> rpc_backoff_policy,
-                  MetadataUpdatePolicy metadata_update_policy,
+  AsyncRowSampler(CompletionQueue cq, std::shared_ptr<bigtable::DataClient> client,
+                  std::unique_ptr<bigtable::RPCRetryPolicy> rpc_retry_policy,
+                  std::unique_ptr<bigtable::RPCBackoffPolicy> rpc_backoff_policy,
+                  bigtable::MetadataUpdatePolicy metadata_update_policy,
                   std::string app_profile_id, std::string table_name);
 
   void StartIteration();
@@ -60,21 +59,20 @@ class AsyncRowSampler : public std::enable_shared_from_this<AsyncRowSampler> {
   void OnFinish(Status const& status);
 
   CompletionQueue cq_;
-  std::shared_ptr<DataClient> client_;
-  std::unique_ptr<RPCRetryPolicy> rpc_retry_policy_;
-  std::unique_ptr<RPCBackoffPolicy> rpc_backoff_policy_;
-  MetadataUpdatePolicy metadata_update_policy_;
+  std::shared_ptr<bigtable::DataClient> client_;
+  std::unique_ptr<bigtable::RPCRetryPolicy> rpc_retry_policy_;
+  std::unique_ptr<bigtable::RPCBackoffPolicy> rpc_backoff_policy_;
+  bigtable::MetadataUpdatePolicy metadata_update_policy_;
   std::string app_profile_id_;
   std::string table_name_;
 
   bool stream_cancelled_;
-  std::vector<RowKeySample> samples_;
-  promise<StatusOr<std::vector<RowKeySample>>> promise_;
+  std::vector<bigtable::RowKeySample> samples_;
+  promise<StatusOr<std::vector<bigtable::RowKeySample>>> promise_;
 };
 
-}  // namespace internal
 }  // namespace BIGTABLE_CLIENT_NS
-}  // namespace bigtable
+}  // namespace bigtable_internal
 }  // namespace cloud
 }  // namespace google
 

--- a/google/cloud/bigtable/internal/async_row_sampler_test.cc
+++ b/google/cloud/bigtable/internal/async_row_sampler_test.cc
@@ -46,7 +46,7 @@ class AsyncSampleRowKeysTest : public bigtable::testing::TableTestFixture {
       : TableTestFixture(
             CompletionQueue(std::make_shared<FakeCompletionQueueImpl>())),
         rpc_retry_policy_(
-            bigtable::DefaultRPCRetryPolicy(internal::kBigtableLimits)),
+            DefaultRPCRetryPolicy(bigtable_internal::kBigtableLimits)),
         metadata_update_policy_("my_table", MetadataParamTypes::NAME) {}
 
   std::shared_ptr<RPCRetryPolicy const> rpc_retry_policy_;
@@ -278,7 +278,7 @@ TEST_F(AsyncSampleRowKeysTest, UsesBackoff) {
         return reader;
       });
 
-  auto samples_future = internal::AsyncRowSampler::Create(
+  auto samples_future = bigtable_internal::AsyncRowSampler::Create(
       cq_, client_, rpc_retry_policy_->clone(), std::move(mock),
       metadata_update_policy_, "my-app-profile", "my-table");
 
@@ -330,7 +330,7 @@ TEST_F(AsyncSampleRowKeysTest, CancelDuringBackoff) {
         return reader;
       });
 
-  auto samples_future = internal::AsyncRowSampler::Create(
+  auto samples_future = bigtable_internal::AsyncRowSampler::Create(
       cq_, client_, rpc_retry_policy_->clone(), std::move(mock),
       metadata_update_policy_, "my-app-profile", "my-table");
 

--- a/google/cloud/bigtable/internal/bulk_mutator.cc
+++ b/google/cloud/bigtable/internal/bulk_mutator.cc
@@ -27,10 +27,10 @@ namespace btproto = ::google::bigtable::v2;
 
 using ::google::cloud::internal::Idempotency;
 
-BulkMutatorState::BulkMutatorState(std::string const& app_profile_id,
-                                   std::string const& table_name,
-                                   bigtable::IdempotentMutationPolicy& idempotent_policy,
-                                   bigtable::BulkMutation mut) {
+BulkMutatorState::BulkMutatorState(
+    std::string const& app_profile_id, std::string const& table_name,
+    bigtable::IdempotentMutationPolicy& idempotent_policy,
+    bigtable::BulkMutation mut) {
   // Every time the client library calls MakeOneRequest(), the data in the
   // "pending_*" variables initializes the next request.  So in the constructor
   // we start by putting the data on the "pending_*" variables.
@@ -161,7 +161,8 @@ void BulkMutatorState::OnFinish(google::cloud::Status finish_status) {
   }
 }
 
-std::vector<bigtable::FailedMutation> BulkMutatorState::ConsumeAccumulatedFailures() {
+std::vector<bigtable::FailedMutation>
+BulkMutatorState::ConsumeAccumulatedFailures() {
   std::vector<bigtable::FailedMutation> res;
   res.swap(failures_);
   return res;

--- a/google/cloud/bigtable/internal/bulk_mutator.h
+++ b/google/cloud/bigtable/internal/bulk_mutator.h
@@ -27,15 +27,14 @@
 
 namespace google {
 namespace cloud {
-namespace bigtable {
+namespace bigtable_internal {
 inline namespace BIGTABLE_CLIENT_NS {
-namespace internal {
 class BulkMutatorState {
  public:
   BulkMutatorState(std::string const& app_profile_id,
                    std::string const& table_name,
-                   IdempotentMutationPolicy& idempotent_policy,
-                   BulkMutation mut);
+                   bigtable::IdempotentMutationPolicy& idempotent_policy,
+                   bigtable::BulkMutation mut);
 
   bool HasPendingMutations() const {
     return pending_mutations_.entries_size() != 0;
@@ -62,10 +61,10 @@ class BulkMutatorState {
    *
    * Whatever is returned, will not be returned by `OnRetryDone()`.
    */
-  std::vector<FailedMutation> ConsumeAccumulatedFailures();
+  std::vector<bigtable::FailedMutation> ConsumeAccumulatedFailures();
 
   /// Terminate the retry loop and return all the failures.
-  std::vector<FailedMutation> OnRetryDone() &&;
+  std::vector<bigtable::FailedMutation> OnRetryDone() &&;
 
  private:
   /// The current request proto.
@@ -81,7 +80,7 @@ class BulkMutatorState {
   google::cloud::Status last_status_;
 
   /// Accumulate any permanent failures and the list of mutations we gave up on.
-  std::vector<FailedMutation> failures_;
+  std::vector<bigtable::FailedMutation> failures_;
 
   /**
    * A small type to keep the annotations about pending mutations.
@@ -117,7 +116,7 @@ class BulkMutatorState {
 class BulkMutator {
  public:
   BulkMutator(std::string const& app_profile_id, std::string const& table_name,
-              IdempotentMutationPolicy& idempotent_policy, BulkMutation mut);
+              bigtable::IdempotentMutationPolicy& idempotent_policy, bigtable::BulkMutation mut);
 
   /// Return true if there are pending mutations in the mutator
   bool HasPendingMutations() const { return state_.HasPendingMutations(); }
@@ -127,15 +126,14 @@ class BulkMutator {
                               grpc::ClientContext& client_context);
 
   /// Give up on any pending mutations, move them to the failures array.
-  std::vector<FailedMutation> OnRetryDone() &&;
+  std::vector<bigtable::FailedMutation> OnRetryDone() &&;
 
  protected:
   BulkMutatorState state_;
 };
 
-}  // namespace internal
 }  // namespace BIGTABLE_CLIENT_NS
-}  // namespace bigtable
+}  // namespace bigtable_internal
 }  // namespace cloud
 }  // namespace google
 

--- a/google/cloud/bigtable/internal/bulk_mutator.h
+++ b/google/cloud/bigtable/internal/bulk_mutator.h
@@ -116,7 +116,8 @@ class BulkMutatorState {
 class BulkMutator {
  public:
   BulkMutator(std::string const& app_profile_id, std::string const& table_name,
-              bigtable::IdempotentMutationPolicy& idempotent_policy, bigtable::BulkMutation mut);
+              bigtable::IdempotentMutationPolicy& idempotent_policy,
+              bigtable::BulkMutation mut);
 
   /// Return true if there are pending mutations in the mutator
   bool HasPendingMutations() const { return state_.HasPendingMutations(); }

--- a/google/cloud/bigtable/internal/bulk_mutator_test.cc
+++ b/google/cloud/bigtable/internal/bulk_mutator_test.cc
@@ -33,8 +33,8 @@ using ::google::cloud::bigtable::testing::MockMutateRowsReader;
 
 std::unique_ptr<grpc::ClientContext> TestContext() {
   auto context = absl::make_unique<grpc::ClientContext>();
-  bigtable::MetadataUpdatePolicy("projects/blah/instances/blah2/tables/table",
-                                 bigtable::MetadataParamTypes::TABLE_NAME)
+  MetadataUpdatePolicy("projects/blah/instances/blah2/tables/table",
+                                 MetadataParamTypes::TABLE_NAME)
       .Setup(*context);
   return context;
 }
@@ -75,7 +75,7 @@ TEST(MultipleRowsMutatorTest, Simple) {
       .WillOnce(reader.release()->MakeMockReturner());
 
   auto policy = DefaultIdempotentMutationPolicy();
-  internal::BulkMutator mutator("", "foo/bar/baz/table", *policy,
+  bigtable_internal::BulkMutator mutator("", "foo/bar/baz/table", *policy,
                                 std::move(mut));
 
   EXPECT_TRUE(mutator.HasPendingMutations());
@@ -129,7 +129,7 @@ TEST(MultipleRowsMutatorTest, BulkApplyAppProfileId) {
       });
 
   auto policy = DefaultIdempotentMutationPolicy();
-  internal::BulkMutator mutator("test-id", "foo/bar/baz/table", *policy,
+  bigtable_internal::BulkMutator mutator("test-id", "foo/bar/baz/table", *policy,
                                 std::move(mut));
 
   EXPECT_TRUE(mutator.HasPendingMutations());
@@ -196,7 +196,7 @@ TEST(MultipleRowsMutatorTest, RetryPartialFailure) {
           });
 
   auto policy = DefaultIdempotentMutationPolicy();
-  internal::BulkMutator mutator("", "foo/bar/baz/table", *policy,
+  bigtable_internal::BulkMutator mutator("", "foo/bar/baz/table", *policy,
                                 std::move(mut));
 
   // This work will be in BulkApply(), but this is the test for BulkMutator in
@@ -260,7 +260,7 @@ TEST(MultipleRowsMutatorTest, PermanentFailure) {
       .WillOnce(r2.release()->MakeMockReturner());
 
   auto policy = DefaultIdempotentMutationPolicy();
-  internal::BulkMutator mutator("", "foo/bar/baz/table", *policy,
+  bigtable_internal::BulkMutator mutator("", "foo/bar/baz/table", *policy,
                                 std::move(mut));
 
   // This work will be in BulkApply(), but this is the test for BulkMutator in
@@ -324,7 +324,7 @@ TEST(MultipleRowsMutatorTest, PartialStream) {
       .WillOnce(r2.release()->MakeMockReturner());
 
   auto policy = DefaultIdempotentMutationPolicy();
-  internal::BulkMutator mutator("", "foo/bar/baz/table", *policy,
+  bigtable_internal::BulkMutator mutator("", "foo/bar/baz/table", *policy,
                                 std::move(mut));
 
   // This work will be in BulkApply(), but this is the test for BulkMutator in
@@ -403,7 +403,7 @@ TEST(MultipleRowsMutatorTest, RetryOnlyIdempotent) {
       });
 
   auto policy = DefaultIdempotentMutationPolicy();
-  internal::BulkMutator mutator("", "foo/bar/baz/table", *policy,
+  bigtable_internal::BulkMutator mutator("", "foo/bar/baz/table", *policy,
                                 std::move(mut));
 
   // This work will be in BulkApply(), but this is the test for BulkMutator in
@@ -465,7 +465,7 @@ TEST(MultipleRowsMutatorTest, UnconfirmedAreFailed) {
       });
 
   auto policy = DefaultIdempotentMutationPolicy();
-  internal::BulkMutator mutator("", "foo/bar/baz/table", *policy,
+  bigtable_internal::BulkMutator mutator("", "foo/bar/baz/table", *policy,
                                 std::move(mut));
 
   EXPECT_TRUE(mutator.HasPendingMutations());

--- a/google/cloud/bigtable/internal/bulk_mutator_test.cc
+++ b/google/cloud/bigtable/internal/bulk_mutator_test.cc
@@ -34,7 +34,7 @@ using ::google::cloud::bigtable::testing::MockMutateRowsReader;
 std::unique_ptr<grpc::ClientContext> TestContext() {
   auto context = absl::make_unique<grpc::ClientContext>();
   MetadataUpdatePolicy("projects/blah/instances/blah2/tables/table",
-                                 MetadataParamTypes::TABLE_NAME)
+                       MetadataParamTypes::TABLE_NAME)
       .Setup(*context);
   return context;
 }
@@ -76,7 +76,7 @@ TEST(MultipleRowsMutatorTest, Simple) {
 
   auto policy = DefaultIdempotentMutationPolicy();
   bigtable_internal::BulkMutator mutator("", "foo/bar/baz/table", *policy,
-                                std::move(mut));
+                                         std::move(mut));
 
   EXPECT_TRUE(mutator.HasPendingMutations());
   auto context = TestContext();
@@ -129,8 +129,8 @@ TEST(MultipleRowsMutatorTest, BulkApplyAppProfileId) {
       });
 
   auto policy = DefaultIdempotentMutationPolicy();
-  bigtable_internal::BulkMutator mutator("test-id", "foo/bar/baz/table", *policy,
-                                std::move(mut));
+  bigtable_internal::BulkMutator mutator("test-id", "foo/bar/baz/table",
+                                         *policy, std::move(mut));
 
   EXPECT_TRUE(mutator.HasPendingMutations());
   auto context = TestContext();
@@ -197,7 +197,7 @@ TEST(MultipleRowsMutatorTest, RetryPartialFailure) {
 
   auto policy = DefaultIdempotentMutationPolicy();
   bigtable_internal::BulkMutator mutator("", "foo/bar/baz/table", *policy,
-                                std::move(mut));
+                                         std::move(mut));
 
   // This work will be in BulkApply(), but this is the test for BulkMutator in
   // isolation, so call MakeOneRequest() twice, for the r1, and the r2 cases.
@@ -261,7 +261,7 @@ TEST(MultipleRowsMutatorTest, PermanentFailure) {
 
   auto policy = DefaultIdempotentMutationPolicy();
   bigtable_internal::BulkMutator mutator("", "foo/bar/baz/table", *policy,
-                                std::move(mut));
+                                         std::move(mut));
 
   // This work will be in BulkApply(), but this is the test for BulkMutator in
   // isolation, so call MakeOneRequest() twice, for the r1, and the r2 cases.
@@ -325,7 +325,7 @@ TEST(MultipleRowsMutatorTest, PartialStream) {
 
   auto policy = DefaultIdempotentMutationPolicy();
   bigtable_internal::BulkMutator mutator("", "foo/bar/baz/table", *policy,
-                                std::move(mut));
+                                         std::move(mut));
 
   // This work will be in BulkApply(), but this is the test for BulkMutator in
   // isolation, so call MakeOneRequest() twice: for the r1 and r2 cases.
@@ -404,7 +404,7 @@ TEST(MultipleRowsMutatorTest, RetryOnlyIdempotent) {
 
   auto policy = DefaultIdempotentMutationPolicy();
   bigtable_internal::BulkMutator mutator("", "foo/bar/baz/table", *policy,
-                                std::move(mut));
+                                         std::move(mut));
 
   // This work will be in BulkApply(), but this is the test for BulkMutator in
   // isolation, so call MakeOneRequest() twice, for the r1, and the r2 cases.
@@ -466,7 +466,7 @@ TEST(MultipleRowsMutatorTest, UnconfirmedAreFailed) {
 
   auto policy = DefaultIdempotentMutationPolicy();
   bigtable_internal::BulkMutator mutator("", "foo/bar/baz/table", *policy,
-                                std::move(mut));
+                                         std::move(mut));
 
   EXPECT_TRUE(mutator.HasPendingMutations());
   auto context = TestContext();

--- a/google/cloud/bigtable/internal/common_client.cc
+++ b/google/cloud/bigtable/internal/common_client.cc
@@ -15,9 +15,8 @@
 
 namespace google {
 namespace cloud {
-namespace bigtable {
+namespace bigtable_internal {
 inline namespace BIGTABLE_CLIENT_NS {
-namespace internal {
 
 ConnectionRefreshState::ConnectionRefreshState(
     std::shared_ptr<CompletionQueue> const& cq,
@@ -125,8 +124,7 @@ void OutstandingTimers::CancelAll() {
   }
 }
 
-}  // namespace internal
 }  // namespace BIGTABLE_CLIENT_NS
-}  // namespace bigtable
+}  // namespace bigtable_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/bigtable/internal/common_client.h
+++ b/google/cloud/bigtable/internal/common_client.h
@@ -29,9 +29,8 @@
 
 namespace google {
 namespace cloud {
-namespace bigtable {
+namespace bigtable_internal {
 inline namespace BIGTABLE_CLIENT_NS {
-namespace internal {
 
 /**
  * Time after which we bail out waiting for a connection to become ready.
@@ -167,7 +166,7 @@ class CommonClient {
     return channel;
   }
 
-  ClientOptions& Options() { return options_; }
+  bigtable::ClientOptions& Options() { return options_; }
 
  private:
   /// Make sure the connections exit, and create them if needed.
@@ -244,7 +243,7 @@ class CommonClient {
 
   std::mutex mu_;
   std::size_t num_pending_refreshes_{};
-  ClientOptions options_;
+  bigtable::ClientOptions options_;
   std::vector<ChannelPtr> channels_;
   std::vector<StubPtr> stubs_;
   std::size_t current_index_;
@@ -259,9 +258,8 @@ class CommonClient {
   std::shared_ptr<ConnectionRefreshState> refresh_state_;
 };
 
-}  // namespace internal
 }  // namespace BIGTABLE_CLIENT_NS
-}  // namespace bigtable
+}  // namespace bigtable_internal
 }  // namespace cloud
 }  // namespace google
 

--- a/google/cloud/bigtable/internal/common_client_test.cc
+++ b/google/cloud/bigtable/internal/common_client_test.cc
@@ -17,9 +17,8 @@
 
 namespace google {
 namespace cloud {
-namespace bigtable {
+namespace bigtable_internal {
 inline namespace BIGTABLE_CLIENT_NS {
-namespace internal {
 
 using TimerFuture = future<StatusOr<std::chrono::system_clock::time_point>>;
 
@@ -107,8 +106,7 @@ TEST_F(OutstandingTimersTest, TimerRegisteredAfterCancelAllGetCancelled) {
   continuation_promise.get_future().get();
 }
 
-}  // namespace internal
 }  // namespace BIGTABLE_CLIENT_NS
-}  // namespace bigtable
+}  // namespace bigtable_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/bigtable/internal/defaults.cc
+++ b/google/cloud/bigtable/internal/defaults.cc
@@ -26,9 +26,8 @@
 
 namespace google {
 namespace cloud {
-namespace bigtable {
+namespace bigtable_internal {
 inline namespace BIGTABLE_CLIENT_NS {
-namespace internal {
 
 namespace {
 
@@ -76,25 +75,25 @@ int DefaultConnectionPoolSize() {
 Options DefaultOptions(Options opts) {
   auto emulator = google::cloud::internal::GetEnv("BIGTABLE_EMULATOR_HOST");
   if (emulator) {
-    opts.set<DataEndpointOption>(*emulator);
-    opts.set<AdminEndpointOption>(*emulator);
-    opts.set<InstanceAdminEndpointOption>(*emulator);
+    opts.set<bigtable::DataEndpointOption>(*emulator);
+    opts.set<bigtable::AdminEndpointOption>(*emulator);
+    opts.set<bigtable::InstanceAdminEndpointOption>(*emulator);
   }
 
   auto instance_admin_emulator =
       google::cloud::internal::GetEnv("BIGTABLE_INSTANCE_ADMIN_EMULATOR_HOST");
   if (instance_admin_emulator) {
-    opts.set<InstanceAdminEndpointOption>(*std::move(instance_admin_emulator));
+    opts.set<bigtable::InstanceAdminEndpointOption>(*std::move(instance_admin_emulator));
   }
 
-  if (!opts.has<DataEndpointOption>()) {
-    opts.set<DataEndpointOption>("bigtable.googleapis.com");
+  if (!opts.has<bigtable::DataEndpointOption>()) {
+    opts.set<bigtable::DataEndpointOption>("bigtable.googleapis.com");
   }
-  if (!opts.has<AdminEndpointOption>()) {
-    opts.set<AdminEndpointOption>("bigtableadmin.googleapis.com");
+  if (!opts.has<bigtable::AdminEndpointOption>()) {
+    opts.set<bigtable::AdminEndpointOption>("bigtableadmin.googleapis.com");
   }
-  if (!opts.has<InstanceAdminEndpointOption>()) {
-    opts.set<InstanceAdminEndpointOption>("bigtableadmin.googleapis.com");
+  if (!opts.has<bigtable::InstanceAdminEndpointOption>()) {
+    opts.set<bigtable::InstanceAdminEndpointOption>("bigtableadmin.googleapis.com");
   }
   if (!opts.has<GrpcCredentialOption>()) {
     opts.set<GrpcCredentialOption>(emulator ? grpc::InsecureChannelCredentials()
@@ -111,11 +110,11 @@ Options DefaultOptions(Options opts) {
   if (!opts.has<GrpcNumChannelsOption>()) {
     opts.set<GrpcNumChannelsOption>(DefaultConnectionPoolSize());
   }
-  if (!opts.has<MinConnectionRefreshOption>()) {
-    opts.set<MinConnectionRefreshOption>(kDefaultMinRefreshPeriod);
+  if (!opts.has<bigtable::MinConnectionRefreshOption>()) {
+    opts.set<bigtable::MinConnectionRefreshOption>(kDefaultMinRefreshPeriod);
   }
-  if (!opts.has<MaxConnectionRefreshOption>()) {
-    opts.set<MaxConnectionRefreshOption>(kDefaultMaxRefreshPeriod);
+  if (!opts.has<bigtable::MaxConnectionRefreshOption>()) {
+    opts.set<bigtable::MaxConnectionRefreshOption>(kDefaultMaxRefreshPeriod);
   }
 
   using ::google::cloud::internal::GetIntChannelArgument;
@@ -143,8 +142,7 @@ Options DefaultOptions(Options opts) {
   return opts;
 }
 
-}  // namespace internal
 }  // namespace BIGTABLE_CLIENT_NS
-}  // namespace bigtable
+}  // namespace bigtable_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/bigtable/internal/defaults.cc
+++ b/google/cloud/bigtable/internal/defaults.cc
@@ -83,7 +83,8 @@ Options DefaultOptions(Options opts) {
   auto instance_admin_emulator =
       google::cloud::internal::GetEnv("BIGTABLE_INSTANCE_ADMIN_EMULATOR_HOST");
   if (instance_admin_emulator) {
-    opts.set<bigtable::InstanceAdminEndpointOption>(*std::move(instance_admin_emulator));
+    opts.set<bigtable::InstanceAdminEndpointOption>(
+        *std::move(instance_admin_emulator));
   }
 
   if (!opts.has<bigtable::DataEndpointOption>()) {
@@ -93,7 +94,8 @@ Options DefaultOptions(Options opts) {
     opts.set<bigtable::AdminEndpointOption>("bigtableadmin.googleapis.com");
   }
   if (!opts.has<bigtable::InstanceAdminEndpointOption>()) {
-    opts.set<bigtable::InstanceAdminEndpointOption>("bigtableadmin.googleapis.com");
+    opts.set<bigtable::InstanceAdminEndpointOption>(
+        "bigtableadmin.googleapis.com");
   }
   if (!opts.has<GrpcCredentialOption>()) {
     opts.set<GrpcCredentialOption>(emulator ? grpc::InsecureChannelCredentials()

--- a/google/cloud/bigtable/internal/defaults.h
+++ b/google/cloud/bigtable/internal/defaults.h
@@ -20,9 +20,8 @@
 
 namespace google {
 namespace cloud {
-namespace bigtable {
+namespace bigtable_internal {
 inline namespace BIGTABLE_CLIENT_NS {
-namespace internal {
 
 int DefaultConnectionPoolSize();
 
@@ -41,9 +40,8 @@ int DefaultConnectionPoolSize();
  */
 Options DefaultOptions(Options opts = {});
 
-}  // namespace internal
 }  // namespace BIGTABLE_CLIENT_NS
-}  // namespace bigtable
+}  // namespace bigtable_internal
 }  // namespace cloud
 }  // namespace google
 

--- a/google/cloud/bigtable/internal/google_bytes_traits.cc
+++ b/google/cloud/bigtable/internal/google_bytes_traits.cc
@@ -16,9 +16,8 @@
 
 namespace google {
 namespace cloud {
-namespace bigtable {
+namespace bigtable_internal {
 inline namespace BIGTABLE_CLIENT_NS {
-namespace internal {
 
 bool ConsecutiveRowKeys(std::string const& a, std::string const& b) {
   // The only way for two strings to be consecutive is for the
@@ -31,8 +30,7 @@ bool ConsecutiveRowKeys(std::string const& a, std::string const& b) {
   }
   return b.compare(0, a.length(), a) == 0;
 }
-}  // namespace internal
 }  // namespace BIGTABLE_CLIENT_NS
-}  // namespace bigtable
+}  // namespace bigtable_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/bigtable/internal/google_bytes_traits.h
+++ b/google/cloud/bigtable/internal/google_bytes_traits.h
@@ -23,9 +23,8 @@
 
 namespace google {
 namespace cloud {
-namespace bigtable {
+namespace bigtable_internal {
 inline namespace BIGTABLE_CLIENT_NS {
-namespace internal {
 //@{
 /**
  * @name Define functions to manipulate `std::string`.
@@ -83,9 +82,8 @@ inline void ReserveCellValue(std::string& value, std::size_t reserve) {
 }
 //@}
 
-}  // namespace internal
 }  // namespace BIGTABLE_CLIENT_NS
-}  // namespace bigtable
+}  // namespace bigtable_internal
 }  // namespace cloud
 }  // namespace google
 

--- a/google/cloud/bigtable/internal/google_bytes_traits_test.cc
+++ b/google/cloud/bigtable/internal/google_bytes_traits_test.cc
@@ -17,9 +17,8 @@
 
 namespace google {
 namespace cloud {
-namespace bigtable {
+namespace bigtable_internal {
 inline namespace BIGTABLE_CLIENT_NS {
-namespace internal {
 namespace {
 
 TEST(GoogleBytesTraitsTest, ConsecutiveRowKeys) {
@@ -31,8 +30,7 @@ TEST(GoogleBytesTraitsTest, ConsecutiveRowKeys) {
 }
 
 }  // namespace
-}  // namespace internal
 }  // namespace BIGTABLE_CLIENT_NS
-}  // namespace bigtable
+}  // namespace bigtable_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/bigtable/internal/logging_admin_client.cc
+++ b/google/cloud/bigtable/internal/logging_admin_client.cc
@@ -21,9 +21,8 @@
 
 namespace google {
 namespace cloud {
-namespace bigtable {
+namespace bigtable_internal {
 inline namespace BIGTABLE_CLIENT_NS {
-namespace internal {
 
 namespace btadmin = ::google::bigtable::admin::v2;
 using ::google::cloud::internal::LogWrapper;
@@ -416,8 +415,7 @@ LoggingAdminClient::AsyncGetOperation(
       stub->AsyncGetOperation(context, request, cq).release());
 }
 
-}  // namespace internal
 }  // namespace BIGTABLE_CLIENT_NS
-}  // namespace bigtable
+}  // namespace bigtable_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/bigtable/internal/logging_admin_client.h
+++ b/google/cloud/bigtable/internal/logging_admin_client.h
@@ -42,7 +42,7 @@ namespace btadmin = ::google::bigtable::admin::v2;
 class LoggingAdminClient : public bigtable::AdminClient {
  public:
   LoggingAdminClient(std::shared_ptr<bigtable::AdminClient> child,
-                     google::cloud::TracingOptions options)
+                     TracingOptions options)
       : child_(std::move(child)), tracing_options_(std::move(options)) {}
 
   std::string const& project() const override { return child_->project(); }
@@ -240,8 +240,8 @@ class LoggingAdminClient : public bigtable::AdminClient {
     return child_->BackgroundThreadsFactory();
   }
 
-  std::shared_ptr<google::cloud::bigtable::AdminClient> child_;
-  google::cloud::TracingOptions tracing_options_;
+  std::shared_ptr<bigtable::AdminClient> child_;
+  TracingOptions tracing_options_;
 };
 
 }  // namespace BIGTABLE_CLIENT_NS

--- a/google/cloud/bigtable/internal/logging_admin_client.h
+++ b/google/cloud/bigtable/internal/logging_admin_client.h
@@ -41,9 +41,8 @@ namespace btadmin = ::google::bigtable::admin::v2;
 
 class LoggingAdminClient : public bigtable::AdminClient {
  public:
-  LoggingAdminClient(
-      std::shared_ptr<bigtable::AdminClient> child,
-      google::cloud::TracingOptions options)
+  LoggingAdminClient(std::shared_ptr<bigtable::AdminClient> child,
+                     google::cloud::TracingOptions options)
       : child_(std::move(child)), tracing_options_(std::move(options)) {}
 
   std::string const& project() const override { return child_->project(); }
@@ -62,8 +61,8 @@ class LoggingAdminClient : public bigtable::AdminClient {
                           btadmin::ListTablesRequest const& request,
                           btadmin::ListTablesResponse* response) override;
 
-  std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<
-      btadmin::ListTablesResponse>>
+  std::unique_ptr<
+      grpc::ClientAsyncResponseReaderInterface<btadmin::ListTablesResponse>>
   AsyncListTables(grpc::ClientContext* context,
                   btadmin::ListTablesRequest const& request,
                   grpc::CompletionQueue* cq) override;
@@ -72,8 +71,7 @@ class LoggingAdminClient : public bigtable::AdminClient {
                         btadmin::GetTableRequest const& request,
                         btadmin::Table* response) override;
 
-  std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<
-      btadmin::Table>>
+  std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<btadmin::Table>>
   AsyncGetTable(grpc::ClientContext* context,
                 btadmin::GetTableRequest const& request,
                 grpc::CompletionQueue* cq) override;
@@ -143,89 +141,74 @@ class LoggingAdminClient : public bigtable::AdminClient {
       google::iam::v1::TestIamPermissionsRequest const& request,
       google::iam::v1::TestIamPermissionsResponse* response) override;
 
-  std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<
-      btadmin::Table>>
-  AsyncCreateTable(
-      grpc::ClientContext* context,
-      btadmin::CreateTableRequest const& request,
-      grpc::CompletionQueue* cq) override;
+  std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<btadmin::Table>>
+  AsyncCreateTable(grpc::ClientContext* context,
+                   btadmin::CreateTableRequest const& request,
+                   grpc::CompletionQueue* cq) override;
 
   std::unique_ptr<
       ::grpc::ClientAsyncResponseReaderInterface<::google::protobuf::Empty>>
-  AsyncDeleteTable(
-      grpc::ClientContext* context,
-      btadmin::DeleteTableRequest const& request,
-      grpc::CompletionQueue* cq) override;
+  AsyncDeleteTable(grpc::ClientContext* context,
+                   btadmin::DeleteTableRequest const& request,
+                   grpc::CompletionQueue* cq) override;
 
   std::unique_ptr<
       grpc::ClientAsyncResponseReaderInterface<google::longrunning::Operation>>
-  AsyncCreateBackup(
-      grpc::ClientContext* context,
-      btadmin::CreateBackupRequest const& request,
-      grpc::CompletionQueue* cq) override;
+  AsyncCreateBackup(grpc::ClientContext* context,
+                    btadmin::CreateBackupRequest const& request,
+                    grpc::CompletionQueue* cq) override;
 
-  std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<
-      btadmin::Backup>>
+  std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<btadmin::Backup>>
   AsyncGetBackup(grpc::ClientContext* context,
                  btadmin::GetBackupRequest const& request,
                  grpc::CompletionQueue* cq) override;
 
-  std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<
-      btadmin::Backup>>
-  AsyncUpdateBackup(
-      grpc::ClientContext* context,
-      btadmin::UpdateBackupRequest const& request,
-      grpc::CompletionQueue* cq) override;
+  std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<btadmin::Backup>>
+  AsyncUpdateBackup(grpc::ClientContext* context,
+                    btadmin::UpdateBackupRequest const& request,
+                    grpc::CompletionQueue* cq) override;
 
   std::unique_ptr<
       grpc::ClientAsyncResponseReaderInterface<google::protobuf::Empty>>
-  AsyncDeleteBackup(
-      grpc::ClientContext* context,
-      btadmin::DeleteBackupRequest const& request,
-      grpc::CompletionQueue* cq) override;
+  AsyncDeleteBackup(grpc::ClientContext* context,
+                    btadmin::DeleteBackupRequest const& request,
+                    grpc::CompletionQueue* cq) override;
 
-  std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<
-      btadmin::ListBackupsResponse>>
-  AsyncListBackups(
-      grpc::ClientContext* context,
-      btadmin::ListBackupsRequest const& request,
-      grpc::CompletionQueue* cq) override;
+  std::unique_ptr<
+      grpc::ClientAsyncResponseReaderInterface<btadmin::ListBackupsResponse>>
+  AsyncListBackups(grpc::ClientContext* context,
+                   btadmin::ListBackupsRequest const& request,
+                   grpc::CompletionQueue* cq) override;
 
   std::unique_ptr<
       grpc::ClientAsyncResponseReaderInterface<google::longrunning::Operation>>
-  AsyncRestoreTable(
-      grpc::ClientContext* context,
-      btadmin::RestoreTableRequest const& request,
-      grpc::CompletionQueue* cq) override;
+  AsyncRestoreTable(grpc::ClientContext* context,
+                    btadmin::RestoreTableRequest const& request,
+                    grpc::CompletionQueue* cq) override;
 
-  std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<
-      btadmin::Table>>
-  AsyncModifyColumnFamilies(
-      grpc::ClientContext* context,
-      btadmin::ModifyColumnFamiliesRequest const& request,
-      grpc::CompletionQueue* cq) override;
+  std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<btadmin::Table>>
+  AsyncModifyColumnFamilies(grpc::ClientContext* context,
+                            btadmin::ModifyColumnFamiliesRequest const& request,
+                            grpc::CompletionQueue* cq) override;
 
   std::unique_ptr<
       grpc::ClientAsyncResponseReaderInterface<google::protobuf::Empty>>
-  AsyncDropRowRange(
-      grpc::ClientContext* context,
-      btadmin::DropRowRangeRequest const& request,
-      grpc::CompletionQueue* cq) override;
+  AsyncDropRowRange(grpc::ClientContext* context,
+                    btadmin::DropRowRangeRequest const& request,
+                    grpc::CompletionQueue* cq) override;
 
   std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<
       btadmin::GenerateConsistencyTokenResponse>>
   AsyncGenerateConsistencyToken(
       grpc::ClientContext* context,
-      btadmin::GenerateConsistencyTokenRequest const&
-          request,
+      btadmin::GenerateConsistencyTokenRequest const& request,
       grpc::CompletionQueue* cq) override;
 
   std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<
       btadmin::CheckConsistencyResponse>>
-  AsyncCheckConsistency(
-      grpc::ClientContext* context,
-      btadmin::CheckConsistencyRequest const& request,
-      grpc::CompletionQueue* cq) override;
+  AsyncCheckConsistency(grpc::ClientContext* context,
+                        btadmin::CheckConsistencyRequest const& request,
+                        grpc::CompletionQueue* cq) override;
 
   std::unique_ptr<
       grpc::ClientAsyncResponseReaderInterface<google::iam::v1::Policy>>

--- a/google/cloud/bigtable/internal/logging_admin_client.h
+++ b/google/cloud/bigtable/internal/logging_admin_client.h
@@ -21,9 +21,8 @@
 
 namespace google {
 namespace cloud {
-namespace bigtable {
+namespace bigtable_internal {
 inline namespace BIGTABLE_CLIENT_NS {
-namespace internal {
 
 namespace btadmin = ::google::bigtable::admin::v2;
 
@@ -40,10 +39,10 @@ namespace btadmin = ::google::bigtable::admin::v2;
  * connections need refreshing.
  */
 
-class LoggingAdminClient : public google::cloud::bigtable::AdminClient {
+class LoggingAdminClient : public bigtable::AdminClient {
  public:
   LoggingAdminClient(
-      std::shared_ptr<google::cloud::bigtable::AdminClient> child,
+      std::shared_ptr<bigtable::AdminClient> child,
       google::cloud::TracingOptions options)
       : child_(std::move(child)), tracing_options_(std::move(options)) {}
 
@@ -64,9 +63,9 @@ class LoggingAdminClient : public google::cloud::bigtable::AdminClient {
                           btadmin::ListTablesResponse* response) override;
 
   std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<
-      google::bigtable::admin::v2::ListTablesResponse>>
+      btadmin::ListTablesResponse>>
   AsyncListTables(grpc::ClientContext* context,
-                  google::bigtable::admin::v2::ListTablesRequest const& request,
+                  btadmin::ListTablesRequest const& request,
                   grpc::CompletionQueue* cq) override;
 
   grpc::Status GetTable(grpc::ClientContext* context,
@@ -74,9 +73,9 @@ class LoggingAdminClient : public google::cloud::bigtable::AdminClient {
                         btadmin::Table* response) override;
 
   std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<
-      google::bigtable::admin::v2::Table>>
+      btadmin::Table>>
   AsyncGetTable(grpc::ClientContext* context,
-                google::bigtable::admin::v2::GetTableRequest const& request,
+                btadmin::GetTableRequest const& request,
                 grpc::CompletionQueue* cq) override;
 
   grpc::Status DeleteTable(grpc::ClientContext* context,
@@ -145,87 +144,87 @@ class LoggingAdminClient : public google::cloud::bigtable::AdminClient {
       google::iam::v1::TestIamPermissionsResponse* response) override;
 
   std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<
-      google::bigtable::admin::v2::Table>>
+      btadmin::Table>>
   AsyncCreateTable(
       grpc::ClientContext* context,
-      google::bigtable::admin::v2::CreateTableRequest const& request,
+      btadmin::CreateTableRequest const& request,
       grpc::CompletionQueue* cq) override;
 
   std::unique_ptr<
       ::grpc::ClientAsyncResponseReaderInterface<::google::protobuf::Empty>>
   AsyncDeleteTable(
       grpc::ClientContext* context,
-      google::bigtable::admin::v2::DeleteTableRequest const& request,
+      btadmin::DeleteTableRequest const& request,
       grpc::CompletionQueue* cq) override;
 
   std::unique_ptr<
       grpc::ClientAsyncResponseReaderInterface<google::longrunning::Operation>>
   AsyncCreateBackup(
       grpc::ClientContext* context,
-      google::bigtable::admin::v2::CreateBackupRequest const& request,
+      btadmin::CreateBackupRequest const& request,
       grpc::CompletionQueue* cq) override;
 
   std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<
-      google::bigtable::admin::v2::Backup>>
+      btadmin::Backup>>
   AsyncGetBackup(grpc::ClientContext* context,
-                 google::bigtable::admin::v2::GetBackupRequest const& request,
+                 btadmin::GetBackupRequest const& request,
                  grpc::CompletionQueue* cq) override;
 
   std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<
-      google::bigtable::admin::v2::Backup>>
+      btadmin::Backup>>
   AsyncUpdateBackup(
       grpc::ClientContext* context,
-      google::bigtable::admin::v2::UpdateBackupRequest const& request,
+      btadmin::UpdateBackupRequest const& request,
       grpc::CompletionQueue* cq) override;
 
   std::unique_ptr<
       grpc::ClientAsyncResponseReaderInterface<google::protobuf::Empty>>
   AsyncDeleteBackup(
       grpc::ClientContext* context,
-      google::bigtable::admin::v2::DeleteBackupRequest const& request,
+      btadmin::DeleteBackupRequest const& request,
       grpc::CompletionQueue* cq) override;
 
   std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<
-      google::bigtable::admin::v2::ListBackupsResponse>>
+      btadmin::ListBackupsResponse>>
   AsyncListBackups(
       grpc::ClientContext* context,
-      google::bigtable::admin::v2::ListBackupsRequest const& request,
+      btadmin::ListBackupsRequest const& request,
       grpc::CompletionQueue* cq) override;
 
   std::unique_ptr<
       grpc::ClientAsyncResponseReaderInterface<google::longrunning::Operation>>
   AsyncRestoreTable(
       grpc::ClientContext* context,
-      google::bigtable::admin::v2::RestoreTableRequest const& request,
+      btadmin::RestoreTableRequest const& request,
       grpc::CompletionQueue* cq) override;
 
   std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<
-      google::bigtable::admin::v2::Table>>
+      btadmin::Table>>
   AsyncModifyColumnFamilies(
       grpc::ClientContext* context,
-      google::bigtable::admin::v2::ModifyColumnFamiliesRequest const& request,
+      btadmin::ModifyColumnFamiliesRequest const& request,
       grpc::CompletionQueue* cq) override;
 
   std::unique_ptr<
       grpc::ClientAsyncResponseReaderInterface<google::protobuf::Empty>>
   AsyncDropRowRange(
       grpc::ClientContext* context,
-      google::bigtable::admin::v2::DropRowRangeRequest const& request,
+      btadmin::DropRowRangeRequest const& request,
       grpc::CompletionQueue* cq) override;
 
   std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<
-      google::bigtable::admin::v2::GenerateConsistencyTokenResponse>>
+      btadmin::GenerateConsistencyTokenResponse>>
   AsyncGenerateConsistencyToken(
       grpc::ClientContext* context,
-      google::bigtable::admin::v2::GenerateConsistencyTokenRequest const&
+      btadmin::GenerateConsistencyTokenRequest const&
           request,
       grpc::CompletionQueue* cq) override;
 
   std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<
-      google::bigtable::admin::v2::CheckConsistencyResponse>>
+      btadmin::CheckConsistencyResponse>>
   AsyncCheckConsistency(
       grpc::ClientContext* context,
-      google::bigtable::admin::v2::CheckConsistencyRequest const& request,
+      btadmin::CheckConsistencyRequest const& request,
       grpc::CompletionQueue* cq) override;
 
   std::unique_ptr<
@@ -262,9 +261,8 @@ class LoggingAdminClient : public google::cloud::bigtable::AdminClient {
   google::cloud::TracingOptions tracing_options_;
 };
 
-}  // namespace internal
 }  // namespace BIGTABLE_CLIENT_NS
-}  // namespace bigtable
+}  // namespace bigtable_internal
 }  // namespace cloud
 }  // namespace google
 

--- a/google/cloud/bigtable/internal/logging_admin_client_test.cc
+++ b/google/cloud/bigtable/internal/logging_admin_client_test.cc
@@ -44,7 +44,7 @@ TEST_F(LoggingAdminClientTest, CreateTable) {
 
   EXPECT_CALL(*mock, CreateTable).WillOnce(Return(grpc::Status()));
 
-  internal::LoggingAdminClient stub(
+  bigtable_internal::LoggingAdminClient stub(
       mock, TracingOptions{}.SetOptions("single_line_mode"));
 
   grpc::ClientContext context;
@@ -62,7 +62,7 @@ TEST_F(LoggingAdminClientTest, ListTables) {
 
   EXPECT_CALL(*mock, ListTables).WillOnce(Return(grpc::Status()));
 
-  internal::LoggingAdminClient stub(
+  bigtable_internal::LoggingAdminClient stub(
       mock, TracingOptions{}.SetOptions("single_line_mode"));
 
   grpc::ClientContext context;
@@ -80,7 +80,7 @@ TEST_F(LoggingAdminClientTest, GetTable) {
 
   EXPECT_CALL(*mock, GetTable).WillOnce(Return(grpc::Status()));
 
-  internal::LoggingAdminClient stub(
+  bigtable_internal::LoggingAdminClient stub(
       mock, TracingOptions{}.SetOptions("single_line_mode"));
 
   grpc::ClientContext context;
@@ -98,7 +98,7 @@ TEST_F(LoggingAdminClientTest, DeleteTable) {
 
   EXPECT_CALL(*mock, DeleteTable).WillOnce(Return(grpc::Status()));
 
-  internal::LoggingAdminClient stub(
+  bigtable_internal::LoggingAdminClient stub(
       mock, TracingOptions{}.SetOptions("single_line_mode"));
 
   grpc::ClientContext context;
@@ -116,7 +116,7 @@ TEST_F(LoggingAdminClientTest, CreateBackup) {
 
   EXPECT_CALL(*mock, CreateBackup).WillOnce(Return(grpc::Status()));
 
-  internal::LoggingAdminClient stub(
+  bigtable_internal::LoggingAdminClient stub(
       mock, TracingOptions{}.SetOptions("single_line_mode"));
 
   grpc::ClientContext context;
@@ -134,7 +134,7 @@ TEST_F(LoggingAdminClientTest, GetBackup) {
 
   EXPECT_CALL(*mock, GetBackup).WillOnce(Return(grpc::Status()));
 
-  internal::LoggingAdminClient stub(
+  bigtable_internal::LoggingAdminClient stub(
       mock, TracingOptions{}.SetOptions("single_line_mode"));
 
   grpc::ClientContext context;
@@ -152,7 +152,7 @@ TEST_F(LoggingAdminClientTest, UpdateBackup) {
 
   EXPECT_CALL(*mock, UpdateBackup).WillOnce(Return(grpc::Status()));
 
-  internal::LoggingAdminClient stub(
+  bigtable_internal::LoggingAdminClient stub(
       mock, TracingOptions{}.SetOptions("single_line_mode"));
 
   grpc::ClientContext context;
@@ -170,7 +170,7 @@ TEST_F(LoggingAdminClientTest, DeleteBackup) {
 
   EXPECT_CALL(*mock, DeleteBackup).WillOnce(Return(grpc::Status()));
 
-  internal::LoggingAdminClient stub(
+  bigtable_internal::LoggingAdminClient stub(
       mock, TracingOptions{}.SetOptions("single_line_mode"));
 
   grpc::ClientContext context;
@@ -188,7 +188,7 @@ TEST_F(LoggingAdminClientTest, ListBackups) {
 
   EXPECT_CALL(*mock, ListBackups).WillOnce(Return(grpc::Status()));
 
-  internal::LoggingAdminClient stub(
+  bigtable_internal::LoggingAdminClient stub(
       mock, TracingOptions{}.SetOptions("single_line_mode"));
 
   grpc::ClientContext context;
@@ -206,7 +206,7 @@ TEST_F(LoggingAdminClientTest, RestoreTable) {
 
   EXPECT_CALL(*mock, RestoreTable).WillOnce(Return(grpc::Status()));
 
-  internal::LoggingAdminClient stub(
+  bigtable_internal::LoggingAdminClient stub(
       mock, TracingOptions{}.SetOptions("single_line_mode"));
 
   grpc::ClientContext context;
@@ -224,7 +224,7 @@ TEST_F(LoggingAdminClientTest, ModifyColumnFamilies) {
 
   EXPECT_CALL(*mock, ModifyColumnFamilies).WillOnce(Return(grpc::Status()));
 
-  internal::LoggingAdminClient stub(
+  bigtable_internal::LoggingAdminClient stub(
       mock, TracingOptions{}.SetOptions("single_line_mode"));
 
   grpc::ClientContext context;
@@ -242,7 +242,7 @@ TEST_F(LoggingAdminClientTest, DropRowRange) {
 
   EXPECT_CALL(*mock, DropRowRange).WillOnce(Return(grpc::Status()));
 
-  internal::LoggingAdminClient stub(
+  bigtable_internal::LoggingAdminClient stub(
       mock, TracingOptions{}.SetOptions("single_line_mode"));
 
   grpc::ClientContext context;
@@ -260,7 +260,7 @@ TEST_F(LoggingAdminClientTest, GenerateConsistencyToken) {
 
   EXPECT_CALL(*mock, GenerateConsistencyToken).WillOnce(Return(grpc::Status()));
 
-  internal::LoggingAdminClient stub(
+  bigtable_internal::LoggingAdminClient stub(
       mock, TracingOptions{}.SetOptions("single_line_mode"));
 
   grpc::ClientContext context;
@@ -279,7 +279,7 @@ TEST_F(LoggingAdminClientTest, CheckConsistency) {
 
   EXPECT_CALL(*mock, CheckConsistency).WillOnce(Return(grpc::Status()));
 
-  internal::LoggingAdminClient stub(
+  bigtable_internal::LoggingAdminClient stub(
       mock, TracingOptions{}.SetOptions("single_line_mode"));
 
   grpc::ClientContext context;
@@ -297,7 +297,7 @@ TEST_F(LoggingAdminClientTest, GetOperation) {
 
   EXPECT_CALL(*mock, GetOperation).WillOnce(Return(grpc::Status()));
 
-  internal::LoggingAdminClient stub(
+  bigtable_internal::LoggingAdminClient stub(
       mock, TracingOptions{}.SetOptions("single_line_mode"));
 
   grpc::ClientContext context;
@@ -315,7 +315,7 @@ TEST_F(LoggingAdminClientTest, GetIamPolicy) {
 
   EXPECT_CALL(*mock, GetIamPolicy).WillOnce(Return(grpc::Status()));
 
-  internal::LoggingAdminClient stub(
+  bigtable_internal::LoggingAdminClient stub(
       mock, TracingOptions{}.SetOptions("single_line_mode"));
 
   grpc::ClientContext context;
@@ -333,7 +333,7 @@ TEST_F(LoggingAdminClientTest, SetIamPolicy) {
 
   EXPECT_CALL(*mock, SetIamPolicy).WillOnce(Return(grpc::Status()));
 
-  internal::LoggingAdminClient stub(
+  bigtable_internal::LoggingAdminClient stub(
       mock, TracingOptions{}.SetOptions("single_line_mode"));
 
   grpc::ClientContext context;
@@ -351,7 +351,7 @@ TEST_F(LoggingAdminClientTest, TestIamPermissions) {
 
   EXPECT_CALL(*mock, TestIamPermissions).WillOnce(Return(grpc::Status()));
 
-  internal::LoggingAdminClient stub(
+  bigtable_internal::LoggingAdminClient stub(
       mock, TracingOptions{}.SetOptions("single_line_mode"));
 
   grpc::ClientContext context;

--- a/google/cloud/bigtable/internal/logging_data_client.cc
+++ b/google/cloud/bigtable/internal/logging_data_client.cc
@@ -21,9 +21,8 @@
 
 namespace google {
 namespace cloud {
-namespace bigtable {
+namespace bigtable_internal {
 inline namespace BIGTABLE_CLIENT_NS {
-namespace internal {
 
 namespace btproto = ::google::bigtable::v2;
 using ::google::cloud::internal::LogWrapper;
@@ -178,8 +177,7 @@ LoggingDataClient::PrepareAsyncMutateRows(
   return child_->PrepareAsyncMutateRows(context, request, cq);
 }
 
-}  // namespace internal
 }  // namespace BIGTABLE_CLIENT_NS
-}  // namespace bigtable
+}  // namespace bigtable_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/bigtable/internal/logging_data_client.h
+++ b/google/cloud/bigtable/internal/logging_data_client.h
@@ -21,9 +21,8 @@
 
 namespace google {
 namespace cloud {
-namespace bigtable {
+namespace bigtable_internal {
 inline namespace BIGTABLE_CLIENT_NS {
-namespace internal {
 
 namespace btproto = ::google::bigtable::v2;
 
@@ -33,10 +32,10 @@ namespace btproto = ::google::bigtable::v2;
  * This implementation does not support multiple threads, or refresh
  * authorization tokens.  In other words, it is extremely bare bones.
  */
-class LoggingDataClient : public DataClient {
+class LoggingDataClient : public bigtable::DataClient {
  public:
-  LoggingDataClient(std::shared_ptr<google::cloud::bigtable::DataClient> child,
-                    google::cloud::TracingOptions options)
+  LoggingDataClient(std::shared_ptr<bigtable::DataClient> child,
+                    TracingOptions options)
       : child_(std::move(child)), tracing_options_(std::move(options)) {}
 
   std::string const& project_id() const override {
@@ -141,13 +140,12 @@ class LoggingDataClient : public DataClient {
     return child_->BackgroundThreadsFactory();
   }
 
-  std::shared_ptr<google::cloud::bigtable::DataClient> child_;
+  std::shared_ptr<bigtable::DataClient> child_;
   google::cloud::TracingOptions tracing_options_;
 };
 
-}  // namespace internal
 }  // namespace BIGTABLE_CLIENT_NS
-}  // namespace bigtable
+}  // namespace bigtable_internal
 }  // namespace cloud
 }  // namespace google
 

--- a/google/cloud/bigtable/internal/logging_data_client_test.cc
+++ b/google/cloud/bigtable/internal/logging_data_client_test.cc
@@ -44,7 +44,7 @@ TEST_F(LoggingDataClientTest, MutateRow) {
 
   EXPECT_CALL(*mock, MutateRow).WillOnce(Return(grpc::Status()));
 
-  internal::LoggingDataClient stub(
+  bigtable_internal::LoggingDataClient stub(
       mock, TracingOptions{}.SetOptions("single_line_mode"));
 
   grpc::ClientContext context;
@@ -62,7 +62,7 @@ TEST_F(LoggingDataClientTest, CheckAndMutateRow) {
 
   EXPECT_CALL(*mock, CheckAndMutateRow).WillOnce(Return(grpc::Status()));
 
-  internal::LoggingDataClient stub(
+  bigtable_internal::LoggingDataClient stub(
       mock, TracingOptions{}.SetOptions("single_line_mode"));
 
   grpc::ClientContext context;
@@ -80,7 +80,7 @@ TEST_F(LoggingDataClientTest, ReadModifyWriteRow) {
 
   EXPECT_CALL(*mock, ReadModifyWriteRow).WillOnce(Return(grpc::Status()));
 
-  internal::LoggingDataClient stub(
+  bigtable_internal::LoggingDataClient stub(
       mock, TracingOptions{}.SetOptions("single_line_mode"));
 
   grpc::ClientContext context;
@@ -102,7 +102,7 @@ TEST_F(LoggingDataClientTest, ReadRows) {
             grpc::ClientReaderInterface<btproto::ReadRowsResponse>>{};
       });
 
-  internal::LoggingDataClient stub(
+  bigtable_internal::LoggingDataClient stub(
       mock, TracingOptions{}.SetOptions("single_line_mode"));
 
   grpc::ClientContext context;
@@ -122,7 +122,7 @@ TEST_F(LoggingDataClientTest, SampleRowKeys) {
             grpc::ClientReaderInterface<btproto::SampleRowKeysResponse>>{};
       });
 
-  internal::LoggingDataClient stub(
+  bigtable_internal::LoggingDataClient stub(
       mock, TracingOptions{}.SetOptions("single_line_mode"));
 
   grpc::ClientContext context;
@@ -142,7 +142,7 @@ TEST_F(LoggingDataClientTest, MutateRows) {
             grpc::ClientReaderInterface<btproto::MutateRowsResponse>>{};
       });
 
-  internal::LoggingDataClient stub(
+  bigtable_internal::LoggingDataClient stub(
       mock, TracingOptions{}.SetOptions("single_line_mode"));
 
   grpc::ClientContext context;

--- a/google/cloud/bigtable/internal/logging_instance_admin_client.cc
+++ b/google/cloud/bigtable/internal/logging_instance_admin_client.cc
@@ -21,9 +21,8 @@
 
 namespace google {
 namespace cloud {
-namespace bigtable {
+namespace bigtable_internal {
 inline namespace BIGTABLE_CLIENT_NS {
-namespace internal {
 
 namespace btadmin = ::google::bigtable::admin::v2;
 using ::google::cloud::internal::LogWrapper;
@@ -432,8 +431,7 @@ LoggingInstanceAdminClient::AsyncGetOperation(
   return child_->AsyncGetOperation(context, request, cq);
 }
 
-}  // namespace internal
 }  // namespace BIGTABLE_CLIENT_NS
-}  // namespace bigtable
+}  // namespace bigtable_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/bigtable/internal/logging_instance_admin_client.h
+++ b/google/cloud/bigtable/internal/logging_instance_admin_client.h
@@ -44,12 +44,11 @@ inline namespace BIGTABLE_CLIENT_NS {
  * `InstanceAdminClient` instances when possible.
  */
 
-class LoggingInstanceAdminClient
-    : public google::cloud::bigtable::InstanceAdminClient {
+class LoggingInstanceAdminClient : public bigtable::InstanceAdminClient {
  public:
   LoggingInstanceAdminClient(
-      std::shared_ptr<google::cloud::bigtable::InstanceAdminClient> child,
-      google::cloud::TracingOptions options)
+      std::shared_ptr<bigtable::InstanceAdminClient> child,
+      TracingOptions options)
       : child_(std::move(child)), tracing_options_(std::move(options)) {}
 
   std::string const& project() const override { return child_->project(); }
@@ -286,8 +285,8 @@ class LoggingInstanceAdminClient
     return child_->BackgroundThreadsFactory();
   }
 
-  std::shared_ptr<google::cloud::bigtable::InstanceAdminClient> child_;
-  google::cloud::TracingOptions tracing_options_;
+  std::shared_ptr<bigtable::InstanceAdminClient> child_;
+  TracingOptions tracing_options_;
 };
 
 }  // namespace BIGTABLE_CLIENT_NS

--- a/google/cloud/bigtable/internal/logging_instance_admin_client.h
+++ b/google/cloud/bigtable/internal/logging_instance_admin_client.h
@@ -21,9 +21,8 @@
 
 namespace google {
 namespace cloud {
-namespace bigtable {
+namespace bigtable_internal {
 inline namespace BIGTABLE_CLIENT_NS {
-namespace internal {
 
 /**
  * Implements a logging InstanceAdminClient.
@@ -291,9 +290,8 @@ class LoggingInstanceAdminClient
   google::cloud::TracingOptions tracing_options_;
 };
 
-}  // namespace internal
 }  // namespace BIGTABLE_CLIENT_NS
-}  // namespace bigtable
+}  // namespace bigtable_internal
 }  // namespace cloud
 }  // namespace google
 

--- a/google/cloud/bigtable/internal/logging_instance_admin_client_test.cc
+++ b/google/cloud/bigtable/internal/logging_instance_admin_client_test.cc
@@ -50,7 +50,7 @@ TEST_F(LoggingInstanceAdminClientTest, ListInstances) {
 
   EXPECT_CALL(*mock, ListInstances).WillOnce(Return(grpc::Status()));
 
-  internal::LoggingInstanceAdminClient stub(
+  bigtable_internal::LoggingInstanceAdminClient stub(
       mock, TracingOptions{}.SetOptions("single_line_mode"));
 
   grpc::ClientContext context;
@@ -68,7 +68,7 @@ TEST_F(LoggingInstanceAdminClientTest, CreateInstance) {
 
   EXPECT_CALL(*mock, CreateInstance).WillOnce(Return(grpc::Status()));
 
-  internal::LoggingInstanceAdminClient stub(
+  bigtable_internal::LoggingInstanceAdminClient stub(
       mock, TracingOptions{}.SetOptions("single_line_mode"));
 
   grpc::ClientContext context;
@@ -86,7 +86,7 @@ TEST_F(LoggingInstanceAdminClientTest, UpdateInstance) {
 
   EXPECT_CALL(*mock, UpdateInstance).WillOnce(Return(grpc::Status()));
 
-  internal::LoggingInstanceAdminClient stub(
+  bigtable_internal::LoggingInstanceAdminClient stub(
       mock, TracingOptions{}.SetOptions("single_line_mode"));
 
   grpc::ClientContext context;
@@ -104,7 +104,7 @@ TEST_F(LoggingInstanceAdminClientTest, GetOperation) {
 
   EXPECT_CALL(*mock, GetOperation).WillOnce(Return(grpc::Status()));
 
-  internal::LoggingInstanceAdminClient stub(
+  bigtable_internal::LoggingInstanceAdminClient stub(
       mock, TracingOptions{}.SetOptions("single_line_mode"));
 
   grpc::ClientContext context;
@@ -122,7 +122,7 @@ TEST_F(LoggingInstanceAdminClientTest, GetInstance) {
 
   EXPECT_CALL(*mock, GetInstance).WillOnce(Return(grpc::Status()));
 
-  internal::LoggingInstanceAdminClient stub(
+  bigtable_internal::LoggingInstanceAdminClient stub(
       mock, TracingOptions{}.SetOptions("single_line_mode"));
 
   grpc::ClientContext context;
@@ -140,7 +140,7 @@ TEST_F(LoggingInstanceAdminClientTest, DeleteInstance) {
 
   EXPECT_CALL(*mock, DeleteInstance).WillOnce(Return(grpc::Status()));
 
-  internal::LoggingInstanceAdminClient stub(
+  bigtable_internal::LoggingInstanceAdminClient stub(
       mock, TracingOptions{}.SetOptions("single_line_mode"));
 
   grpc::ClientContext context;
@@ -158,7 +158,7 @@ TEST_F(LoggingInstanceAdminClientTest, ListClusters) {
 
   EXPECT_CALL(*mock, ListClusters).WillOnce(Return(grpc::Status()));
 
-  internal::LoggingInstanceAdminClient stub(
+  bigtable_internal::LoggingInstanceAdminClient stub(
       mock, TracingOptions{}.SetOptions("single_line_mode"));
 
   grpc::ClientContext context;
@@ -176,7 +176,7 @@ TEST_F(LoggingInstanceAdminClientTest, GetCluster) {
 
   EXPECT_CALL(*mock, GetCluster).WillOnce(Return(grpc::Status()));
 
-  internal::LoggingInstanceAdminClient stub(
+  bigtable_internal::LoggingInstanceAdminClient stub(
       mock, TracingOptions{}.SetOptions("single_line_mode"));
 
   grpc::ClientContext context;
@@ -194,7 +194,7 @@ TEST_F(LoggingInstanceAdminClientTest, DeleteCluster) {
 
   EXPECT_CALL(*mock, DeleteCluster).WillOnce(Return(grpc::Status()));
 
-  internal::LoggingInstanceAdminClient stub(
+  bigtable_internal::LoggingInstanceAdminClient stub(
       mock, TracingOptions{}.SetOptions("single_line_mode"));
 
   grpc::ClientContext context;
@@ -212,7 +212,7 @@ TEST_F(LoggingInstanceAdminClientTest, CreateCluster) {
 
   EXPECT_CALL(*mock, CreateCluster).WillOnce(Return(grpc::Status()));
 
-  internal::LoggingInstanceAdminClient stub(
+  bigtable_internal::LoggingInstanceAdminClient stub(
       mock, TracingOptions{}.SetOptions("single_line_mode"));
 
   grpc::ClientContext context;
@@ -230,7 +230,7 @@ TEST_F(LoggingInstanceAdminClientTest, UpdateCluster) {
 
   EXPECT_CALL(*mock, UpdateCluster).WillOnce(Return(grpc::Status()));
 
-  internal::LoggingInstanceAdminClient stub(
+  bigtable_internal::LoggingInstanceAdminClient stub(
       mock, TracingOptions{}.SetOptions("single_line_mode"));
 
   grpc::ClientContext context;
@@ -248,7 +248,7 @@ TEST_F(LoggingInstanceAdminClientTest, CreateAppProfile) {
 
   EXPECT_CALL(*mock, CreateAppProfile).WillOnce(Return(grpc::Status()));
 
-  internal::LoggingInstanceAdminClient stub(
+  bigtable_internal::LoggingInstanceAdminClient stub(
       mock, TracingOptions{}.SetOptions("single_line_mode"));
 
   grpc::ClientContext context;
@@ -266,7 +266,7 @@ TEST_F(LoggingInstanceAdminClientTest, GetAppProfile) {
 
   EXPECT_CALL(*mock, GetAppProfile).WillOnce(Return(grpc::Status()));
 
-  internal::LoggingInstanceAdminClient stub(
+  bigtable_internal::LoggingInstanceAdminClient stub(
       mock, TracingOptions{}.SetOptions("single_line_mode"));
 
   grpc::ClientContext context;
@@ -284,7 +284,7 @@ TEST_F(LoggingInstanceAdminClientTest, ListAppProfiles) {
 
   EXPECT_CALL(*mock, ListAppProfiles).WillOnce(Return(grpc::Status()));
 
-  internal::LoggingInstanceAdminClient stub(
+  bigtable_internal::LoggingInstanceAdminClient stub(
       mock, TracingOptions{}.SetOptions("single_line_mode"));
 
   grpc::ClientContext context;
@@ -302,7 +302,7 @@ TEST_F(LoggingInstanceAdminClientTest, UpdateAppProfile) {
 
   EXPECT_CALL(*mock, UpdateAppProfile).WillOnce(Return(grpc::Status()));
 
-  internal::LoggingInstanceAdminClient stub(
+  bigtable_internal::LoggingInstanceAdminClient stub(
       mock, TracingOptions{}.SetOptions("single_line_mode"));
 
   grpc::ClientContext context;
@@ -320,7 +320,7 @@ TEST_F(LoggingInstanceAdminClientTest, DeleteAppProfile) {
 
   EXPECT_CALL(*mock, DeleteAppProfile).WillOnce(Return(grpc::Status()));
 
-  internal::LoggingInstanceAdminClient stub(
+  bigtable_internal::LoggingInstanceAdminClient stub(
       mock, TracingOptions{}.SetOptions("single_line_mode"));
 
   grpc::ClientContext context;
@@ -338,7 +338,7 @@ TEST_F(LoggingInstanceAdminClientTest, GetIamPolicy) {
 
   EXPECT_CALL(*mock, GetIamPolicy).WillOnce(Return(grpc::Status()));
 
-  internal::LoggingInstanceAdminClient stub(
+  bigtable_internal::LoggingInstanceAdminClient stub(
       mock, TracingOptions{}.SetOptions("single_line_mode"));
 
   grpc::ClientContext context;
@@ -356,7 +356,7 @@ TEST_F(LoggingInstanceAdminClientTest, SetIamPolicy) {
 
   EXPECT_CALL(*mock, SetIamPolicy).WillOnce(Return(grpc::Status()));
 
-  internal::LoggingInstanceAdminClient stub(
+  bigtable_internal::LoggingInstanceAdminClient stub(
       mock, TracingOptions{}.SetOptions("single_line_mode"));
 
   grpc::ClientContext context;
@@ -374,7 +374,7 @@ TEST_F(LoggingInstanceAdminClientTest, TestIamPermissions) {
 
   EXPECT_CALL(*mock, TestIamPermissions).WillOnce(Return(grpc::Status()));
 
-  internal::LoggingInstanceAdminClient stub(
+  bigtable_internal::LoggingInstanceAdminClient stub(
       mock, TracingOptions{}.SetOptions("single_line_mode"));
 
   grpc::ClientContext context;
@@ -399,7 +399,7 @@ TEST_F(LoggingInstanceAdminClientTest, AsyncCreateInstance) {
             google::longrunning::Operation>>(reader.get());
       });
 
-  internal::LoggingInstanceAdminClient stub(
+  bigtable_internal::LoggingInstanceAdminClient stub(
       mock, TracingOptions{}.SetOptions("single_line_mode"));
 
   grpc::ClientContext context;
@@ -423,7 +423,7 @@ TEST_F(LoggingInstanceAdminClientTest, AsyncUpdateInstance) {
             google::longrunning::Operation>>(reader.get());
       });
 
-  internal::LoggingInstanceAdminClient stub(
+  bigtable_internal::LoggingInstanceAdminClient stub(
       mock, TracingOptions{}.SetOptions("single_line_mode"));
 
   grpc::ClientContext context;

--- a/google/cloud/bigtable/internal/prefix_range_end.cc
+++ b/google/cloud/bigtable/internal/prefix_range_end.cc
@@ -16,9 +16,8 @@
 
 namespace google {
 namespace cloud {
-namespace bigtable {
+namespace bigtable_internal {
 inline namespace BIGTABLE_CLIENT_NS {
-namespace internal {
 
 std::string PrefixRangeEnd(std::string const& key) {
   auto pos = key.find_last_not_of('\xFF');
@@ -37,8 +36,7 @@ std::string PrefixRangeEnd(std::string const& key) {
   return result;
 }
 
-}  // namespace internal
 }  // namespace BIGTABLE_CLIENT_NS
-}  // namespace bigtable
+}  // namespace bigtable_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/bigtable/internal/prefix_range_end.h
+++ b/google/cloud/bigtable/internal/prefix_range_end.h
@@ -20,9 +20,8 @@
 
 namespace google {
 namespace cloud {
-namespace bigtable {
+namespace bigtable_internal {
 inline namespace BIGTABLE_CLIENT_NS {
-namespace internal {
 /**
  * Return the end of the prefix range for @p key.
  *
@@ -33,9 +32,8 @@ namespace internal {
  */
 std::string PrefixRangeEnd(std::string const& key);
 
-}  // namespace internal
 }  // namespace BIGTABLE_CLIENT_NS
-}  // namespace bigtable
+}  // namespace bigtable_internal
 }  // namespace cloud
 }  // namespace google
 

--- a/google/cloud/bigtable/internal/prefix_range_end_test.cc
+++ b/google/cloud/bigtable/internal/prefix_range_end_test.cc
@@ -17,9 +17,8 @@
 
 namespace google {
 namespace cloud {
-namespace bigtable {
+namespace bigtable_internal {
 inline namespace BIGTABLE_CLIENT_NS {
-namespace internal {
 namespace {
 
 TEST(PrefixRangeEndTest, Simple) {
@@ -42,8 +41,7 @@ TEST(PrefixRangeEndTest, MostlyFFs) {
 }
 
 }  // namespace
-}  // namespace internal
 }  // namespace BIGTABLE_CLIENT_NS
-}  // namespace bigtable
+}  // namespace bigtable_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/bigtable/internal/readrowsparser.cc
+++ b/google/cloud/bigtable/internal/readrowsparser.cc
@@ -79,8 +79,8 @@ void ReadRowsParser::HandleChunk(ReadRowsResponse_CellChunk chunk,
   // This is a hint we get about the total size, use it to save some memory
   // allocations.
   if (chunk.value_size() > 0) {
-    bigtable_internal::ReserveCellValue(cell_.value,
-                               static_cast<std::size_t>(chunk.value_size()));
+    bigtable_internal::ReserveCellValue(
+        cell_.value, static_cast<std::size_t>(chunk.value_size()));
   }
 
   // Last chunk in the cell has zero for value size
@@ -170,7 +170,7 @@ bigtable::Cell ReadRowsParser::MovePartialToCell() {
   // ReadRows v2 may reuse them in future chunks. See the CellChunk
   // message comments in bigtable.proto.
   bigtable::Cell cell(cell_.row, cell_.family, cell_.column, cell_.timestamp,
-            std::move(cell_.value), std::move(cell_.labels));
+                      std::move(cell_.value), std::move(cell_.labels));
   cell_.value.clear();
   return cell;
 }

--- a/google/cloud/bigtable/internal/readrowsparser.cc
+++ b/google/cloud/bigtable/internal/readrowsparser.cc
@@ -71,7 +71,7 @@ void ReadRowsParser::HandleChunk(ReadRowsResponse_CellChunk chunk,
     using std::swap;
     swap(*chunk.mutable_value(), cell_.value);
   } else {
-    bigtable_internal::AppendCellValue(cell_.value, chunk.value());
+    AppendCellValue(cell_.value, chunk.value());
   }
 
   cell_first_chunk_ = false;
@@ -79,8 +79,7 @@ void ReadRowsParser::HandleChunk(ReadRowsResponse_CellChunk chunk,
   // This is a hint we get about the total size, use it to save some memory
   // allocations.
   if (chunk.value_size() > 0) {
-    bigtable_internal::ReserveCellValue(
-        cell_.value, static_cast<std::size_t>(chunk.value_size()));
+    ReserveCellValue(cell_.value, static_cast<std::size_t>(chunk.value_size()));
   }
 
   // Last chunk in the cell has zero for value size

--- a/google/cloud/bigtable/internal/readrowsparser.h
+++ b/google/cloud/bigtable/internal/readrowsparser.h
@@ -25,9 +25,8 @@
 
 namespace google {
 namespace cloud {
-namespace bigtable {
+namespace bigtable_internal {
 inline namespace BIGTABLE_CLIENT_NS {
-namespace internal {
 /**
  * Transforms a stream of chunks as returned by the ReadRows streaming
  * RPC into a sequence of rows.
@@ -78,16 +77,16 @@ class ReadRowsParser {
    *
    * @throws std::runtime_error if HasNext() is false.
    */
-  virtual Row Next(grpc::Status& status);
+  virtual bigtable::Row Next(grpc::Status& status);
 
  private:
   /// Holds partially formed data until a full Row is ready.
   struct ParseCell {
-    RowKeyType row;
+    bigtable::RowKeyType row;
     std::string family;
-    ColumnQualifierType column;
+    bigtable::ColumnQualifierType column;
     int64_t timestamp;
-    CellValueType value;
+    bigtable::CellValueType value;
     std::vector<std::string> labels;
   };
 
@@ -98,13 +97,13 @@ class ReadRowsParser {
    * when converting to a result cell, but the key, family and column
    * are copied, because they are possibly reused by following cells.
    */
-  Cell MovePartialToCell();
+  bigtable::Cell MovePartialToCell();
 
   /// Row key for the current row.
-  RowKeyType row_key_;
+  bigtable::RowKeyType row_key_;
 
   /// Parsed cells of a yet unfinished row.
-  std::vector<Cell> cells_;
+  std::vector<bigtable::Cell> cells_;
 
   /// Is the next incoming chunk the first in a cell?
   bool cell_first_chunk_{true};
@@ -113,7 +112,7 @@ class ReadRowsParser {
   ParseCell cell_;
 
   /// Set when a row is ready.
-  RowKeyType last_seen_row_key_;
+  bigtable::RowKeyType last_seen_row_key_;
 
   /// True iff cells_ make up a complete row.
   bool row_ready_{false};
@@ -132,9 +131,8 @@ class ReadRowsParserFactory {
     return absl::make_unique<ReadRowsParser>();
   }
 };
-}  // namespace internal
 }  // namespace BIGTABLE_CLIENT_NS
-}  // namespace bigtable
+}  // namespace bigtable_internal
 }  // namespace cloud
 }  // namespace google
 

--- a/google/cloud/bigtable/internal/readrowsparser_test.cc
+++ b/google/cloud/bigtable/internal/readrowsparser_test.cc
@@ -25,9 +25,8 @@
 
 namespace google {
 namespace cloud {
-namespace bigtable {
+namespace bigtable_internal {
 inline namespace BIGTABLE_CLIENT_NS {
-namespace internal {
 namespace {
 
 using ::google::bigtable::v2::ReadRowsResponse_CellChunk;
@@ -87,7 +86,7 @@ TEST(ReadRowsParserTest, SingleChunkSucceeds) {
   EXPECT_TRUE(status.ok());
   EXPECT_TRUE(parser.HasNext());
 
-  std::vector<google::cloud::bigtable::Row> rows;
+  std::vector<bigtable::Row> rows;
   rows.emplace_back(parser.Next(status));
   EXPECT_TRUE(status.ok());
   EXPECT_FALSE(parser.HasNext());
@@ -142,7 +141,7 @@ TEST(ReadRowsParserTest, NextWithNoDataThrows) {
 
 // **** Acceptance tests helpers ****
 // Can also be used by gtest to print Cell values
-void PrintTo(Cell const& c, std::ostream* os) {
+void PrintTo(bigtable::Cell const& c, std::ostream* os) {
   *os << "rk: " << std::string(c.row_key()) << "\n";
   *os << "fm: " << std::string(c.family_name()) << "\n";
   *os << "qual: " << std::string(c.column_qualifier()) << "\n";
@@ -157,7 +156,7 @@ void PrintTo(Cell const& c, std::ostream* os) {
   *os << "\n";
 }
 
-std::string CellToString(Cell const& cell) {
+std::string CellToString(bigtable::Cell const& cell) {
   std::stringstream ss;
   PrintTo(cell, &ss);
   return ss.str();
@@ -215,15 +214,14 @@ class AcceptanceTest : public ::testing::Test {
 
  private:
   ReadRowsParser parser_;
-  std::vector<google::cloud::bigtable::Row> rows_;
+  std::vector<bigtable::Row> rows_;
 };
 
 // Auto-generated acceptance tests
 #include "google/cloud/bigtable/internal/readrowsparser_acceptance_tests.inc"
 
 }  // namespace
-}  // namespace internal
 }  // namespace BIGTABLE_CLIENT_NS
-}  // namespace bigtable
+}  // namespace bigtable_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/bigtable/internal/rowreaderiterator.cc
+++ b/google/cloud/bigtable/internal/rowreaderiterator.cc
@@ -20,7 +20,8 @@ namespace cloud {
 namespace bigtable_internal {
 inline namespace BIGTABLE_CLIENT_NS {
 
-RowReaderIterator::RowReaderIterator(bigtable::RowReader* owner) : owner_(owner) {
+RowReaderIterator::RowReaderIterator(bigtable::RowReader* owner)
+    : owner_(owner) {
   Advance();
 }
 

--- a/google/cloud/bigtable/internal/rowreaderiterator.cc
+++ b/google/cloud/bigtable/internal/rowreaderiterator.cc
@@ -17,11 +17,10 @@
 
 namespace google {
 namespace cloud {
-namespace bigtable {
+namespace bigtable_internal {
 inline namespace BIGTABLE_CLIENT_NS {
-namespace internal {
 
-RowReaderIterator::RowReaderIterator(RowReader* owner) : owner_(owner) {
+RowReaderIterator::RowReaderIterator(bigtable::RowReader* owner) : owner_(owner) {
   Advance();
 }
 
@@ -44,7 +43,7 @@ RowReaderIterator& RowReaderIterator::operator++() {
 void RowReaderIterator::Advance() {
   auto status_or_optional_row = owner_->Advance();
   if (!status_or_optional_row) {
-    row_ = StatusOr<Row>(std::move(status_or_optional_row).status());
+    row_ = StatusOr<bigtable::Row>(std::move(status_or_optional_row).status());
     return;
   }
   auto& optional_row = *status_or_optional_row;
@@ -56,8 +55,7 @@ void RowReaderIterator::Advance() {
   owner_ = nullptr;
 }
 
-}  // namespace internal
 }  // namespace BIGTABLE_CLIENT_NS
-}  // namespace bigtable
+}  // namespace bigtable_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/bigtable/internal/rowreaderiterator.h
+++ b/google/cloud/bigtable/internal/rowreaderiterator.h
@@ -27,8 +27,11 @@ namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 // Forward declare the owner class of this iterator.
 class RowReader;
+}  // namespace BIGTABLE_CLIENT_NS
+}  // namespace bigtable
 
-namespace internal {
+namespace bigtable_internal {
+inline namespace BIGTABLE_CLIENT_NS {
 
 /**
  * The input iterator used to scan the rows in a RowReader.
@@ -38,13 +41,13 @@ class RowReaderIterator {
   //@{
   /// @name Iterator traits
   using iterator_category = std::input_iterator_tag;
-  using value_type = StatusOr<Row>;
+  using value_type = StatusOr<bigtable::Row>;
   using difference_type = std::ptrdiff_t;
   using pointer = value_type*;
   using reference = value_type&;
   //@}
 
-  explicit RowReaderIterator(RowReader* owner);
+  explicit RowReaderIterator(bigtable::RowReader* owner);
   RowReaderIterator() = default;
 
   RowReaderIterator& operator++();
@@ -68,9 +71,9 @@ class RowReaderIterator {
 
   void Advance();
   /// nullptr indicates end()
-  RowReader* owner_{};
+  bigtable::RowReader* owner_{};
   /// Current value of the iterator.
-  StatusOr<Row> row_;
+  StatusOr<bigtable::Row> row_;
 };
 
 inline bool operator==(RowReaderIterator const& lhs,
@@ -84,9 +87,8 @@ inline bool operator!=(RowReaderIterator const& lhs,
   return std::rel_ops::operator!=(lhs, rhs);
 }
 
-}  // namespace internal
 }  // namespace BIGTABLE_CLIENT_NS
-}  // namespace bigtable
+}  // namespace bigtable_internal
 }  // namespace cloud
 }  // namespace google
 

--- a/google/cloud/bigtable/internal/rpc_policy_parameters.h
+++ b/google/cloud/bigtable/internal/rpc_policy_parameters.h
@@ -20,9 +20,8 @@
 
 namespace google {
 namespace cloud {
-namespace bigtable {
+namespace bigtable_internal {
 inline namespace BIGTABLE_CLIENT_NS {
-namespace internal {
 
 /// Configuration parameters for retry and backoff policies.
 struct RPCPolicyParameters {
@@ -33,9 +32,8 @@ struct RPCPolicyParameters {
 
 #include "google/cloud/bigtable/internal/rpc_policy_parameters.inc"
 
-}  // namespace internal
 }  // namespace BIGTABLE_CLIENT_NS
-}  // namespace bigtable
+}  // namespace bigtable_internal
 }  // namespace cloud
 }  // namespace google
 

--- a/google/cloud/bigtable/internal/unary_client_utils.h
+++ b/google/cloud/bigtable/internal/unary_client_utils.h
@@ -26,9 +26,8 @@
 
 namespace google {
 namespace cloud {
-namespace bigtable {
+namespace bigtable_internal {
 inline namespace BIGTABLE_CLIENT_NS {
-namespace internal {
 /**
  * Helper functions to make (unary) gRPC calls under the right policies.
  *
@@ -212,9 +211,8 @@ struct UnaryClientUtils {
   }
 };
 
-}  // namespace internal
 }  // namespace BIGTABLE_CLIENT_NS
-}  // namespace bigtable
+}  // namespace bigtable_internal
 }  // namespace cloud
 }  // namespace google
 

--- a/google/cloud/bigtable/mutation_batcher.cc
+++ b/google/cloud/bigtable/mutation_batcher.cc
@@ -210,7 +210,7 @@ void MutationBatcher::OnBulkApplyDone(
       std::ostringstream os;
       os << "Index " << idx << " is out of range [0,"
          << batch.mutation_data.size() << ")";
-      google::cloud::internal::ThrowRuntimeError(std::move(os).str());
+      internal::ThrowRuntimeError(std::move(os).str());
     }
     MutationData& data = batch.mutation_data[idx];
     data.completion_promise.set_value(f.status());

--- a/google/cloud/bigtable/mutation_batcher_test.cc
+++ b/google/cloud/bigtable/mutation_batcher_test.cc
@@ -71,7 +71,7 @@ struct Exchange {
 struct MutationState {
   bool admitted{false};
   bool completed{false};
-  google::cloud::Status completion_status;
+  Status completion_status;
 };
 
 class MutationStates {
@@ -171,7 +171,7 @@ class MutationBatcherTest : public bigtable::testing::TableTestFixture {
                                        grpc::CompletionQueue*) {
             EXPECT_STATUS_OK(IsContextMDValid(
                 *context, "google.bigtable.v2.Bigtable.MutateRows",
-                google::cloud::internal::ApiClientHeader()));
+                internal::ApiClientHeader()));
             EXPECT_EQ(exchange.req.size(), r.entries_size());
             for (std::size_t i = 0; i != exchange.req.size(); ++i) {
               btproto::MutateRowsRequest::Entry expected;
@@ -226,11 +226,10 @@ class MutationBatcherTest : public bigtable::testing::TableTestFixture {
       f.get();
       res->admitted = true;
     });
-    admission_and_completion.second.then(
-        [res](future<google::cloud::Status> status) {
-          res->completed = true;
-          res->completion_status = status.get();
-        });
+    admission_and_completion.second.then([res](future<Status> status) {
+      res->completed = true;
+      res->completion_status = status.get();
+    });
     return res;
   }
 

--- a/google/cloud/bigtable/mutations.h
+++ b/google/cloud/bigtable/mutations.h
@@ -77,7 +77,7 @@ Mutation SetCell(std::string family, ColumnType&& column,
   set_cell.set_column_qualifier(std::forward<ColumnType>(column));
   set_cell.set_timestamp_micros(
       std::chrono::duration_cast<std::chrono::microseconds>(timestamp).count());
-  set_cell.set_value(google::cloud::internal::EncodeBigEndian(value));
+  set_cell.set_value(internal::EncodeBigEndian(value));
   return m;
 }
 
@@ -110,7 +110,7 @@ Mutation SetCell(std::string family, ColumnType&& column, std::int64_t value) {
   set_cell.set_family_name(std::move(family));
   set_cell.set_column_qualifier(std::forward<ColumnType>(column));
   set_cell.set_timestamp_micros(ServerSetTimestamp());
-  set_cell.set_value(google::cloud::internal::EncodeBigEndian(value));
+  set_cell.set_value(internal::EncodeBigEndian(value));
   return m;
 }
 
@@ -393,7 +393,7 @@ class SingleRowMutation {
  */
 class FailedMutation {
  public:
-  FailedMutation(google::cloud::Status status, int index)
+  FailedMutation(Status status, int index)
       : status_(std::move(status)), original_index_(index) {}
 
   FailedMutation(google::rpc::Status const& status, int index)
@@ -406,14 +406,14 @@ class FailedMutation {
 
   //@{
   /// @name accessors
-  google::cloud::Status const& status() const { return status_; }
+  Status const& status() const { return status_; }
   int original_index() const { return original_index_; }
   //@}
 
   friend class BulkMutation;
 
  private:
-  google::cloud::Status status_;
+  Status status_;
   int original_index_;
 };
 
@@ -514,7 +514,7 @@ class BulkMutation {
 
   // Add a failed mutation to the batch.
   BulkMutation& emplace_back(FailedMutation fm) {
-    fm.status_ = google::cloud::Status();
+    fm.status_ = Status();
     return *this;
   }
 

--- a/google/cloud/bigtable/mutations_test.cc
+++ b/google/cloud/bigtable/mutations_test.cc
@@ -53,7 +53,7 @@ TEST(MutationsTest, SetCellNumericValue) {
   EXPECT_EQ("family", actual.op.set_cell().family_name());
   EXPECT_EQ("col", actual.op.set_cell().column_qualifier());
   EXPECT_EQ(1234000, actual.op.set_cell().timestamp_micros());
-  auto decoded = internal::DecodeBigEndianCellValue<std::int64_t>(
+  auto decoded = bigtable_internal::DecodeBigEndianCellValue<std::int64_t>(
       actual.op.set_cell().value());
   EXPECT_STATUS_OK(decoded);
   EXPECT_EQ(9876543210, *decoded);
@@ -62,7 +62,7 @@ TEST(MutationsTest, SetCellNumericValue) {
   ASSERT_TRUE(server_set.op.has_set_cell());
   EXPECT_EQ("fam", server_set.op.set_cell().family_name());
   EXPECT_EQ("col", server_set.op.set_cell().column_qualifier());
-  decoded = internal::DecodeBigEndianCellValue<std::int64_t>(
+  decoded = bigtable_internal::DecodeBigEndianCellValue<std::int64_t>(
       server_set.op.set_cell().value());
   EXPECT_STATUS_OK(decoded);
   EXPECT_EQ(32234401, *decoded);

--- a/google/cloud/bigtable/mutations_test.cc
+++ b/google/cloud/bigtable/mutations_test.cc
@@ -173,7 +173,7 @@ TEST(MutationsTest, FailedMutation) {
   status.add_details()->PackFrom(debug_info);
 
   FailedMutation fm(std::move(status), 27);
-  EXPECT_EQ(google::cloud::StatusCode::kFailedPrecondition, fm.status().code());
+  EXPECT_EQ(StatusCode::kFailedPrecondition, fm.status().code());
   EXPECT_EQ("something failed", fm.status().message());
   EXPECT_FALSE(fm.status().message().empty());
   EXPECT_EQ(27, fm.original_index());

--- a/google/cloud/bigtable/polling_policy.cc
+++ b/google/cloud/bigtable/polling_policy.cc
@@ -19,7 +19,7 @@ namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 std::unique_ptr<PollingPolicy> DefaultPollingPolicy(
-    internal::RPCPolicyParameters defaults) {
+    bigtable_internal::RPCPolicyParameters defaults) {
   return std::unique_ptr<PollingPolicy>(new GenericPollingPolicy<>(defaults));
 }
 

--- a/google/cloud/bigtable/polling_policy.h
+++ b/google/cloud/bigtable/polling_policy.h
@@ -59,7 +59,7 @@ class PollingPolicy {
    * Return true if `status` represents a permanent error that cannot be
    * retried.
    */
-  virtual bool IsPermanentError(google::cloud::Status const& status) = 0;
+  virtual bool IsPermanentError(Status const& status) = 0;
 
   /**
    * Handle an RPC failure.
@@ -76,7 +76,7 @@ class PollingPolicy {
    *
    * @return true if the RPC operation should be retried.
    */
-  virtual bool OnFailure(google::cloud::Status const& status) = 0;
+  virtual bool OnFailure(Status const& status) = 0;
 
   /**
    * Return true if we cannot try again.
@@ -124,15 +124,15 @@ class GenericPollingPolicy : public PollingPolicy {
     rpc_backoff_policy_.Setup(context);
   }
 
-  bool IsPermanentError(google::cloud::Status const& status) override {
+  bool IsPermanentError(Status const& status) override {
     return RPCRetryPolicy::IsPermanentFailure(status);
   }
 
-  bool OnFailure(google::cloud::Status const& status) override {
+  bool OnFailure(Status const& status) override {
     return rpc_retry_policy_.OnFailure(status);
   }
 
-  bool Exhausted() override { return !OnFailure(google::cloud::Status()); }
+  bool Exhausted() override { return !OnFailure(Status()); }
 
   std::chrono::milliseconds WaitPeriod() override {
     return rpc_backoff_policy_.OnCompletion(grpc::Status::OK);

--- a/google/cloud/bigtable/polling_policy.h
+++ b/google/cloud/bigtable/polling_policy.h
@@ -108,7 +108,7 @@ template <typename Retry = LimitedTimeRetryPolicy,
           typename Backoff = ExponentialBackoffPolicy>
 class GenericPollingPolicy : public PollingPolicy {
  public:
-  explicit GenericPollingPolicy(internal::RPCPolicyParameters defaults)
+  explicit GenericPollingPolicy(bigtable_internal::RPCPolicyParameters defaults)
       : rpc_retry_policy_(Retry(defaults)),
         rpc_backoff_policy_(Backoff(defaults)) {}
   GenericPollingPolicy(Retry retry, Backoff backoff)
@@ -144,7 +144,7 @@ class GenericPollingPolicy : public PollingPolicy {
 };
 
 std::unique_ptr<PollingPolicy> DefaultPollingPolicy(
-    internal::RPCPolicyParameters defaults);
+    bigtable_internal::RPCPolicyParameters defaults);
 
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable

--- a/google/cloud/bigtable/polling_policy_test.cc
+++ b/google/cloud/bigtable/polling_policy_test.cc
@@ -54,7 +54,7 @@ void CheckLimitedTime(PollingPolicy& tested) {
 /// @test A simple test for the LimitedTimeRetryPolicy.
 TEST(GenericPollingPolicy, Simple) {
   LimitedTimeRetryPolicy retry(kLimitedTimeTestPeriod);
-  ExponentialBackoffPolicy backoff(internal::kBigtableLimits);
+  ExponentialBackoffPolicy backoff(bigtable_internal::kBigtableLimits);
   GenericPollingPolicy<> tested(retry, backoff);
   CheckLimitedTime(tested);
 }
@@ -62,7 +62,7 @@ TEST(GenericPollingPolicy, Simple) {
 /// @test Test cloning for LimitedTimeRetryPolicy.
 TEST(GenericPollingPolicy, Clone) {
   LimitedTimeRetryPolicy retry(kLimitedTimeTestPeriod);
-  ExponentialBackoffPolicy backoff(internal::kBigtableLimits);
+  ExponentialBackoffPolicy backoff(bigtable_internal::kBigtableLimits);
   GenericPollingPolicy<> original(retry, backoff);
   auto tested = original.clone();
   CheckLimitedTime(*tested);
@@ -71,7 +71,7 @@ TEST(GenericPollingPolicy, Clone) {
 /// @test Verify that non-retryable errors cause an immediate failure.
 TEST(GenericPollingPolicy, OnNonRetryable) {
   LimitedTimeRetryPolicy retry(kLimitedTimeTestPeriod);
-  ExponentialBackoffPolicy backoff(internal::kBigtableLimits);
+  ExponentialBackoffPolicy backoff(bigtable_internal::kBigtableLimits);
   GenericPollingPolicy<> tested(retry, backoff);
   EXPECT_FALSE(
       static_cast<PollingPolicy&>(tested).OnFailure(CreatePermanentError()));
@@ -82,7 +82,7 @@ TEST(GenericPollingPolicy, OnNonRetryable) {
 /// @test Verify that IsPermanentError works.
 TEST(GenericPollingPolicy, IsPermanentError) {
   LimitedTimeRetryPolicy retry(kLimitedTimeTestPeriod);
-  ExponentialBackoffPolicy backoff(internal::kBigtableLimits);
+  ExponentialBackoffPolicy backoff(bigtable_internal::kBigtableLimits);
   GenericPollingPolicy<> tested(retry, backoff);
   EXPECT_TRUE(
       tested.IsPermanentError(Status(StatusCode::kPermissionDenied, "")));

--- a/google/cloud/bigtable/row_range.cc
+++ b/google/cloud/bigtable/row_range.cc
@@ -55,7 +55,8 @@ bool RowRange::IsEmpty() const {
   }
 
   // Special case of an open interval of two consecutive strings.
-  if (start_open && end_open && bigtable_internal::ConsecutiveRowKeys(*start, *end)) {
+  if (start_open && end_open &&
+      bigtable_internal::ConsecutiveRowKeys(*start, *end)) {
     return true;
   }
 

--- a/google/cloud/bigtable/row_range.cc
+++ b/google/cloud/bigtable/row_range.cc
@@ -55,12 +55,12 @@ bool RowRange::IsEmpty() const {
   }
 
   // Special case of an open interval of two consecutive strings.
-  if (start_open && end_open && internal::ConsecutiveRowKeys(*start, *end)) {
+  if (start_open && end_open && bigtable_internal::ConsecutiveRowKeys(*start, *end)) {
     return true;
   }
 
   // Compare the strings as byte vectors (careful with unsigned chars).
-  int cmp = internal::CompareRowKey(*start, *end);
+  int cmp = bigtable_internal::CompareRowKey(*start, *end);
   if (cmp == 0) {
     return start_open || end_open;
   }

--- a/google/cloud/bigtable/row_range.h
+++ b/google/cloud/bigtable/row_range.h
@@ -83,7 +83,7 @@ class RowRange {
   /// Return a range that contains all the keys starting with @p prefix.
   template <typename T>
   static RowRange Prefix(T&& prefix) {
-    auto end = internal::PrefixRangeEnd(prefix);
+    auto end = bigtable_internal::PrefixRangeEnd(prefix);
     return RightOpen(std::forward<T>(prefix), std::move(end));
   }
 
@@ -94,7 +94,7 @@ class RowRange {
   static RowRange RightOpen(T&& begin, U&& end) {
     RowRange result;
     result.row_range_.set_start_key_closed(std::forward<T>(begin));
-    if (!internal::IsEmptyRowKey(end)) {
+    if (!bigtable_internal::IsEmptyRowKey(end)) {
       result.row_range_.set_end_key_open(std::forward<U>(end));
     }
     return result;
@@ -105,7 +105,7 @@ class RowRange {
   static RowRange LeftOpen(T&& begin, U&& end) {
     RowRange result;
     result.row_range_.set_start_key_open(std::forward<T>(begin));
-    if (!internal::IsEmptyRowKey(end)) {
+    if (!bigtable_internal::IsEmptyRowKey(end)) {
       result.row_range_.set_end_key_closed(std::forward<U>(end));
     }
     return result;
@@ -116,7 +116,7 @@ class RowRange {
   static RowRange Open(T&& begin, U&& end) {
     RowRange result;
     result.row_range_.set_start_key_open(std::forward<T>(begin));
-    if (!internal::IsEmptyRowKey(end)) {
+    if (!bigtable_internal::IsEmptyRowKey(end)) {
       result.row_range_.set_end_key_open(std::forward<U>(end));
     }
     return result;
@@ -127,7 +127,7 @@ class RowRange {
   static RowRange Closed(T&& begin, U&& end) {
     RowRange result;
     result.row_range_.set_start_key_closed(std::forward<T>(begin));
-    if (!internal::IsEmptyRowKey(end)) {
+    if (!bigtable_internal::IsEmptyRowKey(end)) {
       result.row_range_.set_end_key_closed(std::forward<U>(end));
     }
     return result;

--- a/google/cloud/bigtable/row_reader.cc
+++ b/google/cloud/bigtable/row_reader.cc
@@ -101,7 +101,9 @@ RowReader::iterator RowReader::begin() {
 
 // The name must be all lowercase to work with range-for loops.
 // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
-RowReader::iterator RowReader::end() { return bigtable_internal::RowReaderIterator(); }
+RowReader::iterator RowReader::end() {
+  return bigtable_internal::RowReaderIterator();
+}
 
 void RowReader::MakeRequest() {
   response_ = {};

--- a/google/cloud/bigtable/row_reader.cc
+++ b/google/cloud/bigtable/row_reader.cc
@@ -65,7 +65,7 @@ RowReader::RowReader(
     std::unique_ptr<RPCRetryPolicy> retry_policy,
     std::unique_ptr<RPCBackoffPolicy> backoff_policy,
     MetadataUpdatePolicy metadata_update_policy,
-    std::unique_ptr<internal::ReadRowsParserFactory> parser_factory)
+    std::unique_ptr<bigtable_internal::ReadRowsParserFactory> parser_factory)
     : RowReader(std::move(client), std::string(""), std::move(table_name),
                 std::move(row_set), rows_limit, std::move(filter),
                 std::move(retry_policy), std::move(backoff_policy),
@@ -77,7 +77,7 @@ RowReader::RowReader(
     Filter filter, std::unique_ptr<RPCRetryPolicy> retry_policy,
     std::unique_ptr<RPCBackoffPolicy> backoff_policy,
     MetadataUpdatePolicy metadata_update_policy,
-    std::unique_ptr<internal::ReadRowsParserFactory> parser_factory)
+    std::unique_ptr<bigtable_internal::ReadRowsParserFactory> parser_factory)
     : client_(std::move(client)),
       app_profile_id_(std::move(app_profile_id)),
       table_name_(std::move(table_name)),
@@ -96,12 +96,12 @@ RowReader::RowReader(
 
 // The name must be all lowercase to work with range-for loops.
 RowReader::iterator RowReader::begin() {
-  return internal::RowReaderIterator(this);
+  return bigtable_internal::RowReaderIterator(this);
 }
 
 // The name must be all lowercase to work with range-for loops.
 // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
-RowReader::iterator RowReader::end() { return internal::RowReaderIterator(); }
+RowReader::iterator RowReader::end() { return bigtable_internal::RowReaderIterator(); }
 
 void RowReader::MakeRequest() {
   response_ = {};

--- a/google/cloud/bigtable/row_reader.h
+++ b/google/cloud/bigtable/row_reader.h
@@ -62,21 +62,21 @@ class RowReader {
             std::unique_ptr<RPCRetryPolicy> retry_policy,
             std::unique_ptr<RPCBackoffPolicy> backoff_policy,
             MetadataUpdatePolicy metadata_update_policy,
-            std::unique_ptr<internal::ReadRowsParserFactory> parser_factory);
+            std::unique_ptr<bigtable_internal::ReadRowsParserFactory> parser_factory);
 
   RowReader(std::shared_ptr<DataClient> client, std::string app_profile_id,
             std::string table_name, RowSet row_set, std::int64_t rows_limit,
             Filter filter, std::unique_ptr<RPCRetryPolicy> retry_policy,
             std::unique_ptr<RPCBackoffPolicy> backoff_policy,
             MetadataUpdatePolicy metadata_update_policy,
-            std::unique_ptr<internal::ReadRowsParserFactory> parser_factory);
+            std::unique_ptr<bigtable_internal::ReadRowsParserFactory> parser_factory);
 
   RowReader(RowReader&&) = default;
 
   ~RowReader();
 
-  using iterator = internal::RowReaderIterator;
-  friend class internal::RowReaderIterator;
+  using iterator = bigtable_internal::RowReaderIterator;
+  friend class bigtable_internal::RowReaderIterator;
 
   /**
    * Input iterator over rows in the response.
@@ -147,8 +147,8 @@ class RowReader {
 
   std::unique_ptr<grpc::ClientContext> context_;
 
-  std::unique_ptr<internal::ReadRowsParserFactory> parser_factory_;
-  std::unique_ptr<internal::ReadRowsParser> parser_;
+  std::unique_ptr<bigtable_internal::ReadRowsParserFactory> parser_factory_;
+  std::unique_ptr<bigtable_internal::ReadRowsParser> parser_;
   std::unique_ptr<
       grpc::ClientReaderInterface<google::bigtable::v2::ReadRowsResponse>>
       stream_;

--- a/google/cloud/bigtable/row_reader.h
+++ b/google/cloud/bigtable/row_reader.h
@@ -57,19 +57,21 @@ class RowReader {
   // NOLINTNEXTLINE(readability-identifier-naming)
   static std::int64_t constexpr NO_ROWS_LIMIT = 0;
 
-  RowReader(std::shared_ptr<DataClient> client, std::string table_name,
-            RowSet row_set, std::int64_t rows_limit, Filter filter,
-            std::unique_ptr<RPCRetryPolicy> retry_policy,
-            std::unique_ptr<RPCBackoffPolicy> backoff_policy,
-            MetadataUpdatePolicy metadata_update_policy,
-            std::unique_ptr<bigtable_internal::ReadRowsParserFactory> parser_factory);
+  RowReader(
+      std::shared_ptr<DataClient> client, std::string table_name,
+      RowSet row_set, std::int64_t rows_limit, Filter filter,
+      std::unique_ptr<RPCRetryPolicy> retry_policy,
+      std::unique_ptr<RPCBackoffPolicy> backoff_policy,
+      MetadataUpdatePolicy metadata_update_policy,
+      std::unique_ptr<bigtable_internal::ReadRowsParserFactory> parser_factory);
 
-  RowReader(std::shared_ptr<DataClient> client, std::string app_profile_id,
-            std::string table_name, RowSet row_set, std::int64_t rows_limit,
-            Filter filter, std::unique_ptr<RPCRetryPolicy> retry_policy,
-            std::unique_ptr<RPCBackoffPolicy> backoff_policy,
-            MetadataUpdatePolicy metadata_update_policy,
-            std::unique_ptr<bigtable_internal::ReadRowsParserFactory> parser_factory);
+  RowReader(
+      std::shared_ptr<DataClient> client, std::string app_profile_id,
+      std::string table_name, RowSet row_set, std::int64_t rows_limit,
+      Filter filter, std::unique_ptr<RPCRetryPolicy> retry_policy,
+      std::unique_ptr<RPCBackoffPolicy> backoff_policy,
+      MetadataUpdatePolicy metadata_update_policy,
+      std::unique_ptr<bigtable_internal::ReadRowsParserFactory> parser_factory);
 
   RowReader(RowReader&&) = default;
 

--- a/google/cloud/bigtable/row_reader_test.cc
+++ b/google/cloud/bigtable/row_reader_test.cc
@@ -34,7 +34,6 @@ namespace {
 
 using ::google::bigtable::v2::ReadRowsRequest;
 using ::google::bigtable::v2::ReadRowsResponse_CellChunk;
-using ::google::cloud::bigtable::Row;
 using ::google::cloud::bigtable::testing::MockReadRowsReader;
 using ::google::cloud::testing_util::IsContextMDValid;
 using ::testing::_;
@@ -74,7 +73,7 @@ class ReadRowsParserMock : public bigtable_internal::ReadRowsParser {
   void SetRows(std::initializer_list<std::string> l) {
     std::transform(l.begin(), l.end(), std::back_inserter(rows_),
                    [](std::string const& s) -> Row {
-                     return Row(s, std::vector<bigtable::Cell>());
+                     return Row(s, std::vector<Cell>());
                    });
   }
 
@@ -105,7 +104,7 @@ class ReadRowsParserMockFactory
   std::deque<ParserPtr> parsers_;
 };
 
-class RetryPolicyMock : public bigtable::RPCRetryPolicy {
+class RetryPolicyMock : public RPCRetryPolicy {
  public:
   RetryPolicyMock() = default;
   std::unique_ptr<RPCRetryPolicy> clone() const override {
@@ -117,7 +116,7 @@ class RetryPolicyMock : public bigtable::RPCRetryPolicy {
   bool OnFailure(Status const&) override { return true; }
 };
 
-class BackoffPolicyMock : public bigtable::RPCBackoffPolicy {
+class BackoffPolicyMock : public RPCBackoffPolicy {
  public:
   BackoffPolicyMock() = default;
   std::unique_ptr<RPCBackoffPolicy> clone() const override {
@@ -152,13 +151,12 @@ class RowReaderTest : public bigtable::testing::TableTestFixture {
       : TableTestFixture(CompletionQueue{}),
         retry_policy_(new RetryPolicyMock),
         backoff_policy_(new BackoffPolicyMock),
-        metadata_update_policy_(kTableName,
-                                bigtable::MetadataParamTypes::TABLE_NAME),
+        metadata_update_policy_(kTableName, MetadataParamTypes::TABLE_NAME),
         parser_factory_(new ReadRowsParserMockFactory) {}
 
   std::unique_ptr<RetryPolicyMock> retry_policy_;
   std::unique_ptr<BackoffPolicyMock> backoff_policy_;
-  bigtable::MetadataUpdatePolicy metadata_update_policy_;
+  MetadataUpdatePolicy metadata_update_policy_;
   std::unique_ptr<ReadRowsParserMockFactory> parser_factory_;
 };
 
@@ -169,11 +167,10 @@ TEST_F(RowReaderTest, EmptyReaderHasNoRows) {
   EXPECT_CALL(*stream, Finish).WillOnce(Return(grpc::Status::OK));
   EXPECT_CALL(*client_, ReadRows).WillOnce(stream->MakeMockReturner());
 
-  bigtable::RowReader reader(
-      client_, "", bigtable::RowSet(), bigtable::RowReader::NO_ROWS_LIMIT,
-      bigtable::Filter::PassAllFilter(), std::move(retry_policy_),
-      std::move(backoff_policy_), metadata_update_policy_,
-      std::move(parser_factory_));
+  RowReader reader(client_, "", RowSet(), RowReader::NO_ROWS_LIMIT,
+                   Filter::PassAllFilter(), std::move(retry_policy_),
+                   std::move(backoff_policy_), metadata_update_policy_,
+                   std::move(parser_factory_));
 
   EXPECT_EQ(reader.begin(), reader.end());
 }
@@ -193,11 +190,10 @@ TEST_F(RowReaderTest, ReadOneRow) {
   }
 
   parser_factory_->AddParser(std::move(parser));
-  bigtable::RowReader reader(
-      client_, "", bigtable::RowSet(), bigtable::RowReader::NO_ROWS_LIMIT,
-      bigtable::Filter::PassAllFilter(), std::move(retry_policy_),
-      std::move(backoff_policy_), metadata_update_policy_,
-      std::move(parser_factory_));
+  RowReader reader(client_, "", RowSet(), RowReader::NO_ROWS_LIMIT,
+                   Filter::PassAllFilter(), std::move(retry_policy_),
+                   std::move(backoff_policy_), metadata_update_policy_,
+                   std::move(parser_factory_));
 
   auto it = reader.begin();
   EXPECT_NE(it, reader.end());
@@ -229,11 +225,10 @@ TEST_F(RowReaderTest, ReadOneRowAppProfileId) {
       });
 
   parser_factory_->AddParser(std::move(parser));
-  bigtable::RowReader reader(
-      client_, "test-id", "", bigtable::RowSet(),
-      bigtable::RowReader::NO_ROWS_LIMIT, bigtable::Filter::PassAllFilter(),
-      std::move(retry_policy_), std::move(backoff_policy_),
-      metadata_update_policy_, std::move(parser_factory_));
+  RowReader reader(client_, "test-id", "", RowSet(), RowReader::NO_ROWS_LIMIT,
+                   Filter::PassAllFilter(), std::move(retry_policy_),
+                   std::move(backoff_policy_), metadata_update_policy_,
+                   std::move(parser_factory_));
 
   auto it = reader.begin();
   EXPECT_NE(it, reader.end());
@@ -257,11 +252,10 @@ TEST_F(RowReaderTest, ReadOneRowIteratorPostincrement) {
   }
 
   parser_factory_->AddParser(std::move(parser));
-  bigtable::RowReader reader(
-      client_, "", bigtable::RowSet(), bigtable::RowReader::NO_ROWS_LIMIT,
-      bigtable::Filter::PassAllFilter(), std::move(retry_policy_),
-      std::move(backoff_policy_), metadata_update_policy_,
-      std::move(parser_factory_));
+  RowReader reader(client_, "", RowSet(), RowReader::NO_ROWS_LIMIT,
+                   Filter::PassAllFilter(), std::move(retry_policy_),
+                   std::move(backoff_policy_), metadata_update_policy_,
+                   std::move(parser_factory_));
 
   auto it = reader.begin();
   EXPECT_NE(it, reader.end());
@@ -288,11 +282,10 @@ TEST_F(RowReaderTest, ReadOneOfTwoRowsClosesStream) {
   }
 
   parser_factory_->AddParser(std::move(parser));
-  bigtable::RowReader reader(
-      client_, "", bigtable::RowSet(), bigtable::RowReader::NO_ROWS_LIMIT,
-      bigtable::Filter::PassAllFilter(), std::move(retry_policy_),
-      std::move(backoff_policy_), metadata_update_policy_,
-      std::move(parser_factory_));
+  RowReader reader(client_, "", RowSet(), RowReader::NO_ROWS_LIMIT,
+                   Filter::PassAllFilter(), std::move(retry_policy_),
+                   std::move(backoff_policy_), metadata_update_policy_,
+                   std::move(parser_factory_));
 
   auto it = reader.begin();
   EXPECT_NE(it, reader.end());
@@ -329,11 +322,10 @@ TEST_F(RowReaderTest, FailedStreamIsRetried) {
   }
 
   parser_factory_->AddParser(std::move(parser));
-  bigtable::RowReader reader(
-      client_, "", bigtable::RowSet(), bigtable::RowReader::NO_ROWS_LIMIT,
-      bigtable::Filter::PassAllFilter(), std::move(retry_policy_),
-      std::move(backoff_policy_), metadata_update_policy_,
-      std::move(parser_factory_));
+  RowReader reader(client_, "", RowSet(), RowReader::NO_ROWS_LIMIT,
+                   Filter::PassAllFilter(), std::move(retry_policy_),
+                   std::move(backoff_policy_), metadata_update_policy_,
+                   std::move(parser_factory_));
 
   auto it = reader.begin();
   EXPECT_NE(it, reader.end());
@@ -358,11 +350,10 @@ TEST_F(RowReaderTest, FailedStreamWithNoRetryThrowsNoExcept) {
   }
 
   parser_factory_->AddParser(std::move(parser));
-  bigtable::RowReader reader(
-      client_, "", bigtable::RowSet(), bigtable::RowReader::NO_ROWS_LIMIT,
-      bigtable::Filter::PassAllFilter(), std::move(retry_policy_),
-      std::move(backoff_policy_), metadata_update_policy_,
-      std::move(parser_factory_));
+  RowReader reader(client_, "", RowSet(), RowReader::NO_ROWS_LIMIT,
+                   Filter::PassAllFilter(), std::move(retry_policy_),
+                   std::move(backoff_policy_), metadata_update_policy_,
+                   std::move(parser_factory_));
 
   auto it = reader.begin();
   EXPECT_NE(it, reader.end());
@@ -400,11 +391,10 @@ TEST_F(RowReaderTest, FailedStreamRetriesSkipAlreadyReadRows) {
   }
 
   parser_factory_->AddParser(std::move(parser));
-  bigtable::RowReader reader(
-      client_, "", bigtable::RowSet("r1", "r2"),
-      bigtable::RowReader::NO_ROWS_LIMIT, bigtable::Filter::PassAllFilter(),
-      std::move(retry_policy_), std::move(backoff_policy_),
-      metadata_update_policy_, std::move(parser_factory_));
+  RowReader reader(client_, "", RowSet("r1", "r2"), RowReader::NO_ROWS_LIMIT,
+                   Filter::PassAllFilter(), std::move(retry_policy_),
+                   std::move(backoff_policy_), metadata_update_policy_,
+                   std::move(parser_factory_));
 
   auto it = reader.begin();
   EXPECT_NE(it, reader.end());
@@ -442,11 +432,10 @@ TEST_F(RowReaderTest, FailedParseIsRetried) {
   }
 
   parser_factory_->AddParser(std::move(parser));
-  bigtable::RowReader reader(
-      client_, "", bigtable::RowSet(), bigtable::RowReader::NO_ROWS_LIMIT,
-      bigtable::Filter::PassAllFilter(), std::move(retry_policy_),
-      std::move(backoff_policy_), metadata_update_policy_,
-      std::move(parser_factory_));
+  RowReader reader(client_, "", RowSet(), RowReader::NO_ROWS_LIMIT,
+                   Filter::PassAllFilter(), std::move(retry_policy_),
+                   std::move(backoff_policy_), metadata_update_policy_,
+                   std::move(parser_factory_));
 
   auto it = reader.begin();
   EXPECT_NE(it, reader.end());
@@ -489,11 +478,10 @@ TEST_F(RowReaderTest, FailedParseRetriesSkipAlreadyReadRows) {
   }
 
   parser_factory_->AddParser(std::move(parser));
-  bigtable::RowReader reader(
-      client_, "", bigtable::RowSet("r1", "r2"),
-      bigtable::RowReader::NO_ROWS_LIMIT, bigtable::Filter::PassAllFilter(),
-      std::move(retry_policy_), std::move(backoff_policy_),
-      metadata_update_policy_, std::move(parser_factory_));
+  RowReader reader(client_, "", RowSet("r1", "r2"), RowReader::NO_ROWS_LIMIT,
+                   Filter::PassAllFilter(), std::move(retry_policy_),
+                   std::move(backoff_policy_), metadata_update_policy_,
+                   std::move(parser_factory_));
 
   auto it = reader.begin();
   EXPECT_NE(it, reader.end());
@@ -521,11 +509,10 @@ TEST_F(RowReaderTest, FailedParseWithNoRetryThrowsNoExcept) {
   }
 
   parser_factory_->AddParser(std::move(parser));
-  bigtable::RowReader reader(
-      client_, "", bigtable::RowSet(), bigtable::RowReader::NO_ROWS_LIMIT,
-      bigtable::Filter::PassAllFilter(), std::move(retry_policy_),
-      std::move(backoff_policy_), metadata_update_policy_,
-      std::move(parser_factory_));
+  RowReader reader(client_, "", RowSet(), RowReader::NO_ROWS_LIMIT,
+                   Filter::PassAllFilter(), std::move(retry_policy_),
+                   std::move(backoff_policy_), metadata_update_policy_,
+                   std::move(parser_factory_));
 
   auto it = reader.begin();
   EXPECT_NE(it, reader.end());
@@ -554,11 +541,10 @@ TEST_F(RowReaderTest, FailedStreamWithAllRequiedRowsSeenShouldNotRetry) {
   }
 
   parser_factory_->AddParser(std::move(parser));
-  bigtable::RowReader reader(
-      client_, "", bigtable::RowSet(bigtable::RowRange::Closed("r1", "r2")),
-      bigtable::RowReader::NO_ROWS_LIMIT, bigtable::Filter::PassAllFilter(),
-      std::move(retry_policy_), std::move(backoff_policy_),
-      metadata_update_policy_, std::move(parser_factory_));
+  RowReader reader(client_, "", RowSet(RowRange::Closed("r1", "r2")),
+                   RowReader::NO_ROWS_LIMIT, Filter::PassAllFilter(),
+                   std::move(retry_policy_), std::move(backoff_policy_),
+                   metadata_update_policy_, std::move(parser_factory_));
 
   auto it = reader.begin();
   EXPECT_NE(it, reader.end());
@@ -575,10 +561,9 @@ TEST_F(RowReaderTest, RowLimitIsSent) {
   EXPECT_CALL(*stream, Read).WillOnce(Return(false));
   EXPECT_CALL(*stream, Finish()).WillOnce(Return(grpc::Status::OK));
 
-  bigtable::RowReader reader(
-      client_, "", bigtable::RowSet(), 442, bigtable::Filter::PassAllFilter(),
-      std::move(retry_policy_), std::move(backoff_policy_),
-      metadata_update_policy_, std::move(parser_factory_));
+  RowReader reader(client_, "", RowSet(), 442, Filter::PassAllFilter(),
+                   std::move(retry_policy_), std::move(backoff_policy_),
+                   metadata_update_policy_, std::move(parser_factory_));
 
   auto it = reader.begin();
   EXPECT_EQ(it, reader.end());
@@ -614,10 +599,9 @@ TEST_F(RowReaderTest, RowLimitIsDecreasedOnRetry) {
   }
 
   parser_factory_->AddParser(std::move(parser));
-  bigtable::RowReader reader(
-      client_, "", bigtable::RowSet(), 42, bigtable::Filter::PassAllFilter(),
-      std::move(retry_policy_), std::move(backoff_policy_),
-      metadata_update_policy_, std::move(parser_factory_));
+  RowReader reader(client_, "", RowSet(), 42, Filter::PassAllFilter(),
+                   std::move(retry_policy_), std::move(backoff_policy_),
+                   metadata_update_policy_, std::move(parser_factory_));
 
   auto it = reader.begin();
   EXPECT_NE(it, reader.end());
@@ -647,10 +631,9 @@ TEST_F(RowReaderTest, RowLimitIsNotDecreasedToZero) {
   }
 
   parser_factory_->AddParser(std::move(parser));
-  bigtable::RowReader reader(
-      client_, "", bigtable::RowSet(), 1, bigtable::Filter::PassAllFilter(),
-      std::move(retry_policy_), std::move(backoff_policy_),
-      metadata_update_policy_, std::move(parser_factory_));
+  RowReader reader(client_, "", RowSet(), 1, Filter::PassAllFilter(),
+                   std::move(retry_policy_), std::move(backoff_policy_),
+                   metadata_update_policy_, std::move(parser_factory_));
 
   auto it = reader.begin();
   EXPECT_NE(it, reader.end());
@@ -674,11 +657,10 @@ TEST_F(RowReaderTest, BeginThrowsAfterCancelClosesStreamNoExcept) {
   }
 
   parser_factory_->AddParser(std::move(parser));
-  bigtable::RowReader reader(
-      client_, "", bigtable::RowSet(), bigtable::RowReader::NO_ROWS_LIMIT,
-      bigtable::Filter::PassAllFilter(), std::move(retry_policy_),
-      std::move(backoff_policy_), metadata_update_policy_,
-      std::move(parser_factory_));
+  RowReader reader(client_, "", RowSet(), RowReader::NO_ROWS_LIMIT,
+                   Filter::PassAllFilter(), std::move(retry_policy_),
+                   std::move(backoff_policy_), metadata_update_policy_,
+                   std::move(parser_factory_));
 
   auto it = reader.begin();
   EXPECT_NE(it, reader.end());
@@ -695,11 +677,10 @@ TEST_F(RowReaderTest, BeginThrowsAfterCancelClosesStreamNoExcept) {
 TEST_F(RowReaderTest, BeginThrowsAfterImmediateCancelNoExcept) {
   testing_util::ScopedLog log;
 
-  std::unique_ptr<bigtable::RowReader> reader(new bigtable::RowReader(
-      client_, "", bigtable::RowSet(), bigtable::RowReader::NO_ROWS_LIMIT,
-      bigtable::Filter::PassAllFilter(), std::move(retry_policy_),
-      std::move(backoff_policy_), metadata_update_policy_,
-      std::move(parser_factory_)));
+  std::unique_ptr<RowReader> reader(new RowReader(
+      client_, "", RowSet(), RowReader::NO_ROWS_LIMIT, Filter::PassAllFilter(),
+      std::move(retry_policy_), std::move(backoff_policy_),
+      metadata_update_policy_, std::move(parser_factory_)));
   // Manually cancel the call before a stream was created.
   reader->Cancel();
   reader->begin();
@@ -725,11 +706,10 @@ TEST_F(RowReaderTest, RowReaderConstructorDoesNotCallRpc) {
   EXPECT_CALL(*client_, ReadRows).Times(0);
   EXPECT_CALL(*parser_factory_, CreateHook()).Times(0);
 
-  bigtable::RowReader reader(
-      client_, "", bigtable::RowSet(), bigtable::RowReader::NO_ROWS_LIMIT,
-      bigtable::Filter::PassAllFilter(), std::move(retry_policy_),
-      std::move(backoff_policy_), metadata_update_policy_,
-      std::move(parser_factory_));
+  RowReader reader(client_, "", RowSet(), RowReader::NO_ROWS_LIMIT,
+                   Filter::PassAllFilter(), std::move(retry_policy_),
+                   std::move(backoff_policy_), metadata_update_policy_,
+                   std::move(parser_factory_));
 }
 
 TEST_F(RowReaderTest, FailedStreamRetryNewContext) {
@@ -770,11 +750,10 @@ TEST_F(RowReaderTest, FailedStreamRetryNewContext) {
   }
 
   parser_factory_->AddParser(std::move(parser));
-  bigtable::RowReader reader(
-      client_, "", bigtable::RowSet(), bigtable::RowReader::NO_ROWS_LIMIT,
-      bigtable::Filter::PassAllFilter(), std::move(retry_policy_),
-      std::move(backoff_policy_), metadata_update_policy_,
-      std::move(parser_factory_));
+  RowReader reader(client_, "", RowSet(), RowReader::NO_ROWS_LIMIT,
+                   Filter::PassAllFilter(), std::move(retry_policy_),
+                   std::move(backoff_policy_), metadata_update_policy_,
+                   std::move(parser_factory_));
 
   auto it = reader.begin();
   EXPECT_NE(it, reader.end());

--- a/google/cloud/bigtable/row_reader_test.cc
+++ b/google/cloud/bigtable/row_reader_test.cc
@@ -129,8 +129,7 @@ class BackoffPolicyMock : public bigtable::RPCBackoffPolicy {
   std::chrono::milliseconds OnCompletion(grpc::Status const& s) override {
     return OnCompletionHook(s);
   }
-  std::chrono::milliseconds OnCompletion(
-      Status const&) override {
+  std::chrono::milliseconds OnCompletion(Status const&) override {
     return std::chrono::milliseconds(0);
   }
 };

--- a/google/cloud/bigtable/row_reader_test.cc
+++ b/google/cloud/bigtable/row_reader_test.cc
@@ -49,7 +49,7 @@ using ::testing::Return;
 using ::testing::SetArgPointee;
 using ::testing::SetArgReferee;
 
-class ReadRowsParserMock : public bigtable::internal::ReadRowsParser {
+class ReadRowsParserMock : public bigtable_internal::ReadRowsParser {
  public:
   MOCK_METHOD(void, HandleChunkHook,
               (ReadRowsResponse_CellChunk chunk, grpc::Status& status));
@@ -84,8 +84,8 @@ class ReadRowsParserMock : public bigtable::internal::ReadRowsParser {
 
 // Returns a preconfigured set of parsers, so expectations can be set on each.
 class ReadRowsParserMockFactory
-    : public bigtable::internal::ReadRowsParserFactory {
-  using ParserPtr = std::unique_ptr<bigtable::internal::ReadRowsParser>;
+    : public bigtable_internal::ReadRowsParserFactory {
+  using ParserPtr = std::unique_ptr<bigtable_internal::ReadRowsParser>;
 
  public:
   void AddParser(ParserPtr parser) { parsers_.emplace_back(std::move(parser)); }
@@ -94,7 +94,7 @@ class ReadRowsParserMockFactory
   ParserPtr Create() override {
     CreateHook();
     if (parsers_.empty()) {
-      return ParserPtr(new bigtable::internal::ReadRowsParser);
+      return ParserPtr(new bigtable_internal::ReadRowsParser);
     }
     ParserPtr parser = std::move(parsers_.front());
     parsers_.pop_front();
@@ -109,19 +109,19 @@ class RetryPolicyMock : public bigtable::RPCRetryPolicy {
  public:
   RetryPolicyMock() = default;
   std::unique_ptr<RPCRetryPolicy> clone() const override {
-    google::cloud::internal::ThrowRuntimeError("Mocks cannot be copied.");
+    internal::ThrowRuntimeError("Mocks cannot be copied.");
   }
 
   MOCK_METHOD(void, Setup, (grpc::ClientContext&), (const, override));
   MOCK_METHOD(bool, OnFailure, (grpc::Status const& status), (override));
-  bool OnFailure(google::cloud::Status const&) override { return true; }
+  bool OnFailure(Status const&) override { return true; }
 };
 
 class BackoffPolicyMock : public bigtable::RPCBackoffPolicy {
  public:
   BackoffPolicyMock() = default;
   std::unique_ptr<RPCBackoffPolicy> clone() const override {
-    google::cloud::internal::ThrowRuntimeError("Mocks cannot be copied.");
+    internal::ThrowRuntimeError("Mocks cannot be copied.");
   }
   void Setup(grpc::ClientContext&) const override {}
   MOCK_METHOD(std::chrono::milliseconds, OnCompletionHook,
@@ -130,7 +130,7 @@ class BackoffPolicyMock : public bigtable::RPCBackoffPolicy {
     return OnCompletionHook(s);
   }
   std::chrono::milliseconds OnCompletion(
-      google::cloud::Status const&) override {
+      Status const&) override {
     return std::chrono::milliseconds(0);
   }
 };
@@ -218,7 +218,7 @@ TEST_F(RowReaderTest, ReadOneRowAppProfileId) {
                               ReadRowsRequest const& req) {
         EXPECT_STATUS_OK(
             IsContextMDValid(*context, "google.bigtable.v2.Bigtable.ReadRows",
-                             google::cloud::internal::ApiClientHeader()));
+                             internal::ApiClientHeader()));
         EXPECT_EQ(expected_id, req.app_profile_id());
         auto stream = absl::make_unique<MockReadRowsReader>(
             "google.bigtable.v2.Bigtable.ReadRows");

--- a/google/cloud/bigtable/row_set.cc
+++ b/google/cloud/bigtable/row_set.cc
@@ -18,7 +18,7 @@ namespace google {
 namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
-RowSet RowSet::Intersect(bigtable::RowRange const& range) const {
+RowSet RowSet::Intersect(RowRange const& range) const {
   // Special case: "all rows", return the argument range.
   if (row_set_.row_keys().empty() && row_set_.row_ranges().empty()) {
     return RowSet(range);
@@ -41,7 +41,7 @@ RowSet RowSet::Intersect(bigtable::RowRange const& range) const {
   // means "all rows", but we want "no rows".
   if (result.row_set_.row_keys().empty() &&
       result.row_set_.row_ranges().empty()) {
-    return RowSet(bigtable::RowRange::Empty());
+    return RowSet(RowRange::Empty());
   }
   return result;
 }

--- a/google/cloud/bigtable/row_set.h
+++ b/google/cloud/bigtable/row_set.h
@@ -63,7 +63,7 @@ class RowSet {
    * ranges that do not intersect with @p range, and keeps only the intersection
    * for those ranges that do intersect @p range.
    */
-  RowSet Intersect(bigtable::RowRange const& range) const;
+  RowSet Intersect(RowRange const& range) const;
 
   /**
    * Returns true if the set is empty.

--- a/google/cloud/bigtable/rpc_backoff_policy.cc
+++ b/google/cloud/bigtable/rpc_backoff_policy.cc
@@ -19,13 +19,13 @@ namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 std::unique_ptr<RPCBackoffPolicy> DefaultRPCBackoffPolicy(
-    internal::RPCPolicyParameters defaults) {
+    bigtable_internal::RPCPolicyParameters defaults) {
   return std::unique_ptr<RPCBackoffPolicy>(new ExponentialBackoffPolicy(
       defaults.initial_delay, defaults.maximum_delay));
 }
 
 ExponentialBackoffPolicy::ExponentialBackoffPolicy(
-    internal::RPCPolicyParameters defaults)
+    bigtable_internal::RPCPolicyParameters defaults)
     : ExponentialBackoffPolicy(defaults.initial_delay, defaults.maximum_delay) {
 }
 

--- a/google/cloud/bigtable/rpc_backoff_policy.cc
+++ b/google/cloud/bigtable/rpc_backoff_policy.cc
@@ -36,7 +36,7 @@ std::unique_ptr<RPCBackoffPolicy> ExponentialBackoffPolicy::clone() const {
 void ExponentialBackoffPolicy::Setup(grpc::ClientContext&) const {}
 
 std::chrono::milliseconds ExponentialBackoffPolicy::OnCompletion(
-    google::cloud::Status const&) {
+    Status const&) {
   return impl_.OnCompletion();
 }
 

--- a/google/cloud/bigtable/rpc_backoff_policy.h
+++ b/google/cloud/bigtable/rpc_backoff_policy.h
@@ -66,14 +66,11 @@ class RPCBackoffPolicy {
    * @return true the delay before trying the operation again.
    * @param status the status returned by the last RPC operation.
    */
-  virtual std::chrono::milliseconds OnCompletion(
-      google::cloud::Status const& status) = 0;
+  virtual std::chrono::milliseconds OnCompletion(Status const& status) = 0;
   // TODO(#2344) - remove ::grpc::Status version.
   virtual std::chrono::milliseconds OnCompletion(grpc::Status const& s) = 0;
 
-  std::chrono::milliseconds OnCompletion() {
-    return OnCompletion(google::cloud::Status{});
-  }
+  std::chrono::milliseconds OnCompletion() { return OnCompletion(Status{}); }
 };
 
 /// Return an instance of the default RPCBackoffPolicy.
@@ -93,8 +90,7 @@ class ExponentialBackoffPolicy : public RPCBackoffPolicy {
 
   std::unique_ptr<RPCBackoffPolicy> clone() const override;
   void Setup(grpc::ClientContext& context) const override;
-  std::chrono::milliseconds OnCompletion(
-      google::cloud::Status const& status) override;
+  std::chrono::milliseconds OnCompletion(Status const& status) override;
   // TODO(#2344) - remove ::grpc::Status version.
   std::chrono::milliseconds OnCompletion(grpc::Status const& status) override;
 

--- a/google/cloud/bigtable/rpc_backoff_policy.h
+++ b/google/cloud/bigtable/rpc_backoff_policy.h
@@ -78,7 +78,7 @@ class RPCBackoffPolicy {
 
 /// Return an instance of the default RPCBackoffPolicy.
 std::unique_ptr<RPCBackoffPolicy> DefaultRPCBackoffPolicy(
-    internal::RPCPolicyParameters defaults);
+    bigtable_internal::RPCPolicyParameters defaults);
 
 /**
  * Implement a simple exponential backoff policy.
@@ -86,7 +86,7 @@ std::unique_ptr<RPCBackoffPolicy> DefaultRPCBackoffPolicy(
 class ExponentialBackoffPolicy : public RPCBackoffPolicy {
  public:
   // NOLINTNEXTLINE(google-explicit-constructor)
-  ExponentialBackoffPolicy(internal::RPCPolicyParameters defaults);
+  ExponentialBackoffPolicy(bigtable_internal::RPCPolicyParameters defaults);
   template <typename DurationT1, typename DurationT2>
   ExponentialBackoffPolicy(DurationT1 initial_delay, DurationT2 maximum_delay)
       : impl_(initial_delay / 2, maximum_delay, 2.0) {}

--- a/google/cloud/bigtable/rpc_retry_policy.cc
+++ b/google/cloud/bigtable/rpc_retry_policy.cc
@@ -21,7 +21,7 @@ namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 std::unique_ptr<RPCRetryPolicy> DefaultRPCRetryPolicy(
-    internal::RPCPolicyParameters defaults) {
+    bigtable_internal::RPCPolicyParameters defaults) {
   return std::unique_ptr<RPCRetryPolicy>(
       new LimitedTimeRetryPolicy(defaults.maximum_retry_period));
 }
@@ -43,7 +43,7 @@ bool LimitedErrorCountRetryPolicy::OnFailure(grpc::Status const& status) {
 }
 
 LimitedTimeRetryPolicy::LimitedTimeRetryPolicy(
-    internal::RPCPolicyParameters defaults)
+    bigtable_internal::RPCPolicyParameters defaults)
     : impl_(defaults.maximum_retry_period) {}
 
 std::unique_ptr<RPCRetryPolicy> LimitedTimeRetryPolicy::clone() const {

--- a/google/cloud/bigtable/rpc_retry_policy.cc
+++ b/google/cloud/bigtable/rpc_retry_policy.cc
@@ -33,8 +33,7 @@ std::unique_ptr<RPCRetryPolicy> LimitedErrorCountRetryPolicy::clone() const {
 
 void LimitedErrorCountRetryPolicy::Setup(grpc::ClientContext&) const {}
 
-bool LimitedErrorCountRetryPolicy::OnFailure(
-    google::cloud::Status const& status) {
+bool LimitedErrorCountRetryPolicy::OnFailure(Status const& status) {
   return impl_.OnFailure(status);
 }
 
@@ -56,7 +55,7 @@ void LimitedTimeRetryPolicy::Setup(grpc::ClientContext& context) const {
   }
 }
 
-bool LimitedTimeRetryPolicy::OnFailure(google::cloud::Status const& status) {
+bool LimitedTimeRetryPolicy::OnFailure(Status const& status) {
   return impl_.OnFailure(status);
 }
 

--- a/google/cloud/bigtable/rpc_retry_policy.h
+++ b/google/cloud/bigtable/rpc_retry_policy.h
@@ -24,9 +24,8 @@
 
 namespace google {
 namespace cloud {
-namespace bigtable {
+namespace bigtable_internal {
 inline namespace BIGTABLE_CLIENT_NS {
-namespace internal {
 /// An adapter to use `grpc::Status` with the `google::cloud::*Policies`.
 struct SafeGrpcRetry {
   static inline bool IsTransientFailure(google::cloud::StatusCode code) {
@@ -60,7 +59,10 @@ struct SafeGrpcRetry {
     return !IsOk(status) && !IsTransientFailure(status);
   }
 };
-}  // namespace internal
+}  // namespace BIGTABLE_CLIENT_NS
+}  // namespace bigtable_internal
+namespace bigtable {
+inline namespace BIGTABLE_CLIENT_NS {
 
 /**
  * Define the interface for controlling how the Bigtable client
@@ -80,7 +82,7 @@ struct SafeGrpcRetry {
  */
 class RPCRetryPolicy {
  public:
-  using RetryableTraits = internal::SafeGrpcRetry;
+  using RetryableTraits = bigtable_internal::SafeGrpcRetry;
 
   virtual ~RPCRetryPolicy() = default;
 
@@ -109,17 +111,17 @@ class RPCRetryPolicy {
   virtual bool OnFailure(grpc::Status const& status) = 0;
 
   static bool IsPermanentFailure(google::cloud::Status const& status) {
-    return internal::SafeGrpcRetry::IsPermanentFailure(status);
+    return bigtable_internal::SafeGrpcRetry::IsPermanentFailure(status);
   }
   // TODO(#2344) - remove ::grpc::Status version.
   static bool IsPermanentFailure(grpc::Status const& status) {
-    return internal::SafeGrpcRetry::IsPermanentFailure(status);
+    return bigtable_internal::SafeGrpcRetry::IsPermanentFailure(status);
   }
 };
 
 /// Return an instance of the default RPCRetryPolicy.
 std::unique_ptr<RPCRetryPolicy> DefaultRPCRetryPolicy(
-    internal::RPCPolicyParameters defaults);
+    bigtable_internal::RPCPolicyParameters defaults);
 
 /**
  * Implement a simple "count errors and then stop" retry policy.
@@ -137,7 +139,7 @@ class LimitedErrorCountRetryPolicy : public RPCRetryPolicy {
 
  private:
   using Impl = ::google::cloud::internal::LimitedErrorCountRetryPolicy<
-      internal::SafeGrpcRetry>;
+      bigtable_internal::SafeGrpcRetry>;
   Impl impl_;
 };
 
@@ -146,7 +148,7 @@ class LimitedErrorCountRetryPolicy : public RPCRetryPolicy {
  */
 class LimitedTimeRetryPolicy : public RPCRetryPolicy {
  public:
-  explicit LimitedTimeRetryPolicy(internal::RPCPolicyParameters defaults);
+  explicit LimitedTimeRetryPolicy(bigtable_internal::RPCPolicyParameters defaults);
   template <typename DurationT>
   explicit LimitedTimeRetryPolicy(DurationT maximum_duration)
       : impl_(maximum_duration) {}
@@ -159,7 +161,7 @@ class LimitedTimeRetryPolicy : public RPCRetryPolicy {
 
  private:
   using Impl =
-      google::cloud::internal::LimitedTimeRetryPolicy<internal::SafeGrpcRetry>;
+      google::cloud::internal::LimitedTimeRetryPolicy<bigtable_internal::SafeGrpcRetry>;
   Impl impl_;
 };
 

--- a/google/cloud/bigtable/rpc_retry_policy.h
+++ b/google/cloud/bigtable/rpc_retry_policy.h
@@ -28,18 +28,16 @@ namespace bigtable_internal {
 inline namespace BIGTABLE_CLIENT_NS {
 /// An adapter to use `grpc::Status` with the `google::cloud::*Policies`.
 struct SafeGrpcRetry {
-  static inline bool IsTransientFailure(google::cloud::StatusCode code) {
+  static inline bool IsTransientFailure(StatusCode code) {
     return code == StatusCode::kAborted || code == StatusCode::kUnavailable ||
            code == StatusCode::kDeadlineExceeded;
   }
 
-  static inline bool IsOk(google::cloud::Status const& status) {
-    return status.ok();
-  }
-  static inline bool IsTransientFailure(google::cloud::Status const& status) {
+  static inline bool IsOk(Status const& status) { return status.ok(); }
+  static inline bool IsTransientFailure(Status const& status) {
     return IsTransientFailure(status.code());
   }
-  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+  static inline bool IsPermanentFailure(Status const& status) {
     return !IsOk(status) && !IsTransientFailure(status);
   }
 
@@ -106,11 +104,11 @@ class RPCRetryPolicy {
    *
    * @return true if the RPC operation should be retried.
    */
-  virtual bool OnFailure(google::cloud::Status const& status) = 0;
+  virtual bool OnFailure(Status const& status) = 0;
   // TODO(#2344) - remove ::grpc::Status version.
   virtual bool OnFailure(grpc::Status const& status) = 0;
 
-  static bool IsPermanentFailure(google::cloud::Status const& status) {
+  static bool IsPermanentFailure(Status const& status) {
     return bigtable_internal::SafeGrpcRetry::IsPermanentFailure(status);
   }
   // TODO(#2344) - remove ::grpc::Status version.
@@ -133,7 +131,7 @@ class LimitedErrorCountRetryPolicy : public RPCRetryPolicy {
 
   std::unique_ptr<RPCRetryPolicy> clone() const override;
   void Setup(grpc::ClientContext& context) const override;
-  bool OnFailure(google::cloud::Status const& status) override;
+  bool OnFailure(Status const& status) override;
   // TODO(#2344) - remove ::grpc::Status version.
   bool OnFailure(grpc::Status const& status) override;
 
@@ -156,12 +154,12 @@ class LimitedTimeRetryPolicy : public RPCRetryPolicy {
 
   std::unique_ptr<RPCRetryPolicy> clone() const override;
   void Setup(grpc::ClientContext& context) const override;
-  bool OnFailure(google::cloud::Status const& status) override;
+  bool OnFailure(Status const& status) override;
   // TODO(#2344) - remove ::grpc::Status version.
   bool OnFailure(grpc::Status const& status) override;
 
  private:
-  using Impl = google::cloud::internal::LimitedTimeRetryPolicy<
+  using Impl = ::google::cloud::internal::LimitedTimeRetryPolicy<
       bigtable_internal::SafeGrpcRetry>;
   Impl impl_;
 };

--- a/google/cloud/bigtable/rpc_retry_policy.h
+++ b/google/cloud/bigtable/rpc_retry_policy.h
@@ -148,7 +148,8 @@ class LimitedErrorCountRetryPolicy : public RPCRetryPolicy {
  */
 class LimitedTimeRetryPolicy : public RPCRetryPolicy {
  public:
-  explicit LimitedTimeRetryPolicy(bigtable_internal::RPCPolicyParameters defaults);
+  explicit LimitedTimeRetryPolicy(
+      bigtable_internal::RPCPolicyParameters defaults);
   template <typename DurationT>
   explicit LimitedTimeRetryPolicy(DurationT maximum_duration)
       : impl_(maximum_duration) {}
@@ -160,8 +161,8 @@ class LimitedTimeRetryPolicy : public RPCRetryPolicy {
   bool OnFailure(grpc::Status const& status) override;
 
  private:
-  using Impl =
-      google::cloud::internal::LimitedTimeRetryPolicy<bigtable_internal::SafeGrpcRetry>;
+  using Impl = google::cloud::internal::LimitedTimeRetryPolicy<
+      bigtable_internal::SafeGrpcRetry>;
   Impl impl_;
 };
 

--- a/google/cloud/bigtable/rpc_retry_policy_test.cc
+++ b/google/cloud/bigtable/rpc_retry_policy_test.cc
@@ -46,7 +46,7 @@ auto const kLimitedTimeTolerance = 10_ms;
  * This eliminates some amount of code duplication in the following tests.
  */
 void CheckLimitedTime(RPCRetryPolicy& tested) {
-  google::cloud::testing_util::CheckPredicateBecomesFalse(
+  testing_util::CheckPredicateBecomesFalse(
       [&tested] {
         return tested.OnFailure(
             grpc::Status(grpc::StatusCode::UNAVAILABLE, "please try again"));

--- a/google/cloud/bigtable/table.cc
+++ b/google/cloud/bigtable/table.cc
@@ -160,7 +160,7 @@ std::vector<FailedMutation> Table::BulkApply(BulkMutation mut) {
   auto idempotent_policy = clone_idempotent_mutation_policy();
 
   bigtable_internal::BulkMutator mutator(app_profile_id_, table_name_,
-                                          *idempotent_policy, std::move(mut));
+                                         *idempotent_policy, std::move(mut));
   while (mutator.HasPendingMutations()) {
     grpc::ClientContext client_context;
     backoff_policy->Setup(client_context);

--- a/google/cloud/bigtable/table.cc
+++ b/google/cloud/bigtable/table.cc
@@ -63,7 +63,7 @@ Row TransformReadModifyWriteRowResponse(Response& response) {
 
 }  // namespace
 
-using ClientUtils = bigtable::internal::UnaryClientUtils<DataClient>;
+using ClientUtils = bigtable_internal::UnaryClientUtils<DataClient>;
 
 static_assert(std::is_copy_assignable<bigtable::Table>::value,
               "bigtable::Table must be CopyAssignable");
@@ -159,7 +159,7 @@ std::vector<FailedMutation> Table::BulkApply(BulkMutation mut) {
   auto retry_policy = clone_rpc_retry_policy();
   auto idempotent_policy = clone_idempotent_mutation_policy();
 
-  bigtable::internal::BulkMutator mutator(app_profile_id_, table_name_,
+  bigtable_internal::BulkMutator mutator(app_profile_id_, table_name_,
                                           *idempotent_policy, std::move(mut));
   while (mutator.HasPendingMutations()) {
     grpc::ClientContext client_context;
@@ -179,7 +179,7 @@ std::vector<FailedMutation> Table::BulkApply(BulkMutation mut) {
 future<std::vector<FailedMutation>> Table::AsyncBulkApply(BulkMutation mut) {
   auto cq = background_threads_->cq();
   auto mutation_policy = clone_idempotent_mutation_policy();
-  return internal::AsyncRetryBulkApply::Create(
+  return bigtable_internal::AsyncRetryBulkApply::Create(
       cq, clone_rpc_retry_policy(), clone_rpc_backoff_policy(),
       *mutation_policy, clone_metadata_update_policy(), client_,
       app_profile_id_, table_name(), std::move(mut));
@@ -190,7 +190,7 @@ RowReader Table::ReadRows(RowSet row_set, Filter filter) {
       client_, app_profile_id_, table_name_, std::move(row_set),
       RowReader::NO_ROWS_LIMIT, std::move(filter), clone_rpc_retry_policy(),
       clone_rpc_backoff_policy(), metadata_update_policy_,
-      absl::make_unique<bigtable::internal::ReadRowsParserFactory>());
+      absl::make_unique<bigtable_internal::ReadRowsParserFactory>());
 }
 
 RowReader Table::ReadRows(RowSet row_set, std::int64_t rows_limit,
@@ -199,7 +199,7 @@ RowReader Table::ReadRows(RowSet row_set, std::int64_t rows_limit,
       client_, app_profile_id_, table_name_, std::move(row_set), rows_limit,
       std::move(filter), clone_rpc_retry_policy(), clone_rpc_backoff_policy(),
       metadata_update_policy_,
-      absl::make_unique<bigtable::internal::ReadRowsParserFactory>());
+      absl::make_unique<bigtable_internal::ReadRowsParserFactory>());
 }
 
 StatusOr<std::pair<bool, Row>> Table::ReadRow(std::string row_key,
@@ -346,7 +346,7 @@ StatusOr<std::vector<bigtable::RowKeySample>> Table::SampleRows() {
 
 future<StatusOr<std::vector<bigtable::RowKeySample>>> Table::AsyncSampleRows() {
   auto cq = background_threads_->cq();
-  return internal::AsyncRowSampler::Create(
+  return bigtable_internal::AsyncRowSampler::Create(
       cq, client_, clone_rpc_retry_policy(), clone_rpc_backoff_policy(),
       metadata_update_policy_, app_profile_id_, table_name_);
 }

--- a/google/cloud/bigtable/table.cc
+++ b/google/cloud/bigtable/table.cc
@@ -96,9 +96,8 @@ Status Table::Apply(SingleRowMutation mut) {
     metadata_update_policy_.Setup(client_context);
     status = client_->MutateRow(&client_context, request, &response);
 
-    if (status.ok()) {
-      return google::cloud::Status{};
-    }
+    if (status.ok()) return Status{};
+
     // It is up to the policy to terminate this loop, it could run
     // forever, but that would be a bad policy (pun intended).
     if (!rpc_policy->OnFailure(status) || !is_idempotent) {
@@ -132,7 +131,7 @@ future<Status> Table::AsyncApply(SingleRowMutation mut) {
   auto cq = background_threads_->cq();
   auto client = client_;
   auto metadata_update_policy = clone_metadata_update_policy();
-  return google::cloud::internal::StartRetryAsyncUnaryRpc(
+  return internal::StartRetryAsyncUnaryRpc(
              cq, __func__, clone_rpc_retry_policy(), clone_rpc_backoff_policy(),
              idempotency,
              [client, metadata_update_policy](
@@ -274,7 +273,7 @@ future<StatusOr<MutationBranch>> Table::AsyncCheckAndMutateRow(
   auto cq = background_threads_->cq();
   auto client = client_;
   auto metadata_update_policy = clone_metadata_update_policy();
-  return google::cloud::internal::StartRetryAsyncUnaryRpc(
+  return internal::StartRetryAsyncUnaryRpc(
              cq, __func__, clone_rpc_retry_policy(), clone_rpc_backoff_policy(),
              idempotency,
              [client, metadata_update_policy](
@@ -375,7 +374,7 @@ future<StatusOr<Row>> Table::AsyncReadModifyWriteRowImpl(
   auto cq = background_threads_->cq();
   auto client = client_;
   auto metadata_update_policy = clone_metadata_update_policy();
-  return google::cloud::internal::StartRetryAsyncUnaryRpc(
+  return internal::StartRetryAsyncUnaryRpc(
              cq, __func__, clone_rpc_retry_policy(), clone_rpc_backoff_policy(),
              Idempotency::kNonIdempotent,
              [client, metadata_update_policy](

--- a/google/cloud/bigtable/table.h
+++ b/google/cloud/bigtable/table.h
@@ -215,13 +215,13 @@ class Table {
         table_name_(TableName(client_, table_id)),
         table_id_(table_id),
         rpc_retry_policy_prototype_(
-            bigtable::DefaultRPCRetryPolicy(internal::kBigtableLimits)),
+            DefaultRPCRetryPolicy(bigtable_internal::kBigtableLimits)),
         rpc_backoff_policy_prototype_(
-            bigtable::DefaultRPCBackoffPolicy(internal::kBigtableLimits)),
+            DefaultRPCBackoffPolicy(bigtable_internal::kBigtableLimits)),
         metadata_update_policy_(
             MetadataUpdatePolicy(table_name_, MetadataParamTypes::TABLE_NAME)),
         idempotent_mutation_policy_(
-            bigtable::DefaultIdempotentMutationPolicy()),
+            DefaultIdempotentMutationPolicy()),
         background_threads_(client_->BackgroundThreadsFactory()()) {}
 
   /**
@@ -604,7 +604,7 @@ class Table {
    * @par Examples
    * @snippet data_snippets.cc sample row keys
    */
-  StatusOr<std::vector<bigtable::RowKeySample>> SampleRows();
+  StatusOr<std::vector<RowKeySample>> SampleRows();
 
   /**
    * Asynchronously obtains a sample of the row keys in the table, including
@@ -627,7 +627,7 @@ class Table {
    * @par Examples
    * @snippet data_async_snippets.cc async sample row keys
    */
-  future<StatusOr<std::vector<bigtable::RowKeySample>>> AsyncSampleRows();
+  future<StatusOr<std::vector<RowKeySample>>> AsyncSampleRows();
 
   /**
    * Atomically read and modify the row in the server, returning the
@@ -657,7 +657,7 @@ class Table {
    */
   template <typename... Args>
   StatusOr<Row> ReadModifyWriteRow(std::string row_key,
-                                   bigtable::ReadModifyWriteRule rule,
+                                   ReadModifyWriteRule rule,
                                    Args&&... rules) {
     ::google::bigtable::v2::ReadModifyWriteRowRequest request;
     request.set_row_key(std::move(row_key));
@@ -666,7 +666,7 @@ class Table {
     // if the types do not match
     static_assert(
         absl::conjunction<
-            std::is_convertible<Args, bigtable::ReadModifyWriteRule>...>::value,
+            std::is_convertible<Args, ReadModifyWriteRule>...>::value,
         "The arguments passed to ReadModifyWriteRow(row_key,...) must be "
         "convertible to bigtable::ReadModifyWriteRule");
 
@@ -706,7 +706,7 @@ class Table {
    */
   template <typename... Args>
   future<StatusOr<Row>> AsyncReadModifyWriteRow(
-      std::string row_key, bigtable::ReadModifyWriteRule rule,
+      std::string row_key, ReadModifyWriteRule rule,
       Args&&... rules) {
     ::google::bigtable::v2::ReadModifyWriteRowRequest request;
     request.set_row_key(std::move(row_key));
@@ -715,7 +715,7 @@ class Table {
     // if the types do not match
     static_assert(
         absl::conjunction<
-            std::is_convertible<Args, bigtable::ReadModifyWriteRule>...>::value,
+            std::is_convertible<Args, ReadModifyWriteRule>...>::value,
         "The arguments passed to AsyncReadModifyWriteRow(row_key,...) must be "
         "convertible to bigtable::ReadModifyWriteRule");
 
@@ -805,7 +805,7 @@ class Table {
         std::move(on_row), std::move(on_finish), std::move(row_set), rows_limit,
         std::move(filter), clone_rpc_retry_policy(), clone_rpc_backoff_policy(),
         metadata_update_policy_,
-        absl::make_unique<bigtable::internal::ReadRowsParserFactory>());
+        absl::make_unique<bigtable_internal::ReadRowsParserFactory>());
   }
 
   /**
@@ -856,7 +856,7 @@ class Table {
 
   template <typename... Args>
   void AddRules(google::bigtable::v2::ReadModifyWriteRowRequest& request,
-                bigtable::ReadModifyWriteRule rule, Args&&... args) {
+                ReadModifyWriteRule rule, Args&&... args) {
     *request.add_rules() = std::move(rule).as_proto();
     AddRules(request, std::forward<Args>(args)...);
   }

--- a/google/cloud/bigtable/table.h
+++ b/google/cloud/bigtable/table.h
@@ -220,8 +220,7 @@ class Table {
             DefaultRPCBackoffPolicy(bigtable_internal::kBigtableLimits)),
         metadata_update_policy_(
             MetadataUpdatePolicy(table_name_, MetadataParamTypes::TABLE_NAME)),
-        idempotent_mutation_policy_(
-            DefaultIdempotentMutationPolicy()),
+        idempotent_mutation_policy_(DefaultIdempotentMutationPolicy()),
         background_threads_(client_->BackgroundThreadsFactory()()) {}
 
   /**
@@ -657,8 +656,7 @@ class Table {
    */
   template <typename... Args>
   StatusOr<Row> ReadModifyWriteRow(std::string row_key,
-                                   ReadModifyWriteRule rule,
-                                   Args&&... rules) {
+                                   ReadModifyWriteRule rule, Args&&... rules) {
     ::google::bigtable::v2::ReadModifyWriteRowRequest request;
     request.set_row_key(std::move(row_key));
 
@@ -705,9 +703,9 @@ class Table {
    * @snippet data_async_snippets.cc async read modify write
    */
   template <typename... Args>
-  future<StatusOr<Row>> AsyncReadModifyWriteRow(
-      std::string row_key, ReadModifyWriteRule rule,
-      Args&&... rules) {
+  future<StatusOr<Row>> AsyncReadModifyWriteRow(std::string row_key,
+                                                ReadModifyWriteRule rule,
+                                                Args&&... rules) {
     ::google::bigtable::v2::ReadModifyWriteRowRequest request;
     request.set_row_key(std::move(row_key));
 

--- a/google/cloud/bigtable/table_admin.cc
+++ b/google/cloud/bigtable/table_admin.cc
@@ -232,7 +232,8 @@ StatusOr<btadmin::Backup> TableAdmin::UpdateBackup(
   return result;
 }
 
-Status TableAdmin::DeleteBackup(btadmin::Backup const& backup) {
+Status TableAdmin::DeleteBackup(
+    google::bigtable::admin::v2::Backup const& backup) {
   grpc::Status status;
   btadmin::DeleteBackupRequest request;
   request.set_name(backup.name());

--- a/google/cloud/bigtable/table_admin.cc
+++ b/google/cloud/bigtable/table_admin.cc
@@ -144,8 +144,8 @@ Status TableAdmin::DeleteTable(std::string const& table_id) {
   return MakeStatusFromRpcError(status);
 }
 
-btadmin::CreateBackupRequest
-TableAdmin::CreateBackupParams::AsProto(std::string instance_name) const {
+btadmin::CreateBackupRequest TableAdmin::CreateBackupParams::AsProto(
+    std::string instance_name) const {
   btadmin::CreateBackupRequest proto;
   proto.set_parent(instance_name + "/clusters/" + cluster_id);
   proto.set_backup_id(backup_id);
@@ -162,15 +162,13 @@ StatusOr<btadmin::Backup> TableAdmin::CreateBackup(
   return AsyncCreateBackupImpl(cq, params).get();
 }
 
-future<StatusOr<btadmin::Backup>>
-TableAdmin::AsyncCreateBackupImpl(CompletionQueue& cq,
-                                  CreateBackupParams const& params) {
+future<StatusOr<btadmin::Backup>> TableAdmin::AsyncCreateBackupImpl(
+    CompletionQueue& cq, CreateBackupParams const& params) {
   auto request = params.AsProto(instance_name());
   MetadataUpdatePolicy metadata_update_policy(request.parent(),
                                               MetadataParamTypes::PARENT);
   auto client = client_;
-  return bigtable_internal::AsyncStartPollAfterRetryUnaryRpc<
-      btadmin::Backup>(
+  return bigtable_internal::AsyncStartPollAfterRetryUnaryRpc<btadmin::Backup>(
       __func__, clone_polling_policy(), clone_rpc_retry_policy(),
       clone_rpc_backoff_policy(),
       bigtable_internal::ConstantIdempotencyPolicy(Idempotency::kNonIdempotent),
@@ -183,12 +181,12 @@ TableAdmin::AsyncCreateBackupImpl(CompletionQueue& cq,
       std::move(request), cq);
 }
 
-StatusOr<btadmin::Backup> TableAdmin::GetBackup(
-    std::string const& cluster_id, std::string const& backup_id) {
+StatusOr<btadmin::Backup> TableAdmin::GetBackup(std::string const& cluster_id,
+                                                std::string const& backup_id) {
   grpc::Status status;
   btadmin::GetBackupRequest request;
-  auto name = bigtable::BackupName(project(), instance_id(),
-                                                  cluster_id, backup_id);
+  auto name =
+      bigtable::BackupName(project(), instance_id(), cluster_id, backup_id);
   request.set_name(name);
 
   MetadataUpdatePolicy metadata_update_policy(name, MetadataParamTypes::NAME);
@@ -204,8 +202,7 @@ StatusOr<btadmin::Backup> TableAdmin::GetBackup(
   return result;
 }
 
-btadmin::UpdateBackupRequest
-TableAdmin::UpdateBackupParams::AsProto(
+btadmin::UpdateBackupRequest TableAdmin::UpdateBackupParams::AsProto(
     std::string const& instance_name) const {
   btadmin::UpdateBackupRequest proto;
   proto.mutable_backup()->set_name(instance_name + "/clusters/" + cluster_id +
@@ -235,8 +232,7 @@ StatusOr<btadmin::Backup> TableAdmin::UpdateBackup(
   return result;
 }
 
-Status TableAdmin::DeleteBackup(
-    btadmin::Backup const& backup) {
+Status TableAdmin::DeleteBackup(btadmin::Backup const& backup) {
   grpc::Status status;
   btadmin::DeleteBackupRequest request;
   request.set_name(backup.name());
@@ -257,8 +253,8 @@ Status TableAdmin::DeleteBackup(std::string const& cluster_id,
                                 std::string const& backup_id) {
   grpc::Status status;
   btadmin::DeleteBackupRequest request;
-  request.set_name(bigtable::BackupName(project(), instance_id(),
-                                                       cluster_id, backup_id));
+  request.set_name(
+      bigtable::BackupName(project(), instance_id(), cluster_id, backup_id));
 
   MetadataUpdatePolicy metadata_update_policy(request.name(),
                                               MetadataParamTypes::NAME);
@@ -274,8 +270,8 @@ Status TableAdmin::DeleteBackup(std::string const& cluster_id,
   return {};
 }
 
-btadmin::ListBackupsRequest
-TableAdmin::ListBackupsParams::AsProto(std::string const& instance_name) const {
+btadmin::ListBackupsRequest TableAdmin::ListBackupsParams::AsProto(
+    std::string const& instance_name) const {
   btadmin::ListBackupsRequest proto;
   proto.set_parent(cluster_id ? instance_name + "/clusters/" + *cluster_id
                               : instance_name + "/clusters/-");
@@ -284,8 +280,8 @@ TableAdmin::ListBackupsParams::AsProto(std::string const& instance_name) const {
   return proto;
 }
 
-StatusOr<std::vector<btadmin::Backup>>
-TableAdmin::ListBackups(ListBackupsParams const& params) {
+StatusOr<std::vector<btadmin::Backup>> TableAdmin::ListBackups(
+    ListBackupsParams const& params) {
   grpc::Status status;
 
   // Copy the policies in effect for the operation.
@@ -320,8 +316,7 @@ TableAdmin::ListBackups(ListBackupsParams const& params) {
   return result;
 }
 
-btadmin::RestoreTableRequest
-TableAdmin::RestoreTableParams::AsProto(
+btadmin::RestoreTableRequest TableAdmin::RestoreTableParams::AsProto(
     std::string const& instance_name) const {
   btadmin::RestoreTableRequest proto;
   proto.set_parent(instance_name);
@@ -337,9 +332,8 @@ StatusOr<btadmin::Table> TableAdmin::RestoreTable(
   return AsyncRestoreTableImpl(cq, params).get();
 }
 
-future<StatusOr<btadmin::Table>>
-TableAdmin::AsyncRestoreTableImpl(CompletionQueue& cq,
-                                  RestoreTableParams const& params) {
+future<StatusOr<btadmin::Table>> TableAdmin::AsyncRestoreTableImpl(
+    CompletionQueue& cq, RestoreTableParams const& params) {
   return AsyncRestoreTableImpl(
       cq,
       RestoreTableFromInstanceParams{
@@ -362,14 +356,12 @@ StatusOr<btadmin::Table> TableAdmin::RestoreTable(
   return AsyncRestoreTableImpl(cq, std::move(params)).get();
 }
 
-future<StatusOr<btadmin::Table>>
-TableAdmin::AsyncRestoreTableImpl(CompletionQueue& cq,
-                                  RestoreTableFromInstanceParams params) {
+future<StatusOr<btadmin::Table>> TableAdmin::AsyncRestoreTableImpl(
+    CompletionQueue& cq, RestoreTableFromInstanceParams params) {
   MetadataUpdatePolicy metadata_update_policy(instance_name(),
                                               MetadataParamTypes::PARENT);
   auto client = client_;
-  return bigtable_internal::AsyncStartPollAfterRetryUnaryRpc<
-      btadmin::Table>(
+  return bigtable_internal::AsyncStartPollAfterRetryUnaryRpc<btadmin::Table>(
       __func__, clone_polling_policy(), clone_rpc_retry_policy(),
       clone_rpc_backoff_policy(),
       bigtable_internal::ConstantIdempotencyPolicy(Idempotency::kNonIdempotent),
@@ -426,10 +418,9 @@ future<StatusOr<Consistency>> TableAdmin::WaitForConsistency(
   return AsyncWaitForConsistencyImpl(cq, table_id, consistency_token);
 }
 
-future<StatusOr<Consistency>>
-TableAdmin::AsyncWaitForConsistencyImpl(CompletionQueue& cq,
-                                        std::string const& table_id,
-                                        std::string const& consistency_token) {
+future<StatusOr<Consistency>> TableAdmin::AsyncWaitForConsistencyImpl(
+    CompletionQueue& cq, std::string const& table_id,
+    std::string const& consistency_token) {
   class AsyncWaitForConsistencyState
       : public std::enable_shared_from_this<AsyncWaitForConsistencyState> {
    public:
@@ -747,8 +738,7 @@ StatusOr<std::vector<std::string>> TableAdmin::TestIamPermissions(
 }
 
 std::string TableAdmin::InstanceName() const {
-  return bigtable::InstanceName(client_->project(),
-                                               instance_id_);
+  return bigtable::InstanceName(client_->project(), instance_id_);
 }
 
 }  // namespace BIGTABLE_CLIENT_NS

--- a/google/cloud/bigtable/table_admin.h
+++ b/google/cloud/bigtable/table_admin.h
@@ -144,10 +144,10 @@ class TableAdmin {
       : client_(std::move(client)),
         instance_id_(std::move(instance_id)),
         instance_name_(InstanceName()),
-        rpc_retry_policy_prototype_(
-            DefaultRPCRetryPolicy(bigtable_internal::kBigtableTableAdminLimits)),
-        rpc_backoff_policy_prototype_(
-            DefaultRPCBackoffPolicy(bigtable_internal::kBigtableTableAdminLimits)),
+        rpc_retry_policy_prototype_(DefaultRPCRetryPolicy(
+            bigtable_internal::kBigtableTableAdminLimits)),
+        rpc_backoff_policy_prototype_(DefaultRPCBackoffPolicy(
+            bigtable_internal::kBigtableTableAdminLimits)),
         metadata_update_policy_(instance_name(), MetadataParamTypes::PARENT),
         polling_policy_prototype_(
             DefaultPollingPolicy(bigtable_internal::kBigtableTableAdminLimits)),
@@ -988,21 +988,19 @@ class TableAdmin {
 
   /// Return the fully qualified name of a table in this object's instance.
   std::string TableName(std::string const& table_id) const {
-    return bigtable::TableName(project(), instance_id(),
-                                              table_id);
+    return bigtable::TableName(project(), instance_id(), table_id);
   }
 
   /// Return the fully qualified name of a Cluster.
   std::string ClusterName(std::string const& cluster_id) const {
-    return bigtable::ClusterName(project(), instance_id(),
-                                                cluster_id);
+    return bigtable::ClusterName(project(), instance_id(), cluster_id);
   }
 
   /// Return the fully qualified name of a Backup.
   std::string BackupName(std::string const& cluster_id,
                          std::string const& backup_id) const {
-    return bigtable::BackupName(project(), instance_id(),
-                                               cluster_id, backup_id);
+    return bigtable::BackupName(project(), instance_id(), cluster_id,
+                                backup_id);
   }
 
  private:

--- a/google/cloud/bigtable/table_admin.h
+++ b/google/cloud/bigtable/table_admin.h
@@ -145,12 +145,12 @@ class TableAdmin {
         instance_id_(std::move(instance_id)),
         instance_name_(InstanceName()),
         rpc_retry_policy_prototype_(
-            DefaultRPCRetryPolicy(internal::kBigtableTableAdminLimits)),
+            DefaultRPCRetryPolicy(bigtable_internal::kBigtableTableAdminLimits)),
         rpc_backoff_policy_prototype_(
-            DefaultRPCBackoffPolicy(internal::kBigtableTableAdminLimits)),
+            DefaultRPCBackoffPolicy(bigtable_internal::kBigtableTableAdminLimits)),
         metadata_update_policy_(instance_name(), MetadataParamTypes::PARENT),
         polling_policy_prototype_(
-            DefaultPollingPolicy(internal::kBigtableTableAdminLimits)),
+            DefaultPollingPolicy(bigtable_internal::kBigtableTableAdminLimits)),
         background_threads_(client_->BackgroundThreadsFactory()()) {}
 
   /**
@@ -816,7 +816,7 @@ class TableAdmin {
    * @par Example
    * @snippet table_admin_snippets.cc wait for consistency check
    */
-  google::cloud::future<StatusOr<Consistency>> WaitForConsistency(
+  future<StatusOr<Consistency>> WaitForConsistency(
       std::string const& table_id, std::string const& consistency_token);
 
   /**
@@ -988,20 +988,20 @@ class TableAdmin {
 
   /// Return the fully qualified name of a table in this object's instance.
   std::string TableName(std::string const& table_id) const {
-    return google::cloud::bigtable::TableName(project(), instance_id(),
+    return bigtable::TableName(project(), instance_id(),
                                               table_id);
   }
 
   /// Return the fully qualified name of a Cluster.
   std::string ClusterName(std::string const& cluster_id) const {
-    return google::cloud::bigtable::ClusterName(project(), instance_id(),
+    return bigtable::ClusterName(project(), instance_id(),
                                                 cluster_id);
   }
 
   /// Return the fully qualified name of a Backup.
   std::string BackupName(std::string const& cluster_id,
                          std::string const& backup_id) const {
-    return google::cloud::bigtable::BackupName(project(), instance_id(),
+    return bigtable::BackupName(project(), instance_id(),
                                                cluster_id, backup_id);
   }
 
@@ -1071,7 +1071,7 @@ class TableAdmin {
   std::string instance_name_;
   std::shared_ptr<RPCRetryPolicy const> rpc_retry_policy_prototype_;
   std::shared_ptr<RPCBackoffPolicy const> rpc_backoff_policy_prototype_;
-  bigtable::MetadataUpdatePolicy metadata_update_policy_;
+  MetadataUpdatePolicy metadata_update_policy_;
   std::shared_ptr<PollingPolicy const> polling_policy_prototype_;
   std::shared_ptr<BackgroundThreads> background_threads_;
 };

--- a/google/cloud/bigtable/table_admin_test.cc
+++ b/google/cloud/bigtable/table_admin_test.cc
@@ -110,7 +110,7 @@ auto create_list_tables_lambda =
                  btadmin::ListTablesResponse* response) {
         EXPECT_STATUS_OK(IsContextMDValid(
             *context, "google.bigtable.admin.v2.BigtableTableAdmin.ListTables",
-            google::cloud::internal::ApiClientHeader()));
+            internal::ApiClientHeader()));
         auto const instance_name =
             "projects/" + kProjectId + "/instances/" + kInstanceId;
         EXPECT_EQ(instance_name, request.parent());
@@ -136,7 +136,7 @@ auto create_get_policy_mock = []() {
             ::google::iam::v1::Policy* response) {
     EXPECT_STATUS_OK(IsContextMDValid(
         *context, "google.bigtable.admin.v2.BigtableTableAdmin.GetIamPolicy",
-        google::cloud::internal::ApiClientHeader()));
+        internal::ApiClientHeader()));
     EXPECT_NE(nullptr, response);
     response->set_version(3);
     response->set_etag("random-tag");
@@ -150,7 +150,7 @@ auto create_get_policy_mock_for_backup = [](std::string const& backup_id) {
                      ::google::iam::v1::Policy* response) {
     EXPECT_STATUS_OK(IsContextMDValid(
         *context, "google.bigtable.admin.v2.BigtableTableAdmin.GetIamPolicy",
-        google::cloud::internal::ApiClientHeader(), backup_id));
+        internal::ApiClientHeader(), backup_id));
     EXPECT_NE(nullptr, response);
     response->set_version(3);
     response->set_etag("random-tag");
@@ -163,7 +163,7 @@ auto create_policy_with_params = []() {
             ::google::iam::v1::Policy* response) {
     EXPECT_STATUS_OK(IsContextMDValid(
         *context, "google.bigtable.admin.v2.BigtableTableAdmin.SetIamPolicy",
-        google::cloud::internal::ApiClientHeader()));
+        internal::ApiClientHeader()));
     EXPECT_NE(nullptr, response);
     *response = request.policy();
     return grpc::Status::OK;
@@ -176,7 +176,7 @@ auto create_policy_with_params_for_backup = [](std::string const& backup_id) {
                      ::google::iam::v1::Policy* response) {
     EXPECT_STATUS_OK(IsContextMDValid(
         *context, "google.bigtable.admin.v2.BigtableTableAdmin.SetIamPolicy",
-        google::cloud::internal::ApiClientHeader(), backup_id));
+        internal::ApiClientHeader(), backup_id));
     EXPECT_NE(nullptr, response);
     *response = request.policy();
     return grpc::Status::OK;
@@ -191,7 +191,7 @@ auto create_list_backups_lambda =
                  btadmin::ListBackupsResponse* response) {
         EXPECT_STATUS_OK(IsContextMDValid(
             *context, "google.bigtable.admin.v2.BigtableTableAdmin.ListBackups",
-            google::cloud::internal::ApiClientHeader()));
+            internal::ApiClientHeader()));
         auto const instance_name =
             "projects/" + kProjectId + "/instances/" + kInstanceId;
         auto const cluster_name = instance_name + "/clusters/-";
@@ -234,7 +234,7 @@ struct MockRpcFactory {
                                    RequestType const& request,
                                    ResponseType* response) {
           EXPECT_STATUS_OK(IsContextMDValid(
-              *context, method, google::cloud::internal::ApiClientHeader()));
+              *context, method, internal::ApiClientHeader()));
           if (response == nullptr) {
             return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
                                 "invalid call to MockRpcFactory::Create()");
@@ -282,7 +282,7 @@ TEST_F(TableAdminTest, ListTablesRecoverableFailures) {
                                      btadmin::ListTablesResponse*) {
     EXPECT_STATUS_OK(IsContextMDValid(
         *context, "google.bigtable.admin.v2.BigtableTableAdmin.ListTables",
-        google::cloud::internal::ApiClientHeader()));
+        internal::ApiClientHeader()));
     return grpc::Status(grpc::StatusCode::UNAVAILABLE, "try-again");
   };
   auto batch0 = create_list_tables_lambda("", "token-001", {"t0", "t1"});
@@ -331,7 +331,7 @@ TEST_F(TableAdminTest, ListTablesTooManyFailures) {
                                      btadmin::ListTablesResponse*) {
     EXPECT_STATUS_OK(IsContextMDValid(
         *context, "google.bigtable.admin.v2.BigtableTableAdmin.ListTables",
-        google::cloud::internal::ApiClientHeader()));
+        internal::ApiClientHeader()));
     return grpc::Status(grpc::StatusCode::UNAVAILABLE, "try-again");
   };
   EXPECT_CALL(*client_, ListTables).WillRepeatedly(mock_recoverable_failure);
@@ -537,7 +537,7 @@ TEST_F(TableAdminTest, ListBackupsRecoverableFailures) {
                                      btadmin::ListBackupsResponse*) {
     EXPECT_STATUS_OK(IsContextMDValid(
         *context, "google.bigtable.admin.v2.BigtableTableAdmin.ListBackups",
-        google::cloud::internal::ApiClientHeader()));
+        internal::ApiClientHeader()));
     return grpc::Status(grpc::StatusCode::UNAVAILABLE, "try-again");
   };
   auto batch0 = create_list_backups_lambda("", "token-001", {"b0", "b1"});
@@ -586,7 +586,7 @@ TEST_F(TableAdminTest, ListBackupsTooManyFailures) {
                                      btadmin::ListBackupsResponse*) {
     EXPECT_STATUS_OK(IsContextMDValid(
         *context, "google.bigtable.admin.v2.BigtableTableAdmin.ListBackups",
-        google::cloud::internal::ApiClientHeader()));
+        internal::ApiClientHeader()));
     return grpc::Status(grpc::StatusCode::UNAVAILABLE, "try-again");
   };
   EXPECT_CALL(*client_, ListBackups).WillRepeatedly(mock_recoverable_failure);
@@ -669,7 +669,7 @@ TEST_F(TableAdminTest, UpdateBackupSimple) {
       "2029-12-31T00:00:00.000-05:00", &expire_time));
   TableAdmin::UpdateBackupParams params(
       "the-cluster", "the-backup",
-      google::cloud::internal::ToChronoTimePoint(expire_time));
+      internal::ToChronoTimePoint(expire_time));
   tested.UpdateBackup(std::move(params));
 }
 
@@ -689,7 +689,7 @@ TEST_F(TableAdminTest, UpdateBackupUnrecoverableFailures) {
       "2029-12-31T00:00:00.000-05:00", &expire_time));
   TableAdmin::UpdateBackupParams params(
       "the-cluster", "the-backup",
-      google::cloud::internal::ToChronoTimePoint(expire_time));
+      internal::ToChronoTimePoint(expire_time));
   EXPECT_FALSE(tested.UpdateBackup(std::move(params)));
 }
 
@@ -710,7 +710,7 @@ TEST_F(TableAdminTest, UpdateBackupTooManyFailures) {
       "2029-12-31T00:00:00.000-05:00", &expire_time));
   TableAdmin::UpdateBackupParams params(
       "the-cluster", "the-backup",
-      google::cloud::internal::ToChronoTimePoint(expire_time));
+      internal::ToChronoTimePoint(expire_time));
   EXPECT_FALSE(tested.UpdateBackup(std::move(params)));
 }
 
@@ -985,7 +985,7 @@ TEST_F(TableAdminTest, GetIamPolicyRecoverableError) {
                                      iamproto::Policy*) {
     EXPECT_STATUS_OK(IsContextMDValid(
         *context, "google.bigtable.admin.v2.BigtableTableAdmin.GetIamPolicy",
-        google::cloud::internal::ApiClientHeader()));
+        internal::ApiClientHeader()));
     return grpc::Status(grpc::StatusCode::UNAVAILABLE, "try-again");
   };
   auto mock_policy = create_get_policy_mock();
@@ -1061,7 +1061,7 @@ TEST_F(TableAdminTest, SetIamPolicyRecoverableError) {
                                      iamproto::Policy*) {
     EXPECT_STATUS_OK(IsContextMDValid(
         *context, "google.bigtable.admin.v2.BigtableTableAdmin.SetIamPolicy",
-        google::cloud::internal::ApiClientHeader()));
+        internal::ApiClientHeader()));
     return grpc::Status(grpc::StatusCode::UNAVAILABLE, "try-again");
   };
   auto mock_policy = create_policy_with_params();
@@ -1093,7 +1093,7 @@ TEST_F(TableAdminTest, TestIamPermissions) {
         EXPECT_STATUS_OK(IsContextMDValid(
             *context,
             "google.bigtable.admin.v2.BigtableTableAdmin.TestIamPermissions",
-            google::cloud::internal::ApiClientHeader()));
+            internal::ApiClientHeader()));
         EXPECT_NE(nullptr, response);
         std::vector<std::string> permissions = {"writer", "reader"};
         response->add_permissions(permissions[0]);
@@ -1123,7 +1123,7 @@ TEST_F(TableAdminTest, TestIamPermissionsForBackup) {
         EXPECT_STATUS_OK(IsContextMDValid(
             *context,
             "google.bigtable.admin.v2.BigtableTableAdmin.TestIamPermissions",
-            google::cloud::internal::ApiClientHeader(), backup_id));
+            internal::ApiClientHeader(), backup_id));
         EXPECT_NE(nullptr, response);
         std::vector<std::string> permissions = {"writer", "reader"};
         response->add_permissions(permissions[0]);
@@ -1166,7 +1166,7 @@ TEST_F(TableAdminTest, TestIamPermissionsRecoverableError) {
     EXPECT_STATUS_OK(IsContextMDValid(
         *context,
         "google.bigtable.admin.v2.BigtableTableAdmin.TestIamPermissions",
-        google::cloud::internal::ApiClientHeader()));
+        internal::ApiClientHeader()));
     return grpc::Status(grpc::StatusCode::UNAVAILABLE, "try-again");
   };
 
@@ -1177,7 +1177,7 @@ TEST_F(TableAdminTest, TestIamPermissionsRecoverableError) {
         EXPECT_STATUS_OK(IsContextMDValid(
             *context,
             "google.bigtable.admin.v2.BigtableTableAdmin.TestIamPermissions",
-            google::cloud::internal::ApiClientHeader()));
+            internal::ApiClientHeader()));
         EXPECT_NE(nullptr, response);
         std::vector<std::string> permissions = {"writer", "reader"};
         response->add_permissions(permissions[0]);
@@ -1236,7 +1236,7 @@ TEST_F(TableAdminTest, AsyncWaitForConsistencySimple) {
       EXPECT_STATUS_OK(IsContextMDValid(
           *context,
           "google.bigtable.admin.v2.BigtableTableAdmin.CheckConsistency",
-          google::cloud::internal::ApiClientHeader()));
+          internal::ApiClientHeader()));
       EXPECT_EQ(
           "projects/the-project/instances/test-instance/tables/test-table",
           request.name());
@@ -1255,7 +1255,7 @@ TEST_F(TableAdminTest, AsyncWaitForConsistencySimple) {
   std::shared_ptr<FakeCompletionQueueImpl> cq_impl(new FakeCompletionQueueImpl);
   CompletionQueue cq(cq_impl);
 
-  google::cloud::future<google::cloud::StatusOr<Consistency>> result =
+  future<StatusOr<Consistency>> result =
       table_admin.AsyncWaitForConsistencyImpl(cq, "test-table",
                                               "test-async-token");
 
@@ -1321,7 +1321,7 @@ TEST_F(TableAdminTest, AsyncWaitForConsistencyFailure) {
         EXPECT_STATUS_OK(IsContextMDValid(
             *context,
             "google.bigtable.admin.v2.BigtableTableAdmin.CheckConsistency",
-            google::cloud::internal::ApiClientHeader()));
+            internal::ApiClientHeader()));
         EXPECT_EQ(
             "projects/the-project/instances/test-instance/tables/test-table",
             request.name());
@@ -1333,7 +1333,7 @@ TEST_F(TableAdminTest, AsyncWaitForConsistencyFailure) {
   std::shared_ptr<FakeCompletionQueueImpl> cq_impl(new FakeCompletionQueueImpl);
   CompletionQueue cq(cq_impl);
 
-  google::cloud::future<google::cloud::StatusOr<Consistency>> result =
+  future<StatusOr<Consistency>> result =
       table_admin.AsyncWaitForConsistencyImpl(cq, "test-table",
                                               "test-async-token");
 
@@ -1366,7 +1366,7 @@ class ValidContextMdAsyncTest : public ::testing::Test {
  protected:
   template <typename ResultType>
   void FinishTest(
-      google::cloud::future<google::cloud::StatusOr<ResultType>> res_future) {
+      future<StatusOr<ResultType>> res_future) {
     EXPECT_EQ(1U, cq_impl_->size());
     cq_impl_->SimulateCompletion(true);
     EXPECT_EQ(0U, cq_impl_->size());
@@ -1400,7 +1400,7 @@ TEST_F(ValidContextMdAsyncTest, AsyncCreateBackup) {
       "2029-12-31T00:00:00.000-05:00", &expire_time));
   TableAdmin::CreateBackupParams backup_config(
       "the-cluster", "the-backup", "the-table",
-      google::cloud::internal::ToChronoTimePoint(expire_time));
+      internal::ToChronoTimePoint(expire_time));
   FinishTest(table_admin_.AsyncCreateBackupImpl(cq_, backup_config));
 }
 

--- a/google/cloud/bigtable/table_admin_test.cc
+++ b/google/cloud/bigtable/table_admin_test.cc
@@ -233,8 +233,8 @@ struct MockRpcFactory {
         [expected_request, method](grpc::ClientContext* context,
                                    RequestType const& request,
                                    ResponseType* response) {
-          EXPECT_STATUS_OK(IsContextMDValid(
-              *context, method, internal::ApiClientHeader()));
+          EXPECT_STATUS_OK(
+              IsContextMDValid(*context, method, internal::ApiClientHeader()));
           if (response == nullptr) {
             return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
                                 "invalid call to MockRpcFactory::Create()");
@@ -668,8 +668,7 @@ TEST_F(TableAdminTest, UpdateBackupSimple) {
   EXPECT_TRUE(google::protobuf::util::TimeUtil::FromString(
       "2029-12-31T00:00:00.000-05:00", &expire_time));
   TableAdmin::UpdateBackupParams params(
-      "the-cluster", "the-backup",
-      internal::ToChronoTimePoint(expire_time));
+      "the-cluster", "the-backup", internal::ToChronoTimePoint(expire_time));
   tested.UpdateBackup(std::move(params));
 }
 
@@ -688,8 +687,7 @@ TEST_F(TableAdminTest, UpdateBackupUnrecoverableFailures) {
   EXPECT_TRUE(google::protobuf::util::TimeUtil::FromString(
       "2029-12-31T00:00:00.000-05:00", &expire_time));
   TableAdmin::UpdateBackupParams params(
-      "the-cluster", "the-backup",
-      internal::ToChronoTimePoint(expire_time));
+      "the-cluster", "the-backup", internal::ToChronoTimePoint(expire_time));
   EXPECT_FALSE(tested.UpdateBackup(std::move(params)));
 }
 
@@ -709,8 +707,7 @@ TEST_F(TableAdminTest, UpdateBackupTooManyFailures) {
   EXPECT_TRUE(google::protobuf::util::TimeUtil::FromString(
       "2029-12-31T00:00:00.000-05:00", &expire_time));
   TableAdmin::UpdateBackupParams params(
-      "the-cluster", "the-backup",
-      internal::ToChronoTimePoint(expire_time));
+      "the-cluster", "the-backup", internal::ToChronoTimePoint(expire_time));
   EXPECT_FALSE(tested.UpdateBackup(std::move(params)));
 }
 
@@ -1365,8 +1362,7 @@ class ValidContextMdAsyncTest : public ::testing::Test {
 
  protected:
   template <typename ResultType>
-  void FinishTest(
-      future<StatusOr<ResultType>> res_future) {
+  void FinishTest(future<StatusOr<ResultType>> res_future) {
     EXPECT_EQ(1U, cq_impl_->size());
     cq_impl_->SimulateCompletion(true);
     EXPECT_EQ(0U, cq_impl_->size());

--- a/google/cloud/bigtable/table_admin_test.cc
+++ b/google/cloud/bigtable/table_admin_test.cc
@@ -1412,8 +1412,8 @@ TEST_F(ValidContextMdAsyncTest, AsyncRestoreTable) {
             backup: "projects/the-project/instances/the-instance/clusters/the-cluster/backups/the-backup"
           )pb",
           "google.bigtable.admin.v2.BigtableTableAdmin.RestoreTable"));
-  bigtable::TableAdmin::RestoreTableParams params("restored-table",
-                                                  "the-cluster", "the-backup");
+  TableAdmin::RestoreTableParams params("restored-table", "the-cluster",
+                                        "the-backup");
   FinishTest(table_admin_.AsyncRestoreTableImpl(cq_, std::move(params)));
 }
 

--- a/google/cloud/bigtable/table_admin_test.cc
+++ b/google/cloud/bigtable/table_admin_test.cc
@@ -1377,8 +1377,8 @@ class ValidContextMdAsyncTest : public ::testing::Test {
 };
 
 TEST_F(ValidContextMdAsyncTest, AsyncCreateBackup) {
-  ::google::cloud::bigtable::testing::MockAsyncFailingRpcFactory<
-      btadmin::CreateBackupRequest, google::longrunning::Operation>
+  bigtable::testing::MockAsyncFailingRpcFactory<btadmin::CreateBackupRequest,
+                                                google::longrunning::Operation>
       rpc_factory;
   EXPECT_CALL(*client_, AsyncCreateBackup)
       .WillOnce(rpc_factory.Create(
@@ -1401,8 +1401,8 @@ TEST_F(ValidContextMdAsyncTest, AsyncCreateBackup) {
 }
 
 TEST_F(ValidContextMdAsyncTest, AsyncRestoreTable) {
-  ::google::cloud::bigtable::testing::MockAsyncFailingRpcFactory<
-      btadmin::RestoreTableRequest, google::longrunning::Operation>
+  bigtable::testing::MockAsyncFailingRpcFactory<btadmin::RestoreTableRequest,
+                                                google::longrunning::Operation>
       rpc_factory;
   EXPECT_CALL(*client_, AsyncRestoreTable)
       .WillOnce(rpc_factory.Create(

--- a/google/cloud/bigtable/table_apply_test.cc
+++ b/google/cloud/bigtable/table_apply_test.cc
@@ -33,9 +33,9 @@ auto mock_mutate_row = [](grpc::Status const& status) {
   return [status](grpc::ClientContext* context,
                   google::bigtable::v2::MutateRowRequest const&,
                   google::bigtable::v2::MutateRowResponse*) {
-    EXPECT_STATUS_OK(
-        IsContextMDValid(*context, "google.bigtable.v2.Bigtable.MutateRow",
-                         internal::ApiClientHeader()));
+    EXPECT_STATUS_OK(IsContextMDValid(*context,
+                                      "google.bigtable.v2.Bigtable.MutateRow",
+                                      internal::ApiClientHeader()));
     return status;
   };
 };
@@ -49,8 +49,8 @@ class TableApplyTest : public bigtable::testing::TableTestFixture {
 TEST_F(TableApplyTest, Simple) {
   EXPECT_CALL(*client_, MutateRow).WillOnce(mock_mutate_row(grpc::Status::OK));
 
-  auto status = table_.Apply(SingleRowMutation(
-      "bar", {SetCell("fam", "col", 0_ms, "val")}));
+  auto status = table_.Apply(
+      SingleRowMutation("bar", {SetCell("fam", "col", 0_ms, "val")}));
   ASSERT_STATUS_OK(status);
 }
 
@@ -60,8 +60,8 @@ TEST_F(TableApplyTest, Failure) {
       .WillRepeatedly(mock_mutate_row(
           grpc::Status(grpc::StatusCode::FAILED_PRECONDITION, "uh-oh")));
 
-  auto status = table_.Apply(SingleRowMutation(
-      "bar", {SetCell("fam", "col", 0_ms, "val")}));
+  auto status = table_.Apply(
+      SingleRowMutation("bar", {SetCell("fam", "col", 0_ms, "val")}));
   EXPECT_THAT(status, StatusIs(StatusCode::kFailedPrecondition));
 }
 
@@ -76,8 +76,8 @@ TEST_F(TableApplyTest, Retry) {
           grpc::Status(grpc::StatusCode::UNAVAILABLE, "try-again")))
       .WillOnce(mock_mutate_row((grpc::Status::OK)));
 
-  auto status = table_.Apply(SingleRowMutation(
-      "bar", {SetCell("fam", "col", 0_ms, "val")}));
+  auto status = table_.Apply(
+      SingleRowMutation("bar", {SetCell("fam", "col", 0_ms, "val")}));
   ASSERT_STATUS_OK(status);
 }
 
@@ -87,8 +87,8 @@ TEST_F(TableApplyTest, RetryIdempotent) {
       .WillRepeatedly(mock_mutate_row(
           grpc::Status(grpc::StatusCode::UNAVAILABLE, "try-again")));
 
-  auto status = table_.Apply(SingleRowMutation(
-      "not-idempotent", {SetCell("fam", "col", "val")}));
+  auto status = table_.Apply(
+      SingleRowMutation("not-idempotent", {SetCell("fam", "col", "val")}));
   EXPECT_THAT(status, StatusIs(StatusCode::kUnavailable));
 }
 

--- a/google/cloud/bigtable/table_apply_test.cc
+++ b/google/cloud/bigtable/table_apply_test.cc
@@ -25,7 +25,6 @@ namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 namespace {
 
-namespace bigtable = ::google::cloud::bigtable;
 using ::google::cloud::testing_util::IsContextMDValid;
 using ::google::cloud::testing_util::StatusIs;
 using ::google::cloud::testing_util::chrono_literals::operator"" _ms;
@@ -36,7 +35,7 @@ auto mock_mutate_row = [](grpc::Status const& status) {
                   google::bigtable::v2::MutateRowResponse*) {
     EXPECT_STATUS_OK(
         IsContextMDValid(*context, "google.bigtable.v2.Bigtable.MutateRow",
-                         google::cloud::internal::ApiClientHeader()));
+                         internal::ApiClientHeader()));
     return status;
   };
 };
@@ -50,8 +49,8 @@ class TableApplyTest : public bigtable::testing::TableTestFixture {
 TEST_F(TableApplyTest, Simple) {
   EXPECT_CALL(*client_, MutateRow).WillOnce(mock_mutate_row(grpc::Status::OK));
 
-  auto status = table_.Apply(bigtable::SingleRowMutation(
-      "bar", {bigtable::SetCell("fam", "col", 0_ms, "val")}));
+  auto status = table_.Apply(SingleRowMutation(
+      "bar", {SetCell("fam", "col", 0_ms, "val")}));
   ASSERT_STATUS_OK(status);
 }
 
@@ -61,8 +60,8 @@ TEST_F(TableApplyTest, Failure) {
       .WillRepeatedly(mock_mutate_row(
           grpc::Status(grpc::StatusCode::FAILED_PRECONDITION, "uh-oh")));
 
-  auto status = table_.Apply(bigtable::SingleRowMutation(
-      "bar", {bigtable::SetCell("fam", "col", 0_ms, "val")}));
+  auto status = table_.Apply(SingleRowMutation(
+      "bar", {SetCell("fam", "col", 0_ms, "val")}));
   EXPECT_THAT(status, StatusIs(StatusCode::kFailedPrecondition));
 }
 
@@ -77,8 +76,8 @@ TEST_F(TableApplyTest, Retry) {
           grpc::Status(grpc::StatusCode::UNAVAILABLE, "try-again")))
       .WillOnce(mock_mutate_row((grpc::Status::OK)));
 
-  auto status = table_.Apply(bigtable::SingleRowMutation(
-      "bar", {bigtable::SetCell("fam", "col", 0_ms, "val")}));
+  auto status = table_.Apply(SingleRowMutation(
+      "bar", {SetCell("fam", "col", 0_ms, "val")}));
   ASSERT_STATUS_OK(status);
 }
 
@@ -88,8 +87,8 @@ TEST_F(TableApplyTest, RetryIdempotent) {
       .WillRepeatedly(mock_mutate_row(
           grpc::Status(grpc::StatusCode::UNAVAILABLE, "try-again")));
 
-  auto status = table_.Apply(bigtable::SingleRowMutation(
-      "not-idempotent", {bigtable::SetCell("fam", "col", "val")}));
+  auto status = table_.Apply(SingleRowMutation(
+      "not-idempotent", {SetCell("fam", "col", "val")}));
   EXPECT_THAT(status, StatusIs(StatusCode::kUnavailable));
 }
 

--- a/google/cloud/bigtable/table_bulk_apply_test.cc
+++ b/google/cloud/bigtable/table_bulk_apply_test.cc
@@ -34,8 +34,7 @@ using ::testing::Not;
 using ::testing::Return;
 
 /// Define types and functions used in the tests.
-class TableBulkApplyTest
-    : public ::google::cloud::bigtable::testing::TableTestFixture {
+class TableBulkApplyTest : public bigtable::testing::TableTestFixture {
  public:
   TableBulkApplyTest() : TableTestFixture(CompletionQueue{}) {}
 };

--- a/google/cloud/bigtable/table_bulk_apply_test.cc
+++ b/google/cloud/bigtable/table_bulk_apply_test.cc
@@ -237,8 +237,7 @@ TEST_F(TableBulkApplyTest, TooManyFailures) {
       SingleRowMutation("foo", {SetCell("fam", "col", 0_ms, "baz")}),
       SingleRowMutation("bar", {SetCell("fam", "col", 0_ms, "qux")})));
   EXPECT_FALSE(failures.empty());
-  EXPECT_EQ(StatusCode::kAborted,
-            failures.front().status().code());
+  EXPECT_EQ(StatusCode::kAborted, failures.front().status().code());
 }
 
 /// @test Verify that Table::BulkApply() retries only idempotent mutations.
@@ -296,8 +295,7 @@ TEST_F(TableBulkApplyTest, FailedRPC) {
   EXPECT_EQ(2UL, failures.size());
   EXPECT_THAT(failures.front().status(), Not(IsOk()));
   EXPECT_FALSE(failures.empty());
-  EXPECT_EQ(StatusCode::kFailedPrecondition,
-            failures.front().status().code());
+  EXPECT_EQ(StatusCode::kFailedPrecondition, failures.front().status().code());
 }
 
 }  // anonymous namespace

--- a/google/cloud/bigtable/table_bulk_apply_test.cc
+++ b/google/cloud/bigtable/table_bulk_apply_test.cc
@@ -237,7 +237,7 @@ TEST_F(TableBulkApplyTest, TooManyFailures) {
       SingleRowMutation("foo", {SetCell("fam", "col", 0_ms, "baz")}),
       SingleRowMutation("bar", {SetCell("fam", "col", 0_ms, "qux")})));
   EXPECT_FALSE(failures.empty());
-  EXPECT_EQ(google::cloud::StatusCode::kAborted,
+  EXPECT_EQ(StatusCode::kAborted,
             failures.front().status().code());
 }
 
@@ -296,7 +296,7 @@ TEST_F(TableBulkApplyTest, FailedRPC) {
   EXPECT_EQ(2UL, failures.size());
   EXPECT_THAT(failures.front().status(), Not(IsOk()));
   EXPECT_FALSE(failures.empty());
-  EXPECT_EQ(google::cloud::StatusCode::kFailedPrecondition,
+  EXPECT_EQ(StatusCode::kFailedPrecondition,
             failures.front().status().code());
 }
 

--- a/google/cloud/bigtable/table_check_and_mutate_row_test.cc
+++ b/google/cloud/bigtable/table_check_and_mutate_row_test.cc
@@ -49,10 +49,10 @@ TEST_F(TableCheckAndMutateRowTest, Simple) {
   EXPECT_CALL(*client_, CheckAndMutateRow)
       .WillOnce(mock_check_and_mutate(grpc::Status::OK));
 
-  auto mut = table_.CheckAndMutateRow(
-      "foo", bigtable::Filter::PassAllFilter(),
-      {bigtable::SetCell("fam", "col", 0_ms, "it was true")},
-      {bigtable::SetCell("fam", "col", 0_ms, "it was false")});
+  auto mut =
+      table_.CheckAndMutateRow("foo", Filter::PassAllFilter(),
+                               {SetCell("fam", "col", 0_ms, "it was true")},
+                               {SetCell("fam", "col", 0_ms, "it was false")});
 
   ASSERT_STATUS_OK(mut);
 }
@@ -64,10 +64,10 @@ TEST_F(TableCheckAndMutateRowTest, Failure) {
       .WillRepeatedly(mock_check_and_mutate(
           grpc::Status(grpc::StatusCode::UNAVAILABLE, "try-again")));
 
-  EXPECT_FALSE(table_.CheckAndMutateRow(
-      "foo", bigtable::Filter::PassAllFilter(),
-      {bigtable::SetCell("fam", "col", 0_ms, "it was true")},
-      {bigtable::SetCell("fam", "col", 0_ms, "it was false")}));
+  EXPECT_FALSE(
+      table_.CheckAndMutateRow("foo", Filter::PassAllFilter(),
+                               {SetCell("fam", "col", 0_ms, "it was true")},
+                               {SetCell("fam", "col", 0_ms, "it was false")}));
 }
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 

--- a/google/cloud/bigtable/table_check_and_mutate_row_test.cc
+++ b/google/cloud/bigtable/table_check_and_mutate_row_test.cc
@@ -39,7 +39,7 @@ auto mock_check_and_mutate = [](grpc::Status const& status) {
                   google::bigtable::v2::CheckAndMutateRowResponse*) {
     EXPECT_STATUS_OK(IsContextMDValid(
         *context, "google.bigtable.v2.Bigtable.CheckAndMutateRow",
-        google::cloud::internal::ApiClientHeader()));
+        internal::ApiClientHeader()));
     return status;
   };
 };

--- a/google/cloud/bigtable/table_readmodifywriterow_test.cc
+++ b/google/cloud/bigtable/table_readmodifywriterow_test.cc
@@ -99,10 +99,8 @@ row {
       .WillOnce(mock_read_modify_write_row);
 
   auto row = table_.ReadModifyWriteRow(
-      row_key,
-      bigtable::ReadModifyWriteRule::AppendValue(family1, column_id1, "value1"),
-      bigtable::ReadModifyWriteRule::AppendValue(family1, column_id1,
-                                                 "-value2"));
+      row_key, ReadModifyWriteRule::AppendValue(family1, column_id1, "value1"),
+      ReadModifyWriteRule::AppendValue(family1, column_id1, "-value2"));
 
   ASSERT_STATUS_OK(row);
   EXPECT_EQ("response-row-key", row->row_key());
@@ -169,10 +167,9 @@ TEST_F(TableReadModifyWriteTest, MultipleIncrementAmountTest) {
       .WillOnce(mock_read_modify_write_row);
 
   auto row = table_.ReadModifyWriteRow(
-      row_key,
-      bigtable::ReadModifyWriteRule::IncrementAmount(family1, column_id1, 1000),
-      bigtable::ReadModifyWriteRule::IncrementAmount(family1, column_id2, 200),
-      bigtable::ReadModifyWriteRule::IncrementAmount(family2, column_id2, 400));
+      row_key, ReadModifyWriteRule::IncrementAmount(family1, column_id1, 1000),
+      ReadModifyWriteRule::IncrementAmount(family1, column_id2, 200),
+      ReadModifyWriteRule::IncrementAmount(family2, column_id2, 400));
 
   ASSERT_STATUS_OK(row);
   EXPECT_EQ("response-row-key", row->row_key());
@@ -243,11 +240,9 @@ TEST_F(TableReadModifyWriteTest, MultipleMixedRuleTest) {
       .WillOnce(mock_read_modify_write_row);
 
   auto row = table_.ReadModifyWriteRow(
-      row_key,
-      bigtable::ReadModifyWriteRule::IncrementAmount(family1, column_id1, 1000),
-      bigtable::ReadModifyWriteRule::AppendValue(family1, column_id2,
-                                                 "value_string"),
-      bigtable::ReadModifyWriteRule::IncrementAmount(family2, column_id2, 400));
+      row_key, ReadModifyWriteRule::IncrementAmount(family1, column_id1, 1000),
+      ReadModifyWriteRule::AppendValue(family1, column_id2, "value_string"),
+      ReadModifyWriteRule::IncrementAmount(family2, column_id2, 400));
 
   ASSERT_STATUS_OK(row);
   EXPECT_EQ("response-row-key", row->row_key());
@@ -268,8 +263,8 @@ TEST_F(TableReadModifyWriteTest, UnrecoverableFailureTest) {
 
   EXPECT_CALL(*client_, ReadModifyWriteRow)
       .WillRepeatedly([](grpc::ClientContext* context,
-                         google::bigtable::v2::ReadModifyWriteRowRequest const&,
-                         google::bigtable::v2::ReadModifyWriteRowResponse*) {
+                         btproto::ReadModifyWriteRowRequest const&,
+                         btproto::ReadModifyWriteRowResponse*) {
         EXPECT_STATUS_OK(IsContextMDValid(
             *context, "google.bigtable.v2.Bigtable.ReadModifyWriteRow",
             google::cloud::internal::ApiClientHeader()));
@@ -277,10 +272,8 @@ TEST_F(TableReadModifyWriteTest, UnrecoverableFailureTest) {
       });
 
   EXPECT_FALSE(table_.ReadModifyWriteRow(
-      row_key,
-      bigtable::ReadModifyWriteRule::AppendValue(family1, column_id1, "value1"),
-      bigtable::ReadModifyWriteRule::AppendValue(family1, column_id1,
-                                                 "-value2")));
+      row_key, ReadModifyWriteRule::AppendValue(family1, column_id1, "value1"),
+      ReadModifyWriteRule::AppendValue(family1, column_id1, "-value2")));
 }
 
 }  // anonymous namespace

--- a/google/cloud/bigtable/table_readmodifywriterow_test.cc
+++ b/google/cloud/bigtable/table_readmodifywriterow_test.cc
@@ -45,7 +45,7 @@ auto create_rules_lambda = [](std::string const& expected_request_string,
              btproto::ReadModifyWriteRowResponse* response) {
     EXPECT_STATUS_OK(IsContextMDValid(
         *context, "google.bigtable.v2.Bigtable.ReadModifyWriteRow",
-        google::cloud::internal::ApiClientHeader()));
+        internal::ApiClientHeader()));
     btproto::ReadModifyWriteRowRequest expected_request;
     EXPECT_TRUE(::google::protobuf::TextFormat::ParseFromString(
         expected_request_string, &expected_request));
@@ -267,7 +267,7 @@ TEST_F(TableReadModifyWriteTest, UnrecoverableFailureTest) {
                          btproto::ReadModifyWriteRowResponse*) {
         EXPECT_STATUS_OK(IsContextMDValid(
             *context, "google.bigtable.v2.Bigtable.ReadModifyWriteRow",
-            google::cloud::internal::ApiClientHeader()));
+            internal::ApiClientHeader()));
         return grpc::Status(grpc::StatusCode::PERMISSION_DENIED, "uh oh");
       });
 

--- a/google/cloud/bigtable/table_readrow_test.cc
+++ b/google/cloud/bigtable/table_readrow_test.cc
@@ -61,7 +61,7 @@ TEST_F(TableReadRowTest, ReadRowSimple) {
 
         EXPECT_STATUS_OK(
             IsContextMDValid(*context, "google.bigtable.v2.Bigtable.ReadRows",
-                             google::cloud::internal::ApiClientHeader()));
+                             internal::ApiClientHeader()));
         EXPECT_EQ(1, req.rows().row_keys_size());
         EXPECT_EQ("r1", req.rows().row_keys(0));
         EXPECT_EQ(1, req.rows_limit());
@@ -69,7 +69,7 @@ TEST_F(TableReadRowTest, ReadRowSimple) {
         return stream;
       });
 
-  auto result = table_.ReadRow("r1", bigtable::Filter::PassAllFilter());
+  auto result = table_.ReadRow("r1", Filter::PassAllFilter());
   ASSERT_STATUS_OK(result);
   EXPECT_TRUE(std::get<0>(*result));
   auto row = std::get<1>(*result);
@@ -87,7 +87,7 @@ TEST_F(TableReadRowTest, ReadRowMissing) {
 
         EXPECT_STATUS_OK(
             IsContextMDValid(*context, "google.bigtable.v2.Bigtable.ReadRows",
-                             google::cloud::internal::ApiClientHeader()));
+                             internal::ApiClientHeader()));
         EXPECT_EQ(1, req.rows().row_keys_size());
         EXPECT_EQ("r1", req.rows().row_keys(0));
         EXPECT_EQ(1, req.rows_limit());
@@ -95,7 +95,7 @@ TEST_F(TableReadRowTest, ReadRowMissing) {
         return stream;
       });
 
-  auto result = table_.ReadRow("r1", bigtable::Filter::PassAllFilter());
+  auto result = table_.ReadRow("r1", Filter::PassAllFilter());
   ASSERT_STATUS_OK(result);
   EXPECT_FALSE(std::get<0>(*result));
 }
@@ -113,11 +113,11 @@ TEST_F(TableReadRowTest, UnrecoverableFailure) {
 
         EXPECT_STATUS_OK(
             IsContextMDValid(*context, "google.bigtable.v2.Bigtable.ReadRows",
-                             google::cloud::internal::ApiClientHeader()));
+                             internal::ApiClientHeader()));
         return stream;
       });
 
-  auto row = table_.ReadRow("r1", bigtable::Filter::PassAllFilter());
+  auto row = table_.ReadRow("r1", Filter::PassAllFilter());
   EXPECT_FALSE(row);
 }
 

--- a/google/cloud/bigtable/table_readrows_test.cc
+++ b/google/cloud/bigtable/table_readrows_test.cc
@@ -55,8 +55,7 @@ TEST_F(TableReadRowsTest, ReadRowsCanReadOneRow) {
   EXPECT_CALL(*stream, Finish()).WillOnce(Return(grpc::Status::OK));
   EXPECT_CALL(*client_, ReadRows).WillOnce(stream->MakeMockReturner());
 
-  auto reader =
-      table_.ReadRows(bigtable::RowSet(), bigtable::Filter::PassAllFilter());
+  auto reader = table_.ReadRows(RowSet(), Filter::PassAllFilter());
 
   auto it = reader.begin();
   EXPECT_NE(it, reader.end());
@@ -111,8 +110,7 @@ TEST_F(TableReadRowsTest, ReadRowsCanReadWithRetries) {
 
   EXPECT_CALL(*stream_retry, Finish()).WillOnce(Return(grpc::Status::OK));
 
-  auto reader =
-      table_.ReadRows(bigtable::RowSet(), bigtable::Filter::PassAllFilter());
+  auto reader = table_.ReadRows(RowSet(), Filter::PassAllFilter());
 
   auto it = reader.begin();
   EXPECT_NE(it, reader.end());
@@ -136,13 +134,11 @@ TEST_F(TableReadRowsTest, ReadRowsThrowsWhenTooManyErrors) {
     return stream;
   }));
 
-  auto table = bigtable::Table(
-      client_, "table_id", bigtable::LimitedErrorCountRetryPolicy(3),
-      bigtable::ExponentialBackoffPolicy(std::chrono::seconds(0),
-                                         std::chrono::seconds(0)),
-      bigtable::SafeIdempotentMutationPolicy());
-  auto reader =
-      table.ReadRows(bigtable::RowSet(), bigtable::Filter::PassAllFilter());
+  auto table = Table(client_, "table_id", LimitedErrorCountRetryPolicy(3),
+                     ExponentialBackoffPolicy(std::chrono::seconds(0),
+                                              std::chrono::seconds(0)),
+                     SafeIdempotentMutationPolicy());
+  auto reader = table.ReadRows(RowSet(), Filter::PassAllFilter());
 
   auto it = reader.begin();
   ASSERT_NE(reader.end(), it);

--- a/google/cloud/bigtable/table_sample_row_keys_test.cc
+++ b/google/cloud/bigtable/table_sample_row_keys_test.cc
@@ -30,8 +30,7 @@ using ::google::cloud::bigtable::testing::MockSampleRowKeysReader;
 using ::testing::Return;
 using ::testing::Unused;
 
-class TableSampleRowKeysTest
-    : public ::google::cloud::bigtable::testing::TableTestFixture {
+class TableSampleRowKeysTest : public bigtable::testing::TableTestFixture {
  public:
   TableSampleRowKeysTest() : TableTestFixture(CompletionQueue{}) {}
 };

--- a/google/cloud/bigtable/table_test.cc
+++ b/google/cloud/bigtable/table_test.cc
@@ -28,7 +28,7 @@ using ::google::cloud::testing_util::FakeCompletionQueueImpl;
 
 /// Define types and functions used in the tests.
 namespace {
-class TableTest : public ::google::cloud::bigtable::testing::TableTestFixture {
+class TableTest : public bigtable::testing::TableTestFixture {
  public:
   TableTest() : TableTestFixture(CompletionQueue{}) {}
 };
@@ -119,7 +119,7 @@ class ValidContextMdAsyncTest : public ::testing::Test {
   ValidContextMdAsyncTest()
       : cq_impl_(new FakeCompletionQueueImpl),
         cq_(cq_impl_),
-        client_(new ::google::cloud::bigtable::testing::MockDataClient(
+        client_(new bigtable::testing::MockDataClient(
             ClientOptions().DisableBackgroundThreads(cq_))) {
     EXPECT_CALL(*client_, project_id())
         .WillRepeatedly(::testing::ReturnRef(kProjectId));
@@ -130,23 +130,21 @@ class ValidContextMdAsyncTest : public ::testing::Test {
 
  protected:
   template <typename ResultType>
-  void FinishTest(
-      ::google::cloud::future<google::cloud::StatusOr<ResultType>> res_future) {
+  void FinishTest(future<StatusOr<ResultType>> res_future) {
     EXPECT_EQ(1U, cq_impl_->size());
     cq_impl_->SimulateCompletion(true);
     EXPECT_EQ(0U, cq_impl_->size());
     auto res = res_future.get();
     EXPECT_FALSE(res);
-    EXPECT_EQ(::google::cloud::StatusCode::kPermissionDenied,
-              res.status().code());
+    EXPECT_EQ(StatusCode::kPermissionDenied, res.status().code());
   }
 
-  void FinishTest(::google::cloud::future<google::cloud::Status> res_future) {
+  void FinishTest(future<Status> res_future) {
     EXPECT_EQ(1U, cq_impl_->size());
     cq_impl_->SimulateCompletion(true);
     EXPECT_EQ(0U, cq_impl_->size());
     auto res = res_future.get();
-    EXPECT_EQ(::google::cloud::StatusCode::kPermissionDenied, res.code());
+    EXPECT_EQ(StatusCode::kPermissionDenied, res.code());
   }
 
   std::shared_ptr<FakeCompletionQueueImpl> cq_impl_;

--- a/google/cloud/bigtable/testing/cleanup_stale_resources.cc
+++ b/google/cloud/bigtable/testing/cleanup_stale_resources.cc
@@ -22,7 +22,7 @@ namespace cloud {
 namespace bigtable {
 namespace testing {
 
-Status CleanupStaleTables(google::cloud::bigtable::TableAdmin admin) {
+Status CleanupStaleTables(TableAdmin admin) {
   auto const threshold =
       std::chrono::system_clock::now() - std::chrono::hours(48);
   auto const max_table_id = RandomTableId(threshold);
@@ -43,7 +43,7 @@ Status CleanupStaleTables(google::cloud::bigtable::TableAdmin admin) {
   return Status{};
 }
 
-Status CleanupStaleBackups(google::cloud::bigtable::TableAdmin admin) {
+Status CleanupStaleBackups(TableAdmin admin) {
   auto const threshold =
       std::chrono::system_clock::now() - std::chrono::hours(48);
   auto const max_backup_id = RandomBackupId(threshold);
@@ -64,7 +64,7 @@ Status CleanupStaleBackups(google::cloud::bigtable::TableAdmin admin) {
   return Status{};
 }
 
-Status CleanupStaleInstances(google::cloud::bigtable::InstanceAdmin admin) {
+Status CleanupStaleInstances(InstanceAdmin admin) {
   auto const threshold =
       std::chrono::system_clock::now() - std::chrono::hours(48);
   auto const max_instance_id = RandomInstanceId(threshold);

--- a/google/cloud/bigtable/testing/cleanup_stale_resources.h
+++ b/google/cloud/bigtable/testing/cleanup_stale_resources.h
@@ -33,7 +33,7 @@ namespace testing {
  * times out, and (b) avoiding flakes caused by quota exhaustion is necessary
  * for healthy builds.
  */
-Status CleanupStaleTables(google::cloud::bigtable::TableAdmin admin);
+Status CleanupStaleTables(TableAdmin admin);
 
 /**
  * Remove stale test backups.
@@ -45,7 +45,7 @@ Status CleanupStaleTables(google::cloud::bigtable::TableAdmin admin);
  * times out, and (b) avoiding flakes caused by quota exhaustion is necessary
  * for healthy builds.
  */
-Status CleanupStaleBackups(google::cloud::bigtable::TableAdmin admin);
+Status CleanupStaleBackups(TableAdmin admin);
 
 /**
  * Remove stale test instances.
@@ -57,7 +57,7 @@ Status CleanupStaleBackups(google::cloud::bigtable::TableAdmin admin);
  * crashes or times out, and (b) avoiding flakes caused by quota exhaustion is
  * necessary for healthy builds.
  */
-Status CleanupStaleInstances(google::cloud::bigtable::InstanceAdmin admin);
+Status CleanupStaleInstances(InstanceAdmin admin);
 
 }  // namespace testing
 }  // namespace bigtable

--- a/google/cloud/bigtable/testing/cleanup_stale_resources_test.cc
+++ b/google/cloud/bigtable/testing/cleanup_stale_resources_test.cc
@@ -30,7 +30,7 @@ using ::testing::HasSubstr;
 using ::testing::ReturnRef;
 
 TEST(CleanupStaleResources, CleanupOldTables) {
-  using MockAdminClient = ::google::cloud::bigtable::testing::MockAdminClient;
+  using ::google::cloud::bigtable::testing::MockAdminClient;
   namespace btadmin = ::google::bigtable::admin::v2;
 
   auto const expired_tp =
@@ -60,7 +60,7 @@ TEST(CleanupStaleResources, CleanupOldTables) {
         return grpc::Status::OK;
       });
 
-  bigtable::TableAdmin admin(mock, instance_id);
+  TableAdmin admin(mock, instance_id);
   auto const name_1 = admin.TableName(id_1);
   auto const name_2 = admin.TableName(id_2);
   // Verify only `name_1` and `name_2` are deleted.
@@ -82,7 +82,7 @@ TEST(CleanupStaleResources, CleanupOldTables) {
 }
 
 TEST(CleanupStaleResources, CleanupStaleBackups) {
-  using MockAdminClient = ::google::cloud::bigtable::testing::MockAdminClient;
+  using ::google::cloud::bigtable::testing::MockAdminClient;
   using ::google::protobuf::util::TimeUtil;
   namespace btadmin = ::google::bigtable::admin::v2;
 
@@ -103,7 +103,7 @@ TEST(CleanupStaleResources, CleanupStaleBackups) {
   std::string const prefix = "project/" + project_id + "/instances/" +
                              instance_id + "/clusters/" + cluster_id +
                              "/backups/";
-  google::bigtable::admin::v2::Backup backup_2;
+  btadmin::Backup backup_2;
   backup_2.set_name(prefix + id_2);
   *backup_2.mutable_expire_time() =
       TimeUtil::GetCurrentTime() - TimeUtil::HoursToDuration(24 * 8);
@@ -116,7 +116,7 @@ TEST(CleanupStaleResources, CleanupStaleBackups) {
                     btadmin::ListBackupsResponse* response) {
         for (auto const& backup : {id_1, id_2, id_3, id_4, id_5}) {
           auto& b = *response->add_backups();
-          google::bigtable::admin::v2::Backup backup_1;
+          btadmin::Backup backup_1;
           b.set_name(prefix + backup);
         }
         response->clear_next_page_token();
@@ -149,8 +149,7 @@ TEST(CleanupStaleResources, CleanupStaleBackups) {
 }
 
 TEST(CleanupStaleResources, CleanupOldInstances) {
-  using MockAdminClient =
-      ::google::cloud::bigtable::testing::MockInstanceAdminClient;
+  using ::google::cloud::bigtable::testing::MockInstanceAdminClient;
   namespace btadmin = ::google::bigtable::admin::v2;
 
   auto const expired_tp =
@@ -164,7 +163,7 @@ TEST(CleanupStaleResources, CleanupOldInstances) {
 
   std::string const project_id = "test-project-id";
 
-  auto mock = std::make_shared<MockAdminClient>();
+  auto mock = std::make_shared<MockInstanceAdminClient>();
   EXPECT_CALL(*mock, project()).WillRepeatedly(ReturnRef(project_id));
 
   EXPECT_CALL(*mock, ListInstances)

--- a/google/cloud/bigtable/testing/mock_admin_client.h
+++ b/google/cloud/bigtable/testing/mock_admin_client.h
@@ -24,7 +24,7 @@ namespace cloud {
 namespace bigtable {
 namespace testing {
 
-class MockAdminClient : public bigtable::AdminClient {
+class MockAdminClient : public AdminClient {
  public:
   explicit MockAdminClient(ClientOptions options = {})
       : options_(std::move(options)) {}

--- a/google/cloud/bigtable/testing/table_integration_test.cc
+++ b/google/cloud/bigtable/testing/table_integration_test.cc
@@ -105,13 +105,13 @@ std::string TableTestEnvironment::RandomInstanceId() {
 }
 
 void TableIntegrationTest::SetUp() {
-  admin_client_ = CreateDefaultAdminClient(
-      TableTestEnvironment::project_id(), ClientOptions());
+  admin_client_ = CreateDefaultAdminClient(TableTestEnvironment::project_id(),
+                                           ClientOptions());
   table_admin_ = absl::make_unique<TableAdmin>(
       admin_client_, TableTestEnvironment::instance_id());
-  data_client_ = CreateDefaultDataClient(
-      TableTestEnvironment::project_id(), TableTestEnvironment::instance_id(),
-      ClientOptions());
+  data_client_ = CreateDefaultDataClient(TableTestEnvironment::project_id(),
+                                         TableTestEnvironment::instance_id(),
+                                         ClientOptions());
 
   // In production, we cannot use `DropAllRows()` to cleanup the table because
   // the integration tests sometimes consume all the 'DropRowRangeGroup' quota.
@@ -129,8 +129,7 @@ void TableIntegrationTest::SetUp() {
     if (!row) {
       break;
     }
-    bulk.emplace_back(
-        SingleRowMutation(row->row_key(), DeleteFromRow()));
+    bulk.emplace_back(SingleRowMutation(row->row_key(), DeleteFromRow()));
     if (bulk.size() > maximum_mutations) {
       break;
     }
@@ -156,10 +155,9 @@ Table TableIntegrationTest::GetTable() {
   return Table(data_client_, TableTestEnvironment::table_id());
 }
 
-std::vector<Cell> TableIntegrationTest::ReadRows(
-    Table& table, Filter filter) {
-  auto reader = table.ReadRows(
-      RowSet(RowRange::InfiniteRange()), std::move(filter));
+std::vector<Cell> TableIntegrationTest::ReadRows(Table& table, Filter filter) {
+  auto reader =
+      table.ReadRows(RowSet(RowRange::InfiniteRange()), std::move(filter));
   std::vector<Cell> result;
   for (auto const& row : reader) {
     EXPECT_STATUS_OK(row);
@@ -169,17 +167,17 @@ std::vector<Cell> TableIntegrationTest::ReadRows(
   return result;
 }
 
-std::vector<Cell> TableIntegrationTest::ReadRows(
-    std::string const& table_name, Filter filter) {
+std::vector<Cell> TableIntegrationTest::ReadRows(std::string const& table_name,
+                                                 Filter filter) {
   Table table(data_client_, table_name);
   return ReadRows(table, std::move(filter));
 }
 
-std::vector<Cell> TableIntegrationTest::ReadRows(
-    Table& table, std::int64_t rows_limit, Filter filter) {
-  auto reader =
-      table.ReadRows(RowSet(RowRange::InfiniteRange()),
-                     rows_limit, std::move(filter));
+std::vector<Cell> TableIntegrationTest::ReadRows(Table& table,
+                                                 std::int64_t rows_limit,
+                                                 Filter filter) {
+  auto reader = table.ReadRows(RowSet(RowRange::InfiniteRange()), rows_limit,
+                               std::move(filter));
   std::vector<Cell> result;
   for (auto const& row : reader) {
     EXPECT_STATUS_OK(row);
@@ -189,8 +187,7 @@ std::vector<Cell> TableIntegrationTest::ReadRows(
   return result;
 }
 
-std::vector<Cell> TableIntegrationTest::MoveCellsFromReader(
-    RowReader& reader) {
+std::vector<Cell> TableIntegrationTest::MoveCellsFromReader(RowReader& reader) {
   std::vector<Cell> result;
   for (auto const& row : reader) {
     EXPECT_STATUS_OK(row);
@@ -201,8 +198,8 @@ std::vector<Cell> TableIntegrationTest::MoveCellsFromReader(
 }
 
 /// A helper function to create a list of cells.
-void TableIntegrationTest::CreateCells(
-    Table& table, std::vector<Cell> const& cells) {
+void TableIntegrationTest::CreateCells(Table& table,
+                                       std::vector<Cell> const& cells) {
   std::map<RowKeyType, SingleRowMutation> mutations;
   for (auto const& cell : cells) {
     using std::chrono::duration_cast;
@@ -210,10 +207,10 @@ void TableIntegrationTest::CreateCells(
     using std::chrono::milliseconds;
     auto key = cell.row_key();
     auto inserted = mutations.emplace(key, SingleRowMutation(key));
-    inserted.first->second.emplace_back(SetCell(
-        cell.family_name(), cell.column_qualifier(),
-        duration_cast<milliseconds>(microseconds(cell.timestamp())),
-        cell.value()));
+    inserted.first->second.emplace_back(
+        SetCell(cell.family_name(), cell.column_qualifier(),
+                duration_cast<milliseconds>(microseconds(cell.timestamp())),
+                cell.value()));
   }
   BulkMutation bulk;
   for (auto& kv : mutations) {
@@ -238,8 +235,8 @@ std::vector<Cell> TableIntegrationTest::GetCellsIgnoringTimestamp(
   return return_cells;
 }
 
-void TableIntegrationTest::CheckEqualUnordered(
-    std::vector<Cell> expected, std::vector<Cell> actual) {
+void TableIntegrationTest::CheckEqualUnordered(std::vector<Cell> expected,
+                                               std::vector<Cell> actual) {
   std::sort(expected.begin(), expected.end());
   std::sort(actual.begin(), actual.end());
   EXPECT_THAT(actual, ::testing::ContainerEq(expected));
@@ -264,7 +261,8 @@ std::string TableIntegrationTest::RandomBackupId() {
 }  // namespace testing
 
 int CellCompare(Cell const& lhs, Cell const& rhs) {
-  auto compare_row_key = bigtable_internal::CompareRowKey(lhs.row_key(), rhs.row_key());
+  auto compare_row_key =
+      bigtable_internal::CompareRowKey(lhs.row_key(), rhs.row_key());
   if (compare_row_key != 0) {
     return compare_row_key;
   }
@@ -283,7 +281,8 @@ int CellCompare(Cell const& lhs, Cell const& rhs) {
   if (lhs.timestamp() > rhs.timestamp()) {
     return 1;
   }
-  auto compare_value = bigtable_internal::CompareCellValues(lhs.value(), rhs.value());
+  auto compare_value =
+      bigtable_internal::CompareCellValues(lhs.value(), rhs.value());
   if (compare_value != 0) {
     return compare_value;
   }

--- a/google/cloud/bigtable/tests/admin_backup_integration_test.cc
+++ b/google/cloud/bigtable/tests/admin_backup_integration_test.cc
@@ -44,25 +44,20 @@ class AdminBackupIntegrationTest
   std::unique_ptr<InstanceAdmin> instance_admin_;
 
   void SetUp() override {
-    if (internal::GetEnv(
-            "ENABLE_BIGTABLE_ADMIN_INTEGRATION_TESTS")
+    if (internal::GetEnv("ENABLE_BIGTABLE_ADMIN_INTEGRATION_TESTS")
             .value_or("") != "yes") {
       GTEST_SKIP();
     }
 
     TableIntegrationTest::SetUp();
 
-    std::shared_ptr<AdminClient> admin_client =
-        CreateDefaultAdminClient(
-            bigtable::testing::TableTestEnvironment::project_id(),
-            ClientOptions());
+    std::shared_ptr<AdminClient> admin_client = CreateDefaultAdminClient(
+        bigtable::testing::TableTestEnvironment::project_id(), ClientOptions());
     table_admin_ = absl::make_unique<TableAdmin>(
         admin_client, bigtable::testing::TableTestEnvironment::instance_id());
     auto instance_admin_client = CreateDefaultInstanceAdminClient(
-        bigtable::testing::TableTestEnvironment::project_id(),
-        ClientOptions());
-    instance_admin_ =
-        absl::make_unique<InstanceAdmin>(instance_admin_client);
+        bigtable::testing::TableTestEnvironment::project_id(), ClientOptions());
+    instance_admin_ = absl::make_unique<InstanceAdmin>(instance_admin_client);
   }
 };
 
@@ -82,10 +77,9 @@ TEST_F(AdminBackupIntegrationTest, CreateListGetUpdateRestoreDeleteBackup) {
       << "Table (" << table_id << ") already exists."
       << " This is unexpected, as the table ids are generated at random.";
   // create table config
-  TableConfig table_config(
-      {{"fam", GC::MaxNumVersions(5)},
-       {"foo", GC::MaxAge(std::chrono::hours(24))}},
-      {"a1000", "a2000", "b3000", "m5000"});
+  TableConfig table_config({{"fam", GC::MaxNumVersions(5)},
+                            {"foo", GC::MaxAge(std::chrono::hours(24))}},
+                           {"a1000", "a2000", "b3000", "m5000"});
 
   // create table
   ASSERT_STATUS_OK(table_admin_->CreateTable(table_id, table_config));
@@ -116,9 +110,9 @@ TEST_F(AdminBackupIntegrationTest, CreateListGetUpdateRestoreDeleteBackup) {
       google::protobuf::util::TimeUtil::GetCurrentTime() +
       google::protobuf::util::TimeUtil::HoursToDuration(12);
 
-  auto created_backup = table_admin_->CreateBackup(
-      {backup_cluster_id, backup_id, table_id,
-       internal::ToChronoTimePoint(expire_time)});
+  auto created_backup =
+      table_admin_->CreateBackup({backup_cluster_id, backup_id, table_id,
+                                  internal::ToChronoTimePoint(expire_time)});
   ASSERT_STATUS_OK(created_backup);
   EXPECT_EQ(created_backup->name(), backup_full_name);
 

--- a/google/cloud/bigtable/tests/admin_iam_policy_integration_test.cc
+++ b/google/cloud/bigtable/tests/admin_iam_policy_integration_test.cc
@@ -28,7 +28,6 @@ namespace {
 using ::testing::Contains;
 using ::testing::Not;
 namespace btadmin = ::google::bigtable::admin::v2;
-namespace bigtable = ::google::cloud::bigtable;
 
 class AdminIAMPolicyIntegrationTest
     : public bigtable::testing::TableIntegrationTest {
@@ -38,7 +37,7 @@ class AdminIAMPolicyIntegrationTest
   std::string service_account_;
 
   void SetUp() override {
-    service_account_ = google::cloud::internal::GetEnv(
+    service_account_ = internal::GetEnv(
                            "GOOGLE_CLOUD_CPP_BIGTABLE_TEST_SERVICE_ACCOUNT")
                            .value_or("");
     ASSERT_FALSE(service_account_.empty());
@@ -53,7 +52,7 @@ class AdminIAMPolicyIntegrationTest
 
 /// @test Verify that IAM Policy APIs work as expected.
 TEST_F(AdminIAMPolicyIntegrationTest, SetGetTestIamAPIsTest) {
-  using GC = bigtable::GcRule;
+  using GC = GcRule;
   std::string const table_id = RandomTableId();
 
   // verify new table id in current table list
@@ -67,7 +66,7 @@ TEST_F(AdminIAMPolicyIntegrationTest, SetGetTestIamAPIsTest) {
       << " This is unexpected, as the table ids are generated at random.";
 
   // create table config
-  bigtable::TableConfig table_config(
+  TableConfig table_config(
       {{"fam", GC::MaxNumVersions(5)},
        {"foo", GC::MaxAge(std::chrono::hours(24))}},
       {"a1000", "a2000", "b3000", "m5000"});
@@ -75,7 +74,7 @@ TEST_F(AdminIAMPolicyIntegrationTest, SetGetTestIamAPIsTest) {
   // create table
   ASSERT_STATUS_OK(table_admin_->CreateTable(table_id, table_config));
 
-  auto iam_policy = bigtable::IamPolicy({bigtable::IamBinding(
+  auto iam_policy = IamPolicy({IamBinding(
       "roles/bigtable.reader", {"serviceAccount:" + service_account_})});
 
   auto initial_policy = table_admin_->SetIamPolicy(table_id, iam_policy);

--- a/google/cloud/bigtable/tests/admin_iam_policy_integration_test.cc
+++ b/google/cloud/bigtable/tests/admin_iam_policy_integration_test.cc
@@ -37,9 +37,9 @@ class AdminIAMPolicyIntegrationTest
   std::string service_account_;
 
   void SetUp() override {
-    service_account_ = internal::GetEnv(
-                           "GOOGLE_CLOUD_CPP_BIGTABLE_TEST_SERVICE_ACCOUNT")
-                           .value_or("");
+    service_account_ =
+        internal::GetEnv("GOOGLE_CLOUD_CPP_BIGTABLE_TEST_SERVICE_ACCOUNT")
+            .value_or("");
     ASSERT_FALSE(service_account_.empty());
 
     TableIntegrationTest::SetUp();
@@ -66,10 +66,9 @@ TEST_F(AdminIAMPolicyIntegrationTest, SetGetTestIamAPIsTest) {
       << " This is unexpected, as the table ids are generated at random.";
 
   // create table config
-  TableConfig table_config(
-      {{"fam", GC::MaxNumVersions(5)},
-       {"foo", GC::MaxAge(std::chrono::hours(24))}},
-      {"a1000", "a2000", "b3000", "m5000"});
+  TableConfig table_config({{"fam", GC::MaxNumVersions(5)},
+                            {"foo", GC::MaxAge(std::chrono::hours(24))}},
+                           {"a1000", "a2000", "b3000", "m5000"});
 
   // create table
   ASSERT_STATUS_OK(table_admin_->CreateTable(table_id, table_config));

--- a/google/cloud/bigtable/tests/admin_integration_test.cc
+++ b/google/cloud/bigtable/tests/admin_integration_test.cc
@@ -50,10 +50,8 @@ class AdminIntegrationTest : public bigtable::testing::TableIntegrationTest {
     }
     TableIntegrationTest::SetUp();
 
-    std::shared_ptr<AdminClient> admin_client =
-        CreateDefaultAdminClient(
-            bigtable::testing::TableTestEnvironment::project_id(),
-            ClientOptions());
+    std::shared_ptr<AdminClient> admin_client = CreateDefaultAdminClient(
+        bigtable::testing::TableTestEnvironment::project_id(), ClientOptions());
     table_admin_ = absl::make_unique<TableAdmin>(
         admin_client, bigtable::testing::TableTestEnvironment::instance_id());
   }
@@ -173,10 +171,9 @@ TEST_F(AdminIntegrationTest, CreateListGetDeleteTable) {
       << " This is unexpected, as the table ids are generated at random.";
 
   // create table config
-  TableConfig table_config(
-      {{"fam", GC::MaxNumVersions(5)},
-       {"foo", GC::MaxAge(std::chrono::hours(24))}},
-      {"a1000", "a2000", "b3000", "m5000"});
+  TableConfig table_config({{"fam", GC::MaxNumVersions(5)},
+                            {"foo", GC::MaxAge(std::chrono::hours(24))}},
+                           {"a1000", "a2000", "b3000", "m5000"});
 
   // create table
   ASSERT_STATUS_OK(table_admin_->CreateTable(table_id, table_config));
@@ -244,12 +241,11 @@ TEST_F(AdminIntegrationTest, WaitForConsistencyCheck) {
 
   // Create a bigtable::InstanceAdmin and a bigtable::TableAdmin to create the
   // new instance and the new table.
-  auto instance_admin_client = CreateDefaultInstanceAdminClient(
-      project_id, ClientOptions());
+  auto instance_admin_client =
+      CreateDefaultInstanceAdminClient(project_id, ClientOptions());
   InstanceAdmin instance_admin(instance_admin_client);
 
-  auto admin_client =
-      CreateDefaultAdminClient(project_id, ClientOptions());
+  auto admin_client = CreateDefaultAdminClient(project_id, ClientOptions());
   TableAdmin table_admin(admin_client, id);
 
   // The instance configuration is involved, it needs two clusters, which must
@@ -257,12 +253,10 @@ TEST_F(AdminIntegrationTest, WaitForConsistencyCheck) {
   // they must be in different zones. Also, the display name cannot be longer
   // than 30 characters.
   auto display_name = ("IT " + id).substr(0, 30);
-  auto cluster_config_1 =
-      ClusterConfig(bigtable::testing::TableTestEnvironment::zone_a(),
-                              3, ClusterConfig::HDD);
-  auto cluster_config_2 =
-      ClusterConfig(bigtable::testing::TableTestEnvironment::zone_b(),
-                              3, ClusterConfig::HDD);
+  auto cluster_config_1 = ClusterConfig(
+      bigtable::testing::TableTestEnvironment::zone_a(), 3, ClusterConfig::HDD);
+  auto cluster_config_2 = ClusterConfig(
+      bigtable::testing::TableTestEnvironment::zone_b(), 3, ClusterConfig::HDD);
   InstanceConfig config(
       id, display_name,
       {{id + "-c1", cluster_config_1}, {id + "-c2", cluster_config_2}});
@@ -273,8 +267,8 @@ TEST_F(AdminIntegrationTest, WaitForConsistencyCheck) {
 
   // The table is going to be very simple, just one column family.
   std::string const family = "column_family";
-  TableConfig table_config = TableConfig(
-      {{family, GcRule::MaxNumVersions(10)}}, {});
+  TableConfig table_config =
+      TableConfig({{family, GcRule::MaxNumVersions(10)}}, {});
 
   // Create the new table.
   auto table_created = table_admin.CreateTable(random_table_id, table_config);
@@ -282,8 +276,7 @@ TEST_F(AdminIntegrationTest, WaitForConsistencyCheck) {
 
   // We need to mutate the data in the table and then wait for those mutations
   // to propagate to both clusters. First create a `bigtable::Table` object.
-  auto data_client = CreateDefaultDataClient(
-      project_id, id, ClientOptions());
+  auto data_client = CreateDefaultDataClient(project_id, id, ClientOptions());
   Table table(data_client, random_table_id);
 
   // Insert some cells into the table.
@@ -323,10 +316,9 @@ TEST_F(AdminIntegrationTest, CreateListGetDeleteTableWithLogging) {
 
   std::string const table_id = RandomTableId();
 
-  std::shared_ptr<AdminClient> admin_client =
-      CreateDefaultAdminClient(
-          bigtable::testing::TableTestEnvironment::project_id(),
-          ClientOptions().enable_tracing("rpc"));
+  std::shared_ptr<AdminClient> admin_client = CreateDefaultAdminClient(
+      bigtable::testing::TableTestEnvironment::project_id(),
+      ClientOptions().enable_tracing("rpc"));
   auto table_admin = absl::make_unique<TableAdmin>(
       admin_client, bigtable::testing::TableTestEnvironment::instance_id());
 
@@ -340,10 +332,9 @@ TEST_F(AdminIntegrationTest, CreateListGetDeleteTableWithLogging) {
       << " This is unexpected, as the table ids are generated at random.";
 
   // create table config
-  TableConfig table_config(
-      {{"fam", GC::MaxNumVersions(5)},
-       {"foo", GC::MaxAge(std::chrono::hours(24))}},
-      {"a1000", "a2000", "b3000", "m5000"});
+  TableConfig table_config({{"fam", GC::MaxNumVersions(5)},
+                            {"foo", GC::MaxAge(std::chrono::hours(24))}},
+                           {"a1000", "a2000", "b3000", "m5000"});
 
   // create table
   ASSERT_STATUS_OK(table_admin->CreateTable(table_id, table_config));

--- a/google/cloud/bigtable/tests/data_async_future_integration_test.cc
+++ b/google/cloud/bigtable/tests/data_async_future_integration_test.cc
@@ -30,7 +30,7 @@ TEST_F(DataAsyncFutureIntegrationTest, TableAsyncApply) {
   auto table = GetTable();
 
   std::string const row_key = "key-000010";
-  std::vector<bigtable::Cell> created{{row_key, kFamily, "cc1", 1000, "v1000"},
+  std::vector<Cell> created{{row_key, kFamily, "cc1", 1000, "v1000"},
                                       {row_key, kFamily, "cc2", 2000, "v2000"}};
   SingleRowMutation mut(row_key);
   for (auto const& c : created) {
@@ -49,11 +49,11 @@ TEST_F(DataAsyncFutureIntegrationTest, TableAsyncApply) {
   EXPECT_STATUS_OK(status);
 
   // Validate that the newly created cells are actually in the server.
-  std::vector<bigtable::Cell> expected{
+  std::vector<Cell> expected{
       {row_key, kFamily, "cc1", 1000, "v1000"},
       {row_key, kFamily, "cc2", 2000, "v2000"}};
 
-  auto actual = ReadRows(table, bigtable::Filter::PassAllFilter());
+  auto actual = ReadRows(table, Filter::PassAllFilter());
 
   CheckEqualUnordered(expected, actual);
 }
@@ -63,7 +63,7 @@ TEST_F(DataAsyncFutureIntegrationTest, TableAsyncBulkApply) {
 
   std::string const row_key1 = "key-000010";
   std::string const row_key2 = "key-000020";
-  std::map<std::string, std::vector<bigtable::Cell>> created{
+  std::map<std::string, std::vector<Cell>> created{
       {row_key1,
        {{row_key1, kFamily, "cc1", 1000, "vv10"},
         {row_key1, kFamily, "cc2", 2000, "vv20"}}},
@@ -93,7 +93,7 @@ TEST_F(DataAsyncFutureIntegrationTest, TableAsyncBulkApply) {
   fut_void.get();
 
   // Validate that the newly created cells are actually in the server.
-  std::vector<bigtable::Cell> expected;
+  std::vector<Cell> expected;
   for (auto const& row_cells : created) {
     auto const& cells = row_cells.second;
     for (auto const& c : cells) {
@@ -101,7 +101,7 @@ TEST_F(DataAsyncFutureIntegrationTest, TableAsyncBulkApply) {
     }
   }
 
-  auto actual = ReadRows(table, bigtable::Filter::PassAllFilter());
+  auto actual = ReadRows(table, Filter::PassAllFilter());
 
   CheckEqualUnordered(expected, actual);
 }
@@ -111,13 +111,13 @@ TEST_F(DataAsyncFutureIntegrationTest, TableAsyncCheckAndMutateRowPass) {
 
   std::string const key = "row-key";
 
-  std::vector<bigtable::Cell> created{{key, kFamily, "c1", 0, "v1000"}};
+  std::vector<Cell> created{{key, kFamily, "c1", 0, "v1000"}};
   CreateCells(table, created);
 
   auto fut = table.AsyncCheckAndMutateRow(
-      key, bigtable::Filter::ValueRegex("v1000"),
-      {bigtable::SetCell(kFamily, "c2", 0_ms, "v2000")},
-      {bigtable::SetCell(kFamily, "c3", 0_ms, "v3000")});
+      key, Filter::ValueRegex("v1000"),
+      {SetCell(kFamily, "c2", 0_ms, "v2000")},
+      {SetCell(kFamily, "c3", 0_ms, "v3000")});
 
   // Block until the asynchronous operation completes. This is not what one
   // would do in a real application (the synchronous API is better in that
@@ -125,10 +125,10 @@ TEST_F(DataAsyncFutureIntegrationTest, TableAsyncCheckAndMutateRowPass) {
   auto status = fut.get();
   EXPECT_STATUS_OK(status);
 
-  std::vector<bigtable::Cell> expected{{key, kFamily, "c1", 0, "v1000"},
+  std::vector<Cell> expected{{key, kFamily, "c1", 0, "v1000"},
                                        {key, kFamily, "c2", 0, "v2000"}};
 
-  auto actual = ReadRows(table, bigtable::Filter::PassAllFilter());
+  auto actual = ReadRows(table, Filter::PassAllFilter());
 
   CheckEqualUnordered(expected, actual);
 }
@@ -138,13 +138,13 @@ TEST_F(DataAsyncFutureIntegrationTest, TableAsyncCheckAndMutateRowFail) {
 
   std::string const key = "row-key";
 
-  std::vector<bigtable::Cell> created{{key, kFamily, "c1", 0, "v1000"}};
+  std::vector<Cell> created{{key, kFamily, "c1", 0, "v1000"}};
   CreateCells(table, created);
 
   auto fut = table.AsyncCheckAndMutateRow(
-      key, bigtable::Filter::ValueRegex("not-there"),
-      {bigtable::SetCell(kFamily, "c2", 0_ms, "v2000")},
-      {bigtable::SetCell(kFamily, "c3", 0_ms, "v3000")});
+      key, Filter::ValueRegex("not-there"),
+      {SetCell(kFamily, "c2", 0_ms, "v2000")},
+      {SetCell(kFamily, "c3", 0_ms, "v3000")});
 
   // Block until the asynchronous operation completes. This is not what one
   // would do in a real application (the synchronous API is better in that
@@ -152,10 +152,10 @@ TEST_F(DataAsyncFutureIntegrationTest, TableAsyncCheckAndMutateRowFail) {
   auto status = fut.get();
   EXPECT_STATUS_OK(status);
 
-  std::vector<bigtable::Cell> expected{{key, kFamily, "c1", 0, "v1000"},
+  std::vector<Cell> expected{{key, kFamily, "c1", 0, "v1000"},
                                        {key, kFamily, "c3", 0, "v3000"}};
 
-  auto actual = ReadRows(table, bigtable::Filter::PassAllFilter());
+  auto actual = ReadRows(table, Filter::PassAllFilter());
 
   CheckEqualUnordered(expected, actual);
 }
@@ -174,24 +174,24 @@ TEST_F(DataAsyncFutureIntegrationTest,
   std::string const family3 = "family3";
   std::string const family4 = "family4";
 
-  std::vector<bigtable::Cell> created{
+  std::vector<Cell> created{
       {row_key1, family1, "column-id1", 1000, "v1000"},
       {row_key1, family2, "column-id2", 2000, "v2000"}};
 
-  std::vector<bigtable::Cell> expected_read{
+  std::vector<Cell> expected_read{
       {row_key1, family1, "column-id1", 1000, "v1000"},
       {row_key1, family2, "column-id2", 2000, "v2000"},
       {row_key1, family1, "column-id1", 1000, "v1000" + add_suffix1},
       {row_key1, family2, "column-id2", 2000, "v2000" + add_suffix2},
       {row_key1, family3, "column-id3", 2000, add_suffix3}};
 
-  std::vector<bigtable::Cell> expected_return{
+  std::vector<Cell> expected_return{
       {row_key1, family1, "column-id1", 0, "v1000" + add_suffix1},
       {row_key1, family2, "column-id2", 0, "v2000" + add_suffix2},
       {row_key1, family3, "column-id3", 0, add_suffix3}};
 
   CreateCells(table, created);
-  using R = bigtable::ReadModifyWriteRule;
+  using R = ReadModifyWriteRule;
 
   auto fut = table.AsyncReadModifyWriteRow(
       row_key1, R::AppendValue(family1, "column-id1", add_suffix1),
@@ -208,7 +208,7 @@ TEST_F(DataAsyncFutureIntegrationTest,
   auto row_cells = GetCellsIgnoringTimestamp(row->cells());
   CheckEqualUnordered(GetCellsIgnoringTimestamp(expected_return), row_cells);
 
-  auto actual = ReadRows(table, bigtable::Filter::PassAllFilter());
+  auto actual = ReadRows(table, Filter::PassAllFilter());
   // The returned cells have the timestamps in microseconds and do not match
   // with the ones in the expected cells.
   auto actual_cells_ignore_timestamp = GetCellsIgnoringTimestamp(actual);
@@ -225,7 +225,7 @@ TEST_F(DataAsyncFutureIntegrationTest, TableReadRowsAllRows) {
   std::string const row_key3(1024, '3');    // a long key
   std::string const long_value(1024, 'v');  // a long value
 
-  std::vector<bigtable::Cell> created{
+  std::vector<Cell> created{
       {row_key1, "family1", "c1", 1000, "data1"},
       {row_key1, "family1", "c2", 1000, "data2"},
       {row_key2, "family1", "c1", 1000, ""},
@@ -235,7 +235,7 @@ TEST_F(DataAsyncFutureIntegrationTest, TableReadRowsAllRows) {
 
   std::promise<void> done;
 
-  std::vector<bigtable::Cell> actual;
+  std::vector<Cell> actual;
 
   promise<Status> stream_status_promise;
   table.AsyncReadRows(
@@ -247,7 +247,7 @@ TEST_F(DataAsyncFutureIntegrationTest, TableReadRowsAllRows) {
       [&stream_status_promise](Status const& stream_status) {
         stream_status_promise.set_value(stream_status);
       },
-      bigtable::RowSet(bigtable::RowRange::InfiniteRange()),
+      RowSet(RowRange::InfiniteRange()),
       RowReader::NO_ROWS_LIMIT, Filter::PassAllFilter());
 
   auto stream_status = stream_status_promise.get_future().get();
@@ -261,18 +261,18 @@ TEST_F(DataAsyncFutureIntegrationTest, TableReadRowTest) {
   std::string const row_key1 = "row-key-1";
   std::string const row_key2 = "row-key-2";
 
-  std::vector<bigtable::Cell> created{
+  std::vector<Cell> created{
       {row_key1, "family1", "c1", 1000, "v1000"},
       {row_key2, "family1", "c2", 2000, "v2000"}};
-  std::vector<bigtable::Cell> expected{
+  std::vector<Cell> expected{
       {row_key1, "family1", "c1", 1000, "v1000"}};
 
   CreateCells(table, created);
 
   auto row_cell =
-      table.AsyncReadRow(row_key1, bigtable::Filter::PassAllFilter()).get();
+      table.AsyncReadRow(row_key1, Filter::PassAllFilter()).get();
   ASSERT_STATUS_OK(row_cell);
-  std::vector<bigtable::Cell> actual;
+  std::vector<Cell> actual;
   actual.emplace_back(row_cell->second.cells().at(0));
 
   CheckEqualUnordered(expected, actual);

--- a/google/cloud/bigtable/tests/data_async_future_integration_test.cc
+++ b/google/cloud/bigtable/tests/data_async_future_integration_test.cc
@@ -31,7 +31,7 @@ TEST_F(DataAsyncFutureIntegrationTest, TableAsyncApply) {
 
   std::string const row_key = "key-000010";
   std::vector<Cell> created{{row_key, kFamily, "cc1", 1000, "v1000"},
-                                      {row_key, kFamily, "cc2", 2000, "v2000"}};
+                            {row_key, kFamily, "cc2", 2000, "v2000"}};
   SingleRowMutation mut(row_key);
   for (auto const& c : created) {
     mut.emplace_back(SetCell(
@@ -49,9 +49,8 @@ TEST_F(DataAsyncFutureIntegrationTest, TableAsyncApply) {
   EXPECT_STATUS_OK(status);
 
   // Validate that the newly created cells are actually in the server.
-  std::vector<Cell> expected{
-      {row_key, kFamily, "cc1", 1000, "v1000"},
-      {row_key, kFamily, "cc2", 2000, "v2000"}};
+  std::vector<Cell> expected{{row_key, kFamily, "cc1", 1000, "v1000"},
+                             {row_key, kFamily, "cc2", 2000, "v2000"}};
 
   auto actual = ReadRows(table, Filter::PassAllFilter());
 
@@ -115,8 +114,7 @@ TEST_F(DataAsyncFutureIntegrationTest, TableAsyncCheckAndMutateRowPass) {
   CreateCells(table, created);
 
   auto fut = table.AsyncCheckAndMutateRow(
-      key, Filter::ValueRegex("v1000"),
-      {SetCell(kFamily, "c2", 0_ms, "v2000")},
+      key, Filter::ValueRegex("v1000"), {SetCell(kFamily, "c2", 0_ms, "v2000")},
       {SetCell(kFamily, "c3", 0_ms, "v3000")});
 
   // Block until the asynchronous operation completes. This is not what one
@@ -126,7 +124,7 @@ TEST_F(DataAsyncFutureIntegrationTest, TableAsyncCheckAndMutateRowPass) {
   EXPECT_STATUS_OK(status);
 
   std::vector<Cell> expected{{key, kFamily, "c1", 0, "v1000"},
-                                       {key, kFamily, "c2", 0, "v2000"}};
+                             {key, kFamily, "c2", 0, "v2000"}};
 
   auto actual = ReadRows(table, Filter::PassAllFilter());
 
@@ -141,10 +139,10 @@ TEST_F(DataAsyncFutureIntegrationTest, TableAsyncCheckAndMutateRowFail) {
   std::vector<Cell> created{{key, kFamily, "c1", 0, "v1000"}};
   CreateCells(table, created);
 
-  auto fut = table.AsyncCheckAndMutateRow(
-      key, Filter::ValueRegex("not-there"),
-      {SetCell(kFamily, "c2", 0_ms, "v2000")},
-      {SetCell(kFamily, "c3", 0_ms, "v3000")});
+  auto fut =
+      table.AsyncCheckAndMutateRow(key, Filter::ValueRegex("not-there"),
+                                   {SetCell(kFamily, "c2", 0_ms, "v2000")},
+                                   {SetCell(kFamily, "c3", 0_ms, "v3000")});
 
   // Block until the asynchronous operation completes. This is not what one
   // would do in a real application (the synchronous API is better in that
@@ -153,7 +151,7 @@ TEST_F(DataAsyncFutureIntegrationTest, TableAsyncCheckAndMutateRowFail) {
   EXPECT_STATUS_OK(status);
 
   std::vector<Cell> expected{{key, kFamily, "c1", 0, "v1000"},
-                                       {key, kFamily, "c3", 0, "v3000"}};
+                             {key, kFamily, "c3", 0, "v3000"}};
 
   auto actual = ReadRows(table, Filter::PassAllFilter());
 
@@ -174,9 +172,8 @@ TEST_F(DataAsyncFutureIntegrationTest,
   std::string const family3 = "family3";
   std::string const family4 = "family4";
 
-  std::vector<Cell> created{
-      {row_key1, family1, "column-id1", 1000, "v1000"},
-      {row_key1, family2, "column-id2", 2000, "v2000"}};
+  std::vector<Cell> created{{row_key1, family1, "column-id1", 1000, "v1000"},
+                            {row_key1, family2, "column-id2", 2000, "v2000"}};
 
   std::vector<Cell> expected_read{
       {row_key1, family1, "column-id1", 1000, "v1000"},
@@ -225,11 +222,10 @@ TEST_F(DataAsyncFutureIntegrationTest, TableReadRowsAllRows) {
   std::string const row_key3(1024, '3');    // a long key
   std::string const long_value(1024, 'v');  // a long value
 
-  std::vector<Cell> created{
-      {row_key1, "family1", "c1", 1000, "data1"},
-      {row_key1, "family1", "c2", 1000, "data2"},
-      {row_key2, "family1", "c1", 1000, ""},
-      {row_key3, "family1", "c1", 1000, long_value}};
+  std::vector<Cell> created{{row_key1, "family1", "c1", 1000, "data1"},
+                            {row_key1, "family1", "c2", 1000, "data2"},
+                            {row_key2, "family1", "c1", 1000, ""},
+                            {row_key3, "family1", "c1", 1000, long_value}};
 
   CreateCells(table, created);
 
@@ -247,8 +243,8 @@ TEST_F(DataAsyncFutureIntegrationTest, TableReadRowsAllRows) {
       [&stream_status_promise](Status const& stream_status) {
         stream_status_promise.set_value(stream_status);
       },
-      RowSet(RowRange::InfiniteRange()),
-      RowReader::NO_ROWS_LIMIT, Filter::PassAllFilter());
+      RowSet(RowRange::InfiniteRange()), RowReader::NO_ROWS_LIMIT,
+      Filter::PassAllFilter());
 
   auto stream_status = stream_status_promise.get_future().get();
   ASSERT_STATUS_OK(stream_status);
@@ -261,16 +257,13 @@ TEST_F(DataAsyncFutureIntegrationTest, TableReadRowTest) {
   std::string const row_key1 = "row-key-1";
   std::string const row_key2 = "row-key-2";
 
-  std::vector<Cell> created{
-      {row_key1, "family1", "c1", 1000, "v1000"},
-      {row_key2, "family1", "c2", 2000, "v2000"}};
-  std::vector<Cell> expected{
-      {row_key1, "family1", "c1", 1000, "v1000"}};
+  std::vector<Cell> created{{row_key1, "family1", "c1", 1000, "v1000"},
+                            {row_key2, "family1", "c2", 2000, "v2000"}};
+  std::vector<Cell> expected{{row_key1, "family1", "c1", 1000, "v1000"}};
 
   CreateCells(table, created);
 
-  auto row_cell =
-      table.AsyncReadRow(row_key1, Filter::PassAllFilter()).get();
+  auto row_cell = table.AsyncReadRow(row_key1, Filter::PassAllFilter()).get();
   ASSERT_STATUS_OK(row_cell);
   std::vector<Cell> actual;
   actual.emplace_back(row_cell->second.cells().at(0));

--- a/google/cloud/bigtable/tests/data_integration_test.cc
+++ b/google/cloud/bigtable/tests/data_integration_test.cc
@@ -529,9 +529,8 @@ TEST_F(DataIntegrationTest, TableApplyWithLogging) {
       {});
   ASSERT_STATUS_OK(table_admin_->CreateTable(table_id, table_config));
 
-  std::shared_ptr<DataClient> data_client =
-      CreateDefaultDataClient(project_id(), instance_id(),
-                                        ClientOptions().enable_tracing("rpc"));
+  std::shared_ptr<DataClient> data_client = CreateDefaultDataClient(
+      project_id(), instance_id(), ClientOptions().enable_tracing("rpc"));
 
   Table table(data_client, table_id);
 
@@ -550,8 +549,8 @@ TEST_F(DataIntegrationTest, TableApplyWithLogging) {
 }
 
 TEST(ConnectionRefresh, Disabled) {
-  auto client_options = ClientOptions().set_max_conn_refresh_period(
-      std::chrono::seconds(0));
+  auto client_options =
+      ClientOptions().set_max_conn_refresh_period(std::chrono::seconds(0));
   auto data_client = CreateDefaultDataClient(
       testing::TableTestEnvironment::project_id(),
       testing::TableTestEnvironment::instance_id(), client_options);
@@ -592,11 +591,11 @@ TEST(ConnectionRefresh, Disabled) {
 }
 
 TEST(ConnectionRefresh, Frequent) {
-  auto data_client = CreateDefaultDataClient(
-      testing::TableTestEnvironment::project_id(),
-      testing::TableTestEnvironment::instance_id(),
-      ClientOptions().set_max_conn_refresh_period(
-          std::chrono::milliseconds(100)));
+  auto data_client =
+      CreateDefaultDataClient(testing::TableTestEnvironment::project_id(),
+                              testing::TableTestEnvironment::instance_id(),
+                              ClientOptions().set_max_conn_refresh_period(
+                                  std::chrono::milliseconds(100)));
 
   for (;;) {
     if (data_client->Channel()->GetState(false) == GRPC_CHANNEL_READY) {

--- a/google/cloud/bigtable/tests/data_integration_test.cc
+++ b/google/cloud/bigtable/tests/data_integration_test.cc
@@ -518,8 +518,8 @@ TEST_F(DataIntegrationTest, TableApplyWithLogging) {
   std::string const table_id = RandomTableId();
 
   auto constexpr kTestMaxVersions = 10;
-  auto const test_gc_rule = bigtable::GcRule::MaxNumVersions(kTestMaxVersions);
-  bigtable::TableConfig table_config = bigtable::TableConfig(
+  auto const test_gc_rule = GcRule::MaxNumVersions(kTestMaxVersions);
+  TableConfig table_config = TableConfig(
       {
           {kFamily1, test_gc_rule},
           {kFamily2, test_gc_rule},
@@ -529,8 +529,8 @@ TEST_F(DataIntegrationTest, TableApplyWithLogging) {
       {});
   ASSERT_STATUS_OK(table_admin_->CreateTable(table_id, table_config));
 
-  std::shared_ptr<bigtable::DataClient> data_client =
-      bigtable::CreateDefaultDataClient(project_id(), instance_id(),
+  std::shared_ptr<DataClient> data_client =
+      CreateDefaultDataClient(project_id(), instance_id(),
                                         ClientOptions().enable_tracing("rpc"));
 
   Table table(data_client, table_id);
@@ -550,9 +550,9 @@ TEST_F(DataIntegrationTest, TableApplyWithLogging) {
 }
 
 TEST(ConnectionRefresh, Disabled) {
-  auto client_options = bigtable::ClientOptions().set_max_conn_refresh_period(
+  auto client_options = ClientOptions().set_max_conn_refresh_period(
       std::chrono::seconds(0));
-  auto data_client = bigtable::CreateDefaultDataClient(
+  auto data_client = CreateDefaultDataClient(
       testing::TableTestEnvironment::project_id(),
       testing::TableTestEnvironment::instance_id(), client_options);
   // In general, it is hard to show that something has *not* happened, at best
@@ -573,7 +573,7 @@ TEST(ConnectionRefresh, Disabled) {
     EXPECT_EQ(GRPC_CHANNEL_IDLE, channel->GetState(false));
   }
   // Make sure things still work.
-  bigtable::Table table(data_client, testing::TableTestEnvironment::table_id());
+  Table table(data_client, testing::TableTestEnvironment::table_id());
   std::string const row_key = "row-key-1";
   std::vector<Cell> created{{row_key, kFamily4, "c0", 1000, "v1000"},
                             {row_key, kFamily4, "c1", 2000, "v2000"}};
@@ -592,10 +592,10 @@ TEST(ConnectionRefresh, Disabled) {
 }
 
 TEST(ConnectionRefresh, Frequent) {
-  auto data_client = bigtable::CreateDefaultDataClient(
+  auto data_client = CreateDefaultDataClient(
       testing::TableTestEnvironment::project_id(),
       testing::TableTestEnvironment::instance_id(),
-      bigtable::ClientOptions().set_max_conn_refresh_period(
+      ClientOptions().set_max_conn_refresh_period(
           std::chrono::milliseconds(100)));
 
   for (;;) {
@@ -608,7 +608,7 @@ TEST(ConnectionRefresh, Frequent) {
   }
 
   // Make sure things still work.
-  bigtable::Table table(data_client, testing::TableTestEnvironment::table_id());
+  Table table(data_client, testing::TableTestEnvironment::table_id());
   std::string const row_key = "row-key-1";
   std::vector<Cell> created{{row_key, kFamily4, "c0", 1000, "v1000"},
                             {row_key, kFamily4, "c1", 2000, "v2000"}};

--- a/google/cloud/bigtable/tests/instance_admin_emulator.cc
+++ b/google/cloud/bigtable/tests/instance_admin_emulator.cc
@@ -21,7 +21,7 @@
 #include <sstream>
 
 namespace btadmin = ::google::bigtable::admin::v2;
-namespace bigtable = ::google::cloud::bigtable;
+namespace bigtable_internal = ::google::cloud::bigtable_internal;
 
 /**
  * In-memory implementation of `google.bigtable.admin.v2.InstanceAdmin`.
@@ -190,7 +190,7 @@ class InstanceAdminEmulator final
     instances_.erase(i->first);
 
     std::string prefix_successor =
-        bigtable::internal::PrefixRangeEnd(request->name());
+        bigtable_internal::PrefixRangeEnd(request->name());
     auto begin = clusters_.lower_bound(request->name());
     auto end = clusters_.upper_bound(prefix_successor);
     clusters_.erase(begin, end);

--- a/google/cloud/bigtable/tests/instance_admin_emulator.cc
+++ b/google/cloud/bigtable/tests/instance_admin_emulator.cc
@@ -20,8 +20,10 @@
 #include <grpcpp/grpcpp.h>
 #include <sstream>
 
+namespace {
 namespace btadmin = ::google::bigtable::admin::v2;
 namespace bigtable_internal = ::google::cloud::bigtable_internal;
+}  // namespace
 
 /**
  * In-memory implementation of `google.bigtable.admin.v2.InstanceAdmin`.


### PR DESCRIPTION
No functional changes. This moves `bigtable::internal` to `bigtable_internal`.

I couldn't resist the temptation to clean up a lot of namespace qualifiers along the way.

My plan is to change `bigtable::testing` -> `bigtable_testing` in a subsequent PR.
I may update `bigtable::benchmarks` -> `bigtable_benchmarks` later, too.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7208)
<!-- Reviewable:end -->
