### PR TITLE
cleanup(spanner): prefer obj.FullName() for producing resource names

### DIFF
--- a/google/cloud/kms_key_name_test.cc
+++ b/google/cloud/kms_key_name_test.cc
@@ -25,7 +25,6 @@ namespace {
 
 using ::google::cloud::testing_util::IsOk;
 using ::google::cloud::testing_util::StatusIs;
-using ::testing::Eq;
 
 TEST(KmsKeyNameTest, FromComponents) {
   KmsKeyName key("test-project", "some-location", "a-key-ring", "a-key-name");
@@ -36,11 +35,8 @@ TEST(KmsKeyNameTest, FromComponents) {
 }
 
 TEST(KmsKeyNameTest, MakeKmsKeyName) {
-  auto const k_valid_key_name_name =
-      KmsKeyName("p1", "l1", "r1", "n1").FullName();
-  auto valid_key = MakeKmsKeyName(k_valid_key_name_name);
-  ASSERT_THAT(valid_key, IsOk());
-  EXPECT_THAT(valid_key->FullName(), Eq(k_valid_key_name_name));
+  auto key = KmsKeyName("p1", "l1", "r1", "n1");
+  EXPECT_EQ(key, MakeKmsKeyName(key.FullName()).value());
 
   for (std::string invalid : {
            "projects/p1/locations/l1/keyRings/r1/carlosKey/n1",

--- a/google/cloud/kms_key_name_test.cc
+++ b/google/cloud/kms_key_name_test.cc
@@ -36,11 +36,11 @@ TEST(KmsKeyNameTest, FromComponents) {
 }
 
 TEST(KmsKeyNameTest, MakeKmsKeyName) {
-  auto constexpr kValidKeyNameName =
-      "projects/p1/locations/l1/keyRings/r1/cryptoKeys/n1";
-  auto valid_key = MakeKmsKeyName(kValidKeyNameName);
+  auto const k_valid_key_name_name =
+      KmsKeyName("p1", "l1", "r1", "n1").FullName();
+  auto valid_key = MakeKmsKeyName(k_valid_key_name_name);
   ASSERT_THAT(valid_key, IsOk());
-  EXPECT_THAT(valid_key->FullName(), Eq(kValidKeyNameName));
+  EXPECT_THAT(valid_key->FullName(), Eq(k_valid_key_name_name));
 
   for (std::string invalid : {
            "projects/p1/locations/l1/keyRings/r1/carlosKey/n1",

--- a/google/cloud/project_test.cc
+++ b/google/cloud/project_test.cc
@@ -23,9 +23,7 @@ namespace cloud {
 inline namespace GOOGLE_CLOUD_CPP_NS {
 namespace {
 
-using ::google::cloud::testing_util::IsOk;
 using ::google::cloud::testing_util::StatusIs;
-using ::testing::Eq;
 
 TEST(Project, Basics) {
   Project p("p1");
@@ -56,10 +54,8 @@ TEST(Project, OutputStream) {
 }
 
 TEST(Project, MakeProject) {
-  auto const k_valid_project_name = Project("p1").FullName();
-  auto p = MakeProject(k_valid_project_name);
-  ASSERT_THAT(p, IsOk());
-  EXPECT_THAT(p->FullName(), Eq(k_valid_project_name));
+  auto p = Project("p1");
+  EXPECT_EQ(p, MakeProject(p.FullName()).value());
 
   for (std::string invalid : {
            "",

--- a/google/cloud/project_test.cc
+++ b/google/cloud/project_test.cc
@@ -56,10 +56,10 @@ TEST(Project, OutputStream) {
 }
 
 TEST(Project, MakeProject) {
-  auto constexpr kValidProjectName = "projects/p1";
-  auto p = MakeProject(kValidProjectName);
+  auto const k_valid_project_name = Project("p1").FullName();
+  auto p = MakeProject(k_valid_project_name);
   ASSERT_THAT(p, IsOk());
-  EXPECT_THAT(p->FullName(), Eq(kValidProjectName));
+  EXPECT_THAT(p->FullName(), Eq(k_valid_project_name));
 
   for (std::string invalid : {
            "",

--- a/google/cloud/spanner/admin/integration_tests/instance_admin_integration_test.cc
+++ b/google/cloud/spanner/admin/integration_tests/instance_admin_integration_test.cc
@@ -106,9 +106,8 @@ class InstanceAdminClientTest
       // but if we are running against the emulator we're happy to create one.
       Instance in(ProjectId(), InstanceId());
       auto create_instance_request =
-          CreateInstanceRequestBuilder(in,
-                                       "projects/" + in.project_id() +
-                                           "/instanceConfigs/emulator-config")
+          CreateInstanceRequestBuilder(
+              in, in.project().FullName() + "/instanceConfigs/emulator-config")
               .Build();
       auto instance = client_.CreateInstance(create_instance_request).get();
       if (!instance) {
@@ -134,7 +133,7 @@ TEST_F(InstanceAdminClientTest, InstanceReadOperations) {
 
   auto instance_names = [&in, this]() mutable {
     std::vector<std::string> names;
-    auto const parent = "projects/" + in.project_id();
+    auto const parent = in.project().FullName();
     for (auto const& instance : client_.ListInstances(parent)) {
       EXPECT_STATUS_OK(instance);
       if (!instance) break;
@@ -204,7 +203,7 @@ TEST_F(InstanceAdminClientTest, InstanceConfig) {
 
   auto instance_config_names = [&project_id, this]() mutable {
     std::vector<std::string> names;
-    auto const parent = "projects/" + project_id;
+    auto const parent = Project(project_id).FullName();
     for (auto const& instance_config : client_.ListInstanceConfigs(parent)) {
       EXPECT_STATUS_OK(instance_config);
       if (!instance_config) break;

--- a/google/cloud/spanner/backup_test.cc
+++ b/google/cloud/spanner/backup_test.cc
@@ -63,10 +63,11 @@ TEST(Backup, OutputStream) {
 }
 
 TEST(Backup, MakeBackup) {
-  auto constexpr kValidBackupName = "projects/p1/instances/i1/backups/b1";
-  auto bu = MakeBackup(kValidBackupName);
+  auto const k_valid_backup_name =
+      Backup(Instance(Project("p1"), "i1"), "b1").FullName();
+  auto bu = MakeBackup(k_valid_backup_name);
   ASSERT_THAT(bu, IsOk());
-  EXPECT_THAT(bu->FullName(), Eq(kValidBackupName));
+  EXPECT_THAT(bu->FullName(), Eq(k_valid_backup_name));
 
   for (std::string invalid : {
            "",

--- a/google/cloud/spanner/backup_test.cc
+++ b/google/cloud/spanner/backup_test.cc
@@ -23,9 +23,7 @@ namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
 namespace {
 
-using ::google::cloud::testing_util::IsOk;
 using ::google::cloud::testing_util::StatusIs;
-using ::testing::Eq;
 
 TEST(Backup, Basics) {
   Instance in("p1", "i1");
@@ -63,11 +61,8 @@ TEST(Backup, OutputStream) {
 }
 
 TEST(Backup, MakeBackup) {
-  auto const k_valid_backup_name =
-      Backup(Instance(Project("p1"), "i1"), "b1").FullName();
-  auto bu = MakeBackup(k_valid_backup_name);
-  ASSERT_THAT(bu, IsOk());
-  EXPECT_THAT(bu->FullName(), Eq(k_valid_backup_name));
+  auto bu = Backup(Instance(Project("p1"), "i1"), "b1");
+  EXPECT_EQ(bu, MakeBackup(bu.FullName()).value());
 
   for (std::string invalid : {
            "",

--- a/google/cloud/spanner/create_instance_request_builder.h
+++ b/google/cloud/spanner/create_instance_request_builder.h
@@ -51,7 +51,7 @@ class CreateInstanceRequestBuilder {
    * The display_name is set to a default value of in.instance_id().
    */
   CreateInstanceRequestBuilder(Instance const& in, std::string config) {
-    request_.set_parent("projects/" + in.project_id());
+    request_.set_parent(in.project().FullName());
     request_.set_instance_id(in.instance_id());
     request_.mutable_instance()->set_name(in.FullName());
     request_.mutable_instance()->set_display_name(in.instance_id());

--- a/google/cloud/spanner/create_instance_request_builder_test.cc
+++ b/google/cloud/spanner/create_instance_request_builder_test.cc
@@ -23,15 +23,15 @@ namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
 
 TEST(CreateInstanceRequestBuilder, DefaultValues) {
-  std::string expected_name = "projects/test-project/instances/test-instance";
+  Instance in(Project("test-project"), "test-instance");
+  std::string expected_name = in.FullName();
   std::string expected_config =
-      "projects/test-project/instanceConfigs/test-config";
-  std::string expected_display_name = "test-instance";
-  CreateInstanceRequestBuilder builder(
-      Instance("test-project", "test-instance"), expected_config);
+      in.project().FullName() + "/instanceConfigs/test-config";
+  std::string const& expected_display_name = in.instance_id();
+  CreateInstanceRequestBuilder builder(in, expected_config);
   auto req = builder.Build();
-  EXPECT_EQ("projects/test-project", req.parent());
-  EXPECT_EQ("test-instance", req.instance_id());
+  EXPECT_EQ(in.project().FullName(), req.parent());
+  EXPECT_EQ(in.instance_id(), req.instance_id());
   EXPECT_EQ(expected_name, req.instance().name());
   EXPECT_EQ(expected_config, req.instance().config());
   EXPECT_EQ(1, req.instance().node_count());
@@ -40,19 +40,19 @@ TEST(CreateInstanceRequestBuilder, DefaultValues) {
 }
 
 TEST(CreateInstanceRequestBuilder, RvalueReference) {
-  std::string expected_name = "projects/test-project/instances/test-instance";
+  Instance in(Project("test-project"), "test-instance");
+  std::string expected_name = in.FullName();
   std::string expected_config =
-      "projects/test-project/instanceConfigs/test-config";
+      in.project().FullName() + "/instanceConfigs/test-config";
   std::string expected_display_name = "test-display-name";
-  Instance in("test-project", "test-instance");
 
   auto req = CreateInstanceRequestBuilder(in, expected_config)
                  .SetDisplayName(expected_display_name)
                  .SetNodeCount(1)
                  .SetLabels({{"key", "value"}})
                  .Build();
-  EXPECT_EQ("projects/test-project", req.parent());
-  EXPECT_EQ("test-instance", req.instance_id());
+  EXPECT_EQ(in.project().FullName(), req.parent());
+  EXPECT_EQ(in.instance_id(), req.instance_id());
   EXPECT_EQ(expected_name, req.instance().name());
   EXPECT_EQ(expected_config, req.instance().config());
   EXPECT_EQ(1, req.instance().node_count());
@@ -62,19 +62,19 @@ TEST(CreateInstanceRequestBuilder, RvalueReference) {
 }
 
 TEST(CreateInstanceRequestBuilder, Lvalue) {
-  std::string expected_name = "projects/test-project/instances/test-instance";
+  Instance in(Project("test-project"), "test-instance");
+  std::string expected_name = in.FullName();
   std::string expected_config =
-      "projects/test-project/instanceConfigs/test-config";
+      in.project().FullName() + "/instanceConfigs/test-config";
   std::string expected_display_name = "test-display-name";
-  Instance in("test-project", "test-instance");
 
   auto builder = CreateInstanceRequestBuilder(in, expected_config);
   auto req = builder.SetDisplayName(expected_display_name)
                  .SetProcessingUnits(500)
                  .SetLabels({{"key", "value"}})
                  .Build();
-  EXPECT_EQ("projects/test-project", req.parent());
-  EXPECT_EQ("test-instance", req.instance_id());
+  EXPECT_EQ(in.project().FullName(), req.parent());
+  EXPECT_EQ(in.instance_id(), req.instance_id());
   EXPECT_EQ(expected_name, req.instance().name());
   EXPECT_EQ(expected_config, req.instance().config());
   EXPECT_EQ(500, req.instance().processing_units());

--- a/google/cloud/spanner/create_instance_request_builder_test.cc
+++ b/google/cloud/spanner/create_instance_request_builder_test.cc
@@ -24,7 +24,6 @@ inline namespace SPANNER_CLIENT_NS {
 
 TEST(CreateInstanceRequestBuilder, DefaultValues) {
   Instance in(Project("test-project"), "test-instance");
-  std::string expected_name = in.FullName();
   std::string expected_config =
       in.project().FullName() + "/instanceConfigs/test-config";
   std::string const& expected_display_name = in.instance_id();
@@ -32,7 +31,7 @@ TEST(CreateInstanceRequestBuilder, DefaultValues) {
   auto req = builder.Build();
   EXPECT_EQ(in.project().FullName(), req.parent());
   EXPECT_EQ(in.instance_id(), req.instance_id());
-  EXPECT_EQ(expected_name, req.instance().name());
+  EXPECT_EQ(in.FullName(), req.instance().name());
   EXPECT_EQ(expected_config, req.instance().config());
   EXPECT_EQ(1, req.instance().node_count());
   EXPECT_EQ(0, req.instance().labels_size());
@@ -41,7 +40,6 @@ TEST(CreateInstanceRequestBuilder, DefaultValues) {
 
 TEST(CreateInstanceRequestBuilder, RvalueReference) {
   Instance in(Project("test-project"), "test-instance");
-  std::string expected_name = in.FullName();
   std::string expected_config =
       in.project().FullName() + "/instanceConfigs/test-config";
   std::string expected_display_name = "test-display-name";
@@ -53,7 +51,7 @@ TEST(CreateInstanceRequestBuilder, RvalueReference) {
                  .Build();
   EXPECT_EQ(in.project().FullName(), req.parent());
   EXPECT_EQ(in.instance_id(), req.instance_id());
-  EXPECT_EQ(expected_name, req.instance().name());
+  EXPECT_EQ(in.FullName(), req.instance().name());
   EXPECT_EQ(expected_config, req.instance().config());
   EXPECT_EQ(1, req.instance().node_count());
   EXPECT_EQ(1, req.instance().labels_size());
@@ -63,7 +61,6 @@ TEST(CreateInstanceRequestBuilder, RvalueReference) {
 
 TEST(CreateInstanceRequestBuilder, Lvalue) {
   Instance in(Project("test-project"), "test-instance");
-  std::string expected_name = in.FullName();
   std::string expected_config =
       in.project().FullName() + "/instanceConfigs/test-config";
   std::string expected_display_name = "test-display-name";
@@ -75,7 +72,7 @@ TEST(CreateInstanceRequestBuilder, Lvalue) {
                  .Build();
   EXPECT_EQ(in.project().FullName(), req.parent());
   EXPECT_EQ(in.instance_id(), req.instance_id());
-  EXPECT_EQ(expected_name, req.instance().name());
+  EXPECT_EQ(in.FullName(), req.instance().name());
   EXPECT_EQ(expected_config, req.instance().config());
   EXPECT_EQ(500, req.instance().processing_units());
   EXPECT_EQ(1, req.instance().labels_size());

--- a/google/cloud/spanner/database_test.cc
+++ b/google/cloud/spanner/database_test.cc
@@ -64,10 +64,11 @@ TEST(Database, OutputStream) {
 }
 
 TEST(Database, MakeDatabase) {
-  auto constexpr kValidDatabaseName = "projects/p1/instances/i1/databases/d1";
-  auto db = MakeDatabase(kValidDatabaseName);
+  auto const k_valid_database_name =
+      Database(Instance(Project("p1"), "i1"), "d1").FullName();
+  auto db = MakeDatabase(k_valid_database_name);
   ASSERT_THAT(db, IsOk());
-  EXPECT_THAT(db->FullName(), Eq(kValidDatabaseName));
+  EXPECT_THAT(db->FullName(), Eq(k_valid_database_name));
 
   for (std::string invalid : {
            "",

--- a/google/cloud/spanner/database_test.cc
+++ b/google/cloud/spanner/database_test.cc
@@ -24,9 +24,7 @@ namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
 namespace {
 
-using ::google::cloud::testing_util::IsOk;
 using ::google::cloud::testing_util::StatusIs;
-using ::testing::Eq;
 
 TEST(Database, Basics) {
   Instance in("p1", "i1");
@@ -64,11 +62,8 @@ TEST(Database, OutputStream) {
 }
 
 TEST(Database, MakeDatabase) {
-  auto const k_valid_database_name =
-      Database(Instance(Project("p1"), "i1"), "d1").FullName();
-  auto db = MakeDatabase(k_valid_database_name);
-  ASSERT_THAT(db, IsOk());
-  EXPECT_THAT(db->FullName(), Eq(k_valid_database_name));
+  auto db = Database(Instance(Project("p1"), "i1"), "d1");
+  EXPECT_EQ(db, MakeDatabase(db.FullName()).value());
 
   for (std::string invalid : {
            "",

--- a/google/cloud/spanner/instance_test.cc
+++ b/google/cloud/spanner/instance_test.cc
@@ -61,10 +61,10 @@ TEST(Instance, OutputStream) {
 }
 
 TEST(Instance, MakeInstance) {
-  auto constexpr kValidInstanceName = "projects/p1/instances/i1";
-  auto in = MakeInstance(kValidInstanceName);
+  auto const k_valid_instance_name = Instance(Project("p1"), "i1").FullName();
+  auto in = MakeInstance(k_valid_instance_name);
   ASSERT_THAT(in, IsOk());
-  EXPECT_THAT(in->FullName(), Eq(kValidInstanceName));
+  EXPECT_THAT(in->FullName(), Eq(k_valid_instance_name));
 
   for (std::string invalid : {
            "",

--- a/google/cloud/spanner/instance_test.cc
+++ b/google/cloud/spanner/instance_test.cc
@@ -24,9 +24,7 @@ namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
 namespace {
 
-using ::google::cloud::testing_util::IsOk;
 using ::google::cloud::testing_util::StatusIs;
-using ::testing::Eq;
 
 TEST(Instance, Basics) {
   Instance in("p1", "i1");
@@ -61,10 +59,8 @@ TEST(Instance, OutputStream) {
 }
 
 TEST(Instance, MakeInstance) {
-  auto const k_valid_instance_name = Instance(Project("p1"), "i1").FullName();
-  auto in = MakeInstance(k_valid_instance_name);
-  ASSERT_THAT(in, IsOk());
-  EXPECT_THAT(in->FullName(), Eq(k_valid_instance_name));
+  auto in = Instance(Project("p1"), "i1");
+  EXPECT_EQ(in, MakeInstance(in.FullName()).value());
 
   for (std::string invalid : {
            "",

--- a/google/cloud/spanner/internal/database_admin_metadata_test.cc
+++ b/google/cloud/spanner/internal/database_admin_metadata_test.cc
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 #include "google/cloud/spanner/internal/database_admin_metadata.h"
+#include "google/cloud/spanner/backup.h"
+#include "google/cloud/spanner/database.h"
 #include "google/cloud/spanner/testing/mock_database_admin_stub.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/testing_util/status_matchers.h"
@@ -66,8 +68,9 @@ TEST_F(DatabaseAdminMetadataTest, CreateDatabase) {
   CompletionQueue cq;
   gcsa::CreateDatabaseRequest request;
   request.set_parent(
-      "projects/test-project-id/"
-      "instances/test-instance-id");
+      google::cloud::spanner::Instance(
+          google::cloud::Project("test-project-id"), "test-instance-id")
+          .FullName());
   auto response = stub.AsyncCreateDatabase(
       cq, absl::make_unique<grpc::ClientContext>(), request);
   EXPECT_EQ(TransientError(), response.get().status());
@@ -91,9 +94,11 @@ TEST_F(DatabaseAdminMetadataTest, UpdateDatabase) {
   CompletionQueue cq;
   gcsa::UpdateDatabaseDdlRequest request;
   request.set_database(
-      "projects/test-project-id/"
-      "instances/test-instance-id/"
-      "databases/test-database");
+      google::cloud::spanner::Database(
+          google::cloud::spanner::Instance(
+              google::cloud::Project("test-project-id"), "test-instance-id"),
+          "test-database")
+          .FullName());
   auto response = stub.AsyncUpdateDatabaseDdl(
       cq, absl::make_unique<grpc::ClientContext>(), request);
   EXPECT_EQ(TransientError(), response.get().status());
@@ -115,9 +120,11 @@ TEST_F(DatabaseAdminMetadataTest, DropDatabase) {
   grpc::ClientContext context;
   gcsa::DropDatabaseRequest request;
   request.set_database(
-      "projects/test-project-id/"
-      "instances/test-instance-id/"
-      "databases/test-database");
+      google::cloud::spanner::Database(
+          google::cloud::spanner::Instance(
+              google::cloud::Project("test-project-id"), "test-instance-id"),
+          "test-database")
+          .FullName());
   auto status = stub.DropDatabase(context, request);
   EXPECT_EQ(TransientError(), status);
 }
@@ -138,8 +145,9 @@ TEST_F(DatabaseAdminMetadataTest, ListDatabases) {
   grpc::ClientContext context;
   gcsa::ListDatabasesRequest request;
   request.set_parent(
-      "projects/test-project-id/"
-      "instances/test-instance-id");
+      google::cloud::spanner::Instance(
+          google::cloud::Project("test-project-id"), "test-instance-id")
+          .FullName());
   auto response = stub.ListDatabases(context, request);
   EXPECT_EQ(TransientError(), response.status());
 }
@@ -162,8 +170,9 @@ TEST_F(DatabaseAdminMetadataTest, RestoreDatabase) {
   CompletionQueue cq;
   gcsa::RestoreDatabaseRequest request;
   request.set_parent(
-      "projects/test-project-id/"
-      "instances/test-instance-id");
+      google::cloud::spanner::Instance(
+          google::cloud::Project("test-project-id"), "test-instance-id")
+          .FullName());
   auto response = stub.AsyncRestoreDatabase(
       cq, absl::make_unique<grpc::ClientContext>(), request);
   EXPECT_EQ(TransientError(), response.get().status());
@@ -185,9 +194,11 @@ TEST_F(DatabaseAdminMetadataTest, GetIamPolicy) {
   grpc::ClientContext context;
   google::iam::v1::GetIamPolicyRequest request;
   request.set_resource(
-      "projects/test-project-id/"
-      "instances/test-instance-id/"
-      "databases/test-database");
+      google::cloud::spanner::Database(
+          google::cloud::spanner::Instance(
+              google::cloud::Project("test-project-id"), "test-instance-id"),
+          "test-database")
+          .FullName());
   auto response = stub.GetIamPolicy(context, request);
   EXPECT_EQ(TransientError(), response.status());
 }
@@ -208,9 +219,11 @@ TEST_F(DatabaseAdminMetadataTest, SetIamPolicy) {
   grpc::ClientContext context;
   google::iam::v1::SetIamPolicyRequest request;
   request.set_resource(
-      "projects/test-project-id/"
-      "instances/test-instance-id/"
-      "databases/test-database");
+      google::cloud::spanner::Database(
+          google::cloud::spanner::Instance(
+              google::cloud::Project("test-project-id"), "test-instance-id"),
+          "test-database")
+          .FullName());
   google::iam::v1::Policy policy;
   auto& binding = *policy.add_bindings();
   binding.set_role("roles/spanner.databaseReader");
@@ -237,9 +250,11 @@ TEST_F(DatabaseAdminMetadataTest, TestIamPermissions) {
   grpc::ClientContext context;
   google::iam::v1::TestIamPermissionsRequest request;
   request.set_resource(
-      "projects/test-project-id/"
-      "instances/test-instance-id/"
-      "databases/test-database");
+      google::cloud::spanner::Database(
+          google::cloud::spanner::Instance(
+              google::cloud::Project("test-project-id"), "test-instance-id"),
+          "test-database")
+          .FullName());
   auto response = stub.TestIamPermissions(context, request);
   EXPECT_EQ(TransientError(), response.status());
 }
@@ -262,8 +277,9 @@ TEST_F(DatabaseAdminMetadataTest, CreateBackup) {
   CompletionQueue cq;
   gcsa::CreateBackupRequest request;
   request.set_parent(
-      "projects/test-project-id/"
-      "instances/test-instance-id");
+      google::cloud::spanner::Instance(
+          google::cloud::Project("test-project-id"), "test-instance-id")
+          .FullName());
   auto response = stub.AsyncCreateBackup(
       cq, absl::make_unique<grpc::ClientContext>(), request);
   EXPECT_EQ(TransientError(), response.get().status());
@@ -285,9 +301,11 @@ TEST_F(DatabaseAdminMetadataTest, GetBackup) {
   grpc::ClientContext context;
   gcsa::GetBackupRequest request;
   request.set_name(
-      "projects/test-project-id/"
-      "instances/test-instance-id/"
-      "backups/test-backup-id");
+      google::cloud::spanner::Backup(
+          google::cloud::spanner::Instance(
+              google::cloud::Project("test-project-id"), "test-instance-id"),
+          "test-backup-id")
+          .FullName());
   auto status = stub.GetBackup(context, request);
   EXPECT_EQ(TransientError(), status.status());
 }
@@ -308,9 +326,11 @@ TEST_F(DatabaseAdminMetadataTest, DeleteBackup) {
   grpc::ClientContext context;
   gcsa::DeleteBackupRequest request;
   request.set_name(
-      "projects/test-project-id/"
-      "instances/test-instance-id/"
-      "backups/test-backup");
+      google::cloud::spanner::Backup(
+          google::cloud::spanner::Instance(
+              google::cloud::Project("test-project-id"), "test-instance-id"),
+          "test-backup-id")
+          .FullName());
   auto status = stub.DeleteBackup(context, request);
   EXPECT_EQ(TransientError(), status);
 }
@@ -331,8 +351,9 @@ TEST_F(DatabaseAdminMetadataTest, ListBackups) {
   grpc::ClientContext context;
   gcsa::ListBackupsRequest request;
   request.set_parent(
-      "projects/test-project-id/"
-      "instances/test-instance-id");
+      google::cloud::spanner::Instance(
+          google::cloud::Project("test-project-id"), "test-instance-id")
+          .FullName());
   auto response = stub.ListBackups(context, request);
   EXPECT_EQ(TransientError(), response.status());
 }
@@ -353,9 +374,11 @@ TEST_F(DatabaseAdminMetadataTest, UpdateBackup) {
   grpc::ClientContext context;
   gcsa::UpdateBackupRequest request;
   request.mutable_backup()->set_name(
-      "projects/test-project-id/"
-      "instances/test-instance-id/"
-      "backups/test-backup-id");
+      google::cloud::spanner::Backup(
+          google::cloud::spanner::Instance(
+              google::cloud::Project("test-project-id"), "test-instance-id"),
+          "test-backup-id")
+          .FullName());
   auto status = stub.UpdateBackup(context, request);
   EXPECT_EQ(TransientError(), status.status());
 }
@@ -376,8 +399,9 @@ TEST_F(DatabaseAdminMetadataTest, ListBackupOperations) {
   grpc::ClientContext context;
   gcsa::ListBackupOperationsRequest request;
   request.set_parent(
-      "projects/test-project-id/"
-      "instances/test-instance-id");
+      google::cloud::spanner::Instance(
+          google::cloud::Project("test-project-id"), "test-instance-id")
+          .FullName());
   auto response = stub.ListBackupOperations(context, request);
   EXPECT_EQ(TransientError(), response.status());
 }
@@ -398,8 +422,9 @@ TEST_F(DatabaseAdminMetadataTest, ListDatabaseOperations) {
   grpc::ClientContext context;
   gcsa::ListDatabaseOperationsRequest request;
   request.set_parent(
-      "projects/test-project-id/"
-      "instances/test-instance-id");
+      google::cloud::spanner::Instance(
+          google::cloud::Project("test-project-id"), "test-instance-id")
+          .FullName());
   auto response = stub.ListDatabaseOperations(context, request);
   EXPECT_EQ(TransientError(), response.status());
 }

--- a/google/cloud/spanner/internal/instance_admin_metadata_test.cc
+++ b/google/cloud/spanner/internal/instance_admin_metadata_test.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/spanner/internal/instance_admin_metadata.h"
+#include "google/cloud/spanner/instance.h"
 #include "google/cloud/spanner/testing/mock_instance_admin_stub.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/testing_util/status_matchers.h"
@@ -64,8 +65,9 @@ TEST_F(InstanceAdminMetadataTest, GetInstance) {
   grpc::ClientContext context;
   gcsa::GetInstanceRequest request;
   request.set_name(
-      "projects/test-project-id/"
-      "instances/test-instance-id");
+      google::cloud::spanner::Instance(
+          google::cloud::Project("test-project-id"), "test-instance-id")
+          .FullName());
   auto response = stub.GetInstance(context, request);
   EXPECT_EQ(TransientError(), response.status());
 }
@@ -85,9 +87,8 @@ TEST_F(InstanceAdminMetadataTest, GetInstanceConfig) {
   InstanceAdminMetadata stub(mock_);
   grpc::ClientContext context;
   gcsa::GetInstanceConfigRequest request;
-  request.set_name(
-      "projects/test-project-id/"
-      "instanceConfigs/test-instance-config-id");
+  request.set_name(google::cloud::Project("test-project-id").FullName() +
+                   "/instanceConfigs/test-instance-config-id");
   auto response = stub.GetInstanceConfig(context, request);
   EXPECT_EQ(TransientError(), response.status());
 }
@@ -107,7 +108,7 @@ TEST_F(InstanceAdminMetadataTest, ListInstanceConfigs) {
   InstanceAdminMetadata stub(mock_);
   grpc::ClientContext context;
   gcsa::ListInstanceConfigsRequest request;
-  request.set_parent("projects/test-project-id");
+  request.set_parent(google::cloud::Project("test-project-id").FullName());
   auto response = stub.ListInstanceConfigs(context, request);
   EXPECT_EQ(TransientError(), response.status());
 }
@@ -129,7 +130,7 @@ TEST_F(InstanceAdminMetadataTest, CreateInstance) {
   InstanceAdminMetadata stub(mock_);
   CompletionQueue cq;
   gcsa::CreateInstanceRequest request;
-  request.set_parent("projects/test-project-id");
+  request.set_parent(google::cloud::Project("test-project-id").FullName());
   request.set_instance_id("test-instance-id");
   auto response = stub.AsyncCreateInstance(
       cq, absl::make_unique<grpc::ClientContext>(), request);
@@ -154,7 +155,9 @@ TEST_F(InstanceAdminMetadataTest, UpdateInstance) {
   CompletionQueue cq;
   gcsa::UpdateInstanceRequest request;
   request.mutable_instance()->set_name(
-      "projects/test-project-id/instances/test-instance-id");
+      google::cloud::spanner::Instance(
+          google::cloud::Project("test-project-id"), "test-instance-id")
+          .FullName());
   auto response = stub.AsyncUpdateInstance(
       cq, absl::make_unique<grpc::ClientContext>(), request);
   EXPECT_EQ(TransientError(), response.get().status());
@@ -175,7 +178,10 @@ TEST_F(InstanceAdminMetadataTest, DeleteInstance) {
   InstanceAdminMetadata stub(mock_);
   grpc::ClientContext context;
   gcsa::DeleteInstanceRequest request;
-  request.set_name("projects/test-project-id/instances/test-instance-id");
+  request.set_name(
+      google::cloud::spanner::Instance(
+          google::cloud::Project("test-project-id"), "test-instance-id")
+          .FullName());
   auto status = stub.DeleteInstance(context, request);
   EXPECT_EQ(TransientError(), status);
 }
@@ -195,7 +201,7 @@ TEST_F(InstanceAdminMetadataTest, ListInstances) {
   InstanceAdminMetadata stub(mock_);
   grpc::ClientContext context;
   gcsa::ListInstancesRequest request;
-  request.set_parent("projects/test-project-id");
+  request.set_parent(google::cloud::Project("test-project-id").FullName());
   auto response = stub.ListInstances(context, request);
   EXPECT_EQ(TransientError(), response.status());
 }
@@ -215,8 +221,10 @@ TEST_F(InstanceAdminMetadataTest, GetIamPolicy) {
   InstanceAdminMetadata stub(mock_);
   grpc::ClientContext context;
   google::iam::v1::GetIamPolicyRequest request;
-  request.set_resource("projects/test-project-id/instances/test-instance-id");
-
+  request.set_resource(
+      google::cloud::spanner::Instance(
+          google::cloud::Project("test-project-id"), "test-instance-id")
+          .FullName());
   auto response = stub.GetIamPolicy(context, request);
   EXPECT_EQ(TransientError(), response.status());
 }
@@ -236,7 +244,10 @@ TEST_F(InstanceAdminMetadataTest, SetIamPolicy) {
   InstanceAdminMetadata stub(mock_);
   grpc::ClientContext context;
   google::iam::v1::SetIamPolicyRequest request;
-  request.set_resource("projects/test-project-id/instances/test-instance-id");
+  request.set_resource(
+      google::cloud::spanner::Instance(
+          google::cloud::Project("test-project-id"), "test-instance-id")
+          .FullName());
   auto response = stub.SetIamPolicy(context, request);
   EXPECT_EQ(TransientError(), response.status());
 }
@@ -256,7 +267,10 @@ TEST_F(InstanceAdminMetadataTest, TestIamPermissions) {
   InstanceAdminMetadata stub(mock_);
   grpc::ClientContext context;
   google::iam::v1::TestIamPermissionsRequest request;
-  request.set_resource("projects/test-project-id/instances/test-instance-id");
+  request.set_resource(
+      google::cloud::spanner::Instance(
+          google::cloud::Project("test-project-id"), "test-instance-id")
+          .FullName());
   auto response = stub.TestIamPermissions(context, request);
   EXPECT_EQ(TransientError(), response.status());
 }

--- a/google/cloud/spanner/internal/metadata_spanner_stub_test.cc
+++ b/google/cloud/spanner/internal/metadata_spanner_stub_test.cc
@@ -73,10 +73,12 @@ class MetadataSpannerStubTest : public ::testing::Test {
     grpc::ClientContext context;
     Request request;
     request.set_session(
-        "projects/test-project-id/"
-        "instances/test-instance-id/"
-        "databases/test-database-id/"
-        "sessions/test-session-id");
+        google::cloud::spanner::Database(
+            google::cloud::spanner::Instance(
+                google::cloud::Project("test-project-id"), "test-instance-id"),
+            "test-database-id")
+            .FullName() +
+        "/sessions/test-session-id");
     auto result = (stub.*member_function)(context, request);
     ExpectTransientError(result);
   }
@@ -137,10 +139,12 @@ TEST_F(MetadataSpannerStubTest, GetSession) {
   grpc::ClientContext context;
   spanner_proto::GetSessionRequest request;
   request.set_name(
-      "projects/test-project-id/"
-      "instances/test-instance-id/"
-      "databases/test-database-id/"
-      "sessions/test-session-id");
+      google::cloud::spanner::Database(
+          google::cloud::spanner::Instance(
+              google::cloud::Project("test-project-id"), "test-instance-id"),
+          "test-database-id")
+          .FullName() +
+      "/sessions/test-session-id");
   auto status = stub.GetSession(context, request);
   EXPECT_EQ(TransientError(), status.status());
 }
@@ -177,10 +181,12 @@ TEST_F(MetadataSpannerStubTest, DeleteSession) {
   grpc::ClientContext context;
   spanner_proto::DeleteSessionRequest request;
   request.set_name(
-      "projects/test-project-id/"
-      "instances/test-instance-id/"
-      "databases/test-database-id/"
-      "sessions/test-session-id");
+      google::cloud::spanner::Database(
+          google::cloud::spanner::Instance(
+              google::cloud::Project("test-project-id"), "test-instance-id"),
+          "test-database-id")
+          .FullName() +
+      "/sessions/test-session-id");
   auto status = stub.DeleteSession(context, request);
   EXPECT_EQ(TransientError(), status);
 }
@@ -204,10 +210,12 @@ TEST_F(MetadataSpannerStubTest, ExecuteStreamingSql) {
   grpc::ClientContext context;
   spanner_proto::ExecuteSqlRequest request;
   request.set_session(
-      "projects/test-project-id/"
-      "instances/test-instance-id/"
-      "databases/test-database-id/"
-      "sessions/test-session-id");
+      google::cloud::spanner::Database(
+          google::cloud::spanner::Instance(
+              google::cloud::Project("test-project-id"), "test-instance-id"),
+          "test-database-id")
+          .FullName() +
+      "/sessions/test-session-id");
   auto result = stub.ExecuteStreamingSql(context, request);
   EXPECT_FALSE(result);
 }
@@ -231,10 +239,12 @@ TEST_F(MetadataSpannerStubTest, StreamingRead) {
   grpc::ClientContext context;
   spanner_proto::ReadRequest request;
   request.set_session(
-      "projects/test-project-id/"
-      "instances/test-instance-id/"
-      "databases/test-database-id/"
-      "sessions/test-session-id");
+      google::cloud::spanner::Database(
+          google::cloud::spanner::Instance(
+              google::cloud::Project("test-project-id"), "test-instance-id"),
+          "test-database-id")
+          .FullName() +
+      "/sessions/test-session-id");
   auto result = stub.StreamingRead(context, request);
   EXPECT_FALSE(result);
 }

--- a/google/cloud/spanner/update_instance_request_builder_test.cc
+++ b/google/cloud/spanner/update_instance_request_builder_test.cc
@@ -22,12 +22,12 @@ namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
 
 TEST(UpdateInstanceRequestBuilder, Constructors) {
-  std::string expected_name = "projects/test-project/instances/test-instance";
+  Instance in(Project("test-project"), "test-instance");
+  std::string expected_name = in.FullName();
   UpdateInstanceRequestBuilder builder(expected_name);
   auto req = builder.Build();
   EXPECT_EQ(expected_name, req.instance().name());
 
-  Instance in("test-project", "test-instance");
   builder = UpdateInstanceRequestBuilder(in);
   req = builder.Build();
   EXPECT_EQ(expected_name, req.instance().name());
@@ -43,12 +43,13 @@ TEST(UpdateInstanceRequestBuilder, Constructors) {
 }
 
 TEST(UpdateInstanceRequestBuilder, AddLabels) {
-  std::string expected_name = "projects/test-project/instances/test-instance";
+  Instance in(Project("test-project"), "test-instance");
+  std::string expected_name = in.FullName();
   std::string expected_display_name =
       "projects/test-project/instances/test-display-name";
   google::spanner::admin::instance::v1::Instance instance;
   instance.set_name(expected_name);
-  instance.set_display_name("projects/test-project/insance/old-display-name");
+  instance.set_display_name("projects/test-project/instances/old-display-name");
   instance.set_node_count(1);
   instance.mutable_labels()->insert({"key", "value"});
   auto builder = UpdateInstanceRequestBuilder(instance);
@@ -70,12 +71,13 @@ TEST(UpdateInstanceRequestBuilder, AddLabels) {
 }
 
 TEST(UpdateInstanceRequestBuilder, AddLabelsRvalueReference) {
-  std::string expected_name = "projects/test-project/instances/test-instance";
+  Instance in(Project("test-project"), "test-instance");
+  std::string expected_name = in.FullName();
   std::string expected_display_name =
       "projects/test-project/instances/test-display-name";
   google::spanner::admin::instance::v1::Instance instance;
   instance.set_name(expected_name);
-  instance.set_display_name("projects/test-project/insance/old-display-name");
+  instance.set_display_name("projects/test-project/instances/old-display-name");
   instance.set_node_count(1);
   instance.mutable_labels()->insert({"key", "value"});
   auto req = UpdateInstanceRequestBuilder(instance)
@@ -97,12 +99,13 @@ TEST(UpdateInstanceRequestBuilder, AddLabelsRvalueReference) {
 }
 
 TEST(UpdateInstanceRequestBuilder, SetLabels) {
-  std::string expected_name = "projects/test-project/instances/test-instance";
+  Instance in(Project("test-project"), "test-instance");
+  std::string expected_name = in.FullName();
   std::string expected_display_name =
       "projects/test-project/instances/test-display-name";
   google::spanner::admin::instance::v1::Instance instance;
   instance.set_name(expected_name);
-  instance.set_display_name("projects/test-project/insance/old-display-name");
+  instance.set_display_name("projects/test-project/instances/old-display-name");
   instance.set_node_count(1);
   instance.mutable_labels()->insert({"key", "value"});
   auto builder = UpdateInstanceRequestBuilder(instance);
@@ -124,12 +127,13 @@ TEST(UpdateInstanceRequestBuilder, SetLabels) {
 }
 
 TEST(UpdateInstanceRequestBuilder, SetLabelsRvalueReference) {
-  std::string expected_name = "projects/test-project/instances/test-instance";
+  Instance in(Project("test-project"), "test-instance");
+  std::string expected_name = in.FullName();
   std::string expected_display_name =
       "projects/test-project/instances/test-display-name";
   google::spanner::admin::instance::v1::Instance instance;
   instance.set_name(expected_name);
-  instance.set_display_name("projects/test-project/insance/old-display-name");
+  instance.set_display_name("projects/test-project/instances/old-display-name");
   instance.set_node_count(1);
   instance.mutable_labels()->insert({"key", "value"});
   auto req = UpdateInstanceRequestBuilder(instance)


### PR DESCRIPTION
Eliminate some hand construction of resource names when we have higher
level APIs for doing just that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7328)
<!-- Reviewable:end -->
