### PR TITLE
fix(storage): use CA info options in credentials

### DIFF
--- a/google/cloud/storage/internal/curl_handle_factory.h
+++ b/google/cloud/storage/internal/curl_handle_factory.h
@@ -43,6 +43,11 @@ class CurlHandleFactory {
 
   virtual std::string LastClientIpAddress() const = 0;
 
+  // For testing and debug only, we do not need anything more elaborate as this
+  // class is in `internal::`.
+  virtual absl::optional<std::string> cainfo() const = 0;
+  virtual absl::optional<std::string> capath() const = 0;
+
  protected:
   // Only virtual for testing purposes.
   virtual void SetCurlStringOption(CURL* handle, CURLoption option_tag,
@@ -79,6 +84,9 @@ class DefaultCurlHandleFactory : public CurlHandleFactory {
     std::lock_guard<std::mutex> lk(mu_);
     return last_client_ip_address_;
   }
+
+  absl::optional<std::string> cainfo() const override { return cainfo_; }
+  absl::optional<std::string> capath() const override { return capath_; }
 
  private:
   void SetCurlOptions(CURL* handle);
@@ -123,6 +131,9 @@ class PooledCurlHandleFactory : public CurlHandleFactory {
     std::lock_guard<std::mutex> lk(mu_);
     return multi_handles_.size();
   }
+
+  absl::optional<std::string> cainfo() const override { return cainfo_; }
+  absl::optional<std::string> capath() const override { return capath_; }
 
  private:
   void SetCurlOptions(CURL* handle);

--- a/google/cloud/storage/oauth2/authorized_user_credentials_test.cc
+++ b/google/cloud/storage/oauth2/authorized_user_credentials_test.cc
@@ -35,6 +35,7 @@ using ::google::cloud::storage::testing::MockHttpRequest;
 using ::google::cloud::storage::testing::MockHttpRequestBuilder;
 using ::google::cloud::testing_util::IsOk;
 using ::google::cloud::testing_util::StatusIs;
+using ::testing::_;
 using ::testing::AllOf;
 using ::testing::An;
 using ::testing::AtLeast;
@@ -72,7 +73,7 @@ TEST_F(AuthorizedUserCredentialsTest, Simple) {
 
   auto mock_builder = MockHttpRequestBuilder::mock_;
   EXPECT_CALL(*mock_builder,
-              Constructor(StrEq("https://oauth2.googleapis.com/token")))
+              Constructor(StrEq("https://oauth2.googleapis.com/token"), _, _))
       .Times(1);
   EXPECT_CALL(*mock_builder, BuildRequest()).WillOnce([mock_request]() {
     MockHttpRequest result;
@@ -134,7 +135,7 @@ TEST_F(AuthorizedUserCredentialsTest, Refresh) {
             .WillOnce(Return(HttpResponse{200, r2, {}}));
         return request;
       });
-  EXPECT_CALL(*mock_builder, Constructor(GoogleOAuthRefreshEndpoint()))
+  EXPECT_CALL(*mock_builder, Constructor(GoogleOAuthRefreshEndpoint(), _, _))
       .Times(AtLeast(1));
   EXPECT_CALL(*mock_builder, MakeEscapedString(An<std::string const&>()))
       .WillRepeatedly([](std::string const& s) {
@@ -178,7 +179,7 @@ TEST_F(AuthorizedUserCredentialsTest, FailedRefresh) {
             .WillOnce(Return(HttpResponse{400, "", {}}));
         return request;
       });
-  EXPECT_CALL(*mock_builder, Constructor(GoogleOAuthRefreshEndpoint()))
+  EXPECT_CALL(*mock_builder, Constructor(GoogleOAuthRefreshEndpoint(), _, _))
       .Times(AtLeast(1));
   EXPECT_CALL(*mock_builder, MakeEscapedString(An<std::string const&>()))
       .WillRepeatedly([](std::string const& s) {
@@ -203,6 +204,49 @@ TEST_F(AuthorizedUserCredentialsTest, FailedRefresh) {
   // Response 2
   status = credentials.AuthorizationHeader();
   EXPECT_THAT(status, Not(IsOk()));
+}
+
+/// @test Verify that the options are used in the constructor.
+TEST_F(AuthorizedUserCredentialsTest, UsesCARootsInfo) {
+  // Now setup the builder to return a valid response.
+  auto mock_builder = MockHttpRequestBuilder::mock_;
+  EXPECT_CALL(*mock_builder, BuildRequest()).WillOnce([&] {
+    MockHttpRequest request;
+    nlohmann::json response{{"token_type", "Mock-Type"},
+                            {"access_token", "fake-token"},
+                            {"id_token", "fake-id-token-value"},
+                            {"expires_in", 3600}};
+    EXPECT_CALL(*request.mock, MakeRequest)
+        .WillOnce(Return(HttpResponse{200, response.dump(), {}}));
+    return request;
+  });
+
+  // This is the key check in this test, verify the constructor is called with
+  // the right parameters.
+  auto const cainfo = std::string{"fake-cainfo-path-aka-roots-pem"};
+  EXPECT_CALL(*mock_builder, Constructor(GoogleOAuthRefreshEndpoint(),
+                                         absl::make_optional(cainfo), _))
+      .Times(AtLeast(1));
+  EXPECT_CALL(*mock_builder, MakeEscapedString(An<std::string const&>()))
+      .WillRepeatedly([](std::string const& s) {
+        auto t = std::unique_ptr<char[]>(new char[s.size() + 1]);
+        std::copy(s.begin(), s.end(), t.get());
+        t[s.size()] = '\0';
+        return t;
+      });
+
+  std::string config = R"""({
+      "client_id": "a-client-id.example.com",
+      "client_secret": "a-123456ABCDEF",
+      "refresh_token": "1/THETOKEN",
+      "type": "magic_type"
+})""";
+  auto info = ParseAuthorizedUserCredentials(config, "test");
+  ASSERT_STATUS_OK(info);
+  AuthorizedUserCredentials<MockHttpRequestBuilder> credentials(
+      *info, ChannelOptions().set_ssl_root_path(cainfo));
+  EXPECT_EQ("Authorization: Mock-Type fake-token",
+            credentials.AuthorizationHeader().value());
 }
 
 /// @test Verify that parsing an authorized user account JSON string works.

--- a/google/cloud/storage/oauth2/compute_engine_credentials_test.cc
+++ b/google/cloud/storage/oauth2/compute_engine_credentials_test.cc
@@ -38,6 +38,7 @@ using ::google::cloud::storage::testing::MockHttpRequest;
 using ::google::cloud::storage::testing::MockHttpRequestBuilder;
 using ::google::cloud::testing_util::IsOk;
 using ::google::cloud::testing_util::StatusIs;
+using ::testing::_;
 using ::testing::HasSubstr;
 using ::testing::Not;
 using ::testing::Return;
@@ -96,7 +97,8 @@ TEST_F(ComputeEngineCredentialsTest,
       *mock_req_builder,
       Constructor(StrEq(std::string("http://") + hostname +
                         "/computeMetadata/v1/instance/service-accounts/" +
-                        email + "/token")))
+                        email + "/token"),
+                  _, _))
       .Times(1);
   // Only the call to retrieve service account info sends this query param.
   EXPECT_CALL(*mock_req_builder,
@@ -104,9 +106,10 @@ TEST_F(ComputeEngineCredentialsTest,
       .Times(1);
   EXPECT_CALL(
       *mock_req_builder,
-      Constructor(StrEq(std::string("http://") + hostname +
-                        "/computeMetadata/v1/instance/service-accounts/" +
-                        alias + "/")))
+      Constructor(
+          StrEq(std::string("http://") + hostname +
+                "/computeMetadata/v1/instance/service-accounts/" + alias + "/"),
+          _, _))
       .Times(1);
 
   ComputeEngineCredentials<MockHttpRequestBuilder> credentials(alias);
@@ -241,9 +244,10 @@ TEST_F(ComputeEngineCredentialsTest, FailedRetrieveServiceAccountInfo) {
       .Times(3);
   EXPECT_CALL(
       *mock_req_builder,
-      Constructor(StrEq(std::string("http://") + hostname +
-                        "/computeMetadata/v1/instance/service-accounts/" +
-                        alias + "/")))
+      Constructor(
+          StrEq(std::string("http://") + hostname +
+                "/computeMetadata/v1/instance/service-accounts/" + alias + "/"),
+          _, _))
       .Times(3);
 
   ComputeEngineCredentials<MockHttpRequestBuilder> credentials(alias);
@@ -309,7 +313,8 @@ TEST_F(ComputeEngineCredentialsTest, FailedRefresh) {
       *mock_req_builder,
       Constructor(StrEq(std::string("http://") + hostname +
                         "/computeMetadata/v1/instance/service-accounts/" +
-                        email + "/token")))
+                        email + "/token"),
+                  _, _))
       .Times(3);
   // This is only set when not retrieving the token.
   EXPECT_CALL(*mock_req_builder,
@@ -319,15 +324,17 @@ TEST_F(ComputeEngineCredentialsTest, FailedRefresh) {
   // request succeeds. Then the email is refreshed.
   EXPECT_CALL(
       *mock_req_builder,
-      Constructor(StrEq(std::string("http://") + hostname +
-                        "/computeMetadata/v1/instance/service-accounts/" +
-                        alias + "/")))
+      Constructor(
+          StrEq(std::string("http://") + hostname +
+                "/computeMetadata/v1/instance/service-accounts/" + alias + "/"),
+          _, _))
       .Times(2);
   EXPECT_CALL(
       *mock_req_builder,
-      Constructor(StrEq(std::string("http://") + hostname +
-                        "/computeMetadata/v1/instance/service-accounts/" +
-                        email + "/")))
+      Constructor(
+          StrEq(std::string("http://") + hostname +
+                "/computeMetadata/v1/instance/service-accounts/" + email + "/"),
+          _, _))
       .Times(2);
 
   ComputeEngineCredentials<MockHttpRequestBuilder> credentials(alias);
@@ -378,9 +385,10 @@ TEST_F(ComputeEngineCredentialsTest, AccountEmail) {
       .Times(1);
   EXPECT_CALL(
       *mock_req_builder,
-      Constructor(StrEq(std::string("http://") + hostname +
-                        "/computeMetadata/v1/instance/service-accounts/" +
-                        alias + "/")))
+      Constructor(
+          StrEq(std::string("http://") + hostname +
+                "/computeMetadata/v1/instance/service-accounts/" + alias + "/"),
+          _, _))
       .Times(1);
 
   ComputeEngineCredentials<MockHttpRequestBuilder> credentials(alias);

--- a/google/cloud/storage/oauth2/service_account_credentials.h
+++ b/google/cloud/storage/oauth2/service_account_credentials.h
@@ -180,7 +180,8 @@ class ServiceAccountCredentials : public Credentials {
  private:
   StatusOr<RefreshingCredentialsWrapper::TemporaryToken> Refresh() {
     HttpRequestBuilderType request_builder(
-        info_.token_uri, storage::internal::GetDefaultCurlHandleFactory());
+        info_.token_uri,
+        storage::internal::GetDefaultCurlHandleFactory(options_));
     request_builder.AddHeader(
         "Content-Type: application/x-www-form-urlencoded");
     // This is the value of grant_type for JSON-formatted service account

--- a/google/cloud/storage/oauth2/service_account_credentials_test.cc
+++ b/google/cloud/storage/oauth2/service_account_credentials_test.cc
@@ -47,6 +47,7 @@ using ::google::cloud::storage::testing::MockHttpRequestBuilder;
 using ::google::cloud::storage::testing::WriteBase64AsBinary;
 using ::google::cloud::testing_util::IsOk;
 using ::google::cloud::testing_util::StatusIs;
+using ::testing::_;
 using ::testing::An;
 using ::testing::AtLeast;
 using ::testing::HasSubstr;
@@ -138,7 +139,7 @@ void CheckInfoYieldsExpectedAssertion(ServiceAccountCredentialsInfo const& info,
   std::string expected_header =
       "Content-Type: application/x-www-form-urlencoded";
   EXPECT_CALL(*mock_builder, AddHeader(StrEq(expected_header)));
-  EXPECT_CALL(*mock_builder, Constructor(GoogleOAuthRefreshEndpoint()))
+  EXPECT_CALL(*mock_builder, Constructor(GoogleOAuthRefreshEndpoint(), _, _))
       .Times(1);
   EXPECT_CALL(*mock_builder, MakeEscapedString(An<std::string const&>()))
       .WillRepeatedly([](std::string const& s) -> std::unique_ptr<char[]> {
@@ -209,7 +210,7 @@ TEST_F(ServiceAccountCredentialsTest,
       });
   EXPECT_CALL(*mock_builder, AddHeader(An<std::string const&>()))
       .Times(AtLeast(1));
-  EXPECT_CALL(*mock_builder, Constructor(GoogleOAuthRefreshEndpoint()))
+  EXPECT_CALL(*mock_builder, Constructor(GoogleOAuthRefreshEndpoint(), _, _))
       .Times(AtLeast(1));
   EXPECT_CALL(*mock_builder, MakeEscapedString(An<std::string const&>()))
       .WillRepeatedly([](std::string const& s) -> std::unique_ptr<char[]> {
@@ -435,7 +436,7 @@ TEST_F(ServiceAccountCredentialsTest, RefreshingUpdatesTimestamps) {
       "Content-Type: application/x-www-form-urlencoded";
   EXPECT_CALL(*mock_builder, AddHeader(StrEq(expected_header)))
       .Times(AtLeast(1));
-  EXPECT_CALL(*mock_builder, Constructor(GoogleOAuthRefreshEndpoint()))
+  EXPECT_CALL(*mock_builder, Constructor(GoogleOAuthRefreshEndpoint(), _, _))
       .Times(AtLeast(1));
   EXPECT_CALL(*mock_builder, MakeEscapedString(An<std::string const&>()))
       .WillRepeatedly([](std::string const& s) -> std::unique_ptr<char[]> {
@@ -463,6 +464,51 @@ TEST_F(ServiceAccountCredentialsTest, RefreshingUpdatesTimestamps) {
   ASSERT_STATUS_OK(authorization_header);
   EXPECT_EQ("Authorization: Mock-Type mock-token-value-20000",
             *authorization_header);
+}
+
+/// @test Verify that the options are used in the constructor.
+TEST_F(ServiceAccountCredentialsTest, UsesCARootsInfo) {
+  auto info = ParseServiceAccountCredentials(kJsonKeyfileContents, "test");
+  ASSERT_STATUS_OK(info);
+
+  auto mock_builder = MockHttpRequestBuilder::mock_;
+  EXPECT_CALL(*mock_builder, BuildRequest()).WillOnce([&] {
+    MockHttpRequest result;
+    EXPECT_CALL(*result.mock, MakeRequest).WillOnce([](std::string const&) {
+      nlohmann::json response{{"token_type", "Mock-Type"},
+                              {"access_token", "fake-token"},
+                              {"expires_in", 3600}};
+      return HttpResponse{200, response.dump(), {}};
+    });
+    return result;
+  });
+
+  // This is the key check in this test, verify the constructor is called with
+  // the right parameters.
+  auto const cainfo = std::string{"fake-cainfo-path-aka-roots-pem"};
+  EXPECT_CALL(*mock_builder, Constructor(GoogleOAuthRefreshEndpoint(),
+                                         absl::make_optional(cainfo), _))
+      .Times(AtLeast(1));
+
+  auto const expected_header =
+      std::string{"Content-Type: application/x-www-form-urlencoded"};
+  EXPECT_CALL(*mock_builder, AddHeader(StrEq(expected_header)))
+      .Times(AtLeast(1));
+  EXPECT_CALL(*mock_builder, MakeEscapedString(An<std::string const&>()))
+      .WillRepeatedly([](std::string const& s) -> std::unique_ptr<char[]> {
+        EXPECT_EQ(kGrantParamUnescaped, s);
+        auto t = std::unique_ptr<char[]>(new char[sizeof(kGrantParamEscaped)]);
+        std::copy(kGrantParamEscaped,
+                  kGrantParamEscaped + sizeof(kGrantParamEscaped), t.get());
+        return t;
+      });
+
+  ServiceAccountCredentials<MockHttpRequestBuilder, FakeClock> credentials(
+      *info, ChannelOptions().set_ssl_root_path(cainfo));
+  // Call Refresh to obtain the access token for our authorization header.
+  auto authorization_header = credentials.AuthorizationHeader();
+  ASSERT_STATUS_OK(authorization_header);
+  EXPECT_EQ("Authorization: Mock-Type fake-token", *authorization_header);
 }
 
 /// @test Verify that we can create sign blobs using a service account.

--- a/google/cloud/storage/testing/mock_http_request.h
+++ b/google/cloud/storage/testing/mock_http_request.h
@@ -64,8 +64,8 @@ class MockHttpRequestBuilder {
  public:
   explicit MockHttpRequestBuilder(
       // NOLINTNEXTLINE(performance-unnecessary-value-param)
-      std::string url, std::shared_ptr<internal::CurlHandleFactory>) {
-    mock_->Constructor(std::move(url));
+      std::string url, std::shared_ptr<internal::CurlHandleFactory> h) {
+    mock_->Constructor(std::move(url), h->cainfo(), h->capath());
   }
 
   using RequestType = MockHttpRequest;
@@ -125,7 +125,9 @@ class MockHttpRequestBuilder {
   }
 
   struct Impl {
-    MOCK_METHOD(void, Constructor, (std::string));
+    MOCK_METHOD(void, Constructor,
+                (std::string, absl::optional<std::string>,
+                 absl::optional<std::string>));
     MOCK_METHOD(MockHttpRequest, BuildRequest, ());
     MOCK_METHOD(void, AddUserAgentPrefix, (std::string const&));
     MOCK_METHOD(void, AddHeader, (std::string const&));


### PR DESCRIPTION
I accidentally dropped the `options_` parameter when moving the request
construction from the constructor to when the request is issued. This
restores the use of the `options_` parameter and adds unit tests to
prevent such breaks in the future.

Fixes #7160

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7263)
<!-- Reviewable:end -->
