### PR TITLE
cleanup(generator): don't use defaulted options in internal APIs

### DIFF
--- a/generator/integration_tests/golden/golden_kitchen_sink_connection.h
+++ b/generator/integration_tests/golden/golden_kitchen_sink_connection.h
@@ -88,7 +88,7 @@ inline namespace GOOGLE_CLOUD_CPP_GENERATED_NS {
 std::shared_ptr<golden::GoldenKitchenSinkConnection>
 MakeGoldenKitchenSinkConnection(
     std::shared_ptr<GoldenKitchenSinkStub> stub,
-    Options options = {});
+    Options options);
 
 }  // namespace GOOGLE_CLOUD_CPP_GENERATED_NS
 }  // namespace golden_internal

--- a/generator/integration_tests/golden/golden_thing_admin_connection.h
+++ b/generator/integration_tests/golden/golden_thing_admin_connection.h
@@ -120,7 +120,7 @@ inline namespace GOOGLE_CLOUD_CPP_GENERATED_NS {
 std::shared_ptr<golden::GoldenThingAdminConnection>
 MakeGoldenThingAdminConnection(
     std::shared_ptr<GoldenThingAdminStub> stub,
-    Options options = {});
+    Options options);
 
 }  // namespace GOOGLE_CLOUD_CPP_GENERATED_NS
 }  // namespace golden_internal

--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_option_defaults.h
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_option_defaults.h
@@ -27,7 +27,7 @@ namespace cloud {
 namespace golden_internal {
 inline namespace GOOGLE_CLOUD_CPP_GENERATED_NS {
 
-Options GoldenKitchenSinkDefaultOptions(Options options = {});
+Options GoldenKitchenSinkDefaultOptions(Options options);
 
 }  // namespace GOOGLE_CLOUD_CPP_GENERATED_NS
 }  // namespace golden_internal

--- a/generator/integration_tests/golden/internal/golden_thing_admin_option_defaults.h
+++ b/generator/integration_tests/golden/internal/golden_thing_admin_option_defaults.h
@@ -27,7 +27,7 @@ namespace cloud {
 namespace golden_internal {
 inline namespace GOOGLE_CLOUD_CPP_GENERATED_NS {
 
-Options GoldenThingAdminDefaultOptions(Options options = {});
+Options GoldenThingAdminDefaultOptions(Options options);
 
 }  // namespace GOOGLE_CLOUD_CPP_GENERATED_NS
 }  // namespace golden_internal

--- a/generator/internal/connection_generator.cc
+++ b/generator/internal/connection_generator.cc
@@ -164,7 +164,7 @@ Status ConnectionGenerator::GenerateHeader() {
       "std::shared_ptr<$product_namespace$::$connection_class_name$>\n"
       "Make$connection_class_name$(\n"
       "    std::shared_ptr<$stub_class_name$> stub,\n"
-      "    Options options = {});\n\n");
+      "    Options options);\n\n");
   // clang-format on
   HeaderCloseNamespaces();
 

--- a/generator/internal/option_defaults_generator.cc
+++ b/generator/internal/option_defaults_generator.cc
@@ -52,7 +52,7 @@ Status OptionDefaultsGenerator::GenerateHeader() {
   if (!result.ok()) return result;
 
   HeaderPrint(  // clang-format off
-    "Options $service_name$DefaultOptions(Options options = {});\n\n");
+    "Options $service_name$DefaultOptions(Options options);\n\n");
   //clang-format on
 
   HeaderCloseNamespaces();

--- a/google/cloud/bigquery/bigquery_read_connection.h
+++ b/google/cloud/bigquery/bigquery_read_connection.h
@@ -84,7 +84,7 @@ namespace bigquery_internal {
 inline namespace GOOGLE_CLOUD_CPP_GENERATED_NS {
 
 std::shared_ptr<bigquery::BigQueryReadConnection> MakeBigQueryReadConnection(
-    std::shared_ptr<BigQueryReadStub> stub, Options options = {});
+    std::shared_ptr<BigQueryReadStub> stub, Options options);
 
 }  // namespace GOOGLE_CLOUD_CPP_GENERATED_NS
 }  // namespace bigquery_internal

--- a/google/cloud/bigquery/internal/bigquery_read_option_defaults.h
+++ b/google/cloud/bigquery/internal/bigquery_read_option_defaults.h
@@ -27,7 +27,7 @@ namespace cloud {
 namespace bigquery_internal {
 inline namespace GOOGLE_CLOUD_CPP_GENERATED_NS {
 
-Options BigQueryReadDefaultOptions(Options options = {});
+Options BigQueryReadDefaultOptions(Options options);
 
 }  // namespace GOOGLE_CLOUD_CPP_GENERATED_NS
 }  // namespace bigquery_internal

--- a/google/cloud/iam/iam_connection.h
+++ b/google/cloud/iam/iam_connection.h
@@ -149,7 +149,7 @@ namespace iam_internal {
 inline namespace GOOGLE_CLOUD_CPP_GENERATED_NS {
 
 std::shared_ptr<iam::IAMConnection> MakeIAMConnection(
-    std::shared_ptr<IAMStub> stub, Options options = {});
+    std::shared_ptr<IAMStub> stub, Options options);
 
 }  // namespace GOOGLE_CLOUD_CPP_GENERATED_NS
 }  // namespace iam_internal

