### PR TITLE
test(spanner): avoid multi-region instances in CMEK backup test

### DIFF
--- a/google/cloud/spanner/admin/integration_tests/backup_integration_test.cc
+++ b/google/cloud/spanner/admin/integration_tests/backup_integration_test.cc
@@ -483,8 +483,8 @@ TEST_F(BackupTest, CreateBackupWithFutureVersionTime) {
 TEST_F(BackupTest, BackupTestWithCMEK) {
   if (!RunSlowBackupTests() || Emulator()) GTEST_SKIP();
 
-  auto instance_id =
-      spanner_testing::PickRandomInstance(generator_, ProjectId());
+  auto instance_id = spanner_testing::PickRandomInstance(
+      generator_, ProjectId(), "NOT name:/instances/test-instance-mr-");
   ASSERT_STATUS_OK(instance_id);
   Instance in(ProjectId(), *instance_id);
 

--- a/google/cloud/spanner/integration_tests/backup_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/backup_integration_test.cc
@@ -413,8 +413,8 @@ TEST_F(BackupTest, CreateBackupWithFutureVersionTime) {
 TEST_F(BackupTest, BackupTestWithCMEK) {
   if (!RunSlowBackupTests() || Emulator()) GTEST_SKIP();
 
-  auto instance_id =
-      spanner_testing::PickRandomInstance(generator_, ProjectId());
+  auto instance_id = spanner_testing::PickRandomInstance(
+      generator_, ProjectId(), "NOT name:/instances/test-instance-mr-");
   ASSERT_STATUS_OK(instance_id);
   Instance in(ProjectId(), *instance_id);
 


### PR DESCRIPTION
Not every Cloud Spanner multi-region instance configuration has
a corresponding key ring location in Cloud KMS, so it may not be
possible to create CMEK-enabled databases in such instances.

Fixes #7304.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7307)
<!-- Reviewable:end -->
