### PR TITLE
feat(pubsub): configure SubscriberConnection with Options

### DIFF
--- a/google/cloud/pubsub/integration_tests/subscriber_integration_test.cc
+++ b/google/cloud/pubsub/integration_tests/subscriber_integration_test.cc
@@ -193,10 +193,10 @@ TEST_F(SubscriberIntegrationTest, StreamingSubscriptionBatchSource) {
       std::make_shared<pubsub_internal::StreamingSubscriptionBatchSource>(
           background.cq(), shutdown, stub, subscription_.FullName(),
           "test-client-0001",
-          pubsub::SubscriberOptions{}.set_max_deadline_time(
-              std::chrono::seconds(300)),
-          pubsub_testing::TestRetryPolicy(),
-          pubsub_testing::TestBackoffPolicy());
+          pubsub_internal::DefaultSubscriberOptions(
+              pubsub_testing::MakeTestOptions(
+                  Options{}.set<MaxDeadlineTimeOption>(
+                      std::chrono::seconds(300)))));
 
   // This must be declared after `source` as it captures it and uses it to send
   // back acknowledgements.

--- a/google/cloud/pubsub/internal/streaming_subscription_batch_source.h
+++ b/google/cloud/pubsub/internal/streaming_subscription_batch_source.h
@@ -65,23 +65,22 @@ class StreamingSubscriptionBatchSource
       public std::enable_shared_from_this<StreamingSubscriptionBatchSource> {
  public:
   explicit StreamingSubscriptionBatchSource(
-      google::cloud::CompletionQueue cq,
+      CompletionQueue cq,
       std::shared_ptr<SessionShutdownManager> shutdown_manager,
       std::shared_ptr<SubscriberStub> stub, std::string subscription_full_name,
-      std::string client_id, pubsub::SubscriberOptions const& options,
-      std::unique_ptr<pubsub::RetryPolicy const> retry_policy,
-      std::unique_ptr<pubsub::BackoffPolicy const> backoff_policy,
+      std::string client_id, Options const& opts,
       AckBatchingConfig ack_batching_config = {})
       : cq_(std::move(cq)),
         shutdown_manager_(std::move(shutdown_manager)),
         stub_(std::move(stub)),
         subscription_full_name_(std::move(subscription_full_name)),
         client_id_(std::move(client_id)),
-        max_outstanding_messages_(options.max_outstanding_messages()),
-        max_outstanding_bytes_(options.max_outstanding_bytes()),
-        max_deadline_time_(options.max_deadline_time()),
-        retry_policy_(std::move(retry_policy)),
-        backoff_policy_(std::move(backoff_policy)),
+        max_outstanding_messages_(
+            opts.get<pubsub::MaxOutstandingMessagesOption>()),
+        max_outstanding_bytes_(opts.get<pubsub::MaxOutstandingBytesOption>()),
+        max_deadline_time_(opts.get<pubsub::MaxDeadlineTimeOption>()),
+        retry_policy_(opts.get<pubsub::RetryPolicyOption>()->clone()),
+        backoff_policy_(opts.get<pubsub::BackoffPolicyOption>()->clone()),
         ack_batching_config_(std::move(ack_batching_config)) {}
 
   ~StreamingSubscriptionBatchSource() override = default;
@@ -149,7 +148,7 @@ class StreamingSubscriptionBatchSource
   void ChangeState(std::unique_lock<std::mutex> const& lk, StreamState s,
                    char const* where, char const* reason);
 
-  google::cloud::CompletionQueue cq_;
+  CompletionQueue cq_;
   std::shared_ptr<SessionShutdownManager> const shutdown_manager_;
   std::shared_ptr<SubscriberStub> const stub_;
   std::string const subscription_full_name_;

--- a/google/cloud/pubsub/internal/subscription_session.h
+++ b/google/cloud/pubsub/internal/subscription_session.h
@@ -35,13 +35,9 @@ namespace pubsub_internal {
 inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
 
 future<Status> CreateSubscriptionSession(
-    pubsub::Subscription const& subscription,
-    pubsub::SubscriberOptions const& options,
-    std::shared_ptr<pubsub_internal::SubscriberStub> const& stub,
-    google::cloud::CompletionQueue const& executor, std::string client_id,
-    pubsub::SubscriberConnection::SubscribeParams p,
-    std::unique_ptr<pubsub::RetryPolicy const> retry_policy,
-    std::unique_ptr<pubsub::BackoffPolicy const> backoff_policy);
+    pubsub::Subscription const& subscription, Options const& opts,
+    std::shared_ptr<SubscriberStub> const& stub, CompletionQueue const& cq,
+    std::string client_id, pubsub::SubscriberConnection::SubscribeParams p);
 
 }  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS
 }  // namespace pubsub_internal

