### PR TITLE
cleanup(spanner): further migration to generated admin APIs

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -110,9 +110,9 @@ These are some examples:
 - Spanner has one non-admin client, the
   [spanner::Client](/google/cloud/spanner/client.h). It also has two admin
   clients:
-  [spanner::InstanceAdminClient](/google/cloud/spanner/instance_admin_client.h),
+  [spanner_admin::InstanceAdminClient](/google/cloud/spanner/admin/instance_admin_client.h),
   and
-  [spanner::DatabaseAdminClient](/google/cloud/spanner/database_admin_client.h).
+  [spanner_admin::DatabaseAdminClient](/google/cloud/spanner/admin/database_admin_client.h).
 
 Generally these classes are very "thin"; they take function arguments from the
 application, package them in lightweight structure, and then forward the request

--- a/google/cloud/spanner/benchmarks/single_row_throughput_benchmark.cc
+++ b/google/cloud/spanner/benchmarks/single_row_throughput_benchmark.cc
@@ -12,11 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "google/cloud/spanner/admin/database_admin_client.h"
 #include "google/cloud/spanner/benchmarks/benchmarks_config.h"
 #include "google/cloud/spanner/client.h"
-#include "google/cloud/spanner/database_admin_client.h"
 #include "google/cloud/spanner/testing/pick_random_instance.h"
 #include "google/cloud/spanner/testing/random_database_name.h"
+#include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/internal/random.h"
 #include <algorithm>
@@ -435,17 +436,22 @@ int main(int argc, char* argv[]) {
     return 1;
   }
 
-  google::cloud::spanner::DatabaseAdminClient admin_client;
+  google::cloud::spanner_admin::DatabaseAdminClient admin_client(
+      google::cloud::spanner_admin::MakeDatabaseAdminConnection());
 
   std::cout << "# Waiting for database creation to complete " << std::flush;