--- a/google/cloud/iam/iam_credentials_connection.h
+++ b/google/cloud/iam/iam_credentials_connection.h
@@ -78,7 +78,7 @@ namespace iam_internal {
 inline namespace GOOGLE_CLOUD_CPP_GENERATED_NS {
 
 std::shared_ptr<iam::IAMCredentialsConnection> MakeIAMCredentialsConnection(
-    std::shared_ptr<IAMCredentialsStub> stub, Options options = {});
+    std::shared_ptr<IAMCredentialsStub> stub, Options options);
 
 }  // namespace GOOGLE_CLOUD_CPP_GENERATED_NS
 }  // namespace iam_internal

--- a/google/cloud/iam/internal/iam_credentials_option_defaults.h
+++ b/google/cloud/iam/internal/iam_credentials_option_defaults.h
@@ -27,7 +27,7 @@ namespace cloud {
 namespace iam_internal {
 inline namespace GOOGLE_CLOUD_CPP_GENERATED_NS {
 
-Options IAMCredentialsDefaultOptions(Options options = {});
+Options IAMCredentialsDefaultOptions(Options options);
 
 }  // namespace GOOGLE_CLOUD_CPP_GENERATED_NS
 }  // namespace iam_internal

--- a/google/cloud/iam/internal/iam_option_defaults.h
+++ b/google/cloud/iam/internal/iam_option_defaults.h
@@ -27,7 +27,7 @@ namespace cloud {
 namespace iam_internal {
 inline namespace GOOGLE_CLOUD_CPP_GENERATED_NS {
 
-Options IAMDefaultOptions(Options options = {});
+Options IAMDefaultOptions(Options options);
 
 }  // namespace GOOGLE_CLOUD_CPP_GENERATED_NS
 }  // namespace iam_internal

--- a/google/cloud/logging/internal/logging_service_v2_option_defaults.h
+++ b/google/cloud/logging/internal/logging_service_v2_option_defaults.h
@@ -27,7 +27,7 @@ namespace cloud {
 namespace logging_internal {
 inline namespace GOOGLE_CLOUD_CPP_GENERATED_NS {
 
-Options LoggingServiceV2DefaultOptions(Options options = {});
+Options LoggingServiceV2DefaultOptions(Options options);
 
 }  // namespace GOOGLE_CLOUD_CPP_GENERATED_NS
 }  // namespace logging_internal

--- a/google/cloud/logging/logging_service_v2_connection.h
+++ b/google/cloud/logging/logging_service_v2_connection.h
@@ -82,7 +82,7 @@ inline namespace GOOGLE_CLOUD_CPP_GENERATED_NS {
 
 std::shared_ptr<logging::LoggingServiceV2Connection>
 MakeLoggingServiceV2Connection(std::shared_ptr<LoggingServiceV2Stub> stub,
-                               Options options = {});
+                               Options options);
 
 }  // namespace GOOGLE_CLOUD_CPP_GENERATED_NS
 }  // namespace logging_internal

--- a/google/cloud/spanner/admin/database_admin_connection.h
+++ b/google/cloud/spanner/admin/database_admin_connection.h
@@ -133,7 +133,7 @@ inline namespace GOOGLE_CLOUD_CPP_GENERATED_NS {
 
 std::shared_ptr<spanner_admin::DatabaseAdminConnection>
 MakeDatabaseAdminConnection(std::shared_ptr<DatabaseAdminStub> stub,
-                            Options options = {});
+                            Options options);
 
 }  // namespace GOOGLE_CLOUD_CPP_GENERATED_NS
 }  // namespace spanner_admin_internal

--- a/google/cloud/spanner/admin/instance_admin_connection.h
+++ b/google/cloud/spanner/admin/instance_admin_connection.h
@@ -108,7 +108,7 @@ inline namespace GOOGLE_CLOUD_CPP_GENERATED_NS {
 
 std::shared_ptr<spanner_admin::InstanceAdminConnection>
 MakeInstanceAdminConnection(std::shared_ptr<InstanceAdminStub> stub,
-                            Options options = {});
+                            Options options);
 
 }  // namespace GOOGLE_CLOUD_CPP_GENERATED_NS
 }  // namespace spanner_admin_internal

--- a/google/cloud/spanner/admin/internal/database_admin_option_defaults.h
+++ b/google/cloud/spanner/admin/internal/database_admin_option_defaults.h
@@ -27,7 +27,7 @@ namespace cloud {
 namespace spanner_admin_internal {
 inline namespace GOOGLE_CLOUD_CPP_GENERATED_NS {
 
-Options DatabaseAdminDefaultOptions(Options options = {});
+Options DatabaseAdminDefaultOptions(Options options);
 
 }  // namespace GOOGLE_CLOUD_CPP_GENERATED_NS
 }  // namespace spanner_admin_internal

--- a/google/cloud/spanner/admin/internal/instance_admin_option_defaults.h
+++ b/google/cloud/spanner/admin/internal/instance_admin_option_defaults.h
@@ -27,7 +27,7 @@ namespace cloud {
 namespace spanner_admin_internal {
 inline namespace GOOGLE_CLOUD_CPP_GENERATED_NS {
 
-Options InstanceAdminDefaultOptions(Options options = {});
+Options InstanceAdminDefaultOptions(Options options);
 
 }  // namespace GOOGLE_CLOUD_CPP_GENERATED_NS
 }  // namespace spanner_admin_internal


### PR DESCRIPTION
There is no need for defaulted `Options options = {}` arguments in
internal interfaces.  We always have an `Options` value to pass.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7297)
<!-- Reviewable:end -->
