### PR TITLE
feat(generator): a better default polling policy for generated LROs

### DIFF
--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_option_defaults.cc
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_option_defaults.cc
@@ -62,13 +62,11 @@ Options GoldenKitchenSinkDefaultOptions(Options options) {
         golden::GoldenKitchenSinkLimitedTimeRetryPolicy(
             std::chrono::minutes(30)).clone());
   }
-
   if (!options.has<golden::GoldenKitchenSinkBackoffPolicyOption>()) {
     options.set<golden::GoldenKitchenSinkBackoffPolicyOption>(
         ExponentialBackoffPolicy(std::chrono::seconds(1),
             std::chrono::minutes(5), kBackoffScaling).clone());
   }
-
   if (!options.has<golden::GoldenKitchenSinkConnectionIdempotencyPolicyOption>()) {
     options.set<golden::GoldenKitchenSinkConnectionIdempotencyPolicyOption>(
         golden::MakeDefaultGoldenKitchenSinkConnectionIdempotencyPolicy());

--- a/generator/integration_tests/golden/internal/golden_thing_admin_option_defaults.cc
+++ b/generator/integration_tests/golden/internal/golden_thing_admin_option_defaults.cc
@@ -62,23 +62,20 @@ Options GoldenThingAdminDefaultOptions(Options options) {
         golden::GoldenThingAdminLimitedTimeRetryPolicy(
             std::chrono::minutes(30)).clone());
   }
-
   if (!options.has<golden::GoldenThingAdminBackoffPolicyOption>()) {
     options.set<golden::GoldenThingAdminBackoffPolicyOption>(
         ExponentialBackoffPolicy(std::chrono::seconds(1),
             std::chrono::minutes(5), kBackoffScaling).clone());
   }
-
   if (!options.has<golden::GoldenThingAdminPollingPolicyOption>()) {
     options.set<golden::GoldenThingAdminPollingPolicyOption>(
-        GenericPollingPolicy<golden::GoldenThingAdminLimitedTimeRetryPolicy,
-        ExponentialBackoffPolicy>(
-            golden::GoldenThingAdminLimitedTimeRetryPolicy(
-                std::chrono::minutes(30)),
-                ExponentialBackoffPolicy(std::chrono::seconds(10),
-                    std::chrono::minutes(5), kBackoffScaling)).clone());
+        GenericPollingPolicy<
+            golden::GoldenThingAdminRetryPolicyOption::Type,
+            golden::GoldenThingAdminBackoffPolicyOption::Type>(
+            options.get<golden::GoldenThingAdminRetryPolicyOption>()->clone(),
+            options.get<golden::GoldenThingAdminBackoffPolicyOption>()->clone())
+            .clone());
   }
-
   if (!options.has<golden::GoldenThingAdminConnectionIdempotencyPolicyOption>()) {
     options.set<golden::GoldenThingAdminConnectionIdempotencyPolicyOption>(
         golden::MakeDefaultGoldenThingAdminConnectionIdempotencyPolicy());

--- a/generator/internal/option_defaults_generator.cc
+++ b/generator/internal/option_defaults_generator.cc
@@ -119,24 +119,21 @@ Status OptionDefaultsGenerator::GenerateCc() {
     "        $product_namespace$::$limited_time_retry_policy_name$(\n"
     "            std::chrono::minutes(30)).clone());\n"
     "  }\n"
-    "\n"
     "  if (!options.has<$product_namespace$::$service_name$BackoffPolicyOption>()) {\n"
     "    options.set<$product_namespace$::$service_name$BackoffPolicyOption>(\n"
     "        ExponentialBackoffPolicy(std::chrono::seconds(1),\n"
     "            std::chrono::minutes(5), kBackoffScaling).clone());\n"
-    "  }\n"
-    "\n"},
+    "  }\n"},
    {[this]{return HasLongrunningMethod();},
     "  if (!options.has<$product_namespace$::$service_name$PollingPolicyOption>()) {\n"
     "    options.set<$product_namespace$::$service_name$PollingPolicyOption>(\n"
-    "        GenericPollingPolicy<$product_namespace$::$limited_time_retry_policy_name$,\n"
-    "        ExponentialBackoffPolicy>(\n"
-    "            $product_namespace$::$limited_time_retry_policy_name$(\n"
-    "                std::chrono::minutes(30)),\n"
-    "                ExponentialBackoffPolicy(std::chrono::seconds(10),\n"
-    "                    std::chrono::minutes(5), kBackoffScaling)).clone());\n"
-    "  }\n"
-    "\n", ""},
+    "        GenericPollingPolicy<\n"
+    "            $product_namespace$::$retry_policy_name$Option::Type,\n"
+    "            $product_namespace$::$service_name$BackoffPolicyOption::Type>(\n"
+    "            options.get<$product_namespace$::$retry_policy_name$Option>()->clone(),\n"
+    "            options.get<$product_namespace$::$service_name$BackoffPolicyOption>()->clone())\n"
+    "            .clone());\n"
+    "  }\n", ""},
    {"  if (!options.has<$product_namespace$::$idempotency_class_name$Option>()) {\n"
     "    options.set<$product_namespace$::$idempotency_class_name$Option>(\n"
     "        $product_namespace$::MakeDefault$idempotency_class_name$());\n"

--- a/google/cloud/bigquery/internal/bigquery_read_option_defaults.cc
+++ b/google/cloud/bigquery/internal/bigquery_read_option_defaults.cc
@@ -59,14 +59,12 @@ Options BigQueryReadDefaultOptions(Options options) {
         bigquery::BigQueryReadLimitedTimeRetryPolicy(std::chrono::minutes(30))
             .clone());
   }
