### PR TITLE
feat(pubsub): add policy options; default common options

### DIFF
--- a/google/cloud/internal/retry_policy.h
+++ b/google/cloud/internal/retry_policy.h
@@ -136,6 +136,7 @@ class LimitedErrorCountRetryPolicy
   bool IsExhausted() const override {
     return failure_count_ > maximum_failures_;
   }
+  int maximum_failures() const { return maximum_failures_; }
 
  protected:
   void OnFailureImpl() override { ++failure_count_; }

--- a/google/cloud/pubsub/internal/defaults.h
+++ b/google/cloud/pubsub/internal/defaults.h
@@ -23,7 +23,9 @@ namespace cloud {
 namespace pubsub_internal {
 inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
 
-std::size_t DefaultMaxConcurrency();
+std::size_t DefaultThreadCount();
+
+Options DefaultCommonOptions(Options opts);
 
 Options DefaultPublisherOptions(Options opts);
 

--- a/google/cloud/pubsub/options.h
+++ b/google/cloud/pubsub/options.h
@@ -38,6 +38,8 @@
  * @see `google::cloud::GrpcOptionList`
  */
 
+#include "google/cloud/pubsub/backoff_policy.h"
+#include "google/cloud/pubsub/retry_policy.h"
 #include "google/cloud/pubsub/version.h"
 #include "google/cloud/options.h"
 #include <chrono>
@@ -46,6 +48,19 @@ namespace google {
 namespace cloud {
 namespace pubsub {
 inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
+
+/// The retry policy
+struct RetryPolicyOption {
+  using Type = std::shared_ptr<pubsub::RetryPolicy>;
+};
+
+/// The backoff policy
+struct BackoffPolicyOption {
+  using Type = std::shared_ptr<pubsub::BackoffPolicy>;
+};
+
+/// The list of all "policy" options.
+using PolicyOptionList = OptionList<RetryPolicyOption, BackoffPolicyOption>;
 
 /**
  * The maximum hold time for the messages.

--- a/google/cloud/pubsub/subscriber_options.cc
+++ b/google/cloud/pubsub/subscriber_options.cc
@@ -49,8 +49,8 @@ SubscriberOptions& SubscriberOptions::set_max_outstanding_bytes(
 }
 
 SubscriberOptions& SubscriberOptions::set_max_concurrency(std::size_t v) {
-  opts_.set<MaxConcurrencyOption>(
-      v == 0 ? pubsub_internal::DefaultMaxConcurrency() : v);
+  opts_.set<MaxConcurrencyOption>(v == 0 ? pubsub_internal::DefaultThreadCount()
+                                         : v);
   return *this;
 }
 


### PR DESCRIPTION
Part of the work for #6306 

This change may seem strange on its own, because the code it is "replacing" is not touched in this PR. I did this because the full change is too large, and I want the PR's to be manageable. A (somewhat accurate) draft of the bigger picture can be found [here](https://github.com/dbolduc/google-cloud-cpp/commits/pubsub-options-big-picture).

Here are the sources for the default values:
* The logic related to `PUBSUB_EMULATOR_HOST` comes from `internal/emulator_overrides*` which will eventually be removed.
* The defaults for options from `GrpcOptionList` and `CommonOptionList` come from: [connection_options.cc](https://github.com/googleapis/google-cloud-cpp/blob/99a1cfd88cd67ed0e88c6c50712964ba8b3306c7/google/cloud/pubsub/connection_options.cc), except for `GrpcBackgroundThreadPoolSizeOption` which comes from [here (publisher)](https://github.com/googleapis/google-cloud-cpp/blob/99a1cfd88cd67ed0e88c6c50712964ba8b3306c7/google/cloud/pubsub/publisher_connection.cc#L123-L131) and [here(subscriber)](https://github.com/googleapis/google-cloud-cpp/blob/99a1cfd88cd67ed0e88c6c50712964ba8b3306c7/google/cloud/pubsub/subscriber_connection.cc#L147-L155)
* The defaults for options from `PolicyOptionList` come from: [here (publisher)](https://github.com/googleapis/google-cloud-cpp/blob/99a1cfd88cd67ed0e88c6c50712964ba8b3306c7/google/cloud/pubsub/publisher_connection.cc#L112-L113) and  [here (subscriber)](https://github.com/googleapis/google-cloud-cpp/blob/99a1cfd88cd67ed0e88c6c50712964ba8b3306c7/google/cloud/pubsub/subscriber_connection.cc#L136-L137)** (Note the special retry policy for the subscriber)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7335)
<!-- Reviewable:end -->
