### PR TITLE
cleanup(generator): do not sort includes for golden files

### DIFF
--- a/generator/integration_tests/golden/.clang-format
+++ b/generator/integration_tests/golden/.clang-format
@@ -1,1 +1,2 @@
 DisableFormat: true
+SortIncludes: false


### PR DESCRIPTION
It appears (by experiment) that `DisableFormat: true` does not
imply `SortIncludes: false` for `clang-format`. This means that
a `CompareGeneratedToGolden` test could fail if a `checkers`
build is run between generation and the `generator_integration_test`.
So, explicitly disable the sorting of includes for golden files.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7271)
<!-- Reviewable:end -->
