### PR TITLE
docs(bigtable): add documentation for no automatic channel refresh

### DIFF
--- a/google/cloud/bigtable/options.h
+++ b/google/cloud/bigtable/options.h
@@ -81,7 +81,9 @@ struct MinConnectionRefreshOption {
 /**
  * Maximum time in ms to refresh connections.
  *
- * The server will disconnect idle connections before this time.
+ * The server will disconnect idle connections before this time. The
+ * connections will not be automatically refreshed in the background if this
+ * value is set to `0`.
  *
  * @note If this value is less than the value of `MinConnectionRefreshOption`,
  * it will be set to the value of `MinConnectionRefreshOption`.


### PR DESCRIPTION
Just making a note in the documentation for this behavior:
https://github.com/googleapis/google-cloud-cpp/blob/113dc999516ce9e0c00705654ecb3a06bfbc6e37/google/cloud/bigtable/internal/common_client.h#L220-L222

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7373)
<!-- Reviewable:end -->
