### PR TITLE
feat(GCS+gRPC): support timeouts for all requests

### DIFF
--- a/google/cloud/storage/internal/grpc_client.h
+++ b/google/cloud/storage/internal/grpc_client.h
@@ -41,7 +41,8 @@ class StorageStub;
 class GrpcClient : public RawClient,
                    public std::enable_shared_from_this<GrpcClient> {
  public:
-  static std::shared_ptr<GrpcClient> Create(Options const& opts);
+  // Creates a new instance, assumes the options have all default values set.
+  static std::shared_ptr<GrpcClient> Create(Options opts);
 
   // This is used to create a client from a mocked StorageStub.
   static std::shared_ptr<GrpcClient> CreateMock(
@@ -217,10 +218,11 @@ class GrpcClient : public RawClient,
   static std::string ComputeMD5Hash(std::string const& payload);
 
  protected:
-  explicit GrpcClient(Options const& opts);
-  explicit GrpcClient(std::shared_ptr<StorageStub> stub, Options const& opts);
+  explicit GrpcClient(Options opts);
+  explicit GrpcClient(std::shared_ptr<StorageStub> stub, Options opts);
 
  private:
+  Options options_;
   ClientOptions backwards_compatibility_options_;
   std::unique_ptr<google::cloud::BackgroundThreads> background_;
   std::shared_ptr<StorageStub> stub_;

--- a/google/cloud/storage/internal/grpc_resumable_upload_session.cc
+++ b/google/cloud/storage/internal/grpc_resumable_upload_session.cc
@@ -80,7 +80,6 @@ GrpcResumableUploadSession::last_response() const {
 
 StatusOr<ResumableUploadResponse> GrpcResumableUploadSession::UploadGeneric(
     ConstBufferSequence buffers, bool final_chunk, HashValues const& hashes) {
-  // TODO(#4216) - set the timeout
   auto context = absl::make_unique<grpc::ClientContext>();
   ApplyQueryParameters(*context, request_, "resource");
   auto writer = client_->CreateUploadWriter(std::move(context));


### PR DESCRIPTION
This change makes the gRPC plugin support timeouts for all requests,
just like we do in REST.  The REST timeouts are more clever, based on
progress vs. completion, I am planning to create a separate bug to
improve GCS+gRPC and support progress-based timeouts too.

Fixes #4216

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7299)
<!-- Reviewable:end -->
