### PR TITLE
feat(generator): add default tracing components and options

### DIFF
--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_option_defaults.cc
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_option_defaults.cc
@@ -20,6 +20,7 @@
 #include "generator/integration_tests/golden/golden_kitchen_sink_connection.h"
 #include "generator/integration_tests/golden/golden_kitchen_sink_options.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/connection_options.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/internal/user_agent_prefix.h"
@@ -46,6 +47,12 @@ Options GoldenKitchenSinkDefaultOptions(Options options) {
   }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
+  }
+  if (!options.has<TracingComponentsOption>()) {
+    options.set<TracingComponentsOption>(internal::DefaultTracingComponents());
+  }
+  if (!options.has<GrpcTracingOptionsOption>()) {
+    options.set<GrpcTracingOptionsOption>(internal::DefaultTracingOptions());
   }
   auto& products = options.lookup<UserAgentProductsOption>();
   products.insert(products.begin(), google::cloud::internal::UserAgentPrefix());

--- a/generator/integration_tests/golden/internal/golden_thing_admin_option_defaults.cc
+++ b/generator/integration_tests/golden/internal/golden_thing_admin_option_defaults.cc
@@ -20,6 +20,7 @@
 #include "generator/integration_tests/golden/golden_thing_admin_connection.h"
 #include "generator/integration_tests/golden/golden_thing_admin_options.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/connection_options.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/internal/user_agent_prefix.h"
@@ -46,6 +47,12 @@ Options GoldenThingAdminDefaultOptions(Options options) {
   }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
+  }
+  if (!options.has<TracingComponentsOption>()) {
+    options.set<TracingComponentsOption>(internal::DefaultTracingComponents());
+  }
+  if (!options.has<GrpcTracingOptionsOption>()) {
+    options.set<GrpcTracingOptionsOption>(internal::DefaultTracingOptions());
   }
   auto& products = options.lookup<UserAgentProductsOption>();
   products.insert(products.begin(), google::cloud::internal::UserAgentPrefix());

--- a/generator/internal/option_defaults_generator.cc
+++ b/generator/internal/option_defaults_generator.cc
@@ -75,7 +75,8 @@ Status OptionDefaultsGenerator::GenerateCc() {
   CcLocalIncludes(
       {vars("option_defaults_header_path"), vars("connection_header_path"),
        vars("options_header_path"), "google/cloud/common_options.h",
-       "google/cloud/grpc_options.h", "google/cloud/internal/getenv.h",
+       "google/cloud/connection_options.h", "google/cloud/grpc_options.h",
+       "google/cloud/internal/getenv.h",
        "google/cloud/internal/user_agent_prefix.h", "google/cloud/options.h"});
   CcSystemIncludes({"memory"});
   CcPrint("\n");
@@ -103,6 +104,12 @@ Status OptionDefaultsGenerator::GenerateCc() {
     "  }\n"},
    {"  if (!options.has<GrpcCredentialOption>()) {\n"
     "    options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());\n"
+    "  }\n"
+    "  if (!options.has<TracingComponentsOption>()) {\n"
+    "    options.set<TracingComponentsOption>(internal::DefaultTracingComponents());\n"
+    "  }\n"
+    "  if (!options.has<GrpcTracingOptionsOption>()) {\n"
+    "    options.set<GrpcTracingOptionsOption>(internal::DefaultTracingOptions());\n"
     "  }\n"
     "  auto& products = options.lookup<UserAgentProductsOption>();\n"
     "  products.insert(products.begin(), google::cloud::internal::UserAgentPrefix());\n"

--- a/google/cloud/bigquery/internal/bigquery_read_option_defaults.cc
+++ b/google/cloud/bigquery/internal/bigquery_read_option_defaults.cc
@@ -20,6 +20,7 @@
 #include "google/cloud/bigquery/bigquery_read_connection.h"
 #include "google/cloud/bigquery/bigquery_read_options.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/connection_options.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/internal/user_agent_prefix.h"
@@ -42,6 +43,12 @@ Options BigQueryReadDefaultOptions(Options options) {
   }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
+  }
+  if (!options.has<TracingComponentsOption>()) {
+    options.set<TracingComponentsOption>(internal::DefaultTracingComponents());
+  }
+  if (!options.has<GrpcTracingOptionsOption>()) {
+    options.set<GrpcTracingOptionsOption>(internal::DefaultTracingOptions());
   }
   auto& products = options.lookup<UserAgentProductsOption>();
   products.insert(products.begin(), google::cloud::internal::UserAgentPrefix());

--- a/google/cloud/iam/internal/iam_credentials_option_defaults.cc
+++ b/google/cloud/iam/internal/iam_credentials_option_defaults.cc
@@ -20,6 +20,7 @@
 #include "google/cloud/iam/iam_credentials_connection.h"
 #include "google/cloud/iam/iam_credentials_options.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/connection_options.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/internal/user_agent_prefix.h"
@@ -42,6 +43,12 @@ Options IAMCredentialsDefaultOptions(Options options) {
   }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
+  }
+  if (!options.has<TracingComponentsOption>()) {
+    options.set<TracingComponentsOption>(internal::DefaultTracingComponents());
+  }
+  if (!options.has<GrpcTracingOptionsOption>()) {
+    options.set<GrpcTracingOptionsOption>(internal::DefaultTracingOptions());
   }
   auto& products = options.lookup<UserAgentProductsOption>();
   products.insert(products.begin(), google::cloud::internal::UserAgentPrefix());

