### PR TITLE
cleanup(docs): initial capitalization

### DIFF
--- a/google/cloud/bigtable/client_options.h
+++ b/google/cloud/bigtable/client_options.h
@@ -431,7 +431,7 @@ class ClientOptions {
   /**
    * Set the number of background threads.
    *
-   * @note this value is not used if `DisableBackgroundThreads()` is called.
+   * @note This value is not used if `DisableBackgroundThreads()` is called.
    */
   ClientOptions& set_background_thread_pool_size(std::size_t s) {
     opts_.set<GrpcBackgroundThreadPoolSizeOption>(s);

--- a/google/cloud/bigtable/table.h
+++ b/google/cloud/bigtable/table.h
@@ -504,7 +504,7 @@ class Table {
    * @param row_key the row to read.
    * @param filter a filter expression, can be used to select a subset of the
    *     column families and columns in the row.
-   * @returns A tuple, the first element is a boolean, with value `false` if the
+   * @returns a tuple, the first element is a boolean, with value `false` if the
    *     row does not exist.  If the first element is `true` the second element
    *     has the contents of the Row.  Note that the contents may be empty
    *     if the filter expression removes all column families and columns.
@@ -588,10 +588,9 @@ class Table {
   /**
    * Sample of the row keys in the table, including approximate data sizes.
    *
-   * @returns Note that the sample may only include one element for small
-   *     tables.  In addition, the sample may include row keys that do not exist
-   *     on the table, and may include the empty row key to indicate
-   *     "end of table".
+   * @note The sample may only include one element for small tables.  In
+   *     addition, the sample may include row keys that do not exist on the
+   *     table, and may include the empty row key to indicate "end of table".
    *
    * @par Idempotency
    * This operation is always treated as idempotent.
@@ -610,11 +609,11 @@ class Table {
    * Asynchronously obtains a sample of the row keys in the table, including
    * approximate data sizes.
    *
-   * @returns A future, that becomes satisfied when the operation completes.
-   *     Note that the sample may only include one element for small tables.
-   *     In addition, the sample may include row keys that do not exist on
-   *     the table, and may include the empty row key to indicate "end of
-   *     table".
+   * @returns a future, that becomes satisfied when the operation completes.
+   *
+   * @note The sample may only include one element for small tables. In
+   *     addition, the sample may include row keys that do not exist on the
+   *     table, and may include the empty row key to indicate "end of table".
    *
    * @par Idempotency
    * This operation is always treated as idempotent.
@@ -642,7 +641,7 @@ class Table {
    *     and add the value provided.
    *     Both rules accept the family and column identifier to modify.
    * @param rules is the zero or more ReadModifyWriteRules to apply on a row.
-   * @returns The new contents of all modified cells.
+   * @returns the new contents of all modified cells.
    *
    * @par Idempotency
    * This operation is always treated as non-idempotent.
@@ -691,7 +690,7 @@ class Table {
    *     and add the value provided.
    *     Both rules accept the family and column identifier to modify.
    * @param rules is the zero or more ReadModifyWriteRules to apply on a row.
-   * @returns A future, that becomes satisfied when the operation completes,
+   * @returns a future, that becomes satisfied when the operation completes,
    *     at that point the future has the contents of all modified cells.
    *
    * @par Idempotency
@@ -818,7 +817,7 @@ class Table {
    * @param row_key the row to read.
    * @param filter a filter expression, can be used to select a subset of the
    *     column families and columns in the row.
-   * @returns A future satisfied when the operation completes, fails
+   * @returns a future satisfied when the operation completes, fails
    *     permanently or keeps failing transiently, but the retry policy has been
    *     exhausted. The future will return a tuple. The first element is a
    *     boolean, with value `false` if the row does not exist.  If the first

--- a/google/cloud/bigtable/table.h
+++ b/google/cloud/bigtable/table.h
@@ -504,7 +504,7 @@ class Table {
    * @param row_key the row to read.
    * @param filter a filter expression, can be used to select a subset of the
    *     column families and columns in the row.
-   * @returns a tuple, the first element is a boolean, with value `false` if the
+   * @returns A tuple, the first element is a boolean, with value `false` if the
    *     row does not exist.  If the first element is `true` the second element
    *     has the contents of the Row.  Note that the contents may be empty
    *     if the filter expression removes all column families and columns.
@@ -818,7 +818,7 @@ class Table {
    * @param row_key the row to read.
    * @param filter a filter expression, can be used to select a subset of the
    *     column families and columns in the row.
-   * @returns a future satisfied when the operation completes, fails
+   * @returns A future satisfied when the operation completes, fails
    *     permanently or keeps failing transiently, but the retry policy has been
    *     exhausted. The future will return a tuple. The first element is a
    *     boolean, with value `false` if the row does not exist.  If the first

--- a/google/cloud/connection_options.h
+++ b/google/cloud/connection_options.h
@@ -206,7 +206,7 @@ class ConnectionOptions {
   /**
    * Set the number of background threads.
    *
-   * @note this value is not used if `DisableBackgroundThreads()` is called.
+   * @note This value is not used if `DisableBackgroundThreads()` is called.
    */
   ConnectionOptions& set_background_thread_pool_size(std::size_t s) {
     background_thread_pool_size_ = s;

--- a/google/cloud/grpc_options.h
+++ b/google/cloud/grpc_options.h
@@ -96,7 +96,7 @@ struct GrpcTracingOptionsOption {
 /**
  * The size of the background thread pool
  *
- * @note This is ingored if `GrpcBackgroundThreadsFactoryOption` is set.
+ * @note This is ignored if `GrpcBackgroundThreadsFactoryOption` is set.
  */
 struct GrpcBackgroundThreadPoolSizeOption {
   using Type = std::size_t;

--- a/google/cloud/grpc_options.h
+++ b/google/cloud/grpc_options.h
@@ -96,7 +96,7 @@ struct GrpcTracingOptionsOption {
 /**
  * The size of the background thread pool
  *
- * @note this is ingored if `GrpcBackgroundThreadsFactoryOption` is set.
+ * @note This is ingored if `GrpcBackgroundThreadsFactoryOption` is set.
  */
 struct GrpcBackgroundThreadPoolSizeOption {
   using Type = std::size_t;

--- a/google/cloud/internal/async_read_write_stream_impl.h
+++ b/google/cloud/internal/async_read_write_stream_impl.h
@@ -160,7 +160,7 @@ using PrepareAsyncReadWriteRpc = absl::FunctionRef<
 /**
  * Make an asynchronous streaming read/write RPC using `CompletionQueue`.
  *
- * @note in the past we would have made this a member function of the
+ * @note In the past we would have made this a member function of the
  *     `CompletionQueue` class. We want to avoid this as (a) we are not certain
  *     this is the long term API we want to expose, (b) once in the public
  *     `CompletionQueue` class it is hard to remove member functions.  Placing

--- a/google/cloud/internal/retry_policy.h
+++ b/google/cloud/internal/retry_policy.h
@@ -79,7 +79,7 @@ class TraitBasedRetryPolicy : public RetryPolicy {
  public:
   ///@{
   /**
-   * @name type traits
+   * @name Type traits
    */
   /// The traits describing which errors are permanent failures
   using RetryableTraits = RetryableTraitsP;

--- a/google/cloud/internal/streaming_read_rpc.h
+++ b/google/cloud/internal/streaming_read_rpc.h
@@ -77,7 +77,7 @@ void StreamingReadRpcReportUnhandledError(Status const& status,
 /**
  * Implement `StreamingReadRpc<ResponseType>` using the gRPC abstractions.
  *
- * @note this class is thread compatible, but it is not thread safe. It should
+ * @note This class is thread compatible, but it is not thread safe. It should
  *   not be used from multiple threads at the same time.
  */
 template <typename ResponseType>

--- a/google/cloud/internal/streaming_write_rpc.h
+++ b/google/cloud/internal/streaming_write_rpc.h
@@ -68,7 +68,7 @@ void StreamingWriteRpcReportUnhandledError(Status const& status,
  * Implement `StreamingWriteRpc<RequestType, ResponseType>` using the gRPC
  * abstractions.
  *
- * @note this class is thread compatible, but it is not thread safe. It should
+ * @note This class is thread compatible, but it is not thread safe. It should
  *   not be used from multiple threads at the same time.
  */
 template <typename RequestType, typename ResponseType>

--- a/google/cloud/kms_key_name.h
+++ b/google/cloud/kms_key_name.h
@@ -37,7 +37,7 @@ StatusOr<KmsKeyName> MakeKmsKeyName(std::string full_name);
  * A KMS key is identified by its `project_id`, `location`, `key_ring`,
  * and `kms_key_name`.
  *
- * @note this class makes no effort to validate the components of the key,
+ * @note This class makes no effort to validate the components of the key,
  *     It is the application's responsibility to provide a valid project id,
  *     location, key ring, and KMS key name. Passing invalid values will not
  *     be checked until the key is used in a RPC.

--- a/google/cloud/pubsub/publisher_options.h
+++ b/google/cloud/pubsub/publisher_options.h
@@ -67,12 +67,12 @@ class PublisherOptions {
   /**
    * Sets the maximum hold time for the messages.
    *
-   * @note while this function accepts durations in arbitrary precision, the
+   * @note While this function accepts durations in arbitrary precision, the
    *     implementation depends on the granularity of your OS timers. It is
    *     possible that messages are held for slightly longer times than the
    *     value set here.
    *
-   * @note the first message in a batch starts the hold time counter. New
+   * @note The first message in a batch starts the hold time counter. New
    *     messages do not extend the life of the batch. For example, if you have
    *     set the holding time to 10 milliseconds, start a batch with message 1,
    *     and publish a second message 5 milliseconds later, the second message

--- a/google/cloud/pubsub/schema_admin_client.h
+++ b/google/cloud/pubsub/schema_admin_client.h
@@ -32,7 +32,7 @@ inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
  * Applications use this class to perform operations on
  * [Cloud Pub/Sub][pubsub-doc-link].
  *
- * @warning the Cloud Pub/Sub schema API and the C++ client library for the
+ * @warning The Cloud Pub/Sub schema API and the C++ client library for the
  *     Cloud Pub/Sub schema APIs are experimental. They are subject to change,
  *     including complete removal, without notice.
  *

--- a/google/cloud/spanner/backup.h
+++ b/google/cloud/spanner/backup.h
@@ -30,7 +30,7 @@ inline namespace SPANNER_CLIENT_NS {
  *
  * A Cloud Spanner backup is identified by an `Instance` and a `backup_id`.
  *
- * @note this class makes no effort to validate the components of the
+ * @note This class makes no effort to validate the components of the
  *     backup name. It is the application's responsibility to provide valid
  *     project, instance, and backup ids. Passing invalid values will not be
  *     checked until the backup name is used in a RPC to spanner.

--- a/google/cloud/spanner/database.h
+++ b/google/cloud/spanner/database.h
@@ -32,7 +32,7 @@ inline namespace SPANNER_CLIENT_NS {
  * A Cloud Spanner database is identified by its `project_id`, `instance_id`,
  * and `database_id`.
  *
- * @note this class makes no effort to validate the components of the
+ * @note This class makes no effort to validate the components of the
  *     database name. It is the application's responsibility to provide valid
  *     project, instance, and database ids. Passing invalid values will not be
  *     checked until the database name is used in a RPC to spanner.

--- a/google/cloud/spanner/instance.h
+++ b/google/cloud/spanner/instance.h
@@ -30,7 +30,7 @@ inline namespace SPANNER_CLIENT_NS {
  *
  * A Cloud Spanner instance is identified by its `project_id` and `instance_id`.
  *
- * @note this class makes no effort to validate the components of the
+ * @note This class makes no effort to validate the components of the
  *     database name. It is the application's responsibility to provide valid
  *     project, and instance ids. Passing invalid values will not be checked
  *     until the instance name is used in a RPC to spanner.

--- a/google/cloud/spanner/internal/session_pool.h
+++ b/google/cloud/spanner/internal/session_pool.h
@@ -108,7 +108,7 @@ class SessionPool : public std::enable_shared_from_this<SessionPool> {
   /**
    * Construct a `SessionPool`.
    *
-   * @warning must call Initialize() once immediately after the constructor.
+   * @warning Must call Initialize() once immediately after the constructor.
    */
   SessionPool(spanner::Database db,
               std::vector<std::shared_ptr<SpannerStub>> stubs,

--- a/google/cloud/spanner/row.h
+++ b/google/cloud/spanner/row.h
@@ -435,7 +435,7 @@ class TupleStream {
  *
  * @snippet samples.cc stream-of
  *
- * @note ownership of the @p range is not transferred, so it must outlive the
+ * @note Ownership of the @p range is not transferred, so it must outlive the
  *     returned `TupleStream`.
  *
  * @tparam RowRange must be a range defined by `RowStreamIterator`s.

--- a/google/cloud/storage/grpc_plugin.h
+++ b/google/cloud/storage/grpc_plugin.h
@@ -59,12 +59,12 @@ struct GrpcPluginOption {
 /**
  * Create a `google::cloud::storage::Client` object configured to use gRPC.
  *
- * @note the Credentials parameter in the configuration is ignored. The gRPC
+ * @note The Credentials parameter in the configuration is ignored. The gRPC
  *     client only supports Google Default Credentials.
  *
  * @param opts the configuration parameters for the Client.
  *
- * @warning this is an experimental feature, and subject to change without
+ * @warning This is an experimental feature, and subject to change without
  *     notice.
  *
  * @par Example storage_grpc_samples.cc grpc-read-write

--- a/google/cloud/storage/internal/hash_validator.h
+++ b/google/cloud/storage/internal/hash_validator.h
@@ -59,7 +59,7 @@ class HashValidator {
   /**
    * Compute the final hash values.
    *
-   * @returns The two hashes, expected is the locally computed value, actual is
+   * @returns the two hashes. Expected is the locally computed value, actual is
    *   the value reported by the service. Note that this can be empty for
    *   validators that disable validation.
    */

--- a/google/cloud/storage/internal/policy_document_request.h
+++ b/google/cloud/storage/internal/policy_document_request.h
@@ -47,7 +47,7 @@ class PolicyDocumentRequest {
   /**
    * Creates the string to be signed.
    *
-   * @note unlike signed URLs, policy documents are base64-encoded before
+   * @note Unlike signed URLs, policy documents are base64-encoded before
    * being signed.
    */
   std::string StringToSign() const;
@@ -92,7 +92,7 @@ class PolicyDocumentV4Request {
   /**
    * Creates the string to be signed.
    *
-   * @note unlike signed URLs, policy documents are base64-encoded before
+   * @note Unlike signed URLs, policy documents are base64-encoded before
    * being signed.
    */
   std::string StringToSign() const;

--- a/google/cloud/storage/object_read_stream.h
+++ b/google/cloud/storage/object_read_stream.h
@@ -127,7 +127,7 @@ class ObjectReadStream : public std::basic_istream<char> {
   /**
    * The headers (if any) returned by the service. For debugging only.
    *
-   * @warning the contents of these headers may change without notice. Unless
+   * @warning The contents of these headers may change without notice. Unless
    *     documented in the API, headers may be removed or added by the service.
    *     Also note that the client library uses both the XML and JSON API,
    *     choosing between them based on the feature set (some functionality is

--- a/google/cloud/storage/object_write_stream.h
+++ b/google/cloud/storage/object_write_stream.h
@@ -233,7 +233,7 @@ class ObjectWriteStream : public std::basic_ostream<char> {
   /**
    * The headers (if any) returned by the service. For debugging only.
    *
-   * @warning the contents of these headers may change without notice. Unless
+   * @warning The contents of these headers may change without notice. Unless
    *     documented in the API, headers may be removed or added by the service.
    *     Also note that the client library uses both the XML and JSON API,
    *     choosing between them based on the feature set (some functionality is

--- a/google/cloud/testing_util/example_driver.h
+++ b/google/cloud/testing_util/example_driver.h
@@ -46,7 +46,7 @@ using Commands = std::map<std::string, CommandType>;
 /**
  * Drive the execution of code examples for the Cloud C++ client libraries.
  *
- * @note the examples always assume that exceptions are enabled. We prefer
+ * @note The examples always assume that exceptions are enabled. We prefer
  * clarity over portability for example code.
  *
  * We often (ideally always) write examples showing how to use each key API in

--- a/google/cloud/testing_util/validate_metadata.h
+++ b/google/cloud/testing_util/validate_metadata.h
@@ -42,7 +42,7 @@ namespace testing_util {
  * @param resource_prefix_header if specified, this is the expected value for
  *     the google-cloud-resource-prefix metadata header.
  *
- * @warning the `context` will be destroyed and shouldn't be used after passing
+ * @warning The `context` will be destroyed and shouldn't be used after passing
  *     it to this function.
  *
  * @return an OK status if the `context` is properly set up
@@ -60,7 +60,7 @@ Status IsContextMDValid(
  * does. In order to transform the `ClientContext` into `ServerContext`
  * we spin up a server and a client and send some garbage with this context.
  *
- * @note this invalidates the @p context parameter.
+ * @note This invalidates the @p context parameter.
  */
 std::multimap<std::string, std::string> GetMetadata(
     grpc::ClientContext& context);


### PR DESCRIPTION
Capitalize initial letter for `@name`, `@note`, `@returns`, and `@warning` doxygen comments.

I didn't touch `@param [[:alpha:]]* [[:alpha:]]`, but I would be happy to. By my count there are:

| Initial Capitalization | Lines | Files |
|-|-|-|
| Lowercase | 455 | 68 |
| Uppercase | 60 | 6 |

I think using Uppercase with would be slightly better, but I don't really want to change the majority of the instances.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7310)
<!-- Reviewable:end -->
