### PR TITLE
doc(storage): 'unspecified' value for PAP is deprecated

### DIFF
--- a/ci/cloudbuild/builds/lib/integration.sh
+++ b/ci/cloudbuild/builds/lib/integration.sh
@@ -28,7 +28,8 @@ source module ci/lib/io.sh
 
 # To run the integration tests we need to install the dependencies for the storage emulator
 export PATH="${HOME}/.local/bin:${PATH}"
-python3 -m pip install --quiet --user "git+git://github.com/googleapis/storage-testbench@v0.4.0"
+# python3 -m pip install --quiet --user "git+git://github.com/googleapis/storage-testbench@v0.4.0"
+python3 -m pip install --quiet --user "git+git://github.com/coryan/storage-testbench@6d675db5a92eb2d03f610039a9534fc4f409187e"
 
 # Some of the tests will need a valid roots.pem file.
 rm -f /dev/shm/roots.pem

--- a/ci/cloudbuild/builds/lib/integration.sh
+++ b/ci/cloudbuild/builds/lib/integration.sh
@@ -28,8 +28,7 @@ source module ci/lib/io.sh
 
 # To run the integration tests we need to install the dependencies for the storage emulator
 export PATH="${HOME}/.local/bin:${PATH}"
-# python3 -m pip install --quiet --user "git+git://github.com/googleapis/storage-testbench@v0.4.0"
-python3 -m pip install --quiet --user "git+git://github.com/coryan/storage-testbench@6d675db5a92eb2d03f610039a9534fc4f409187e"
+python3 -m pip install --quiet --user "git+git://github.com/googleapis/storage-testbench@v0.7.0"
 
 # Some of the tests will need a valid roots.pem file.
 rm -f /dev/shm/roots.pem

--- a/google/cloud/storage/bucket_metadata.cc
+++ b/google/cloud/storage/bucket_metadata.cc
@@ -33,9 +33,8 @@ absl::optional<std::string> const& NormalizePap(
     absl::optional<std::string> const& pap) {
   static auto const* normalized =
       new absl::optional<std::string>(PublicAccessPreventionInherited());
-  if (!pap.has_value()) return pap;
-  if (*pap == PublicAccessPreventionUnspecified()) return *normalized;
-  return pap;
+  if (!pap.has_value() || *pap != "unspecified") return pap;
+  return *normalized;
 }
 }  // namespace internal
 

--- a/google/cloud/storage/bucket_metadata.h
+++ b/google/cloud/storage/bucket_metadata.h
@@ -218,6 +218,7 @@ struct BucketIamConfiguration {
 /// @name Public Access Prevention helper functions
 inline std::string PublicAccessPreventionEnforced() { return "enforced"; }
 inline std::string PublicAccessPreventionInherited() { return "inherited"; }
+GOOGLE_CLOUD_CPP_DEPRECATED("Use PublicAccessPreventionInherited()")
 inline std::string PublicAccessPreventionUnspecified() { return "unspecified"; }
 //@}
 

--- a/google/cloud/storage/bucket_metadata_test.cc
+++ b/google/cloud/storage/bucket_metadata_test.cc
@@ -170,7 +170,7 @@ TEST(BucketMetadataTest, NormalizePap) {
   EXPECT_EQ(internal::NormalizePap(absl::nullopt), absl::nullopt);
   EXPECT_EQ(internal::NormalizePap(PublicAccessPreventionInherited()),
             PublicAccessPreventionInherited());
-  EXPECT_EQ(internal::NormalizePap(PublicAccessPreventionUnspecified()),
+  EXPECT_EQ(internal::NormalizePap("unspecified"),
             PublicAccessPreventionInherited());
   EXPECT_EQ(internal::NormalizePap(PublicAccessPreventionEnforced()),
             PublicAccessPreventionEnforced());

--- a/google/cloud/storage/examples/storage_bucket_samples.cc
+++ b/google/cloud/storage/examples/storage_bucket_samples.cc
@@ -377,28 +377,26 @@ void SetPublicAccessPreventionEnforced(google::cloud::storage::Client client,
   (std::move(client), argv.at(0));
 }
 
-void SetPublicAccessPreventionUnspecified(
-    google::cloud::storage::Client client,
-    std::vector<std::string> const& argv) {
+void SetPublicAccessPreventionInherited(google::cloud::storage::Client client,
+                                        std::vector<std::string> const& argv) {
   // [START storage_set_public_access_prevention_unspecified]
+  // [START storage_set_public_access_prevention_inherited]
   namespace gcs = ::google::cloud::storage;
   using ::google::cloud::StatusOr;
   [](gcs::Client client, std::string const& bucket_name) {
     gcs::BucketIamConfiguration configuration;
     configuration.public_access_prevention =
-        gcs::PublicAccessPreventionUnspecified();
-    StatusOr<gcs::BucketMetadata> updated_metadata = client.PatchBucket(
+        gcs::PublicAccessPreventionInherited();
+    auto updated = client.PatchBucket(
         bucket_name, gcs::BucketMetadataPatchBuilder().SetIamConfiguration(
                          std::move(configuration)));
+    if (!updated) throw std::runtime_error(updated.status().message());
 
-    if (!updated_metadata) {
-      throw std::runtime_error(updated_metadata.status().message());
-    }
-
-    std::cout << "Public Access Prevention is set to 'unspecified' for "
-              << updated_metadata->name() << "\n";
+    std::cout << "Public Access Prevention is set to 'inherited' for "
+              << updated->name() << "\n";
   }
   // [END storage_set_public_access_prevention_unspecified]
+  // [END storage_set_public_access_prevention_inherited]
   (std::move(client), argv.at(0));
 }
 
@@ -575,9 +573,9 @@ void RunAll(std::vector<std::string> const& argv) {
             << std::endl;
   SetPublicAccessPreventionEnforced(client, {bucket_name});
 
-  std::cout << "\nRunning SetPublicAccessPreventionUnspecified() example"
+  std::cout << "\nRunning SetPublicAccessPreventionInherited() example"
             << std::endl;
-  SetPublicAccessPreventionUnspecified(client, {bucket_name});
+  SetPublicAccessPreventionInherited(client, {bucket_name});
 
   std::cout << "\nRunning GetPublicAccessPrevention() example" << std::endl;
   GetPublicAccessPrevention(client, {bucket_name});
@@ -654,8 +652,8 @@ int main(int argc, char* argv[]) {
                  DisableUniformBucketLevelAccess),
       make_entry("get-uniform-bucket-level-access", {},
                  GetUniformBucketLevelAccess),
-      make_entry("set-public-access-prevention-unspecified", {},
-                 SetPublicAccessPreventionUnspecified),
+      make_entry("set-public-access-prevention-inherited", {},
+                 SetPublicAccessPreventionInherited),
       make_entry("set-public-access-prevention-enforced", {},
                  SetPublicAccessPreventionEnforced),
       make_entry("get-public-access-prevention", {}, GetPublicAccessPrevention),


### PR DESCRIPTION
Only tests can use the value. Change the examples to use the new value.
Leave the existing region tags in place so the website continues to find
said region tags, but point customers to use the right functions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7377)
<!-- Reviewable:end -->