--- a/google/cloud/pubsub/subscriber_connection.cc
+++ b/google/cloud/pubsub/subscriber_connection.cc
@@ -14,10 +14,12 @@
 
 #include "google/cloud/pubsub/subscriber_connection.h"
 #include "google/cloud/pubsub/internal/default_retry_policies.h"
+#include "google/cloud/pubsub/internal/defaults.h"
 #include "google/cloud/pubsub/internal/subscriber_logging.h"
 #include "google/cloud/pubsub/internal/subscriber_metadata.h"
 #include "google/cloud/pubsub/internal/subscriber_round_robin.h"
 #include "google/cloud/pubsub/internal/subscription_session.h"
+#include "google/cloud/pubsub/options.h"
 #include "google/cloud/pubsub/retry_policy.h"
 #include "google/cloud/internal/random.h"
 #include "google/cloud/log.h"
@@ -39,21 +41,38 @@ future<Status> SubscriberConnection::Subscribe(SubscribeParams) {
 }
 
 std::shared_ptr<SubscriberConnection> MakeSubscriberConnection(
+    Subscription subscription,
+    std::initializer_list<pubsub_internal::NonConstructible>) {
+  return MakeSubscriberConnection(std::move(subscription));
+}
+
+std::shared_ptr<SubscriberConnection> MakeSubscriberConnection(
+    Subscription subscription, Options opts) {
+  internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 PolicyOptionList, SubscriberOptionList>(
+      opts, __func__);
+  opts = pubsub_internal::DefaultSubscriberOptions(std::move(opts));
+  std::vector<std::shared_ptr<pubsub_internal::SubscriberStub>> children(
+      opts.get<GrpcNumChannelsOption>());
+  int id = 0;
+  std::generate(children.begin(), children.end(), [&id, &opts] {
+    return pubsub_internal::CreateDefaultSubscriberStub(opts, id++);
+  });
+  return pubsub_internal::MakeSubscriberConnection(
+      std::move(subscription), std::move(opts), std::move(children));
+}
+
+std::shared_ptr<SubscriberConnection> MakeSubscriberConnection(
     Subscription subscription, SubscriberOptions options,
     ConnectionOptions connection_options,
     std::unique_ptr<pubsub::RetryPolicy const> retry_policy,
     std::unique_ptr<pubsub::BackoffPolicy const> backoff_policy) {
-  std::vector<std::shared_ptr<pubsub_internal::SubscriberStub>> children(
-      connection_options.num_channels());
-  int id = 0;
-  std::generate(children.begin(), children.end(), [&id, &connection_options] {
-    return pubsub_internal::CreateDefaultSubscriberStub(connection_options,
-                                                        id++);
-  });
-  return pubsub_internal::MakeSubscriberConnection(
-      std::move(subscription), std::move(options),
-      std::move(connection_options), std::move(children),
-      std::move(retry_policy), std::move(backoff_policy));
+  auto opts = internal::MergeOptions(
+      pubsub_internal::MakeOptions(std::move(options)),
+      internal::MakeOptions(std::move(connection_options)));
+  if (retry_policy) opts.set<RetryPolicyOption>(retry_policy->clone());
+  if (backoff_policy) opts.set<BackoffPolicyOption>(backoff_policy->clone());
+  return MakeSubscriberConnection(std::move(subscription), std::move(opts));
 }
 
 }  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS
@@ -65,18 +84,13 @@ namespace {
 class SubscriberConnectionImpl : public pubsub::SubscriberConnection {
  public:
   explicit SubscriberConnectionImpl(
-      pubsub::Subscription subscription, pubsub::SubscriberOptions options,
-      pubsub::ConnectionOptions const& connection_options,
-      std::shared_ptr<pubsub_internal::SubscriberStub> stub,
-      std::unique_ptr<pubsub::RetryPolicy const> retry_policy,
-      std::unique_ptr<pubsub::BackoffPolicy const> backoff_policy)
+      pubsub::Subscription subscription, Options opts,
+      std::shared_ptr<pubsub_internal::SubscriberStub> stub)
       : subscription_(std::move(subscription)),
-        options_(std::move(options)),
+        opts_(std::move(opts)),
         stub_(std::move(stub)),
-        background_(connection_options.background_threads_factory()()),
-        retry_policy_(std::move(retry_policy)),
-        backoff_policy_(std::move(backoff_policy)),
-        generator_(google::cloud::internal::MakeDefaultPRNG()) {}
+        background_(internal::MakeBackgroundThreadsFactory(opts_)()),
+        generator_(internal::MakeDefaultPRNG()) {}
 
   ~SubscriberConnectionImpl() override = default;
 
@@ -85,78 +99,39 @@ class SubscriberConnectionImpl : public pubsub::SubscriberConnection {
       std::lock_guard<std::mutex> lk(mu_);
       auto constexpr kLength = 32;
       auto constexpr kChars = "abcdefghijklmnopqrstuvwxyz0123456789";
-      return google::cloud::internal::Sample(generator_, kLength, kChars);
+      return internal::Sample(generator_, kLength, kChars);
     }();
-    return CreateSubscriptionSession(
-        subscription_, options_, stub_, background_->cq(), std::move(client_id),
-        std::move(p), retry_policy_->clone(), backoff_policy_->clone());
+    return CreateSubscriptionSession(subscription_, opts_, stub_,
+                                     background_->cq(), std::move(client_id),
+                                     std::move(p));
   }
 
  private:
   pubsub::Subscription const subscription_;
-  pubsub::SubscriberOptions const options_;
+  Options const opts_;
   std::shared_ptr<pubsub_internal::SubscriberStub> stub_;
   std::shared_ptr<BackgroundThreads> background_;
-  std::unique_ptr<pubsub::RetryPolicy const> retry_policy_;
-  std::unique_ptr<pubsub::BackoffPolicy const> backoff_policy_;
   std::mutex mu_;
-  google::cloud::internal::DefaultPRNG generator_;
+  internal::DefaultPRNG generator_;
 };
 }  // namespace
 
 std::shared_ptr<pubsub::SubscriberConnection> MakeSubscriberConnection(
-    pubsub::Subscription subscription, pubsub::SubscriberOptions options,
-    pubsub::ConnectionOptions connection_options,
-    std::shared_ptr<SubscriberStub> stub,
-    std::unique_ptr<pubsub::RetryPolicy const> retry_policy,
-    std::unique_ptr<pubsub::BackoffPolicy const> backoff_policy) {
-  std::vector<std::shared_ptr<SubscriberStub>> children{std::move(stub)};
-  return MakeSubscriberConnection(std::move(subscription), std::move(options),
-                                  std::move(connection_options),
-                                  std::move(children), std::move(retry_policy),
-                                  std::move(backoff_policy));
-}
-
-std::shared_ptr<pubsub::SubscriberConnection> MakeSubscriberConnection(
-    pubsub::Subscription subscription, pubsub::SubscriberOptions options,
-    pubsub::ConnectionOptions connection_options,
-    std::vector<std::shared_ptr<SubscriberStub>> stubs,
-    std::unique_ptr<pubsub::RetryPolicy const> retry_policy,
-    std::unique_ptr<pubsub::BackoffPolicy const> backoff_policy) {
-  auto default_retry_policy = [] {
-    // Subscribers are special: by default we want to retry essentially forever
-    // because (a) the service will disconnect the streaming pull from time to
-    // time, but that is not a "failure", (b) applications can change this
-    // behavior if they need, and this is easier than some hard-coded
-    // "treat these disconnects as non-failures" code.
-    return pubsub::LimitedErrorCountRetryPolicy(std::numeric_limits<int>::max())
-        .clone();
-  };
+    pubsub::Subscription subscription, Options opts,
+    std::vector<std::shared_ptr<SubscriberStub>> stubs) {
   if (stubs.empty()) return nullptr;
-  if (!retry_policy) retry_policy = default_retry_policy();
-  if (!backoff_policy) backoff_policy = DefaultBackoffPolicy();
   std::shared_ptr<SubscriberStub> stub =
       std::make_shared<SubscriberRoundRobin>(std::move(stubs));
   stub = std::make_shared<SubscriberMetadata>(std::move(stub));
-  if (connection_options.tracing_enabled("rpc")) {
+  auto const& tracing = opts.get<TracingComponentsOption>();
+  if (internal::Contains(tracing, "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
-    stub = std::make_shared<pubsub_internal::SubscriberLogging>(
-        std::move(stub), connection_options.tracing_options(),
-        connection_options.tracing_enabled("rpc-streams"));
-  }
-  auto default_thread_pool_size = []() -> std::size_t {
-    auto constexpr kDefaultThreadPoolSize = 4;
-    auto const n = std::thread::hardware_concurrency();
-    return n == 0 ? kDefaultThreadPoolSize : n;
-  };
-  if (connection_options.background_thread_pool_size() == 0) {
-    connection_options.set_background_thread_pool_size(
-        default_thread_pool_size());
+    stub = std::make_shared<SubscriberLogging>(
+        std::move(stub), opts.get<GrpcTracingOptionsOption>(),
+        internal::Contains(tracing, "rpc-streams"));
   }
   return std::make_shared<SubscriberConnectionImpl>(
-      std::move(subscription), std::move(options),
-      std::move(connection_options), std::move(stub), std::move(retry_policy),
-      std::move(backoff_policy));
+      std::move(subscription), std::move(opts), std::move(stub));
 }
 
 }  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS

