### PR TITLE
feat(generator): generate a SetIamPolicy() overload with an OCC loop

### DIFF
--- a/generator/integration_tests/golden/golden_thing_admin_client.cc
+++ b/generator/integration_tests/golden/golden_thing_admin_client.cc
@@ -18,6 +18,9 @@
 
 #include "generator/integration_tests/golden/golden_thing_admin_client.h"
 #include <memory>
+#include "generator/integration_tests/golden/golden_thing_admin_options.h"
+#include "generator/integration_tests/golden/internal/golden_thing_admin_option_defaults.h"
+#include <thread>
 
 namespace google {
 namespace cloud {
@@ -77,6 +80,28 @@ GoldenThingAdminClient::SetIamPolicy(std::string const& resource, google::iam::v
   request.set_resource(resource);
   *request.mutable_policy() = policy;
   return connection_->SetIamPolicy(request);
+}
+
+StatusOr<google::iam::v1::Policy>
+GoldenThingAdminClient::SetIamPolicy(std::string const& resource, IamUpdater const& updater, Options options) {
+  internal::CheckExpectedOptions<GoldenThingAdminBackoffPolicyOption>(options, __func__);
+  options = golden_internal::GoldenThingAdminDefaultOptions(std::move(options));
+  auto backoff_policy = options.get<GoldenThingAdminBackoffPolicyOption>()->clone();
+  for (;;) {
+    auto recent = GetIamPolicy(resource);
+    if (!recent) {
+      return recent.status();
+    }
+    auto policy = updater(*std::move(recent));
+    if (!policy) {
+      return Status(StatusCode::kCancelled, "updater did not yield a policy");
+    }
+    auto result = SetIamPolicy(resource, *std::move(policy));
+    if (result || result.status().code() != StatusCode::kAborted) {
+      return result;
+    }
+    std::this_thread::sleep_for(backoff_policy->OnCompletion());
+  }
 }
 
 StatusOr<google::iam::v1::Policy>

--- a/generator/integration_tests/golden/golden_thing_admin_client.h
+++ b/generator/integration_tests/golden/golden_thing_admin_client.h
@@ -24,6 +24,8 @@
 #include "google/cloud/polling_policy.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
+#include "google/cloud/iam_updater.h"
+#include "google/cloud/options.h"
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
@@ -160,6 +162,20 @@ class GoldenThingAdminClient {
    */
   StatusOr<google::iam::v1::Policy>
   SetIamPolicy(std::string const& resource, google::iam::v1::Policy const& policy);
+
+  /**
+   * Updates the IAM policy for @p resource using an optimistic concurrency control loop.
+   *
+   * The loop fetches the current policy for @p resource, and passes it to @p updater, which should return the new policy. This new policy should use the current etag so that the read-modify-write cycle can detect races and rerun the update when there is a mismatch. If the new policy does not have an etag, the existing policy will be blindly overwritten. If @p updater does not yield a policy, the control loop is terminated and kCancelled is returned.
+   *
+   * @param resource  Required. The resource for which the policy is being specified. See the operation documentation for the appropriate value for this field.
+   * @param updater  Required. Functor to map the current policy to a new one.
+   * @param options  Optional. Options to control the loop. Expected options are:
+   *       - `GoldenThingAdminBackoffPolicyOption`
+   * @return google::iam::v1::Policy
+   */
+  StatusOr<google::iam::v1::Policy>
+  SetIamPolicy(std::string const& resource, IamUpdater const& updater, Options options = {});
 
   /**
    * Gets the access control policy for a database or backup resource.

--- a/generator/integration_tests/golden/golden_thing_admin_client.h
+++ b/generator/integration_tests/golden/golden_thing_admin_client.h
@@ -164,13 +164,23 @@ class GoldenThingAdminClient {
   SetIamPolicy(std::string const& resource, google::iam::v1::Policy const& policy);
 
   /**
-   * Updates the IAM policy for @p resource using an optimistic concurrency control loop.
+   * Updates the IAM policy for @p resource using an optimistic concurrency
+   * control loop.
    *
-   * The loop fetches the current policy for @p resource, and passes it to @p updater, which should return the new policy. This new policy should use the current etag so that the read-modify-write cycle can detect races and rerun the update when there is a mismatch. If the new policy does not have an etag, the existing policy will be blindly overwritten. If @p updater does not yield a policy, the control loop is terminated and kCancelled is returned.
+   * The loop fetches the current policy for @p resource, and passes it to @p
+   * updater, which should return the new policy. This new policy should use the
+   * current etag so that the read-modify-write cycle can detect races and rerun
+   * the update when there is a mismatch. If the new policy does not have an
+   * etag, the existing policy will be blindly overwritten. If @p updater does
+   * not yield a policy, the control loop is terminated and kCancelled is
+   * returned.
    *
-   * @param resource  Required. The resource for which the policy is being specified. See the operation documentation for the appropriate value for this field.
+   * @param resource  Required. The resource for which the policy is being
+   * specified. See the operation documentation for the appropriate value for
+   * this field.
    * @param updater  Required. Functor to map the current policy to a new one.
-   * @param options  Optional. Options to control the loop. Expected options are:
+   * @param options  Optional. Options to control the loop. Expected options
+   * are:
    *       - `GoldenThingAdminBackoffPolicyOption`
    * @return google::iam::v1::Policy
    */

--- a/generator/internal/client_generator.cc
+++ b/generator/internal/client_generator.cc
@@ -176,27 +176,26 @@ Status ClientGenerator::GenerateHeader() {
         auto get_method_name = get_iam_policy_extension_->name();
         HeaderPrint({
             PredicatedFragment<void>(""),
-            {"  /**\n"
-             "   * Updates the IAM policy for @p resource using an"
-             " optimistic concurrency control loop.\n"
-             "   *\n"
-             "   * The loop fetches the current policy for @p resource, and"
-             " passes it to @p updater, which should return the new policy."
-             " This new policy should use the current etag so that the"
-             " read-modify-write cycle can detect races and rerun the update"
-             " when there is a mismatch. If the new policy does not have an"
-             " etag, the existing policy will be blindly overwritten. If"
-             " @p updater does not yield a policy, the control loop is"
-             " terminated and kCancelled is returned.\n"
-             "   *\n"
-             "   * @param resource  Required. The resource for which the"
-             " policy is being specified. See the operation documentation"
-             " for the appropriate value for this field.\n"
-             "   * @param updater  Required. Functor to map the current policy"
-             " to a new one.\n"
-             "   * @param options  Optional. Options to control the loop."
-             " Expected options are:\n"
-             "   *       - `$service_name$BackoffPolicyOption`\n"},
+            {R"""(  /**
+   * Updates the IAM policy for @p resource using an optimistic concurrency
+   * control loop.
+   *
+   * The loop fetches the current policy for @p resource, and passes it to @p
+   * updater, which should return the new policy. This new policy should use the
+   * current etag so that the read-modify-write cycle can detect races and rerun
+   * the update when there is a mismatch. If the new policy does not have an
+   * etag, the existing policy will be blindly overwritten. If @p updater does
+   * not yield a policy, the control loop is terminated and kCancelled is
+   * returned.
+   *
+   * @param resource  Required. The resource for which the policy is being
+   * specified. See the operation documentation for the appropriate value for
+   * this field.
+   * @param updater  Required. Functor to map the current policy to a new one.
+   * @param options  Optional. Options to control the loop. Expected options
+   * are:
+   *       - `$service_name$BackoffPolicyOption`
+)"""},
             {"   * @return " + response_type + "\n"},
             {"   */\n"},
             {"  StatusOr<" + response_type + ">\n"},

--- a/generator/internal/client_generator.cc
+++ b/generator/internal/client_generator.cc
@@ -33,7 +33,29 @@ ClientGenerator::ClientGenerator(
     google::protobuf::compiler::GeneratorContext* context)
     : ServiceCodeGenerator("client_header_path", "client_cc_path",
                            service_descriptor, std::move(service_vars),
-                           std::move(service_method_vars), context) {}
+                           std::move(service_method_vars), context) {
+  // Remember if there are methods from google.iam.v1.GetIamPolicyRequest and
+  // google.iam.v1.SetIamPolicyRequest to google.iam.v1.Policy with signature
+  // extensions. If so, we'll generate a "set" wrapper method to help prevent
+  // simultaneous updates of a policy from overwriting each other.
+  for (google::protobuf::MethodDescriptor const& method : methods()) {
+    auto const& method_signature_extension =
+        method.options().GetRepeatedExtension(google::api::method_signature);
+    if (method.output_type()->full_name() == "google.iam.v1.Policy") {
+      auto const& input_type = method.input_type()->full_name();
+      for (auto const& extension : method_signature_extension) {
+        if (input_type == "google.iam.v1.GetIamPolicyRequest" &&
+            extension == "resource") {
+          get_iam_policy_extension_ = &method;
+        }
+        if (input_type == "google.iam.v1.SetIamPolicyRequest" &&
+            extension == "resource,policy") {
+          set_iam_policy_extension_ = &method;
+        }
+      }
+    }
+  }
+}
 
 Status ClientGenerator::GenerateHeader() {
   HeaderPrint(CopyrightLicenseFileHeader());
@@ -51,6 +73,10 @@ Status ClientGenerator::GenerateHeader() {
   HeaderLocalIncludes({vars("connection_header_path"), "google/cloud/future.h",
                        "google/cloud/polling_policy.h",
                        "google/cloud/status_or.h", "google/cloud/version.h"});
+  if (get_iam_policy_extension_ && set_iam_policy_extension_) {
+    HeaderLocalIncludes(
+        {"google/cloud/iam_updater.h", "google/cloud/options.h"});
+  }
   HeaderSystemIncludes(MethodSignatureWellKnownProtobufTypeIncludes());
   HeaderSystemIncludes(
       {HasLongrunningMethod() ? "google/longrunning/operations.grpc.pb.h" : "",
@@ -142,6 +168,44 @@ Status ClientGenerator::GenerateHeader() {
                },
                IsStreamingRead)},
           __FILE__, __LINE__);
+
+      if (get_iam_policy_extension_ && set_iam_policy_extension_ == &method) {
+        auto response_type = ProtoNameToCppName(
+            set_iam_policy_extension_->output_type()->full_name());
+        auto set_method_name = set_iam_policy_extension_->name();
+        auto get_method_name = get_iam_policy_extension_->name();
+        HeaderPrint({
+            PredicatedFragment<void>(""),
+            {"  /**\n"
+             "   * Updates the IAM policy for @p resource using an"
+             " optimistic concurrency control loop.\n"
+             "   *\n"
+             "   * The loop fetches the current policy for @p resource, and"
+             " passes it to @p updater, which should return the new policy."
+             " This new policy should use the current etag so that the"
+             " read-modify-write cycle can detect races and rerun the update"
+             " when there is a mismatch. If the new policy does not have an"
+             " etag, the existing policy will be blindly overwritten. If"
+             " @p updater does not yield a policy, the control loop is"
+             " terminated and kCancelled is returned.\n"
+             "   *\n"
+             "   * @param resource  Required. The resource for which the"
+             " policy is being specified. See the operation documentation"
+             " for the appropriate value for this field.\n"
+             "   * @param updater  Required. Functor to map the current policy"
+             " to a new one.\n"
+             "   * @param options  Optional. Options to control the loop."
+             " Expected options are:\n"
+             "   *       - `$service_name$BackoffPolicyOption`\n"},
+            {"   * @return " + response_type + "\n"},
+            {"   */\n"},
+            {"  StatusOr<" + response_type + ">\n"},
+            {"  " + set_method_name},
+            {"(std::string const& resource,"
+             " IamUpdater const& updater,"
+             " Options options = {});\n\n"},
+        });
+      }
     }
   }
 
@@ -227,6 +291,11 @@ Status ClientGenerator::GenerateCc() {
   // includes
   CcLocalIncludes({vars("client_header_path")});
   CcSystemIncludes({"memory"});
+  if (get_iam_policy_extension_ && set_iam_policy_extension_) {
+    CcLocalIncludes(
+        {vars("options_header_path"), vars("option_defaults_header_path")});
+    CcSystemIncludes({"thread"});
+  }
   CcPrint("\n");
 
   auto result = CcOpenNamespaces();
@@ -305,6 +374,47 @@ Status ClientGenerator::GenerateCc() {
                },
                IsStreamingRead)},
           __FILE__, __LINE__);
+
+      if (get_iam_policy_extension_ && set_iam_policy_extension_ == &method) {
+        auto response_type = ProtoNameToCppName(
+            set_iam_policy_extension_->output_type()->full_name());
+        auto set_method_name = set_iam_policy_extension_->name();
+        auto get_method_name = get_iam_policy_extension_->name();
+        CcPrint({
+            PredicatedFragment<void>(""),
+            {"StatusOr<" + response_type + ">\n"},
+            {"$client_class_name$::" + set_method_name},
+            {"(std::string const& resource,"
+             " IamUpdater const& updater,"
+             " Options options) {\n"
+             "  internal::CheckExpectedOptions<$service_name$"
+             "BackoffPolicyOption>(options, __func__);\n"
+             "  options = $product_internal_namespace$::$service_name$"
+             "DefaultOptions(std::move(options));\n"
+             "  auto backoff_policy = options.get<$service_name$"
+             "BackoffPolicyOption>()->clone();\n"
+             "  for (;;) {\n"},
+            {"    auto recent = " + get_method_name + "(resource);\n"},
+            {"    if (!recent) {\n"
+             "      return recent.status();\n"
+             "    }\n"
+             "    auto policy = updater(*std::move(recent));\n"
+             "    if (!policy) {\n"
+             "      return Status(StatusCode::kCancelled,"
+             " \"updater did not yield a policy\");\n"
+             "    }\n"},
+            {"    auto result = " + set_method_name +
+             "(resource, *std::move(policy));\n"},
+            {"    if (result || result.status().code() != StatusCode::kAborted)"
+             " {\n"
+             "      return result;\n"
+             "    }\n"
+             "    std::this_thread::sleep_for("
+             "backoff_policy->OnCompletion());\n"
+             "  }\n"
+             "}\n\n"},
+        });
+      }
     }
   }
 

