### PR TITLE
refactor(storage): split JSON parsing and generation

### DIFF
--- a/google/cloud/storage/internal/bucket_metadata_parser.cc
+++ b/google/cloud/storage/internal/bucket_metadata_parser.cc
@@ -17,6 +17,7 @@
 #include "google/cloud/storage/internal/common_metadata_parser.h"
 #include "google/cloud/storage/internal/lifecycle_rule_parser.h"
 #include "google/cloud/storage/internal/object_access_control_parser.h"
+#include "absl/functional/function_ref.h"
 #include "absl/strings/str_format.h"
 #include <nlohmann/json.hpp>
 
@@ -26,6 +27,14 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace internal {
 namespace {
+void SetIfNotEmpty(nlohmann::json& json, char const* key,
+                   std::string const& value) {
+  if (value.empty()) {
+    return;
+  }
+  json[key] = value;
+}
+
 StatusOr<CorsEntry> ParseCors(nlohmann::json const& json) {
   auto parse_string_list = [](nlohmann::json const& json,
                               char const* field_name) {
@@ -49,14 +58,6 @@ StatusOr<CorsEntry> ParseCors(nlohmann::json const& json) {
   return result;
 }
 
-void SetIfNotEmpty(nlohmann::json& json, char const* key,
-                   std::string const& value) {
-  if (value.empty()) {
-    return;
-  }
-  json[key] = value;
-}
-
 StatusOr<UniformBucketLevelAccess> ParseUniformBucketLevelAccess(
     nlohmann::json const& json) {
   auto enabled = internal::ParseBoolField(json, "enabled");
@@ -67,6 +68,342 @@ StatusOr<UniformBucketLevelAccess> ParseUniformBucketLevelAccess(
   return UniformBucketLevelAccess{*enabled, *locked_time};
 }
 
+Status ParseAcl(std::vector<BucketAccessControl>& acl,
+                nlohmann::json const& json) {
+  if (!json.contains("acl")) return Status{};
+
+  std::vector<BucketAccessControl> value;
+  for (auto const& kv : json["acl"].items()) {
+    auto parsed = internal::BucketAccessControlParser::FromJson(kv.value());
+    if (!parsed.ok()) return std::move(parsed).status();
+    value.push_back(std::move(*parsed));
+  }
+  acl = std::move(value);
+  return Status{};
+}
+
+Status ParseBilling(absl::optional<BucketBilling>& billing,
+                    nlohmann::json const& json) {
+  if (!json.contains("billing")) return Status{};
+  auto b = json["billing"];
+  auto requester_pays = internal::ParseBoolField(b, "requesterPays");
+  if (!requester_pays) return std::move(requester_pays).status();
+  billing = BucketBilling{*requester_pays};
+  return Status{};
+}
+
+Status ParseCorsList(std::vector<CorsEntry>& list, nlohmann::json const& json) {
+  if (!json.contains("cors")) return Status{};
+  std::vector<CorsEntry> value;
+  for (auto const& kv : json["cors"].items()) {
+    auto cors = ParseCors(kv.value());
+    if (!cors) return std::move(cors).status();
+    value.push_back(*std::move(cors));
+  }
+  list = std::move(value);
+  return Status{};
+}
+
+Status ParseDefaultEventBasedHold(bool& default_event_based_hold,
+                                  nlohmann::json const& json) {
+  if (json.contains("defaultEventBasedHold")) {
+    default_event_based_hold = json.value("defaultEventBasedHold", false);
+  }
+  return Status{};
+}
+
+Status ParseDefaultObjectAcl(std::vector<ObjectAccessControl>& acl,
+                             nlohmann::json const& json) {
+  if (!json.contains("defaultObjectAcl")) return Status{};
+  std::vector<ObjectAccessControl> value;
+  for (auto const& kv : json["defaultObjectAcl"].items()) {
+    auto parsed = internal::ObjectAccessControlParser::FromJson(kv.value());
+    if (!parsed.ok()) return std::move(parsed).status();
+    value.push_back(std::move(*parsed));
+  }
+  acl = std::move(value);
+  return Status{};
+}
+
+Status ParseEncryption(absl::optional<BucketEncryption>& encryption,
+                       nlohmann::json const& json) {
+  if (json.contains("encryption")) {
+    BucketEncryption e;
+    e.default_kms_key_name = json["encryption"].value("defaultKmsKeyName", "");
+    encryption = std::move(e);
+  }
+  return Status{};
+}
+
+Status ParseIamConfiguration(
+    absl::optional<BucketIamConfiguration>& iam_configuration,
+    nlohmann::json const& json) {
+  if (!json.contains("iamConfiguration")) return Status{};
+  BucketIamConfiguration value;
+  auto c = json["iamConfiguration"];
+  if (c.contains("uniformBucketLevelAccess")) {
+    auto ubla = ParseUniformBucketLevelAccess(c["uniformBucketLevelAccess"]);
+    if (!ubla) return std::move(ubla).status();
+    value.uniform_bucket_level_access = *ubla;
+  }
+  if (c.contains("publicAccessPrevention")) {
+    value.public_access_prevention = c.value("publicAccessPrevention", "");
+  }
+  iam_configuration = std::move(value);
+  return Status{};
+}
+
+Status ParseLifecycle(absl::optional<BucketLifecycle>& lifecycle,
+                      nlohmann::json const& json) {
+  if (!json.contains("lifecycle")) return Status{};
+  auto l = json["lifecycle"];
+  BucketLifecycle value;
+  if (l.contains("rule")) {
+    for (auto const& kv : l["rule"].items()) {
+      auto parsed = internal::LifecycleRuleParser::FromJson(kv.value());
+      if (!parsed.ok()) return std::move(parsed).status();
+      value.rule.emplace_back(std::move(*parsed));
+    }
+  }
+  lifecycle = std::move(value);
+  return Status{};
+}
+
+Status ParseLogging(absl::optional<BucketLogging>& logging,
+                    nlohmann::json const& json) {
+  if (!json.contains("logging")) return Status{};
+  auto l = json["logging"];
+  BucketLogging value;
+  value.log_bucket = l.value("logBucket", "");
+  value.log_object_prefix = l.value("logObjectPrefix", "");
+  logging = std::move(value);
+  return Status{};
+}
+
+std::map<std::string, std::string> ParseLabels(nlohmann::json const& json) {
+  if (!json.contains("labels")) return {};
+  std::map<std::string, std::string> value;
+  for (auto const& kv : json["labels"].items()) {
+    value.emplace(kv.key(), kv.value().get<std::string>());
+  }
+  return value;
+}
+
+Status ParseProjectNumber(std::int64_t& project_number,
+                          nlohmann::json const& json) {
+  auto p = internal::ParseLongField(json, "projectNumber");
+  if (!p) return std::move(p).status();
+  project_number = *p;
+  return Status{};
+}
+
+Status ParseRetentionPolicy(
+    absl::optional<BucketRetentionPolicy>& retention_policy,
+    nlohmann::json const& json) {
+  if (!json.contains("retentionPolicy")) return Status{};
+  auto r = json["retentionPolicy"];
+  auto is_locked = internal::ParseBoolField(r, "isLocked");
+  if (!is_locked) return std::move(is_locked).status();
+  auto retention_period = internal::ParseLongField(r, "retentionPeriod");
+  if (!retention_period) return std::move(retention_period).status();
+  auto effective_time = internal::ParseTimestampField(r, "effectiveTime");
+  if (!effective_time) return std::move(effective_time).status();
+  retention_policy = BucketRetentionPolicy{
+      std::chrono::seconds(*retention_period), *effective_time, *is_locked};
+  return Status{};
+}
+
+Status ParseVersioning(absl::optional<BucketVersioning>& versioning,
+                       nlohmann::json const& json) {
+  if (!json.contains("versioning")) return Status{};
+  auto v = json["versioning"];
+  if (!v.contains("enabled")) return Status{};
+  auto enabled = internal::ParseBoolField(v, "enabled");
+  if (!enabled) return std::move(enabled).status();
+  versioning = BucketVersioning{*enabled};
+  return Status{};
+}
+
+Status ParseWebsite(absl::optional<BucketWebsite>& website,
+                    nlohmann::json const& json) {
+  if (!json.contains("website")) return Status{};
+  auto w = json["website"];
+  BucketWebsite value;
+  value.main_page_suffix = w.value("mainPageSuffix", "");
+  value.not_found_page = w.value("notFoundPage", "");
+  website = std::move(value);
+  return Status{};
+}
+
+void ToJsonAcl(nlohmann::json& json, BucketMetadata const& meta) {
+  if (meta.acl().empty()) return;
+  nlohmann::json value;
+  for (BucketAccessControl const& a : meta.acl()) {
+    nlohmann::json entry;
+    SetIfNotEmpty(entry, "entity", a.entity());
+    SetIfNotEmpty(entry, "role", a.role());
+    value.push_back(std::move(entry));
+  }
+  json["acl"] = std::move(value);
+}
+
+void ToJsonCors(nlohmann::json& json, BucketMetadata const& meta) {
+  if (meta.cors().empty()) return;
+
+  nlohmann::json value;
+  for (CorsEntry const& v : meta.cors()) {
+    nlohmann::json cors_as_json;
+    if (v.max_age_seconds.has_value()) {
+      cors_as_json["maxAgeSeconds"] = *v.max_age_seconds;
+    }
+    if (!v.method.empty()) {
+      cors_as_json["method"] = v.method;
+    }
+    if (!v.origin.empty()) {
+      cors_as_json["origin"] = v.origin;
+    }
+    if (!v.response_header.empty()) {
+      cors_as_json["responseHeader"] = v.response_header;
+    }
+    value.emplace_back(std::move(cors_as_json));
+  }
+  json["cors"] = std::move(value);
+}
+
+void ToJsonBilling(nlohmann::json& json, BucketMetadata const& meta) {
+  if (!meta.has_billing()) return;
+  json["billing"] = nlohmann::json{
+      {"requesterPays", meta.billing().requester_pays},
+  };
+}
+
+void ToJsonDefaultEventBasedHold(nlohmann::json& json,
+                                 BucketMetadata const& meta) {
+  json["defaultEventBasedHold"] = meta.default_event_based_hold();
+}
+
+void ToJsonDefaultAcl(nlohmann::json& json, BucketMetadata const& meta) {
+  if (meta.default_acl().empty()) return;
+  nlohmann::json value;
+  for (ObjectAccessControl const& a : meta.default_acl()) {
+    nlohmann::json entry;
+    SetIfNotEmpty(entry, "entity", a.entity());
+    SetIfNotEmpty(entry, "role", a.role());
+    value.push_back(std::move(entry));
+  }
+  json["defaultObjectAcl"] = std::move(value);
+}
+
+void ToJsonEncryption(nlohmann::json& json, BucketMetadata const& meta) {
+  if (!meta.has_encryption()) return;
+  nlohmann::json e;
+  SetIfNotEmpty(e, "defaultKmsKeyName", meta.encryption().default_kms_key_name);
+  json["encryption"] = std::move(e);
+}
+
+void ToJsonIamConfiguration(nlohmann::json& json, BucketMetadata const& meta) {
+  if (!meta.has_iam_configuration()) return;
+  nlohmann::json value;
+  if (meta.iam_configuration().uniform_bucket_level_access.has_value()) {
+    // The lockedTime field is not mutable and should not be set by the client
+    // the server will provide a value.
+    value["uniformBucketLevelAccess"] = nlohmann::json{
+        {"enabled",
+         meta.iam_configuration().uniform_bucket_level_access->enabled}};
+  }
+  if (meta.iam_configuration().public_access_prevention.has_value()) {
+    value["publicAccessPrevention"] =
+        *meta.iam_configuration().public_access_prevention;
+  }
+  json["iamConfiguration"] = std::move(value);
+}
+
+void ToJsonLabels(nlohmann::json& json, BucketMetadata const& meta) {
+  if (meta.labels().empty()) return;
+  nlohmann::json value;
+  for (auto const& kv : meta.labels()) {
+    value[kv.first] = kv.second;
+  }
+  json["labels"] = std::move(value);
+}
+
+void ToJsonLifecycle(nlohmann::json& json, BucketMetadata const& meta) {
+  if (!meta.has_lifecycle()) return;
+  nlohmann::json value;
+  for (LifecycleRule const& v : meta.lifecycle().rule) {
+    nlohmann::json condition;
+    auto const& c = v.condition();
+    if (c.age) {
+      condition["age"] = *c.age;
+    }
+    if (c.created_before.has_value()) {
+      condition["createdBefore"] =
+          absl::StrFormat("%04d-%02d-%02d", c.created_before->year(),
+                          c.created_before->month(), c.created_before->day());
+    }
+    if (c.is_live) {
+      condition["isLive"] = *c.is_live;
+    }
+    if (c.matches_storage_class) {
+      condition["matchesStorageClass"] = *c.matches_storage_class;
+    }
+    if (c.num_newer_versions) {
+      condition["numNewerVersions"] = *c.num_newer_versions;
+    }
+    nlohmann::json action{{"type", v.action().type}};
+    if (!v.action().storage_class.empty()) {
+      action["storageClass"] = v.action().storage_class;
+    }
+    value.emplace_back(nlohmann::json{{"condition", std::move(condition)},
+                                      {"action", std::move(action)}});
+  }
+  json["lifecycle"] = nlohmann::json{{"rule", std::move(value)}};
+}
+
+void ToJsonLocation(nlohmann::json& json, BucketMetadata const& meta) {
+  SetIfNotEmpty(json, "location", meta.location());
+}
+
+void ToJsonLocationType(nlohmann::json& json, BucketMetadata const& meta) {
+  SetIfNotEmpty(json, "locationType", meta.location_type());
+}
+
+void ToJsonLogging(nlohmann::json& json, BucketMetadata const& meta) {
+  if (!meta.has_logging()) return;
+
+  nlohmann::json value;
+  SetIfNotEmpty(value, "logBucket", meta.logging().log_bucket);
+  SetIfNotEmpty(value, "logObjectPrefix", meta.logging().log_object_prefix);
+  json["logging"] = std::move(value);
+}
+
+void ToJsonName(nlohmann::json& json, BucketMetadata const& meta) {
+  SetIfNotEmpty(json, "name", meta.name());
+}
+
+void ToJsonRetentionPolicy(nlohmann::json& json, BucketMetadata const& meta) {
+  if (!meta.has_retention_policy()) return;
+  json["retentionPolicy"] = nlohmann::json{
+      {"retentionPeriod", meta.retention_policy().retention_period.count()}};
+}
+
+void ToJsonStorageClass(nlohmann::json& json, BucketMetadata const& meta) {
+  SetIfNotEmpty(json, "storageClass", meta.storage_class());
+}
+
+void ToJsonVersioning(nlohmann::json& json, BucketMetadata const& meta) {
+  if (!meta.versioning().has_value()) return;
+  json["versioning"] = nlohmann::json{{"enabled", meta.versioning()->enabled}};
+}
+
+void ToJsonWebsite(nlohmann::json& json, BucketMetadata const& meta) {
+  if (!meta.has_website()) return;
+  nlohmann::json value;
+  SetIfNotEmpty(value, "mainPageSuffix", meta.website().main_page_suffix);
+  SetIfNotEmpty(value, "notFoundPage", meta.website().not_found_page);
+  json["website"] = std::move(value);
+}
+
 }  // namespace
 
 StatusOr<BucketMetadata> BucketMetadataParser::FromJson(
@@ -74,137 +411,72 @@ StatusOr<BucketMetadata> BucketMetadataParser::FromJson(
   if (!json.is_object()) {
     return Status(StatusCode::kInvalidArgument, __func__);
   }
-  BucketMetadata result{};
-  auto status = CommonMetadataParser<BucketMetadata>::FromJson(result, json);
-  if (!status.ok()) {
-    return status;
-  }
 
-  if (json.count("acl") != 0) {
-    for (auto const& kv : json["acl"].items()) {
-      auto parsed = internal::BucketAccessControlParser::FromJson(kv.value());
-      if (!parsed.ok()) {
-        return std::move(parsed).status();
-      }
-      result.acl_.emplace_back(std::move(*parsed));
-    }
-  }
-  if (json.count("billing") != 0) {
-    auto billing = json["billing"];
-    auto requester_pays = internal::ParseBoolField(billing, "requesterPays");
-    if (!requester_pays) return std::move(requester_pays).status();
-    BucketBilling b;
-    b.requester_pays = *requester_pays;
-    result.billing_ = b;
-  }
-  if (json.count("cors") != 0) {
-    for (auto const& kv : json["cors"].items()) {
-      auto cors = ParseCors(kv.value());
-      if (!cors) return std::move(cors).status();
-      result.cors_.push_back(*std::move(cors));
-    }
-  }
-  if (json.count("defaultEventBasedHold") != 0) {
-    result.default_event_based_hold_ =
-        json.value("defaultEventBasedHold", false);
-  }
-  if (json.count("defaultObjectAcl") != 0) {
-    for (auto const& kv : json["defaultObjectAcl"].items()) {
-      auto parsed = ObjectAccessControlParser::FromJson(kv.value());
-      if (!parsed.ok()) {
-        return std::move(parsed).status();
-      }
-      result.default_acl_.emplace_back(std::move(*parsed));
-    }
-  }
-  if (json.count("encryption") != 0) {
-    BucketEncryption e;
-    e.default_kms_key_name = json["encryption"].value("defaultKmsKeyName", "");
-    result.encryption_ = std::move(e);
-  }
+  using Parser =
+      absl::FunctionRef<Status(BucketMetadata&, nlohmann::json const&)>;
+  Parser parsers[] = {
+      [](BucketMetadata& meta, nlohmann::json const& json) {
+        return CommonMetadataParser<BucketMetadata>::FromJson(meta, json);
+      },
+      [](BucketMetadata& meta, nlohmann::json const& json) {
+        return ParseAcl(meta.acl_, json);
+      },
+      [](BucketMetadata& meta, nlohmann::json const& json) {
+        return ParseBilling(meta.billing_, json);
+      },
+      [](BucketMetadata& meta, nlohmann::json const& json) {
+        return ParseCorsList(meta.cors_, json);
+      },
+      [](BucketMetadata& meta, nlohmann::json const& json) {
+        return ParseDefaultEventBasedHold(meta.default_event_based_hold_, json);
+      },
+      [](BucketMetadata& meta, nlohmann::json const& json) {
+        return ParseDefaultObjectAcl(meta.default_acl_, json);
+      },
+      [](BucketMetadata& meta, nlohmann::json const& json) {
+        return ParseEncryption(meta.encryption_, json);
+      },
+      [](BucketMetadata& meta, nlohmann::json const& json) {
+        return ParseIamConfiguration(meta.iam_configuration_, json);
+      },
+      [](BucketMetadata& meta, nlohmann::json const& json) {
+        return ParseLifecycle(meta.lifecycle_, json);
+      },
+      [](BucketMetadata& meta, nlohmann::json const& json) {
+        meta.location_ = json.value("location", "");
+        return Status{};
+      },
+      [](BucketMetadata& meta, nlohmann::json const& json) {
+        meta.location_type_ = json.value("locationType", "");
+        return Status{};
+      },
+      [](BucketMetadata& meta, nlohmann::json const& json) {
+        return ParseLogging(meta.logging_, json);
+      },
+      [](BucketMetadata& meta, nlohmann::json const& json) {
+        return ParseProjectNumber(meta.project_number_, json);
+      },
+      [](BucketMetadata& meta, nlohmann::json const& json) {
+        meta.labels_ = ParseLabels(json);
+        return Status{};
+      },
+      [](BucketMetadata& meta, nlohmann::json const& json) {
+        return ParseRetentionPolicy(meta.retention_policy_, json);
+      },
+      [](BucketMetadata& meta, nlohmann::json const& json) {
+        return ParseVersioning(meta.versioning_, json);
+      },
+      [](BucketMetadata& meta, nlohmann::json const& json) {
+        return ParseWebsite(meta.website_, json);
+      },
+  };
 
-  if (json.count("iamConfiguration") != 0) {
-    BucketIamConfiguration c;
-    auto config = json["iamConfiguration"];
-    if (config.count("uniformBucketLevelAccess") != 0) {
-      auto ubla =
-          ParseUniformBucketLevelAccess(config["uniformBucketLevelAccess"]);
-      if (!ubla) return std::move(ubla).status();
-      c.uniform_bucket_level_access = *ubla;
-    }
-    if (config.count("publicAccessPrevention") != 0) {
-      c.public_access_prevention = config.value("publicAccessPrevention", "");
-    }
-    result.iam_configuration_ = c;
+  BucketMetadata meta{};
+  for (auto const& p : parsers) {
+    auto status = p(meta, json);
+    if (!status.ok()) return status;
   }
-
-  if (json.count("lifecycle") != 0) {
-    auto lifecycle = json["lifecycle"];
-    BucketLifecycle value;
-    if (lifecycle.count("rule") != 0) {
-      for (auto const& kv : lifecycle["rule"].items()) {
-        auto parsed = internal::LifecycleRuleParser::FromJson(kv.value());
-        if (!parsed.ok()) {
-          return std::move(parsed).status();
-        }
-        value.rule.emplace_back(std::move(*parsed));
-      }
-    }
-    result.lifecycle_ = std::move(value);
-  }
-
-  result.location_ = json.value("location", "");
-
-  result.location_type_ = json.value("locationType", "");
-
-  if (json.count("logging") != 0) {
-    auto logging = json["logging"];
-    BucketLogging l;
-    l.log_bucket = logging.value("logBucket", "");
-    l.log_object_prefix = logging.value("logObjectPrefix", "");
-    result.logging_ = std::move(l);
-  }
-  auto project_number = internal::ParseLongField(json, "projectNumber");
-  if (!project_number) return std::move(project_number).status();
-  result.project_number_ = *project_number;
-  if (json.count("labels") > 0) {
-    for (auto const& kv : json["labels"].items()) {
-      result.labels_.emplace(kv.key(), kv.value().get<std::string>());
-    }
-  }
-
-  if (json.count("retentionPolicy") != 0) {
-    auto retention_policy = json["retentionPolicy"];
-    auto is_locked = internal::ParseBoolField(retention_policy, "isLocked");
-    if (!is_locked) return std::move(is_locked).status();
-    auto retention_period =
-        internal::ParseLongField(retention_policy, "retentionPeriod");
-    if (!retention_period) return std::move(retention_period).status();
-    auto effective_time =
-        internal::ParseTimestampField(retention_policy, "effectiveTime");
-    if (!effective_time) return std::move(effective_time).status();
-
-    result.retention_policy_ = BucketRetentionPolicy{
-        std::chrono::seconds(*retention_period), *effective_time, *is_locked};
-  }
-
-  if (json.count("versioning") != 0) {
-    auto versioning = json["versioning"];
-    if (versioning.count("enabled") != 0) {
-      auto enabled = internal::ParseBoolField(versioning, "enabled");
-      if (!enabled) return std::move(enabled).status();
-      result.versioning_ = BucketVersioning{*enabled};
-    }
-  }
-
-  if (json.count("website") != 0) {
-    auto website = json["website"];
-    BucketWebsite w;
-    w.main_page_suffix = website.value("mainPageSuffix", "");
-    w.not_found_page = website.value("notFoundPage", "");
-    result.website_ = std::move(w);
-  }
-  return result;
+  return meta;
 }
 
 StatusOr<BucketMetadata> BucketMetadataParser::FromString(
@@ -214,151 +486,26 @@ StatusOr<BucketMetadata> BucketMetadataParser::FromString(
 }
 
 std::string BucketMetadataToJsonString(BucketMetadata const& meta) {
-  nlohmann::json metadata_as_json;
-  if (!meta.acl().empty()) {
-    for (BucketAccessControl const& a : meta.acl()) {
-      nlohmann::json entry;
-      SetIfNotEmpty(entry, "entity", a.entity());
-      SetIfNotEmpty(entry, "role", a.role());
-      metadata_as_json["acl"].emplace_back(std::move(entry));
-    }
-  }
+  nlohmann::json json;
+  ToJsonAcl(json, meta);
+  ToJsonBilling(json, meta);
+  ToJsonCors(json, meta);
+  ToJsonDefaultEventBasedHold(json, meta);
+  ToJsonDefaultAcl(json, meta);
+  ToJsonEncryption(json, meta);
+  ToJsonIamConfiguration(json, meta);
+  ToJsonLabels(json, meta);
+  ToJsonLifecycle(json, meta);
+  ToJsonLocation(json, meta);
+  ToJsonLocationType(json, meta);
+  ToJsonLogging(json, meta);
+  ToJsonName(json, meta);
+  ToJsonRetentionPolicy(json, meta);
+  ToJsonStorageClass(json, meta);
+  ToJsonVersioning(json, meta);
+  ToJsonWebsite(json, meta);
 
-  if (!meta.cors().empty()) {
-    for (CorsEntry const& v : meta.cors()) {
-      nlohmann::json cors_as_json;
-      if (v.max_age_seconds.has_value()) {
-        cors_as_json["maxAgeSeconds"] = *v.max_age_seconds;
-      }
-      if (!v.method.empty()) {
-        cors_as_json["method"] = v.method;
-      }
-      if (!v.origin.empty()) {
-        cors_as_json["origin"] = v.origin;
-      }
-      if (!v.response_header.empty()) {
-        cors_as_json["responseHeader"] = v.response_header;
-      }
-      metadata_as_json["cors"].emplace_back(std::move(cors_as_json));
-    }
-  }
-
-  if (meta.has_billing()) {
-    nlohmann::json b{
-        {"requesterPays", meta.billing().requester_pays},
-    };
-    metadata_as_json["billing"] = std::move(b);
-  }
-
-  metadata_as_json["defaultEventBasedHold"] = meta.default_event_based_hold();
-
-  if (!meta.default_acl().empty()) {
-    for (ObjectAccessControl const& a : meta.default_acl()) {
-      nlohmann::json entry;
-      SetIfNotEmpty(entry, "entity", a.entity());
-      SetIfNotEmpty(entry, "role", a.role());
-      metadata_as_json["defaultObjectAcl"].emplace_back(std::move(entry));
-    }
-  }
-
-  if (meta.has_encryption()) {
-    nlohmann::json e;
-    SetIfNotEmpty(e, "defaultKmsKeyName",
-                  meta.encryption().default_kms_key_name);
-    metadata_as_json["encryption"] = std::move(e);
-  }
-
-  if (meta.has_iam_configuration()) {
-    nlohmann::json c;
-    if (meta.iam_configuration().uniform_bucket_level_access.has_value()) {
-      nlohmann::json ubla;
-      ubla["enabled"] =
-          meta.iam_configuration().uniform_bucket_level_access->enabled;
-      // The lockedTime field is not mutable and should not be set by the client
-      // the server will provide a value.
-      c["uniformBucketLevelAccess"] = std::move(ubla);
-    }
-    if (meta.iam_configuration().public_access_prevention.has_value()) {
-      c["publicAccessPrevention"] =
-          *meta.iam_configuration().public_access_prevention;
-    }
-    metadata_as_json["iamConfiguration"] = std::move(c);
-  }
-
-  if (!meta.labels().empty()) {
-    nlohmann::json labels_as_json;
-    for (auto const& kv : meta.labels()) {
-      labels_as_json[kv.first] = kv.second;
-    }
-    metadata_as_json["labels"] = std::move(labels_as_json);
-  }
-
-  if (meta.has_lifecycle()) {
-    nlohmann::json rule;
-    for (LifecycleRule const& v : meta.lifecycle().rule) {
-      nlohmann::json condition;
-      auto const& c = v.condition();
-      if (c.age) {
-        condition["age"] = *c.age;
-      }
-      if (c.created_before.has_value()) {
-        condition["createdBefore"] =
-            absl::StrFormat("%04d-%02d-%02d", c.created_before->year(),
-                            c.created_before->month(), c.created_before->day());
-      }
-      if (c.is_live) {
-        condition["isLive"] = *c.is_live;
-      }
-      if (c.matches_storage_class) {
-        condition["matchesStorageClass"] = *c.matches_storage_class;
-      }
-      if (c.num_newer_versions) {
-        condition["numNewerVersions"] = *c.num_newer_versions;
-      }
-      nlohmann::json action{{"type", v.action().type}};
-      if (!v.action().storage_class.empty()) {
-        action["storageClass"] = v.action().storage_class;
-      }
-      rule.emplace_back(nlohmann::json{{"condition", std::move(condition)},
-                                       {"action", std::move(action)}});
-    }
-    metadata_as_json["lifecycle"] = nlohmann::json{{"rule", std::move(rule)}};
-  }
-
-  SetIfNotEmpty(metadata_as_json, "location", meta.location());
-
-  SetIfNotEmpty(metadata_as_json, "locationType", meta.location_type());
-
-  if (meta.has_logging()) {
-    nlohmann::json l;
-    SetIfNotEmpty(l, "logBucket", meta.logging().log_bucket);
-    SetIfNotEmpty(l, "logObjectPrefix", meta.logging().log_object_prefix);
-    metadata_as_json["logging"] = std::move(l);
-  }
-
-  SetIfNotEmpty(metadata_as_json, "name", meta.name());
-
-  if (meta.has_retention_policy()) {
-    nlohmann::json r{
-        {"retentionPeriod", meta.retention_policy().retention_period.count()}};
-    metadata_as_json["retentionPolicy"] = std::move(r);
-  }
-
-  SetIfNotEmpty(metadata_as_json, "storageClass", meta.storage_class());
-
-  if (meta.versioning().has_value()) {
-    metadata_as_json["versioning"] =
-        nlohmann::json{{"enabled", meta.versioning()->enabled}};
-  }
-
-  if (meta.has_website()) {
-    nlohmann::json w;
-    SetIfNotEmpty(w, "mainPageSuffix", meta.website().main_page_suffix);
-    SetIfNotEmpty(w, "notFoundPage", meta.website().not_found_page);
-    metadata_as_json["website"] = std::move(w);
-  }
-
-  return metadata_as_json.dump();
+  return json.dump();
 }
 
 }  // namespace internal

--- a/google/cloud/storage/internal/bucket_metadata_parser.cc
+++ b/google/cloud/storage/internal/bucket_metadata_parser.cc
@@ -249,7 +249,6 @@ void ToJsonAcl(nlohmann::json& json, BucketMetadata const& meta) {
 
 void ToJsonCors(nlohmann::json& json, BucketMetadata const& meta) {
   if (meta.cors().empty()) return;
-
   nlohmann::json value;
   for (CorsEntry const& v : meta.cors()) {
     nlohmann::json cors_as_json;
@@ -370,7 +369,6 @@ void ToJsonLocationType(nlohmann::json& json, BucketMetadata const& meta) {
 
 void ToJsonLogging(nlohmann::json& json, BucketMetadata const& meta) {
   if (!meta.has_logging()) return;
-
   nlohmann::json value;
   SetIfNotEmpty(value, "logBucket", meta.logging().log_bucket);
   SetIfNotEmpty(value, "logObjectPrefix", meta.logging().log_object_prefix);


### PR DESCRIPTION
The functions to convert `g::c::s::BucketMetadata` to and from JSON
strings was getting too long and hard to grok. Soon, I will need to add
a couple more attributes, seems like a good time to split these
functions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7361)
<!-- Reviewable:end -->