--- a/google/cloud/pubsub/subscriber_connection.h
+++ b/google/cloud/pubsub/subscriber_connection.h
@@ -19,6 +19,7 @@
 #include "google/cloud/pubsub/application_callback.h"
 #include "google/cloud/pubsub/backoff_policy.h"
 #include "google/cloud/pubsub/connection_options.h"
+#include "google/cloud/pubsub/internal/non_constructible.h"
 #include "google/cloud/pubsub/internal/subscriber_stub.h"
 #include "google/cloud/pubsub/message.h"
 #include "google/cloud/pubsub/retry_policy.h"
@@ -27,6 +28,7 @@
 #include "google/cloud/pubsub/version.h"
 #include "google/cloud/status_or.h"
 #include <functional>
+#include <initializer_list>
 #include <vector>
 
 namespace google {
@@ -37,9 +39,9 @@ inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
 /**
  * A connection to the Cloud Pub/Sub service to receive events.
  *
- * This interface defines pure-virtual methods for each of the user-facing
+ * This interface defines pure-virtual functions for each of the user-facing
  * overload sets in `Subscriber`. That is, all of `Subscriber`'s overloads will
- * forward to the one pure-virtual method declared in this interface. This
+ * forward to the one pure-virtual function declared in this interface. This
  * allows users to inject custom behavior (e.g., with a Google Mock object) in a
  * `Subscriber` object for use in their own tests.
  *
@@ -68,13 +70,60 @@ class SubscriberConnection {
 /**
  * Creates a new `SubscriberConnection` object to work with `Subscriber`.
  *
+ * @note This function exists solely for backwards compatibility. It prevents
+ *     existing code, which calls `MakeSubscriberConnection(subscription, {})`
+ *     from breaking, due to ambiguity.
+ *
+ * @deprecated Please use the `MakeSubscriberConnection` function which accepts
+ *     `google::cloud::Options` instead.
+ */
+std::shared_ptr<SubscriberConnection> MakeSubscriberConnection(
+    Subscription subscription,
+    std::initializer_list<pubsub_internal::NonConstructible>);
+
+/**
+ * Creates a new `SubscriberConnection` object to work with `Subscriber`.
+ *
  * The `SubscriberConnection` class is not intended for direct use in
  * applications, it is provided for applications wanting to mock the
- * `SubscriberClient` behavior in their tests.
+ * `Subscriber` behavior in their tests.
  *
  * @par Performance
  * Creating a new `SubscriberConnection` is relatively expensive. This typically
  * initiate connections to the service, and therefore these objects should be
+ * shared and reused when possible. Note that gRPC reuses existing OS resources
+ * (sockets) whenever possible, so applications may experience better
+ * performance on the second (and subsequent) calls to this function with the
+ * same `Options` from `GrpcOptionList` and `CommonOptionList`. However, this
+ * behavior is not guaranteed and applications should not rely on it.
+ *
+ * @see `SubscriberConnection`
+ *
+ * @par Changing Retry Parameters Example
+ * @snippet samples.cc subscriber-retry-settings
+ *
+ * @param subscription the Cloud Pub/Sub subscription used by the returned
+ *     connection.
+ * @param opts The options to use for this call. Expected options are any
+ *     of the types in the following option lists.
+ *       - `google::cloud::CommonOptionList`
+ *       - `google::cloud::GrpcOptionList`
+ *       - `google::cloud::pubsub::PolicyOptionList`
+ *       - `google::cloud::pubsub::SubscriberOptionList`
+ */
+std::shared_ptr<SubscriberConnection> MakeSubscriberConnection(
+    Subscription subscription, Options opts = {});
+
+/**
+ * Creates a new `SubscriberConnection` object to work with `Subscriber`.
+ *
+ * The `SubscriberConnection` class is not intended for direct use in
+ * applications, it is provided for applications wanting to mock the
+ * `Subscriber` behavior in their tests.
+ *
+ * @par Performance
+ * Creating a new `SubscriberConnection` is relatively expensive. This typically
+ * initiates connections to the service, and therefore these objects should be
  * shared and reused when possible. Note that gRPC reuses existing OS resources
  * (sockets) whenever possible, so applications may experience better
  * performance on the second (and subsequent) calls to this function with the
@@ -96,9 +145,12 @@ class SubscriberConnection {
  *     RPCs attempted.
  * @param backoff_policy controls the backoff behavior between retry attempts,
  *     typically some form of exponential backoff with jitter.
+ *
+ * @deprecated Please use the `MakeSubscriberConnection` function which accepts
+ *     `google::cloud::Options` instead.
  */
 std::shared_ptr<SubscriberConnection> MakeSubscriberConnection(
-    Subscription subscription, SubscriberOptions options = {},
+    Subscription subscription, SubscriberOptions options,
     ConnectionOptions connection_options = {},
     std::unique_ptr<pubsub::RetryPolicy const> retry_policy = {},
     std::unique_ptr<pubsub::BackoffPolicy const> backoff_policy = {});
@@ -110,18 +162,8 @@ namespace pubsub_internal {
 inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
 
 std::shared_ptr<pubsub::SubscriberConnection> MakeSubscriberConnection(
-    pubsub::Subscription subscription, pubsub::SubscriberOptions options,
-    pubsub::ConnectionOptions connection_options,
-    std::shared_ptr<SubscriberStub> stub,
-    std::unique_ptr<pubsub::RetryPolicy const> retry_policy,
-    std::unique_ptr<pubsub::BackoffPolicy const> backoff_policy);
-
-std::shared_ptr<pubsub::SubscriberConnection> MakeSubscriberConnection(
-    pubsub::Subscription subscription, pubsub::SubscriberOptions options,
-    pubsub::ConnectionOptions connection_options,
-    std::vector<std::shared_ptr<SubscriberStub>> stubs,
-    std::unique_ptr<pubsub::RetryPolicy const> retry_policy,
-    std::unique_ptr<pubsub::BackoffPolicy const> backoff_policy);
+    pubsub::Subscription subscription, Options opts,
+    std::vector<std::shared_ptr<SubscriberStub>> stubs);
 
 }  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS
 }  // namespace pubsub_internal


### PR DESCRIPTION
Part of the work for #6306 (so close....)

Half of `subscription_session_test.cc` used different test policies. Changing it to the test policies that every other test uses seems to be fine.

Only cleanups remain:
* tidying up code
* preferring the new methods in examples, benchmarks, quickstart
* deprecating old methods

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7342)
<!-- Reviewable:end -->
