### PR TITLE
cleanup(pubsub): rename Maximum to Max in Options

### DIFF
--- a/google/cloud/pubsub/internal/defaults.cc
+++ b/google/cloud/pubsub/internal/defaults.cc
@@ -24,21 +24,21 @@ namespace pubsub_internal {
 inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
 
 Options DefaultPublisherOptions(Options opts) {
-  if (!opts.has<pubsub::MaximumHoldTimeOption>()) {
-    opts.set<pubsub::MaximumHoldTimeOption>(std::chrono::milliseconds(10));
+  if (!opts.has<pubsub::MaxHoldTimeOption>()) {
+    opts.set<pubsub::MaxHoldTimeOption>(std::chrono::milliseconds(10));
   }
-  if (!opts.has<pubsub::MaximumBatchMessagesOption>()) {
-    opts.set<pubsub::MaximumBatchMessagesOption>(100);
+  if (!opts.has<pubsub::MaxBatchMessagesOption>()) {
+    opts.set<pubsub::MaxBatchMessagesOption>(100);
   }
-  if (!opts.has<pubsub::MaximumBatchBytesOption>()) {
-    opts.set<pubsub::MaximumBatchBytesOption>(1024 * 1024L);
+  if (!opts.has<pubsub::MaxBatchBytesOption>()) {
+    opts.set<pubsub::MaxBatchBytesOption>(1024 * 1024L);
   }
-  if (!opts.has<pubsub::MaximumPendingBytesOption>()) {
-    opts.set<pubsub::MaximumPendingBytesOption>(
+  if (!opts.has<pubsub::MaxPendingBytesOption>()) {
+    opts.set<pubsub::MaxPendingBytesOption>(
         (std::numeric_limits<std::size_t>::max)());
   }
-  if (!opts.has<pubsub::MaximumPendingMessagesOption>()) {
-    opts.set<pubsub::MaximumPendingMessagesOption>(
+  if (!opts.has<pubsub::MaxPendingMessagesOption>()) {
+    opts.set<pubsub::MaxPendingMessagesOption>(
         (std::numeric_limits<std::size_t>::max)());
   }
   if (!opts.has<pubsub::MessageOrderingOption>()) {

--- a/google/cloud/pubsub/internal/defaults_test.cc
+++ b/google/cloud/pubsub/internal/defaults_test.cc
@@ -27,13 +27,13 @@ using ms = std::chrono::milliseconds;
 
 TEST(OptionsTest, PublisherDefaults) {
   auto opts = DefaultPublisherOptions(Options{});
-  EXPECT_EQ(ms(10), opts.get<pubsub::MaximumHoldTimeOption>());
-  EXPECT_EQ(100, opts.get<pubsub::MaximumBatchMessagesOption>());
-  EXPECT_EQ(1024 * 1024L, opts.get<pubsub::MaximumBatchBytesOption>());
+  EXPECT_EQ(ms(10), opts.get<pubsub::MaxHoldTimeOption>());
+  EXPECT_EQ(100, opts.get<pubsub::MaxBatchMessagesOption>());
+  EXPECT_EQ(1024 * 1024L, opts.get<pubsub::MaxBatchBytesOption>());
   EXPECT_EQ((std::numeric_limits<std::size_t>::max)(),
-            opts.get<pubsub::MaximumPendingBytesOption>());
+            opts.get<pubsub::MaxPendingBytesOption>());
   EXPECT_EQ((std::numeric_limits<std::size_t>::max)(),
-            opts.get<pubsub::MaximumPendingMessagesOption>());
+            opts.get<pubsub::MaxPendingMessagesOption>());
   EXPECT_EQ(false, opts.get<pubsub::MessageOrderingOption>());
   EXPECT_EQ(pubsub::FullPublisherAction::kBlocks,
             opts.get<pubsub::FullPublisherActionOption>());
@@ -42,20 +42,20 @@ TEST(OptionsTest, PublisherDefaults) {
 TEST(OptionsTest, UserSetPublisherOptions) {
   auto opts =
       DefaultPublisherOptions(Options{}
-                                  .set<pubsub::MaximumHoldTimeOption>(ms(100))
-                                  .set<pubsub::MaximumBatchMessagesOption>(1)
-                                  .set<pubsub::MaximumBatchBytesOption>(2)
-                                  .set<pubsub::MaximumPendingBytesOption>(3)
-                                  .set<pubsub::MaximumPendingMessagesOption>(4)
+                                  .set<pubsub::MaxHoldTimeOption>(ms(100))
+                                  .set<pubsub::MaxBatchMessagesOption>(1)
+                                  .set<pubsub::MaxBatchBytesOption>(2)
+                                  .set<pubsub::MaxPendingBytesOption>(3)
+                                  .set<pubsub::MaxPendingMessagesOption>(4)
                                   .set<pubsub::MessageOrderingOption>(true)
                                   .set<pubsub::FullPublisherActionOption>(
                                       pubsub::FullPublisherAction::kIgnored));
 
-  EXPECT_EQ(ms(100), opts.get<pubsub::MaximumHoldTimeOption>());
-  EXPECT_EQ(1U, opts.get<pubsub::MaximumBatchMessagesOption>());
-  EXPECT_EQ(2U, opts.get<pubsub::MaximumBatchBytesOption>());
-  EXPECT_EQ(3U, opts.get<pubsub::MaximumPendingBytesOption>());
-  EXPECT_EQ(4U, opts.get<pubsub::MaximumPendingMessagesOption>());
+  EXPECT_EQ(ms(100), opts.get<pubsub::MaxHoldTimeOption>());
+  EXPECT_EQ(1U, opts.get<pubsub::MaxBatchMessagesOption>());
+  EXPECT_EQ(2U, opts.get<pubsub::MaxBatchBytesOption>());
+  EXPECT_EQ(3U, opts.get<pubsub::MaxPendingBytesOption>());
+  EXPECT_EQ(4U, opts.get<pubsub::MaxPendingMessagesOption>());
   EXPECT_EQ(true, opts.get<pubsub::MessageOrderingOption>());
   EXPECT_EQ(pubsub::FullPublisherAction::kIgnored,
             opts.get<pubsub::FullPublisherActionOption>());

--- a/google/cloud/pubsub/options.h
+++ b/google/cloud/pubsub/options.h
@@ -60,7 +60,7 @@ inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
  *     and publish a second message 5 milliseconds later, the second message
  *     will be flushed approximately 5 milliseconds after it is published.
  */
-struct MaximumHoldTimeOption {
+struct MaxHoldTimeOption {
   using Type = std::chrono::microseconds;
 };
 
@@ -74,7 +74,7 @@ struct MaximumHoldTimeOption {
  *
  * [pubsub-quota-link]: https://cloud.google.com/pubsub/quotas#resource_limits
  */
-struct MaximumBatchMessagesOption {
+struct MaxBatchMessagesOption {
   using Type = std::size_t;
 };
 
@@ -88,7 +88,7 @@ struct MaximumBatchMessagesOption {
  *
  * [pubsub-quota-link]: https://cloud.google.com/pubsub/quotas#resource_limits
  */
-struct MaximumBatchBytesOption {
+struct MaxBatchBytesOption {
   using Type = std::size_t;
 };
 
@@ -103,7 +103,7 @@ struct MaximumBatchBytesOption {
  * messages they can tolerate in this pending state, and may prefer to block
  * or reject messages.
  */
-struct MaximumPendingMessagesOption {
+struct MaxPendingMessagesOption {
   using Type = std::size_t;
 };
 
@@ -118,7 +118,7 @@ struct MaximumPendingMessagesOption {
  * messages they can tolerate in this pending state, and may prefer to block
  * or reject messages.
  */
-struct MaximumPendingBytesOption {
+struct MaxPendingBytesOption {
   using Type = std::size_t;
 };
 
@@ -156,10 +156,9 @@ struct FullPublisherActionOption {
 
 /// The list of options specific to publishers
 using PublisherOptionList =
-    OptionList<MaximumHoldTimeOption, MaximumBatchMessagesOption,
-               MaximumBatchBytesOption, MaximumPendingMessagesOption,
-               MaximumPendingBytesOption, MessageOrderingOption,
-               FullPublisherActionOption>;
+    OptionList<MaxHoldTimeOption, MaxBatchMessagesOption, MaxBatchBytesOption,
+               MaxPendingMessagesOption, MaxPendingBytesOption,
+               MessageOrderingOption, FullPublisherActionOption>;
 
 }  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS
 }  // namespace pubsub

--- a/google/cloud/pubsub/publisher_options.h
+++ b/google/cloud/pubsub/publisher_options.h
@@ -88,7 +88,7 @@ class PublisherOptions {
    * [quota limits]: https://cloud.google.com/pubsub/quotas#resource_limits
    */
   std::chrono::microseconds maximum_hold_time() const {
-    return opts_.get<MaximumHoldTimeOption>();
+    return opts_.get<MaxHoldTimeOption>();
   }
 
   /**
@@ -108,13 +108,13 @@ class PublisherOptions {
   template <typename Rep, typename Period>
   PublisherOptions& set_maximum_hold_time(
       std::chrono::duration<Rep, Period> v) {
-    opts_.set<MaximumHoldTimeOption>(
+    opts_.set<MaxHoldTimeOption>(
         std::chrono::duration_cast<std::chrono::microseconds>(v));
     return *this;
   }
 
   std::size_t maximum_batch_message_count() const {
-    return opts_.get<MaximumBatchMessagesOption>();
+    return opts_.get<MaxBatchMessagesOption>();
   }
 
   /**
@@ -128,12 +128,12 @@ class PublisherOptions {
    * [pubsub-quota-link]: https://cloud.google.com/pubsub/quotas#resource_limits
    */
   PublisherOptions& set_maximum_batch_message_count(std::size_t v) {
-    opts_.set<MaximumBatchMessagesOption>(v);
+    opts_.set<MaxBatchMessagesOption>(v);
     return *this;
   }
 
   std::size_t maximum_batch_bytes() const {
-    return opts_.get<MaximumBatchBytesOption>();
+    return opts_.get<MaxBatchBytesOption>();
   }
 
   /**
@@ -147,7 +147,7 @@ class PublisherOptions {
    * [pubsub-quota-link]: https://cloud.google.com/pubsub/quotas#resource_limits
    */
   PublisherOptions& set_maximum_batch_bytes(std::size_t v) {
-    opts_.set<MaximumBatchBytesOption>(v);
+    opts_.set<MaxBatchBytesOption>(v);
     return *this;
   }
   //@}
@@ -205,21 +205,21 @@ class PublisherOptions {
 
   /// Flow control based on pending bytes.
   PublisherOptions& set_maximum_pending_bytes(std::size_t v) {
-    opts_.set<MaximumPendingBytesOption>(v);
+    opts_.set<MaxPendingBytesOption>(v);
     return *this;
   }
 
   /// Flow control based on pending messages.
   PublisherOptions& set_maximum_pending_messages(std::size_t v) {
-    opts_.set<MaximumPendingMessagesOption>(v);
+    opts_.set<MaxPendingMessagesOption>(v);
     return *this;
   }
 
   std::size_t maximum_pending_bytes() const {
-    return opts_.get<MaximumPendingBytesOption>();
+    return opts_.get<MaxPendingBytesOption>();
   }
   std::size_t maximum_pending_messages() const {
-    return opts_.get<MaximumPendingMessagesOption>();
+    return opts_.get<MaxPendingMessagesOption>();
   }
 
   /// The current action for a full publisher

--- a/google/cloud/pubsub/publisher_options_test.cc
+++ b/google/cloud/pubsub/publisher_options_test.cc
@@ -82,11 +82,11 @@ TEST(PublisherOptions, FullPublisherAction) {
 TEST(PublisherOptions, OptionsConstructor) {
   auto const b = PublisherOptions(
       Options{}
-          .set<MaximumHoldTimeOption>(std::chrono::seconds(12))
-          .set<MaximumBatchMessagesOption>(10)
-          .set<MaximumBatchBytesOption>(123)
-          .set<MaximumPendingMessagesOption>(4)
-          .set<MaximumPendingBytesOption>(444)
+          .set<MaxHoldTimeOption>(std::chrono::seconds(12))
+          .set<MaxBatchMessagesOption>(10)
+          .set<MaxBatchBytesOption>(123)
+          .set<MaxPendingMessagesOption>(4)
+          .set<MaxPendingBytesOption>(444)
           .set<MessageOrderingOption>(true)
           .set<FullPublisherActionOption>(FullPublisherAction::kRejects));
 
@@ -111,11 +111,11 @@ TEST(PublisherOptions, MakeOptions) {
                .enable_message_ordering();
 
   auto opts = pubsub_internal::MakeOptions(std::move(b));
-  EXPECT_EQ(std::chrono::seconds(12), opts.get<MaximumHoldTimeOption>());
-  EXPECT_EQ(10, opts.get<MaximumBatchMessagesOption>());
-  EXPECT_EQ(123, opts.get<MaximumBatchBytesOption>());
-  EXPECT_EQ(4, opts.get<MaximumPendingMessagesOption>());
-  EXPECT_EQ(444, opts.get<MaximumPendingBytesOption>());
+  EXPECT_EQ(std::chrono::seconds(12), opts.get<MaxHoldTimeOption>());
+  EXPECT_EQ(10, opts.get<MaxBatchMessagesOption>());
+  EXPECT_EQ(123, opts.get<MaxBatchBytesOption>());
+  EXPECT_EQ(4, opts.get<MaxPendingMessagesOption>());
+  EXPECT_EQ(444, opts.get<MaxPendingBytesOption>());
   EXPECT_EQ(true, opts.get<MessageOrderingOption>());
 
   auto ignored = PublisherOptions{}.set_full_publisher_ignored();


### PR DESCRIPTION
This is technically a breaking change of anyone who lives at HEAD and who has updated in the last 22 hours.

I would just prefer to use shorter names, that are more consistent with other Options in our library.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7315)
<!-- Reviewable:end -->
