### PR TITLE
feat(common): add ability to supply a user-run CQ to gRPC options

### DIFF
--- a/google/cloud/bigtable/benchmarks/benchmark.cc
+++ b/google/cloud/bigtable/benchmarks/benchmark.cc
@@ -290,10 +290,7 @@ int Benchmark::read_rows_count() const {
 }
 
 void Benchmark::DisableBackgroundThreads(CompletionQueue& cq) {
-  opts_.set<GrpcBackgroundThreadsFactoryOption>([&cq] {
-    return absl::make_unique<
-        google::cloud::internal::CustomerSuppliedBackgroundThreads>(cq);
-  });
+  opts_.set<GrpcCompletionQueueOption>(cq);
 }
 
 google::cloud::StatusOr<BenchmarkResult> Benchmark::PopulateTableShard(

--- a/google/cloud/bigtable/client_options.cc
+++ b/google/cloud/bigtable/client_options.cc
@@ -63,10 +63,7 @@ std::string ClientOptions::UserAgentPrefix() {
 
 ClientOptions& ClientOptions::DisableBackgroundThreads(
     google::cloud::CompletionQueue const& cq) {
-  opts_.set<GrpcBackgroundThreadsFactoryOption>([cq] {
-    return absl::make_unique<
-        google::cloud::internal::CustomerSuppliedBackgroundThreads>(cq);
-  });
+  opts_.set<GrpcCompletionQueueOption>(cq);
   return *this;
 }
 

--- a/google/cloud/bigtable/client_options_test.cc
+++ b/google/cloud/bigtable/client_options_test.cc
@@ -578,7 +578,8 @@ TEST(ClientOptionsTest, CustomBackgroundThreads) {
   cq = CompletionQueue();
   client_options = ClientOptions().DisableBackgroundThreads(cq);
   auto opts = internal::MakeOptions(std::move(client_options));
-  background = opts.get<GrpcBackgroundThreadsFactoryOption>()();
+  background =
+      google::cloud::internal::MakeBackgroundThreadsFactory(std::move(opts))();
 
   check(cq, std::move(background));
 }

--- a/google/cloud/bigtable/instance_admin_test.cc
+++ b/google/cloud/bigtable/instance_admin_test.cc
@@ -866,11 +866,7 @@ class ValidContextMdAsyncTest : public ::testing::Test {
       : cq_impl_(new FakeCompletionQueueImpl),
         cq_(cq_impl_),
         client_(new MockAdminClient(
-            Options{}.set<GrpcBackgroundThreadsFactoryOption>([&] {
-              return absl::make_unique<
-                  google::cloud::internal::CustomerSuppliedBackgroundThreads>(
-                  cq_);
-            }))) {
+            Options{}.set<GrpcCompletionQueueOption>(cq_))) {
     EXPECT_CALL(*client_, project()).WillRepeatedly(ReturnRef(kProjectId));
     instance_admin_ = absl::make_unique<InstanceAdmin>(client_);
   }

--- a/google/cloud/bigtable/internal/async_longrunning_op_test.cc
+++ b/google/cloud/bigtable/internal/async_longrunning_op_test.cc
@@ -64,10 +64,7 @@ class AsyncLongrunningOpFutureTest : public bigtable::testing::TableTestFixture,
 TEST_P(AsyncLongrunningOpFutureTest, EndToEnd) {
   auto const success = GetParam();
   auto client = std::make_shared<testing::MockAdminClient>(
-      Options{}.set<GrpcBackgroundThreadsFactoryOption>([&] {
-        return absl::make_unique<
-            google::cloud::internal::CustomerSuppliedBackgroundThreads>(cq_);
-      }));
+      Options{}.set<GrpcCompletionQueueOption>(cq_));
 
   auto longrunning_reader = absl::make_unique<MockAsyncLongrunningOpReader>();
   EXPECT_CALL(*longrunning_reader, Finish)

--- a/google/cloud/bigtable/internal/async_poll_op_test.cc
+++ b/google/cloud/bigtable/internal/async_poll_op_test.cc
@@ -61,11 +61,7 @@ class AsyncPollOpTest : public bigtable::testing::TableTestFixture {
             bigtable::DefaultPollingPolicy(internal::kBigtableLimits)),
         metadata_update_policy_("test_operation_id", MetadataParamTypes::NAME),
         client_(new testing::MockAdminClient(
-            Options{}.set<GrpcBackgroundThreadsFactoryOption>([&] {
-              return absl::make_unique<
-                  google::cloud::internal::CustomerSuppliedBackgroundThreads>(
-                  cq_);
-            }))) {}
+            Options{}.set<GrpcCompletionQueueOption>(cq_))) {}
 
   std::shared_ptr<PollingPolicy const> polling_policy_;
   MetadataUpdatePolicy metadata_update_policy_;

