### PR TITLE
cleanup: add missing option to option list

### DIFF
--- a/google/cloud/grpc_options.h
+++ b/google/cloud/grpc_options.h
@@ -124,7 +124,8 @@ struct GrpcBackgroundThreadsFactoryOption {
 using GrpcOptionList =
     OptionList<GrpcCredentialOption, GrpcNumChannelsOption,
                GrpcChannelArgumentsOption, GrpcChannelArgumentsNativeOption,
-               GrpcTracingOptionsOption, GrpcBackgroundThreadsFactoryOption>;
+               GrpcTracingOptionsOption, GrpcBackgroundThreadPoolSizeOption,
+               GrpcBackgroundThreadsFactoryOption>;
 
 namespace internal {
 

--- a/google/cloud/grpc_options_test.cc
+++ b/google/cloud/grpc_options_test.cc
@@ -180,10 +180,16 @@ TEST(GrpcOptionList, GrpcBackgroundThreadPoolSizeIgnored) {
 
 TEST(GrpcOptionList, Expected) {
   testing_util::ScopedLog log;
-  Options opts;
-  opts.set<GrpcNumChannelsOption>(42);
+  auto opts = Options{}
+                  .set<GrpcCredentialOption>({})
+                  .set<GrpcNumChannelsOption>({})
+                  .set<GrpcChannelArgumentsOption>({})
+                  .set<GrpcChannelArgumentsNativeOption>({})
+                  .set<GrpcTracingOptionsOption>({})
+                  .set<GrpcBackgroundThreadPoolSizeOption>({})
+                  .set<GrpcBackgroundThreadsFactoryOption>({});
   internal::CheckExpectedOptions<GrpcOptionList>(opts, "caller");
-  EXPECT_TRUE(log.ExtractLines().empty());
+  EXPECT_THAT(log.ExtractLines(), testing::IsEmpty());
 }
 
 TEST(GrpcOptionList, Unexpected) {


### PR DESCRIPTION
`GrpcBackgroundThreadPoolSizeOption` was missing from `GrpcOptionList`

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7351)
<!-- Reviewable:end -->
