### PR TITLE
cleanup: upstream patches from conan recipe

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,9 +34,8 @@ set(GOOGLE_CLOUD_CPP_CXX_STANDARD
     CACHE STRING "Unused. Prefer CMAKE_CXX_STANDARD")
 mark_as_advanced(GOOGLE_CLOUD_CPP_CXX_STANDARD)
 
-set(CMAKE_CXX_STANDARD
-    11
-    CACHE STRING "Configure the C++ standard version for all targets.")
+# Allow applications to override the CMAKE_CXX_STANDARD, but if not set use 11.
+set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 if (NOT ("${GOOGLE_CLOUD_CPP_CXX_STANDARD}" STREQUAL ""))

--- a/external/googleapis/CMakeLists.txt
+++ b/external/googleapis/CMakeLists.txt
@@ -14,8 +14,6 @@
 # limitations under the License.
 # ~~~
 
-cmake_minimum_required(VERSION 3.5)
-
 # Give application developers a hook to configure the version and hash
 # downloaded from GitHub.
 set(GOOGLE_CLOUD_CPP_GOOGLEAPIS_URL
@@ -25,7 +23,7 @@ set(GOOGLE_CLOUD_CPP_GOOGLEAPIS_SHA256
     "127d7ef9c8803ab246ec3c7ab83489ae386d74766725477c444c5ea8948cb9e5")
 
 set(EXTERNAL_GOOGLEAPIS_SOURCE
-    "${CMAKE_BINARY_DIR}/external/googleapis/src/googleapis_download")
+    "${PROJECT_BINARY_DIR}/external/googleapis/src/googleapis_download")
 
 set(EXTERNAL_GOOGLEAPIS_PROTO_FILES
     "google/api/http.proto"
@@ -165,7 +163,7 @@ include(ExternalProject)
 ExternalProject_Add(
     googleapis_download
     EXCLUDE_FROM_ALL ON
-    PREFIX "${CMAKE_BINARY_DIR}/external/googleapis"
+    PREFIX "${PROJECT_BINARY_DIR}/external/googleapis"
     URL ${GOOGLE_CLOUD_CPP_GOOGLEAPIS_URL}
     URL_HASH SHA256=${GOOGLE_CLOUD_CPP_GOOGLEAPIS_SHA256}
     PATCH_COMMAND


### PR DESCRIPTION
For our builds this change has (basically) no effect. For builds
importing `google-cloud-cpp` via `git submodule` or `FetchContent` or
something similar, this isolates the downloaded googleapis files to a
subdirectory of the build.

Fixes #7298 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7301)
<!-- Reviewable:end -->
