### PR TITLE
doc(storage): handle kNotFound in example

### DIFF
--- a/google/cloud/storage/examples/storage_object_resumable_write_samples.cc
+++ b/google/cloud/storage/examples/storage_object_resumable_write_samples.cc
@@ -119,7 +119,10 @@ void DeleteResumableUpload(google::cloud::storage::Client client,
               << "\n";
 
     auto status = client.DeleteResumableUpload(stream.resumable_session_id());
-    if (!status.ok()) throw std::runtime_error(status.message());
+    if (!status.ok() && status.code() != google::cloud::StatusCode::kNotFound) {
+      throw std::runtime_error(status.message());
+    }
+    // kNotFound implies it was already deleted, maybe as a result of a retry.
     std::cout << "Deleted resumable upload: " << stream.resumable_session_id()
               << "\n";
 


### PR DESCRIPTION
Deleting a resumable upload can be retried, and when it is, the result
may be `kNotFound` as the upload is deleted in a previous attempt.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7252)
<!-- Reviewable:end -->