-
   if (!options.has<bigquery::BigQueryReadBackoffPolicyOption>()) {
     options.set<bigquery::BigQueryReadBackoffPolicyOption>(
         ExponentialBackoffPolicy(std::chrono::seconds(1),
                                  std::chrono::minutes(5), kBackoffScaling)
             .clone());
   }
-
   if (!options.has<bigquery::BigQueryReadConnectionIdempotencyPolicyOption>()) {
     options.set<bigquery::BigQueryReadConnectionIdempotencyPolicyOption>(
         bigquery::MakeDefaultBigQueryReadConnectionIdempotencyPolicy());

--- a/google/cloud/iam/internal/iam_credentials_option_defaults.cc
+++ b/google/cloud/iam/internal/iam_credentials_option_defaults.cc
@@ -59,14 +59,12 @@ Options IAMCredentialsDefaultOptions(Options options) {
         iam::IAMCredentialsLimitedTimeRetryPolicy(std::chrono::minutes(30))
             .clone());
   }
-
   if (!options.has<iam::IAMCredentialsBackoffPolicyOption>()) {
     options.set<iam::IAMCredentialsBackoffPolicyOption>(
         ExponentialBackoffPolicy(std::chrono::seconds(1),
                                  std::chrono::minutes(5), kBackoffScaling)
             .clone());
   }
-
   if (!options.has<iam::IAMCredentialsConnectionIdempotencyPolicyOption>()) {
     options.set<iam::IAMCredentialsConnectionIdempotencyPolicyOption>(
         iam::MakeDefaultIAMCredentialsConnectionIdempotencyPolicy());

--- a/google/cloud/iam/internal/iam_option_defaults.cc
+++ b/google/cloud/iam/internal/iam_option_defaults.cc
@@ -58,14 +58,12 @@ Options IAMDefaultOptions(Options options) {
     options.set<iam::IAMRetryPolicyOption>(
         iam::IAMLimitedTimeRetryPolicy(std::chrono::minutes(30)).clone());
   }
-
   if (!options.has<iam::IAMBackoffPolicyOption>()) {
     options.set<iam::IAMBackoffPolicyOption>(
         ExponentialBackoffPolicy(std::chrono::seconds(1),
                                  std::chrono::minutes(5), kBackoffScaling)
             .clone());
   }
-
   if (!options.has<iam::IAMConnectionIdempotencyPolicyOption>()) {
     options.set<iam::IAMConnectionIdempotencyPolicyOption>(
         iam::MakeDefaultIAMConnectionIdempotencyPolicy());

--- a/google/cloud/logging/internal/logging_service_v2_option_defaults.cc
+++ b/google/cloud/logging/internal/logging_service_v2_option_defaults.cc
@@ -60,14 +60,12 @@ Options LoggingServiceV2DefaultOptions(Options options) {
             std::chrono::minutes(30))
             .clone());
   }
-
   if (!options.has<logging::LoggingServiceV2BackoffPolicyOption>()) {
     options.set<logging::LoggingServiceV2BackoffPolicyOption>(
         ExponentialBackoffPolicy(std::chrono::seconds(1),
                                  std::chrono::minutes(5), kBackoffScaling)
             .clone());
   }
-
   if (!options
            .has<logging::LoggingServiceV2ConnectionIdempotencyPolicyOption>()) {
     options.set<logging::LoggingServiceV2ConnectionIdempotencyPolicyOption>(

--- a/google/cloud/polling_policy.h
+++ b/google/cloud/polling_policy.h
@@ -86,15 +86,24 @@ class GenericPollingPolicy : public PollingPolicy {
   }
 
   bool OnFailure(google::cloud::Status const& status) override {
-    return retry_policy_.OnFailure(status);
+    return maybe_deref(retry_policy_).OnFailure(status);
   }
 
   std::chrono::milliseconds WaitPeriod() override {
-    return backoff_policy_.OnCompletion();
+    return maybe_deref(backoff_policy_).OnCompletion();
   }
   //@}
 
  private:
+  template <typename T>
+  T& maybe_deref(T& v) {
+    return v;
+  }
+  template <typename T>
+  T& maybe_deref(std::shared_ptr<T>& v) {
+    return *v;
+  }
+
   Retry retry_policy_;
   Backoff backoff_policy_;
 };

--- a/google/cloud/spanner/admin/integration_tests/backup_integration_test.cc
+++ b/google/cloud/spanner/admin/integration_tests/backup_integration_test.cc
@@ -87,13 +87,6 @@ class BackupTest : public ::google::cloud::testing_util::IntegrationTest {
                 .set<spanner_admin::DatabaseAdminBackoffPolicyOption>(
                     ExponentialBackoffPolicy(std::chrono::seconds(1),
                                              std::chrono::minutes(1), 2.0)
-                        .clone())
-                .set<spanner_admin::DatabaseAdminPollingPolicyOption>(
-                    spanner::GenericPollingPolicy<>(
-                        spanner::LimitedTimeRetryPolicy(
-                            std::chrono::minutes(60)),
-                        ExponentialBackoffPolicy(std::chrono::seconds(1),
-                                                 std::chrono::minutes(1), 2.0))
                         .clone()))) {}
 
  protected:

