### PR TITLE
feat(generator): add "generator" to API client header "gccl" semver

### DIFF
--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_metadata_decorator.cc
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_metadata_decorator.cc
@@ -30,7 +30,7 @@ inline namespace GOOGLE_CLOUD_CPP_GENERATED_NS {
 GoldenKitchenSinkMetadata::GoldenKitchenSinkMetadata(
     std::shared_ptr<GoldenKitchenSinkStub> child)
     : child_(std::move(child)),
-      api_client_header_(google::cloud::internal::ApiClientHeader()) {}
+      api_client_header_(google::cloud::internal::ApiClientHeader("generator")) {}
 
 StatusOr<google::test::admin::database::v1::GenerateAccessTokenResponse>
 GoldenKitchenSinkMetadata::GenerateAccessToken(

--- a/generator/integration_tests/golden/internal/golden_thing_admin_metadata_decorator.cc
+++ b/generator/integration_tests/golden/internal/golden_thing_admin_metadata_decorator.cc
@@ -30,7 +30,7 @@ inline namespace GOOGLE_CLOUD_CPP_GENERATED_NS {
 GoldenThingAdminMetadata::GoldenThingAdminMetadata(
     std::shared_ptr<GoldenThingAdminStub> child)
     : child_(std::move(child)),
-      api_client_header_(google::cloud::internal::ApiClientHeader()) {}
+      api_client_header_(google::cloud::internal::ApiClientHeader("generator")) {}
 
 StatusOr<google::test::admin::database::v1::ListDatabasesResponse>
 GoldenThingAdminMetadata::ListDatabases(

--- a/generator/integration_tests/golden/tests/golden_kitchen_sink_metadata_decorator_test.cc
+++ b/generator/integration_tests/golden/tests/golden_kitchen_sink_metadata_decorator_test.cc
@@ -39,7 +39,8 @@ using ::testing::Return;
 class MetadataDecoratorTest : public ::testing::Test {
  protected:
   void SetUp() override {
-    expected_api_client_header_ = google::cloud::internal::ApiClientHeader();
+    expected_api_client_header_ =
+        google::cloud::internal::ApiClientHeader("generator");
     mock_ = std::make_shared<MockGoldenKitchenSinkStub>();
   }
 

--- a/generator/integration_tests/golden/tests/golden_thing_admin_metadata_decorator_test.cc
+++ b/generator/integration_tests/golden/tests/golden_thing_admin_metadata_decorator_test.cc
@@ -32,7 +32,8 @@ using ::google::cloud::testing_util::IsContextMDValid;
 class MetadataDecoratorTest : public ::testing::Test {
  protected:
   void SetUp() override {
-    expected_api_client_header_ = google::cloud::internal::ApiClientHeader();
+    expected_api_client_header_ =
+        google::cloud::internal::ApiClientHeader("generator");
     mock_ = std::make_shared<MockGoldenThingAdminStub>();
   }
 

--- a/generator/internal/metadata_decorator_generator.cc
+++ b/generator/internal/metadata_decorator_generator.cc
@@ -155,7 +155,7 @@ Status MetadataDecoratorGenerator::GenerateCc() {
     "$metadata_class_name$::$metadata_class_name$(\n"
     "    std::shared_ptr<$stub_class_name$> child)\n"
     "    : child_(std::move(child)),\n"
-    "      api_client_header_(google::cloud::internal::ApiClientHeader()) {}\n"
+    "      api_client_header_(google::cloud::internal::ApiClientHeader(\"generator\")) {}\n"
     "\n");
   // clang-format on
 

--- a/google/cloud/bigquery/internal/bigquery_read_metadata_decorator.cc
+++ b/google/cloud/bigquery/internal/bigquery_read_metadata_decorator.cc
@@ -30,7 +30,8 @@ inline namespace GOOGLE_CLOUD_CPP_GENERATED_NS {
 BigQueryReadMetadata::BigQueryReadMetadata(
     std::shared_ptr<BigQueryReadStub> child)
     : child_(std::move(child)),
-      api_client_header_(google::cloud::internal::ApiClientHeader()) {}
+      api_client_header_(
+          google::cloud::internal::ApiClientHeader("generator")) {}
 
 StatusOr<google::cloud::bigquery::storage::v1::ReadSession>
 BigQueryReadMetadata::CreateReadSession(

--- a/google/cloud/iam/internal/iam_credentials_metadata_decorator.cc
+++ b/google/cloud/iam/internal/iam_credentials_metadata_decorator.cc
@@ -30,7 +30,8 @@ inline namespace GOOGLE_CLOUD_CPP_GENERATED_NS {
 IAMCredentialsMetadata::IAMCredentialsMetadata(
     std::shared_ptr<IAMCredentialsStub> child)
     : child_(std::move(child)),
-      api_client_header_(google::cloud::internal::ApiClientHeader()) {}
+      api_client_header_(
+          google::cloud::internal::ApiClientHeader("generator")) {}
 
 StatusOr<google::iam::credentials::v1::GenerateAccessTokenResponse>
 IAMCredentialsMetadata::GenerateAccessToken(

--- a/google/cloud/iam/internal/iam_metadata_decorator.cc
+++ b/google/cloud/iam/internal/iam_metadata_decorator.cc
@@ -29,7 +29,8 @@ inline namespace GOOGLE_CLOUD_CPP_GENERATED_NS {
 
 IAMMetadata::IAMMetadata(std::shared_ptr<IAMStub> child)
     : child_(std::move(child)),
-      api_client_header_(google::cloud::internal::ApiClientHeader()) {}
+      api_client_header_(
+          google::cloud::internal::ApiClientHeader("generator")) {}
 
 StatusOr<google::iam::admin::v1::ListServiceAccountsResponse>
 IAMMetadata::ListServiceAccounts(

--- a/google/cloud/internal/api_client_header.cc
+++ b/google/cloud/internal/api_client_header.cc
@@ -20,12 +20,27 @@ namespace cloud {
 inline namespace GOOGLE_CLOUD_CPP_NS {
 namespace internal {
 
-std::string ApiClientHeader() {
+std::string ApiClientVersion(std::string const& build_identifier) {
+  auto client_library_version = version_string();
+  if (!client_library_version.empty() && client_library_version[0] == 'v') {
+    // Remove the leading 'v'. Without it, version_string() is a valid
+    // SemVer string: "<major>.<minor>.<patch>[-<prerelease>][+<build>]".
+    client_library_version.erase(0, 1);
+  }
+  if (!build_identifier.empty()) {
+    auto pos = client_library_version.find('+');
+    client_library_version.append(1, pos == std::string::npos ? '+' : '.');
+    client_library_version.append(build_identifier);
+  }
+  return client_library_version;
+}
+
+std::string ApiClientHeader(std::string const& build_identifier) {
   return "gl-cpp/" + google::cloud::internal::CompilerId() + "-" +
          google::cloud::internal::CompilerVersion() + "-" +
          google::cloud::internal::CompilerFeatures() + "-" +
          google::cloud::internal::LanguageVersion() + " gccl/" +
-         version_string();
+         ApiClientVersion(build_identifier);
 }
 
 }  // namespace internal

--- a/google/cloud/internal/api_client_header.h
+++ b/google/cloud/internal/api_client_header.h
@@ -23,8 +23,11 @@ namespace cloud {
 inline namespace GOOGLE_CLOUD_CPP_NS {
 namespace internal {
 
+/// Return the semantic versioning string (https://semver.org/).
+std::string ApiClientVersion(std::string const& build_identifier);
+
 /// Return the value for the x-goog-api-client header (aka metadata).
-std::string ApiClientHeader();
+std::string ApiClientHeader(std::string const& build_identifier = "");
 
 }  // namespace internal
 }  // namespace GOOGLE_CLOUD_CPP_NS

--- a/google/cloud/internal/api_client_header_test.cc
+++ b/google/cloud/internal/api_client_header_test.cc
@@ -25,14 +25,16 @@ namespace {
 using ::testing::HasSubstr;
 
 TEST(ApiClientHeaderTest, Basic) {
-  auto actual = ApiClientHeader();
-
-  EXPECT_THAT(actual, HasSubstr("gccl/" + version_string()));
-  EXPECT_THAT(actual,
-              HasSubstr("gl-cpp/" + google::cloud::internal::CompilerId() +
-                        "-" + google::cloud::internal::CompilerVersion() + "-" +
-                        google::cloud::internal::CompilerFeatures() + "-" +
-                        google::cloud::internal::LanguageVersion()));
+  for (auto const& build_identifier : {"", "build-identifier"}) {
+    auto actual = ApiClientHeader(build_identifier);
+    EXPECT_THAT(actual,
+                HasSubstr("gl-cpp/" + google::cloud::internal::CompilerId() +
+                          "-" + google::cloud::internal::CompilerVersion() +
+                          "-" + google::cloud::internal::CompilerFeatures() +
+                          "-" + google::cloud::internal::LanguageVersion()));
+    EXPECT_THAT(actual,
+                HasSubstr("gccl/" + ApiClientVersion(build_identifier)));
+  }
 }
 
 }  // namespace

--- a/google/cloud/logging/internal/logging_service_v2_metadata_decorator.cc
+++ b/google/cloud/logging/internal/logging_service_v2_metadata_decorator.cc
@@ -30,7 +30,8 @@ inline namespace GOOGLE_CLOUD_CPP_GENERATED_NS {
 LoggingServiceV2Metadata::LoggingServiceV2Metadata(
     std::shared_ptr<LoggingServiceV2Stub> child)
     : child_(std::move(child)),
-      api_client_header_(google::cloud::internal::ApiClientHeader()) {}
+      api_client_header_(
+          google::cloud::internal::ApiClientHeader("generator")) {}
 
 Status LoggingServiceV2Metadata::DeleteLog(
     grpc::ClientContext& context,

--- a/google/cloud/spanner/admin/internal/database_admin_metadata_decorator.cc
+++ b/google/cloud/spanner/admin/internal/database_admin_metadata_decorator.cc
@@ -30,7 +30,8 @@ inline namespace GOOGLE_CLOUD_CPP_GENERATED_NS {
 DatabaseAdminMetadata::DatabaseAdminMetadata(
     std::shared_ptr<DatabaseAdminStub> child)
     : child_(std::move(child)),
-      api_client_header_(google::cloud::internal::ApiClientHeader()) {}
+      api_client_header_(
+          google::cloud::internal::ApiClientHeader("generator")) {}
 
 StatusOr<google::spanner::admin::database::v1::ListDatabasesResponse>
 DatabaseAdminMetadata::ListDatabases(

--- a/google/cloud/spanner/admin/internal/instance_admin_metadata_decorator.cc
+++ b/google/cloud/spanner/admin/internal/instance_admin_metadata_decorator.cc
@@ -30,7 +30,8 @@ inline namespace GOOGLE_CLOUD_CPP_GENERATED_NS {
 InstanceAdminMetadata::InstanceAdminMetadata(
     std::shared_ptr<InstanceAdminStub> child)
     : child_(std::move(child)),
-      api_client_header_(google::cloud::internal::ApiClientHeader()) {}
+      api_client_header_(
+          google::cloud::internal::ApiClientHeader("generator")) {}
 
 StatusOr<google::spanner::admin::instance::v1::ListInstanceConfigsResponse>
 InstanceAdminMetadata::ListInstanceConfigs(


### PR DESCRIPTION
1. Strip the leading "v" from the value of the "gccl" component in the
   `X-Goog-Api-Client` header so that what remains is a valid semantic
   version string (see https://semver.org/).

2. Add a "generator" build identifier to the "gccl" semver for requests
   sent from generated clients.

The upshot is that the library-version component of the client header
will be `gccl/<major>.<minor>.<patch>+<git-hash>.generator`, allowing
us to identify requests from generated clients.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7383)
<!-- Reviewable:end -->
