### PR TITLE
cleanup(storage): prevent reuse of CurlRequest*

### DIFF
--- a/google/cloud/storage/internal/curl_client.cc
+++ b/google/cloud/storage/internal/curl_client.cc
@@ -193,7 +193,8 @@ StatusOr<ResumableUploadResponse> CurlClient::UploadChunk(
   // default (at least in this case), and that wastes bandwidth as the content
   // length is known.
   builder.AddHeader("Transfer-Encoding:");
-  auto response = builder.BuildRequest().MakeUploadRequest(request.payload());
+  auto response =
+      std::move(builder).BuildRequest().MakeUploadRequest(request.payload());
   if (!response.ok()) {
     return std::move(response).status();
   }
@@ -214,7 +215,7 @@ StatusOr<ResumableUploadResponse> CurlClient::QueryResumableUpload(
   builder.AddHeader("Content-Range: bytes */*");
   builder.AddHeader("Content-Type: application/octet-stream");
   builder.AddHeader("Content-Length: 0");
-  auto response = builder.BuildRequest().MakeRequest(std::string{});
+  auto response = std::move(builder).BuildRequest().MakeRequest(std::string{});
   if (!response.ok()) {
     return std::move(response).status();
   }
@@ -244,7 +245,7 @@ StatusOr<ListBucketsResponse> CurlClient::ListBuckets(
   }
   builder.AddQueryParameter("project", request.project_id());
   return ParseFromHttpResponse<ListBucketsResponse>(
-      builder.BuildRequest().MakeRequest(std::string{}));
+      std::move(builder).BuildRequest().MakeRequest(std::string{}));
 }
 
 StatusOr<BucketMetadata> CurlClient::CreateBucket(
@@ -258,7 +259,7 @@ StatusOr<BucketMetadata> CurlClient::CreateBucket(
   builder.AddQueryParameter("project", request.project_id());
   builder.AddHeader("Content-Type: application/json");
   return CheckedFromString<BucketMetadataParser>(
-      builder.BuildRequest().MakeRequest(request.json_payload()));
+      std::move(builder).BuildRequest().MakeRequest(request.json_payload()));
 }
 
 StatusOr<BucketMetadata> CurlClient::GetBucketMetadata(
@@ -271,7 +272,7 @@ StatusOr<BucketMetadata> CurlClient::GetBucketMetadata(
     return status;
   }
   return CheckedFromString<BucketMetadataParser>(
-      builder.BuildRequest().MakeRequest(std::string{}));
+      std::move(builder).BuildRequest().MakeRequest(std::string{}));
 }
 
 StatusOr<EmptyResponse> CurlClient::DeleteBucket(
@@ -283,7 +284,8 @@ StatusOr<EmptyResponse> CurlClient::DeleteBucket(
   if (!status.ok()) {
     return status;
   }
-  return ReturnEmptyResponse(builder.BuildRequest().MakeRequest(std::string{}));
+  return ReturnEmptyResponse(
+      std::move(builder).BuildRequest().MakeRequest(std::string{}));
 }
 
 StatusOr<BucketMetadata> CurlClient::UpdateBucket(
@@ -297,7 +299,7 @@ StatusOr<BucketMetadata> CurlClient::UpdateBucket(
   }
   builder.AddHeader("Content-Type: application/json");
   return CheckedFromString<BucketMetadataParser>(
-      builder.BuildRequest().MakeRequest(request.json_payload()));
+      std::move(builder).BuildRequest().MakeRequest(request.json_payload()));
 }
 
 StatusOr<BucketMetadata> CurlClient::PatchBucket(
@@ -311,7 +313,7 @@ StatusOr<BucketMetadata> CurlClient::PatchBucket(
   }
   builder.AddHeader("Content-Type: application/json");
   return CheckedFromString<BucketMetadataParser>(
-      builder.BuildRequest().MakeRequest(request.payload()));
+      std::move(builder).BuildRequest().MakeRequest(request.payload()));
 }
 
 StatusOr<IamPolicy> CurlClient::GetBucketIamPolicy(
@@ -323,7 +325,7 @@ StatusOr<IamPolicy> CurlClient::GetBucketIamPolicy(
   if (!status.ok()) {
     return status;
   }
-  auto response = builder.BuildRequest().MakeRequest(std::string{});
+  auto response = std::move(builder).BuildRequest().MakeRequest(std::string{});
   if (!response.ok()) {
     return std::move(response).status();
   }
@@ -342,7 +344,7 @@ StatusOr<NativeIamPolicy> CurlClient::GetNativeBucketIamPolicy(
   if (!status.ok()) {
     return status;
   }
-  auto response = builder.BuildRequest().MakeRequest(std::string{});
+  auto response = std::move(builder).BuildRequest().MakeRequest(std::string{});
   if (!response.ok()) {
     return std::move(response).status();
   }
@@ -362,7 +364,8 @@ StatusOr<IamPolicy> CurlClient::SetBucketIamPolicy(
     return status;
   }
   builder.AddHeader("Content-Type: application/json");
-  auto response = builder.BuildRequest().MakeRequest(request.json_payload());
+  auto response =
+      std::move(builder).BuildRequest().MakeRequest(request.json_payload());
   if (!response.ok()) {
     return std::move(response).status();
   }
@@ -382,7 +385,8 @@ StatusOr<NativeIamPolicy> CurlClient::SetNativeBucketIamPolicy(
     return status;
   }
   builder.AddHeader("Content-Type: application/json");
-  auto response = builder.BuildRequest().MakeRequest(request.json_payload());
+  auto response =
+      std::move(builder).BuildRequest().MakeRequest(request.json_payload());
   if (!response.ok()) {
     return std::move(response).status();
   }
@@ -404,7 +408,7 @@ StatusOr<TestBucketIamPermissionsResponse> CurlClient::TestBucketIamPermissions(
   for (auto const& perm : request.permissions()) {
     builder.AddQueryParameter("permissions", perm);
   }
-  auto response = builder.BuildRequest().MakeRequest(std::string{});
+  auto response = std::move(builder).BuildRequest().MakeRequest(std::string{});
   if (!response.ok()) {
     return std::move(response).status();
   }
@@ -427,7 +431,7 @@ StatusOr<BucketMetadata> CurlClient::LockBucketRetentionPolicy(
   builder.AddHeader("content-length: 0");
   builder.AddOption(IfMetagenerationMatch(request.metageneration()));
   return CheckedFromString<BucketMetadataParser>(
-      builder.BuildRequest().MakeRequest(std::string{}));
+      std::move(builder).BuildRequest().MakeRequest(std::string{}));
 }
 
 StatusOr<ObjectMetadata> CurlClient::InsertObjectMedia(
@@ -480,7 +484,7 @@ StatusOr<ObjectMetadata> CurlClient::CopyObject(
                        .dump();
   }
   return CheckedFromString<ObjectMetadataParser>(
-      builder.BuildRequest().MakeRequest(json_payload));
+      std::move(builder).BuildRequest().MakeRequest(json_payload));
 }
 
 StatusOr<ObjectMetadata> CurlClient::GetObjectMetadata(
@@ -493,7 +497,7 @@ StatusOr<ObjectMetadata> CurlClient::GetObjectMetadata(
     return status;
   }
   return CheckedFromString<ObjectMetadataParser>(
-      builder.BuildRequest().MakeRequest(std::string{}));
+      std::move(builder).BuildRequest().MakeRequest(std::string{}));
 }
 
 StatusOr<std::unique_ptr<ObjectReadSource>> CurlClient::ReadObject(
@@ -537,7 +541,7 @@ StatusOr<ListObjectsResponse> CurlClient::ListObjects(
   }
   builder.AddQueryParameter("pageToken", request.page_token());
   return ParseFromHttpResponse<ListObjectsResponse>(
-      builder.BuildRequest().MakeRequest(std::string{}));
+      std::move(builder).BuildRequest().MakeRequest(std::string{}));
 }
 
 StatusOr<EmptyResponse> CurlClient::DeleteObject(
@@ -550,7 +554,8 @@ StatusOr<EmptyResponse> CurlClient::DeleteObject(
   if (!status.ok()) {
     return status;
   }
-  return ReturnEmptyResponse(builder.BuildRequest().MakeRequest(std::string{}));
+  return ReturnEmptyResponse(
+      std::move(builder).BuildRequest().MakeRequest(std::string{}));
 }
 
 StatusOr<ObjectMetadata> CurlClient::UpdateObject(
@@ -564,7 +569,7 @@ StatusOr<ObjectMetadata> CurlClient::UpdateObject(
   }
   builder.AddHeader("Content-Type: application/json");
   return CheckedFromString<ObjectMetadataParser>(
-      builder.BuildRequest().MakeRequest(request.json_payload()));
+      std::move(builder).BuildRequest().MakeRequest(request.json_payload()));
 }
 
 StatusOr<ObjectMetadata> CurlClient::PatchObject(
@@ -578,7 +583,7 @@ StatusOr<ObjectMetadata> CurlClient::PatchObject(
   }
   builder.AddHeader("Content-Type: application/json");
   return CheckedFromString<ObjectMetadataParser>(
-      builder.BuildRequest().MakeRequest(request.payload()));
+      std::move(builder).BuildRequest().MakeRequest(request.payload()));
 }
 
 StatusOr<ObjectMetadata> CurlClient::ComposeObject(
@@ -593,7 +598,7 @@ StatusOr<ObjectMetadata> CurlClient::ComposeObject(
   }
   builder.AddHeader("Content-Type: application/json");
   return CheckedFromString<ObjectMetadataParser>(
-      builder.BuildRequest().MakeRequest(request.JsonPayload()));
+      std::move(builder).BuildRequest().MakeRequest(request.JsonPayload()));
 }
 
 StatusOr<RewriteObjectResponse> CurlClient::RewriteObject(
@@ -618,7 +623,7 @@ StatusOr<RewriteObjectResponse> CurlClient::RewriteObject(
                        request.GetOption<WithObjectMetadata>().value())
                        .dump();
   }
