### PR TITLE
refactor(storage): reduce indirection on restoring uploads

### DIFF
--- a/google/cloud/storage/CMakeLists.txt
+++ b/google/cloud/storage/CMakeLists.txt
@@ -174,6 +174,7 @@ add_library(
     internal/patch_builder.h
     internal/policy_document_request.cc
     internal/policy_document_request.h
+    internal/raw_client.cc
     internal/raw_client.h
     internal/raw_client_wrapper_utils.h
     internal/resumable_upload_session.cc

--- a/google/cloud/storage/google_cloud_cpp_storage.bzl
+++ b/google/cloud/storage/google_cloud_cpp_storage.bzl
@@ -191,6 +191,7 @@ google_cloud_cpp_storage_srcs = [
     "internal/openssl_util.cc",
     "internal/patch_builder.cc",
     "internal/policy_document_request.cc",
+    "internal/raw_client.cc",
     "internal/resumable_upload_session.cc",
     "internal/retry_client.cc",
     "internal/retry_object_read_source.cc",

--- a/google/cloud/storage/internal/curl_client.cc
+++ b/google/cloud/storage/internal/curl_client.cc
@@ -231,10 +231,8 @@ CurlClient::FullyRestoreResumableSession(ResumableUploadRequest const& request,
   auto session = absl::make_unique<CurlResumableUploadSession>(
       shared_from_this(), request, session_id);
   auto response = session->ResetSession();
-  if (response.status().ok()) {
-    return std::unique_ptr<ResumableUploadSession>(std::move(session));
-  }
-  return std::move(response).status();
+  if (!response) std::move(response).status();
+  return std::unique_ptr<ResumableUploadSession>(std::move(session));
 }
 
 StatusOr<ListBucketsResponse> CurlClient::ListBuckets(

--- a/google/cloud/storage/internal/curl_client.h
+++ b/google/cloud/storage/internal/curl_client.h
@@ -72,13 +72,16 @@ class CurlClient : public RawClient,
   /// @name Implement the CurlResumableSession operations.
   // Note that these member functions are not inherited from RawClient, they are
   // called only by `CurlResumableUploadSession`, because the retry loop for
-  // them is very different from the standard retry loop. Also note that these
-  // are virtual functions only because we need to override them in the unit
-  // tests.
+  // them is very different from the standard retry loop. Also note that some of
+  // these member functions are virtual, but only because we need to override
+  // them in the *library* unit tests.
   virtual StatusOr<ResumableUploadResponse> UploadChunk(
       UploadChunkRequest const&);
   virtual StatusOr<ResumableUploadResponse> QueryResumableUpload(
       QueryResumableUploadRequest const&);
+  StatusOr<std::unique_ptr<ResumableUploadSession>>
+  FullyRestoreResumableSession(ResumableUploadRequest const& request,
+                               std::string const& session_id);
   //@}
 
   ClientOptions const& client_options() const override {
@@ -127,8 +130,6 @@ class CurlClient : public RawClient,
       ComposeObjectRequest const& request) override;
   StatusOr<std::unique_ptr<ResumableUploadSession>> CreateResumableSession(
       ResumableUploadRequest const& request) override;
-  StatusOr<std::unique_ptr<ResumableUploadSession>> RestoreResumableSession(
-      std::string const& session_id) override;
   StatusOr<EmptyResponse> DeleteResumableUpload(
       DeleteResumableUploadRequest const& request) override;
 

--- a/google/cloud/storage/internal/curl_resumable_upload_session.cc
+++ b/google/cloud/storage/internal/curl_resumable_upload_session.cc
@@ -23,7 +23,7 @@ namespace internal {
 StatusOr<ResumableUploadResponse> CurlResumableUploadSession::UploadChunk(
     ConstBufferSequence const& buffers) {
   UploadChunkRequest request(session_id_, next_expected_, buffers);
-  request.set_option(custom_header());
+  request.set_multiple_options(request_.GetOption<CustomHeader>());
   auto result = client_->UploadChunk(request);
   Update(result, TotalBytes(buffers));
   return result;
@@ -33,7 +33,7 @@ StatusOr<ResumableUploadResponse> CurlResumableUploadSession::UploadFinalChunk(
     ConstBufferSequence const& buffers, std::uint64_t upload_size,
     HashValues const& /*full_object_hashes*/) {
   UploadChunkRequest request(session_id_, next_expected_, buffers, upload_size);
-  request.set_option(custom_header());
+  request.set_multiple_options(request_.GetOption<CustomHeader>());
   auto result = client_->UploadChunk(request);
   Update(result, TotalBytes(buffers));
   return result;
@@ -41,6 +41,7 @@ StatusOr<ResumableUploadResponse> CurlResumableUploadSession::UploadFinalChunk(
 
 StatusOr<ResumableUploadResponse> CurlResumableUploadSession::ResetSession() {
   QueryResumableUploadRequest request(session_id_);
+  request.set_multiple_options(request_.GetOption<CustomHeader>());
   auto result = client_->QueryResumableUpload(request);
   Update(result, 0);
   return result;

--- a/google/cloud/storage/internal/curl_resumable_upload_session.h
+++ b/google/cloud/storage/internal/curl_resumable_upload_session.h
@@ -30,12 +30,12 @@ namespace internal {
  */
 class CurlResumableUploadSession : public ResumableUploadSession {
  public:
-  explicit CurlResumableUploadSession(
-      std::shared_ptr<CurlClient> client, std::string session_id,
-      CustomHeader custom_header = CustomHeader())
+  explicit CurlResumableUploadSession(std::shared_ptr<CurlClient> client,
+                                      ResumableUploadRequest request,
+                                      std::string session_id)
       : client_(std::move(client)),
-        session_id_(std::move(session_id)),
-        custom_header_(std::move(custom_header)) {}
+        request_(std::move(request)),
+        session_id_(std::move(session_id)) {}
 
   StatusOr<ResumableUploadResponse> UploadChunk(
       ConstBufferSequence const& buffers) override;
@@ -50,8 +50,6 @@ class CurlResumableUploadSession : public ResumableUploadSession {
 
   std::string const& session_id() const override { return session_id_; }
 
-  CustomHeader const& custom_header() const { return custom_header_; }
-
   bool done() const override { return done_; }
 
   StatusOr<ResumableUploadResponse> const& last_response() const override {
@@ -63,8 +61,8 @@ class CurlResumableUploadSession : public ResumableUploadSession {
               std::size_t chunk_size);
 
   std::shared_ptr<CurlClient> client_;
+  ResumableUploadRequest request_;
   std::string session_id_;
-  CustomHeader custom_header_;
   std::uint64_t next_expected_ = 0;
   bool done_ = false;
   StatusOr<ResumableUploadResponse> last_response_;

--- a/google/cloud/storage/internal/grpc_client.h
+++ b/google/cloud/storage/internal/grpc_client.h
@@ -53,9 +53,9 @@ class GrpcClient : public RawClient,
   /// @name Implement the ResumableSession operations.
   // Note that these member functions are not inherited from RawClient, they are
   // called only by `GrpcResumableUploadSession`, because the retry loop for
-  // them is very different from the standard retry loop. Also note that these
-  // are virtual functions only because we need to override them in the unit
-  // tests.
+  // them is very different from the standard retry loop. Also note that some of
+  // these member functions are virtual, but only because we need to override
+  // them in the *library* unit tests.
   using WriteObjectStream = ::google::cloud::internal::StreamingWriteRpc<
       google::storage::v2::WriteObjectRequest,
       google::storage::v2::WriteObjectResponse>;
@@ -63,6 +63,9 @@ class GrpcClient : public RawClient,
       std::unique_ptr<grpc::ClientContext> context);
   virtual StatusOr<ResumableUploadResponse> QueryResumableUpload(
       QueryResumableUploadRequest const&);
+  StatusOr<std::unique_ptr<ResumableUploadSession>>
+  FullyRestoreResumableSession(ResumableUploadRequest const& request,
+                               std::string const& upload_url);
   //@}
 
   ClientOptions const& client_options() const override;
@@ -113,8 +116,6 @@ class GrpcClient : public RawClient,
       RewriteObjectRequest const&) override;
   StatusOr<std::unique_ptr<ResumableUploadSession>> CreateResumableSession(
       ResumableUploadRequest const& request) override;
-  StatusOr<std::unique_ptr<ResumableUploadSession>> RestoreResumableSession(
-      std::string const& upload_url) override;
   StatusOr<EmptyResponse> DeleteResumableUpload(
       DeleteResumableUploadRequest const& request) override;
 

--- a/google/cloud/storage/internal/grpc_resumable_upload_session.cc
+++ b/google/cloud/storage/internal/grpc_resumable_upload_session.cc
@@ -33,9 +33,10 @@ static_assert(google::storage::v2::ServiceConstants::MAX_WRITE_CHUNK_BYTES >
               "the chunk quantum");
 
 GrpcResumableUploadSession::GrpcResumableUploadSession(
-    std::shared_ptr<GrpcClient> client,
+    std::shared_ptr<GrpcClient> client, ResumableUploadRequest request,
     ResumableUploadSessionGrpcParams session_id_params)
     : client_(std::move(client)),
+      request_(std::move(request)),
       session_id_params_(std::move(session_id_params)),
       session_url_(EncodeGrpcResumableUploadSessionUrl(session_id_params_)) {}
 

--- a/google/cloud/storage/internal/grpc_resumable_upload_session.h
+++ b/google/cloud/storage/internal/grpc_resumable_upload_session.h
@@ -30,7 +30,7 @@ namespace internal {
 class GrpcResumableUploadSession : public ResumableUploadSession {
  public:
   explicit GrpcResumableUploadSession(
-      std::shared_ptr<GrpcClient> client,
+      std::shared_ptr<GrpcClient> client, ResumableUploadRequest request,
       ResumableUploadSessionGrpcParams session_id_params);
 
   StatusOr<ResumableUploadResponse> UploadChunk(
@@ -61,6 +61,7 @@ class GrpcResumableUploadSession : public ResumableUploadSession {
                                                   HashValues const& hashes);
 
   std::shared_ptr<GrpcClient> client_;
+  ResumableUploadRequest request_;
   ResumableUploadSessionGrpcParams session_id_params_;
   std::string session_url_;
 

--- a/google/cloud/storage/internal/grpc_resumable_upload_session_test.cc
+++ b/google/cloud/storage/internal/grpc_resumable_upload_session_test.cc
@@ -73,8 +73,9 @@ StatusOr<google::storage::v2::WriteObjectResponse> MockCloseError(Status s) {
 
 TEST(GrpcResumableUploadSessionTest, Simple) {
   auto mock = MockGrpcClient::Create();
+  ResumableUploadRequest request("test-bucket", "test-object");
   GrpcResumableUploadSession session(
-      mock, {"test-bucket", "test-object", "test-upload-id"});
+      mock, request, {"test-bucket", "test-object", "test-upload-id"});
 
   std::string const payload = "test payload";
   auto const size = payload.size();
@@ -138,8 +139,9 @@ TEST(GrpcResumableUploadSessionTest, Simple) {
 
 TEST(GrpcResumableUploadSessionTest, SingleStreamForLargeChunks) {
   auto mock = MockGrpcClient::Create();
+  ResumableUploadRequest request("test-bucket", "test-object");
   GrpcResumableUploadSession session(
-      mock, {"test-bucket", "test-object", "test-upload-id"});
+      mock, request, {"test-bucket", "test-object", "test-upload-id"});
 
   auto rng = google::cloud::internal::MakeDefaultPRNG();
   auto const payload = MakeRandomData(rng, 8 * 1024 * 1024L);
@@ -190,8 +192,9 @@ TEST(GrpcResumableUploadSessionTest, SingleStreamForLargeChunks) {
 
 TEST(GrpcResumableUploadSessionTest, Reset) {
   auto mock = MockGrpcClient::Create();
+  ResumableUploadRequest request("test-bucket", "test-object");
   GrpcResumableUploadSession session(
-      mock, {"test-bucket", "test-object", "test-upload-id"});
+      mock, request, {"test-bucket", "test-object", "test-upload-id"});
 
   std::string const payload = "test payload";
   auto const size = payload.size();
@@ -257,8 +260,9 @@ TEST(GrpcResumableUploadSessionTest, Reset) {
 
 TEST(GrpcResumableUploadSessionTest, ResumeFromEmpty) {
   auto mock = MockGrpcClient::Create();
+  ResumableUploadRequest request("test-bucket", "test-object");
   GrpcResumableUploadSession session(
-      mock, {"test-bucket", "test-object", "test-upload-id"});
+      mock, request, {"test-bucket", "test-object", "test-upload-id"});
 
   std::string const payload = "test payload";
   auto const size = payload.size();

--- a/google/cloud/storage/internal/hybrid_client.cc
+++ b/google/cloud/storage/internal/hybrid_client.cc
@@ -148,14 +148,6 @@ HybridClient::CreateResumableSession(ResumableUploadRequest const& request) {
   return grpc_->CreateResumableSession(request);
 }
 
-StatusOr<std::unique_ptr<ResumableUploadSession>>
-HybridClient::RestoreResumableSession(std::string const& upload_id) {
-  if (internal::IsGrpcResumableSessionUrl(upload_id)) {
-    return grpc_->RestoreResumableSession(upload_id);
-  }
-  return curl_->RestoreResumableSession(upload_id);
-}
-
 StatusOr<EmptyResponse> HybridClient::DeleteResumableUpload(
     DeleteResumableUploadRequest const& request) {
   if (internal::IsGrpcResumableSessionUrl(request.upload_session_url())) {

--- a/google/cloud/storage/internal/hybrid_client.h
+++ b/google/cloud/storage/internal/hybrid_client.h
@@ -80,8 +80,6 @@ class HybridClient : public RawClient {
       RewriteObjectRequest const&) override;
   StatusOr<std::unique_ptr<ResumableUploadSession>> CreateResumableSession(
       ResumableUploadRequest const& request) override;
-  StatusOr<std::unique_ptr<ResumableUploadSession>> RestoreResumableSession(
-      std::string const& upload_id) override;
   StatusOr<EmptyResponse> DeleteResumableUpload(
       DeleteResumableUploadRequest const& request) override;
 

--- a/google/cloud/storage/internal/logging_client.cc
+++ b/google/cloud/storage/internal/logging_client.cc
@@ -213,12 +213,6 @@ LoggingClient::CreateResumableSession(ResumableUploadRequest const& request) {
           std::move(result).value()));
 }
 
-StatusOr<std::unique_ptr<ResumableUploadSession>>
-LoggingClient::RestoreResumableSession(std::string const& request) {
-  return MakeCallNoResponseLogging(
-      *client_, &RawClient::RestoreResumableSession, request, __func__);
-}
-
 StatusOr<EmptyResponse> LoggingClient::DeleteResumableUpload(
     DeleteResumableUploadRequest const& request) {
   return MakeCall(*client_, &RawClient::DeleteResumableUpload, request,

--- a/google/cloud/storage/internal/logging_client.h
+++ b/google/cloud/storage/internal/logging_client.h
@@ -78,8 +78,6 @@ class LoggingClient : public RawClient {
       RewriteObjectRequest const&) override;
   StatusOr<std::unique_ptr<ResumableUploadSession>> CreateResumableSession(
       ResumableUploadRequest const& request) override;
-  StatusOr<std::unique_ptr<ResumableUploadSession>> RestoreResumableSession(
-      std::string const& request) override;
   StatusOr<EmptyResponse> DeleteResumableUpload(
       DeleteResumableUploadRequest const& request) override;
 

--- a/google/cloud/storage/internal/raw_client.cc
+++ b/google/cloud/storage/internal/raw_client.cc
@@ -1,0 +1,32 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/storage/internal/raw_client.h"
+
+namespace google {
+namespace cloud {
+namespace storage {
+inline namespace STORAGE_CLIENT_NS {
+namespace internal {
+
+StatusOr<std::unique_ptr<ResumableUploadSession>>
+RawClient::RestoreResumableSession(std::string const& /*session_id*/) {
+  return Status(StatusCode::kUnimplemented, "removed, see #7282 for details");
+}
+
+}  // namespace internal
+}  // namespace STORAGE_CLIENT_NS
+}  // namespace storage
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/storage/internal/raw_client.h
+++ b/google/cloud/storage/internal/raw_client.h
@@ -101,8 +101,10 @@ class RawClient {
       RewriteObjectRequest const&) = 0;
   virtual StatusOr<std::unique_ptr<ResumableUploadSession>>
   CreateResumableSession(ResumableUploadRequest const& request) = 0;
+  /// @deprecated this function is no longer used, see #7282 for details.
+  GOOGLE_CLOUD_CPP_STORAGE_RESTORE_UPLOAD_DEPRECATED()
   virtual StatusOr<std::unique_ptr<ResumableUploadSession>>
-  RestoreResumableSession(std::string const& session_id) = 0;
+  RestoreResumableSession(std::string const& session_id);
   virtual StatusOr<EmptyResponse> DeleteResumableUpload(
       DeleteResumableUploadRequest const& request) = 0;
   //@}

--- a/google/cloud/storage/internal/retry_client.cc
+++ b/google/cloud/storage/internal/retry_client.cc
@@ -379,15 +379,6 @@ RetryClient::CreateResumableSession(ResumableUploadRequest const& request) {
           std::move(backoff_policy)));
 }
 
-StatusOr<std::unique_ptr<ResumableUploadSession>>
-RetryClient::RestoreResumableSession(std::string const& request) {
-  auto retry_policy = retry_policy_prototype_->clone();
-  auto backoff_policy = backoff_policy_prototype_->clone();
-  return MakeCall(*retry_policy, *backoff_policy, Idempotency::kIdempotent,
-                  *client_, &RawClient::RestoreResumableSession, request,
-                  __func__);
-}
-
 StatusOr<EmptyResponse> RetryClient::DeleteResumableUpload(
     DeleteResumableUploadRequest const& request) {
   auto retry_policy = retry_policy_prototype_->clone();

--- a/google/cloud/storage/internal/retry_client.h
+++ b/google/cloud/storage/internal/retry_client.h
@@ -89,8 +89,6 @@ class RetryClient : public RawClient,
       RewriteObjectRequest const&) override;
   StatusOr<std::unique_ptr<ResumableUploadSession>> CreateResumableSession(
       ResumableUploadRequest const& request) override;
-  StatusOr<std::unique_ptr<ResumableUploadSession>> RestoreResumableSession(
-      std::string const& request) override;
   StatusOr<EmptyResponse> DeleteResumableUpload(
       DeleteResumableUploadRequest const& request) override;
 

--- a/google/cloud/storage/tests/curl_resumable_upload_session_integration_test.cc
+++ b/google/cloud/storage/tests/curl_resumable_upload_session_integration_test.cc
@@ -124,7 +124,8 @@ TEST_F(CurlResumableUploadIntegrationTest, Restore) {
   ASSERT_STATUS_OK(response.status());
 
   StatusOr<std::unique_ptr<ResumableUploadSession>> session =
-      client->RestoreResumableSession((*old_session)->session_id());
+      client->FullyRestoreResumableSession(request,
+                                           (*old_session)->session_id());
   EXPECT_EQ(contents.size(), (*session)->next_expected_byte());
   old_session->reset();
 

--- a/google/cloud/storage/version.h
+++ b/google/cloud/storage/version.h
@@ -27,6 +27,13 @@
       " instead. The function will be removed on 2022-04-01 or shortly "       \
       "after. See GitHub issue #5929 for more information.")
 
+#define GOOGLE_CLOUD_CPP_STORAGE_RESTORE_UPLOAD_DEPRECATED()                   \
+  GOOGLE_CLOUD_CPP_DEPRECATED(                                                 \
+      "this function is not used within the library. There was never a need"   \
+      " to mock this function, but it is preserved to avoid breaking existing" \
+      " applications. The function may be removed after 2022-10-01, more"      \
+      " details on GitHub issue #7282.")
+
 #define STORAGE_CLIENT_NS GOOGLE_CLOUD_CPP_NS
 
 namespace google {


### PR DESCRIPTION
The `RawClient::RestoreResumableUpload()` function is not really used,
and it lacks a parameter with the original request (which may have set
options, such as custom headers). With this cleanup the function is
deprecated. This enables a change to fully support standard parameters
when restoring resumable uploads.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7283)
<!-- Reviewable:end -->
