### PR TITLE
ci(gcb): increase the GCB timeout

### DIFF
--- a/ci/cloudbuild/cloudbuild.yaml
+++ b/ci/cloudbuild/cloudbuild.yaml
@@ -43,7 +43,7 @@ substitutions:
   _TRIGGER_TYPE: 'manual'
   _LOGS_BUCKET: 'cloud-cpp-community-publiclogs'
 
-timeout: 7500s
+timeout: 9000s
 tags: [
   '${_TRIGGER_TYPE}',
   '${_BUILD_NAME}',

--- a/ci/cloudbuild/cloudbuild.yaml
+++ b/ci/cloudbuild/cloudbuild.yaml
@@ -43,7 +43,7 @@ substitutions:
   _TRIGGER_TYPE: 'manual'
   _LOGS_BUCKET: 'cloud-cpp-community-publiclogs'
 
-timeout: 7200s
+timeout: 7500s
 tags: [
   '${_TRIGGER_TYPE}',
   '${_BUILD_NAME}',


### PR DESCRIPTION
Increase the GCB timeout by 5m so that it is strictly greater than
the bazel timeout for the `integration-daily` Spanner integration
tests against prod, giving the bazel timeout the chance to fire first
and produce its test summary.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7296)
<!-- Reviewable:end -->