-  auto response = builder.BuildRequest().MakeRequest(json_payload);
+  auto response = std::move(builder).BuildRequest().MakeRequest(json_payload);
   if (!response.ok()) {
     return std::move(response).status();
   }
@@ -696,7 +701,8 @@ CurlClient::CreateResumableSession(ResumableUploadRequest const& request) {
 
   builder.AddHeader("Content-Length: " +
                     std::to_string(request_payload.size()));
-  auto http_response = builder.BuildRequest().MakeRequest(request_payload);
+  auto http_response =
+      std::move(builder).BuildRequest().MakeRequest(request_payload);
   if (!http_response.ok()) {
     return std::move(http_response).status();
   }
@@ -724,7 +730,7 @@ StatusOr<EmptyResponse> CurlClient::DeleteResumableUpload(
   if (!status.ok()) {
     return status;
   }
-  auto response = builder.BuildRequest().MakeRequest(std::string{});
+  auto response = std::move(builder).BuildRequest().MakeRequest(std::string{});
   if (!response.ok()) {
     return std::move(response).status();
   }
@@ -744,7 +750,7 @@ StatusOr<ListBucketAclResponse> CurlClient::ListBucketAcl(
   if (!status.ok()) {
     return status;
   }
-  auto response = builder.BuildRequest().MakeRequest(std::string{});
+  auto response = std::move(builder).BuildRequest().MakeRequest(std::string{});
   if (!response.ok()) {
     return std::move(response).status();
   }
@@ -764,7 +770,7 @@ StatusOr<BucketAccessControl> CurlClient::GetBucketAcl(
     return status;
   }
   return CheckedFromString<internal::BucketAccessControlParser>(
-      builder.BuildRequest().MakeRequest(std::string{}));
+      std::move(builder).BuildRequest().MakeRequest(std::string{}));
 }
 
 StatusOr<BucketAccessControl> CurlClient::CreateBucketAcl(
@@ -781,7 +787,7 @@ StatusOr<BucketAccessControl> CurlClient::CreateBucketAcl(
   object["entity"] = request.entity();
   object["role"] = request.role();
   return CheckedFromString<internal::BucketAccessControlParser>(
-      builder.BuildRequest().MakeRequest(object.dump()));
+      std::move(builder).BuildRequest().MakeRequest(object.dump()));
 }
 
 StatusOr<EmptyResponse> CurlClient::DeleteBucketAcl(
@@ -793,7 +799,8 @@ StatusOr<EmptyResponse> CurlClient::DeleteBucketAcl(
   if (!status.ok()) {
     return status;
   }
-  return ReturnEmptyResponse(builder.BuildRequest().MakeRequest(std::string{}));
+  return ReturnEmptyResponse(
+      std::move(builder).BuildRequest().MakeRequest(std::string{}));
 }
 
 StatusOr<BucketAccessControl> CurlClient::UpdateBucketAcl(
@@ -810,7 +817,7 @@ StatusOr<BucketAccessControl> CurlClient::UpdateBucketAcl(
   patch["entity"] = request.entity();
   patch["role"] = request.role();
   return CheckedFromString<internal::BucketAccessControlParser>(
-      builder.BuildRequest().MakeRequest(patch.dump()));
+      std::move(builder).BuildRequest().MakeRequest(patch.dump()));
 }
 
 StatusOr<BucketAccessControl> CurlClient::PatchBucketAcl(
@@ -824,7 +831,7 @@ StatusOr<BucketAccessControl> CurlClient::PatchBucketAcl(
   }
   builder.AddHeader("Content-Type: application/json");
   return CheckedFromString<internal::BucketAccessControlParser>(
-      builder.BuildRequest().MakeRequest(request.payload()));
+      std::move(builder).BuildRequest().MakeRequest(request.payload()));
 }
 
 StatusOr<ListObjectAclResponse> CurlClient::ListObjectAcl(
@@ -839,7 +846,7 @@ StatusOr<ListObjectAclResponse> CurlClient::ListObjectAcl(
     return status;
   }
   return ParseFromHttpResponse<ListObjectAclResponse>(
-      builder.BuildRequest().MakeRequest(std::string{}));
+      std::move(builder).BuildRequest().MakeRequest(std::string{}));
 }
 
 StatusOr<ObjectAccessControl> CurlClient::CreateObjectAcl(
@@ -857,7 +864,7 @@ StatusOr<ObjectAccessControl> CurlClient::CreateObjectAcl(
   object["entity"] = request.entity();
   object["role"] = request.role();
   return CheckedFromString<ObjectAccessControlParser>(
-      builder.BuildRequest().MakeRequest(object.dump()));
+      std::move(builder).BuildRequest().MakeRequest(object.dump()));
 }
 
 StatusOr<EmptyResponse> CurlClient::DeleteObjectAcl(
@@ -871,7 +878,8 @@ StatusOr<EmptyResponse> CurlClient::DeleteObjectAcl(
   if (!status.ok()) {
     return status;
   }
-  return ReturnEmptyResponse(builder.BuildRequest().MakeRequest(std::string{}));
+  return ReturnEmptyResponse(
+      std::move(builder).BuildRequest().MakeRequest(std::string{}));
 }
 
 StatusOr<ObjectAccessControl> CurlClient::GetObjectAcl(
@@ -886,7 +894,7 @@ StatusOr<ObjectAccessControl> CurlClient::GetObjectAcl(
     return status;
   }
   return CheckedFromString<ObjectAccessControlParser>(
-      builder.BuildRequest().MakeRequest(std::string{}));
+      std::move(builder).BuildRequest().MakeRequest(std::string{}));
 }
 
 StatusOr<ObjectAccessControl> CurlClient::UpdateObjectAcl(
@@ -905,7 +913,7 @@ StatusOr<ObjectAccessControl> CurlClient::UpdateObjectAcl(
   object["entity"] = request.entity();
   object["role"] = request.role();
   return CheckedFromString<ObjectAccessControlParser>(
-      builder.BuildRequest().MakeRequest(object.dump()));
+      std::move(builder).BuildRequest().MakeRequest(object.dump()));
 }
 
 StatusOr<ObjectAccessControl> CurlClient::PatchObjectAcl(
@@ -921,7 +929,7 @@ StatusOr<ObjectAccessControl> CurlClient::PatchObjectAcl(
   }
   builder.AddHeader("Content-Type: application/json");
   return CheckedFromString<ObjectAccessControlParser>(
-      builder.BuildRequest().MakeRequest(request.payload()));
+      std::move(builder).BuildRequest().MakeRequest(request.payload()));
 }
 
 StatusOr<ListDefaultObjectAclResponse> CurlClient::ListDefaultObjectAcl(
@@ -935,7 +943,7 @@ StatusOr<ListDefaultObjectAclResponse> CurlClient::ListDefaultObjectAcl(
     return status;
   }
   return ParseFromHttpResponse<ListDefaultObjectAclResponse>(
-      builder.BuildRequest().MakeRequest(std::string{}));
+      std::move(builder).BuildRequest().MakeRequest(std::string{}));
 }
 
 StatusOr<ObjectAccessControl> CurlClient::CreateDefaultObjectAcl(
@@ -952,7 +960,7 @@ StatusOr<ObjectAccessControl> CurlClient::CreateDefaultObjectAcl(
   object["role"] = request.role();
   builder.AddHeader("Content-Type: application/json");
   return CheckedFromString<ObjectAccessControlParser>(
-      builder.BuildRequest().MakeRequest(object.dump()));
+      std::move(builder).BuildRequest().MakeRequest(object.dump()));
 }
 
 StatusOr<EmptyResponse> CurlClient::DeleteDefaultObjectAcl(
@@ -965,7 +973,8 @@ StatusOr<EmptyResponse> CurlClient::DeleteDefaultObjectAcl(
   if (!status.ok()) {
     return status;
   }
-  return ReturnEmptyResponse(builder.BuildRequest().MakeRequest(std::string{}));
+  return ReturnEmptyResponse(
+      std::move(builder).BuildRequest().MakeRequest(std::string{}));
 }
 
 StatusOr<ObjectAccessControl> CurlClient::GetDefaultObjectAcl(
@@ -979,7 +988,7 @@ StatusOr<ObjectAccessControl> CurlClient::GetDefaultObjectAcl(
     return status;
   }
   return CheckedFromString<ObjectAccessControlParser>(
-      builder.BuildRequest().MakeRequest(std::string{}));
+      std::move(builder).BuildRequest().MakeRequest(std::string{}));
 }
 
 StatusOr<ObjectAccessControl> CurlClient::UpdateDefaultObjectAcl(
@@ -997,7 +1006,7 @@ StatusOr<ObjectAccessControl> CurlClient::UpdateDefaultObjectAcl(
   object["entity"] = request.entity();
   object["role"] = request.role();
   return CheckedFromString<ObjectAccessControlParser>(
-      builder.BuildRequest().MakeRequest(object.dump()));
+      std::move(builder).BuildRequest().MakeRequest(object.dump()));
 }
 
 StatusOr<ObjectAccessControl> CurlClient::PatchDefaultObjectAcl(
@@ -1012,7 +1021,7 @@ StatusOr<ObjectAccessControl> CurlClient::PatchDefaultObjectAcl(
   }
   builder.AddHeader("Content-Type: application/json");
   return CheckedFromString<ObjectAccessControlParser>(
-      builder.BuildRequest().MakeRequest(request.payload()));
+      std::move(builder).BuildRequest().MakeRequest(request.payload()));
 }
 
 StatusOr<ServiceAccount> CurlClient::GetServiceAccount(
@@ -1025,7 +1034,7 @@ StatusOr<ServiceAccount> CurlClient::GetServiceAccount(
     return status;
   }
   return CheckedFromString<ServiceAccountParser>(
-      builder.BuildRequest().MakeRequest(std::string{}));
+      std::move(builder).BuildRequest().MakeRequest(std::string{}));
 }
 
 StatusOr<ListHmacKeysResponse> CurlClient::ListHmacKeys(
@@ -1038,7 +1047,7 @@ StatusOr<ListHmacKeysResponse> CurlClient::ListHmacKeys(
     return status;
   }
   return ParseFromHttpResponse<ListHmacKeysResponse>(
-      builder.BuildRequest().MakeRequest(std::string{}));
+      std::move(builder).BuildRequest().MakeRequest(std::string{}));
 }
 
 StatusOr<CreateHmacKeyResponse> CurlClient::CreateHmacKey(
@@ -1053,7 +1062,7 @@ StatusOr<CreateHmacKeyResponse> CurlClient::CreateHmacKey(
   builder.AddQueryParameter("serviceAccountEmail", request.service_account());
   builder.AddHeader("content-length: 0");
   return ParseFromHttpResponse<CreateHmacKeyResponse>(
-      builder.BuildRequest().MakeRequest(std::string{}));
+      std::move(builder).BuildRequest().MakeRequest(std::string{}));
 }
 
 StatusOr<EmptyResponse> CurlClient::DeleteHmacKey(
@@ -1066,7 +1075,8 @@ StatusOr<EmptyResponse> CurlClient::DeleteHmacKey(
   if (!status.ok()) {
     return status;
   }
-  return ReturnEmptyResponse(builder.BuildRequest().MakeRequest(std::string{}));
+  return ReturnEmptyResponse(
+      std::move(builder).BuildRequest().MakeRequest(std::string{}));
 }
 
 StatusOr<HmacKeyMetadata> CurlClient::GetHmacKey(
@@ -1080,7 +1090,7 @@ StatusOr<HmacKeyMetadata> CurlClient::GetHmacKey(
     return status;
   }
   return CheckedFromString<HmacKeyMetadataParser>(
-      builder.BuildRequest().MakeRequest(std::string{}));
+      std::move(builder).BuildRequest().MakeRequest(std::string{}));
 }
 
 StatusOr<HmacKeyMetadata> CurlClient::UpdateHmacKey(
@@ -1102,7 +1112,7 @@ StatusOr<HmacKeyMetadata> CurlClient::UpdateHmacKey(
   }
   builder.AddHeader("Content-Type: application/json");
   return CheckedFromString<HmacKeyMetadataParser>(
-      builder.BuildRequest().MakeRequest(payload.dump()));
+      std::move(builder).BuildRequest().MakeRequest(payload.dump()));
 }
 
 StatusOr<SignBlobResponse> CurlClient::SignBlob(
@@ -1121,7 +1131,7 @@ StatusOr<SignBlobResponse> CurlClient::SignBlob(
   }
   builder.AddHeader("Content-Type: application/json");
   return ParseFromHttpResponse<SignBlobResponse>(
-      builder.BuildRequest().MakeRequest(payload.dump()));
+      std::move(builder).BuildRequest().MakeRequest(payload.dump()));
 }
 
 StatusOr<ListNotificationsResponse> CurlClient::ListNotifications(
@@ -1135,7 +1145,7 @@ StatusOr<ListNotificationsResponse> CurlClient::ListNotifications(
     return status;
   }
   return ParseFromHttpResponse<ListNotificationsResponse>(
-      builder.BuildRequest().MakeRequest(std::string{}));
+      std::move(builder).BuildRequest().MakeRequest(std::string{}));
 }
 
 StatusOr<NotificationMetadata> CurlClient::CreateNotification(
@@ -1149,7 +1159,7 @@ StatusOr<NotificationMetadata> CurlClient::CreateNotification(
   }
   builder.AddHeader("Content-Type: application/json");
   return CheckedFromString<NotificationMetadataParser>(
-      builder.BuildRequest().MakeRequest(request.json_payload()));
+      std::move(builder).BuildRequest().MakeRequest(request.json_payload()));
 }
 
 StatusOr<NotificationMetadata> CurlClient::GetNotification(
@@ -1163,7 +1173,7 @@ StatusOr<NotificationMetadata> CurlClient::GetNotification(
     return status;
   }
   return CheckedFromString<NotificationMetadataParser>(
-      builder.BuildRequest().MakeRequest(std::string{}));
+      std::move(builder).BuildRequest().MakeRequest(std::string{}));
 }
 
 StatusOr<EmptyResponse> CurlClient::DeleteNotification(
@@ -1176,7 +1186,8 @@ StatusOr<EmptyResponse> CurlClient::DeleteNotification(
   if (!status.ok()) {
     return status;
   }
-  return ReturnEmptyResponse(builder.BuildRequest().MakeRequest(std::string{}));
+  return ReturnEmptyResponse(
+      std::move(builder).BuildRequest().MakeRequest(std::string{}));
 }
 
 StatusOr<ObjectMetadata> CurlClient::InsertObjectMediaXml(
@@ -1250,7 +1261,8 @@ StatusOr<ObjectMetadata> CurlClient::InsertObjectMediaXml(
 
   builder.AddHeader("Content-Length: " +
                     std::to_string(request.contents().size()));
-  auto response = builder.BuildRequest().MakeRequest(request.contents());
+  auto response =
+      std::move(builder).BuildRequest().MakeRequest(request.contents());
   if (!response.ok()) {
     return std::move(response).status();
   }
@@ -1369,7 +1381,7 @@ StatusOr<ObjectMetadata> CurlClient::InsertObjectMediaMultipart(
   auto contents = std::move(writer).str();
   builder.AddHeader("Content-Length: " + std::to_string(contents.size()));
   return CheckedFromString<ObjectMetadataParser>(
-      builder.BuildRequest().MakeRequest(contents));
+      std::move(builder).BuildRequest().MakeRequest(contents));
 }
 
 std::string CurlClient::PickBoundary(std::string const& text_to_avoid) {
@@ -1409,7 +1421,7 @@ StatusOr<ObjectMetadata> CurlClient::InsertObjectMediaSimple(
   builder.AddHeader("Content-Length: " +
                     std::to_string(request.contents().size()));
   return CheckedFromString<ObjectMetadataParser>(
-      builder.BuildRequest().MakeRequest(request.contents()));
+      std::move(builder).BuildRequest().MakeRequest(request.contents()));
 }
 
 }  // namespace internal

--- a/google/cloud/storage/internal/curl_request.cc
+++ b/google/cloud/storage/internal/curl_request.cc
@@ -68,7 +68,7 @@ CurlRequest::~CurlRequest() {
   if (factory_) factory_->CleanupHandle(std::move(handle_));
 }
 
-StatusOr<HttpResponse> CurlRequest::MakeRequest(std::string const& payload) {
+StatusOr<HttpResponse> CurlRequest::MakeRequest(std::string const& payload) && {
   handle_.SetOption(CURLOPT_UPLOAD, 0L);
   if (!payload.empty()) {
     handle_.SetOption(CURLOPT_POSTFIELDSIZE, payload.length());
@@ -78,7 +78,7 @@ StatusOr<HttpResponse> CurlRequest::MakeRequest(std::string const& payload) {
 }
 
 StatusOr<HttpResponse> CurlRequest::MakeUploadRequest(
-    ConstBufferSequence payload) {
+    ConstBufferSequence payload) && {
   handle_.SetOption(CURLOPT_UPLOAD, 0L);
   if (payload.empty()) return MakeRequestImpl();
   if (payload.size() == 1) {

--- a/google/cloud/storage/internal/curl_request.h
+++ b/google/cloud/storage/internal/curl_request.h
@@ -47,10 +47,10 @@ class CurlRequest {
    *
    * @return The response HTTP error code, the headers and an empty payload.
    */
-  StatusOr<HttpResponse> MakeRequest(std::string const& payload);
+  StatusOr<HttpResponse> MakeRequest(std::string const& payload) &&;
 
   /// @copydoc MakeRequest(std::string const&)
-  StatusOr<HttpResponse> MakeUploadRequest(ConstBufferSequence payload);
+  StatusOr<HttpResponse> MakeUploadRequest(ConstBufferSequence payload) &&;
 
  private:
   /// Handle a libcurl error during the request.

--- a/google/cloud/storage/internal/curl_request_builder.cc
+++ b/google/cloud/storage/internal/curl_request_builder.cc
@@ -45,7 +45,7 @@ CurlRequestBuilder::CurlRequestBuilder(
       logging_enabled_(false),
       transfer_stall_timeout_(0) {}
 
-CurlRequest CurlRequestBuilder::BuildRequest() {
+CurlRequest CurlRequestBuilder::BuildRequest() && {
   ValidateBuilderState(__func__);
   CurlRequest request;
   request.url_ = std::move(url_);

--- a/google/cloud/storage/internal/curl_request_builder.h
+++ b/google/cloud/storage/internal/curl_request_builder.h
@@ -45,7 +45,7 @@ class CurlRequestBuilder {
    * This function invalidates the builder. The application should not use this
    * builder once this function is called.
    */
-  CurlRequest BuildRequest();
+  CurlRequest BuildRequest() &&;
 
   /**
    * Creates a non-blocking http request.

--- a/google/cloud/storage/internal/minimal_iam_credentials_rest.cc
+++ b/google/cloud/storage/internal/minimal_iam_credentials_rest.cc
@@ -58,7 +58,8 @@ class MinimalIamCredentialsRestImpl : public MinimalIamCredentialsRest {
         {"scope", request.scopes},
         {"lifetime", std::to_string(request.lifetime.count()) + "s"},
     };
-    auto response = builder.BuildRequest().MakeRequest(payload.dump());
+    auto response =
+        std::move(builder).BuildRequest().MakeRequest(payload.dump());
     if (!response) return std::move(response).status();
     if (response->status_code >= HttpStatusCode::kMinNotSuccess) {
       return AsStatus(*response);

--- a/google/cloud/storage/oauth2/authorized_user_credentials.h
+++ b/google/cloud/storage/oauth2/authorized_user_credentials.h
@@ -94,17 +94,17 @@ class AuthorizedUserCredentials : public Credentials {
 
  private:
   StatusOr<RefreshingCredentialsWrapper::TemporaryToken> Refresh() {
-    HttpRequestBuilderType request_builder(
+    HttpRequestBuilderType builder(
         info_.token_uri,
         storage::internal::GetDefaultCurlHandleFactory(options_));
     std::string payload("grant_type=refresh_token");
     payload += "&client_id=";
-    payload += request_builder.MakeEscapedString(info_.client_id).get();
+    payload += builder.MakeEscapedString(info_.client_id).get();
     payload += "&client_secret=";
-    payload += request_builder.MakeEscapedString(info_.client_secret).get();
+    payload += builder.MakeEscapedString(info_.client_secret).get();
     payload += "&refresh_token=";
-    payload += request_builder.MakeEscapedString(info_.refresh_token).get();
-    auto response = request_builder.BuildRequest().MakeRequest(payload);
+    payload += builder.MakeEscapedString(info_.refresh_token).get();
+    auto response = std::move(builder).BuildRequest().MakeRequest(payload);
     if (!response) return std::move(response).status();
     if (response->status_code >= 300) return AsStatus(*response);
     return ParseAuthorizedUserRefreshResponse(*response, clock_.now());

--- a/google/cloud/storage/oauth2/compute_engine_credentials.h
+++ b/google/cloud/storage/oauth2/compute_engine_credentials.h
@@ -137,14 +137,12 @@ class ComputeEngineCredentials : public Credentials {
     std::string metadata_server_hostname =
         google::cloud::storage::internal::GceMetadataHostname();
 
-    HttpRequestBuilderType request_builder(
+    HttpRequestBuilderType builder(
         std::move("http://" + metadata_server_hostname + path),
         storage::internal::GetDefaultCurlHandleFactory());
-    request_builder.AddHeader("metadata-flavor: Google");
-    if (recursive) {
-      request_builder.AddQueryParameter("recursive", "true");
-    }
-    return request_builder.BuildRequest().MakeRequest(std::string{});
+    builder.AddHeader("metadata-flavor: Google");
+    if (recursive) builder.AddQueryParameter("recursive", "true");
+    return std::move(builder).BuildRequest().MakeRequest(std::string{});
   }
 
   /**

--- a/google/cloud/storage/tests/curl_request_integration_test.cc
+++ b/google/cloud/storage/tests/curl_request_integration_test.cc
@@ -84,7 +84,7 @@ TEST(CurlRequestTest, SimpleGET) {
     builder.AddQueryParameter("bar", "bar1==bar2=");
     builder.AddHeader("Accept: application/json");
     builder.AddHeader("charsets: utf-8");
-    return builder.BuildRequest();
+    return std::move(builder).BuildRequest();
   };
 
   auto response = RetryMakeRequest(factory);
@@ -105,7 +105,7 @@ TEST(CurlRequestTest, AddParametersToComplexUrl) {
     builder.AddQueryParameter("baz", "baz-value");
     builder.AddHeader("Accept: application/json");
     builder.AddHeader("charsets: utf-8");
-    return builder.BuildRequest();
+    return std::move(builder).BuildRequest();
   };
   auto response = RetryMakeRequest(factory);
   ASSERT_STATUS_OK(response);
@@ -123,7 +123,7 @@ TEST(CurlRequestTest, FailedGET) {
   CurlRequestBuilder builder("https://localhost:1/",
                              storage::internal::GetDefaultCurlHandleFactory());
 
-  auto response = builder.BuildRequest().MakeRequest({});
+  auto response = std::move(builder).BuildRequest().MakeRequest({});
   EXPECT_THAT(response, Not(IsOk()));
 }
 
@@ -155,7 +155,7 @@ TEST(CurlRequestTest, SimplePOST) {
     builder.AddHeader("Accept: application/json");
     builder.AddHeader("Content-Type: application/x-www-form-urlencoded");
     builder.AddHeader("charsets: utf-8");
-    return builder.BuildRequest();
+    return std::move(builder).BuildRequest();
   };
 
   auto response = RetryMakeRequest(factory, data);
@@ -190,7 +190,7 @@ TEST(CurlRequestTest, MultiBufferPUT) {
     builder.AddHeader("Accept: application/json");
     builder.AddHeader("Content-Type: application/octet-stream");
     builder.AddHeader("charsets: utf-8");
-    return builder.BuildRequest();
+    return std::move(builder).BuildRequest();
   };
 
   auto response = RetryMakeUploadRequest(factory, data);
@@ -210,7 +210,7 @@ TEST(CurlRequestTest, MultiBufferEmptyPUT) {
     builder.AddHeader("Accept: application/json");
     builder.AddHeader("Content-Type: application/octet-stream");
     builder.AddHeader("charsets: utf-8");
-    return builder.BuildRequest();
+    return std::move(builder).BuildRequest();
   };
 
   auto response = RetryMakeRequest(factory);
@@ -251,7 +251,7 @@ TEST(CurlRequestTest, MultiBufferLargePUT) {
     builder.AddHeader("Accept: application/json");
     builder.AddHeader("Content-Type: application/octet-stream");
     builder.AddHeader("charsets: utf-8");
-    return builder.BuildRequest();
+    return std::move(builder).BuildRequest();
   };
 
   auto response = RetryMakeUploadRequest(factory, data);
@@ -270,7 +270,7 @@ TEST(CurlRequestTest, Handle404) {
         storage::internal::GetDefaultCurlHandleFactory());
     builder.AddHeader("Accept: application/json");
     builder.AddHeader("charsets: utf-8");
-    return builder.BuildRequest();
+    return std::move(builder).BuildRequest();
   };
 
   auto response = RetryMakeRequest(factory);
@@ -286,7 +286,7 @@ TEST(CurlRequestTest, HandleTeapot) {
         storage::internal::GetDefaultCurlHandleFactory());
     builder.AddHeader("Accept: application/json");
     builder.AddHeader("charsets: utf-8");
-    return builder.BuildRequest();
+    return std::move(builder).BuildRequest();
   };
 
   auto response = RetryMakeRequest(factory);
@@ -310,7 +310,7 @@ TEST(CurlRequestTest, CheckResponseHeaders) {
         storage::internal::GetDefaultCurlHandleFactory());
     builder.AddHeader("Accept: application/json");
     builder.AddHeader("charsets: utf-8");
-    return builder.BuildRequest();
+    return std::move(builder).BuildRequest();
   };
 
   auto response = RetryMakeRequest(factory);
@@ -338,7 +338,7 @@ TEST(CurlRequestTest, UserAgent) {
     builder.ApplyClientOptions(options);
     builder.AddHeader("Accept: application/json");
     builder.AddHeader("charsets: utf-8");
-    return builder.BuildRequest();
+    return std::move(builder).BuildRequest();
   };
 
   auto response = RetryMakeRequest(factory);
@@ -378,7 +378,7 @@ TEST(CurlRequestTest, HttpVersion) {
       builder.ApplyClientOptions(options);
       builder.AddHeader("Accept: application/json");
       builder.AddHeader("charsets: utf-8");
-      return builder.BuildRequest();
+      return std::move(builder).BuildRequest();
     };
 
     auto response = RetryMakeRequest(factory);
@@ -397,7 +397,7 @@ TEST(CurlRequestTest, WellKnownQueryParametersProjection) {
     builder.AddHeader("Accept: application/json");
     builder.AddHeader("charsets: utf-8");
     builder.AddOption(storage::Projection("full"));
-    return builder.BuildRequest();
+    return std::move(builder).BuildRequest();
   };
 
   auto response = RetryMakeRequest(factory);
@@ -423,7 +423,7 @@ TEST(CurlRequestTest, WellKnownQueryParametersUserProject) {
     builder.AddHeader("Accept: application/json");
     builder.AddHeader("charsets: utf-8");
     builder.AddOption(storage::UserProject("a-project"));
-    return builder.BuildRequest();
+    return std::move(builder).BuildRequest();
   };
 
   auto response = RetryMakeRequest(factory);
@@ -449,7 +449,7 @@ TEST(CurlRequestTest, WellKnownQueryParametersIfGenerationMatch) {
     builder.AddHeader("Accept: application/json");
     builder.AddHeader("charsets: utf-8");
     builder.AddOption(storage::IfGenerationMatch(42));
-    return builder.BuildRequest();
+    return std::move(builder).BuildRequest();
   };
 
   auto response = RetryMakeRequest(factory);
@@ -475,7 +475,7 @@ TEST(CurlRequestTest, WellKnownQueryParametersIfGenerationNotMatch) {
     builder.AddHeader("Accept: application/json");
     builder.AddHeader("charsets: utf-8");
     builder.AddOption(storage::IfGenerationNotMatch(42));
-    return builder.BuildRequest();
+    return std::move(builder).BuildRequest();
   };
 
   auto response = RetryMakeRequest(factory);
@@ -501,7 +501,7 @@ TEST(CurlRequestTest, WellKnownQueryParametersIfMetagenerationMatch) {
     builder.AddHeader("Accept: application/json");
     builder.AddHeader("charsets: utf-8");
     builder.AddOption(storage::IfMetagenerationMatch(42));
-    return builder.BuildRequest();
+    return std::move(builder).BuildRequest();
   };
 
   auto response = RetryMakeRequest(factory);
@@ -527,7 +527,7 @@ TEST(CurlRequestTest, WellKnownQueryParametersIfMetagenerationNotMatch) {
     builder.AddHeader("Accept: application/json");
     builder.AddHeader("charsets: utf-8");
     builder.AddOption(storage::IfMetagenerationNotMatch(42));
-    return builder.BuildRequest();
+    return std::move(builder).BuildRequest();
   };
 
   auto response = RetryMakeRequest(factory);
@@ -555,7 +555,7 @@ TEST(CurlRequestTest, WellKnownQueryParametersMultiple) {
     builder.AddOption(storage::UserProject("user-project-id"));
     builder.AddOption(storage::IfMetagenerationMatch(7));
     builder.AddOption(storage::IfGenerationNotMatch(42));
-    return builder.BuildRequest();
+    return std::move(builder).BuildRequest();
   };
 
   auto response = RetryMakeRequest(factory);
@@ -605,7 +605,7 @@ TEST(CurlRequestTest, Logging) {
       builder.AddHeader("Accept: application/json");
       builder.AddHeader("charsets: utf-8");
       builder.AddHeader("x-test-header: foo");
-      return builder.BuildRequest();
+      return std::move(builder).BuildRequest();
     };
 
     auto response = RetryMakeRequest(factory, "this is some text");

--- a/google/cloud/storage/tests/key_file_integration_test.cc
+++ b/google/cloud/storage/tests/key_file_integration_test.cc
@@ -100,7 +100,7 @@ TEST_P(KeyFileIntegrationTest, ObjectWriteSignAndReadDefaultAccount) {
   auto factory = [&] {
     internal::CurlRequestBuilder builder(
         *signed_url, storage::internal::GetDefaultCurlHandleFactory());
-    return builder.BuildRequest();
+    return std::move(builder).BuildRequest();
   };
 
   auto response = RetryHttpRequest(factory);
@@ -134,7 +134,7 @@ TEST_P(KeyFileIntegrationTest, ObjectWriteSignAndReadExplicitAccount) {
   auto factory = [&] {
     internal::CurlRequestBuilder builder(
         *signed_url, storage::internal::GetDefaultCurlHandleFactory());
-    return builder.BuildRequest();
+    return std::move(builder).BuildRequest();
   };
 
   auto response = RetryHttpRequest(factory);

--- a/google/cloud/storage/tests/signed_url_integration_test.cc
+++ b/google/cloud/storage/tests/signed_url_integration_test.cc
@@ -83,7 +83,7 @@ TEST_F(SignedUrlIntegrationTest, CreateV2SignedUrlGet) {
   auto factory = [&] {
     internal::CurlRequestBuilder builder(
         *signed_url, storage::internal::GetDefaultCurlHandleFactory());
-    return builder.BuildRequest();
+    return std::move(builder).BuildRequest();
   };
 
   auto response = RetryHttpRequest(factory);
@@ -114,7 +114,7 @@ TEST_F(SignedUrlIntegrationTest, CreateV2SignedUrlPut) {
         *signed_url, storage::internal::GetDefaultCurlHandleFactory());
     builder.SetMethod("PUT");
     builder.AddHeader("content-type: application/octet-stream");
-    return builder.BuildRequest();
+    return std::move(builder).BuildRequest();
   };
 
   auto response = RetryHttpRequest(factory, expected);
@@ -153,7 +153,7 @@ TEST_F(SignedUrlIntegrationTest, CreateV4SignedUrlGet) {
   auto factory = [&] {
     internal::CurlRequestBuilder builder(
         *signed_url, storage::internal::GetDefaultCurlHandleFactory());
-    return builder.BuildRequest();
+    return std::move(builder).BuildRequest();
   };
 
   auto response = RetryHttpRequest(factory);
@@ -182,7 +182,7 @@ TEST_F(SignedUrlIntegrationTest, CreateV4SignedUrlPut) {
     internal::CurlRequestBuilder builder(
         *signed_url, storage::internal::GetDefaultCurlHandleFactory());
     builder.SetMethod("PUT");
-    return builder.BuildRequest();
+    return std::move(builder).BuildRequest();
   };
 
   auto response = RetryHttpRequest(factory, expected);


### PR DESCRIPTION
Use `&&` overloads to prevent us (these are internal-only classes) from
re-using a `internal::CurlRequestBuilder` or `internal::CurlRequest`
after the destructive operations.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7376)
<!-- Reviewable:end -->
