### PR TITLE
test(bigtable): add Options constructor for mock clients

### DIFF
--- a/google/cloud/bigtable/testing/mock_admin_client.h
+++ b/google/cloud/bigtable/testing/mock_admin_client.h
@@ -26,8 +26,13 @@ namespace testing {
 
 class MockAdminClient : public bigtable::AdminClient {
  public:
-  explicit MockAdminClient(ClientOptions options = {})
-      : options_(std::move(options)) {}
+  MockAdminClient() = default;
+
+  explicit MockAdminClient(Options options) : options_(std::move(options)) {}
+
+  /// @deprecated use constructor that takes `google::cloud::Options`
+  explicit MockAdminClient(ClientOptions options)
+      : options_(internal::MakeOptions(std::move(options))) {}
 
   MOCK_METHOD(std::string const&, project, (), (const, override));
   MOCK_METHOD(std::shared_ptr<grpc::Channel>, Channel, (), (override));
@@ -258,10 +263,10 @@ class MockAdminClient : public bigtable::AdminClient {
 
  private:
   google::cloud::BackgroundThreadsFactory BackgroundThreadsFactory() override {
-    return options_.background_threads_factory();
+    return google::cloud::internal::MakeBackgroundThreadsFactory(options_);
   }
 
-  ClientOptions options_;
+  Options options_;
 };
 
 }  // namespace testing

--- a/google/cloud/bigtable/testing/mock_data_client.h
+++ b/google/cloud/bigtable/testing/mock_data_client.h
@@ -26,8 +26,13 @@ namespace testing {
 
 class MockDataClient : public bigtable::DataClient {
  public:
-  explicit MockDataClient(ClientOptions options = {})
-      : options_(std::move(options)) {}
+  MockDataClient() = default;
+
+  explicit MockDataClient(Options options) : options_(std::move(options)) {}
+
+  /// @deprecated use constructor that takes `google::cloud::Options`
+  explicit MockDataClient(ClientOptions options)
+      : options_(internal::MakeOptions(std::move(options))) {}
 
   MOCK_METHOD(std::string const&, project_id, (), (const, override));
   MOCK_METHOD(std::string const&, instance_id, (), (const, override));
@@ -132,12 +137,11 @@ class MockDataClient : public bigtable::DataClient {
               (override));
 
  private:
-  /// The thread factory from `ClientOptions` this client was created with.
   google::cloud::BackgroundThreadsFactory BackgroundThreadsFactory() override {
-    return options_.background_threads_factory();
+    return google::cloud::internal::MakeBackgroundThreadsFactory(options_);
   }
 
-  ClientOptions options_;
+  Options options_;
 };
 
 }  // namespace testing

--- a/google/cloud/bigtable/testing/mock_instance_admin_client.h
+++ b/google/cloud/bigtable/testing/mock_instance_admin_client.h
@@ -26,8 +26,14 @@ namespace testing {
 
 class MockInstanceAdminClient : public bigtable::InstanceAdminClient {
  public:
-  explicit MockInstanceAdminClient(ClientOptions options = {})
+  MockInstanceAdminClient() = default;
+
+  explicit MockInstanceAdminClient(Options options)
       : options_(std::move(options)) {}
+
+  /// @deprecated use constructor that takes `google::cloud::Options`
+  explicit MockInstanceAdminClient(ClientOptions options)
+      : options_(internal::MakeOptions(std::move(options))) {}
 
   MOCK_METHOD(std::string const&, project, (), (const, override));
   MOCK_METHOD(std::shared_ptr<grpc::Channel>, Channel, (), (override));
@@ -301,10 +307,10 @@ class MockInstanceAdminClient : public bigtable::InstanceAdminClient {
 
  private:
   google::cloud::BackgroundThreadsFactory BackgroundThreadsFactory() override {
-    return options_.background_threads_factory();
+    return google::cloud::internal::MakeBackgroundThreadsFactory(options_);
   }
 
-  ClientOptions options_;
+  Options options_;
 };
 
 }  // namespace testing


### PR DESCRIPTION
Part of the work for #6307

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7232)
<!-- Reviewable:end -->
