### PR TITLE
fix(generator): ignore empty endpoint-override env vars

### DIFF
--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_option_defaults.cc
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_option_defaults.cc
@@ -39,7 +39,7 @@ auto constexpr kBackoffScaling = 2.0;
 Options GoldenKitchenSinkDefaultOptions(Options options) {
   if (!options.has<EndpointOption>()) {
     auto env = internal::GetEnv("GOLDEN_KITCHEN_SINK_ENDPOINT");
-    options.set<EndpointOption>(env ? *env : "goldenkitchensink.googleapis.com");
+    options.set<EndpointOption>(env && !env->empty() ? *env : "goldenkitchensink.googleapis.com");
   }
   if (auto emulator = internal::GetEnv("GOLDEN_KITCHEN_SINK_EMULATOR_HOST")) {
     options.set<EndpointOption>(*emulator).set<GrpcCredentialOption>(

--- a/generator/integration_tests/golden/internal/golden_thing_admin_option_defaults.cc
+++ b/generator/integration_tests/golden/internal/golden_thing_admin_option_defaults.cc
@@ -39,7 +39,7 @@ auto constexpr kBackoffScaling = 2.0;
 Options GoldenThingAdminDefaultOptions(Options options) {
   if (!options.has<EndpointOption>()) {
     auto env = internal::GetEnv("GOLDEN_KITCHEN_SINK_ENDPOINT");
-    options.set<EndpointOption>(env ? *env : "test.googleapis.com");
+    options.set<EndpointOption>(env && !env->empty() ? *env : "test.googleapis.com");
   }
   if (auto emulator = internal::GetEnv("GOLDEN_KITCHEN_SINK_EMULATOR_HOST")) {
     options.set<EndpointOption>(*emulator).set<GrpcCredentialOption>(

--- a/generator/internal/option_defaults_generator.cc
+++ b/generator/internal/option_defaults_generator.cc
@@ -95,7 +95,7 @@ Status OptionDefaultsGenerator::GenerateCc() {
   {{"Options $service_name$DefaultOptions(Options options) {\n"
     "  if (!options.has<EndpointOption>()) {\n"
     "    auto env = internal::GetEnv(\"$service_endpoint_env_var$\");\n"
-    "    options.set<EndpointOption>(env ? *env : \"$service_endpoint$\");\n"
+    "    options.set<EndpointOption>(env && !env->empty() ? *env : \"$service_endpoint$\");\n"
     "  }\n"},
    {[this]{return vars("emulator_endpoint_env_var").empty();}, "",
     "  if (auto emulator = internal::GetEnv(\"$emulator_endpoint_env_var$\")) {\n"

--- a/google/cloud/bigquery/internal/bigquery_read_option_defaults.cc
+++ b/google/cloud/bigquery/internal/bigquery_read_option_defaults.cc
@@ -39,7 +39,8 @@ auto constexpr kBackoffScaling = 2.0;
 Options BigQueryReadDefaultOptions(Options options) {
   if (!options.has<EndpointOption>()) {
     auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_BIGQUERY_READ_ENDPOINT");
-    options.set<EndpointOption>(env ? *env : "bigquerystorage.googleapis.com");
+    options.set<EndpointOption>(
+        env && !env->empty() ? *env : "bigquerystorage.googleapis.com");
   }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());

--- a/google/cloud/iam/internal/iam_credentials_option_defaults.cc
+++ b/google/cloud/iam/internal/iam_credentials_option_defaults.cc
@@ -39,7 +39,8 @@ auto constexpr kBackoffScaling = 2.0;
 Options IAMCredentialsDefaultOptions(Options options) {
   if (!options.has<EndpointOption>()) {
     auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_IAM_CREDENTIALS_ENDPOINT");
-    options.set<EndpointOption>(env ? *env : "iamcredentials.googleapis.com");
+    options.set<EndpointOption>(
+        env && !env->empty() ? *env : "iamcredentials.googleapis.com");
   }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());

--- a/google/cloud/iam/internal/iam_option_defaults.cc
+++ b/google/cloud/iam/internal/iam_option_defaults.cc
@@ -39,7 +39,8 @@ auto constexpr kBackoffScaling = 2.0;
 Options IAMDefaultOptions(Options options) {
   if (!options.has<EndpointOption>()) {
     auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_IAM_ENDPOINT");
-    options.set<EndpointOption>(env ? *env : "iam.googleapis.com");
+    options.set<EndpointOption>(env && !env->empty() ? *env
+                                                     : "iam.googleapis.com");
   }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());

--- a/google/cloud/logging/internal/logging_service_v2_option_defaults.cc
+++ b/google/cloud/logging/internal/logging_service_v2_option_defaults.cc
@@ -39,7 +39,8 @@ auto constexpr kBackoffScaling = 2.0;
 Options LoggingServiceV2DefaultOptions(Options options) {
   if (!options.has<EndpointOption>()) {
     auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_LOGGING_SERVICE_V2_ENDPOINT");
-    options.set<EndpointOption>(env ? *env : "logging.googleapis.com");
+    options.set<EndpointOption>(
+        env && !env->empty() ? *env : "logging.googleapis.com");
   }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());

--- a/google/cloud/spanner/admin/internal/database_admin_option_defaults.cc
+++ b/google/cloud/spanner/admin/internal/database_admin_option_defaults.cc
@@ -39,7 +39,8 @@ auto constexpr kBackoffScaling = 2.0;
 Options DatabaseAdminDefaultOptions(Options options) {
   if (!options.has<EndpointOption>()) {
     auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_SPANNER_DEFAULT_ENDPOINT");
-    options.set<EndpointOption>(env ? *env : "spanner.googleapis.com");
+    options.set<EndpointOption>(
+        env && !env->empty() ? *env : "spanner.googleapis.com");
   }
   if (auto emulator = internal::GetEnv("SPANNER_EMULATOR_HOST")) {
     options.set<EndpointOption>(*emulator).set<GrpcCredentialOption>(

--- a/google/cloud/spanner/admin/internal/instance_admin_option_defaults.cc
+++ b/google/cloud/spanner/admin/internal/instance_admin_option_defaults.cc
@@ -39,7 +39,8 @@ auto constexpr kBackoffScaling = 2.0;
 Options InstanceAdminDefaultOptions(Options options) {
   if (!options.has<EndpointOption>()) {
     auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_SPANNER_DEFAULT_ENDPOINT");
-    options.set<EndpointOption>(env ? *env : "spanner.googleapis.com");
+    options.set<EndpointOption>(
+        env && !env->empty() ? *env : "spanner.googleapis.com");
   }
   if (auto emulator = internal::GetEnv("SPANNER_EMULATOR_HOST")) {
     options.set<EndpointOption>(*emulator).set<GrpcCredentialOption>(


### PR DESCRIPTION
Ignore the endpoint-override environment variable not only when it is
unset, but also when it is set and empty.  This preserves the behavior
we had already set for `${GOOGLE_CLOUD_CPP_SPANNER_DEFAULT_ENDPOINT}`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7293)
<!-- Reviewable:end -->
