### PR TITLE
ci: deflake bazelisk installation

### DIFF
--- a/ci/kokoro/windows/build-32.bat
+++ b/ci/kokoro/windows/build-32.bat
@@ -12,15 +12,20 @@
 @REM See the License for the specific language governing permissions and
 @REM limitations under the License.
 
-REM Change PATH to use chocolatey's version of Bazel
-set PATH=C:\ProgramData\chocolatey\bin;%PATH%
+REM Install Bazelisk.
+@echo %date% %time%
+@cd github\google-cloud-cpp
+@powershell -exec bypass ci\kokoro\windows\install-bazelisk.ps1
+@if NOT ERRORLEVEL 0 exit /b 1
+
+REM Change PATH to install the Bazelisk version we just installed
+@set PATH=C:\bin;%PATH%
 
 REM Configure the environment to use MSVC 2019 and then switch to PowerShell.
 call "c:\Program Files (x86)\Microsoft Visual Studio\%MSVC_VERSION%\Community\VC\Auxiliary\Build\vcvars32.bat"
 
 REM The remaining of the build script is implemented in PowerShell.
-echo %date% %time%
-cd github\google-cloud-cpp
+@echo %date% %time%
 powershell -exec bypass ci\kokoro\windows\build.ps1
 if %errorlevel% neq 0 exit /b %errorlevel%
 

--- a/ci/kokoro/windows/build.bat
+++ b/ci/kokoro/windows/build.bat
@@ -12,20 +12,22 @@
 @REM See the License for the specific language governing permissions and
 @REM limitations under the License.
 
-REM Install Bazelisk using Chocolatey.
-choco install --no-progress -y bazelisk
+REM Install Bazelisk.
+@echo %date% %time%
+@cd github\google-cloud-cpp
+@powershell -exec bypass ci\kokoro\windows\install-bazelisk.ps1
+@if NOT ERRORLEVEL 0 exit /b 1
 
-REM Change PATH to use chocolatey's version of Bazel
-set PATH=C:\ProgramData\chocolatey\bin;%PATH%
+REM Change PATH to install the Bazelisk version we just installed
+@set PATH=C:\bin;%PATH%
 
 REM Configure the environment to use MSVC %MSVC_VERSION% and then switch to PowerShell.
 call "c:\Program Files (x86)\Microsoft Visual Studio\%MSVC_VERSION%\Community\VC\Auxiliary\Build\vcvars64.bat"
 
 REM The remaining of the build script is implemented in PowerShell.
-echo %date% %time%
-cd github\google-cloud-cpp
+@echo %date% %time%
 powershell -exec bypass ci\kokoro\windows\build.ps1
-if %errorlevel% neq 0 exit /b %errorlevel%
+if NOT ERRORLEVEL 0 exit /b 1
 
 @echo DONE "============================================="
 @echo %date% %time%

--- a/ci/kokoro/windows/install-bazelisk.ps1
+++ b/ci/kokoro/windows/install-bazelisk.ps1
@@ -1,0 +1,34 @@
+#!/usr/bin/env powershell
+#
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Stop on errors. This is similar to `set -e` on Unix shells.
+$ErrorActionPreference = "Stop"
+
+New-Item -ItemType Directory -Force -Path "C:\bin"
+
+ForEach($_ in (30, 60, 120, 240, 0)) {
+    Write-Host -ForegroundColor Yellow "Downloading bazelisk.exe to C:\Windows"
+    try {
+        (New-Object System.Net.WebClient).Downloadfile('https://github.com/bazelbuild/bazelisk/releases/download/v1.10.1/bazelisk-windows-amd64.exe', 'C:\bin\bazelisk.exe');
+        Write-Host -ForegroundColor Green "bazelisk successfully downloaded"
+        Exit 0
+    } catch {
+    }
+    Start-Sleep -Seconds $_
+}
+
+Write-Host -ForegroundColor Red "bazelisk download failed"
+Exit 1


### PR DESCRIPTION
Download Bazelisk directly from its GitHub releases. Use a retry loop to
deal with flakes. Also install for the 32-bit builds, currently unused,
but I think the consistency is worth the couple of seconds added to
these builds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7266)
<!-- Reviewable:end -->
