### PR TITLE
feat(pubsub): configure SubscriptionAdminConnection with Options

### DIFF
--- a/google/cloud/pubsub/integration_tests/subscriber_integration_test.cc
+++ b/google/cloud/pubsub/integration_tests/subscriber_integration_test.cc
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "google/cloud/pubsub/internal/defaults.h"
 #include "google/cloud/pubsub/internal/streaming_subscription_batch_source.h"
 #include "google/cloud/pubsub/publisher.h"
 #include "google/cloud/pubsub/subscriber.h"
@@ -106,7 +107,8 @@ TEST_F(SubscriberIntegrationTest, RawStub) {
   auto publisher = Publisher(MakePublisherConnection(topic_, {}));
 
   internal::AutomaticallyCreatedBackgroundThreads background(4);
-  auto stub = pubsub_internal::CreateDefaultSubscriberStub({}, 0);
+  auto stub = pubsub_internal::CreateDefaultSubscriberStub(
+      pubsub_internal::DefaultCommonOptions({}), 0);
   google::pubsub::v1::StreamingPullRequest request;
   request.set_client_id("test-client-0001");
   request.set_subscription(subscription_.FullName());
@@ -183,7 +185,8 @@ TEST_F(SubscriberIntegrationTest, StreamingSubscriptionBatchSource) {
       pubsub::ConnectionOptions{}.set_background_thread_pool_size(2)));
 
   internal::AutomaticallyCreatedBackgroundThreads background(4);
-  auto stub = pubsub_internal::CreateDefaultSubscriberStub({}, 0);
+  auto stub = pubsub_internal::CreateDefaultSubscriberStub(
+      pubsub_internal::DefaultCommonOptions({}), 0);
 
   auto shutdown = std::make_shared<pubsub_internal::SessionShutdownManager>();
   auto source =

--- a/google/cloud/pubsub/internal/subscriber_stub.cc
+++ b/google/cloud/pubsub/internal/subscriber_stub.cc
@@ -193,6 +193,12 @@ class DefaultSubscriberStub : public SubscriberStub {
   std::unique_ptr<google::pubsub::v1::Subscriber::StubInterface> grpc_stub_;
 };
 
