### PR TITLE
refactor(storage): simplify internal::CurlClient

### DIFF
--- a/google/cloud/storage/internal/curl_client.h
+++ b/google/cloud/storage/internal/curl_client.h
@@ -224,10 +224,6 @@ class CurlClient : public RawClient,
   StatusOr<ObjectMetadata> InsertObjectMediaSimple(
       InsertObjectMediaRequest const& request);
 
-  template <typename RequestType>
-  StatusOr<std::unique_ptr<ResumableUploadSession>>
-  CreateResumableSessionGeneric(RequestType const& request);
-
   google::cloud::Options opts_;
   ClientOptions backwards_compatibility_options_;
   std::string const x_goog_api_client_header_;


### PR DESCRIPTION
Refactor a template member function that no longer needs to be a
template. This will enable further changes related to
RestoreResumableSession.

This is motivated by the comments in #7272, so let's call it part of the work for #6982

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7281)
<!-- Reviewable:end -->