+  google::spanner::admin::database::v1::CreateDatabaseRequest request;
+  request.set_parent(database.instance().FullName());
+  request.set_create_statement(
+      absl::StrCat("CREATE DATABASE `", database.database_id(), "`"));
+  request.add_extra_statements(R"sql(CREATE TABLE KeyValue (
+                                        Key   INT64 NOT NULL,
+                                        Data  STRING(1024),
+                                     ) PRIMARY KEY (Key))sql");
   google::cloud::StatusOr<google::spanner::admin::database::v1::Database> db;
   int constexpr kMaxCreateDatabaseRetries = 3;
   for (int retry = 0; retry <= kMaxCreateDatabaseRetries; ++retry) {
-    auto create_future =
-        admin_client.CreateDatabase(database, {R"sql(CREATE TABLE KeyValue (
-                                Key   INT64 NOT NULL,
-                                Data  STRING(1024),
-                             ) PRIMARY KEY (Key))sql"});
+    auto create_future = admin_client.CreateDatabase(request);
     for (;;) {
       auto status = create_future.wait_for(std::chrono::seconds(1));
       if (status == std::future_status::ready) break;
@@ -492,7 +498,7 @@ int main(int argc, char* argv[]) {
   experiment->Run(config, database, cout_sink);
 
   if (!user_specified_database) {
-    auto drop = admin_client.DropDatabase(database);
+    auto drop = admin_client.DropDatabase(database.FullName());
     if (!drop.ok()) {
       std::cerr << "# Error dropping database: " << drop << "\n";
     }

--- a/google/cloud/spanner/integration_tests/rpc_failure_threshold_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/rpc_failure_threshold_integration_test.cc
@@ -12,12 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "google/cloud/spanner/admin/database_admin_client.h"
 #include "google/cloud/spanner/client.h"
 #include "google/cloud/spanner/database.h"
-#include "google/cloud/spanner/database_admin_client.h"
 #include "google/cloud/spanner/mutations.h"
 #include "google/cloud/spanner/testing/pick_random_instance.h"
 #include "google/cloud/spanner/testing/random_database_name.h"
+#include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/internal/random.h"
 #include "google/cloud/testing_util/integration_test.h"
@@ -51,13 +52,18 @@ class RpcFailureThresholdTest
 
     std::cout << "Creating database [" << database_id << "] and table "
               << std::flush;
-    DatabaseAdminClient admin_client;
-    auto database_future =
-        admin_client.CreateDatabase(*db_, {R"""(CREATE TABLE Singers (
-                                SingerId   INT64 NOT NULL,
-                                FirstName  STRING(1024),
-                                LastName   STRING(1024)
-                             ) PRIMARY KEY (SingerId))"""});
+    spanner_admin::DatabaseAdminClient admin_client(
+        spanner_admin::MakeDatabaseAdminConnection());
+    google::spanner::admin::database::v1::CreateDatabaseRequest request;
+    request.set_parent(db_->instance().FullName());
+    request.set_create_statement(
+        absl::StrCat("CREATE DATABASE `", db_->database_id(), "`"));
+    request.add_extra_statements(R"""(CREATE TABLE Singers (
+                                         SingerId   INT64 NOT NULL,
+                                         FirstName  STRING(1024),
+                                         LastName   STRING(1024)
+                                      ) PRIMARY KEY (SingerId))""");
+    auto database_future = admin_client.CreateDatabase(request);
     int i = 0;
     int const timeout = 120;
     while (++i < timeout) {
@@ -79,8 +85,9 @@ class RpcFailureThresholdTest
       return;
     }
     std::cout << "Dropping database " << db_->database_id() << std::flush;
-    DatabaseAdminClient admin_client;
-    auto drop_status = admin_client.DropDatabase(*db_);
+    spanner_admin::DatabaseAdminClient admin_client(
+        spanner_admin::MakeDatabaseAdminConnection());
+    auto drop_status = admin_client.DropDatabase(db_->FullName());
     std::cout << " DONE\n";
     EXPECT_STATUS_OK(drop_status);
   }

--- a/google/cloud/spanner/testing/cleanup_stale_databases.h
+++ b/google/cloud/spanner/testing/cleanup_stale_databases.h
@@ -15,7 +15,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_TESTING_CLEANUP_STALE_DATABASES_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_TESTING_CLEANUP_STALE_DATABASES_H
 
-#include "google/cloud/spanner/database_admin_client.h"
+#include "google/cloud/spanner/admin/database_admin_client.h"
 #include "google/cloud/spanner/version.h"
 #include <chrono>
 #include <string>
@@ -26,7 +26,7 @@ namespace spanner_testing {
 inline namespace SPANNER_CLIENT_NS {
 
 Status CleanupStaleDatabases(
-    google::cloud::spanner::DatabaseAdminClient admin_client,
+    google::cloud::spanner_admin::DatabaseAdminClient admin_client,
     std::string const& project_id, std::string const& instance_id,
     std::chrono::system_clock::time_point tp);
 

--- a/google/cloud/spanner/testing/cleanup_stale_instances.cc
+++ b/google/cloud/spanner/testing/cleanup_stale_instances.cc
@@ -13,10 +13,11 @@
 // limitations under the License.
 
 #include "google/cloud/spanner/testing/cleanup_stale_instances.h"
-#include "google/cloud/spanner/database_admin_client.h"
-#include "google/cloud/spanner/instance_admin_client.h"
+#include "google/cloud/spanner/admin/database_admin_client.h"
+#include "google/cloud/spanner/admin/instance_admin_client.h"
 #include "google/cloud/spanner/version.h"
 #include "google/cloud/internal/format_time_point.h"
+#include "google/cloud/project.h"
 #include <chrono>
 #include <vector>
 
@@ -27,19 +28,17 @@ inline namespace SPANNER_CLIENT_NS {
 
 Status CleanupStaleInstances(std::string const& project_id,
                              std::regex const& instance_name_regex) {
-  spanner::DatabaseAdminClient database_admin_client(
-      spanner::MakeDatabaseAdminConnection());
-  spanner::InstanceAdminClient instance_admin_client(
-      spanner::MakeInstanceAdminConnection());
-  std::vector<std::string> instance_ids = [&]() -> std::vector<std::string> {
-    std::vector<std::string> instance_ids;
+  Project project(project_id);
+  spanner_admin::InstanceAdminClient instance_admin_client(
+      spanner_admin::MakeInstanceAdminConnection());
+  std::vector<std::string> instances = [&]() -> std::vector<std::string> {
+    std::vector<std::string> instances;
     for (auto const& instance :
-         instance_admin_client.ListInstances(project_id, {})) {
+         instance_admin_client.ListInstances(project.FullName())) {
       if (!instance) break;
       auto name = instance->name();
       std::smatch m;
       if (std::regex_match(name, m, instance_name_regex)) {
-        auto instance_id = m[1];
         auto date_str = m[2];
         auto cutoff_date =
             google::cloud::internal::FormatRfc3339(
@@ -47,23 +46,24 @@ Status CleanupStaleInstances(std::string const& project_id,
                 .substr(0, 10);
         // Compare the strings
         if (date_str < cutoff_date) {
-          instance_ids.push_back(instance_id);
+          instances.push_back(name);
         }
       }
     }
-    return instance_ids;
+    return instances;
   }();
   // Let it fail if we have too many leaks.
-  if (instance_ids.size() > 20) {
+  if (instances.size() > 20) {
     return Status(StatusCode::kInternal, "too many stale instances");
   }
+  spanner_admin::DatabaseAdminClient database_admin_client(
+      spanner_admin::MakeDatabaseAdminConnection());
   // We ignore failures here.
-  for (auto const& id_to_delete : instance_ids) {
-    google::cloud::spanner::Instance in(project_id, id_to_delete);
-    for (auto const& b : database_admin_client.ListBackups(in, {})) {
-      database_admin_client.DeleteBackup(b.value());
+  for (auto const& instance : instances) {
+    for (auto const& backup : database_admin_client.ListBackups(instance)) {
+      database_admin_client.DeleteBackup(backup->name());
     }
-    instance_admin_client.DeleteInstance(in);
+    instance_admin_client.DeleteInstance(instance);
   }
   return Status();
 }

--- a/google/cloud/spanner/testing/instance_location.cc
+++ b/google/cloud/spanner/testing/instance_location.cc
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/spanner/testing/instance_location.h"
-#include "google/cloud/spanner/instance_admin_client.h"
+#include "google/cloud/spanner/admin/instance_admin_client.h"
 
 namespace google {
 namespace cloud {
@@ -21,8 +21,9 @@ namespace spanner_testing {
 inline namespace SPANNER_CLIENT_NS {
 
 StatusOr<std::string> InstanceLocation(spanner::Instance const& in) {
-  spanner::InstanceAdminClient client(spanner::MakeInstanceAdminConnection());
-  auto instance = client.GetInstance(in);
+  spanner_admin::InstanceAdminClient client(
+      spanner_admin::MakeInstanceAdminConnection());
+  auto instance = client.GetInstance(in.FullName());
   if (!instance) return std::move(instance).status();
   auto instance_config = client.GetInstanceConfig(instance->config());
   if (!instance_config) return std::move(instance_config).status();

--- a/google/cloud/spanner/testing/pick_instance_config.cc
+++ b/google/cloud/spanner/testing/pick_instance_config.cc
@@ -13,7 +13,8 @@
 // limitations under the License.
 
 #include "google/cloud/spanner/testing/pick_instance_config.h"
-#include "google/cloud/spanner/instance_admin_client.h"
+#include "google/cloud/spanner/admin/instance_admin_client.h"
+#include "google/cloud/project.h"
 #include <regex>
 
 namespace google {
@@ -24,13 +25,15 @@ inline namespace SPANNER_CLIENT_NS {
 std::string PickInstanceConfig(
     std::string const& project_id, std::regex const& filter_regex,
     google::cloud::internal::DefaultPRNG& generator) {
-  spanner::InstanceAdminClient client(spanner::MakeInstanceAdminConnection());
+  spanner_admin::InstanceAdminClient client(
+      spanner_admin::MakeInstanceAdminConnection());
   std::string instance_config_name{};
   auto instance_configs =
       [&client, &instance_config_name, &project_id,
        &filter_regex]() mutable -> std::vector<std::string> {
     std::vector<std::string> ret;
-    for (auto const& instance_config : client.ListInstanceConfigs(project_id)) {
+    for (auto const& instance_config :
+         client.ListInstanceConfigs(Project(project_id).FullName())) {
       if (!instance_config) return ret;
       if (instance_config_name.empty()) {
         instance_config_name = instance_config->name();

--- a/google/cloud/spanner/testing/pick_instance_config.h
+++ b/google/cloud/spanner/testing/pick_instance_config.h
@@ -15,7 +15,6 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_TESTING_PICK_INSTANCE_CONFIG_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_TESTING_PICK_INSTANCE_CONFIG_H
 
-#include "google/cloud/spanner/instance_admin_client.h"
 #include "google/cloud/spanner/version.h"
 #include "google/cloud/internal/random.h"
 #include <regex>


### PR DESCRIPTION
Migration to generated `InstanceAdminClient` and `DatabaseAdminClient` for:
- google/cloud/examples
- google/cloud/spanner/benchmarks
- google/cloud/spanner/integration_tests (non-API specific)
- google/cloud/spanner/testing (test helpers)

Also update ARCHITECTURE.md.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7327)
<!-- Reviewable:end -->