+std::shared_ptr<SubscriberStub> CreateDefaultSubscriberStub(Options const& opts,
+                                                            int channel_id) {
+  return std::make_shared<DefaultSubscriberStub>(
+      google::pubsub::v1::Subscriber::NewStub(CreateChannel(opts, channel_id)));
+}
+
 std::shared_ptr<SubscriberStub> CreateDefaultSubscriberStub(
     pubsub::ConnectionOptions options, int channel_id) {
   return std::make_shared<DefaultSubscriberStub>(

--- a/google/cloud/pubsub/internal/subscriber_stub.h
+++ b/google/cloud/pubsub/internal/subscriber_stub.h
@@ -124,6 +124,16 @@ class SubscriberStub {
 };
 
 /**
+ * Creates a SubscriberStub configured with @p opts and @p channel_id.
+ *
+ * @p channel_id should be unique among all stubs in the same Connection pool,
+ * to ensure they use different underlying connections.
+ */
+std::shared_ptr<SubscriberStub> CreateDefaultSubscriberStub(Options const& opts,
+                                                            int channel_id);
+
+// TODO(#6306) - Remove this function when we are done with it.
+/**
  * Creates a SubscriberStub configured with @p options and @p channel_id.
  *
  * @p channel_id should be unique among all stubs in the same Connection pool,

--- a/google/cloud/pubsub/schema_admin_connection_test.cc
+++ b/google/cloud/pubsub/schema_admin_connection_test.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "schema_admin_connection.h"
+#include "google/cloud/pubsub/schema_admin_connection.h"
 #include "google/cloud/pubsub/internal/defaults.h"
 #include "google/cloud/pubsub/testing/mock_schema_stub.h"
 #include "google/cloud/pubsub/testing/test_retry_policies.h"

--- a/google/cloud/pubsub/subscription_admin_connection.cc
+++ b/google/cloud/pubsub/subscription_admin_connection.cc
@@ -17,10 +17,10 @@
 #include "google/cloud/pubsub/internal/defaults.h"
 #include "google/cloud/pubsub/internal/subscriber_logging.h"
 #include "google/cloud/pubsub/internal/subscriber_metadata.h"
+#include "google/cloud/pubsub/internal/subscriber_stub.h"
 #include "google/cloud/pubsub/options.h"
 #include "google/cloud/internal/retry_loop.h"
 #include "google/cloud/log.h"
-#include "internal/subscriber_stub.h"
 #include <memory>
 
 namespace google {

--- a/google/cloud/pubsub/subscription_admin_connection.cc
+++ b/google/cloud/pubsub/subscription_admin_connection.cc
@@ -14,10 +14,13 @@
 
 #include "google/cloud/pubsub/subscription_admin_connection.h"
 #include "google/cloud/pubsub/internal/default_retry_policies.h"
+#include "google/cloud/pubsub/internal/defaults.h"
 #include "google/cloud/pubsub/internal/subscriber_logging.h"
 #include "google/cloud/pubsub/internal/subscriber_metadata.h"
+#include "google/cloud/pubsub/options.h"
 #include "google/cloud/internal/retry_loop.h"
 #include "google/cloud/log.h"
+#include "internal/subscriber_stub.h"
 #include <memory>
 
 namespace google {
@@ -247,20 +250,19 @@ class SubscriptionAdminConnectionImpl
 }  // namespace
 
 std::shared_ptr<pubsub::SubscriptionAdminConnection>
-MakeSubscriptionAdminConnection(
-    pubsub::ConnectionOptions const& options,
-    std::shared_ptr<SubscriberStub> stub,
-    std::unique_ptr<pubsub::RetryPolicy const> retry_policy,
-    std::unique_ptr<pubsub::BackoffPolicy const> backoff_policy) {
+MakeSubscriptionAdminConnection(Options const& opts,
+                                std::shared_ptr<SubscriberStub> stub) {
   stub = std::make_shared<SubscriberMetadata>(std::move(stub));
-  if (options.tracing_enabled("rpc")) {
+  auto const& tracing = opts.get<TracingComponentsOption>();
+  if (internal::Contains(tracing, "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
-    stub = std::make_shared<pubsub_internal::SubscriberLogging>(
-        std::move(stub), options.tracing_options(),
-        options.tracing_enabled("rpc-streams"));
+    stub = std::make_shared<SubscriberLogging>(
+        std::move(stub), opts.get<GrpcTracingOptionsOption>(),
+        internal::Contains(tracing, "rpc-streams"));
   }
   return std::make_shared<SubscriptionAdminConnectionImpl>(
-      std::move(stub), std::move(retry_policy), std::move(backoff_policy));
+      std::move(stub), opts.get<pubsub::RetryPolicyOption>()->clone(),
+      opts.get<pubsub::BackoffPolicyOption>()->clone());
 }
 
 }  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS
@@ -270,15 +272,29 @@ namespace pubsub {
 inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
 
 std::shared_ptr<SubscriptionAdminConnection> MakeSubscriptionAdminConnection(
-    ConnectionOptions const& options,
+    std::initializer_list<pubsub_internal::NonConstructible>) {
+  return MakeSubscriptionAdminConnection();
+}
+
+std::shared_ptr<SubscriptionAdminConnection> MakeSubscriptionAdminConnection(
+    Options opts) {
+  internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 PolicyOptionList>(opts, __func__);
+  opts = pubsub_internal::DefaultCommonOptions(std::move(opts));
+  auto stub =
+      pubsub_internal::CreateDefaultSubscriberStub(opts, /*channel_id=*/0);
+  return pubsub_internal::MakeSubscriptionAdminConnection(std::move(opts),
+                                                          std::move(stub));
+}
+
+std::shared_ptr<SubscriptionAdminConnection> MakeSubscriptionAdminConnection(
+    pubsub::ConnectionOptions const& options,
     std::unique_ptr<pubsub::RetryPolicy const> retry_policy,
     std::unique_ptr<pubsub::BackoffPolicy const> backoff_policy) {
-  if (!retry_policy) retry_policy = pubsub_internal::DefaultRetryPolicy();
-  if (!backoff_policy) backoff_policy = pubsub_internal::DefaultBackoffPolicy();
-  return pubsub_internal::MakeSubscriptionAdminConnection(
-      options,
-      pubsub_internal::CreateDefaultSubscriberStub(options, /*channel_id=*/0),
-      std::move(retry_policy), std::move(backoff_policy));
+  auto opts = internal::MakeOptions(options);
+  if (retry_policy) opts.set<RetryPolicyOption>(retry_policy->clone());
+  if (backoff_policy) opts.set<BackoffPolicyOption>(backoff_policy->clone());
+  return MakeSubscriptionAdminConnection(std::move(opts));
 }
 
 SubscriptionAdminConnection::~SubscriptionAdminConnection() = default;

