### PR TITLE
cleanup(bigtable): remove ClientOptions from benchmark

### DIFF
--- a/google/cloud/bigtable/benchmarks/benchmark.h
+++ b/google/cloud/bigtable/benchmarks/benchmark.h
@@ -119,8 +119,7 @@ class Benchmark {
   int read_rows_count() const;
   //@}
 
-  /// Return a mutable reference to client options.
-  ClientOptions& ClientOptionsRef() { return client_options_; }
+  void DisableBackgroundThreads(CompletionQueue& cq);
 
  private:
   /// Populate the table rows in the range [@p begin, @p end)
@@ -135,7 +134,7 @@ class Benchmark {
 
   BenchmarkOptions options_;
   int key_width_;
-  bigtable::ClientOptions client_options_;
+  Options opts_;
   std::unique_ptr<EmbeddedServer> server_;
   std::thread server_thread_;
 };

--- a/google/cloud/bigtable/benchmarks/read_sync_vs_async_benchmark.cc
+++ b/google/cloud/bigtable/benchmarks/read_sync_vs_async_benchmark.cc
@@ -147,7 +147,7 @@ int main(int argc, char* argv[]) {
 
   Benchmark benchmark(*options);
   google::cloud::CompletionQueue cq;
-  benchmark.ClientOptionsRef().DisableBackgroundThreads(cq);
+  benchmark.DisableBackgroundThreads(cq);
 
   // Create and populate the table for the benchmark.
   benchmark.CreateTable();

--- a/google/cloud/bigtable/testing/embedded_server_test_fixture.cc
+++ b/google/cloud/bigtable/testing/embedded_server_test_fixture.cc
@@ -15,6 +15,7 @@
 #include "google/cloud/bigtable/testing/embedded_server_test_fixture.h"
 #include "google/cloud/grpc_error_delegate.h"
 #include "google/cloud/internal/build_info.h"
+#include "google/cloud/internal/user_agent_prefix.h"
 #include <thread>
 
 namespace google {
@@ -48,7 +49,8 @@ void EmbeddedServerTestFixture::SetUp() {
   StartServer();
 
   grpc::ChannelArguments channel_arguments;
-  channel_arguments.SetUserAgentPrefix(ClientOptions::UserAgentPrefix());
+  channel_arguments.SetUserAgentPrefix(
+      google::cloud::internal::UserAgentPrefix());
   std::string project_id = kProjectId;
   std::string instance_id = kInstanceId;
   std::string table_id = kTableId;


### PR DESCRIPTION
Part of the work for #6307

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7233)
<!-- Reviewable:end -->
