### PR TITLE
cleanup(pubsub): switch over to new Make*Connection functions in tests, benchmarks, examples

### DIFF
--- a/google/cloud/pubsub/benchmarks/endurance.cc
+++ b/google/cloud/pubsub/benchmarks/endurance.cc
@@ -17,9 +17,11 @@
 #include "google/cloud/pubsub/subscription_admin_client.h"
 #include "google/cloud/pubsub/testing/random_names.h"
 #include "google/cloud/pubsub/topic_admin_client.h"
+#include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/format_time_point.h"
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/internal/random.h"
+#include "google/cloud/options.h"
 #include "google/cloud/testing_util/command_line_parsing.h"
 #include "absl/memory/memory.h"
 #include <chrono>
@@ -427,9 +429,10 @@ void PublisherTask(Config const& config, ExperimentFlowControl& flow_control,
   auto make_publisher = [config, task] {
     auto const topic = pubsub::Topic(config.project_id, config.topic_id);
     return pubsub::Publisher(pubsub::MakePublisherConnection(
-        topic, {},
-        pubsub::ConnectionOptions{}.set_channel_pool_domain(
-            "publisher:" + std::to_string(task))));
+        topic,
+        google::cloud::Options{}.set<google::cloud::GrpcChannelArgumentsOption>(
+            {{GRPC_ARG_CHANNEL_POOL_DOMAIN,
+              "publisher: " + std::to_string(task)}})));
   };
   auto publisher = make_publisher();
 

