### PR TITLE
feat(pubsub): introduce SubscriberOptionList

### DIFF
--- a/google/cloud/pubsub/internal/defaults.cc
+++ b/google/cloud/pubsub/internal/defaults.cc
@@ -17,11 +17,20 @@
 #include "google/cloud/options.h"
 #include <chrono>
 #include <limits>
+#include <thread>
 
 namespace google {
 namespace cloud {
 namespace pubsub_internal {
 inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
+
+using std::chrono::seconds;
+
+std::size_t DefaultMaxConcurrency() {
+  auto constexpr kDefaultMaxConcurrency = 4;
+  auto const n = std::thread::hardware_concurrency();
+  return n == 0 ? kDefaultMaxConcurrency : n;
+}
 
 Options DefaultPublisherOptions(Options opts) {
   if (!opts.has<pubsub::MaxHoldTimeOption>()) {
@@ -47,6 +56,43 @@ Options DefaultPublisherOptions(Options opts) {
   if (!opts.has<pubsub::FullPublisherActionOption>()) {
     opts.set<pubsub::FullPublisherActionOption>(
         pubsub::FullPublisherAction::kBlocks);
+  }
+
+  return opts;
+}
+
+Options DefaultSubscriberOptions(Options opts) {
+  if (!opts.has<pubsub::MaxDeadlineTimeOption>()) {
+    opts.set<pubsub::MaxDeadlineTimeOption>(seconds(0));
+  }
+  if (!opts.has<pubsub::MaxDeadlineExtensionOption>()) {
+    opts.set<pubsub::MaxDeadlineExtensionOption>(seconds(600));
+  }
+  if (!opts.has<pubsub::MaxOutstandingMessagesOption>()) {
+    opts.set<pubsub::MaxOutstandingMessagesOption>(1000);
+  }
+  if (!opts.has<pubsub::MaxOutstandingBytesOption>()) {
+    opts.set<pubsub::MaxOutstandingBytesOption>(100 * 1024 * 1024L);
+  }
+  if (!opts.has<pubsub::MaxConcurrencyOption>()) {
+    opts.set<pubsub::MaxConcurrencyOption>(DefaultMaxConcurrency());
+  }
+  if (!opts.has<pubsub::ShutdownPollingPeriodOption>()) {
+    opts.set<pubsub::ShutdownPollingPeriodOption>(seconds(5));
+  }
+
+  // Enforce constraints
+  auto& extension = opts.lookup<pubsub::MaxDeadlineExtensionOption>();
+  extension = (std::max)((std::min)(extension, seconds(600)), seconds(10));
+
+  auto& messages = opts.lookup<pubsub::MaxOutstandingMessagesOption>();
+  messages = std::max<std::int64_t>(0, messages);
+
+  auto& bytes = opts.lookup<pubsub::MaxOutstandingBytesOption>();
+  bytes = std::max<std::int64_t>(0, bytes);
+
+  if (opts.get<pubsub::MaxConcurrencyOption>() == 0) {
+    opts.set<pubsub::MaxConcurrencyOption>(DefaultMaxConcurrency());
   }
 
   return opts;

--- a/google/cloud/pubsub/internal/defaults.h
+++ b/google/cloud/pubsub/internal/defaults.h
@@ -23,7 +23,11 @@ namespace cloud {
 namespace pubsub_internal {
 inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
 
+std::size_t DefaultMaxConcurrency();
+
 Options DefaultPublisherOptions(Options opts);
+
+Options DefaultSubscriberOptions(Options opts);
 
 }  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS
 }  // namespace pubsub_internal

--- a/google/cloud/pubsub/internal/defaults_test.cc
+++ b/google/cloud/pubsub/internal/defaults_test.cc
@@ -24,6 +24,7 @@ inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
 namespace {
 
 using ms = std::chrono::milliseconds;
+using std::chrono::seconds;
 
 TEST(OptionsTest, PublisherDefaults) {
   auto opts = DefaultPublisherOptions(Options{});
@@ -59,6 +60,52 @@ TEST(OptionsTest, UserSetPublisherOptions) {
   EXPECT_EQ(true, opts.get<pubsub::MessageOrderingOption>());
   EXPECT_EQ(pubsub::FullPublisherAction::kIgnored,
             opts.get<pubsub::FullPublisherActionOption>());
+}
+
+TEST(OptionsTest, SubscriberDefaults) {
+  auto opts = DefaultSubscriberOptions(Options{});
+  EXPECT_EQ(seconds(0), opts.get<pubsub::MaxDeadlineTimeOption>());
+  EXPECT_LE(seconds(10), opts.get<pubsub::MaxDeadlineExtensionOption>());
+  EXPECT_GE(seconds(600), opts.get<pubsub::MaxDeadlineExtensionOption>());
+  EXPECT_LT(0, opts.get<pubsub::MaxOutstandingMessagesOption>());
+  EXPECT_LT(0, opts.get<pubsub::MaxOutstandingBytesOption>());
+  EXPECT_LT(0, opts.get<pubsub::MaxConcurrencyOption>());
+}
+
+TEST(OptionsTest, SubscriberConstraints) {
+  auto opts = DefaultSubscriberOptions(
+      Options{}
+          .set<pubsub::MaxOutstandingMessagesOption>(-1)
+          .set<pubsub::MaxOutstandingBytesOption>(-2)
+          .set<pubsub::MaxConcurrencyOption>(0));
+
+  EXPECT_EQ(0, opts.get<pubsub::MaxOutstandingMessagesOption>());
+  EXPECT_EQ(0, opts.get<pubsub::MaxOutstandingBytesOption>());
+  EXPECT_EQ(DefaultMaxConcurrency(), opts.get<pubsub::MaxConcurrencyOption>());
+
+  opts = DefaultSubscriberOptions(
+      Options{}.set<pubsub::MaxDeadlineExtensionOption>(seconds(5)));
+  EXPECT_EQ(seconds(10), opts.get<pubsub::MaxDeadlineExtensionOption>());
+
+  opts = DefaultSubscriberOptions(
+      Options{}.set<pubsub::MaxDeadlineExtensionOption>(seconds(5000)));
+  EXPECT_EQ(seconds(600), opts.get<pubsub::MaxDeadlineExtensionOption>());
+}
+
+TEST(OptionsTest, UserSetSubscriberOptions) {
+  auto opts = DefaultSubscriberOptions(
+      Options{}
+          .set<pubsub::MaxDeadlineTimeOption>(seconds(2))
+          .set<pubsub::MaxDeadlineExtensionOption>(seconds(30))
+          .set<pubsub::MaxOutstandingMessagesOption>(4)
+          .set<pubsub::MaxOutstandingBytesOption>(5)
+          .set<pubsub::MaxConcurrencyOption>(6));
+
+  EXPECT_EQ(seconds(2), opts.get<pubsub::MaxDeadlineTimeOption>());
+  EXPECT_EQ(seconds(30), opts.get<pubsub::MaxDeadlineExtensionOption>());
+  EXPECT_EQ(4, opts.get<pubsub::MaxOutstandingMessagesOption>());
+  EXPECT_EQ(5, opts.get<pubsub::MaxOutstandingBytesOption>());
+  EXPECT_EQ(6, opts.get<pubsub::MaxConcurrencyOption>());
 }
 
 }  // namespace

--- a/google/cloud/pubsub/options.h
+++ b/google/cloud/pubsub/options.h
@@ -154,11 +154,120 @@ struct FullPublisherActionOption {
   using Type = FullPublisherAction;
 };
 
-/// The list of options specific to publishers
+/// The list of options specific to publishers.
 using PublisherOptionList =
     OptionList<MaxHoldTimeOption, MaxBatchMessagesOption, MaxBatchBytesOption,
                MaxPendingMessagesOption, MaxPendingBytesOption,
                MessageOrderingOption, FullPublisherActionOption>;
+
+/**
+ * The maximum deadline for each incoming message.
+ *
+ * Configure how long the application has to respond (ACK or NACK) to an
+ * incoming message. Note that this might be longer, or shorter, than the
+ * deadline configured in the server-side subscription.
+ *
+ * The value `0` is reserved to leave the deadline unmodified and just use the
+ * server-side configuration.
+ *
+ * @note The deadline applies to each message as it is delivered to the
+ *     application, thus, if the library receives a batch of N messages their
+ *     deadline for all the messages is extended repeatedly. Only once the
+ *     message is delivered to a callback does the deadline become immutable.
+ */
+struct MaxDeadlineTimeOption {
+  using Type = std::chrono::seconds;
+};
+
+/**
+ * The maximum time by which the deadline for each incoming message is extended.
+ *
+ * The Cloud Pub/Sub C++ client library will extend the deadline by at most this
+ * amount, while waiting for an ack or nack. The default extension is 10
+ * minutes. An application may wish to reduce this extension so that the Pub/Sub
+ * service will resend a message sooner when it does not hear back from a
+ * Subscriber.
+ *
+ * The value is clamped between 10 seconds and 10 minutes.
+ */
+struct MaxDeadlineExtensionOption {
+  using Type = std::chrono::seconds;
+};
+
+/**
+ * The maximum number of outstanding messages per streaming pull.
+ *
+ * The Cloud Pub/Sub C++ client library uses streaming pull requests to receive
+ * messages from the service. The service will stop delivering messages if this
+ * many messages or more have neither been acknowledged nor rejected.
+ *
+ * If a negative or 0 value is supplied, the number of messages will be
+ * unlimited.
+ *
+ * @par Example
+ * @snippet samples.cc subscriber-flow-control
+ */
+struct MaxOutstandingMessagesOption {
+  using Type = std::int64_t;
+};
+
+/**
+ * The maximum number of outstanding bytes per streaming pull.
+ *
+ * The Cloud Pub/Sub C++ client library uses streaming pull requests to receive
+ * messages from the service. The service will stop delivering messages if this
+ * many bytes or more worth of messages have not been acknowledged nor rejected.
+ *
+ * If a negative or 0 value is supplied, the number of bytes will be unlimited.
+ *
+ * @par Example
+ * @snippet samples.cc subscriber-flow-control
+ */
+struct MaxOutstandingBytesOption {
+  using Type = std::int64_t;
+};
+
+/**
+ * The maximum callback concurrency.
+ *
+ * The Cloud Pub/Sub C++ client library will schedule parallel callbacks as long
+ * as the number of outstanding callbacks is less than this maximum.
+ *
+ * Note that this controls the number of callbacks *scheduled*, not the number
+ * of callbacks actually executing at a time. The application needs to create
+ * (or configure) the background threads pool with enough parallelism to execute
+ * more than one callback at a time.
+ *
+ * Some applications may want to share a thread pool across many subscriptions,
+ * the additional level of control (scheduled vs. running callbacks) allows
+ * applications, for example, to ensure that at most `K` threads in the pool are
+ * used by any given subscription.
+ *
+ * @par Example
+ * @snippet samples.cc subscriber-concurrency
+ */
+struct MaxConcurrencyOption {
+  using Type = std::size_t;
+};
+
+/**
+ * How often the session polls for automatic shutdowns.
+ *
+ * Applications can shutdown a session by calling `.cancel()` on the returned
+ * `future<Status>`.  In addition, applications can fire & forget a session,
+ * which is only shutdown once the completion queue servicing the session shuts
+ * down. In this latter case the session polls periodically to detect if the CQ
+ * has shutdown. This controls how often this polling happens.
+ */
+struct ShutdownPollingPeriodOption {
+  using Type = std::chrono::milliseconds;
+};
+
+/// The list of options specific to subscribers.
+using SubscriberOptionList =
+    OptionList<MaxDeadlineTimeOption, MaxDeadlineExtensionOption,
+               MaxOutstandingMessagesOption, MaxOutstandingBytesOption,
+               MaxConcurrencyOption, ShutdownPollingPeriodOption>;
 
 }  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS
 }  // namespace pubsub

--- a/google/cloud/pubsub/options.h
+++ b/google/cloud/pubsub/options.h
@@ -238,8 +238,8 @@ struct MaxOutstandingBytesOption {
  * (or configure) the background threads pool with enough parallelism to execute
  * more than one callback at a time.
  *
- * Some applications may want to share a thread pool across many subscriptions,
- * the additional level of control (scheduled vs. running callbacks) allows
+ * Some applications may want to share a thread pool across many subscriptions.
+ * The additional level of control (scheduled vs. running callbacks) allows
  * applications, for example, to ensure that at most `K` threads in the pool are
  * used by any given subscription.
  *

--- a/google/cloud/pubsub/subscriber_options.cc
+++ b/google/cloud/pubsub/subscriber_options.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/pubsub/subscriber_options.h"
+#include "google/cloud/pubsub/internal/defaults.h"
 #include <algorithm>
 
 namespace google {
@@ -22,27 +23,34 @@ inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
 
 using seconds = std::chrono::seconds;
 
+SubscriberOptions::SubscriberOptions(Options opts) {
+  internal::CheckExpectedOptions<SubscriberOptionList>(opts, __func__);
+  opts_ = pubsub_internal::DefaultSubscriberOptions(std::move(opts));
+}
+
 SubscriberOptions& SubscriberOptions::set_max_deadline_extension(
     seconds extension) {
-  max_deadline_extension_ =
-      (std::max)((std::min)(extension, seconds(600)), seconds(10));
+  opts_.set<MaxDeadlineExtensionOption>(
+      (std::max)((std::min)(extension, seconds(600)), seconds(10)));
   return *this;
 }
 
 SubscriberOptions& SubscriberOptions::set_max_outstanding_messages(
     std::int64_t message_count) {
-  max_outstanding_messages_ = (std::max<std::int64_t>)(0, message_count);
+  opts_.set<MaxOutstandingMessagesOption>(
+      (std::max<std::int64_t>)(0, message_count));
   return *this;
 }
 
 SubscriberOptions& SubscriberOptions::set_max_outstanding_bytes(
     std::int64_t bytes) {
-  max_outstanding_bytes_ = (std::max<std::int64_t>)(0, bytes);
+  opts_.set<MaxOutstandingBytesOption>((std::max<std::int64_t>)(0, bytes));
   return *this;
 }
 
 SubscriberOptions& SubscriberOptions::set_max_concurrency(std::size_t v) {
-  max_concurrency_ = v == 0 ? DefaultMaxConcurrency() : v;
+  opts_.set<MaxConcurrencyOption>(
+      v == 0 ? pubsub_internal::DefaultMaxConcurrency() : v);
   return *this;
 }
 


### PR DESCRIPTION
part of the work for #6306 

**Some choices:**

A value of `0` supplied to `MaxConcurrencyOption` uses `DefaultMaxConcurrency()`. Perhaps it would be simpler if a `0` value just becomes `1` or `4`, and an unset option uses `DefaultMaxConcurrency()`. But I know the value cannot stay `0`.

I made new Options for `MaxOutstanding(Bytes|Messages)Option` even though they seem very similar to `MaxPending(Bytes|Messages)Option`. I think it is best to separate the publisher options from the subscriber options, and to rely on the `PublisherOptionList` and `SubscriberOptionList` to check that the user has set the correct one. Maybe publisher/subscriber should be mentioned in the option name?

I am including the `@snippet`s for `MaxOutstanding(Bytes|Messages)Option` even though they point to a sample in which the new options are not used. I know that the code it points to will be updated in the future, and I would rather keep the tag, instead of removing it and potentially forgetting to add it back in later.

I have been convinced to not check for equality for default option values. I will update the `PublisherDefaults` test to do the same in a subsequent PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7319)
<!-- Reviewable:end -->
