### PR TITLE
feat(spanner): support for JSON as a column type

### DIFF
--- a/google/cloud/spanner/CMakeLists.txt
+++ b/google/cloud/spanner/CMakeLists.txt
@@ -145,6 +145,7 @@ add_library(
     internal/transaction_impl.cc
     internal/transaction_impl.h
     internal/tuple_utils.h
+    json.h
     keys.cc
     keys.h
     mutations.cc
@@ -326,6 +327,7 @@ function (spanner_client_define_tests)
         internal/status_utils_test.cc
         internal/transaction_impl_test.cc
         internal/tuple_utils_test.cc
+        json_test.cc
         keys_test.cc
         mutations_test.cc
         numeric_test.cc

--- a/google/cloud/spanner/google_cloud_cpp_spanner.bzl
+++ b/google/cloud/spanner/google_cloud_cpp_spanner.bzl
@@ -81,6 +81,7 @@ google_cloud_cpp_spanner_hdrs = [
     "internal/status_utils.h",
     "internal/transaction_impl.h",
     "internal/tuple_utils.h",
+    "json.h",
     "keys.h",
     "mutations.h",
     "numeric.h",

--- a/google/cloud/spanner/integration_tests/data_types_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/data_types_integration_test.cc
@@ -30,6 +30,9 @@ namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
 namespace {
 
+using ::google::cloud::testing_util::IsOk;
+using ::google::cloud::testing_util::StatusIs;
+using ::testing::HasSubstr;
 using ::testing::UnorderedElementsAreArray;
 
 absl::Time MakeTime(std::time_t sec, int nanos) {
@@ -217,6 +220,21 @@ TEST_F(DataTypeIntegrationTest, WriteReadDate) {
   EXPECT_THAT(*result, UnorderedElementsAreArray(data));
 }
 
+TEST_F(DataTypeIntegrationTest, WriteReadJSON) {
+  // TODO(#6873): Remove this check when the emulator supports JSON.
+  if (UsingEmulator()) GTEST_SKIP();
+
+  std::vector<JSON> const data = {
+      JSON(),                     //
+      JSON(R"("Hello world!")"),  //
+      JSON("42"),                 //
+      JSON("true"),               //
+  };
+  auto result = WriteReadData(*client_, data, "JsonValue");
+  ASSERT_STATUS_OK(result);
+  EXPECT_THAT(*result, UnorderedElementsAreArray(data));
+}
+
 TEST_F(DataTypeIntegrationTest, WriteReadNumeric) {
   // TODO(#5024): Remove this check when the emulator supports NUMERIC.
   if (UsingEmulator()) GTEST_SKIP();
@@ -327,6 +345,25 @@ TEST_F(DataTypeIntegrationTest, WriteReadArrayDate) {
   EXPECT_THAT(*result, UnorderedElementsAreArray(data));
 }
 
+TEST_F(DataTypeIntegrationTest, WriteReadArrayJSON) {
+  // TODO(#6873): Remove this check when the emulator supports JSON.
+  if (UsingEmulator()) GTEST_SKIP();
+
+  std::vector<std::vector<JSON>> const data = {
+      std::vector<JSON>{},
+      std::vector<JSON>{JSON()},
+      std::vector<JSON>{
+          JSON(),
+          JSON(R"("Hello world!")"),
+          JSON("42"),
+          JSON("true"),
+      },
+  };
+  auto result = WriteReadData(*client_, data, "ArrayJsonValue");
+  ASSERT_STATUS_OK(result);
+  EXPECT_THAT(*result, UnorderedElementsAreArray(data));
+}
+
 TEST_F(DataTypeIntegrationTest, WriteReadArrayNumeric) {
   // TODO(#5024): Remove this check when the emulator supports NUMERIC.
   if (UsingEmulator()) GTEST_SKIP();
@@ -406,6 +443,39 @@ TEST_F(DataTypeIntegrationTest, InsertAndQueryWithStruct) {
   auto const& v = std::get<0>(*row);
   EXPECT_EQ(1, v.size());
   EXPECT_EQ(data, v[0]);
+}
+
+// Verify maximum JSON nesting.
+TEST_F(DataTypeIntegrationTest, JSONMaxNesting) {
+  // TODO(#6873): Remove this check when the emulator supports JSON.
+  if (UsingEmulator()) GTEST_SKIP();
+
+  // The default value of the backend max-nesting-level flag.
+  int const k_spanner_json_max_nesting_level = 100;
+
+  // Nested arrays that exceed `k_spanner_json_max_nesting_level` by one.
+  std::string bad_json;
+  for (int i = 0; i != k_spanner_json_max_nesting_level + 1; ++i)
+    bad_json.append(1, '[');
+  bad_json.append("null");
+  for (int i = 0; i != k_spanner_json_max_nesting_level + 1; ++i)
+    bad_json.append(1, ']');
+
+  // Nested arrays that match `k_spanner_json_max_nesting_level`.
+  std::string good_json = bad_json.substr(1, bad_json.size() - 2);
+
+  std::vector<JSON> const good_data = {JSON(good_json)};
+  auto result = WriteReadData(*client_, good_data, "JsonValue");
+  ASSERT_THAT(result, IsOk());
+  EXPECT_THAT(*result, UnorderedElementsAreArray(good_data));
+
+  std::vector<JSON> const bad_data = {JSON(bad_json)};
+  result = WriteReadData(*client_, bad_data, "JsonValue");
+  // NOTE: The backend is currently dropping a more specific "Max nesting
+  // of 100 had been exceeded [INVALID_ARGUMENT]" error, so expect this
+  // expectation to change when that problem is fixed.
+  EXPECT_THAT(result, StatusIs(StatusCode::kFailedPrecondition,
+                               HasSubstr("Expected JSON")));
 }
 
 }  // namespace

--- a/google/cloud/spanner/integration_tests/data_types_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/data_types_integration_test.cc
@@ -220,15 +220,15 @@ TEST_F(DataTypeIntegrationTest, WriteReadDate) {
   EXPECT_THAT(*result, UnorderedElementsAreArray(data));
 }
 
-TEST_F(DataTypeIntegrationTest, WriteReadJSON) {
+TEST_F(DataTypeIntegrationTest, WriteReadJson) {
   // TODO(#6873): Remove this check when the emulator supports JSON.
   if (UsingEmulator()) GTEST_SKIP();
 
-  std::vector<JSON> const data = {
-      JSON(),                     //
-      JSON(R"("Hello world!")"),  //
-      JSON("42"),                 //
-      JSON("true"),               //
+  std::vector<Json> const data = {
+      Json(),                     //
+      Json(R"("Hello world!")"),  //
+      Json("42"),                 //
+      Json("true"),               //
   };
   auto result = WriteReadData(*client_, data, "JsonValue");
   ASSERT_STATUS_OK(result);
@@ -345,18 +345,18 @@ TEST_F(DataTypeIntegrationTest, WriteReadArrayDate) {
   EXPECT_THAT(*result, UnorderedElementsAreArray(data));
 }
 
-TEST_F(DataTypeIntegrationTest, WriteReadArrayJSON) {
+TEST_F(DataTypeIntegrationTest, WriteReadArrayJson) {
   // TODO(#6873): Remove this check when the emulator supports JSON.
   if (UsingEmulator()) GTEST_SKIP();
 
-  std::vector<std::vector<JSON>> const data = {
-      std::vector<JSON>{},
-      std::vector<JSON>{JSON()},
-      std::vector<JSON>{
-          JSON(),
-          JSON(R"("Hello world!")"),
-          JSON("42"),
-          JSON("true"),
+  std::vector<std::vector<Json>> const data = {
+      std::vector<Json>{},
+      std::vector<Json>{Json()},
+      std::vector<Json>{
+          Json(),
+          Json(R"("Hello world!")"),
+          Json("42"),
+          Json("true"),
       },
   };
   auto result = WriteReadData(*client_, data, "ArrayJsonValue");
@@ -446,7 +446,7 @@ TEST_F(DataTypeIntegrationTest, InsertAndQueryWithStruct) {
 }
 
 // Verify maximum JSON nesting.
-TEST_F(DataTypeIntegrationTest, JSONMaxNesting) {
+TEST_F(DataTypeIntegrationTest, JsonMaxNesting) {
   // TODO(#6873): Remove this check when the emulator supports JSON.
   if (UsingEmulator()) GTEST_SKIP();
 
@@ -464,12 +464,12 @@ TEST_F(DataTypeIntegrationTest, JSONMaxNesting) {
   // Nested arrays that match `k_spanner_json_max_nesting_level`.
   std::string good_json = bad_json.substr(1, bad_json.size() - 2);
 
-  std::vector<JSON> const good_data = {JSON(good_json)};
+  std::vector<Json> const good_data = {Json(good_json)};
   auto result = WriteReadData(*client_, good_data, "JsonValue");
   ASSERT_THAT(result, IsOk());
   EXPECT_THAT(*result, UnorderedElementsAreArray(good_data));
 
-  std::vector<JSON> const bad_data = {JSON(bad_json)};
+  std::vector<Json> const bad_data = {Json(bad_json)};
   result = WriteReadData(*client_, bad_data, "JsonValue");
   // NOTE: The backend is currently dropping a more specific "Max nesting
   // of 100 had been exceeded [INVALID_ARGUMENT]" error, so expect this

--- a/google/cloud/spanner/json.h
+++ b/google/cloud/spanner/json.h
@@ -1,0 +1,89 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_JSON_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_JSON_H
+
+#include "google/cloud/spanner/version.h"
+#include <ostream>
+#include <string>
+
+namespace google {
+namespace cloud {
+namespace spanner {
+inline namespace SPANNER_CLIENT_NS {
+
+/**
+ * A simple representation for the Spanner JSON type: a lightweight,
+ * text-based, language-independent data interchange format. JSON (the
+ * JavaScript Object Notation) defines a small set of formatting rules
+ * for the portable representation of structured data. See RFC 7159.
+ *
+ * A `JSON` value can be constructed from, and converted to a `std::string`.
+ * `JSON` values can be compared (by string) for equality, and streamed.
+ *
+ * There is no syntax checking of JSON strings in this interface. The user
+ * is expected to only construct `JSON` values from well-formatted strings.
+ */
+class JSON {
+ public:
+  /// A null value.
+  JSON() : rep_("null") {}
+
+  /// Regular value type, supporting copy, assign, move.
+  ///@{
+  JSON(JSON const&) = default;
+  JSON& operator=(JSON const&) = default;
+  JSON(JSON&&) = default;
+  JSON& operator=(JSON&&) = default;
+  ///@}
+
+  /**
+   * Construction from a JSON-formatted string. Note that there is no check
+   * here that the argument string is indeed well-formatted. Error detection
+   * will be delayed until the value is passed to Spanner.
+   */
+  explicit JSON(std::string s) : rep_(std::move(s)) {}
+
+  /// Conversion to a JSON-formatted string.
+  ///@{
+  explicit operator std::string() const& { return rep_; }
+  explicit operator std::string() && { return std::move(rep_); }
+  ///@}
+
+ private:
+  std::string rep_;  // a (presumably) JSON-formatted string
+};
+
+/// @name Relational operators
+///@{
+inline bool operator==(JSON const& lhs, JSON const& rhs) {
+  return std::string(lhs) == std::string(rhs);
+}
+inline bool operator!=(JSON const& lhs, JSON const& rhs) {
+  return !(lhs == rhs);
+}
+///@}
+
+/// Outputs a JSON-formatted string to the provided stream.
+inline std::ostream& operator<<(std::ostream& os, JSON const& json) {
+  return os << std::string(json);
+}
+
+}  // namespace SPANNER_CLIENT_NS
+}  // namespace spanner
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_JSON_H

--- a/google/cloud/spanner/json.h
+++ b/google/cloud/spanner/json.h
@@ -30,23 +30,23 @@ inline namespace SPANNER_CLIENT_NS {
  * JavaScript Object Notation) defines a small set of formatting rules
  * for the portable representation of structured data. See RFC 7159.
  *
- * A `JSON` value can be constructed from, and converted to a `std::string`.
- * `JSON` values can be compared (by string) for equality, and streamed.
+ * A `Json` value can be constructed from, and converted to a `std::string`.
+ * `Json` values can be compared (by string) for equality, and streamed.
  *
  * There is no syntax checking of JSON strings in this interface. The user
- * is expected to only construct `JSON` values from well-formatted strings.
+ * is expected to only construct `Json` values from well-formatted strings.
  */
-class JSON {
+class Json {
  public:
   /// A null value.
-  JSON() : rep_("null") {}
+  Json() : rep_("null") {}
 
   /// Regular value type, supporting copy, assign, move.
   ///@{
-  JSON(JSON const&) = default;
-  JSON& operator=(JSON const&) = default;
-  JSON(JSON&&) = default;
-  JSON& operator=(JSON&&) = default;
+  Json(Json const&) = default;
+  Json& operator=(Json const&) = default;
+  Json(Json&&) = default;
+  Json& operator=(Json&&) = default;
   ///@}
 
   /**
@@ -54,7 +54,7 @@ class JSON {
    * here that the argument string is indeed well-formatted. Error detection
    * will be delayed until the value is passed to Spanner.
    */
-  explicit JSON(std::string s) : rep_(std::move(s)) {}
+  explicit Json(std::string s) : rep_(std::move(s)) {}
 
   /// Conversion to a JSON-formatted string.
   ///@{
@@ -68,16 +68,16 @@ class JSON {
 
 /// @name Relational operators
 ///@{
-inline bool operator==(JSON const& lhs, JSON const& rhs) {
+inline bool operator==(Json const& lhs, Json const& rhs) {
   return std::string(lhs) == std::string(rhs);
 }
-inline bool operator!=(JSON const& lhs, JSON const& rhs) {
+inline bool operator!=(Json const& lhs, Json const& rhs) {
   return !(lhs == rhs);
 }
 ///@}
 
 /// Outputs a JSON-formatted string to the provided stream.
-inline std::ostream& operator<<(std::ostream& os, JSON const& json) {
+inline std::ostream& operator<<(std::ostream& os, Json const& json) {
   return os << std::string(json);
 }
 

--- a/google/cloud/spanner/json_test.cc
+++ b/google/cloud/spanner/json_test.cc
@@ -1,0 +1,75 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/spanner/json.h"
+#include <gtest/gtest.h>
+#include <sstream>
+#include <string>
+
+namespace google {
+namespace cloud {
+namespace spanner {
+inline namespace SPANNER_CLIENT_NS {
+namespace {
+
+TEST(JSON, DefaultCtor) { EXPECT_EQ("null", std::string(JSON())); }
+
+TEST(JSON, RegularSemantics) {
+  JSON j("true");
+
+  // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
+  JSON const copy1(j);
+  EXPECT_EQ(copy1, j);
+
+  // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
+  JSON const copy2 = j;
+  EXPECT_EQ(copy2, j);
+
+  JSON assign;
+  assign = j;
+  EXPECT_EQ(assign, j);
+}
+
+TEST(JSON, RelationalOperators) {
+  EXPECT_EQ(JSON("42"), JSON("42"));
+  EXPECT_NE(JSON("true"), JSON(R"("Hello world!")"));
+
+  // We do not even trim whitespace surrounding the JSON string.
+  EXPECT_NE(JSON(" true "), JSON("true"));
+}
+
+TEST(JSON, RoundTrip) {
+  for (auto const& j : {"null", R"("Hello world!")", "42", "true"}) {
+    EXPECT_EQ(std::string(JSON(j)), j);
+  }
+}
+
+TEST(JSON, OutputStreaming) {
+  auto stream = [](JSON const& j) {
+    std::ostringstream ss;
+    ss << j;
+    return std::move(ss).str();
+  };
+
+  for (auto const& j :
+       {JSON(), JSON(R"("Hello world!")"), JSON("42"), JSON("true")}) {
+    EXPECT_EQ(stream(j), std::string(j));
+  }
+}
+
+}  // namespace
+}  // namespace SPANNER_CLIENT_NS
+}  // namespace spanner
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/spanner/json_test.cc
+++ b/google/cloud/spanner/json_test.cc
@@ -23,47 +23,47 @@ namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
 namespace {
 
-TEST(JSON, DefaultCtor) { EXPECT_EQ("null", std::string(JSON())); }
+TEST(Json, DefaultCtor) { EXPECT_EQ("null", std::string(Json())); }
 
-TEST(JSON, RegularSemantics) {
-  JSON j("true");
+TEST(Json, RegularSemantics) {
+  Json j("true");
 
   // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
-  JSON const copy1(j);
+  Json const copy1(j);
   EXPECT_EQ(copy1, j);
 
   // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
-  JSON const copy2 = j;
+  Json const copy2 = j;
   EXPECT_EQ(copy2, j);
 
-  JSON assign;
+  Json assign;
   assign = j;
   EXPECT_EQ(assign, j);
 }
 
-TEST(JSON, RelationalOperators) {
-  EXPECT_EQ(JSON("42"), JSON("42"));
-  EXPECT_NE(JSON("true"), JSON(R"("Hello world!")"));
+TEST(Json, RelationalOperators) {
+  EXPECT_EQ(Json("42"), Json("42"));
+  EXPECT_NE(Json("true"), Json(R"("Hello world!")"));
 
   // We do not even trim whitespace surrounding the JSON string.
-  EXPECT_NE(JSON(" true "), JSON("true"));
+  EXPECT_NE(Json(" true "), Json("true"));
 }
 
-TEST(JSON, RoundTrip) {
+TEST(Json, RoundTrip) {
   for (auto const& j : {"null", R"("Hello world!")", "42", "true"}) {
-    EXPECT_EQ(std::string(JSON(j)), j);
+    EXPECT_EQ(std::string(Json(j)), j);
   }
 }
 
-TEST(JSON, OutputStreaming) {
-  auto stream = [](JSON const& j) {
+TEST(Json, OutputStreaming) {
+  auto stream = [](Json const& j) {
     std::ostringstream ss;
     ss << j;
     return std::move(ss).str();
   };
 
   for (auto const& j :
-       {JSON(), JSON(R"("Hello world!")"), JSON("42"), JSON("true")}) {
+       {Json(), Json(R"("Hello world!")"), Json("42"), Json("true")}) {
     EXPECT_EQ(stream(j), std::string(j));
   }
 }

--- a/google/cloud/spanner/samples/samples.cc
+++ b/google/cloud/spanner/samples/samples.cc
@@ -1821,16 +1821,16 @@ void AddJsonColumn(google::cloud::spanner::DatabaseAdminClient client,
 //! [START spanner_update_data_with_json_column]
 void UpdateDataWithJson(google::cloud::spanner::Client client) {
   namespace spanner = ::google::cloud::spanner;
-  auto venue19_details = spanner::JSON(R"""(
+  auto venue19_details = spanner::Json(R"""(
         {"rating": 9, "open": true}
       )""");  // object
-  auto venue4_details = spanner::JSON(R"""(
+  auto venue4_details = spanner::Json(R"""(
         [
           {"name": "room 1", "open": true},
           {"name": "room 2", "open": false}
         ]
       )""");  // array
-  auto venue42_details = spanner::JSON(R"""(
+  auto venue42_details = spanner::Json(R"""(
         {
           "name": null,
           "open": {"Monday": true, "Tuesday": false},
@@ -1858,7 +1858,7 @@ void UpdateDataWithJson(google::cloud::spanner::Client client) {
 // [START spanner_query_with_json_parameter]
 void QueryWithJsonParameter(google::cloud::spanner::Client client) {
   namespace spanner = ::google::cloud::spanner;
-  auto rating9_details = spanner::JSON(R"""(
+  auto rating9_details = spanner::Json(R"""(
         {"rating": 9}
       )""");  // object
   spanner::SqlStatement select(
@@ -1867,7 +1867,7 @@ void QueryWithJsonParameter(google::cloud::spanner::Client client) {
       " WHERE JSON_VALUE(VenueDetails, '$.rating') ="
       "       JSON_VALUE(@details, '$.rating')",
       {{"details", spanner::Value(std::move(rating9_details))}});
-  using RowType = std::tuple<std::int64_t, absl::optional<spanner::JSON>>;
+  using RowType = std::tuple<std::int64_t, absl::optional<spanner::Json>>;
 
   auto rows = client.ExecuteQuery(select);
   for (auto const& row : spanner::StreamOf<RowType>(rows)) {

--- a/google/cloud/spanner/spanner_client_unit_tests.bzl
+++ b/google/cloud/spanner/spanner_client_unit_tests.bzl
@@ -48,6 +48,7 @@ spanner_client_unit_tests = [
     "internal/status_utils_test.cc",
     "internal/transaction_impl_test.cc",
     "internal/tuple_utils_test.cc",
+    "json_test.cc",
     "keys_test.cc",
     "mutations_test.cc",
     "numeric_test.cc",

--- a/google/cloud/spanner/testing/database_integration_test.cc
+++ b/google/cloud/spanner/testing/database_integration_test.cc
@@ -76,6 +76,10 @@ void DatabaseIntegrationTest::SetUpTestSuite() {
           DateValue DATE,
       )sql";
   if (!emulator) {
+    // TODO(#6873): Remove this check when the emulator supports JSON.
+    create_datatypes.append(R"sql(JsonValue JSON,)sql");
+  }
+  if (!emulator) {
     // TODO(#5024): Remove this check when the emulator supports NUMERIC.
     create_datatypes.append(R"sql(NumericValue NUMERIC,)sql");
   }
@@ -88,6 +92,10 @@ void DatabaseIntegrationTest::SetUpTestSuite() {
           ArrayTimestampValue ARRAY<TIMESTAMP>,
           ArrayDateValue ARRAY<DATE>
       )sql");
+  if (!emulator) {
+    // TODO(#6873): Remove this check when the emulator supports JSON.
+    create_datatypes.append(R"sql(,ArrayJsonValue ARRAY<JSON>)sql");
+  }
   if (!emulator) {
     // TODO(#5024): Remove this check when the emulator supports NUMERIC.
     create_datatypes.append(R"sql(,ArrayNumericValue ARRAY<NUMERIC>)sql");

--- a/google/cloud/spanner/value.cc
+++ b/google/cloud/spanner/value.cc
@@ -233,7 +233,7 @@ bool Value::TypeProtoIs(Bytes const&, google::spanner::v1::Type const& type) {
   return type.code() == google::spanner::v1::TypeCode::BYTES;
 }
 
-bool Value::TypeProtoIs(JSON const&, google::spanner::v1::Type const& type) {
+bool Value::TypeProtoIs(Json const&, google::spanner::v1::Type const& type) {
   return type.code() == google::spanner::v1::TypeCode::JSON;
 }
 
@@ -275,7 +275,7 @@ google::spanner::v1::Type Value::MakeTypeProto(Bytes const&) {
   return t;
 }
 
-google::spanner::v1::Type Value::MakeTypeProto(JSON const&) {
+google::spanner::v1::Type Value::MakeTypeProto(Json const&) {
   google::spanner::v1::Type t;
   t.set_code(google::spanner::v1::TypeCode::JSON);
   return t;
@@ -353,7 +353,7 @@ google::protobuf::Value Value::MakeValueProto(Bytes bytes) {
   return v;
 }
 
-google::protobuf::Value Value::MakeValueProto(JSON j) {
+google::protobuf::Value Value::MakeValueProto(Json j) {
   google::protobuf::Value v;
   v.set_string_value(std::string(std::move(j)));
   return v;
@@ -476,12 +476,12 @@ StatusOr<Bytes> Value::GetValue(Bytes const&, google::protobuf::Value const& pv,
   return *decoded;
 }
 
-StatusOr<JSON> Value::GetValue(JSON const&, google::protobuf::Value const& pv,
+StatusOr<Json> Value::GetValue(Json const&, google::protobuf::Value const& pv,
                                google::spanner::v1::Type const&) {
   if (pv.kind_case() != google::protobuf::Value::kStringValue) {
     return Status(StatusCode::kUnknown, "missing JSON");
   }
-  return JSON(pv.string_value());
+  return Json(pv.string_value());
 }
 
 StatusOr<Numeric> Value::GetValue(Numeric const&,

--- a/google/cloud/spanner/value.h
+++ b/google/cloud/spanner/value.h
@@ -18,6 +18,7 @@
 #include "google/cloud/spanner/bytes.h"
 #include "google/cloud/spanner/date.h"
 #include "google/cloud/spanner/internal/tuple_utils.h"
+#include "google/cloud/spanner/json.h"
 #include "google/cloud/spanner/numeric.h"
 #include "google/cloud/spanner/timestamp.h"
 #include "google/cloud/spanner/version.h"
@@ -63,6 +64,7 @@ inline namespace SPANNER_CLIENT_NS {
  * FLOAT64      | `double`
  * STRING       | `std::string`
  * BYTES        | `google::cloud::spanner::Bytes`
+ * JSON         | `google::cloud::spanner::JSON`
  * NUMERIC      | `google::cloud::spanner::Numeric`
  * TIMESTAMP    | `google::cloud::spanner::Timestamp`
  * DATE         | `absl::CivilDay`
@@ -188,6 +190,8 @@ class Value {
   explicit Value(std::string v) : Value(PrivateConstructor{}, std::move(v)) {}
   /// @copydoc Value(bool)
   explicit Value(Bytes v) : Value(PrivateConstructor{}, std::move(v)) {}
+  /// @copydoc Value(bool)
+  explicit Value(JSON v) : Value(PrivateConstructor{}, std::move(v)) {}
   /// @copydoc Value(bool)
   explicit Value(Numeric v) : Value(PrivateConstructor{}, std::move(v)) {}
   /// @copydoc Value(bool)
@@ -358,6 +362,7 @@ class Value {
   static bool TypeProtoIs(absl::CivilDay, google::spanner::v1::Type const&);
   static bool TypeProtoIs(std::string const&, google::spanner::v1::Type const&);
   static bool TypeProtoIs(Bytes const&, google::spanner::v1::Type const&);
+  static bool TypeProtoIs(JSON const&, google::spanner::v1::Type const&);
   static bool TypeProtoIs(Numeric const&, google::spanner::v1::Type const&);
   template <typename T>
   static bool TypeProtoIs(absl::optional<T>,
@@ -404,6 +409,7 @@ class Value {
   static google::spanner::v1::Type MakeTypeProto(double);
   static google::spanner::v1::Type MakeTypeProto(std::string const&);
   static google::spanner::v1::Type MakeTypeProto(Bytes const&);
+  static google::spanner::v1::Type MakeTypeProto(JSON const&);
   static google::spanner::v1::Type MakeTypeProto(Numeric const&);
   static google::spanner::v1::Type MakeTypeProto(Timestamp);
   static google::spanner::v1::Type MakeTypeProto(CommitTimestamp);
@@ -464,6 +470,7 @@ class Value {
   static google::protobuf::Value MakeValueProto(double d);
   static google::protobuf::Value MakeValueProto(std::string s);
   static google::protobuf::Value MakeValueProto(Bytes b);
+  static google::protobuf::Value MakeValueProto(JSON j);
   static google::protobuf::Value MakeValueProto(Numeric n);
   static google::protobuf::Value MakeValueProto(Timestamp ts);
   static google::protobuf::Value MakeValueProto(CommitTimestamp ts);
@@ -526,6 +533,8 @@ class Value {
                                         google::spanner::v1::Type const&);
   static StatusOr<Bytes> GetValue(Bytes const&, google::protobuf::Value const&,
                                   google::spanner::v1::Type const&);
+  static StatusOr<JSON> GetValue(JSON const&, google::protobuf::Value const&,
+                                 google::spanner::v1::Type const&);
   static StatusOr<Numeric> GetValue(Numeric const&,
                                     google::protobuf::Value const&,
                                     google::spanner::v1::Type const&);

--- a/google/cloud/spanner/value.h
+++ b/google/cloud/spanner/value.h
@@ -64,7 +64,7 @@ inline namespace SPANNER_CLIENT_NS {
  * FLOAT64      | `double`
  * STRING       | `std::string`
  * BYTES        | `google::cloud::spanner::Bytes`
- * JSON         | `google::cloud::spanner::JSON`
+ * JSON         | `google::cloud::spanner::Json`
  * NUMERIC      | `google::cloud::spanner::Numeric`
  * TIMESTAMP    | `google::cloud::spanner::Timestamp`
  * DATE         | `absl::CivilDay`
@@ -191,7 +191,7 @@ class Value {
   /// @copydoc Value(bool)
   explicit Value(Bytes v) : Value(PrivateConstructor{}, std::move(v)) {}
   /// @copydoc Value(bool)
-  explicit Value(JSON v) : Value(PrivateConstructor{}, std::move(v)) {}
+  explicit Value(Json v) : Value(PrivateConstructor{}, std::move(v)) {}
   /// @copydoc Value(bool)
   explicit Value(Numeric v) : Value(PrivateConstructor{}, std::move(v)) {}
   /// @copydoc Value(bool)
@@ -362,7 +362,7 @@ class Value {
   static bool TypeProtoIs(absl::CivilDay, google::spanner::v1::Type const&);
   static bool TypeProtoIs(std::string const&, google::spanner::v1::Type const&);
   static bool TypeProtoIs(Bytes const&, google::spanner::v1::Type const&);
-  static bool TypeProtoIs(JSON const&, google::spanner::v1::Type const&);
+  static bool TypeProtoIs(Json const&, google::spanner::v1::Type const&);
   static bool TypeProtoIs(Numeric const&, google::spanner::v1::Type const&);
   template <typename T>
   static bool TypeProtoIs(absl::optional<T>,
@@ -409,7 +409,7 @@ class Value {
   static google::spanner::v1::Type MakeTypeProto(double);
   static google::spanner::v1::Type MakeTypeProto(std::string const&);
   static google::spanner::v1::Type MakeTypeProto(Bytes const&);
-  static google::spanner::v1::Type MakeTypeProto(JSON const&);
+  static google::spanner::v1::Type MakeTypeProto(Json const&);
   static google::spanner::v1::Type MakeTypeProto(Numeric const&);
   static google::spanner::v1::Type MakeTypeProto(Timestamp);
   static google::spanner::v1::Type MakeTypeProto(CommitTimestamp);
@@ -470,7 +470,7 @@ class Value {
   static google::protobuf::Value MakeValueProto(double d);
   static google::protobuf::Value MakeValueProto(std::string s);
   static google::protobuf::Value MakeValueProto(Bytes b);
-  static google::protobuf::Value MakeValueProto(JSON j);
+  static google::protobuf::Value MakeValueProto(Json j);
   static google::protobuf::Value MakeValueProto(Numeric n);
   static google::protobuf::Value MakeValueProto(Timestamp ts);
   static google::protobuf::Value MakeValueProto(CommitTimestamp ts);
@@ -533,7 +533,7 @@ class Value {
                                         google::spanner::v1::Type const&);
   static StatusOr<Bytes> GetValue(Bytes const&, google::protobuf::Value const&,
                                   google::spanner::v1::Type const&);
-  static StatusOr<JSON> GetValue(JSON const&, google::protobuf::Value const&,
+  static StatusOr<Json> GetValue(Json const&, google::protobuf::Value const&,
                                  google::spanner::v1::Type const&);
   static StatusOr<Numeric> GetValue(Numeric const&,
                                     google::protobuf::Value const&,

--- a/google/cloud/spanner/value_test.cc
+++ b/google/cloud/spanner/value_test.cc
@@ -140,12 +140,12 @@ TEST(Value, BasicSemantics) {
     TestBasicSemantics(v);
   }
 
-  for (auto const& x : std::vector<JSON>{JSON(), JSON(R"("Hello world!")"),
-                                         JSON("42"), JSON("true")}) {
+  for (auto const& x : std::vector<Json>{Json(), Json(R"("Hello world!")"),
+                                         Json("42"), Json("true")}) {
     SCOPED_TRACE("Testing: JSON " + std::string(x));
     TestBasicSemantics(x);
-    TestBasicSemantics(std::vector<JSON>(5, x));
-    std::vector<absl::optional<JSON>> v(5, x);
+    TestBasicSemantics(std::vector<Json>(5, x));
+    std::vector<absl::optional<Json>> v(5, x);
     v.resize(10);
     TestBasicSemantics(v);
   }
@@ -223,7 +223,7 @@ TEST(Value, Equality) {
       {Value(3.14), Value(42.0)},
       {Value("foo"), Value("bar")},
       {Value(Bytes("foo")), Value(Bytes("bar"))},
-      {Value(JSON("42")), Value(JSON("true"))},
+      {Value(Json("42")), Value(Json("true"))},
       {Value(MakeNumeric(0).value()), Value(MakeNumeric(1).value())},
       {Value(absl::CivilDay(1970, 1, 1)), Value(absl::CivilDay(2020, 3, 15))},
       {Value(std::vector<double>{1.2, 3.4}),
@@ -381,9 +381,9 @@ TEST(Value, BytesRelationalOperators) {
   EXPECT_NE(b1, b2);
 }
 
-TEST(Value, JSONRelationalOperators) {
-  JSON j1("42");
-  JSON j2("true");
+TEST(Value, JsonRelationalOperators) {
+  Json j1("42");
+  Json j2("true");
 
   EXPECT_EQ(j1, j1);
   EXPECT_NE(j1, j2);
@@ -684,9 +684,9 @@ TEST(Value, ProtoConversionBytes) {
   }
 }
 
-TEST(Value, ProtoConversionJSON) {
-  for (auto const& x : std::vector<JSON>{JSON(), JSON(R"("Hello world!")"),
-                                         JSON("42"), JSON("true")}) {
+TEST(Value, ProtoConversionJson) {
+  for (auto const& x : std::vector<Json>{Json(), Json(R"("Hello world!")"),
+                                         Json("42"), Json("true")}) {
     Value const v(x);
     auto const p = spanner_internal::ToProto(v);
     EXPECT_EQ(v, spanner_internal::FromProto(p.first, p.second));
@@ -893,19 +893,19 @@ TEST(Value, GetBadBytes) {
   EXPECT_THAT(v.get<Bytes>(), Not(IsOk()));
 }
 
-TEST(Value, GetBadJSON) {
-  Value v(JSON("true"));
+TEST(Value, GetBadJson) {
+  Value v(Json("true"));
   ClearProtoKind(v);
-  EXPECT_THAT(v.get<JSON>(), Not(IsOk()));
+  EXPECT_THAT(v.get<Json>(), Not(IsOk()));
 
   SetProtoKind(v, google::protobuf::NULL_VALUE);
-  EXPECT_THAT(v.get<JSON>(), Not(IsOk()));
+  EXPECT_THAT(v.get<Json>(), Not(IsOk()));
 
   SetProtoKind(v, true);
-  EXPECT_THAT(v.get<JSON>(), Not(IsOk()));
+  EXPECT_THAT(v.get<Json>(), Not(IsOk()));
 
   SetProtoKind(v, 0.0);
-  EXPECT_THAT(v.get<JSON>(), Not(IsOk()));
+  EXPECT_THAT(v.get<Json>(), Not(IsOk()));
 }
 
 TEST(Value, GetBadNumeric) {
@@ -1118,8 +1118,8 @@ TEST(Value, OutputStream) {
       {Value("foo"), "foo", normal},
       {Value("NULL"), "NULL", normal},
       {Value(Bytes(std::string("DEADBEEF"))), R"(B"DEADBEEF")", normal},
-      {Value(JSON()), "null", normal},
-      {Value(JSON("true")), "true", normal},
+      {Value(Json()), "null", normal},
+      {Value(Json("true")), "true", normal},
       {Value(MakeNumeric(1234567890).value()), "1234567890", normal},
       {Value(absl::CivilDay()), "1970-01-01", normal},
       {Value(Timestamp()), "1970-01-01T00:00:00Z", normal},
@@ -1143,7 +1143,7 @@ TEST(Value, OutputStream) {
       {MakeNullValue<double>(), "NULL", normal},
       {MakeNullValue<std::string>(), "NULL", normal},
       {MakeNullValue<Bytes>(), "NULL", normal},
-      {MakeNullValue<JSON>(), "NULL", normal},
+      {MakeNullValue<Json>(), "NULL", normal},
       {MakeNullValue<Numeric>(), "NULL", normal},
       {MakeNullValue<absl::CivilDay>(), "NULL", normal},
       {MakeNullValue<Timestamp>(), "NULL", normal},
@@ -1157,7 +1157,7 @@ TEST(Value, OutputStream) {
       {Value(std::vector<double>{1.0, 2.0}), "[1.000, 2.000]", float4},
       {Value(std::vector<std::string>{"a", "b"}), R"(["a", "b"])", normal},
       {Value(std::vector<Bytes>{2}), R"([B"", B""])", normal},
-      {Value(std::vector<JSON>{2}), R"([null, null])", normal},
+      {Value(std::vector<Json>{2}), R"([null, null])", normal},
       {Value(std::vector<Numeric>{2}), "[0, 0]", normal},
       {Value(std::vector<absl::CivilDay>{2}), "[1970-01-01, 1970-01-01]",
        normal},
@@ -1171,7 +1171,7 @@ TEST(Value, OutputStream) {
       {MakeNullValue<std::vector<double>>(), "NULL", normal},
       {MakeNullValue<std::vector<std::string>>(), "NULL", normal},
       {MakeNullValue<std::vector<Bytes>>(), "NULL", normal},
-      {MakeNullValue<std::vector<JSON>>(), "NULL", normal},
+      {MakeNullValue<std::vector<Json>>(), "NULL", normal},
       {MakeNullValue<std::vector<Numeric>>(), "NULL", normal},
       {MakeNullValue<std::vector<absl::CivilDay>>(), "NULL", normal},
       {MakeNullValue<std::vector<Timestamp>>(), "NULL", normal},
@@ -1215,7 +1215,7 @@ TEST(Value, OutputStream) {
       {MakeNullValue<std::tuple<bool, std::string>>(), "NULL", normal},
       {MakeNullValue<std::tuple<double, Bytes, Timestamp>>(), "NULL", normal},
       {MakeNullValue<std::tuple<Numeric, absl::CivilDay>>(), "NULL", normal},
-      {MakeNullValue<std::tuple<JSON, std::vector<bool>>>(), "NULL", normal},
+      {MakeNullValue<std::tuple<Json, std::vector<bool>>>(), "NULL", normal},
   };
 
   for (auto const& tc : test_case) {
@@ -1266,10 +1266,10 @@ TEST(Value, OutputStreamMatchesT) {
   StreamMatchesValueStream(Bytes("foo"));
 
   // JSON
-  StreamMatchesValueStream(JSON());
-  StreamMatchesValueStream(JSON(R"("Hello world!")"));
-  StreamMatchesValueStream(JSON("42"));
-  StreamMatchesValueStream(JSON("true"));
+  StreamMatchesValueStream(Json());
+  StreamMatchesValueStream(Json(R"("Hello world!")"));
+  StreamMatchesValueStream(Json("42"));
+  StreamMatchesValueStream(Json("true"));
 
   // Numeric
   StreamMatchesValueStream(MakeNumeric("999").value());

--- a/google/cloud/spanner/value_test.cc
+++ b/google/cloud/spanner/value_test.cc
@@ -140,6 +140,16 @@ TEST(Value, BasicSemantics) {
     TestBasicSemantics(v);
   }
 
+  for (auto const& x : std::vector<JSON>{JSON(), JSON(R"("Hello world!")"),
+                                         JSON("42"), JSON("true")}) {
+    SCOPED_TRACE("Testing: JSON " + std::string(x));
+    TestBasicSemantics(x);
+    TestBasicSemantics(std::vector<JSON>(5, x));
+    std::vector<absl::optional<JSON>> v(5, x);
+    v.resize(10);
+    TestBasicSemantics(v);
+  }
+
   for (auto const& x : {
            MakeNumeric(-0.9e29).value(),
            MakeNumeric(-1).value(),
@@ -213,6 +223,7 @@ TEST(Value, Equality) {
       {Value(3.14), Value(42.0)},
       {Value("foo"), Value("bar")},
       {Value(Bytes("foo")), Value(Bytes("bar"))},
+      {Value(JSON("42")), Value(JSON("true"))},
       {Value(MakeNumeric(0).value()), Value(MakeNumeric(1).value())},
       {Value(absl::CivilDay(1970, 1, 1)), Value(absl::CivilDay(2020, 3, 15))},
       {Value(std::vector<double>{1.2, 3.4}),
@@ -368,6 +379,14 @@ TEST(Value, BytesRelationalOperators) {
 
   EXPECT_EQ(b1, b1);
   EXPECT_NE(b1, b2);
+}
+
+TEST(Value, JSONRelationalOperators) {
+  JSON j1("42");
+  JSON j2("true");
+
+  EXPECT_EQ(j1, j1);
+  EXPECT_NE(j1, j2);
 }
 
 TEST(Value, ConstructionFromLiterals) {
@@ -665,6 +684,17 @@ TEST(Value, ProtoConversionBytes) {
   }
 }
 
+TEST(Value, ProtoConversionJSON) {
+  for (auto const& x : std::vector<JSON>{JSON(), JSON(R"("Hello world!")"),
+                                         JSON("42"), JSON("true")}) {
+    Value const v(x);
+    auto const p = spanner_internal::ToProto(v);
+    EXPECT_EQ(v, spanner_internal::FromProto(p.first, p.second));
+    EXPECT_EQ(google::spanner::v1::TypeCode::JSON, p.first.code());
+    EXPECT_EQ(std::string(x), p.second.string_value());
+  }
+}
+
 TEST(Value, ProtoConversionNumeric) {
   for (auto const& x : std::vector<Numeric>{
            MakeNumeric(-0.9e29).value(),
@@ -861,6 +891,21 @@ TEST(Value, GetBadBytes) {
 
   SetProtoKind(v, 0.0);
   EXPECT_THAT(v.get<Bytes>(), Not(IsOk()));
+}
+
+TEST(Value, GetBadJSON) {
+  Value v(JSON("true"));
+  ClearProtoKind(v);
+  EXPECT_THAT(v.get<JSON>(), Not(IsOk()));
+
+  SetProtoKind(v, google::protobuf::NULL_VALUE);
+  EXPECT_THAT(v.get<JSON>(), Not(IsOk()));
+
+  SetProtoKind(v, true);
+  EXPECT_THAT(v.get<JSON>(), Not(IsOk()));
+
+  SetProtoKind(v, 0.0);
+  EXPECT_THAT(v.get<JSON>(), Not(IsOk()));
 }
 
 TEST(Value, GetBadNumeric) {
@@ -1073,6 +1118,8 @@ TEST(Value, OutputStream) {
       {Value("foo"), "foo", normal},
       {Value("NULL"), "NULL", normal},
       {Value(Bytes(std::string("DEADBEEF"))), R"(B"DEADBEEF")", normal},
+      {Value(JSON()), "null", normal},
+      {Value(JSON("true")), "true", normal},
       {Value(MakeNumeric(1234567890).value()), "1234567890", normal},
       {Value(absl::CivilDay()), "1970-01-01", normal},
       {Value(Timestamp()), "1970-01-01T00:00:00Z", normal},
@@ -1096,6 +1143,7 @@ TEST(Value, OutputStream) {
       {MakeNullValue<double>(), "NULL", normal},
       {MakeNullValue<std::string>(), "NULL", normal},
       {MakeNullValue<Bytes>(), "NULL", normal},
+      {MakeNullValue<JSON>(), "NULL", normal},
       {MakeNullValue<Numeric>(), "NULL", normal},
       {MakeNullValue<absl::CivilDay>(), "NULL", normal},
       {MakeNullValue<Timestamp>(), "NULL", normal},
@@ -1109,6 +1157,7 @@ TEST(Value, OutputStream) {
       {Value(std::vector<double>{1.0, 2.0}), "[1.000, 2.000]", float4},
       {Value(std::vector<std::string>{"a", "b"}), R"(["a", "b"])", normal},
       {Value(std::vector<Bytes>{2}), R"([B"", B""])", normal},
+      {Value(std::vector<JSON>{2}), R"([null, null])", normal},
       {Value(std::vector<Numeric>{2}), "[0, 0]", normal},
       {Value(std::vector<absl::CivilDay>{2}), "[1970-01-01, 1970-01-01]",
        normal},
@@ -1122,6 +1171,7 @@ TEST(Value, OutputStream) {
       {MakeNullValue<std::vector<double>>(), "NULL", normal},
       {MakeNullValue<std::vector<std::string>>(), "NULL", normal},
       {MakeNullValue<std::vector<Bytes>>(), "NULL", normal},
+      {MakeNullValue<std::vector<JSON>>(), "NULL", normal},
       {MakeNullValue<std::vector<Numeric>>(), "NULL", normal},
       {MakeNullValue<std::vector<absl::CivilDay>>(), "NULL", normal},
       {MakeNullValue<std::vector<Timestamp>>(), "NULL", normal},
@@ -1165,7 +1215,7 @@ TEST(Value, OutputStream) {
       {MakeNullValue<std::tuple<bool, std::string>>(), "NULL", normal},
       {MakeNullValue<std::tuple<double, Bytes, Timestamp>>(), "NULL", normal},
       {MakeNullValue<std::tuple<Numeric, absl::CivilDay>>(), "NULL", normal},
-      {MakeNullValue<std::tuple<std::vector<bool>>>(), "NULL", normal},
+      {MakeNullValue<std::tuple<JSON, std::vector<bool>>>(), "NULL", normal},
   };
 
   for (auto const& tc : test_case) {
@@ -1214,6 +1264,12 @@ TEST(Value, OutputStreamMatchesT) {
   // Bytes
   StreamMatchesValueStream(Bytes());
   StreamMatchesValueStream(Bytes("foo"));
+
+  // JSON
+  StreamMatchesValueStream(JSON());
+  StreamMatchesValueStream(JSON(R"("Hello world!")"));
+  StreamMatchesValueStream(JSON("42"));
+  StreamMatchesValueStream(JSON("true"));
 
   // Numeric
   StreamMatchesValueStream(MakeNumeric("999").value());


### PR DESCRIPTION
`google::cloud::spanner::JSON` is just a strongly-typed string.
That is, a `JSON` value can be constructed from, and converted
to a `std::string`. `JSON` values can also be compared (by string)
for equality, and streamed.

There is no syntax checking of JSON strings in the client library.
All checking is done on the server. The user is expected to build
`JSON` values from well-formatted strings, probably produced by
a separate JSON library. Similarly, `JSON` values should be parsed
by that separate library.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7212)
<!-- Reviewable:end -->