--- a/google/cloud/pubsub/integration_tests/schema_admin_integration_test.cc
+++ b/google/cloud/pubsub/integration_tests/schema_admin_integration_test.cc
@@ -29,14 +29,17 @@ namespace pubsub {
 inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
 namespace {
 
-using ::google::cloud::pubsub_testing::TestBackoffPolicy;
-using ::google::cloud::pubsub_testing::TestRetryPolicy;
+using ::google::cloud::pubsub_testing::MakeTestOptions;
 using ::google::cloud::testing_util::IsOk;
 using ::google::cloud::testing_util::IsProtoEqual;
 using ::google::cloud::testing_util::ScopedEnvironment;
 using ::google::cloud::testing_util::StatusIs;
 using ::testing::Contains;
 using ::testing::Not;
+
+SchemaAdminClient MakeTestSchemaAdminClient() {
+  return SchemaAdminClient(MakeSchemaAdminConnection(MakeTestOptions()));
+}
 
 using SchemaAdminIntegrationTest =
     ::google::cloud::testing_util::IntegrationTest;
@@ -46,8 +49,7 @@ TEST_F(SchemaAdminIntegrationTest, SchemaCRUD) {
       google::cloud::internal::GetEnv("GOOGLE_CLOUD_PROJECT").value_or("");
   ASSERT_FALSE(project_id.empty());
 
-  auto schema_admin =
-      SchemaAdminClient(MakeSchemaAdminConnection(pubsub::ConnectionOptions{}));
+  auto schema_admin = SchemaAdminClient(MakeSchemaAdminConnection());
 
   auto constexpr kTestAvroSchema = R"js({
      "type": "record",
@@ -93,8 +95,7 @@ TEST_F(SchemaAdminIntegrationTest, SchemaCRUD) {
 
 TEST_F(SchemaAdminIntegrationTest, CreateSchema) {
   ScopedEnvironment env("PUBSUB_EMULATOR_HOST", "localhost:1");
-  auto schema_admin = SchemaAdminClient(MakeSchemaAdminConnection(
-      pubsub::ConnectionOptions{}, TestRetryPolicy(), TestBackoffPolicy()));
+  auto schema_admin = MakeTestSchemaAdminClient();
   google::pubsub::v1::CreateSchemaRequest request;
   auto response = schema_admin.CreateSchema(request);
   EXPECT_THAT(response, Not(IsOk()));
@@ -102,8 +103,7 @@ TEST_F(SchemaAdminIntegrationTest, CreateSchema) {
 
 TEST_F(SchemaAdminIntegrationTest, GetSchema) {
   ScopedEnvironment env("PUBSUB_EMULATOR_HOST", "localhost:1");
-  auto schema_admin = SchemaAdminClient(MakeSchemaAdminConnection(
-      pubsub::ConnectionOptions{}, TestRetryPolicy(), TestBackoffPolicy()));
+  auto schema_admin = MakeTestSchemaAdminClient();
   auto response = schema_admin.GetSchema(
       Schema("--invalid-project--", "--invalid-schema--"));
   EXPECT_THAT(response, Not(IsOk()));
@@ -111,8 +111,7 @@ TEST_F(SchemaAdminIntegrationTest, GetSchema) {
 
 TEST_F(SchemaAdminIntegrationTest, ListSchema) {
   ScopedEnvironment env("PUBSUB_EMULATOR_HOST", "localhost:1");
-  auto schema_admin = SchemaAdminClient(MakeSchemaAdminConnection(
-      pubsub::ConnectionOptions{}, TestRetryPolicy(), TestBackoffPolicy()));
+  auto schema_admin = MakeTestSchemaAdminClient();
   auto response = schema_admin.ListSchemas("--invalid-project");
   auto i = response.begin();
   ASSERT_FALSE(i == response.end());
@@ -121,8 +120,7 @@ TEST_F(SchemaAdminIntegrationTest, ListSchema) {
 
 TEST_F(SchemaAdminIntegrationTest, DeleteSchema) {
   ScopedEnvironment env("PUBSUB_EMULATOR_HOST", "localhost:1");
-  auto schema_admin = SchemaAdminClient(MakeSchemaAdminConnection(
-      pubsub::ConnectionOptions{}, TestRetryPolicy(), TestBackoffPolicy()));
+  auto schema_admin = MakeTestSchemaAdminClient();
   auto response = schema_admin.DeleteSchema(
       Schema("--invalid-project--", "--invalid-schema--"));
   EXPECT_THAT(response, Not(IsOk()));
@@ -130,8 +128,7 @@ TEST_F(SchemaAdminIntegrationTest, DeleteSchema) {
 
 TEST_F(SchemaAdminIntegrationTest, ValidateSchema) {
   ScopedEnvironment env("PUBSUB_EMULATOR_HOST", "localhost:1");
-  auto schema_admin = SchemaAdminClient(MakeSchemaAdminConnection(
-      pubsub::ConnectionOptions{}, TestRetryPolicy(), TestBackoffPolicy()));
+  auto schema_admin = MakeTestSchemaAdminClient();
   auto response = schema_admin.ValidateSchema("--invalid-project--",
                                               google::pubsub::v1::Schema{});
   EXPECT_THAT(response, Not(IsOk()));
@@ -139,8 +136,7 @@ TEST_F(SchemaAdminIntegrationTest, ValidateSchema) {
 
 TEST_F(SchemaAdminIntegrationTest, ValidateMessage) {
   ScopedEnvironment env("PUBSUB_EMULATOR_HOST", "localhost:1");
-  auto schema_admin = SchemaAdminClient(MakeSchemaAdminConnection(
-      pubsub::ConnectionOptions{}, TestRetryPolicy(), TestBackoffPolicy()));
+  auto schema_admin = MakeTestSchemaAdminClient();
   google::pubsub::v1::ValidateMessageRequest request;
   auto response = schema_admin.ValidateMessage(request);
   EXPECT_THAT(response, Not(IsOk()));

--- a/google/cloud/pubsub/integration_tests/subscriber_integration_test.cc
+++ b/google/cloud/pubsub/integration_tests/subscriber_integration_test.cc
@@ -104,7 +104,7 @@ class SubscriberIntegrationTest
 };
 
 TEST_F(SubscriberIntegrationTest, RawStub) {
-  auto publisher = Publisher(MakePublisherConnection(topic_, {}));
+  auto publisher = Publisher(MakePublisherConnection(topic_));
 
   internal::AutomaticallyCreatedBackgroundThreads background(4);
   auto stub = pubsub_internal::CreateDefaultSubscriberStub(
@@ -181,8 +181,7 @@ TEST_F(SubscriberIntegrationTest, StreamingSubscriptionBatchSource) {
   };
 
   auto publisher = Publisher(MakePublisherConnection(
-      topic_, {},
-      pubsub::ConnectionOptions{}.set_background_thread_pool_size(2)));
+      topic_, Options{}.set<GrpcBackgroundThreadPoolSizeOption>(2)));
 
   internal::AutomaticallyCreatedBackgroundThreads background(4);
   auto stub = pubsub_internal::CreateDefaultSubscriberStub(
@@ -262,7 +261,7 @@ TEST_F(SubscriberIntegrationTest, StreamingSubscriptionBatchSource) {
 }
 
 TEST_F(SubscriberIntegrationTest, PublishPullAck) {
-  auto publisher = Publisher(MakePublisherConnection(topic_, {}));
+  auto publisher = Publisher(MakePublisherConnection(topic_));
   auto subscriber = Subscriber(MakeSubscriberConnection(subscription_));
 
   std::mutex mu;
@@ -317,7 +316,7 @@ TEST_F(SubscriberIntegrationTest, FireAndForget) {
   std::vector<Status> publish_errors;
   auto constexpr kMinimumMessages = 10;
 
-  auto publisher = Publisher(MakePublisherConnection(topic_, {}));
+  auto publisher = Publisher(MakePublisherConnection(topic_));
   auto subscriber = Subscriber(MakeSubscriberConnection(subscription_));
   {
     (void)subscriber
@@ -364,7 +363,7 @@ TEST_F(SubscriberIntegrationTest, FireAndForget) {
 }
 
 TEST_F(SubscriberIntegrationTest, ReportNotFound) {
-  auto publisher = Publisher(MakePublisherConnection(topic_, {}));
+  auto publisher = Publisher(MakePublisherConnection(topic_));
   auto const not_found_id = pubsub_testing::RandomSubscriptionId(generator_);
   auto project_id =
       google::cloud::internal::GetEnv("GOOGLE_CLOUD_PROJECT").value_or("");
@@ -381,7 +380,7 @@ TEST_F(SubscriberIntegrationTest, ReportNotFound) {
 
 TEST_F(SubscriberIntegrationTest, PublishOrdered) {
   auto publisher = Publisher(MakePublisherConnection(
-      topic_, pubsub::PublisherOptions{}.enable_message_ordering()));
+      topic_, Options{}.set<MessageOrderingOption>(true)));
   auto subscriber = Subscriber(MakeSubscriberConnection(ordered_subscription_));
 
   struct SampleData {

--- a/google/cloud/pubsub/integration_tests/subscription_admin_integration_test.cc
+++ b/google/cloud/pubsub/integration_tests/subscription_admin_integration_test.cc
@@ -33,8 +33,7 @@ namespace pubsub {
 inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
 namespace {
 
-using ::google::cloud::pubsub_testing::TestBackoffPolicy;
-using ::google::cloud::pubsub_testing::TestRetryPolicy;
+using ::google::cloud::pubsub_testing::MakeTestOptions;
 using ::google::cloud::testing_util::IsOk;
 using ::google::cloud::testing_util::IsProtoEqual;
 using ::google::cloud::testing_util::ScopedEnvironment;
@@ -45,6 +44,11 @@ using ::testing::Not;
 
 bool UsingEmulator() {
   return google::cloud::internal::GetEnv("PUBSUB_EMULATOR_HOST").has_value();
+}
+
+SubscriptionAdminClient MakeTestSubscriptionAdminClient() {
+  return SubscriptionAdminClient(
+      MakeSubscriptionAdminConnection(MakeTestOptions()));
 }
 
 using SubscriptionAdminIntegrationTest =
@@ -197,8 +201,7 @@ TEST_F(SubscriptionAdminIntegrationTest, SubscriptionCRUD) {
 TEST_F(SubscriptionAdminIntegrationTest, CreateSubscriptionFailure) {
   // Use an invalid endpoint to force a connection error.
   ScopedEnvironment env("PUBSUB_EMULATOR_HOST", "localhost:1");
-  auto client = SubscriptionAdminClient(MakeSubscriptionAdminConnection(
-      {}, TestRetryPolicy(), TestBackoffPolicy()));
+  auto client = MakeTestSubscriptionAdminClient();
   auto create_response = client.CreateSubscription(
       Topic("--invalid-project--", "--invalid-topic--"),
       Subscription("--invalid-project--", "--invalid-subscription--"));
@@ -208,8 +211,7 @@ TEST_F(SubscriptionAdminIntegrationTest, CreateSubscriptionFailure) {
 TEST_F(SubscriptionAdminIntegrationTest, GetSubscriptionFailure) {
   // Use an invalid endpoint to force a connection error.
   ScopedEnvironment env("PUBSUB_EMULATOR_HOST", "localhost:1");
-  auto client = SubscriptionAdminClient(MakeSubscriptionAdminConnection(
-      {}, TestRetryPolicy(), TestBackoffPolicy()));
+  auto client = MakeTestSubscriptionAdminClient();
   auto create_response = client.GetSubscription(
       Subscription("--invalid-project--", "--invalid-subscription--"));
   ASSERT_FALSE(create_response.ok());
@@ -218,8 +220,7 @@ TEST_F(SubscriptionAdminIntegrationTest, GetSubscriptionFailure) {
 TEST_F(SubscriptionAdminIntegrationTest, UpdateSubscriptionFailure) {
   // Use an invalid endpoint to force a connection error.
   ScopedEnvironment env("PUBSUB_EMULATOR_HOST", "localhost:1");
-  auto client = SubscriptionAdminClient(MakeSubscriptionAdminConnection(
-      {}, TestRetryPolicy(), TestBackoffPolicy()));
+  auto client = MakeTestSubscriptionAdminClient();
   auto create_response = client.UpdateSubscription(
       Subscription("--invalid-project--", "--invalid-subscription--"),
       SubscriptionBuilder{}.set_ack_deadline(std::chrono::seconds(20)));
@@ -229,8 +230,7 @@ TEST_F(SubscriptionAdminIntegrationTest, UpdateSubscriptionFailure) {
 TEST_F(SubscriptionAdminIntegrationTest, ListSubscriptionsFailure) {
   // Use an invalid endpoint to force a connection error.
   ScopedEnvironment env("PUBSUB_EMULATOR_HOST", "localhost:1");
-  auto client = SubscriptionAdminClient(MakeSubscriptionAdminConnection(
-      {}, TestRetryPolicy(), TestBackoffPolicy()));
+  auto client = MakeTestSubscriptionAdminClient();
   auto list = client.ListSubscriptions("--invalid-project--");
   auto i = list.begin();
   EXPECT_FALSE(i == list.end());
@@ -240,8 +240,7 @@ TEST_F(SubscriptionAdminIntegrationTest, ListSubscriptionsFailure) {
 TEST_F(SubscriptionAdminIntegrationTest, DeleteSubscriptionFailure) {
   // Use an invalid endpoint to force a connection error.
   ScopedEnvironment env("PUBSUB_EMULATOR_HOST", "localhost:1");
-  auto client = SubscriptionAdminClient(MakeSubscriptionAdminConnection(
-      {}, TestRetryPolicy(), TestBackoffPolicy()));
+  auto client = MakeTestSubscriptionAdminClient();
   auto delete_response = client.DeleteSubscription(
       Subscription("--invalid-project--", "--invalid-subscription--"));
   ASSERT_FALSE(delete_response.ok());
@@ -250,8 +249,7 @@ TEST_F(SubscriptionAdminIntegrationTest, DeleteSubscriptionFailure) {
 TEST_F(SubscriptionAdminIntegrationTest, ModifyPushConfigFailure) {
   // Use an invalid endpoint to force a connection error.
   ScopedEnvironment env("PUBSUB_EMULATOR_HOST", "localhost:1");
-  auto client = SubscriptionAdminClient(MakeSubscriptionAdminConnection(
-      {}, TestRetryPolicy(), TestBackoffPolicy()));
+  auto client = MakeTestSubscriptionAdminClient();
   auto delete_response = client.ModifyPushSubscription(
       Subscription("--invalid-project--", "--invalid-subscription--"),
       PushConfigBuilder{});
@@ -261,8 +259,7 @@ TEST_F(SubscriptionAdminIntegrationTest, ModifyPushConfigFailure) {
 TEST_F(SubscriptionAdminIntegrationTest, CreateSnapshotFailure) {
   // Use an invalid endpoint to force a connection error.
   ScopedEnvironment env("PUBSUB_EMULATOR_HOST", "localhost:1");
-  auto client = SubscriptionAdminClient(MakeSubscriptionAdminConnection(
-      {}, TestRetryPolicy(), TestBackoffPolicy()));
+  auto client = MakeTestSubscriptionAdminClient();
   auto response = client.CreateSnapshot(
       Subscription("--invalid-project--", "--invalid-subscription--"));
   ASSERT_FALSE(response.ok());
@@ -271,8 +268,7 @@ TEST_F(SubscriptionAdminIntegrationTest, CreateSnapshotFailure) {
 TEST_F(SubscriptionAdminIntegrationTest, GetSnapshotFailure) {
   // Use an invalid endpoint to force a connection error.
   ScopedEnvironment env("PUBSUB_EMULATOR_HOST", "localhost:1");
-  auto client = SubscriptionAdminClient(MakeSubscriptionAdminConnection(
-      {}, TestRetryPolicy(), TestBackoffPolicy()));
+  auto client = MakeTestSubscriptionAdminClient();
   auto response = client.GetSnapshot(
       Snapshot("--invalid-project--", "--invalid-snapshot--"));
   ASSERT_FALSE(response.ok());
@@ -281,8 +277,7 @@ TEST_F(SubscriptionAdminIntegrationTest, GetSnapshotFailure) {
 TEST_F(SubscriptionAdminIntegrationTest, ListSnapshotsFailure) {
   // Use an invalid endpoint to force a connection error.
   ScopedEnvironment env("PUBSUB_EMULATOR_HOST", "localhost:1");
-  auto client = SubscriptionAdminClient(MakeSubscriptionAdminConnection(
-      {}, TestRetryPolicy(), TestBackoffPolicy()));
+  auto client = MakeTestSubscriptionAdminClient();
   auto list = client.ListSnapshots("--invalid-project--");
   auto i = list.begin();
   EXPECT_FALSE(i == list.end());
@@ -292,8 +287,7 @@ TEST_F(SubscriptionAdminIntegrationTest, ListSnapshotsFailure) {
 TEST_F(SubscriptionAdminIntegrationTest, UpdateSnapshotFailure) {
   // Use an invalid endpoint to force a connection error.
   ScopedEnvironment env("PUBSUB_EMULATOR_HOST", "localhost:1");
-  auto client = SubscriptionAdminClient(MakeSubscriptionAdminConnection(
-      {}, TestRetryPolicy(), TestBackoffPolicy()));
+  auto client = MakeTestSubscriptionAdminClient();
   auto response = client.UpdateSnapshot(
       Snapshot("--invalid-project--", "--invalid-snapshot--"),
       SnapshotBuilder{}.clear_labels());
@@ -303,8 +297,7 @@ TEST_F(SubscriptionAdminIntegrationTest, UpdateSnapshotFailure) {
 TEST_F(SubscriptionAdminIntegrationTest, DeleteSnapshotFailure) {
   // Use an invalid endpoint to force a connection error.
   ScopedEnvironment env("PUBSUB_EMULATOR_HOST", "localhost:1");
-  auto client = SubscriptionAdminClient(MakeSubscriptionAdminConnection(
-      {}, TestRetryPolicy(), TestBackoffPolicy()));
+  auto client = MakeTestSubscriptionAdminClient();
   auto response = client.DeleteSnapshot(
       Snapshot("--invalid-project--", "--invalid-snapshot--"));
   ASSERT_FALSE(response.ok());
@@ -313,8 +306,7 @@ TEST_F(SubscriptionAdminIntegrationTest, DeleteSnapshotFailure) {
 TEST_F(SubscriptionAdminIntegrationTest, SeekFailureTimestamp) {
   // Use an invalid endpoint to force a connection error.
   ScopedEnvironment env("PUBSUB_EMULATOR_HOST", "localhost:1");
-  auto client = SubscriptionAdminClient(MakeSubscriptionAdminConnection(
-      {}, TestRetryPolicy(), TestBackoffPolicy()));
+  auto client = MakeTestSubscriptionAdminClient();
   auto response = client.Seek(
       Subscription("--invalid-project--", "--invalid-subscription--"),
       std::chrono::system_clock::now());
@@ -324,8 +316,7 @@ TEST_F(SubscriptionAdminIntegrationTest, SeekFailureTimestamp) {
 TEST_F(SubscriptionAdminIntegrationTest, SeekFailureSnapshot) {
   // Use an invalid endpoint to force a connection error.
   ScopedEnvironment env("PUBSUB_EMULATOR_HOST", "localhost:1");
-  auto client = SubscriptionAdminClient(MakeSubscriptionAdminConnection(
-      {}, TestRetryPolicy(), TestBackoffPolicy()));
+  auto client = MakeTestSubscriptionAdminClient();
   auto response = client.Seek(
       Subscription("--invalid-project--", "--invalid-subscription--"),
       Snapshot("--invalid-project--", "--invalid-snapshot--"));

--- a/google/cloud/pubsub/integration_tests/topic_admin_integration_test.cc
+++ b/google/cloud/pubsub/integration_tests/topic_admin_integration_test.cc
@@ -30,8 +30,7 @@ namespace pubsub {
 inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
 namespace {
 
-using ::google::cloud::pubsub_testing::TestBackoffPolicy;
-using ::google::cloud::pubsub_testing::TestRetryPolicy;
+using ::google::cloud::pubsub_testing::MakeTestOptions;
 using ::google::cloud::testing_util::IsOk;
 using ::google::cloud::testing_util::IsProtoEqual;
 using ::google::cloud::testing_util::ScopedEnvironment;
@@ -42,6 +41,10 @@ using ::testing::Not;
 
 bool UsingEmulator() {
   return google::cloud::internal::GetEnv("PUBSUB_EMULATOR_HOST").has_value();
+}
+
+TopicAdminClient MakeTestTopicAdminClient() {
+  return TopicAdminClient(MakeTopicAdminConnection(MakeTestOptions()));
 }
 
 using TopicAdminIntegrationTest =
@@ -66,8 +69,7 @@ TEST_F(TopicAdminIntegrationTest, TopicCRUD) {
   auto generator = google::cloud::internal::MakeDefaultPRNG();
   Topic topic(project_id, pubsub_testing::RandomTopicId(generator));
 
-  auto publisher =
-      TopicAdminClient(MakeTopicAdminConnection(ConnectionOptions{}));
+  auto publisher = TopicAdminClient(MakeTopicAdminConnection());
 
   EXPECT_THAT(topic_names(publisher, project_id),
               Not(Contains(topic.FullName())));
@@ -102,8 +104,7 @@ TEST_F(TopicAdminIntegrationTest, TopicCRUD) {
 
 TEST_F(TopicAdminIntegrationTest, CreateTopicFailure) {
   ScopedEnvironment env("PUBSUB_EMULATOR_HOST", "localhost:1");
-  auto publisher = TopicAdminClient(
-      MakeTopicAdminConnection({}, TestRetryPolicy(), TestBackoffPolicy()));
+  auto publisher = MakeTestTopicAdminClient();
   auto create_response = publisher.CreateTopic(
       TopicBuilder(Topic("invalid-project", "invalid-topic")));
   ASSERT_FALSE(create_response);
@@ -111,16 +112,14 @@ TEST_F(TopicAdminIntegrationTest, CreateTopicFailure) {
 
 TEST_F(TopicAdminIntegrationTest, GetTopicFailure) {
   ScopedEnvironment env("PUBSUB_EMULATOR_HOST", "localhost:1");
-  auto publisher = TopicAdminClient(
-      MakeTopicAdminConnection({}, TestRetryPolicy(), TestBackoffPolicy()));
+  auto publisher = MakeTestTopicAdminClient();
   auto response = publisher.GetTopic(Topic("invalid-project", "invalid-topic"));
   ASSERT_FALSE(response);
 }
 
 TEST_F(TopicAdminIntegrationTest, UpdateTopicFailure) {
   ScopedEnvironment env("PUBSUB_EMULATOR_HOST", "localhost:1");
-  auto publisher = TopicAdminClient(
-      MakeTopicAdminConnection({}, TestRetryPolicy(), TestBackoffPolicy()));
+  auto publisher = MakeTestTopicAdminClient();
   auto response = publisher.UpdateTopic(
       TopicBuilder(Topic("invalid-project", "invalid-topic")));
   ASSERT_FALSE(response);
@@ -128,8 +127,7 @@ TEST_F(TopicAdminIntegrationTest, UpdateTopicFailure) {
 
 TEST_F(TopicAdminIntegrationTest, ListTopicsFailure) {
   ScopedEnvironment env("PUBSUB_EMULATOR_HOST", "localhost:1");
-  auto publisher = TopicAdminClient(
-      MakeTopicAdminConnection({}, TestRetryPolicy(), TestBackoffPolicy()));
+  auto publisher = MakeTestTopicAdminClient();
   auto list = publisher.ListTopics("--invalid-project--");
   auto i = list.begin();
   EXPECT_FALSE(i == list.end());
@@ -138,8 +136,7 @@ TEST_F(TopicAdminIntegrationTest, ListTopicsFailure) {
 
 TEST_F(TopicAdminIntegrationTest, DeleteTopicFailure) {
   ScopedEnvironment env("PUBSUB_EMULATOR_HOST", "localhost:1");
-  auto publisher = TopicAdminClient(
-      MakeTopicAdminConnection({}, TestRetryPolicy(), TestBackoffPolicy()));
+  auto publisher = MakeTestTopicAdminClient();
   auto delete_response =
       publisher.DeleteTopic(Topic("invalid-project", "invalid-topic"));
   ASSERT_FALSE(delete_response.ok());
@@ -147,8 +144,7 @@ TEST_F(TopicAdminIntegrationTest, DeleteTopicFailure) {
 
 TEST_F(TopicAdminIntegrationTest, DetachSubscriptionFailure) {
   ScopedEnvironment env("PUBSUB_EMULATOR_HOST", "localhost:1");
-  auto publisher = TopicAdminClient(
-      MakeTopicAdminConnection({}, TestRetryPolicy(), TestBackoffPolicy()));
+  auto publisher = MakeTestTopicAdminClient();
   auto response = publisher.DetachSubscription(
       Subscription("invalid-project", "invalid-subscription"));
   ASSERT_FALSE(response.ok());
@@ -156,8 +152,7 @@ TEST_F(TopicAdminIntegrationTest, DetachSubscriptionFailure) {
 
 TEST_F(TopicAdminIntegrationTest, ListTopicSubscriptionsFailure) {
   ScopedEnvironment env("PUBSUB_EMULATOR_HOST", "localhost:1");
-  auto publisher = TopicAdminClient(
-      MakeTopicAdminConnection({}, TestRetryPolicy(), TestBackoffPolicy()));
+  auto publisher = MakeTestTopicAdminClient();
   auto list = publisher.ListTopicSubscriptions(
       Topic("invalid-project", "invalid-topic"));
   auto i = list.begin();
@@ -167,8 +162,7 @@ TEST_F(TopicAdminIntegrationTest, ListTopicSubscriptionsFailure) {
 
 TEST_F(TopicAdminIntegrationTest, ListTopicSnapshotsFailure) {
   ScopedEnvironment env("PUBSUB_EMULATOR_HOST", "localhost:1");
-  auto publisher = TopicAdminClient(
-      MakeTopicAdminConnection({}, TestRetryPolicy(), TestBackoffPolicy()));
+  auto publisher = MakeTestTopicAdminClient();
   auto list =
       publisher.ListTopicSnapshots(Topic("invalid-project", "invalid-topic"));
   auto i = list.begin();

--- a/google/cloud/pubsub/samples/pubsub_samples_common.cc
+++ b/google/cloud/pubsub/samples/pubsub_samples_common.cc
@@ -38,7 +38,7 @@ google::cloud::testing_util::Commands::value_type CreatePublisherCommand(
     Topic const topic(argv.at(0), argv.at(1));
     argv.erase(argv.begin(), argv.begin() + 2);
     google::cloud::pubsub::Publisher client(
-        google::cloud::pubsub::MakePublisherConnection(topic, {}));
+        google::cloud::pubsub::MakePublisherConnection(topic));
     command(std::move(client), std::move(argv));
   };
   return google::cloud::testing_util::Commands::value_type{name,


### PR DESCRIPTION
Part of the work for #6306 

The only remaining calls to the old functions are captured in: #7347 and #7344

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7349)
<!-- Reviewable:end -->
