### PR TITLE
cleanup(bigtable): don't test time output, which could change

### DIFF
--- a/google/cloud/bigtable/benchmarks/benchmark_options_test.cc
+++ b/google/cloud/bigtable/benchmarks/benchmark_options_test.cc
@@ -64,7 +64,6 @@ TEST(BenchmarkOptions, Defaults) {
 
 TEST(BenchmarkOptions, Initialization) {
   auto const re = std::regex(testing::RandomTableIdRegex());
-  auto const now = absl::FormatTime("%FT%TZ", absl::Now(), absl::UTCTimeZone());
   auto options = ParseBenchmarkOptions(
       {
           "self-test",
@@ -72,7 +71,6 @@ TEST(BenchmarkOptions, Initialization) {
           "--instance-id=b",
       },
       "");
-  EXPECT_EQ(now, options->start_time);
   EXPECT_TRUE(std::regex_match(options->table_id, re));
   EXPECT_THAT(options->notes, ::testing::HasSubstr(bigtable::version_string()));
 }


### PR DESCRIPTION
The time could advance, changing the output by the time we initialize it. The check was unnecessary.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7250)
<!-- Reviewable:end -->
