### PR TITLE
fix(pubsub): dont move PublisherOptions that we are still using

### DIFF
--- a/google/cloud/pubsub/publisher_connection.cc
+++ b/google/cloud/pubsub/publisher_connection.cc
@@ -138,13 +138,13 @@ std::shared_ptr<pubsub::PublisherConnection> MakePublisherConnection(
     if (options.message_ordering()) {
       auto factory = [topic, options, sink, cq](std::string const& key) {
         return BatchingPublisherConnection::Create(
-            topic, options, key, SequentialBatchSink::Create(std::move(sink)),
-            cq);
+            std::move(topic), std::move(options), key,
+            SequentialBatchSink::Create(std::move(sink)), std::move(cq));
       };
       return OrderingKeyPublisherConnection::Create(std::move(factory));
     }
     return RejectsWithOrderingKey::Create(BatchingPublisherConnection::Create(
-        std::move(topic), options, {}, sink, std::move(cq)));
+        topic, options, {}, std::move(sink), std::move(cq)));
   };
   auto connection = make_connection();
   if (options.full_publisher_rejects() || options.full_publisher_blocks()) {

--- a/google/cloud/pubsub/publisher_connection.cc
+++ b/google/cloud/pubsub/publisher_connection.cc
@@ -138,13 +138,12 @@ std::shared_ptr<pubsub::PublisherConnection> MakePublisherConnection(
     if (options.message_ordering()) {
       auto factory = [topic, options, sink, cq](std::string const& key) {
         return BatchingPublisherConnection::Create(
-            std::move(topic), std::move(options), key,
-            SequentialBatchSink::Create(std::move(sink)), std::move(cq));
+            topic, options, key, SequentialBatchSink::Create(sink), cq);
       };
       return OrderingKeyPublisherConnection::Create(std::move(factory));
     }
     return RejectsWithOrderingKey::Create(BatchingPublisherConnection::Create(
-        topic, options, {}, std::move(sink), std::move(cq)));
+        std::move(topic), options, {}, std::move(sink), std::move(cq)));
   };
   auto connection = make_connection();
   if (options.full_publisher_rejects() || options.full_publisher_blocks()) {

--- a/google/cloud/pubsub/publisher_connection.cc
+++ b/google/cloud/pubsub/publisher_connection.cc
@@ -144,7 +144,7 @@ std::shared_ptr<pubsub::PublisherConnection> MakePublisherConnection(
       return OrderingKeyPublisherConnection::Create(std::move(factory));
     }
     return RejectsWithOrderingKey::Create(BatchingPublisherConnection::Create(
-        std::move(topic), std::move(options), {}, sink, std::move(cq)));
+        std::move(topic), options, {}, sink, std::move(cq)));
   };
   auto connection = make_connection();
   if (options.full_publisher_rejects() || options.full_publisher_blocks()) {


### PR DESCRIPTION
we `std::move(options)` in the `make_connection` lambda which captures by reference. Then we keep using `options`... 

I am not sure how to test for this change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7270)
<!-- Reviewable:end -->