--- a/google/cloud/spanner/admin/internal/database_admin_option_defaults.cc
+++ b/google/cloud/spanner/admin/internal/database_admin_option_defaults.cc
@@ -64,25 +64,23 @@ Options DatabaseAdminDefaultOptions(Options options) {
             std::chrono::minutes(30))
             .clone());
   }
-
   if (!options.has<spanner_admin::DatabaseAdminBackoffPolicyOption>()) {
     options.set<spanner_admin::DatabaseAdminBackoffPolicyOption>(
         ExponentialBackoffPolicy(std::chrono::seconds(1),
                                  std::chrono::minutes(5), kBackoffScaling)
             .clone());
   }
-
   if (!options.has<spanner_admin::DatabaseAdminPollingPolicyOption>()) {
     options.set<spanner_admin::DatabaseAdminPollingPolicyOption>(
-        GenericPollingPolicy<spanner_admin::DatabaseAdminLimitedTimeRetryPolicy,
-                             ExponentialBackoffPolicy>(
-            spanner_admin::DatabaseAdminLimitedTimeRetryPolicy(
-                std::chrono::minutes(30)),
-            ExponentialBackoffPolicy(std::chrono::seconds(10),
-                                     std::chrono::minutes(5), kBackoffScaling))
+        GenericPollingPolicy<
+            spanner_admin::DatabaseAdminRetryPolicyOption::Type,
+            spanner_admin::DatabaseAdminBackoffPolicyOption::Type>(
+            options.get<spanner_admin::DatabaseAdminRetryPolicyOption>()
+                ->clone(),
+            options.get<spanner_admin::DatabaseAdminBackoffPolicyOption>()
+                ->clone())
             .clone());
   }
-
   if (!options.has<
           spanner_admin::DatabaseAdminConnectionIdempotencyPolicyOption>()) {
     options.set<spanner_admin::DatabaseAdminConnectionIdempotencyPolicyOption>(

--- a/google/cloud/spanner/admin/internal/instance_admin_option_defaults.cc
+++ b/google/cloud/spanner/admin/internal/instance_admin_option_defaults.cc
@@ -64,25 +64,23 @@ Options InstanceAdminDefaultOptions(Options options) {
             std::chrono::minutes(30))
             .clone());
   }
-
   if (!options.has<spanner_admin::InstanceAdminBackoffPolicyOption>()) {
     options.set<spanner_admin::InstanceAdminBackoffPolicyOption>(
         ExponentialBackoffPolicy(std::chrono::seconds(1),
                                  std::chrono::minutes(5), kBackoffScaling)
             .clone());
   }
-
   if (!options.has<spanner_admin::InstanceAdminPollingPolicyOption>()) {
     options.set<spanner_admin::InstanceAdminPollingPolicyOption>(
-        GenericPollingPolicy<spanner_admin::InstanceAdminLimitedTimeRetryPolicy,
-                             ExponentialBackoffPolicy>(
-            spanner_admin::InstanceAdminLimitedTimeRetryPolicy(
-                std::chrono::minutes(30)),
-            ExponentialBackoffPolicy(std::chrono::seconds(10),
-                                     std::chrono::minutes(5), kBackoffScaling))
+        GenericPollingPolicy<
+            spanner_admin::InstanceAdminRetryPolicyOption::Type,
+            spanner_admin::InstanceAdminBackoffPolicyOption::Type>(
+            options.get<spanner_admin::InstanceAdminRetryPolicyOption>()
+                ->clone(),
+            options.get<spanner_admin::InstanceAdminBackoffPolicyOption>()
+                ->clone())
             .clone());
   }
-
   if (!options.has<
           spanner_admin::InstanceAdminConnectionIdempotencyPolicyOption>()) {
     options.set<spanner_admin::InstanceAdminConnectionIdempotencyPolicyOption>(


### PR DESCRIPTION
Add support for constructing a `google::cloud::GenericPollingPolicy` from
`std::shared_ptr<BasePolicy>` values (in addition to the existing support
for `ConcretePolicy` values).

This means that a polling policy can be created from dynamic retry-policy
and backoff-policy values.

Use this in generated `$service_name$DefaultOptions()` functions to build
the default `$service_name$PollingPolicyOption`, for services with long-
running operations, from the prevailing retry and backoff policies (be
they defaulted or not) instead of from some other hard-coded policies.

One slight operation difference for completely defaulted policies is that
the LRO polling policy will now start its doubling exponential backoff at
1s (matching the backoff policy for retry loops) instead of 10s.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7305)
<!-- Reviewable:end -->
