### PR TITLE
doc: minimal install for quickstarts

### DIFF
--- a/google/cloud/bigquery/quickstart/README.md
+++ b/google/cloud/bigquery/quickstart/README.md
@@ -92,7 +92,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/vcpkg
-   ./vcpkg install google-cloud-cpp
+   ./vcpkg install google-cloud-cpp[core,bigquery]
    ```
 
    Note that, as it is often the case with C++ libraries, compiling these

--- a/google/cloud/bigtable/quickstart/README.md
+++ b/google/cloud/bigtable/quickstart/README.md
@@ -93,7 +93,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/vcpkg
-   ./vcpkg install google-cloud-cpp
+   ./vcpkg install google-cloud-cpp[core,bigtable]
    ```
 
    Note that, as it is often the case with C++ libraries, compiling these

--- a/google/cloud/iam/quickstart/README.md
+++ b/google/cloud/iam/quickstart/README.md
@@ -91,7 +91,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/vcpkg
-   ./vcpkg install google-cloud-cpp
+   ./vcpkg install google-cloud-cpp[core,iam]
    ```
 
    Note that, as it is often the case with C++ libraries, compiling these

--- a/google/cloud/pubsub/quickstart/README.md
+++ b/google/cloud/pubsub/quickstart/README.md
@@ -92,7 +92,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/vcpkg
-   ./vcpkg install google-cloud-cpp
+   ./vcpkg install google-cloud-cpp[core,pubsub]
    ```
 
    Note that, as it is often the case with C++ libraries, compiling these

--- a/google/cloud/spanner/quickstart/README.md
+++ b/google/cloud/spanner/quickstart/README.md
@@ -93,7 +93,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/vcpkg
-   ./vcpkg install google-cloud-cpp
+   ./vcpkg install google-cloud-cpp[core,spanner]
    ```
 
    Note that, as it is often the case with C++ libraries, compiling these

--- a/google/cloud/storage/quickstart/README.md
+++ b/google/cloud/storage/quickstart/README.md
@@ -94,7 +94,7 @@ https://cloud.google.com/docs/authentication/production
 
    ```bash
    cd $HOME/vcpkg
-   ./vcpkg install google-cloud-cpp
+   ./vcpkg install google-cloud-cpp[core,storage]
    ```
 
    Note that, as it is often the case with C++ libraries, compiling these


### PR DESCRIPTION
Change the quickstart README files to recommend a minimal `vcpkg`
install for each library.

There is a downside to this change: folks may be surprised if they try to
use a different library after the minimal `make install`. It also depends
on the "latest" version of `vcpkg`, but the half-life of that problem is 
pretty short.
