### PR TITLE
chore: update main changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,12 @@
   clearly labeled `experimental`.  Regardless, we apologize if this causes you
   inconvenience or additional work.
 
+## v1.31.1 - 2021-09
+
+### [Storage](https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/storage/README.md)
+
+* fix(storage): use CA info options in credentials ([#7263](https://github.com/googleapis/google-cloud-cpp/pull/7263))
+
 ## v1.31.0 - 2021-09
 
 ### [BigQuery](https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/bigquery/README.md)


### PR DESCRIPTION
Capture the v1.31.1 release in the `main` CHANGELOG.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7267)
<!-- Reviewable:end -->