--- a/google/cloud/iam/internal/iam_option_defaults.cc
+++ b/google/cloud/iam/internal/iam_option_defaults.cc
@@ -20,6 +20,7 @@
 #include "google/cloud/iam/iam_connection.h"
 #include "google/cloud/iam/iam_options.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/connection_options.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/internal/user_agent_prefix.h"
@@ -42,6 +43,12 @@ Options IAMDefaultOptions(Options options) {
   }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
+  }
+  if (!options.has<TracingComponentsOption>()) {
+    options.set<TracingComponentsOption>(internal::DefaultTracingComponents());
+  }
+  if (!options.has<GrpcTracingOptionsOption>()) {
+    options.set<GrpcTracingOptionsOption>(internal::DefaultTracingOptions());
   }
   auto& products = options.lookup<UserAgentProductsOption>();
   products.insert(products.begin(), google::cloud::internal::UserAgentPrefix());

--- a/google/cloud/logging/internal/logging_service_v2_option_defaults.cc
+++ b/google/cloud/logging/internal/logging_service_v2_option_defaults.cc
@@ -20,6 +20,7 @@
 #include "google/cloud/logging/logging_service_v2_connection.h"
 #include "google/cloud/logging/logging_service_v2_options.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/connection_options.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/internal/user_agent_prefix.h"
@@ -42,6 +43,12 @@ Options LoggingServiceV2DefaultOptions(Options options) {
   }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
+  }
+  if (!options.has<TracingComponentsOption>()) {
+    options.set<TracingComponentsOption>(internal::DefaultTracingComponents());
+  }
+  if (!options.has<GrpcTracingOptionsOption>()) {
+    options.set<GrpcTracingOptionsOption>(internal::DefaultTracingOptions());
   }
   auto& products = options.lookup<UserAgentProductsOption>();
   products.insert(products.begin(), google::cloud::internal::UserAgentPrefix());

--- a/google/cloud/spanner/admin/internal/database_admin_option_defaults.cc
+++ b/google/cloud/spanner/admin/internal/database_admin_option_defaults.cc
@@ -20,6 +20,7 @@
 #include "google/cloud/spanner/admin/database_admin_connection.h"
 #include "google/cloud/spanner/admin/database_admin_options.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/connection_options.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/internal/user_agent_prefix.h"
@@ -46,6 +47,12 @@ Options DatabaseAdminDefaultOptions(Options options) {
   }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
+  }
+  if (!options.has<TracingComponentsOption>()) {
+    options.set<TracingComponentsOption>(internal::DefaultTracingComponents());
+  }
+  if (!options.has<GrpcTracingOptionsOption>()) {
+    options.set<GrpcTracingOptionsOption>(internal::DefaultTracingOptions());
   }
   auto& products = options.lookup<UserAgentProductsOption>();
   products.insert(products.begin(), google::cloud::internal::UserAgentPrefix());

--- a/google/cloud/spanner/admin/internal/instance_admin_option_defaults.cc
+++ b/google/cloud/spanner/admin/internal/instance_admin_option_defaults.cc
@@ -20,6 +20,7 @@
 #include "google/cloud/spanner/admin/instance_admin_connection.h"
 #include "google/cloud/spanner/admin/instance_admin_options.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/connection_options.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/internal/user_agent_prefix.h"
@@ -46,6 +47,12 @@ Options InstanceAdminDefaultOptions(Options options) {
   }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
+  }
+  if (!options.has<TracingComponentsOption>()) {
+    options.set<TracingComponentsOption>(internal::DefaultTracingComponents());
+  }
+  if (!options.has<GrpcTracingOptionsOption>()) {
+    options.set<GrpcTracingOptionsOption>(internal::DefaultTracingOptions());
   }
   auto& products = options.lookup<UserAgentProductsOption>();
   products.insert(products.begin(), google::cloud::internal::UserAgentPrefix());


### PR DESCRIPTION
Add default `GrpcTracingOptionsOption` and `TracingComponentsOption`
values to the `Options` used to make connections in generated interfaces.
This means environment variables `GOOGLE_CLOUD_CPP_ENABLE_TRACING` and
`GOOGLE_CLOUD_CPP_TRACING_OPTIONS` will now have an effect.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7219)
<!-- Reviewable:end -->
