### PR TITLE
test(spanner): extend timeouts for "slow" database operations

### DIFF
--- a/ci/cloudbuild/builds/integration-daily.sh
+++ b/ci/cloudbuild/builds/integration-daily.sh
@@ -47,5 +47,5 @@ integration::bazel_with_emulators test "${args[@]}" "${integration_args[@]}"
 
 io::log_h2 "Running Spanner integration tests (against prod)"
 bazel test "${args[@]}" "${integration_args[@]}" \
-  --test_tag_filters="integration-test" --test_timeout=-1,-1,-1,7200 \
+  --test_tag_filters="integration-test" --test_timeout=-1,-1,-1,10800 \
   google/cloud/spanner/...

--- a/ci/cloudbuild/cloudbuild.yaml
+++ b/ci/cloudbuild/cloudbuild.yaml
@@ -43,7 +43,7 @@ substitutions:
   _TRIGGER_TYPE: 'manual'
   _LOGS_BUCKET: 'cloud-cpp-community-publiclogs'
 
-timeout: 9000s
+timeout: 12600s
 tags: [
   '${_TRIGGER_TYPE}',
   '${_BUILD_NAME}',

--- a/google/cloud/spanner/admin/integration_tests/backup_integration_test.cc
+++ b/google/cloud/spanner/admin/integration_tests/backup_integration_test.cc
@@ -90,7 +90,7 @@ class BackupTest : public ::google::cloud::testing_util::IntegrationTest {
                         .clone())
                 .set<spanner_admin::DatabaseAdminPollingPolicyOption>(
                     GenericPollingPolicy<>(
-                        LimitedTimeRetryPolicy(std::chrono::hours(2)),
+                        LimitedTimeRetryPolicy(std::chrono::hours(3)),
                         ExponentialBackoffPolicy(std::chrono::seconds(1),
                                                  std::chrono::minutes(1), 2.0))
                         .clone()))) {}

--- a/google/cloud/spanner/integration_tests/backup_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/backup_integration_test.cc
@@ -79,7 +79,7 @@ class BackupTest : public ::google::cloud::testing_util::IntegrationTest {
                                      std::chrono::minutes(1), 2.0)
                 .clone(),
             GenericPollingPolicy<>(
-                LimitedTimeRetryPolicy(std::chrono::hours(2)),
+                LimitedTimeRetryPolicy(std::chrono::hours(3)),
                 ExponentialBackoffPolicy(std::chrono::seconds(1),
                                          std::chrono::minutes(1), 2.0))
                 .clone())) {}


### PR DESCRIPTION
Creating/restoring backups are not only long-running operations,
but their service time is variable (apparently because they are
batch-scheduled in the backend).

So:
- Extend the test timeout and the per-operation polling timeout
  for "eternal" integration tests in the `integration-daily` build
  (where they run against prod) from 2h to 3h.
- Extend the GCB timeout from 2.5h to 3.5h.

Part of #4306.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7353)
<!-- Reviewable:end -->
