### PR TITLE
cleanup: using directives for some tests

### DIFF
--- a/google/cloud/bigtable/benchmarks/benchmark_options_test.cc
+++ b/google/cloud/bigtable/benchmarks/benchmark_options_test.cc
@@ -28,6 +28,8 @@ namespace bigtable {
 namespace benchmarks {
 namespace {
 
+using ::testing::HasSubstr;
+
 TEST(BenchmarkOptions, Basic) {
   auto options = ParseBenchmarkOptions(
       {"self-test", "--project-id=test-project", "--instance-id=test-instance",
@@ -72,7 +74,7 @@ TEST(BenchmarkOptions, Initialization) {
       },
       "");
   EXPECT_TRUE(std::regex_match(options->table_id, re));
-  EXPECT_THAT(options->notes, ::testing::HasSubstr(bigtable::version_string()));
+  EXPECT_THAT(options->notes, HasSubstr(bigtable::version_string()));
 }
 
 TEST(BenchmarkOptions, Description) {

--- a/google/cloud/bigtable/metadata_update_policy_test.cc
+++ b/google/cloud/bigtable/metadata_update_policy_test.cc
@@ -75,7 +75,7 @@ TEST_F(MetadataUpdatePolicyTest, SimpleDefault) {
   EXPECT_THAT(created.api_client_header(), HasSubstr("gl-cpp/"));
   EXPECT_THAT(created.api_client_header(), HasSubstr("gccl/"));
   EXPECT_THAT(created.api_client_header(),
-              ::testing::AnyOf(HasSubstr("-noex-"), HasSubstr("-ex-")));
+              AnyOf(HasSubstr("-noex-"), HasSubstr("-ex-")));
 }
 
 }  // namespace

--- a/google/cloud/bigtable/table_test.cc
+++ b/google/cloud/bigtable/table_test.cc
@@ -26,6 +26,7 @@ namespace {
 
 namespace btproto = ::google::bigtable::v2;
 using ::google::cloud::testing_util::FakeCompletionQueueImpl;
+using ::testing::HasSubstr;
 
 /// Define types and functions used in the tests.
 namespace {
@@ -94,21 +95,21 @@ TEST_F(TableTest, MoveAssignment) {
 TEST_F(TableTest, ChangeOnePolicy) {
   Table table(client_, "some-table", AlwaysRetryMutationPolicy());
   EXPECT_EQ("", table.app_profile_id());
-  EXPECT_THAT(table.table_name(), ::testing::HasSubstr("some-table"));
+  EXPECT_THAT(table.table_name(), HasSubstr("some-table"));
 }
 
 TEST_F(TableTest, ChangePolicies) {
   Table table(client_, "some-table", AlwaysRetryMutationPolicy(),
               LimitedErrorCountRetryPolicy(42));
   EXPECT_EQ("", table.app_profile_id());
-  EXPECT_THAT(table.table_name(), ::testing::HasSubstr("some-table"));
+  EXPECT_THAT(table.table_name(), HasSubstr("some-table"));
 }
 
 TEST_F(TableTest, ConstructorWithAppProfileAndPolicies) {
   Table table(client_, "test-profile-id", "some-table",
               AlwaysRetryMutationPolicy(), LimitedErrorCountRetryPolicy(42));
   EXPECT_EQ("test-profile-id", table.app_profile_id());
-  EXPECT_THAT(table.table_name(), ::testing::HasSubstr("some-table"));
+  EXPECT_THAT(table.table_name(), HasSubstr("some-table"));
 }
 
 std::string const kProjectId = "the-project";

--- a/google/cloud/bigtable/testing/table_integration_test.cc
+++ b/google/cloud/bigtable/testing/table_integration_test.cc
@@ -26,6 +26,9 @@ namespace cloud {
 namespace bigtable {
 namespace testing {
 
+using ::testing::ContainerEq;
+using ::testing::IsEmpty;
+
 std::string TableTestEnvironment::project_id_;
 std::string TableTestEnvironment::instance_id_;
 std::string TableTestEnvironment::zone_a_;
@@ -218,7 +221,7 @@ void TableIntegrationTest::CreateCells(
     bulk.emplace_back(std::move(kv.second));
   }
   auto failures = table.BulkApply(std::move(bulk));
-  ASSERT_THAT(failures, ::testing::IsEmpty());
+  ASSERT_THAT(failures, IsEmpty());
 }
 
 std::vector<bigtable::Cell> TableIntegrationTest::GetCellsIgnoringTimestamp(
@@ -240,7 +243,7 @@ void TableIntegrationTest::CheckEqualUnordered(
     std::vector<bigtable::Cell> expected, std::vector<bigtable::Cell> actual) {
   std::sort(expected.begin(), expected.end());
   std::sort(actual.begin(), actual.end());
-  EXPECT_THAT(actual, ::testing::ContainerEq(expected));
+  EXPECT_THAT(actual, ContainerEq(expected));
 }
 
 std::string TableIntegrationTest::RandomTableId() {

--- a/google/cloud/bigtable/tests/filters_integration_test.cc
+++ b/google/cloud/bigtable/tests/filters_integration_test.cc
@@ -22,6 +22,8 @@ namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 namespace {
 
+using ::testing::ContainerEq;
+
 using FilterIntegrationTest =
     ::google::cloud::bigtable::testing::TableIntegrationTest;
 
@@ -326,7 +328,7 @@ TEST_F(FilterIntegrationTest, CellsRowLimit) {
                                      {RowKeyType(prefix + "/many-columns"), 3},
                                      {RowKeyType(prefix + "/complex"), 3}};
 
-  EXPECT_THAT(expected, ::testing::ContainerEq(actual));
+  EXPECT_THAT(expected, ContainerEq(actual));
 }
 
 TEST_F(FilterIntegrationTest, CellsRowOffset) {
@@ -347,7 +349,7 @@ TEST_F(FilterIntegrationTest, CellsRowOffset) {
                                      {RowKeyType(prefix + "/many-columns"), 2},
                                      {RowKeyType(prefix + "/complex"), 78}};
 
-  EXPECT_THAT(expected, ::testing::ContainerEq(actual));
+  EXPECT_THAT(expected, ContainerEq(actual));
 }
 
 TEST_F(FilterIntegrationTest, RowSample) {

--- a/google/cloud/grpc_options_test.cc
+++ b/google/cloud/grpc_options_test.cc
@@ -29,6 +29,7 @@ namespace {
 
 using ::testing::Contains;
 using ::testing::ContainsRegex;
+using ::testing::IsEmpty;
 using ::testing::NotNull;
 using ThreadPool = internal::AutomaticallyCreatedBackgroundThreads;
 
@@ -189,7 +190,7 @@ TEST(GrpcOptionList, Expected) {
                   .set<GrpcBackgroundThreadPoolSizeOption>({})
                   .set<GrpcBackgroundThreadsFactoryOption>({});
   internal::CheckExpectedOptions<GrpcOptionList>(opts, "caller");
-  EXPECT_THAT(log.ExtractLines(), testing::IsEmpty());
+  EXPECT_THAT(log.ExtractLines(), IsEmpty());
 }
 
 TEST(GrpcOptionList, Unexpected) {

--- a/google/cloud/spanner/internal/connection_impl_test.cc
+++ b/google/cloud/spanner/internal/connection_impl_test.cc
@@ -2302,8 +2302,7 @@ TEST(ConnectionImplTest, PartitionReadSuccess) {
           "CAFEDEAD", "", "test-session-name", "DEADBEEF", "table",
           spanner::KeySet::All(), {"UserId", "UserName"}, read_options)};
 
-  EXPECT_THAT(*result, testing::UnorderedPointwise(testing::Eq(),
-                                                   expected_read_partitions));
+  EXPECT_THAT(*result, UnorderedPointwise(Eq(), expected_read_partitions));
 }
 
 TEST(ConnectionImplTest, PartitionReadPermanentFailure) {
@@ -2406,8 +2405,7 @@ TEST(ConnectionImplTest, PartitionQuerySuccess) {
       spanner_internal::MakeQueryPartition("CAFEDEAD", "", "test-session-name",
                                            "DEADBEEF", sql_statement)};
 
-  EXPECT_THAT(*result, testing::UnorderedPointwise(testing::Eq(),
-                                                   expected_query_partitions));
+  EXPECT_THAT(*result, UnorderedPointwise(Eq(), expected_query_partitions));
 }
 
 TEST(ConnectionImplTest, PartitionQueryPermanentFailure) {

--- a/google/cloud/spanner/internal/tuple_utils_test.cc
+++ b/google/cloud/spanner/internal/tuple_utils_test.cc
@@ -22,6 +22,8 @@ namespace cloud {
 namespace spanner_internal {
 inline namespace SPANNER_CLIENT_NS {
 
+using ::testing::ElementsAre;
+
 TEST(TupleUtils, IsTuple) {
   using T0 = std::tuple<>;
   static_assert(IsTuple<T0>::value, "");
@@ -56,7 +58,7 @@ TEST(TupleUtils, ForEachMultipleTypes) {
   auto tup = std::make_tuple(true, 42);
   std::vector<std::string> v;
   ForEach(tup, Stringify{}, v);
-  EXPECT_THAT(v, testing::ElementsAre("1", "42"));
+  EXPECT_THAT(v, ElementsAre("1", "42"));
 }
 
 TEST(TupleUtils, ForEachMutate) {

--- a/google/cloud/storage/internal/bucket_requests_test.cc
+++ b/google/cloud/storage/internal/bucket_requests_test.cc
@@ -174,7 +174,7 @@ TEST(ListBucketsResponseTest, Parse) {
 
   auto actual = ListBucketsResponse::FromHttpResponse(text).value();
   EXPECT_EQ("some-token-42", actual.next_page_token);
-  EXPECT_THAT(actual.items, ::testing::ElementsAre(b1, b2));
+  EXPECT_THAT(actual.items, ElementsAre(b1, b2));
 }
 
 TEST(ListBucketsResponseTest, ParseFailure) {

--- a/google/cloud/storage/internal/curl_handle_factory_test.cc
+++ b/google/cloud/storage/internal/curl_handle_factory_test.cc
@@ -23,6 +23,7 @@ inline namespace STORAGE_CLIENT_NS {
 namespace internal {
 namespace {
 
+using ::testing::ElementsAre;
 using ::testing::IsEmpty;
 
 // Version of DefaultCurlHandleFactory that keeps track of what calls have been
@@ -80,7 +81,7 @@ TEST(CurlHandleFactoryTest, DefaultFactoryChannelOptionsCallsSetOptions) {
   auto const expected = std::make_pair(CURLOPT_CAINFO, std::string("foo"));
 
   object_under_test.CreateHandle();
-  EXPECT_THAT(object_under_test.set_options_, testing::ElementsAre(expected));
+  EXPECT_THAT(object_under_test.set_options_, ElementsAre(expected));
 }
 
 TEST(CurlHandleFactoryTest, PooledFactoryNoChannelOptionsDoesntCallSetOptions) {
@@ -98,14 +99,14 @@ TEST(CurlHandleFactoryTest, PooledFactoryChannelOptionsCallsSetOptions) {
 
   {
     object_under_test.CreateHandle();
-    EXPECT_THAT(object_under_test.set_options_, testing::ElementsAre(expected));
+    EXPECT_THAT(object_under_test.set_options_, ElementsAre(expected));
   }
   // the above should have left the handle in the cache. Check that cached
   // handles get their options set again.
   object_under_test.set_options_.clear();
 
   object_under_test.CreateHandle();
-  EXPECT_THAT(object_under_test.set_options_, testing::ElementsAre(expected));
+  EXPECT_THAT(object_under_test.set_options_, ElementsAre(expected));
 }
 
 }  // namespace

--- a/google/cloud/storage/internal/grpc_resumable_upload_session_url_test.cc
+++ b/google/cloud/storage/internal/grpc_resumable_upload_session_url_test.cc
@@ -24,6 +24,8 @@ inline namespace STORAGE_CLIENT_NS {
 namespace internal {
 namespace {
 
+using ::testing::HasSubstr;
+
 TEST(GrpcUploadSessionTest, SimpleEncodeDecode) {
   ResumableUploadSessionGrpcParams input{"some-upload-id"};
   auto encoded = EncodeGrpcResumableUploadSessionUrl(input);
@@ -40,8 +42,7 @@ TEST(GrpcUploadSessionTest, MalformedUri) {
   auto res = DecodeGrpcResumableUploadSessionUrl("");
   ASSERT_FALSE(res);
   EXPECT_EQ(StatusCode::kInvalidArgument, res.status().code());
-  EXPECT_THAT(res.status().message(),
-              ::testing::HasSubstr("different implementation"));
+  EXPECT_THAT(res.status().message(), HasSubstr("different implementation"));
 }
 
 }  // namespace

--- a/google/cloud/storage/internal/hmac_key_requests_test.cc
+++ b/google/cloud/storage/internal/hmac_key_requests_test.cc
@@ -25,6 +25,7 @@ namespace internal {
 namespace {
 
 using ::google::cloud::testing_util::IsOk;
+using ::testing::ElementsAre;
 using ::testing::HasSubstr;
 using ::testing::Not;
 
@@ -165,7 +166,7 @@ TEST(HmacKeysRequestsTest, ParseListResponse) {
 
   auto actual = ListHmacKeysResponse::FromHttpResponse(text).value();
   EXPECT_EQ("some-token-42", actual.next_page_token);
-  EXPECT_THAT(actual.items, ::testing::ElementsAre(key1, key2));
+  EXPECT_THAT(actual.items, ElementsAre(key1, key2));
 }
 
 TEST(HmacKeysRequestsTest, ParseListResponseFailure) {

--- a/google/cloud/storage/internal/object_requests_test.cc
+++ b/google/cloud/storage/internal/object_requests_test.cc
@@ -28,6 +28,7 @@ namespace internal {
 namespace {
 
 using ::google::cloud::testing_util::IsOk;
+using ::testing::ElementsAre;
 using ::testing::HasSubstr;
 using ::testing::Not;
 
@@ -122,8 +123,8 @@ TEST(ObjectRequestsTest, ParseListResponse) {
 
   auto actual = ListObjectsResponse::FromHttpResponse(text).value();
   EXPECT_EQ("some-token-42", actual.next_page_token);
-  EXPECT_THAT(actual.items, ::testing::ElementsAre(o1, o2));
-  EXPECT_THAT(actual.prefixes, ::testing::ElementsAre("foo/", "qux/"));
+  EXPECT_THAT(actual.items, ElementsAre(o1, o2));
+  EXPECT_THAT(actual.prefixes, ElementsAre("foo/", "qux/"));
 }
 
 TEST(ObjectRequestsTest, ParseListResponseFailure) {

--- a/google/cloud/storage/internal/policy_document_request_test.cc
+++ b/google/cloud/storage/internal/policy_document_request_test.cc
@@ -26,6 +26,7 @@ namespace internal {
 namespace {
 
 using ::google::cloud::testing_util::StatusIs;
+using ::testing::ElementsAre;
 
 TEST(PolicyDocumentRequest, SigningAccount) {
   PolicyDocumentRequest request;
@@ -39,7 +40,7 @@ TEST(PolicyDocumentRequest, SigningAccount) {
   ASSERT_TRUE(request.signing_account_delegates().has_value());
   EXPECT_EQ("another-account@example.com", request.signing_account().value());
   EXPECT_THAT(request.signing_account_delegates().value(),
-              ::testing::ElementsAre("test-delegate1", "test-delegate2"));
+              ElementsAre("test-delegate1", "test-delegate2"));
 }
 
 TEST(PolicyDocumentV4Request, SigningAccount) {
@@ -54,7 +55,7 @@ TEST(PolicyDocumentV4Request, SigningAccount) {
   ASSERT_TRUE(request.signing_account_delegates().has_value());
   EXPECT_EQ("another-account@example.com", request.signing_account().value());
   EXPECT_THAT(request.signing_account_delegates().value(),
-              ::testing::ElementsAre("test-delegate1", "test-delegate2"));
+              ElementsAre("test-delegate1", "test-delegate2"));
 }
 
 TEST(PostPolicyV4EscapeTest, OnlyAscii) {

--- a/google/cloud/storage/internal/signed_url_requests_test.cc
+++ b/google/cloud/storage/internal/signed_url_requests_test.cc
@@ -26,6 +26,7 @@ namespace internal {
 namespace {
 
 using ::google::cloud::testing_util::StatusIs;
+using ::testing::ElementsAre;
 using ::testing::HasSubstr;
 
 TEST(V2SignedUrlRequests, Sign) {
@@ -86,7 +87,7 @@ TEST(V2SignedUrlRequests, SigningAccount) {
   ASSERT_TRUE(request.signing_account_delegates().has_value());
   EXPECT_EQ("another-account@example.com", request.signing_account().value());
   EXPECT_THAT(request.signing_account_delegates().value(),
-              ::testing::ElementsAre("test-delegate1", "test-delegate2"));
+              ElementsAre("test-delegate1", "test-delegate2"));
 }
 
 TEST(V2SignedUrlRequests, SignEscaped) {
@@ -245,7 +246,7 @@ TEST(V4SignUrlRequest, SigningAccount) {
   ASSERT_TRUE(request.signing_account_delegates().has_value());
   EXPECT_EQ("another-account@example.com", request.signing_account().value());
   EXPECT_THAT(request.signing_account_delegates().value(),
-              ::testing::ElementsAre("test-delegate1", "test-delegate2"));
+              ElementsAre("test-delegate1", "test-delegate2"));
 }
 
 TEST(V4SignedUrlRequests, CanonicalQueryStringBasic) {

--- a/google/cloud/storage/internal/storage_auth_test.cc
+++ b/google/cloud/storage/internal/storage_auth_test.cc
@@ -108,8 +108,7 @@ TEST(StorageAuthTest, WriteObject) {
 TEST(StorageAuthTest, StartResumableWrite) {
   auto mock = std::make_shared<MockStorageStub>();
   EXPECT_CALL(*mock, StartResumableWrite)
-      .WillOnce(
-          ::testing::Return(Status(StatusCode::kPermissionDenied, "uh-oh")));
+      .WillOnce(Return(Status(StatusCode::kPermissionDenied, "uh-oh")));
 
   auto under_test = StorageAuth(MakeMockAuth(), mock);
   google::storage::v2::StartResumableWriteRequest request;
@@ -126,8 +125,7 @@ TEST(StorageAuthTest, StartResumableWrite) {
 TEST(StorageAuthTest, QueryWriteStatus) {
   auto mock = std::make_shared<MockStorageStub>();
   EXPECT_CALL(*mock, QueryWriteStatus)
-      .WillOnce(
-          ::testing::Return(Status(StatusCode::kPermissionDenied, "uh-oh")));
+      .WillOnce(Return(Status(StatusCode::kPermissionDenied, "uh-oh")));
 
   auto under_test = StorageAuth(MakeMockAuth(), mock);
   google::storage::v2::QueryWriteStatusRequest request;

--- a/google/cloud/storage/lifecycle_rule_test.cc
+++ b/google/cloud/storage/lifecycle_rule_test.cc
@@ -24,6 +24,12 @@ namespace cloud {
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace {
+
+using ::testing::ElementsAre;
+using ::testing::HasSubstr;
+using ::testing::Not;
+using ::testing::UnorderedElementsAre;
+
 LifecycleRule CreateLifecycleRuleForTest() {
   std::string text = R"""({
       "condition": {
@@ -51,8 +57,8 @@ TEST(LifecycleRuleTest, LifecycleRuleActionStream) {
   std::ostringstream os;
   os << action;
   auto actual = os.str();
-  EXPECT_THAT(actual, ::testing::HasSubstr("SetStorageClass"));
-  EXPECT_THAT(actual, ::testing::HasSubstr("STANDARD"));
+  EXPECT_THAT(actual, HasSubstr("SetStorageClass"));
+  EXPECT_THAT(actual, HasSubstr("STANDARD"));
 }
 
 /// @test Verify that LifecycleRule::DeleteAction() works as expected.
@@ -106,13 +112,13 @@ TEST(LifecycleRuleTest, ConditionStream) {
   std::ostringstream os;
   os << condition;
   auto actual = os.str();
-  EXPECT_THAT(actual, ::testing::HasSubstr("age=42"));
-  EXPECT_THAT(actual, ::testing::HasSubstr("num_newer_versions=7"));
-  EXPECT_THAT(actual,
-              ::testing::HasSubstr(
-                  "matches_storage_class=[NEARLINE, STANDARD, REGIONAL]"));
-  EXPECT_THAT(actual, ::testing::Not(::testing::HasSubstr("created_before")));
-  EXPECT_THAT(actual, ::testing::Not(::testing::HasSubstr("is_live")));
+  EXPECT_THAT(actual, HasSubstr("age=42"));
+  EXPECT_THAT(actual, HasSubstr("num_newer_versions=7"));
+  EXPECT_THAT(
+      actual,
+      HasSubstr("matches_storage_class=[NEARLINE, STANDARD, REGIONAL]"));
+  EXPECT_THAT(actual, Not(HasSubstr("created_before")));
+  EXPECT_THAT(actual, Not(HasSubstr("is_live")));
 }
 
 /// @test Verify that LifecycleRule::MaxAge() works as expected.
@@ -157,9 +163,9 @@ TEST(LifecycleRuleTest, MatchesStorageClasses) {
   auto condition = LifecycleRule::MatchesStorageClasses(
       {storage_class::Standard(), storage_class::Regional()});
   ASSERT_TRUE(condition.matches_storage_class.has_value());
-  EXPECT_THAT(*condition.matches_storage_class,
-              ::testing::ElementsAre(storage_class::Standard(),
-                                     storage_class::Regional()));
+  EXPECT_THAT(
+      *condition.matches_storage_class,
+      ElementsAre(storage_class::Standard(), storage_class::Regional()));
 }
 
 /// @test Verify that LifecycleRule::MatchesStorageClasses works as expected.
@@ -170,8 +176,8 @@ TEST(LifecycleRuleTest, MatchesStorageClassesIterator) {
       LifecycleRule::MatchesStorageClasses(classes.begin(), classes.end());
   ASSERT_TRUE(condition.matches_storage_class.has_value());
   EXPECT_THAT(*condition.matches_storage_class,
-              ::testing::UnorderedElementsAre(storage_class::Standard(),
-                                              storage_class::Regional()));
+              UnorderedElementsAre(storage_class::Standard(),
+                                   storage_class::Regional()));
 }
 
 /// @test LifecycleRule::MatchesStorageClassStandard.
@@ -331,7 +337,7 @@ TEST(LifecycleRuleTest, ConditionConjunctionIsLiveInvalid) {
       try {
         LifecycleRule::ConditionConjunction(c1, c2);
       } catch (std::exception const& ex) {
-        EXPECT_THAT(ex.what(), ::testing::HasSubstr("LifecycleRule"));
+        EXPECT_THAT(ex.what(), HasSubstr("LifecycleRule"));
         throw;
       },
       std::invalid_argument);
@@ -369,8 +375,8 @@ TEST(LifecycleRuleTest, ConditionConjunctionMatchesStorageClass) {
   auto condition = LifecycleRule::ConditionConjunction(c1, c2);
   ASSERT_TRUE(condition.matches_storage_class.has_value());
   EXPECT_THAT(*condition.matches_storage_class,
-              ::testing::UnorderedElementsAre(storage_class::Standard(),
-                                              storage_class::Nearline()));
+              UnorderedElementsAre(storage_class::Standard(),
+                                   storage_class::Nearline()));
 }
 
 /// @test Verify that LifecycleRule::ConditionConjunction() works as expected.
@@ -435,10 +441,10 @@ TEST(LifecycleRuleTest, ConditionConjunctionMultiple) {
   ASSERT_TRUE(condition.num_newer_versions.has_value());
   EXPECT_EQ(7, *condition.num_newer_versions);
   ASSERT_TRUE(condition.matches_storage_class.has_value());
-  EXPECT_THAT(*condition.matches_storage_class,
-              ::testing::UnorderedElementsAre(storage_class::Nearline(),
-                                              storage_class::Standard(),
-                                              storage_class::Regional()));
+  EXPECT_THAT(
+      *condition.matches_storage_class,
+      UnorderedElementsAre(storage_class::Nearline(), storage_class::Standard(),
+                           storage_class::Regional()));
 }
 
 /// @test Verify that LifecycleRule parsing works as expected.
@@ -469,10 +475,10 @@ TEST(LifecycleRuleTest, LifecycleRuleStream) {
   std::ostringstream os;
   os << rule;
   auto actual = os.str();
-  EXPECT_THAT(actual, ::testing::HasSubstr("age=42"));
-  EXPECT_THAT(actual, ::testing::HasSubstr("NEARLINE"));
-  EXPECT_THAT(actual, ::testing::HasSubstr("days_since_custom_time="));
-  EXPECT_THAT(actual, ::testing::HasSubstr("custom_time_before="));
+  EXPECT_THAT(actual, HasSubstr("age=42"));
+  EXPECT_THAT(actual, HasSubstr("NEARLINE"));
+  EXPECT_THAT(actual, HasSubstr("days_since_custom_time="));
+  EXPECT_THAT(actual, HasSubstr("custom_time_before="));
 }
 
 }  // namespace

--- a/google/cloud/storage/policy_document_test.cc
+++ b/google/cloud/storage/policy_document_test.cc
@@ -24,6 +24,9 @@ namespace cloud {
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace {
+
+using ::testing::IsSubsetOf;
+
 PolicyDocument CreatePolicyDocumentForTest() {
   PolicyDocument result;
   result.expiration =
@@ -88,7 +91,7 @@ TEST(PolicyDocumentTests, Parsing) {
 TEST(PolicyDocumentTests, StartsWith) {
   auto condition = PolicyDocumentCondition::StartsWith("key", "");
   std::vector<std::string> subset = {"starts-with", "$key", ""};
-  EXPECT_THAT(subset, ::testing::IsSubsetOf(condition));
+  EXPECT_THAT(subset, IsSubsetOf(condition));
 }
 
 /**
@@ -98,7 +101,7 @@ TEST(PolicyDocumentTests, StartsWith) {
 TEST(PolicyDocumentTests, ExactMatchObject) {
   auto condition = PolicyDocumentCondition::ExactMatch("bucket", "travel-maps");
   std::vector<std::string> subset = {"eq", "$bucket", "travel-maps"};
-  EXPECT_THAT(subset, ::testing::IsSubsetOf(condition));
+  EXPECT_THAT(subset, IsSubsetOf(condition));
 }
 
 /// @test Verify that PolicyDocumentCondition::ExactMatchObject works as
@@ -107,7 +110,7 @@ TEST(PolicyDocumentTests, ExactMatch) {
   auto condition =
       PolicyDocumentCondition::ExactMatchObject("Content-Type", "image/jpeg");
   std::vector<std::string> subset = {"Content-Type", "image/jpeg"};
-  EXPECT_THAT(subset, ::testing::IsSubsetOf(condition));
+  EXPECT_THAT(subset, IsSubsetOf(condition));
 }
 
 /**
@@ -117,7 +120,7 @@ TEST(PolicyDocumentTests, ExactMatch) {
 TEST(PolicyDocumentTests, ContentLengthRange) {
   auto condition = PolicyDocumentCondition::ContentLengthRange(0, 42);
   std::vector<std::string> subset = {"content-length-range", "0", "42"};
-  EXPECT_THAT(subset, ::testing::IsSubsetOf(condition));
+  EXPECT_THAT(subset, IsSubsetOf(condition));
 }
 
 /// @test Verify that PolicyDocumentCondition comparisons work as expected.

--- a/google/cloud/storage/tests/object_basic_crud_integration_test.cc
+++ b/google/cloud/storage/tests/object_basic_crud_integration_test.cc
@@ -37,6 +37,7 @@ namespace {
 using ::google::cloud::testing_util::ContainsOnce;
 using ::testing::Contains;
 using ::testing::Not;
+using ::testing::UnorderedElementsAreArray;
 using ObjectBasicCRUDIntegrationTest =
     ::google::cloud::storage::testing::ObjectIntegrationTest;
 
@@ -138,7 +139,7 @@ TEST_F(ObjectBasicCRUDIntegrationTest, BasicCRUD) {
         };
     auto expected = acl_to_string_vector(update.acl());
     auto actual = acl_to_string_vector(updated_meta->acl());
-    EXPECT_THAT(expected, ::testing::UnorderedElementsAreArray(actual));
+    EXPECT_THAT(expected, UnorderedElementsAreArray(actual));
   }
   EXPECT_EQ(update.cache_control(), updated_meta->cache_control())
       << *updated_meta;

--- a/google/cloud/storage/tests/object_file_integration_test.cc
+++ b/google/cloud/storage/tests/object_file_integration_test.cc
@@ -32,6 +32,7 @@ namespace {
 using ::google::cloud::testing_util::IsOk;
 using ::google::cloud::testing_util::StatusIs;
 using ::testing::AnyOf;
+using ::testing::ElementsAreArray;
 using ::testing::Eq;
 using ::testing::HasSubstr;
 using ::testing::Not;
@@ -250,7 +251,7 @@ TEST_F(ObjectFileIntegrationTest, UploadFileBinary) {
   std::string actual(std::istreambuf_iterator<char>{stream}, {});
   ASSERT_FALSE(actual.empty());
   EXPECT_EQ(expected.size(), actual.size()) << " meta=" << *meta;
-  EXPECT_THAT(actual, ::testing::ElementsAreArray(expected));
+  EXPECT_THAT(actual, ElementsAreArray(expected));
 
   EXPECT_EQ(0, std::remove(file_name.c_str()));
 }

--- a/google/cloud/storage/tests/object_list_objects_versions_integration_test.cc
+++ b/google/cloud/storage/tests/object_list_objects_versions_integration_test.cc
@@ -33,6 +33,8 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace {
 
+using ::testing::IsSupersetOf;
+
 using ObjectListObjectsVersionsIntegrationTest =
     ::google::cloud::storage::testing::ObjectIntegrationTest;
 
@@ -76,7 +78,7 @@ TEST_F(ObjectListObjectsVersionsIntegrationTest, ListObjectsVersions) {
     auto const& meta = it.value();
     actual.emplace_back(meta.name(), meta.generation());
   }
-  EXPECT_THAT(actual, ::testing::IsSupersetOf(expected));
+  EXPECT_THAT(actual, IsSupersetOf(expected));
 }
 
 }  // anonymous namespace

--- a/google/cloud/testing_util/command_line_parsing_test.cc
+++ b/google/cloud/testing_util/command_line_parsing_test.cc
@@ -21,6 +21,7 @@ inline namespace GOOGLE_CLOUD_CPP_NS {
 namespace testing_util {
 namespace {
 
+using ::testing::ElementsAre;
 using ::testing::HasSubstr;
 
 TEST(CommandLineParsing, UsageSimple) {
@@ -58,8 +59,8 @@ TEST(CommandLineParsing, Simple) {
       OptionsParse(desc, {"command-name", "skip1", "--option2=value2", "skip2",
                           "skip3", "--option1=value1", "skip4", "skip5"});
 
-  EXPECT_THAT(unparsed, ::testing::ElementsAre("command-name", "skip1", "skip2",
-                                               "skip3", "skip4", "skip5"));
+  EXPECT_THAT(unparsed, ElementsAre("command-name", "skip1", "skip2", "skip3",
+                                    "skip4", "skip5"));
   EXPECT_EQ(option1_val, "value1");
   EXPECT_EQ(option2_val, "value2");
 }
@@ -79,8 +80,7 @@ TEST(CommandLineParsing, PrefixArgument) {
       OptionsParse(desc, {"command-name", "--option1-with-suffix=suffix1",
                           "skip1", "skip2", "--option1=value1"});
 
-  EXPECT_THAT(unparsed,
-              ::testing::ElementsAre("command-name", "skip1", "skip2"));
+  EXPECT_THAT(unparsed, ElementsAre("command-name", "skip1", "skip2"));
   EXPECT_EQ(option1_with_suffix_val, "suffix1");
   EXPECT_EQ(option1_val, "value1");
 }


### PR DESCRIPTION
I left:
* [this](https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/spanner/internal/tuple_utils.h#L72) and [this](https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/testing_util/scoped_log.h#L38) because they are comments
* [this](https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/internal/compiler_info_test.cc#L37) because it's in an `#if` block
* and things like `::testing::Values` or `::testing::InSequence` which I didn't think were worth changing

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7352)
<!-- Reviewable:end -->
