### PR TITLE
test(spanner): extend RestoreDatabase() polling retry time

### DIFF
--- a/google/cloud/spanner/admin/integration_tests/backup_integration_test.cc
+++ b/google/cloud/spanner/admin/integration_tests/backup_integration_test.cc
@@ -87,6 +87,12 @@ class BackupTest : public ::google::cloud::testing_util::IntegrationTest {
                 .set<spanner_admin::DatabaseAdminBackoffPolicyOption>(
                     ExponentialBackoffPolicy(std::chrono::seconds(1),
                                              std::chrono::minutes(1), 2.0)
+                        .clone())
+                .set<spanner_admin::DatabaseAdminPollingPolicyOption>(
+                    GenericPollingPolicy<>(
+                        LimitedTimeRetryPolicy(std::chrono::hours(2)),
+                        ExponentialBackoffPolicy(std::chrono::seconds(1),
+                                                 std::chrono::minutes(1), 2.0))
                         .clone()))) {}
 
  protected:

--- a/google/cloud/spanner/integration_tests/backup_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/backup_integration_test.cc
@@ -79,7 +79,7 @@ class BackupTest : public ::google::cloud::testing_util::IntegrationTest {
                                      std::chrono::minutes(1), 2.0)
                 .clone(),
             GenericPollingPolicy<>(
-                LimitedTimeRetryPolicy(std::chrono::minutes(60)),
+                LimitedTimeRetryPolicy(std::chrono::hours(2)),
                 ExponentialBackoffPolicy(std::chrono::seconds(1),
                                          std::chrono::minutes(1), 2.0))
                 .clone())) {}

--- a/google/cloud/spanner/samples/samples.cc
+++ b/google/cloud/spanner/samples/samples.cc
@@ -3869,6 +3869,15 @@ void RunAll(bool emulator) {
                        DatabaseAdminBackoffPolicyOption>(
                   google::cloud::spanner::ExponentialBackoffPolicy(
                       std::chrono::seconds(1), std::chrono::minutes(1), 2.0)
+                      .clone())
+              .set<google::cloud::spanner_admin::
+                       DatabaseAdminPollingPolicyOption>(
+                  google::cloud::spanner::GenericPollingPolicy<>(
+                      google::cloud::spanner::LimitedTimeRetryPolicy(
+                          std::chrono::hours(2)),
+                      google::cloud::spanner::ExponentialBackoffPolicy(
+                          std::chrono::seconds(1), std::chrono::minutes(1),
+                          2.0))
                       .clone())));
 
   RunAllSlowInstanceTests(instance_admin_client, database_admin_client,


### PR DESCRIPTION
Embue each `DatabaseAdminConnection` that might be used to restore a
database during an integration test with a LRO polling time limit that
is at least as long as the timeout for the entire test.  It is no use
giving up on the operation before we would give up altogether.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7318)
<!-- Reviewable:end -->