--- a/generator/internal/client_generator.h
+++ b/generator/internal/client_generator.h
@@ -48,6 +48,10 @@ class ClientGenerator : public ServiceCodeGenerator {
  private:
   Status GenerateHeader() override;
   Status GenerateCc() override;
+
+  // Descriptors for IAM policy producing method_signature extensions, if any.
+  google::protobuf::MethodDescriptor const* get_iam_policy_extension_ = nullptr;
+  google::protobuf::MethodDescriptor const* set_iam_policy_extension_ = nullptr;
 };
 
 }  // namespace generator_internal

--- a/google/cloud/CMakeLists.txt
+++ b/google/cloud/CMakeLists.txt
@@ -120,6 +120,7 @@ add_library(
     iam_bindings.h
     iam_policy.cc
     iam_policy.h
+    iam_updater.h
     internal/absl_flat_hash_map_quiet.h
     internal/absl_str_cat_quiet.h
     internal/absl_str_join_quiet.h

--- a/google/cloud/google_cloud_cpp_common.bzl
+++ b/google/cloud/google_cloud_cpp_common.bzl
@@ -26,6 +26,7 @@ google_cloud_cpp_common_hdrs = [
     "iam_binding.h",
     "iam_bindings.h",
     "iam_policy.h",
+    "iam_updater.h",
     "internal/absl_flat_hash_map_quiet.h",
     "internal/absl_str_cat_quiet.h",
     "internal/absl_str_join_quiet.h",

--- a/google/cloud/iam/iam_client.h
+++ b/google/cloud/iam/iam_client.h
@@ -21,6 +21,8 @@
 
 #include "google/cloud/iam/iam_connection.h"
 #include "google/cloud/future.h"
+#include "google/cloud/iam_updater.h"
+#include "google/cloud/options.h"
 #include "google/cloud/polling_policy.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
@@ -276,6 +278,31 @@ class IAMClient {
    */
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
       std::string const& resource, google::iam::v1::Policy const& policy);
+
+  /**
+   * Updates the IAM policy for @p resource using an optimistic concurrency
+   * control loop.
+   *
+   * The loop fetches the current policy for @p resource, and passes it to @p
+   * updater, which should return the new policy. This new policy should use the
+   * current etag so that the read-modify-write cycle can detect races and rerun
+   * the update when there is a mismatch. If the new policy does not have an
+   * etag, the existing policy will be blindly overwritten. If @p updater does
+   * not yield a policy, the control loop is terminated and kCancelled is
+   * returned.
+   *
+   * @param resource  Required. The resource for which the policy is being
+   * specified. See the operation documentation for the appropriate value for
+   * this field.
+   * @param updater  Required. Functor to map the current policy to a new one.
+   * @param options  Optional. Options to control the loop. Expected options
+   * are:
+   *       - `IAMBackoffPolicyOption`
+   * @return google::iam::v1::Policy
+   */
+  StatusOr<google::iam::v1::Policy> SetIamPolicy(std::string const& resource,
+                                                 IamUpdater const& updater,
+                                                 Options options = {});
 
   /**
    * Tests whether the caller has the specified permissions on a

--- a/google/cloud/iam_updater.h
+++ b/google/cloud/iam_updater.h
@@ -1,0 +1,48 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_IAM_UPDATER_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_IAM_UPDATER_H
+
+#include "google/cloud/version.h"
+#include "absl/types/optional.h"
+#include <google/iam/v1/policy.pb.h>
+#include <functional>
+
+namespace google {
+namespace cloud {
+inline namespace GOOGLE_CLOUD_CPP_NS {
+
+/**
+ * Used in the `SetIamPolicy()` read-modify-write cycles where an `etag` helps
+ * prevent simultaneous updates of a policy from overwriting each other.
+ *
+ * The updater is called with a recently fetched policy, and should either
+ * return an empty optional if no changes are required, or return a new policy
+ * to be set. In the latter case the updater should either (1) set the `etag`
+ * of the returned policy to that of the recently fetched policy (strongly
+ * suggested), or (2) not set the `etag` at all.
+ *
+ * In case (1) if the `etag` does not match the existing policy (i.e., there
+ * has been an intermediate update), this update is dropped and a new cycle is
+ * initiated. In case (2) the existing policy is overwritten blindly.
+ */
+using IamUpdater = std::function<absl::optional<google::iam::v1::Policy>(
+    google::iam::v1::Policy)>;
+
+}  // namespace GOOGLE_CLOUD_CPP_NS
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_IAM_UPDATER_H

--- a/google/cloud/spanner/iam_updater.h
+++ b/google/cloud/spanner/iam_updater.h
@@ -16,18 +16,27 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_IAM_UPDATER_H
 
 #include "google/cloud/spanner/version.h"
-#include "google/cloud/optional.h"
-#include "absl/types/optional.h"
-#include <google/iam/v1/policy.pb.h>
-#include <functional>
+#include "google/cloud/iam_updater.h"
 
 namespace google {
 namespace cloud {
 namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
 
-using IamUpdater = std::function<absl::optional<google::iam::v1::Policy>(
-    google::iam::v1::Policy)>;
+/**
+ * Type alias for google::cloud::IamUpdater.
+ *
+ * Used in the `SetIamPolicy()` read-modify-write cycle of the Spanner admin
+ * clients, `DatabaseAdminClient` and `InstanceAdminClient`, in order to avoid
+ * race conditions.
+ *
+ * The updater is called with a recently fetched policy, and should either
+ * return an empty optional if no changes are required, or return a new policy
+ * to be set. In the latter case the control loop will always set the `etag`
+ * of the new policy to that of the recently fetched one. A failure to update
+ * then indicates a race, and the process will repeat.
+ */
+using IamUpdater = ::google::cloud::IamUpdater;
 
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner


### PR DESCRIPTION
For generated clients with standard `GetIamPolicy()` and `SetIamPolicy()`
operations, also generate a `SetIamPolicy()` overload that implements an
optimistic concurrency control loop, where the `Policy.etag` field is
used to prevent simultaneous updates of a policy from overwriting each
other.

Fixes #7168.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7276)
<!-- Reviewable:end -->