--- a/google/cloud/pubsub/subscription_admin_connection.h
+++ b/google/cloud/pubsub/subscription_admin_connection.h
@@ -246,7 +246,7 @@ std::shared_ptr<SubscriptionAdminConnection> MakeSubscriptionAdminConnection(
  * @see `SubscriberConnection`
  *
  * @param options (optional) configure the `SubscriptionAdminConnection` created
- * by this function.
+ *     by this function.
  * @param retry_policy control for how long (or how many times) are retryable
  *     RPCs attempted.
  * @param backoff_policy controls the backoff behavior between retry attempts,
@@ -256,7 +256,7 @@ std::shared_ptr<SubscriptionAdminConnection> MakeSubscriptionAdminConnection(
  *     accepts `google::cloud::Options` instead.
  */
 std::shared_ptr<SubscriptionAdminConnection> MakeSubscriptionAdminConnection(
-    ConnectionOptions const& option,
+    ConnectionOptions const& options,
     std::unique_ptr<pubsub::RetryPolicy const> retry_policy = {},
     std::unique_ptr<pubsub::BackoffPolicy const> backoff_policy = {});
 

--- a/google/cloud/pubsub/subscription_admin_connection.h
+++ b/google/cloud/pubsub/subscription_admin_connection.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/pubsub/backoff_policy.h"
 #include "google/cloud/pubsub/connection_options.h"
+#include "google/cloud/pubsub/internal/non_constructible.h"
 #include "google/cloud/pubsub/internal/subscriber_stub.h"
 #include "google/cloud/pubsub/retry_policy.h"
 #include "google/cloud/pubsub/snapshot.h"
@@ -25,6 +26,7 @@
 #include "google/cloud/internal/pagination_range.h"
 #include "google/cloud/status_or.h"
 #include <google/pubsub/v1/pubsub.pb.h>
+#include <initializer_list>
 #include <memory>
 #include <string>
 
@@ -61,13 +63,12 @@ using ListSnapshotsRange =
  * A connection to Cloud Pub/Sub for subscription-related administrative
  * operations.
  *
- * This interface defines pure-virtual methods for each of the user-facing
- * overload sets in `SubscriberAdminClient`. That is, all of
- * `SubscriberAdminClient`'s `CreateSubscription()` overloads will forward to
- * the one pure-virtual `CreateSubscription()` method declared in this
- * interface, and similar for `SubscriberClient`'s other methods. This allows
- * users to inject custom behavior (e.g., with a Google Mock object) in a
- * `SubscriberClient` object for use in their own tests.
+ * This interface defines pure-virtual functions for each of the user-facing
+ * overload sets in `SubscriptionAdminClient`. That is, all of
+ * `SubscriptionAdminClient` overloads will forward to the one pure-virtual
+ * function declared in this interface. This allows users to inject custom
+ * behavior (e.g., with a Google Mock object) in a `SubscriptionAdminClient`
+ * object for use in their own tests.
  *
  * To create a concrete instance that connects you to the real Cloud Pub/Sub
  * service, see `MakeSubscriptionAdminConnection()`.
@@ -185,16 +186,57 @@ class SubscriptionAdminConnection {
 };
 
 /**
- * Returns an SubscriberConnection object to work with Cloud Pub/Sub subscriber
- * APIs.
+ * Creates a new `SubscriptionAdminConnection` object to work with
+ * `SubscriptionAdminClient`.
  *
- * The `SubscriberConnection` class is not intended for direct use in
- * applications, it is provided for applications wanting to mock the
- * `SubscriberClient` behavior in their tests.
+ * @note This function exists solely for backwards compatibility. It prevents
+ *     existing code that calls `MakeSubscriptionAdminConnection({})` from
+ *     breaking, due to ambiguity.
+ *
+ * @deprecated Please use `MakeSubscriptionAdminConnection()` instead.
+ */
+std::shared_ptr<SubscriptionAdminConnection> MakeSubscriptionAdminConnection(
+    std::initializer_list<pubsub_internal::NonConstructible>);
+
+/**
+ * Creates a new `SubscriptionAdminConnection` object to work with
+ * `SubscriptionAdminClient`.
+ *
+ * The `SubscriptionAdminConnection` class is provided for applications wanting
+ * to mock the `SubscriptionAdminClient` behavior in their tests. It is not
+ * intended for direct use.
  *
  * @par Performance
  * Creating a new `SubscriptionAdminConnection` is relatively expensive. This
- * typically initiate connections to the service, and therefore these objects
+ * typically initiates connections to the service, and therefore these objects
+ * should be shared and reused when possible. Note that gRPC reuses existing OS
+ * resources (sockets) whenever possible, so applications may experience better
+ * performance on the second (and subsequent) calls to this function with the
+ * same `Options` from `GrpcOptionList` and `CommonOptionList`. However, this
+ * behavior is not guaranteed and applications should not rely on it.
+ *
+ * @see `SubscriptionAdminClient`
+ *
+ * @param opts The options to use for this call. Expected options are any of
+ *     the types in the following option lists.
+ *       - `google::cloud::CommonOptionList`
+ *       - `google::cloud::GrpcOptionList`
+ *       - `google::cloud::pubsub::PolicyOptionList`
+ */
+std::shared_ptr<SubscriptionAdminConnection> MakeSubscriptionAdminConnection(
+    Options opts = {});
+
+/**
+ * Creates a new `SubscriptionAdminConnection` object to work with
+ * `SubscriptionAdminClient`.
+ *
+ * The `SubscriptionAdminConnection` class is not intended for direct use in
+ * applications, it is provided for applications wanting to mock the
+ * `SubscriptionAdminClient` behavior in their tests.
+ *
+ * @par Performance
+ * Creating a new `SubscriptionAdminConnection` is relatively expensive. This
+ * typically initiates connections to the service, and therefore these objects
  * should be shared and reused when possible. Note that gRPC reuses existing OS
  * resources (sockets) whenever possible, so applications may experience better
  * performance on the second (and subsequent) calls to this function with the
@@ -203,15 +245,18 @@ class SubscriptionAdminConnection {
  *
  * @see `SubscriberConnection`
  *
- * @param options (optional) configure the `SubscriberConnection` created by
- *     this function.
+ * @param options (optional) configure the `SubscriptionAdminConnection` created
+ * by this function.
  * @param retry_policy control for how long (or how many times) are retryable
  *     RPCs attempted.
  * @param backoff_policy controls the backoff behavior between retry attempts,
  *     typically some form of exponential backoff with jitter.
+ *
+ * @deprecated Please use the `MakeSubscriptionAdminConnection` function that
+ *     accepts `google::cloud::Options` instead.
  */
 std::shared_ptr<SubscriptionAdminConnection> MakeSubscriptionAdminConnection(
-    ConnectionOptions const& options = ConnectionOptions(),
+    ConnectionOptions const& option,
     std::unique_ptr<pubsub::RetryPolicy const> retry_policy = {},
     std::unique_ptr<pubsub::BackoffPolicy const> backoff_policy = {});
 
@@ -222,11 +267,8 @@ namespace pubsub_internal {
 inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
 
 std::shared_ptr<pubsub::SubscriptionAdminConnection>
-MakeSubscriptionAdminConnection(
-    pubsub::ConnectionOptions const& options,
-    std::shared_ptr<SubscriberStub> stub,
-    std::unique_ptr<pubsub::RetryPolicy const> retry_policy,
-    std::unique_ptr<pubsub::BackoffPolicy const> backoff_policy);
+MakeSubscriptionAdminConnection(Options const& opts,
+                                std::shared_ptr<SubscriberStub> stub);
 
 }  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS
 }  // namespace pubsub_internal


### PR DESCRIPTION
Part of the work for #6306 

Still TODO for the task:
* `MakePublisherConnection` and `MakeSubscriberConnection` functions need to take `Options`. (These may be more involved, than the previous 3 PRs)
* Then just cleanups.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7339)
<!-- Reviewable:end -->
