### PR TITLE
fix: substitute build metadata (git commit) in bazel builds

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# NOTE: This file is not loaded if google-cloud-cpp is built as part of a
+# larger project.
+
 # To workaround a bug in Bazel [1], gRPC requires this flag on macOS builds,
 # and there is (AFAIK) no way to "inherit" their definitions.
 #   [1]: https://github.com/bazelbuild/bazel/issues/4341

--- a/.bazelrc
+++ b/.bazelrc
@@ -21,6 +21,14 @@ build --copt=-DGRPC_BAZEL_BUILD
 # inside a docker image.
 build --experimental_convenience_symlinks=ignore
 
+# Use host-OS-specific config lines from bazelrc files.
+build --enable_platform_specific_config=true
+
+# Specify a binary that Bazel runs before each build. The program can report
+# information about the status of the workspace, such as the current source
+# control revision.
+build:linux --workspace_status_command=bazel/workspace_status_command.sh
+
 # Clang Sanitizers, use with (for example):
 #
 # --client_env=CXX=clang++ --client_env=CC=clang --config asan

--- a/bazel/workspace_status_command.sh
+++ b/bazel/workspace_status_command.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+#
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This program should print zero or more key/value pairs to standard
+# output, one entry on each line, and then exit with zero (otherwise
+# the build fails). The key names can be anything but they may only use
+# upper case letters and underscores. The first space after the key
+# name separates it from the value. The value is the rest of the line
+# (including additional whitespaces). Neither the key nor the value may
+# span multiple lines. Keys must not be duplicated.
+
+echo "STABLE_GIT_COMMIT $(git rev-parse --short HEAD || echo "unknown")"

--- a/google/cloud/BUILD
+++ b/google/cloud/BUILD
@@ -21,11 +21,12 @@ genrule(
     srcs = ["internal/build_info.cc.in"],
     outs = ["internal/build_info.cc"],
     cmd = """
-V=$$(git rev-parse --short HEAD 2>/dev/null || echo "unknown");
+V=$$(sed -n -e 's/^STABLE_GIT_COMMIT  *//p' bazel-out/stable-status.txt)
 sed -e "s;@CMAKE_CXX_FLAGS@;$(CC_FLAGS);" \
     -e "s;\\$${CMAKE_CXX_FLAGS_.*};$(COMPILATION_MODE);" \
-    -e "s;@GOOGLE_CLOUD_CPP_GIT_HEAD@;$${V};" < $< > $@
+    -e "s;@GOOGLE_CLOUD_CPP_BUILD_METADATA@;$${V:-unknown};" < $< > $@
   """,
+    stamp = True,
     toolchains = [
         "@bazel_tools//tools/cpp:current_cc_toolchain",
         "@bazel_tools//tools/cpp:cc_flags",

--- a/google/cloud/spanner/spanner_version_test.cc
+++ b/google/cloud/spanner/spanner_version_test.cc
@@ -43,6 +43,7 @@ TEST(SpannerVersionTest, Format) {
 /// @test Verify the version does not contain build info for release builds.
 TEST(SpannerVersionTest, NoBuildInfoInRelease) {
   if (!google::cloud::internal::build_metadata().empty()) {
+    EXPECT_THAT(google::cloud::internal::build_metadata(), Not(HasSubstr("@")));
     EXPECT_THAT(VersionString(),
                 HasSubstr("+" + google::cloud::internal::build_metadata()));
     return;


### PR DESCRIPTION
- Use bazel's `workspace_status_command` to report the git commit.
- Substitute it into `google::cloud::internal::build_metadata()`.
- Test that `build_metadata()` does not contain a "@" delimiter.

Fixes #4035.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7378)
<!-- Reviewable:end -->
