### PR TITLE
feat(storage): support timeouts for all requests

### DIFF
--- a/google/cloud/storage/benchmarks/aggregate_download_throughput_benchmark.cc
+++ b/google/cloud/storage/benchmarks/aggregate_download_throughput_benchmark.cc
@@ -123,7 +123,7 @@ gcs::Client MakeClient(AggregateDownloadThroughputOptions const& options) {
   auto client_options =
       google::cloud::Options{}
           .set<gcs_experimental::HttpVersionOption>(options.rest_http_version)
-          .set<gcs::DownloadStallTimeoutOption>(options.download_stall_timeout);
+          .set<gcs::TransferStallTimeoutOption>(options.download_stall_timeout);
 #if GOOGLE_CLOUD_CPP_STORAGE_HAVE_GRPC
   if (options.api == ApiName::kApiGrpc) {
     auto channels = options.grpc_channel_count;

--- a/google/cloud/storage/client_options.cc
+++ b/google/cloud/storage/client_options.cc
@@ -168,7 +168,7 @@ Options DefaultOptions(std::shared_ptr<oauth2::Credentials> credentials,
           .set<EnableCurlSigpipeHandlerOption>(true)
           .set<MaximumCurlSocketRecvSizeOption>(0)
           .set<MaximumCurlSocketSendSizeOption>(0)
-          .set<DownloadStallTimeoutOption>(std::chrono::seconds(
+          .set<TransferStallTimeoutOption>(std::chrono::seconds(
               GOOGLE_CLOUD_CPP_STORAGE_DEFAULT_DOWNLOAD_STALL_TIMEOUT))
           .set<RetryPolicyOption>(
               LimitedTimeRetryPolicy(

--- a/google/cloud/storage/client_options.h
+++ b/google/cloud/storage/client_options.h
@@ -251,10 +251,10 @@ class ClientOptions {
    * The default value is 2 minutes. Can be disabled by setting the value to 0.
    */
   std::chrono::seconds download_stall_timeout() const {
-    return opts_.get<DownloadStallTimeoutOption>();
+    return opts_.get<TransferStallTimeoutOption>();
   }
   ClientOptions& set_download_stall_timeout(std::chrono::seconds v) {
-    opts_.set<DownloadStallTimeoutOption>(std::move(v));
+    opts_.set<TransferStallTimeoutOption>(std::move(v));
     return *this;
   }
   //@}

--- a/google/cloud/storage/client_options_test.cc
+++ b/google/cloud/storage/client_options_test.cc
@@ -324,7 +324,7 @@ TEST_F(ClientOptionsTest, MakeOptionsFromDefault) {
   EXPECT_TRUE(opts.has<EnableCurlSigpipeHandlerOption>());
   EXPECT_EQ(0, opts.get<MaximumCurlSocketSendSizeOption>());
   EXPECT_EQ(0, opts.get<MaximumCurlSocketRecvSizeOption>());
-  EXPECT_LT(0, opts.get<DownloadStallTimeoutOption>().count());
+  EXPECT_LT(0, opts.get<TransferStallTimeoutOption>().count());
   EXPECT_THAT(opts.get<CARootsFilePathOption>(), IsEmpty());
 }
 

--- a/google/cloud/storage/internal/curl_download_request.cc
+++ b/google/cloud/storage/internal/curl_download_request.cc
@@ -85,7 +85,7 @@ extern "C" std::size_t CurlDownloadRequestHeader(char* contents,
 CurlDownloadRequest::CurlDownloadRequest(CurlHeaders headers, CurlHandle handle,
                                          CurlMulti multi)
     : headers_(std::move(headers)),
-      download_stall_timeout_(0),
+      transfer_stall_timeout_(0),
       handle_(std::move(handle)),
       multi_(std::move(multi)),
       spill_(CURL_MAX_WRITE_SIZE) {}
@@ -227,14 +227,14 @@ void CurlDownloadRequest::SetOptions() {
   handle_.SetSocketCallback(socket_options_);
   handle_.SetOptionUnchecked(CURLOPT_HTTP_VERSION,
                              VersionToCurlCode(http_version_));
-  if (download_stall_timeout_.count() != 0) {
+  if (transfer_stall_timeout_.count() != 0) {
+    // NOLINTNEXTLINE(google-runtime-int) - libcurl *requires* `long`
+    auto const timeout = static_cast<long>(transfer_stall_timeout_.count());
+    handle_.SetOption(CURLOPT_CONNECTTIMEOUT, timeout);
     // Timeout if the download receives less than 1 byte/second (i.e.
-    // effectively no bytes) for `download_stall_timeout_` seconds.
+    // effectively no bytes) for `transfer_stall_timeout_` seconds.
     handle_.SetOption(CURLOPT_LOW_SPEED_LIMIT, 1L);
-    handle_.SetOption(
-        CURLOPT_LOW_SPEED_TIME,
-        // NOLINTNEXTLINE(google-runtime-int) - libcurl *requires* `long`
-        static_cast<long>(download_stall_timeout_.count()));
+    handle_.SetOption(CURLOPT_LOW_SPEED_TIME, timeout);
   }
   if (in_multi_) GCP_LOG(FATAL) << "in_multi_ should be false in `SetOptions`";
   auto error = curl_multi_add_handle(multi_.get(), handle_.handle_.get());

--- a/google/cloud/storage/internal/curl_download_request.h
+++ b/google/cloud/storage/internal/curl_download_request.h
@@ -133,7 +133,7 @@ class CurlDownloadRequest : public ObjectReadSource {
   std::int32_t http_code_ = 0;
   bool logging_enabled_ = false;
   CurlHandle::SocketOptions socket_options_;
-  std::chrono::seconds download_stall_timeout_;
+  std::chrono::seconds transfer_stall_timeout_;
   CurlHandle handle_;
   CurlMulti multi_;
   std::shared_ptr<CurlHandleFactory> factory_;

--- a/google/cloud/storage/internal/curl_request.h
+++ b/google/cloud/storage/internal/curl_request.h
@@ -76,6 +76,7 @@ class CurlRequest {
   CurlReceivedHeaders received_headers_;
   bool logging_enabled_ = false;
   CurlHandle::SocketOptions socket_options_;
+  std::chrono::seconds transfer_stall_timeout_;
   CurlHandle handle_;
   std::shared_ptr<CurlHandleFactory> factory_;
 };

--- a/google/cloud/storage/internal/curl_request_builder.cc
+++ b/google/cloud/storage/internal/curl_request_builder.cc
@@ -43,7 +43,7 @@ CurlRequestBuilder::CurlRequestBuilder(
       url_(std::move(base_url)),
       query_parameter_separator_(InitialQueryParameterSeparator(url_)),
       logging_enabled_(false),
-      download_stall_timeout_(0) {}
+      transfer_stall_timeout_(0) {}
 
 CurlRequest CurlRequestBuilder::BuildRequest() {
   ValidateBuilderState(__func__);
@@ -56,6 +56,7 @@ CurlRequest CurlRequestBuilder::BuildRequest() {
   request.factory_ = std::move(factory_);
   request.logging_enabled_ = logging_enabled_;
   request.socket_options_ = socket_options_;
+  request.transfer_stall_timeout_ = transfer_stall_timeout_;
   return request;
 }
 
@@ -71,7 +72,7 @@ CurlRequestBuilder::BuildDownloadRequest() && {
   request->factory_ = factory_;
   request->logging_enabled_ = logging_enabled_;
   request->socket_options_ = socket_options_;
-  request->download_stall_timeout_ = download_stall_timeout_;
+  request->transfer_stall_timeout_ = transfer_stall_timeout_;
   request->SetOptions();
   return request;
 }
@@ -90,7 +91,7 @@ CurlRequestBuilder& CurlRequestBuilder::ApplyClientOptions(
   user_agent_prefix_ = absl::StrJoin(agents, " ");
   http_version_ =
       std::move(options.get<storage_experimental::HttpVersionOption>());
-  download_stall_timeout_ = options.get<DownloadStallTimeoutOption>();
+  transfer_stall_timeout_ = options.get<TransferStallTimeoutOption>();
   return *this;
 }
 

--- a/google/cloud/storage/internal/curl_request_builder.h
+++ b/google/cloud/storage/internal/curl_request_builder.h
@@ -195,7 +195,7 @@ class CurlRequestBuilder {
   std::string user_agent_prefix_;
   bool logging_enabled_;
   CurlHandle::SocketOptions socket_options_;
-  std::chrono::seconds download_stall_timeout_;
+  std::chrono::seconds transfer_stall_timeout_;
   std::string http_version_;
 };
 

--- a/google/cloud/storage/internal/grpc_client_read_object_test.cc
+++ b/google/cloud/storage/internal/grpc_client_read_object_test.cc
@@ -88,7 +88,7 @@ TEST(GrpcClientReadObjectTest, WithExplicitTimeout) {
       });
 
   auto client = GrpcClient::CreateMock(
-      mock, Options{}.set<DownloadStallTimeoutOption>(configured_timeout));
+      mock, Options{}.set<TransferStallTimeoutOption>(configured_timeout));
   auto stream =
       client->ReadObject(ReadObjectRangeRequest("test-bucket", "test-object"));
   ASSERT_STATUS_OK(stream);

--- a/google/cloud/storage/options.h
+++ b/google/cloud/storage/options.h
@@ -202,15 +202,27 @@ struct MaximumCurlSocketSendSizeOption {
 };
 
 /**
- * Sets the "stall" timeout.
+ * Sets the transfer stall timeout.
  *
- * If the download "stalls", i.e., no bytes are received for a significant
- * period, it may be better to restart the download as this may indicate a
- * network glitch.
+ * If a transfer (upload, download, or request) *stalls*, i.e., no bytes are
+ * sent or received for a significant period, it may be better to restart the
+ * transfer as this may indicate a network glitch.
+ *
+ * For large requests (e.g. downloads in the GiB to TiB range) this is a better
+ * configuration parameter than a simple parameter, as the transfers will take
+ * minutes or hours to complete. Relying on a timeout value for them would not
+ * work, as the timeout would be too large to be useful. For small requests,
+ * this is as effective as a timeout parameter, but maybe unfamiliar and thus
+ * harder to reason about.
  */
-struct DownloadStallTimeoutOption {
+struct TransferStallTimeoutOption {
   using Type = std::chrono::seconds;
 };
+
+/**
+ * @deprecated Please use TransferStallTimeoutOption instead
+ */
+using DownloadStallTimeoutOption = TransferStallTimeoutOption;
 
 /// Set the retry policy for a GCS client.
 struct RetryPolicyOption {
@@ -234,7 +246,7 @@ using ClientOptionList = ::google::cloud::OptionList<
     DownloadBufferSizeOption, UploadBufferSizeOption,
     EnableCurlSslLockingOption, EnableCurlSigpipeHandlerOption,
     MaximumCurlSocketRecvSizeOption, MaximumCurlSocketSendSizeOption,
-    DownloadStallTimeoutOption, RetryPolicyOption, BackoffPolicyOption,
+    TransferStallTimeoutOption, RetryPolicyOption, BackoffPolicyOption,
     IdempotencyPolicyOption, CARootsFilePathOption,
     storage_experimental::HttpVersionOption>;
 

--- a/google/cloud/storage/options.h
+++ b/google/cloud/storage/options.h
@@ -209,7 +209,7 @@ struct MaximumCurlSocketSendSizeOption {
  * transfer as this may indicate a network glitch.
  *
  * For large requests (e.g. downloads in the GiB to TiB range) this is a better
- * configuration parameter than a simple parameter, as the transfers will take
+ * configuration parameter than a simple timeout, as the transfers will take
  * minutes or hours to complete. Relying on a timeout value for them would not
  * work, as the timeout would be too large to be useful. For small requests,
  * this is as effective as a timeout parameter, but maybe unfamiliar and thus

--- a/google/cloud/storage/tests/object_media_integration_test.cc
+++ b/google/cloud/storage/tests/object_media_integration_test.cc
@@ -612,7 +612,7 @@ TEST_F(ObjectMediaIntegrationTest, StreamingReadTimeout) {
 
   Client client(
       Options{}
-          .set<DownloadStallTimeoutOption>(std::chrono::seconds(3))
+          .set<TransferStallTimeoutOption>(std::chrono::seconds(3))
           .set<RetryPolicyOption>(LimitedErrorCountRetryPolicy(3).clone()));
 
   auto object_name = MakeRandomObjectName();
@@ -642,7 +642,7 @@ TEST_F(ObjectMediaIntegrationTest, StreamingReadTimeoutContinues) {
 
   Client client(
       Options{}
-          .set<DownloadStallTimeoutOption>(std::chrono::seconds(3))
+          .set<TransferStallTimeoutOption>(std::chrono::seconds(3))
           .set<RetryPolicyOption>(LimitedErrorCountRetryPolicy(10).clone()));
 
   auto object_name = MakeRandomObjectName();
@@ -678,7 +678,7 @@ TEST_F(ObjectMediaIntegrationTest, StreamingReadInternalError) {
 
   Client client(
       Options{}
-          .set<DownloadStallTimeoutOption>(std::chrono::seconds(3))
+          .set<TransferStallTimeoutOption>(std::chrono::seconds(3))
           .set<RetryPolicyOption>(LimitedErrorCountRetryPolicy(5).clone()));
 
   auto object_name = MakeRandomObjectName();


### PR DESCRIPTION
With this PR the application can set timeouts for uploads, downloads, or
any other requests. Previously only downloads got timeouts, based on
whether the download "stalled". Now all requests, including uploads
(which are really just a sequence of PUT requests) have a minimum rate
configured.

The application expresses timeouts as "maximum stall time", that is, the
maximum time when no bytes are transferred. Since no bytes are
transferred while the connection is being setup, the same option
configures the maximum connection time.

Fixes #5180

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7295)
<!-- Reviewable:end -->
