### PR TITLE
feat(pubsub): configure PublisherConnection with Options

### DIFF
--- a/google/cloud/pubsub/internal/batching_publisher_connection.cc
+++ b/google/cloud/pubsub/internal/batching_publisher_connection.cc
@@ -51,7 +51,7 @@ struct Batch {
 
 future<StatusOr<std::string>> BatchingPublisherConnection::Publish(
     PublishParams p) {
-  auto const bytes = pubsub_internal::MessageSize(p.message);
+  auto const bytes = MessageSize(p.message);
   std::unique_lock<std::mutex> lk(mu_);
   do {
     if (!corked_on_status_.ok()) return CorkedError();
@@ -59,9 +59,9 @@ future<StatusOr<std::string>> BatchingPublisherConnection::Publish(
     // otherwise the message may be dropped.
     if (waiters_.empty()) break;
     auto const has_bytes_capacity =
-        current_bytes_ + bytes <= options_.maximum_batch_bytes();
+        current_bytes_ + bytes <= opts_.get<pubsub::MaxBatchBytesOption>();
     auto const has_messages_capacity =
-        waiters_.size() < options_.maximum_batch_message_count();
+        waiters_.size() < opts_.get<pubsub::MaxBatchMessagesOption>();
     // If there is enough room just add the message below.
     if (has_bytes_capacity && has_messages_capacity) break;
     // We need to flush the existing batch, that will release the lock, and then
@@ -70,7 +70,7 @@ future<StatusOr<std::string>> BatchingPublisherConnection::Publish(
     lk = std::unique_lock<std::mutex>(mu_);
   } while (true);
 
-  auto proto = pubsub_internal::ToProto(std::move(p.message));
+  auto proto = ToProto(std::move(p.message));
   waiters_.emplace_back();
   auto f = waiters_.back().get_future();
 
@@ -126,8 +126,9 @@ void BatchingPublisherConnection::HandleError(Status const& status) {
 
 void BatchingPublisherConnection::MaybeFlush(std::unique_lock<std::mutex> lk) {
   auto const too_many_messages =
-      waiters_.size() >= options_.maximum_batch_message_count();
-  auto const too_many_bytes = current_bytes_ >= options_.maximum_batch_bytes();
+      waiters_.size() >= opts_.get<pubsub::MaxBatchMessagesOption>();
+  auto const too_many_bytes =
+      current_bytes_ >= opts_.get<pubsub::MaxBatchBytesOption>();
   if (too_many_messages || too_many_bytes) {
     FlushImpl(std::move(lk));
     return;
@@ -137,7 +138,7 @@ void BatchingPublisherConnection::MaybeFlush(std::unique_lock<std::mutex> lk) {
   // to set it again.
   if (pending_.messages_size() != 1) return;
   auto const expiration = batch_expiration_ =
-      std::chrono::system_clock::now() + options_.maximum_hold_time();
+      std::chrono::system_clock::now() + opts_.get<pubsub::MaxHoldTimeOption>();
   lk.unlock();
   // We need a weak_ptr<> because this class owns the completion queue,
   // creating a lambda with a shared_ptr<> owning this class would create a
@@ -186,7 +187,7 @@ void BatchingPublisherConnection::FlushImpl(std::unique_lock<std::mutex> lk) {
   request.Swap(&pending_);
   // Reserve enough capacity for the next batch.
   pending_.mutable_messages()->Reserve(
-      static_cast<int>(options_.maximum_batch_message_count()));
+      static_cast<int>(opts_.get<pubsub::MaxBatchMessagesOption>()));
   current_bytes_ = 0;
   lk.unlock();
 

--- a/google/cloud/pubsub/internal/batching_publisher_connection.h
+++ b/google/cloud/pubsub/internal/batching_publisher_connection.h
@@ -34,11 +34,10 @@ class BatchingPublisherConnection
       public std::enable_shared_from_this<BatchingPublisherConnection> {
  public:
   static std::shared_ptr<BatchingPublisherConnection> Create(
-      pubsub::Topic topic, pubsub::PublisherOptions options,
-      std::string ordering_key, std::shared_ptr<BatchSink> sink,
-      google::cloud::CompletionQueue cq) {
+      pubsub::Topic topic, Options opts, std::string ordering_key,
+      std::shared_ptr<BatchSink> sink, CompletionQueue cq) {
     return std::shared_ptr<BatchingPublisherConnection>(
-        new BatchingPublisherConnection(std::move(topic), std::move(options),
+        new BatchingPublisherConnection(std::move(topic), std::move(opts),
                                         std::move(ordering_key),
                                         std::move(sink), std::move(cq)));
   }
@@ -50,14 +49,13 @@ class BatchingPublisherConnection
   void HandleError(Status const& status);
 
  private:
-  explicit BatchingPublisherConnection(pubsub::Topic topic,
-                                       pubsub::PublisherOptions options,
+  explicit BatchingPublisherConnection(pubsub::Topic topic, Options opts,
                                        std::string ordering_key,
                                        std::shared_ptr<BatchSink> sink,
-                                       google::cloud::CompletionQueue cq)
+                                       CompletionQueue cq)
       : topic_(std::move(topic)),
         topic_full_name_(topic_.FullName()),
-        options_(std::move(options)),
+        opts_(std::move(opts)),
         ordering_key_(std::move(ordering_key)),
         sink_(std::move(sink)),
         cq_(std::move(cq)) {}
@@ -71,10 +69,10 @@ class BatchingPublisherConnection
 
   pubsub::Topic const topic_;
   std::string const topic_full_name_;
-  pubsub::PublisherOptions const options_;
+  Options const opts_;
   std::string const ordering_key_;
   std::shared_ptr<BatchSink> const sink_;
-  google::cloud::CompletionQueue cq_;
+  CompletionQueue cq_;
 
   std::mutex mu_;
   std::vector<promise<StatusOr<std::string>>> waiters_;

--- a/google/cloud/pubsub/internal/default_batch_sink.h
+++ b/google/cloud/pubsub/internal/default_batch_sink.h
@@ -32,13 +32,10 @@ inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
 class DefaultBatchSink : public BatchSink {
  public:
   static std::shared_ptr<DefaultBatchSink> Create(
-      std::shared_ptr<pubsub_internal::PublisherStub> stub,
-      google::cloud::CompletionQueue cq,
-      std::unique_ptr<pubsub::RetryPolicy const> retry_policy,
-      std::unique_ptr<pubsub::BackoffPolicy const> backoff_policy) {
-    return std::shared_ptr<DefaultBatchSink>(new DefaultBatchSink(
-        std::move(stub), std::move(cq), std::move(retry_policy),
-        std::move(backoff_policy)));
+      std::shared_ptr<PublisherStub> stub, CompletionQueue cq,
+      Options const& opts) {
+    return std::shared_ptr<DefaultBatchSink>(
+        new DefaultBatchSink(std::move(stub), std::move(cq), opts));
   }
 
   ~DefaultBatchSink() override = default;
@@ -49,13 +46,11 @@ class DefaultBatchSink : public BatchSink {
   void ResumePublish(std::string const& ordering_key) override;
 
  private:
-  DefaultBatchSink(std::shared_ptr<pubsub_internal::PublisherStub> stub,
-                   google::cloud::CompletionQueue cq,
-                   std::unique_ptr<pubsub::RetryPolicy const> retry_policy,
-                   std::unique_ptr<pubsub::BackoffPolicy const> backoff_policy);
+  DefaultBatchSink(std::shared_ptr<PublisherStub> stub, CompletionQueue cq,
+                   Options const& opts);
 
-  std::shared_ptr<pubsub_internal::PublisherStub> stub_;
-  google::cloud::CompletionQueue cq_;
+  std::shared_ptr<PublisherStub> stub_;
+  CompletionQueue cq_;
   std::unique_ptr<pubsub::RetryPolicy const> retry_policy_;
   std::unique_ptr<pubsub::BackoffPolicy const> backoff_policy_;
 };

--- a/google/cloud/pubsub/internal/default_batch_sink_test.cc
+++ b/google/cloud/pubsub/internal/default_batch_sink_test.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/pubsub/internal/default_batch_sink.h"
+#include "google/cloud/pubsub/internal/defaults.h"
 #include "google/cloud/pubsub/testing/mock_publisher_stub.h"
 #include "google/cloud/pubsub/testing/test_retry_policies.h"
 #include "google/cloud/pubsub/topic.h"
@@ -32,6 +33,13 @@ using ::google::cloud::testing_util::StatusIs;
 using ::testing::AtLeast;
 using ::testing::HasSubstr;
 using ::testing::Unused;
+
+std::shared_ptr<DefaultBatchSink> MakeTestBatchSink(
+    std::shared_ptr<PublisherStub> mock, CompletionQueue cq) {
+  return DefaultBatchSink::Create(
+      std::move(mock), std::move(cq),
+      DefaultPublisherOptions(pubsub_testing::MakeTestOptions()));
+}
 
 pubsub::Topic TestTopic() {
   return pubsub::Topic("test-project", "test-topic");
@@ -69,9 +77,7 @@ TEST(DefaultBatchSinkTest, BasicWithRetry) {
       });
 
   internal::AutomaticallyCreatedBackgroundThreads background;
-  auto uut = DefaultBatchSink::Create(mock, background.cq(),
-                                      pubsub_testing::TestRetryPolicy(),
-                                      pubsub_testing::TestBackoffPolicy());
+  auto uut = MakeTestBatchSink(mock, background.cq());
 
   auto response = uut->AsyncPublish(MakeRequest(3)).get();
   ASSERT_THAT(response, IsOk());
@@ -88,9 +94,7 @@ TEST(DefaultBatchSinkTest, PermanentError) {
   });
 
   internal::AutomaticallyCreatedBackgroundThreads background;
-  auto uut = DefaultBatchSink::Create(mock, background.cq(),
-                                      pubsub_testing::TestRetryPolicy(),
-                                      pubsub_testing::TestBackoffPolicy());
+  auto uut = MakeTestBatchSink(mock, background.cq());
 
   auto response = uut->AsyncPublish(MakeRequest(3)).get();
   ASSERT_THAT(response,
@@ -107,9 +111,7 @@ TEST(DefaultBatchSinkTest, TooManyTransients) {
       });
 
   internal::AutomaticallyCreatedBackgroundThreads background;
-  auto uut = DefaultBatchSink::Create(mock, background.cq(),
-                                      pubsub_testing::TestRetryPolicy(),
-                                      pubsub_testing::TestBackoffPolicy());
+  auto uut = MakeTestBatchSink(mock, background.cq());
 
   auto response = uut->AsyncPublish(MakeRequest(3)).get();
   ASSERT_THAT(response,

--- a/google/cloud/pubsub/publisher_connection.cc
+++ b/google/cloud/pubsub/publisher_connection.cc
@@ -16,7 +16,9 @@
 #include "google/cloud/pubsub/internal/batching_publisher_connection.h"
 #include "google/cloud/pubsub/internal/default_batch_sink.h"
 #include "google/cloud/pubsub/internal/default_retry_policies.h"
+#include "google/cloud/pubsub/internal/defaults.h"
 #include "google/cloud/pubsub/internal/flow_controlled_publisher_connection.h"
+#include "google/cloud/pubsub/internal/non_constructible.h"
 #include "google/cloud/pubsub/internal/ordering_key_publisher_connection.h"
 #include "google/cloud/pubsub/internal/publisher_logging.h"
 #include "google/cloud/pubsub/internal/publisher_metadata.h"
@@ -24,6 +26,7 @@
 #include "google/cloud/pubsub/internal/publisher_stub.h"
 #include "google/cloud/pubsub/internal/rejects_with_ordering_key.h"
 #include "google/cloud/pubsub/internal/sequential_batch_sink.h"
+#include "google/cloud/pubsub/options.h"
 #include "google/cloud/future_void.h"
 #include "google/cloud/log.h"
 #include <memory>
@@ -69,19 +72,36 @@ void PublisherConnection::Flush(FlushParams) {}
 void PublisherConnection::ResumePublish(ResumePublishParams) {}
 
 std::shared_ptr<PublisherConnection> MakePublisherConnection(
+    Topic topic, std::initializer_list<pubsub_internal::NonConstructible>) {
+  return MakePublisherConnection(std::move(topic));
+}
+
+std::shared_ptr<PublisherConnection> MakePublisherConnection(Topic topic,
+                                                             Options opts) {
+  internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 PolicyOptionList, PublisherOptionList>(
+      opts, __func__);
+  opts = pubsub_internal::DefaultPublisherOptions(std::move(opts));
+  std::vector<std::shared_ptr<pubsub_internal::PublisherStub>> children(
+      opts.get<GrpcNumChannelsOption>());
+  int id = 0;
+  std::generate(children.begin(), children.end(), [&id, &opts] {
+    return pubsub_internal::CreateDefaultPublisherStub(opts, id++);
+  });
+  return pubsub_internal::MakePublisherConnection(
+      std::move(topic), std::move(opts), std::move(children));
+}
+
+std::shared_ptr<PublisherConnection> MakePublisherConnection(
     Topic topic, PublisherOptions options, ConnectionOptions connection_options,
     std::unique_ptr<pubsub::RetryPolicy const> retry_policy,
     std::unique_ptr<pubsub::BackoffPolicy const> backoff_policy) {
-  std::vector<std::shared_ptr<pubsub_internal::PublisherStub>> children(
-      connection_options.num_channels());
-  int id = 0;
-  std::generate(children.begin(), children.end(), [&id, &connection_options] {
-    return pubsub_internal::CreateDefaultPublisherStub(connection_options,
-                                                       id++);
-  });
-  return pubsub_internal::MakePublisherConnection(
-      std::move(topic), std::move(options), std::move(connection_options),
-      std::move(children), std::move(retry_policy), std::move(backoff_policy));
+  auto opts = internal::MergeOptions(
+      pubsub_internal::MakeOptions(std::move(options)),
+      internal::MakeOptions(std::move(connection_options)));
+  if (retry_policy) opts.set<RetryPolicyOption>(retry_policy->clone());
+  if (backoff_policy) opts.set<BackoffPolicyOption>(backoff_policy->clone());
+  return MakePublisherConnection(std::move(topic), std::move(opts));
 }
 
 }  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS
@@ -91,64 +111,37 @@ namespace pubsub_internal {
 inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
 
 std::shared_ptr<pubsub::PublisherConnection> MakePublisherConnection(
-    pubsub::Topic topic, pubsub::PublisherOptions options,
-    pubsub::ConnectionOptions connection_options,
-    std::shared_ptr<PublisherStub> stub,
-    std::unique_ptr<pubsub::RetryPolicy const> retry_policy,
-    std::unique_ptr<pubsub::BackoffPolicy const> backoff_policy) {
-  std::vector<std::shared_ptr<PublisherStub>> children{std::move(stub)};
-  return MakePublisherConnection(
-      std::move(topic), std::move(options), std::move(connection_options),
-      std::move(children), std::move(retry_policy), std::move(backoff_policy));
-}
-
-std::shared_ptr<pubsub::PublisherConnection> MakePublisherConnection(
-    pubsub::Topic topic, pubsub::PublisherOptions options,
-    pubsub::ConnectionOptions connection_options,
-    std::vector<std::shared_ptr<PublisherStub>> stubs,
-    std::unique_ptr<pubsub::RetryPolicy const> retry_policy,
-    std::unique_ptr<pubsub::BackoffPolicy const> backoff_policy) {
+    pubsub::Topic topic, Options opts,
+    std::vector<std::shared_ptr<PublisherStub>> stubs) {
   if (stubs.empty()) return nullptr;
-  if (!retry_policy) retry_policy = DefaultRetryPolicy();
-  if (!backoff_policy) backoff_policy = DefaultBackoffPolicy();
   std::shared_ptr<PublisherStub> stub =
       std::make_shared<PublisherRoundRobin>(std::move(stubs));
   stub = std::make_shared<PublisherMetadata>(std::move(stub));
-  if (connection_options.tracing_enabled("rpc")) {
+  if (internal::Contains(opts.get<TracingComponentsOption>(), "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<PublisherLogging>(
-        std::move(stub), connection_options.tracing_options());
+        std::move(stub), opts.get<GrpcTracingOptionsOption>());
   }
 
-  auto default_thread_pool_size = []() -> std::size_t {
-    auto constexpr kDefaultThreadPoolSize = 4;
-    auto const n = std::thread::hardware_concurrency();
-    return n == 0 ? kDefaultThreadPoolSize : n;
-  };
-  if (connection_options.background_thread_pool_size() == 0) {
-    connection_options.set_background_thread_pool_size(
-        default_thread_pool_size());
-  }
-
-  auto background = connection_options.background_threads_factory()();
+  auto background = internal::MakeBackgroundThreadsFactory(opts)();
   auto make_connection = [&]() -> std::shared_ptr<pubsub::PublisherConnection> {
     auto cq = background->cq();
-    std::shared_ptr<BatchSink> sink = DefaultBatchSink::Create(
-        stub, cq, std::move(retry_policy), std::move(backoff_policy));
-    if (options.message_ordering()) {
-      auto factory = [topic, options, sink, cq](std::string const& key) {
+    std::shared_ptr<BatchSink> sink = DefaultBatchSink::Create(stub, cq, opts);
+    if (opts.get<pubsub::MessageOrderingOption>()) {
+      auto factory = [topic, opts, sink, cq](std::string const& key) {
         return BatchingPublisherConnection::Create(
-            topic, options, key, SequentialBatchSink::Create(sink), cq);
+            topic, opts, key, SequentialBatchSink::Create(sink), cq);
       };
       return OrderingKeyPublisherConnection::Create(std::move(factory));
     }
     return RejectsWithOrderingKey::Create(BatchingPublisherConnection::Create(
-        std::move(topic), options, {}, std::move(sink), std::move(cq)));
+        std::move(topic), opts, {}, std::move(sink), std::move(cq)));
   };
   auto connection = make_connection();
-  if (options.full_publisher_rejects() || options.full_publisher_blocks()) {
+  if (opts.get<pubsub::FullPublisherActionOption>() !=
+      pubsub::FullPublisherAction::kIgnored) {
     connection = FlowControlledPublisherConnection::Create(
-        options, std::move(connection));
+        std::move(opts), std::move(connection));
   }
   return std::make_shared<pubsub::ContainingPublisherConnection>(
       std::move(background), std::move(connection));

--- a/google/cloud/pubsub/testing/test_retry_policies.h
+++ b/google/cloud/pubsub/testing/test_retry_policies.h
@@ -26,7 +26,7 @@ namespace cloud {
 namespace pubsub_testing {
 inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
 
-Options MakeTestOptions(Options opts);
+Options MakeTestOptions(Options opts = {});
 
 std::unique_ptr<pubsub::RetryPolicy const> TestRetryPolicy();
 


### PR DESCRIPTION
Part of the work for #6306 

Only `SubscriberConnection` remains.... (for the feature part of the task, the rest is cleanup)

Note: We are now done with the `CreateDefaultPublisherStub` function that takes `ConnectionOptions`. My plan is to clean that up all at one time, along with the following, which are all used in some way by `the SubscriberConnection`:
* the `CreateDefaultSubscriberStub` function that takes `ConnectionOptions`
* the `CreateChannel` function that takes `ConnectionOptions`
* the emulator overrides
* default retry policies
* test retry policies

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7341)
<!-- Reviewable:end -->
