### PR TITLE
cleanup(GCS+gRPC): rename stub functions to match protos

### DIFF
--- a/google/cloud/storage/internal/grpc_client.cc
+++ b/google/cloud/storage/internal/grpc_client.cc
@@ -167,7 +167,7 @@ GrpcClient::GrpcClient(std::shared_ptr<StorageStub> stub, Options const& opts)
       background_(MakeBackgroundThreadsFactory(opts)()),
       stub_(std::move(stub)) {}
 
-std::unique_ptr<GrpcClient::InsertStream> GrpcClient::CreateUploadWriter(
+std::unique_ptr<GrpcClient::WriteObjectStream> GrpcClient::CreateUploadWriter(
     std::unique_ptr<grpc::ClientContext> context) {
   return stub_->WriteObject(std::move(context));
 }
@@ -180,7 +180,7 @@ StatusOr<ResumableUploadResponse> GrpcClient::QueryResumableUpload(
 
   ResumableUploadResponse response;
   response.upload_state = ResumableUploadResponse::kInProgress;
-  // TODO(#6982) / TODO(#6880) - cleanup the committed_byte vs. size thing
+  // TODO(#6880) - cleanup the committed_byte vs. size thing
   if (status->has_committed_size() && status->committed_size()) {
     response.last_committed_byte =
         static_cast<std::uint64_t>(status->committed_size());
@@ -926,7 +926,7 @@ ResumableUploadResponse GrpcClient::FromProto(
   ResumableUploadResponse response;
   response.upload_state = ResumableUploadResponse::kInProgress;
   if (p.has_committed_size() && p.committed_size() > 0) {
-    // TODO(#6982) / TODO(#6880) - cleanup the committed_byte vs. size thing
+    // TODO(#6880) - cleanup the committed_byte vs. size thing
     response.last_committed_byte =
         static_cast<std::uint64_t>(p.committed_size()) - 1;
   } else {

--- a/google/cloud/storage/internal/grpc_client.cc
+++ b/google/cloud/storage/internal/grpc_client.cc
@@ -169,7 +169,7 @@ GrpcClient::GrpcClient(std::shared_ptr<StorageStub> stub, Options const& opts)
 
 std::unique_ptr<GrpcClient::InsertStream> GrpcClient::CreateUploadWriter(
     std::unique_ptr<grpc::ClientContext> context) {
-  return stub_->InsertObjectMedia(std::move(context));
+  return stub_->WriteObject(std::move(context));
 }
 
 StatusOr<ResumableUploadResponse> GrpcClient::QueryResumableUpload(
@@ -260,8 +260,7 @@ StatusOr<ObjectMetadata> GrpcClient::InsertObjectMedia(
   if (!r) return std::move(r).status();
   auto proto_request = *r;
 
-  auto stream =
-      stub_->InsertObjectMedia(absl::make_unique<grpc::ClientContext>());
+  auto stream = stub_->WriteObject(absl::make_unique<grpc::ClientContext>());
 
   auto const& contents = request.contents();
   auto const contents_size = static_cast<std::int64_t>(contents.size());
@@ -327,7 +326,7 @@ StatusOr<std::unique_ptr<ObjectReadSource>> GrpcClient::ReadObject(
   }
   return std::unique_ptr<ObjectReadSource>(
       absl::make_unique<GrpcObjectReadSource>(
-          stub_->GetObjectMedia(std::move(context), ToProto(request))));
+          stub_->ReadObject(std::move(context), ToProto(request))));
 }
 
 StatusOr<ListObjectsResponse> GrpcClient::ListObjects(

--- a/google/cloud/storage/internal/grpc_client.h
+++ b/google/cloud/storage/internal/grpc_client.h
@@ -56,11 +56,10 @@ class GrpcClient : public RawClient,
   // them is very different from the standard retry loop. Also note that these
   // are virtual functions only because we need to override them in the unit
   // tests.
-  // TODO(#6982) - rename WriteObjectStream to WriteStream.
-  using InsertStream = ::google::cloud::internal::StreamingWriteRpc<
+  using WriteObjectStream = ::google::cloud::internal::StreamingWriteRpc<
       google::storage::v2::WriteObjectRequest,
       google::storage::v2::WriteObjectResponse>;
-  virtual std::unique_ptr<InsertStream> CreateUploadWriter(
+  virtual std::unique_ptr<WriteObjectStream> CreateUploadWriter(
       std::unique_ptr<grpc::ClientContext> context);
   virtual StatusOr<ResumableUploadResponse> QueryResumableUpload(
       QueryResumableUploadRequest const&);

--- a/google/cloud/storage/internal/grpc_client.h
+++ b/google/cloud/storage/internal/grpc_client.h
@@ -56,7 +56,7 @@ class GrpcClient : public RawClient,
   // them is very different from the standard retry loop. Also note that these
   // are virtual functions only because we need to override them in the unit
   // tests.
-  // TODO(#6982) - rename InsertStream to WriteStream.
+  // TODO(#6982) - rename WriteObjectStream to WriteStream.
   using InsertStream = ::google::cloud::internal::StreamingWriteRpc<
       google::storage::v2::WriteObjectRequest,
       google::storage::v2::WriteObjectResponse>;

--- a/google/cloud/storage/internal/grpc_client_insert_object_media_test.cc
+++ b/google/cloud/storage/internal/grpc_client_insert_object_media_test.cc
@@ -69,7 +69,7 @@ TEST(GrpcClientInsertObjectMediaTest, Small) {
   ASSERT_TRUE(TextFormat::ParseFromString(kWriteRequestText, &write_request));
 
   auto mock = std::make_shared<MockStorageStub>();
-  EXPECT_CALL(*mock, InsertObjectMedia)
+  EXPECT_CALL(*mock, WriteObject)
       .WillOnce([&](std::unique_ptr<grpc::ClientContext>) {
         auto stream = absl::make_unique<MockInsertStream>();
         EXPECT_CALL(*stream, Write(IsProtoEqual(write_request), _))

--- a/google/cloud/storage/internal/grpc_client_read_object_test.cc
+++ b/google/cloud/storage/internal/grpc_client_read_object_test.cc
@@ -45,7 +45,7 @@ TEST(GrpcClientReadObjectTest, WithDefaultTimeout) {
       TextFormat::ParseFromString(kExpectedRequestText, &expected_request));
 
   auto mock = std::make_shared<MockStorageStub>();
-  EXPECT_CALL(*mock, GetObjectMedia)
+  EXPECT_CALL(*mock, ReadObject)
       .WillOnce([&](std::unique_ptr<grpc::ClientContext> context,
                     ReadObjectRequest const& request) {
         EXPECT_THAT(request, IsProtoEqual(expected_request));
@@ -76,7 +76,7 @@ TEST(GrpcClientReadObjectTest, WithExplicitTimeout) {
   auto const configured_timeout = std::chrono::seconds(3);
 
   auto mock = std::make_shared<MockStorageStub>();
-  EXPECT_CALL(*mock, GetObjectMedia)
+  EXPECT_CALL(*mock, ReadObject)
       .WillOnce([&](std::unique_ptr<grpc::ClientContext> context,
                     ReadObjectRequest const& request) {
         EXPECT_THAT(request, IsProtoEqual(expected_request));

--- a/google/cloud/storage/internal/storage_auth.cc
+++ b/google/cloud/storage/internal/storage_auth.cc
@@ -20,24 +20,24 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace internal {
 
-std::unique_ptr<StorageStub::ObjectMediaStream> StorageAuth::GetObjectMedia(
+std::unique_ptr<StorageStub::ReadObjectStream> StorageAuth::ReadObject(
     std::unique_ptr<grpc::ClientContext> context,
     google::storage::v2::ReadObjectRequest const& request) {
   using ErrorStream = ::google::cloud::internal::StreamingReadRpcError<
       google::storage::v2::ReadObjectResponse>;
   auto status = auth_->ConfigureContext(*context);
   if (!status.ok()) return absl::make_unique<ErrorStream>(std::move(status));
-  return child_->GetObjectMedia(std::move(context), request);
+  return child_->ReadObject(std::move(context), request);
 }
 
-std::unique_ptr<StorageStub::InsertStream> StorageAuth::InsertObjectMedia(
+std::unique_ptr<StorageStub::WriteObjectStream> StorageAuth::WriteObject(
     std::unique_ptr<grpc::ClientContext> context) {
   using ErrorStream = ::google::cloud::internal::StreamingWriteRpcError<
       google::storage::v2::WriteObjectRequest,
       google::storage::v2::WriteObjectResponse>;
   auto status = auth_->ConfigureContext(*context);
   if (!status.ok()) return absl::make_unique<ErrorStream>(std::move(status));
-  return child_->InsertObjectMedia(std::move(context));
+  return child_->WriteObject(std::move(context));
 }
 
 StatusOr<google::storage::v2::StartResumableWriteResponse>

--- a/google/cloud/storage/internal/storage_auth.h
+++ b/google/cloud/storage/internal/storage_auth.h
@@ -33,11 +33,11 @@ class StorageAuth : public StorageStub {
       : auth_(std::move(auth)), child_(std::move(child)) {}
   ~StorageAuth() override = default;
 
-  std::unique_ptr<ObjectMediaStream> GetObjectMedia(
+  std::unique_ptr<ReadObjectStream> ReadObject(
       std::unique_ptr<grpc::ClientContext> context,
       google::storage::v2::ReadObjectRequest const& request) override;
 
-  std::unique_ptr<InsertStream> InsertObjectMedia(
+  std::unique_ptr<WriteObjectStream> WriteObject(
       std::unique_ptr<grpc::ClientContext> context) override;
 
   StatusOr<google::storage::v2::StartResumableWriteResponse>

--- a/google/cloud/storage/internal/storage_round_robin.cc
+++ b/google/cloud/storage/internal/storage_round_robin.cc
@@ -20,16 +20,15 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace internal {
 
-std::unique_ptr<StorageStub::ObjectMediaStream>
-StorageRoundRobin::GetObjectMedia(
+std::unique_ptr<StorageStub::ReadObjectStream> StorageRoundRobin::ReadObject(
     std::unique_ptr<grpc::ClientContext> context,
     google::storage::v2::ReadObjectRequest const& request) {
-  return Child()->GetObjectMedia(std::move(context), request);
+  return Child()->ReadObject(std::move(context), request);
 }
 
-std::unique_ptr<StorageStub::InsertStream> StorageRoundRobin::InsertObjectMedia(
+std::unique_ptr<StorageStub::WriteObjectStream> StorageRoundRobin::WriteObject(
     std::unique_ptr<grpc::ClientContext> context) {
-  return Child()->InsertObjectMedia(std::move(context));
+  return Child()->WriteObject(std::move(context));
 }
 
 StatusOr<google::storage::v2::StartResumableWriteResponse>

--- a/google/cloud/storage/internal/storage_round_robin.h
+++ b/google/cloud/storage/internal/storage_round_robin.h
@@ -32,11 +32,11 @@ class StorageRoundRobin : public StorageStub {
       : children_(std::move(children)) {}
   ~StorageRoundRobin() override = default;
 
-  std::unique_ptr<ObjectMediaStream> GetObjectMedia(
+  std::unique_ptr<ReadObjectStream> ReadObject(
       std::unique_ptr<grpc::ClientContext> context,
       google::storage::v2::ReadObjectRequest const& request) override;
 
-  std::unique_ptr<InsertStream> InsertObjectMedia(
+  std::unique_ptr<WriteObjectStream> WriteObject(
       std::unique_ptr<grpc::ClientContext> context) override;
 
   StatusOr<google::storage::v2::StartResumableWriteResponse>

--- a/google/cloud/storage/internal/storage_stub.cc
+++ b/google/cloud/storage/internal/storage_stub.cc
@@ -32,7 +32,7 @@ class StorageStubImpl : public StorageStub {
       : impl_(std::move(impl)) {}
   ~StorageStubImpl() override = default;
 
-  std::unique_ptr<ObjectMediaStream> GetObjectMedia(
+  std::unique_ptr<ReadObjectStream> ReadObject(
       std::unique_ptr<grpc::ClientContext> context,
       google::storage::v2::ReadObjectRequest const& request) override {
     using ::google::cloud::internal::StreamingReadRpcImpl;
@@ -42,7 +42,7 @@ class StorageStubImpl : public StorageStub {
         std::move(context), std::move(stream));
   }
 
-  std::unique_ptr<InsertStream> InsertObjectMedia(
+  std::unique_ptr<WriteObjectStream> WriteObject(
       std::unique_ptr<grpc::ClientContext> context) override {
     using ::google::cloud::internal::StreamingWriteRpcImpl;
     using ResponseType = ::google::storage::v2::WriteObjectResponse;

--- a/google/cloud/storage/internal/storage_stub.h
+++ b/google/cloud/storage/internal/storage_stub.h
@@ -32,18 +32,16 @@ class StorageStub {
  public:
   virtual ~StorageStub() = default;
 
-  // TODO(#6982) - update the name of this stream
-  using ObjectMediaStream = ::google::cloud::internal::StreamingReadRpc<
+  using ReadObjectStream = ::google::cloud::internal::StreamingReadRpc<
       google::storage::v2::ReadObjectResponse>;
-  virtual std::unique_ptr<ObjectMediaStream> GetObjectMedia(
+  virtual std::unique_ptr<ReadObjectStream> ReadObject(
       std::unique_ptr<grpc::ClientContext> context,
       google::storage::v2::ReadObjectRequest const& request) = 0;
 
-  // TODO(#6982) - update the name of this stream
-  using InsertStream = ::google::cloud::internal::StreamingWriteRpc<
+  using WriteObjectStream = ::google::cloud::internal::StreamingWriteRpc<
       google::storage::v2::WriteObjectRequest,
       google::storage::v2::WriteObjectResponse>;
-  virtual std::unique_ptr<InsertStream> InsertObjectMedia(
+  virtual std::unique_ptr<WriteObjectStream> WriteObject(
       std::unique_ptr<grpc::ClientContext> context) = 0;
 
   virtual StatusOr<google::storage::v2::StartResumableWriteResponse>

--- a/google/cloud/storage/testing/mock_storage_stub.h
+++ b/google/cloud/storage/testing/mock_storage_stub.h
@@ -25,11 +25,11 @@ namespace testing {
 
 class MockStorageStub : public internal::StorageStub {
  public:
-  MOCK_METHOD(std::unique_ptr<ObjectMediaStream>, GetObjectMedia,
+  MOCK_METHOD(std::unique_ptr<ReadObjectStream>, ReadObject,
               (std::unique_ptr<grpc::ClientContext>,
                google::storage::v2::ReadObjectRequest const&),
               (override));
-  MOCK_METHOD(std::unique_ptr<InsertStream>, InsertObjectMedia,
+  MOCK_METHOD(std::unique_ptr<WriteObjectStream>, WriteObject,
               (std::unique_ptr<grpc::ClientContext>), (override));
   MOCK_METHOD(StatusOr<google::storage::v2::StartResumableWriteResponse>,
               StartResumableWrite,
@@ -43,7 +43,7 @@ class MockStorageStub : public internal::StorageStub {
               (override));
 };
 
-class MockInsertStream : public internal::StorageStub::InsertStream {
+class MockInsertStream : public internal::StorageStub::WriteObjectStream {
  public:
   MOCK_METHOD(void, Cancel, (), (override));
   MOCK_METHOD(bool, Write,
@@ -54,7 +54,7 @@ class MockInsertStream : public internal::StorageStub::InsertStream {
               (override));
 };
 
-class MockObjectMediaStream : public internal::StorageStub::ObjectMediaStream {
+class MockObjectMediaStream : public internal::StorageStub::ReadObjectStream {
  public:
   MOCK_METHOD(void, Cancel, (), (override));
   using ReadResultType =


### PR DESCRIPTION
I thought the previous PR was too large already, and pushed this cleanup
for later. Now it is "later". All these changes are in `internal`
classes, nothing is breaking.

Part of the work for #6982

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7255)
<!-- Reviewable:end -->
