### PR TITLE
test(spanner): flush log on InstanceAdminClientTest failure

### DIFF
--- a/google/cloud/spanner/integration_tests/instance_admin_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/instance_admin_integration_test.cc
@@ -20,6 +20,7 @@
 #include "google/cloud/spanner/update_instance_request_builder.h"
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/internal/random.h"
+#include "google/cloud/testing_util/integration_test.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
 #include <algorithm>
@@ -89,7 +90,8 @@ class CleanupStaleInstances : public ::testing::Environment {
 ::testing::Environment* const kCleanupEnv =
     ::testing::AddGlobalTestEnvironment(new CleanupStaleInstances);
 
-class InstanceAdminClientTest : public testing::Test {
+class InstanceAdminClientTest
+    : public ::google::cloud::testing_util::IntegrationTest {
  public:
   InstanceAdminClientTest()
       : generator_(internal::MakeDefaultPRNG()),


### PR DESCRIPTION
Derive `InstanceAdminClientTest` from `testing_util::IntegrationTest`
so that buffered "lastN" log messages are emitted after a test failure.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7220)
<!-- Reviewable:end -->
