### PR TITLE
feat(storage): use generic parameters when resuming uploads

### DIFF
--- a/google/cloud/storage/internal/curl_resumable_upload_session.cc
+++ b/google/cloud/storage/internal/curl_resumable_upload_session.cc
@@ -23,7 +23,10 @@ namespace internal {
 StatusOr<ResumableUploadResponse> CurlResumableUploadSession::UploadChunk(
     ConstBufferSequence const& buffers) {
   UploadChunkRequest request(session_id_, next_expected_, buffers);
-  request.set_multiple_options(request_.GetOption<CustomHeader>());
+  request.set_multiple_options(
+      request_.GetOption<CustomHeader>(), request_.GetOption<Fields>(),
+      request_.GetOption<IfMatchEtag>(), request_.GetOption<IfNoneMatchEtag>(),
+      request_.GetOption<QuotaUser>(), request_.GetOption<UserIp>());
   auto result = client_->UploadChunk(request);
   Update(result, TotalBytes(buffers));
   return result;
@@ -33,7 +36,10 @@ StatusOr<ResumableUploadResponse> CurlResumableUploadSession::UploadFinalChunk(
     ConstBufferSequence const& buffers, std::uint64_t upload_size,
     HashValues const& /*full_object_hashes*/) {
   UploadChunkRequest request(session_id_, next_expected_, buffers, upload_size);
-  request.set_multiple_options(request_.GetOption<CustomHeader>());
+  request.set_multiple_options(
+      request_.GetOption<CustomHeader>(), request_.GetOption<Fields>(),
+      request_.GetOption<IfMatchEtag>(), request_.GetOption<IfNoneMatchEtag>(),
+      request_.GetOption<QuotaUser>(), request_.GetOption<UserIp>());
   auto result = client_->UploadChunk(request);
   Update(result, TotalBytes(buffers));
   return result;
@@ -41,7 +47,10 @@ StatusOr<ResumableUploadResponse> CurlResumableUploadSession::UploadFinalChunk(
 
 StatusOr<ResumableUploadResponse> CurlResumableUploadSession::ResetSession() {
   QueryResumableUploadRequest request(session_id_);
-  request.set_multiple_options(request_.GetOption<CustomHeader>());
+  request.set_multiple_options(
+      request_.GetOption<CustomHeader>(), request_.GetOption<Fields>(),
+      request_.GetOption<IfMatchEtag>(), request_.GetOption<IfNoneMatchEtag>(),
+      request_.GetOption<QuotaUser>(), request_.GetOption<UserIp>());
   auto result = client_->QueryResumableUpload(request);
   Update(result, 0);
   return result;


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7292)
<!-- Reviewable:end -->
