### PR TITLE
feat(common): add convenience method for generating a BackgroundThreadFactory via a CQ

### DIFF
--- a/google/cloud/CMakeLists.txt
+++ b/google/cloud/CMakeLists.txt
@@ -382,6 +382,8 @@ if (GOOGLE_CLOUD_CPP_ENABLE_GRPC)
         google_cloud_cpp_grpc_utils # cmake-format: sort
         async_operation.h
         background_threads.h
+        background_threads_factory.cc
+        background_threads_factory.h
         completion_queue.cc
         completion_queue.h
         connection_options.cc
@@ -533,6 +535,7 @@ if (GOOGLE_CLOUD_CPP_ENABLE_GRPC)
         # List the unit tests, then setup the targets and dependencies.
         set(google_cloud_cpp_grpc_utils_unit_tests
             # cmake-format: sort
+            background_threads_factory_test.cc
             completion_queue_test.cc
             connection_options_test.cc
             grpc_error_delegate_test.cc

--- a/google/cloud/background_threads_factory.cc
+++ b/google/cloud/background_threads_factory.cc
@@ -1,0 +1,30 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/background_threads_factory.h"
+#include "google/cloud/internal/background_threads_impl.h"
+
+namespace google {
+namespace cloud {
+inline namespace GOOGLE_CLOUD_CPP_NS {
+
+BackgroundThreadsFactory CustomBackgroundThreads(CompletionQueue const& cq) {
+  return [cq] {
+    return absl::make_unique<internal::CustomerSuppliedBackgroundThreads>(cq);
+  };
+}
+
+}  // namespace GOOGLE_CLOUD_CPP_NS
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/background_threads_factory.h
+++ b/google/cloud/background_threads_factory.h
@@ -1,0 +1,38 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BACKGROUND_THREADS_FACTORY_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BACKGROUND_THREADS_FACTORY_H
+
+#include "google/cloud/background_threads.h"
+#include "google/cloud/version.h"
+#include <functional>
+#include <memory>
+
+namespace google {
+namespace cloud {
+inline namespace GOOGLE_CLOUD_CPP_NS {
+
+/// A function to generate `BackgroundThreads`
+using BackgroundThreadsFactory =
+    std::function<std::unique_ptr<BackgroundThreads>()>;
+
+/// Create a `BackgroundThreadsFactory` that uses @p cq for all background work.
+BackgroundThreadsFactory CustomBackgroundThreads(CompletionQueue const& cq);
+
+}  // namespace GOOGLE_CLOUD_CPP_NS
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BACKGROUND_THREADS_FACTORY_H

--- a/google/cloud/background_threads_factory_test.cc
+++ b/google/cloud/background_threads_factory_test.cc
@@ -14,6 +14,9 @@
 
 #include "google/cloud/background_threads_factory.h"
 #include <gmock/gmock.h>
+#include <chrono>
+#include <future>
+#include <thread>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/background_threads_factory_test.cc
+++ b/google/cloud/background_threads_factory_test.cc
@@ -1,0 +1,47 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/background_threads_factory.h"
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+inline namespace GOOGLE_CLOUD_CPP_NS {
+namespace {
+
+TEST(BackgroundThreadsFactory, CustomBackgroundThreads) {
+  using ms = std::chrono::milliseconds;
+  CompletionQueue cq;
+  auto background = CustomBackgroundThreads(cq)();
+
+  // Schedule some work that cannot execute because there is no thread draining
+  // the completion queue.
+  promise<std::thread::id> p;
+  auto background_thread_id = p.get_future();
+  background->cq().RunAsync(
+      [&p](CompletionQueue&) { p.set_value(std::this_thread::get_id()); });
+  EXPECT_NE(std::future_status::ready, background_thread_id.wait_for(ms(10)));
+
+  // Verify we can create our own threads to drain the completion queue.
+  std::thread t([&cq] { cq.Run(); });
+  EXPECT_EQ(t.get_id(), background_thread_id.get());
+
+  cq.Shutdown();
+  t.join();
+}
+
+}  // namespace
+}  // namespace GOOGLE_CLOUD_CPP_NS
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/bigtable/benchmarks/benchmark.cc
+++ b/google/cloud/bigtable/benchmarks/benchmark.cc
@@ -290,10 +290,7 @@ int Benchmark::read_rows_count() const {
 }
 
 void Benchmark::DisableBackgroundThreads(CompletionQueue& cq) {
-  opts_.set<GrpcBackgroundThreadsFactoryOption>([&cq] {
-    return absl::make_unique<
-        google::cloud::internal::CustomerSuppliedBackgroundThreads>(cq);
-  });
+  opts_.set<GrpcBackgroundThreadsFactoryOption>(CustomBackgroundThreads(cq));
 }
 
 google::cloud::StatusOr<BenchmarkResult> Benchmark::PopulateTableShard(

--- a/google/cloud/bigtable/client_options.cc
+++ b/google/cloud/bigtable/client_options.cc
@@ -63,10 +63,7 @@ std::string ClientOptions::UserAgentPrefix() {
 
 ClientOptions& ClientOptions::DisableBackgroundThreads(
     google::cloud::CompletionQueue const& cq) {
-  opts_.set<GrpcBackgroundThreadsFactoryOption>([cq] {
-    return absl::make_unique<
-        google::cloud::internal::CustomerSuppliedBackgroundThreads>(cq);
-  });
+  opts_.set<GrpcBackgroundThreadsFactoryOption>(CustomBackgroundThreads(cq));
   return *this;
 }
 

--- a/google/cloud/bigtable/instance_admin_test.cc
+++ b/google/cloud/bigtable/instance_admin_test.cc
@@ -866,11 +866,8 @@ class ValidContextMdAsyncTest : public ::testing::Test {
       : cq_impl_(new FakeCompletionQueueImpl),
         cq_(cq_impl_),
         client_(new MockAdminClient(
-            Options{}.set<GrpcBackgroundThreadsFactoryOption>([&] {
-              return absl::make_unique<
-                  google::cloud::internal::CustomerSuppliedBackgroundThreads>(
-                  cq_);
-            }))) {
+            Options{}.set<GrpcBackgroundThreadsFactoryOption>(
+                CustomBackgroundThreads(cq_)))) {
     EXPECT_CALL(*client_, project()).WillRepeatedly(ReturnRef(kProjectId));
     instance_admin_ = absl::make_unique<InstanceAdmin>(client_);
   }

--- a/google/cloud/bigtable/internal/async_longrunning_op_test.cc
+++ b/google/cloud/bigtable/internal/async_longrunning_op_test.cc
@@ -64,10 +64,8 @@ class AsyncLongrunningOpFutureTest : public bigtable::testing::TableTestFixture,
 TEST_P(AsyncLongrunningOpFutureTest, EndToEnd) {
   auto const success = GetParam();
   auto client = std::make_shared<testing::MockAdminClient>(
-      Options{}.set<GrpcBackgroundThreadsFactoryOption>([&] {
-        return absl::make_unique<
-            google::cloud::internal::CustomerSuppliedBackgroundThreads>(cq_);
-      }));
+      Options{}.set<GrpcBackgroundThreadsFactoryOption>(
+          CustomBackgroundThreads(cq_)));
 
   auto longrunning_reader = absl::make_unique<MockAsyncLongrunningOpReader>();
   EXPECT_CALL(*longrunning_reader, Finish)

--- a/google/cloud/bigtable/internal/async_poll_op_test.cc
+++ b/google/cloud/bigtable/internal/async_poll_op_test.cc
@@ -61,11 +61,8 @@ class AsyncPollOpTest : public bigtable::testing::TableTestFixture {
             bigtable::DefaultPollingPolicy(internal::kBigtableLimits)),
         metadata_update_policy_("test_operation_id", MetadataParamTypes::NAME),
         client_(new testing::MockAdminClient(
-            Options{}.set<GrpcBackgroundThreadsFactoryOption>([&] {
-              return absl::make_unique<
-                  google::cloud::internal::CustomerSuppliedBackgroundThreads>(
-                  cq_);
-            }))) {}
+            Options{}.set<GrpcBackgroundThreadsFactoryOption>(
+                CustomBackgroundThreads(cq_)))) {}
 
   std::shared_ptr<PollingPolicy const> polling_policy_;
   MetadataUpdatePolicy metadata_update_policy_;

--- a/google/cloud/bigtable/internal/async_retry_unary_rpc_and_poll_test.cc
+++ b/google/cloud/bigtable/internal/async_retry_unary_rpc_and_poll_test.cc
@@ -67,11 +67,8 @@ class AsyncStartPollAfterRetryUnaryRpcTest
             "projects/" + k_project_id + "/instances/" + k_instance_id,
             MetadataParamTypes::PARENT),
         client(std::make_shared<testing::MockInstanceAdminClient>(
-            Options{}.set<GrpcBackgroundThreadsFactoryOption>([&] {
-              return absl::make_unique<
-                  google::cloud::internal::CustomerSuppliedBackgroundThreads>(
-                  cq_);
-            }))),
+            Options{}.set<GrpcBackgroundThreadsFactoryOption>(
+                CustomBackgroundThreads(cq_)))),
         create_cluster_reader(
             absl::make_unique<MockAsyncLongrunningOpReader>()),
         get_operation_reader(

--- a/google/cloud/bigtable/table_test.cc
+++ b/google/cloud/bigtable/table_test.cc
@@ -121,11 +121,8 @@ class ValidContextMdAsyncTest : public ::testing::Test {
       : cq_impl_(new FakeCompletionQueueImpl),
         cq_(cq_impl_),
         client_(new ::google::cloud::bigtable::testing::MockDataClient(
-            Options{}.set<GrpcBackgroundThreadsFactoryOption>([&] {
-              return absl::make_unique<
-                  google::cloud::internal::CustomerSuppliedBackgroundThreads>(
-                  cq_);
-            }))) {
+            Options{}.set<GrpcBackgroundThreadsFactoryOption>(
+                CustomBackgroundThreads(cq_)))) {
     EXPECT_CALL(*client_, project_id())
         .WillRepeatedly(::testing::ReturnRef(kProjectId));
     EXPECT_CALL(*client_, instance_id())

--- a/google/cloud/bigtable/testing/table_test_fixture.cc
+++ b/google/cloud/bigtable/testing/table_test_fixture.cc
@@ -44,10 +44,8 @@ google::bigtable::v2::ReadRowsResponse ReadRowsResponseFromString(
 
 std::shared_ptr<MockDataClient> TableTestFixture::SetupMockClient() {
   auto client = std::make_shared<MockDataClient>(
-      Options{}.set<GrpcBackgroundThreadsFactoryOption>([&] {
-        return absl::make_unique<
-            google::cloud::internal::CustomerSuppliedBackgroundThreads>(cq_);
-      }));
+      Options{}.set<GrpcBackgroundThreadsFactoryOption>(
+          CustomBackgroundThreads(cq_)));
   EXPECT_CALL(*client, project_id())
       .WillRepeatedly(::testing::ReturnRef(project_id_));
   EXPECT_CALL(*client, instance_id())

--- a/google/cloud/bigtable/tests/instance_admin_integration_test.cc
+++ b/google/cloud/bigtable/tests/instance_admin_integration_test.cc
@@ -502,10 +502,8 @@ TEST_F(InstanceAdminIntegrationTest,
 TEST_F(InstanceAdminIntegrationTest, CustomWorkers) {
   CompletionQueue cq;
   auto instance_admin_client = bigtable::MakeInstanceAdminClient(
-      project_id_, Options{}.set<GrpcBackgroundThreadsFactoryOption>([&cq] {
-        return absl::make_unique<
-            google::cloud::internal::CustomerSuppliedBackgroundThreads>(cq);
-      }));
+      project_id_, Options{}.set<GrpcBackgroundThreadsFactoryOption>(
+                       CustomBackgroundThreads(cq)));
   instance_admin_ = absl::make_unique<bigtable::InstanceAdmin>(
       instance_admin_client,
       *DefaultRPCRetryPolicy({std::chrono::seconds(1), std::chrono::seconds(1),

--- a/google/cloud/connection_options.h
+++ b/google/cloud/connection_options.h
@@ -24,6 +24,7 @@
 #include "google/cloud/status_or.h"
 #include "google/cloud/tracing_options.h"
 #include "google/cloud/version.h"
+#include "background_threads_factory.h"
 #include <grpcpp/grpcpp.h>
 #include <functional>
 #include <memory>
@@ -228,9 +229,7 @@ class ConnectionOptions {
    */
   ConnectionOptions& DisableBackgroundThreads(
       google::cloud::CompletionQueue const& cq) {
-    background_threads_factory_ = [cq] {
-      return absl::make_unique<internal::CustomerSuppliedBackgroundThreads>(cq);
-    };
+    background_threads_factory_ = CustomBackgroundThreads(cq);
     return *this;
   }
 

--- a/google/cloud/google_cloud_cpp_grpc_utils.bzl
+++ b/google/cloud/google_cloud_cpp_grpc_utils.bzl
@@ -19,6 +19,7 @@
 google_cloud_cpp_grpc_utils_hdrs = [
     "async_operation.h",
     "background_threads.h",
+    "background_threads_factory.h",
     "completion_queue.h",
     "connection_options.h",
     "grpc_error_delegate.h",
@@ -60,6 +61,7 @@ google_cloud_cpp_grpc_utils_hdrs = [
 ]
 
 google_cloud_cpp_grpc_utils_srcs = [
+    "background_threads_factory.cc",
     "completion_queue.cc",
     "connection_options.cc",
     "grpc_error_delegate.cc",

--- a/google/cloud/google_cloud_cpp_grpc_utils_unit_tests.bzl
+++ b/google/cloud/google_cloud_cpp_grpc_utils_unit_tests.bzl
@@ -17,6 +17,7 @@
 """Automatically generated unit tests list - DO NOT EDIT."""
 
 google_cloud_cpp_grpc_utils_unit_tests = [
+    "background_threads_factory_test.cc",
     "completion_queue_test.cc",
     "connection_options_test.cc",
     "grpc_error_delegate_test.cc",

--- a/google/cloud/grpc_options.h
+++ b/google/cloud/grpc_options.h
@@ -16,6 +16,7 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_GRPC_OPTIONS_H
 
 #include "google/cloud/background_threads.h"
+#include "google/cloud/background_threads_factory.h"
 #include "google/cloud/options.h"
 #include "google/cloud/tracing_options.h"
 #include "google/cloud/version.h"
@@ -102,8 +103,6 @@ struct GrpcBackgroundThreadPoolSizeOption {
   using Type = std::size_t;
 };
 
-using BackgroundThreadsFactory =
-    std::function<std::unique_ptr<BackgroundThreads>()>;
 /**
  * Changes the `BackgroundThreadsFactory`.
  *


### PR DESCRIPTION
This change does 3 things.

1. moves definition of `google::cloud::BackgroundThreadsFactory` out of `grpc_options.h` and into its own file.
2. adds a `CustomBackgroundThreads(CompletionQueue cq)` convenience method for generating background threads that just return that CQ.
3. implements the new method in our code, to clean things up.

I think we want the function for convenience. Users that relied on the simplicity of `ConnectionOptions::DisableBacgkroundThreads(cq)` in pubsub or `ClientOptions::DisableBackgroundThreads(cq)` in bigtable will appreciate not having to construct the factory themselves. I think the difference in our code speaks for itself.

I am obviously open to changing the name and/or the location of the function.

Other names considered were: `DisableBackgroundThreads(cq)`, `DisableBackgroundThreadsFactory(cq)`, `CustomBackgroundThreadsFactory(cq)`.

I considered putting the function in `grpc_options.h` and `background_threads.h`, but neither seemed to be the right place for it.


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7345)
<!-- Reviewable:end -->
