### PR TITLE
test(pubsub): update pubsub options tests

### DIFF
--- a/google/cloud/pubsub/internal/defaults_test.cc
+++ b/google/cloud/pubsub/internal/defaults_test.cc
@@ -28,13 +28,11 @@ using std::chrono::seconds;
 
 TEST(OptionsTest, PublisherDefaults) {
   auto opts = DefaultPublisherOptions(Options{});
-  EXPECT_EQ(ms(10), opts.get<pubsub::MaxHoldTimeOption>());
-  EXPECT_EQ(100, opts.get<pubsub::MaxBatchMessagesOption>());
-  EXPECT_EQ(1024 * 1024L, opts.get<pubsub::MaxBatchBytesOption>());
-  EXPECT_EQ((std::numeric_limits<std::size_t>::max)(),
-            opts.get<pubsub::MaxPendingBytesOption>());
-  EXPECT_EQ((std::numeric_limits<std::size_t>::max)(),
-            opts.get<pubsub::MaxPendingMessagesOption>());
+  EXPECT_LT(0, opts.get<pubsub::MaxHoldTimeOption>().count());
+  EXPECT_LT(0L, opts.get<pubsub::MaxBatchMessagesOption>());
+  EXPECT_LT(0L, opts.get<pubsub::MaxBatchBytesOption>());
+  EXPECT_LT(0L, opts.get<pubsub::MaxPendingBytesOption>());
+  EXPECT_LT(0L, opts.get<pubsub::MaxPendingMessagesOption>());
   EXPECT_EQ(false, opts.get<pubsub::MessageOrderingOption>());
   EXPECT_EQ(pubsub::FullPublisherAction::kBlocks,
             opts.get<pubsub::FullPublisherActionOption>());

--- a/google/cloud/pubsub/internal/defaults_test.cc
+++ b/google/cloud/pubsub/internal/defaults_test.cc
@@ -28,12 +28,14 @@ using std::chrono::seconds;
 
 TEST(OptionsTest, PublisherDefaults) {
   auto opts = DefaultPublisherOptions(Options{});
-  EXPECT_LT(0, opts.get<pubsub::MaxHoldTimeOption>().count());
-  EXPECT_LT(0L, opts.get<pubsub::MaxBatchMessagesOption>());
-  EXPECT_LT(0L, opts.get<pubsub::MaxBatchBytesOption>());
-  EXPECT_LT(0L, opts.get<pubsub::MaxPendingBytesOption>());
-  EXPECT_LT(0L, opts.get<pubsub::MaxPendingMessagesOption>());
-  EXPECT_EQ(false, opts.get<pubsub::MessageOrderingOption>());
+  EXPECT_EQ(ms(10), opts.get<pubsub::MaxHoldTimeOption>());
+  EXPECT_EQ(100, opts.get<pubsub::MaxBatchMessagesOption>());
+  EXPECT_EQ(1024 * 1024L, opts.get<pubsub::MaxBatchBytesOption>());
+  EXPECT_EQ((std::numeric_limits<std::size_t>::max)(),
+            opts.get<pubsub::MaxPendingBytesOption>());
+  EXPECT_EQ((std::numeric_limits<std::size_t>::max)(),
+            opts.get<pubsub::MaxPendingMessagesOption>());
+  EXPECT_FALSE(opts.get<pubsub::MessageOrderingOption>());
   EXPECT_EQ(pubsub::FullPublisherAction::kBlocks,
             opts.get<pubsub::FullPublisherActionOption>());
 }
@@ -55,7 +57,7 @@ TEST(OptionsTest, UserSetPublisherOptions) {
   EXPECT_EQ(2U, opts.get<pubsub::MaxBatchBytesOption>());
   EXPECT_EQ(3U, opts.get<pubsub::MaxPendingBytesOption>());
   EXPECT_EQ(4U, opts.get<pubsub::MaxPendingMessagesOption>());
-  EXPECT_EQ(true, opts.get<pubsub::MessageOrderingOption>());
+  EXPECT_TRUE(opts.get<pubsub::MessageOrderingOption>());
   EXPECT_EQ(pubsub::FullPublisherAction::kIgnored,
             opts.get<pubsub::FullPublisherActionOption>());
 }
@@ -63,11 +65,10 @@ TEST(OptionsTest, UserSetPublisherOptions) {
 TEST(OptionsTest, SubscriberDefaults) {
   auto opts = DefaultSubscriberOptions(Options{});
   EXPECT_EQ(seconds(0), opts.get<pubsub::MaxDeadlineTimeOption>());
-  EXPECT_LE(seconds(10), opts.get<pubsub::MaxDeadlineExtensionOption>());
-  EXPECT_GE(seconds(600), opts.get<pubsub::MaxDeadlineExtensionOption>());
-  EXPECT_LT(0, opts.get<pubsub::MaxOutstandingMessagesOption>());
-  EXPECT_LT(0, opts.get<pubsub::MaxOutstandingBytesOption>());
-  EXPECT_LT(0, opts.get<pubsub::MaxConcurrencyOption>());
+  EXPECT_EQ(seconds(600), opts.get<pubsub::MaxDeadlineExtensionOption>());
+  EXPECT_EQ(1000, opts.get<pubsub::MaxOutstandingMessagesOption>());
+  EXPECT_EQ(100 * 1024 * 1024L, opts.get<pubsub::MaxOutstandingBytesOption>());
+  EXPECT_EQ(DefaultMaxConcurrency(), opts.get<pubsub::MaxConcurrencyOption>());
 }
 
 TEST(OptionsTest, SubscriberConstraints) {

--- a/google/cloud/pubsub/publisher_options_test.cc
+++ b/google/cloud/pubsub/publisher_options_test.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/pubsub/publisher_options.h"
+#include "google/cloud/testing_util/scoped_log.h"
 #include <gmock/gmock.h>
 
 namespace google {
@@ -20,6 +21,9 @@ namespace cloud {
 namespace pubsub {
 inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
 namespace {
+
+using ::testing::Contains;
+using ::testing::HasSubstr;
 
 TEST(PublisherOptions, Setters) {
   auto const b0 = PublisherOptions{};
@@ -99,6 +103,16 @@ TEST(PublisherOptions, OptionsConstructor) {
   EXPECT_EQ(444, b.maximum_pending_bytes());
   EXPECT_TRUE(b.message_ordering());
   EXPECT_TRUE(b.full_publisher_rejects());
+}
+
+TEST(PublisherOptions, ExpectedOptionsCheck) {
+  struct NonOption {
+    using Type = bool;
+  };
+
+  testing_util::ScopedLog log;
+  auto b = PublisherOptions(Options{}.set<NonOption>(true));
+  EXPECT_THAT(log.ExtractLines(), Contains(HasSubstr("Unexpected option")));
 }
 
 TEST(PublisherOptions, MakeOptions) {

--- a/google/cloud/pubsub/publisher_options_test.cc
+++ b/google/cloud/pubsub/publisher_options_test.cc
@@ -130,7 +130,7 @@ TEST(PublisherOptions, MakeOptions) {
   EXPECT_EQ(123, opts.get<MaxBatchBytesOption>());
   EXPECT_EQ(4, opts.get<MaxPendingMessagesOption>());
   EXPECT_EQ(444, opts.get<MaxPendingBytesOption>());
-  EXPECT_EQ(true, opts.get<MessageOrderingOption>());
+  EXPECT_TRUE(opts.get<MessageOrderingOption>());
 
   auto ignored = PublisherOptions{}.set_full_publisher_ignored();
   opts = pubsub_internal::MakeOptions(std::move(ignored));


### PR DESCRIPTION
Make the publisher options default test check only that a default is set (instead of checking the exact value of a default)

Also add a mini test to ensure we are outputting warnings if an option not in the expected `OptionList` is supplied to the `PublisherOptions` constructor.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7320)
<!-- Reviewable:end -->
