### PR TITLE
test(storage): switch integration tests to httpbin.org

### DIFF
--- a/google/cloud/storage/tests/curl_download_request_integration_test.cc
+++ b/google/cloud/storage/tests/curl_download_request_integration_test.cc
@@ -37,7 +37,7 @@ using ::testing::StartsWith;
 
 std::string HttpBinEndpoint() {
   return google::cloud::internal::GetEnv("HTTPBIN_ENDPOINT")
-      .value_or("https://nghttp2.org/httpbin");
+      .value_or("https://httpbin.org");
 }
 
 Status Make3Attempts(std::function<Status()> const& attempt) {

--- a/google/cloud/storage/tests/curl_request_integration_test.cc
+++ b/google/cloud/storage/tests/curl_request_integration_test.cc
@@ -42,7 +42,7 @@ using ::testing::StartsWith;
 
 std::string HttpBinEndpoint() {
   return google::cloud::internal::GetEnv("HTTPBIN_ENDPOINT")
-      .value_or("https://nghttp2.org/httpbin");
+      .value_or("https://httpbin.org");
 }
 
 // The integration tests sometimes flake (e.g. DNS failures) if we do not have a


### PR DESCRIPTION
My current hypothesis is that the https://nghttp2.org/ certificate
expired, so change version of httpbin.

Fixes #7381

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7382)
<!-- Reviewable:end -->