--- a/google/cloud/bigtable/internal/async_retry_unary_rpc_and_poll_test.cc
+++ b/google/cloud/bigtable/internal/async_retry_unary_rpc_and_poll_test.cc
@@ -67,11 +67,7 @@ class AsyncStartPollAfterRetryUnaryRpcTest
             "projects/" + k_project_id + "/instances/" + k_instance_id,
             MetadataParamTypes::PARENT),
         client(std::make_shared<testing::MockInstanceAdminClient>(
-            Options{}.set<GrpcBackgroundThreadsFactoryOption>([&] {
-              return absl::make_unique<
-                  google::cloud::internal::CustomerSuppliedBackgroundThreads>(
-                  cq_);
-            }))),
+            Options{}.set<GrpcCompletionQueueOption>(cq_))),
         create_cluster_reader(
             absl::make_unique<MockAsyncLongrunningOpReader>()),
         get_operation_reader(

--- a/google/cloud/bigtable/table_test.cc
+++ b/google/cloud/bigtable/table_test.cc
@@ -122,11 +122,7 @@ class ValidContextMdAsyncTest : public ::testing::Test {
       : cq_impl_(new FakeCompletionQueueImpl),
         cq_(cq_impl_),
         client_(new ::google::cloud::bigtable::testing::MockDataClient(
-            Options{}.set<GrpcBackgroundThreadsFactoryOption>([&] {
-              return absl::make_unique<
-                  google::cloud::internal::CustomerSuppliedBackgroundThreads>(
-                  cq_);
-            }))) {
+            Options{}.set<GrpcCompletionQueueOption>(cq_))) {
     EXPECT_CALL(*client_, project_id())
         .WillRepeatedly(::testing::ReturnRef(kProjectId));
     EXPECT_CALL(*client_, instance_id())

--- a/google/cloud/bigtable/testing/table_test_fixture.cc
+++ b/google/cloud/bigtable/testing/table_test_fixture.cc
@@ -44,10 +44,7 @@ google::bigtable::v2::ReadRowsResponse ReadRowsResponseFromString(
 
 std::shared_ptr<MockDataClient> TableTestFixture::SetupMockClient() {
   auto client = std::make_shared<MockDataClient>(
-      Options{}.set<GrpcBackgroundThreadsFactoryOption>([&] {
-        return absl::make_unique<
-            google::cloud::internal::CustomerSuppliedBackgroundThreads>(cq_);
-      }));
+      Options{}.set<GrpcCompletionQueueOption>(cq_));
   EXPECT_CALL(*client, project_id())
       .WillRepeatedly(::testing::ReturnRef(project_id_));
   EXPECT_CALL(*client, instance_id())

--- a/google/cloud/bigtable/tests/instance_admin_integration_test.cc
+++ b/google/cloud/bigtable/tests/instance_admin_integration_test.cc
@@ -502,10 +502,7 @@ TEST_F(InstanceAdminIntegrationTest,
 TEST_F(InstanceAdminIntegrationTest, CustomWorkers) {
   CompletionQueue cq;
   auto instance_admin_client = bigtable::MakeInstanceAdminClient(
-      project_id_, Options{}.set<GrpcBackgroundThreadsFactoryOption>([&cq] {
-        return absl::make_unique<
-            google::cloud::internal::CustomerSuppliedBackgroundThreads>(cq);
-      }));
+      project_id_, Options{}.set<GrpcCompletionQueueOption>(cq));
   instance_admin_ = absl::make_unique<bigtable::InstanceAdmin>(
       instance_admin_client,
       *DefaultRPCRetryPolicy({std::chrono::seconds(1), std::chrono::seconds(1),

--- a/google/cloud/grpc_options.cc
+++ b/google/cloud/grpc_options.cc
@@ -61,6 +61,12 @@ absl::optional<std::string> GetStringChannelArgument(
 }
 
 BackgroundThreadsFactory MakeBackgroundThreadsFactory(Options const& opts) {
+  if (opts.has<GrpcCompletionQueueOption>()) {
+    auto const& cq = opts.get<GrpcCompletionQueueOption>();
+    return [cq] {
+      return absl::make_unique<CustomerSuppliedBackgroundThreads>(cq);
+    };
+  }
   if (opts.has<GrpcBackgroundThreadsFactoryOption>()) {
     return opts.get<GrpcBackgroundThreadsFactoryOption>();
   }

--- a/google/cloud/grpc_options.h
+++ b/google/cloud/grpc_options.h
@@ -112,15 +112,10 @@ struct GrpcBackgroundThreadPoolSizeOption {
 /**
  * The `CompletionQueue` to use for background gRPC work.
  *
- * Connections need to perform background work on behalf of the application.
- * Normally they just create a background thread and a `CompletionQueue` for
- * this work, but the application may need more fine-grained control of their
- * threads.
- *
- * It is assumed that if an application sets this option, the application is
- * already running the `CompletionQueue` on a thread pool it has created. The
- * client library will not create any background threads or attempt to call
- * `CompletionQueue::Run()`.
+ * If this option is set, the library will use the supplied `CompletionQueue`
+ * instead of its own. The caller is responsible for making sure there are
+ * thread(s) servicing this `CompletionQueue`. The client library will not
+ * create any background threads or attempt to call `CompletionQueue::Run()`.
  *
  * @note `GrpcBackgroundThreadPoolSizeOption`, `GrpcCompletionQueueOption`, and
  *     `GrpcBackgroundThreadsFactoryOption` are mutually exclusive.

--- a/google/cloud/pubsub/subscriber_connection_test.cc
+++ b/google/cloud/pubsub/subscriber_connection_test.cc
@@ -51,10 +51,7 @@ std::shared_ptr<SubscriberConnection> MakeTestSubscriberConnection(
 }
 
 Options UserSuppliedThreadsOption(CompletionQueue const& cq) {
-  return Options{}.set<GrpcBackgroundThreadsFactoryOption>([cq] {
-    return absl::make_unique<
-        google::cloud::internal::CustomerSuppliedBackgroundThreads>(cq);
-  });
+  return Options{}.set<GrpcCompletionQueueOption>(cq);
 }
 
 TEST(SubscriberConnectionTest, Basic) {


### PR DESCRIPTION
Fixes #7346 

I went with `GrpcCompletionQueueOption` as the name.

I went with `GrpcCompletionQueueOption` > `GrpcBackgroundThreadsFactoryOption` > `GrpcBackgroundThreadPoolSizeOption`. (I put the CQ option first in case we ever deprecate the factory option.)

For testing the precedence, we have `a > b > c` so I just checked that `a > b && b > c`

I did not propagate the test for the option into things like Spanner, which tests other options from `GrpcOptionList`. We should think about how to test common options that show up in all of our libraries. Do we want to duplicate a common test N times? maybe.

Bigtable's `client_options_test.cc` should always have been using the `MakeBackgroundThreadsFactory(opts)` method instead of checking the option.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7354)
<!-- Reviewable:end -->
