### PR TITLE
test(spanner): partition concurrent RestoreDatabase() calls by instance

### DIFF
--- a/google/cloud/spanner/admin/integration_tests/backup_integration_test.cc
+++ b/google/cloud/spanner/admin/integration_tests/backup_integration_test.cc
@@ -104,8 +104,8 @@ class BackupTest : public ::google::cloud::testing_util::IntegrationTest {
 TEST_F(BackupTest, BackupTest) {
   if (!RunSlowBackupTests() || Emulator()) GTEST_SKIP();
 
-  auto instance_id =
-      spanner_testing::PickRandomInstance(generator_, ProjectId());
+  auto instance_id = spanner_testing::PickRandomInstance(
+      generator_, ProjectId(), "labels.restore-database-partition:generated");
   ASSERT_STATUS_OK(instance_id);
   Instance in(ProjectId(), *instance_id);
   Database db(in, spanner_testing::RandomDatabaseName(generator_));
@@ -238,8 +238,8 @@ TEST_F(BackupTest, BackupTest) {
 TEST_F(BackupTest, CreateBackupWithVersionTime) {
   if (!RunSlowBackupTests()) GTEST_SKIP();
 
-  auto instance_id =
-      spanner_testing::PickRandomInstance(generator_, ProjectId());
+  auto instance_id = spanner_testing::PickRandomInstance(
+      generator_, ProjectId(), "labels.restore-database-partition:generated");
   ASSERT_THAT(instance_id, IsOk()) << instance_id.status();
   Instance in(ProjectId(), *instance_id);
   Database db(in, spanner_testing::RandomDatabaseName(generator_));
@@ -483,7 +483,9 @@ TEST_F(BackupTest, BackupTestWithCMEK) {
   if (!RunSlowBackupTests() || Emulator()) GTEST_SKIP();
 
   auto instance_id = spanner_testing::PickRandomInstance(
-      generator_, ProjectId(), "NOT name:/instances/test-instance-mr-");
+      generator_, ProjectId(),
+      "labels.restore-database-partition:generated"
+      " NOT name:/instances/test-instance-mr-");
   ASSERT_STATUS_OK(instance_id);
   Instance in(ProjectId(), *instance_id);
 

--- a/google/cloud/spanner/integration_tests/backup_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/backup_integration_test.cc
@@ -93,8 +93,8 @@ class BackupTest : public ::google::cloud::testing_util::IntegrationTest {
 TEST_F(BackupTest, BackupTest) {
   if (!RunSlowBackupTests() || Emulator()) GTEST_SKIP();
 
-  auto instance_id =
-      spanner_testing::PickRandomInstance(generator_, ProjectId());
+  auto instance_id = spanner_testing::PickRandomInstance(
+      generator_, ProjectId(), "labels.restore-database-partition:legacy");
   ASSERT_STATUS_OK(instance_id);
   Instance in(ProjectId(), *instance_id);
   Database db(in, spanner_testing::RandomDatabaseName(generator_));
@@ -203,8 +203,8 @@ TEST_F(BackupTest, BackupTest) {
 TEST_F(BackupTest, CreateBackupWithVersionTime) {
   if (!RunSlowBackupTests()) GTEST_SKIP();
 
-  auto instance_id =
-      spanner_testing::PickRandomInstance(generator_, ProjectId());
+  auto instance_id = spanner_testing::PickRandomInstance(
+      generator_, ProjectId(), "labels.restore-database-partition:legacy");
   ASSERT_THAT(instance_id, IsOk()) << instance_id.status();
   Instance in(ProjectId(), *instance_id);
   Database db(in, spanner_testing::RandomDatabaseName(generator_));
@@ -420,7 +420,9 @@ TEST_F(BackupTest, BackupTestWithCMEK) {
   if (!RunSlowBackupTests() || Emulator()) GTEST_SKIP();
 
   auto instance_id = spanner_testing::PickRandomInstance(
-      generator_, ProjectId(), "NOT name:/instances/test-instance-mr-");
+      generator_, ProjectId(),
+      "labels.restore-database-partition:legacy"
+      " NOT name:/instances/test-instance-mr-");
   ASSERT_STATUS_OK(instance_id);
   Instance in(ProjectId(), *instance_id);
 


### PR DESCRIPTION
The `integration-daily` build runs `backup_integration_test` for
both versions of the Spanner admin APIs (hand-written and generated)
concurrently.  This risks each invocation randomly selecting the same
test instance, and then hitting the hard limit of one ongoing restore
database operation per instance".

So, partition the instances into two groups, "legacy" and "generated",
using the "restore-database-partition" label, and have the tests
select an instance only from their respective partition.

Fixes #7306.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7329)
<!-- Reviewable:end -->
