### PR TITLE
feat(GCS+gRPC): implement standard parameters

### DIFF
--- a/google/cloud/storage/CMakeLists.txt
+++ b/google/cloud/storage/CMakeLists.txt
@@ -318,6 +318,7 @@ if (GOOGLE_CLOUD_CPP_STORAGE_ENABLE_GRPC)
         grpc_plugin.h
         internal/grpc_client.cc
         internal/grpc_client.h
+        internal/grpc_configure_client_context.h
         internal/grpc_object_read_source.cc
         internal/grpc_object_read_source.h
         internal/grpc_resumable_upload_session.cc
@@ -582,6 +583,7 @@ if (GOOGLE_CLOUD_CPP_STORAGE_ENABLE_GRPC)
             internal/grpc_client_object_request_test.cc
             internal/grpc_client_read_object_test.cc
             internal/grpc_client_test.cc
+            internal/grpc_configure_client_context_test.cc
             internal/grpc_object_read_source_test.cc
             internal/grpc_resumable_upload_session_test.cc
             internal/grpc_resumable_upload_session_url_test.cc

--- a/google/cloud/storage/google_cloud_cpp_storage_grpc.bzl
+++ b/google/cloud/storage/google_cloud_cpp_storage_grpc.bzl
@@ -19,6 +19,7 @@
 google_cloud_cpp_storage_grpc_hdrs = [
     "grpc_plugin.h",
     "internal/grpc_client.h",
+    "internal/grpc_configure_client_context.h",
     "internal/grpc_object_read_source.h",
     "internal/grpc_resumable_upload_session.h",
     "internal/grpc_resumable_upload_session_url.h",

--- a/google/cloud/storage/internal/grpc_client.cc
+++ b/google/cloud/storage/internal/grpc_client.cc
@@ -176,7 +176,7 @@ std::unique_ptr<GrpcClient::WriteObjectStream> GrpcClient::CreateUploadWriter(
 StatusOr<ResumableUploadResponse> GrpcClient::QueryResumableUpload(
     QueryResumableUploadRequest const& request) {
   grpc::ClientContext context;
-  ApplyQueryParameters(context, request);
+  ApplyQueryParameters(context, request, "resource");
   auto status = stub_->QueryWriteStatus(context, ToProto(request));
   if (!status) return std::move(status).status();
 
@@ -395,7 +395,7 @@ GrpcClient::CreateResumableSession(ResumableUploadRequest const& request) {
   if (!proto_request) return std::move(proto_request).status();
 
   grpc::ClientContext context;
-  ApplyQueryParameters(context, request);
+  ApplyQueryParameters(context, request, "resource");
   auto response = stub_->StartResumableWrite(context, *proto_request);
   if (!response.ok()) return std::move(response).status();
 

--- a/google/cloud/storage/internal/grpc_client.cc
+++ b/google/cloud/storage/internal/grpc_client.cc
@@ -201,16 +201,12 @@ GrpcClient::FullyRestoreResumableSession(ResumableUploadRequest const& request,
                                          std::string const& upload_url) {
   auto self = shared_from_this();
   auto upload_session_params = DecodeGrpcResumableUploadSessionUrl(upload_url);
-  if (!upload_session_params) {
-    return upload_session_params.status();
-  }
+  if (!upload_session_params) return std::move(upload_session_params).status();
   auto session = std::unique_ptr<ResumableUploadSession>(
       new GrpcResumableUploadSession(self, request, *upload_session_params));
   auto response = session->ResetSession();
-  if (response.status().ok()) {
-    return session;
-  }
-  return std::move(response).status();
+  if (!response) std::move(response).status();
+  return session;
 }
 
 ClientOptions const& GrpcClient::client_options() const {

--- a/google/cloud/storage/internal/grpc_configure_client_context.h
+++ b/google/cloud/storage/internal/grpc_configure_client_context.h
@@ -1,0 +1,68 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_GRPC_CONFIGURE_CLIENT_CONTEXT_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_GRPC_CONFIGURE_CLIENT_CONTEXT_H
+
+#include "google/cloud/storage/internal/generic_request.h"
+#include "google/cloud/storage/version.h"
+#include <grpcpp/client_context.h>
+
+namespace google {
+namespace cloud {
+namespace storage {
+inline namespace STORAGE_CLIENT_NS {
+namespace internal {
+
+/**
+ * Inject request query parameters into grpc::ClientContext.
+ *
+ * The REST API has a number of "standard" query parameters that are not part of
+ * the gRPC request body, instead they are send via metadata headers in the gRPC
+ * request.
+ *
+ * @see https://cloud.google.com/apis/docs/system-parameters
+ */
+template <typename Request>
+void ApplyQueryParameters(grpc::ClientContext& context, Request const& request,
+                          std::string const& prefix = std::string{}) {
+  // The gRPC API has a single field for the `QuotaUser` parameter, while the
+  // JSON API has two:
+  //    https://cloud.google.com/storage/docs/json_api/v1/parameters#quotaUser
+  // Fortunately the semantics are to use `quotaUser` if set, so we can set
+  // the `UserIp` value into the `quota_user` field, and overwrite it if
+  // `QuotaUser` is also set. A bit bizarre, but at least it is backwards
+  // compatible.
+  if (request.template HasOption<QuotaUser>()) {
+    context.AddMetadata("x-goog-quota-user",
+                        request.template GetOption<QuotaUser>().value());
+  } else if (request.template HasOption<UserIp>()) {
+    context.AddMetadata("x-goog-quota-user",
+                        request.template GetOption<UserIp>().value());
+  }
+
+  if (request.template HasOption<Fields>()) {
+    auto field_mask = request.template GetOption<Fields>().value();
+    if (!prefix.empty()) field_mask = prefix + "(" + field_mask + ")";
+    context.AddMetadata("x-goog-fieldmask", std::move(field_mask));
+  }
+}
+
+}  // namespace internal
+}  // namespace STORAGE_CLIENT_NS
+}  // namespace storage
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_GRPC_CONFIGURE_CLIENT_CONTEXT_H

--- a/google/cloud/storage/internal/grpc_configure_client_context_test.cc
+++ b/google/cloud/storage/internal/grpc_configure_client_context_test.cc
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -74,7 +74,7 @@ TEST(GrpcConfigureClientContext, ApplyQueryParametersQuotaUserAndUserIp) {
       {ReadObjectRangeRequest("b", "o").set_option(
            QuotaUser("test-only-quota-user")),
        "test-only-quota-user"},
-  };
+\  };
 
   for (auto const& test : cases) {
     auto description = [&test] {

--- a/google/cloud/storage/internal/grpc_configure_client_context_test.cc
+++ b/google/cloud/storage/internal/grpc_configure_client_context_test.cc
@@ -74,7 +74,7 @@ TEST(GrpcConfigureClientContext, ApplyQueryParametersQuotaUserAndUserIp) {
       {ReadObjectRangeRequest("b", "o").set_option(
            QuotaUser("test-only-quota-user")),
        "test-only-quota-user"},
-\  };
+  };
 
   for (auto const& test : cases) {
     auto description = [&test] {

--- a/google/cloud/storage/internal/grpc_configure_client_context_test.cc
+++ b/google/cloud/storage/internal/grpc_configure_client_context_test.cc
@@ -1,0 +1,98 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/storage/internal/grpc_configure_client_context.h"
+#include "google/cloud/storage/internal/object_requests.h"
+#include "google/cloud/testing_util/validate_metadata.h"
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+namespace storage {
+inline namespace STORAGE_CLIENT_NS {
+namespace internal {
+namespace {
+
+using ::google::cloud::testing_util::GetMetadata;
+using ::testing::Contains;
+using ::testing::IsEmpty;
+using ::testing::Pair;
+
+TEST(GrpcConfigureClientContext, ApplyQueryParametersEmpty) {
+  grpc::ClientContext context;
+  ApplyQueryParameters(context,
+                       ReadObjectRangeRequest("test-bucket", "test-object"));
+  auto metadata = GetMetadata(context);
+  EXPECT_THAT(metadata, IsEmpty());
+}
+
+TEST(GrpcConfigureClientContext, ApplyQueryParametersWithFields) {
+  grpc::ClientContext context;
+  ApplyQueryParameters(
+      context, ReadObjectRangeRequest("test-bucket", "test-object")
+                   .set_option(Fields("bucket,name,generation,contentType")));
+  auto metadata = GetMetadata(context);
+  EXPECT_THAT(metadata, Contains(Pair("x-goog-fieldmask",
+                                      "bucket,name,generation,contentType")));
+}
+
+TEST(GrpcConfigureClientContext, ApplyQueryParametersWithFieldsAndPrefix) {
+  grpc::ClientContext context;
+  ApplyQueryParameters(
+      context,
+      InsertObjectMediaRequest("test-bucket", "test-object", "content")
+          .set_option(Fields("bucket,name,generation,contentType")),
+      "resource");
+  auto metadata = GetMetadata(context);
+  EXPECT_THAT(metadata,
+              Contains(Pair("x-goog-fieldmask",
+                            "resource(bucket,name,generation,contentType)")));
+}
+
+TEST(GrpcConfigureClientContext, ApplyQueryParametersQuotaUserAndUserIp) {
+  struct {
+    ReadObjectRangeRequest request;
+    std::string expected;
+  } cases[] = {
+      {ReadObjectRangeRequest("b", "o").set_option(UserIp("1.2.3.4")),
+       "1.2.3.4"},
+      {ReadObjectRangeRequest("b", "o")
+           .set_option(QuotaUser("test-only-quota-user"))
+           .set_option(UserIp("1.2.3.4")),
+       "test-only-quota-user"},
+      {ReadObjectRangeRequest("b", "o").set_option(
+           QuotaUser("test-only-quota-user")),
+       "test-only-quota-user"},
+  };
+
+  for (auto const& test : cases) {
+    auto description = [&test] {
+      std::ostringstream os;
+      os << "Testing with request=" << test.request;
+      return std::move(os).str();
+    };
+    SCOPED_TRACE(description());
+    grpc::ClientContext context;
+    ApplyQueryParameters(context, test.request);
+    auto metadata = GetMetadata(context);
+    EXPECT_THAT(metadata, Contains(Pair("x-goog-quota-user", test.expected)));
+  }
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace STORAGE_CLIENT_NS
+}  // namespace storage
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/storage/internal/grpc_resumable_upload_session.cc
+++ b/google/cloud/storage/internal/grpc_resumable_upload_session.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/storage/internal/grpc_resumable_upload_session.h"
+#include "google/cloud/storage/internal/grpc_configure_client_context.h"
 #include "google/cloud/grpc_error_delegate.h"
 #include "absl/memory/memory.h"
 #include <crc32c/crc32c.h>
@@ -81,6 +82,7 @@ StatusOr<ResumableUploadResponse> GrpcResumableUploadSession::UploadGeneric(
     ConstBufferSequence buffers, bool final_chunk, HashValues const& hashes) {
   // TODO(#4216) - set the timeout
   auto context = absl::make_unique<grpc::ClientContext>();
+  ApplyQueryParameters(*context, request_, "resource");
   auto writer = client_->CreateUploadWriter(std::move(context));
 
   std::size_t const maximum_chunk_size =

--- a/google/cloud/storage/storage_client_grpc_unit_tests.bzl
+++ b/google/cloud/storage/storage_client_grpc_unit_tests.bzl
@@ -22,6 +22,7 @@ storage_client_grpc_unit_tests = [
     "internal/grpc_client_object_request_test.cc",
     "internal/grpc_client_read_object_test.cc",
     "internal/grpc_client_test.cc",
+    "internal/grpc_configure_client_context_test.cc",
     "internal/grpc_object_read_source_test.cc",
     "internal/grpc_resumable_upload_session_test.cc",
     "internal/grpc_resumable_upload_session_url_test.cc",

--- a/google/cloud/storage/tests/grpc_integration_test.cc
+++ b/google/cloud/storage/tests/grpc_integration_test.cc
@@ -242,13 +242,16 @@ TEST_P(GrpcIntegrationTest, FieldFilter) {
 
   auto metadata = client->InsertObject(
       bucket_name(), object_name, LoremIpsum(), IfGenerationMatch(0),
-      Fields("resource(bucket,name,generation,contentType)"));
+      ContentType("text/plain"), ContentEncoding("utf-8"),
+      Fields("bucket,name,generation,contentType"));
   ASSERT_STATUS_OK(metadata);
   ScheduleForDelete(*metadata);
 
   // If the Fields() filter works, then size() would be 0
   if (!UsingEmulator()) {
     EXPECT_EQ(metadata->size(), 0);
+    EXPECT_EQ(metadata->content_type(), "text/plain");
+    EXPECT_EQ(metadata->content_encoding(), "");
   }
 }
 

--- a/google/cloud/storage/tests/grpc_integration_test.cc
+++ b/google/cloud/storage/tests/grpc_integration_test.cc
@@ -38,6 +38,10 @@ inline namespace STORAGE_CLIENT_NS {
 namespace internal {
 namespace {
 
+using ::google::cloud::internal::GetEnv;
+using ::testing::IsEmpty;
+using ::testing::Not;
+
 // When GOOGLE_CLOUD_CPP_HAVE_GRPC is not set these tests compile, but they
 // actually just run against the regular GCS REST API. That is fine.
 class GrpcIntegrationTest
@@ -51,12 +55,18 @@ class GrpcIntegrationTest
     std::string const grpc_config_value = GetParam();
     google::cloud::internal::SetEnv("GOOGLE_CLOUD_CPP_STORAGE_GRPC_CONFIG",
                                     grpc_config_value);
-    project_id_ =
-        google::cloud::internal::GetEnv("GOOGLE_CLOUD_PROJECT").value_or("");
-    ASSERT_FALSE(project_id_.empty()) << "GOOGLE_CLOUD_PROJECT is not set";
+    project_id_ = GetEnv("GOOGLE_CLOUD_PROJECT").value_or("");
+    ASSERT_THAT(project_id_, Not(IsEmpty()))
+        << "GOOGLE_CLOUD_PROJECT is not set";
+
+    bucket_name_ =
+        GetEnv("GOOGLE_CLOUD_CPP_STORAGE_TEST_BUCKET_NAME").value_or("");
+    ASSERT_THAT(bucket_name_, Not(IsEmpty()))
+        << "GOOGLE_CLOUD_CPP_STORAGE_TEST_BUCKET_NAME is not set";
   }
 
   std::string project_id() const { return project_id_; }
+  std::string bucket_name() const { return bucket_name_; }
 
   std::string MakeEntityName() {
     // We always use the viewers for the project because it is known to exist.
@@ -65,7 +75,7 @@ class GrpcIntegrationTest
 
  private:
   std::string project_id_;
-  std::string topic_name_;
+  std::string bucket_name_;
   testing_util::ScopedEnvironment grpc_config_;
 };
 
@@ -209,6 +219,37 @@ TEST_P(GrpcIntegrationTest, StreamLargeChunks) {
   ScheduleForDelete(stream.metadata().value());
 
   EXPECT_EQ(2 * desired_size, stream.metadata()->size());
+}
+
+TEST_P(GrpcIntegrationTest, QuotaUser) {
+  auto client = MakeIntegrationTestClient();
+  ASSERT_STATUS_OK(client);
+
+  auto object_name = MakeRandomObjectName();
+
+  auto metadata =
+      client->InsertObject(bucket_name(), object_name, LoremIpsum(),
+                           IfGenerationMatch(0), QuotaUser("test-only"));
+  ASSERT_STATUS_OK(metadata);
+  ScheduleForDelete(*metadata);
+}
+
+TEST_P(GrpcIntegrationTest, FieldFilter) {
+  auto client = MakeIntegrationTestClient();
+  ASSERT_STATUS_OK(client);
+
+  auto object_name = MakeRandomObjectName();
+
+  auto metadata = client->InsertObject(
+      bucket_name(), object_name, LoremIpsum(), IfGenerationMatch(0),
+      Fields("resource(bucket,name,generation,contentType)"));
+  ASSERT_STATUS_OK(metadata);
+  ScheduleForDelete(*metadata);
+
+  // If the Fields() filter works, then size() would be 0
+  if (!UsingEmulator()) {
+    EXPECT_EQ(metadata->size(), 0);
+  }
 }
 
 INSTANTIATE_TEST_SUITE_P(GrpcIntegrationMediaTest, GrpcIntegrationTest,

--- a/google/cloud/testing_util/validate_metadata.cc
+++ b/google/cloud/testing_util/validate_metadata.cc
@@ -33,70 +33,6 @@ namespace testing_util {
 namespace {
 
 /**
- * GetMetadata from `ClientContext`.
- *
- * `ClientContext` doesn't give access to the metadata, but `ServerContext`
- * does. In order to transform the `ClientContext` into `ServerContext`
- * we spin up a server and a client and send some garbage with this context.
- */
-std::multimap<std::string, std::string> GetMetadata(
-    grpc::ClientContext& context) {
-  // Set the deadline to far in the future. If the deadline is in the past, gRPC
-  // doesn't send the initial metadata at all (which makes sense, given that the
-  // context is already expired). The `context` is destroyed by this function
-  // anyway, so we're not making things worse by changing the deadline.
-  context.set_deadline(std::chrono::system_clock::now() +
-                       std::chrono::hours(24));
-
-  // Start the generic server.
-  grpc::ServerBuilder builder;
-  grpc::AsyncGenericService generic_service;
-  builder.RegisterAsyncGenericService(&generic_service);
-  auto srv_cq = builder.AddCompletionQueue();
-  auto server = builder.BuildAndStart();
-
-  // Send some garbage with the supplied context.
-  grpc::GenericStub generic_stub(
-      server->InProcessChannel(grpc::ChannelArguments()));
-  grpc::CompletionQueue cli_cq;
-  auto cli_stream =
-      generic_stub.PrepareCall(&context, "made_up_method", &cli_cq);
-  cli_stream->StartCall(nullptr);
-  bool ok;
-  void* placeholder;
-  cli_cq.Next(&placeholder, &ok);  // actually start the client call
-
-  // Receive the garbage with the supplied context.
-  grpc::GenericServerContext server_context;
-  grpc::GenericServerAsyncReaderWriter reader_writer(&server_context);
-  generic_service.RequestCall(&server_context, &reader_writer, srv_cq.get(),
-                              srv_cq.get(), nullptr);
-  srv_cq->Next(&placeholder, &ok);  // actually receive the data
-
-  // Now we've got the data - save it before cleaning up.
-  std::multimap<std::string, std::string> res;
-  auto const& cli_md = server_context.client_metadata();
-  std::transform(cli_md.begin(), cli_md.end(), std::inserter(res, res.begin()),
-                 [](std::pair<grpc::string_ref, grpc::string_ref> const& md) {
-                   return std::make_pair(
-                       std::string(md.first.data(), md.first.length()),
-                       std::string(md.second.data(), md.second.length()));
-                 });
-
-  // Shut everything down.
-  server->Shutdown(std::chrono::system_clock::now());
-  srv_cq->Shutdown();
-  cli_cq.Shutdown();
-  // Drain completion queues.
-  while (srv_cq->Next(&placeholder, &ok))
-    ;
-  while (cli_cq.Next(&placeholder, &ok))
-    ;
-
-  return res;
-}
-
-/**
  * Check if the `header` is of "foo=bar&baz=rab&..." and if it is, return a
  * `map` containing `"foo"->"bar", "baz"->"rab"`.
  */
@@ -284,6 +220,63 @@ Status IsContextMDValid(
   }
 
   return Status();
+}
+
+std::multimap<std::string, std::string> GetMetadata(
+    grpc::ClientContext& context) {
+  // Set the deadline to far in the future. If the deadline is in the past, gRPC
+  // doesn't send the initial metadata at all (which makes sense, given that the
+  // context is already expired). The `context` is destroyed by this function
+  // anyway, so we're not making things worse by changing the deadline.
+  context.set_deadline(std::chrono::system_clock::now() +
+                       std::chrono::hours(24));
+
+  // Start the generic server.
+  grpc::ServerBuilder builder;
+  grpc::AsyncGenericService generic_service;
+  builder.RegisterAsyncGenericService(&generic_service);
+  auto srv_cq = builder.AddCompletionQueue();
+  auto server = builder.BuildAndStart();
+
+  // Send some garbage with the supplied context.
+  grpc::GenericStub generic_stub(
+      server->InProcessChannel(grpc::ChannelArguments()));
+  grpc::CompletionQueue cli_cq;
+  auto cli_stream =
+      generic_stub.PrepareCall(&context, "made_up_method", &cli_cq);
+  cli_stream->StartCall(nullptr);
+  bool ok;
+  void* placeholder;
+  cli_cq.Next(&placeholder, &ok);  // actually start the client call
+
+  // Receive the garbage with the supplied context.
+  grpc::GenericServerContext server_context;
+  grpc::GenericServerAsyncReaderWriter reader_writer(&server_context);
+  generic_service.RequestCall(&server_context, &reader_writer, srv_cq.get(),
+                              srv_cq.get(), nullptr);
+  srv_cq->Next(&placeholder, &ok);  // actually receive the data
+
+  // Now we've got the data - save it before cleaning up.
+  std::multimap<std::string, std::string> res;
+  auto const& cli_md = server_context.client_metadata();
+  std::transform(cli_md.begin(), cli_md.end(), std::inserter(res, res.begin()),
+                 [](std::pair<grpc::string_ref, grpc::string_ref> const& md) {
+                   return std::make_pair(
+                       std::string(md.first.data(), md.first.length()),
+                       std::string(md.second.data(), md.second.length()));
+                 });
+
+  // Shut everything down.
+  server->Shutdown(std::chrono::system_clock::now());
+  srv_cq->Shutdown();
+  cli_cq.Shutdown();
+  // Drain completion queues.
+  while (srv_cq->Next(&placeholder, &ok))
+    ;
+  while (cli_cq.Next(&placeholder, &ok))
+    ;
+
+  return res;
 }
 
 }  // namespace testing_util

--- a/google/cloud/testing_util/validate_metadata.h
+++ b/google/cloud/testing_util/validate_metadata.h
@@ -19,6 +19,7 @@
 #include "google/cloud/version.h"
 #include "absl/types/optional.h"
 #include <grpcpp/client_context.h>
+#include <map>
 #include <string>
 
 namespace google {
@@ -51,6 +52,18 @@ Status IsContextMDValid(
     std::string const& api_client_header,
     absl::optional<std::string> const& resource_name = {},
     absl::optional<std::string> const& resource_prefix_header = {});
+
+/**
+ * GetMetadata from `ClientContext`.
+ *
+ * `ClientContext` doesn't give access to the metadata, but `ServerContext`
+ * does. In order to transform the `ClientContext` into `ServerContext`
+ * we spin up a server and a client and send some garbage with this context.
+ *
+ * @note this invalidates the @p context parameter.
+ */
+std::multimap<std::string, std::string> GetMetadata(
+    grpc::ClientContext& context);
 
 }  // namespace testing_util
 }  // namespace GOOGLE_CLOUD_CPP_NS


### PR DESCRIPTION
The REST API has a small number of "standard" query parameters which are
not part of the gRPC requests. They are implemented using special
`x-goog-*` "metadata" via the `grpc::ClientContext`. These are
documented at:

https://cloud.google.com/apis/docs/system-parameters

With this change the GCS+gRPC plugin fills out those headers from the
`*Request` object.

Fixes #4215 and fixes #6982

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7272)
<!-- Reviewable:end -->
