### PR TITLE
feat(storage): add bucket attributes for RPO

### DIFF
--- a/ci/cloudbuild/builds/lib/integration.sh
+++ b/ci/cloudbuild/builds/lib/integration.sh
@@ -28,7 +28,7 @@ source module ci/lib/io.sh
 
 # To run the integration tests we need to install the dependencies for the storage emulator
 export PATH="${HOME}/.local/bin:${PATH}"
-python3 -m pip install --quiet --user "git+git://github.com/googleapis/storage-testbench@v0.4.0"
+python3 -m pip install --quiet --user "git+git://github.com/googleapis/storage-testbench@v0.7.0"
 
 # Some of the tests will need a valid roots.pem file.
 rm -f /dev/shm/roots.pem

--- a/google/cloud/storage/bucket_metadata.cc
+++ b/google/cloud/storage/bucket_metadata.cc
@@ -101,7 +101,8 @@ bool operator==(BucketMetadata const& lhs, BucketMetadata const& rhs) {
          lhs.location_type_ == rhs.location_type_ &&
          lhs.logging_ == rhs.logging_ && lhs.labels_ == rhs.labels_ &&
          lhs.retention_policy_ == rhs.retention_policy_ &&
-         lhs.versioning_ == rhs.versioning_ && lhs.website_ == rhs.website_;
+         lhs.rpo_ == rhs.rpo_ && lhs.versioning_ == rhs.versioning_ &&
+         lhs.website_ == rhs.website_;
 }
 
 std::ostream& operator<<(std::ostream& os, BucketMetadata const& rhs) {
@@ -183,6 +184,8 @@ std::ostream& operator<<(std::ostream& os, BucketMetadata const& rhs) {
        << ", retention_policy.is_locked=" << std::boolalpha
        << rhs.retention_policy().is_locked;
   }
+
+  os << ", rpo=" << rhs.rpo();
 
   if (rhs.versioning().has_value()) {
     auto previous_flags = os.flags();
@@ -460,6 +463,18 @@ BucketMetadataPatchBuilder& BucketMetadataPatchBuilder::SetRetentionPolicy(
 
 BucketMetadataPatchBuilder& BucketMetadataPatchBuilder::ResetRetentionPolicy() {
   impl_.RemoveField("retentionPolicy");
+  return *this;
+}
+
+BucketMetadataPatchBuilder& BucketMetadataPatchBuilder::SetRpo(
+    std::string const& v) {
+  if (v.empty()) return ResetRpo();
+  impl_.SetStringField("rpo", v);
+  return *this;
+}
+
+BucketMetadataPatchBuilder& BucketMetadataPatchBuilder::ResetRpo() {
+  impl_.RemoveField("rpo");
   return *this;
 }
 

--- a/google/cloud/storage/bucket_metadata.h
+++ b/google/cloud/storage/bucket_metadata.h
@@ -436,6 +436,12 @@ inline bool operator>=(BucketRetentionPolicy const& lhs,
 
 std::ostream& operator<<(std::ostream& os, BucketRetentionPolicy const& rhs);
 
+/// A helper function to avoid typos in the RPO configuration
+inline std::string RpoDefault() { return "DEFAULT"; }
+
+/// A helper function to avoid typos in the RPO configuration
+inline std::string RpoAsyncTurbo() { return "ASYNC_TURBO"; }
+
 /**
  * The versioning configuration for a Bucket.
  *
@@ -818,6 +824,17 @@ class BucketMetadata : private internal::CommonMetadata<BucketMetadata> {
   }
   //@}
 
+  //@{
+  /**
+   * @name Accessors and modifiers for the Recovery Point Objective.
+   */
+  std::string const& rpo() const { return rpo_; }
+  BucketMetadata& set_rpo(std::string v) {
+    rpo_ = std::move(v);
+    return *this;
+  }
+  //@}
+
   using CommonMetadata::storage_class;
   BucketMetadata& set_storage_class(std::string v) {
     CommonMetadata::set_storage_class(std::move(v));
@@ -893,6 +910,7 @@ class BucketMetadata : private internal::CommonMetadata<BucketMetadata> {
   absl::optional<BucketLogging> logging_;
   std::int64_t project_number_ = 0;
   absl::optional<BucketRetentionPolicy> retention_policy_;
+  std::string rpo_;
   absl::optional<BucketVersioning> versioning_;
   absl::optional<BucketWebsite> website_;
 };
@@ -976,6 +994,9 @@ class BucketMetadataPatchBuilder {
         retention_period, std::chrono::system_clock::time_point{}, false});
   }
   BucketMetadataPatchBuilder& ResetRetentionPolicy();
+
+  BucketMetadataPatchBuilder& SetRpo(std::string const& v);
+  BucketMetadataPatchBuilder& ResetRpo();
 
   BucketMetadataPatchBuilder& SetStorageClass(std::string const& v);
   BucketMetadataPatchBuilder& ResetStorageClass();

--- a/google/cloud/storage/examples/storage_bucket_samples.cc
+++ b/google/cloud/storage/examples/storage_bucket_samples.cc
@@ -430,6 +430,75 @@ void GetPublicAccessPrevention(google::cloud::storage::Client client,
   (std::move(client), argv.at(0));
 }
 
+void CreateBucketAsyncTurbo(google::cloud::storage::Client client,
+                            std::vector<std::string> const& argv) {
+  // [START storage_create_bucket_turbo_replication]
+  namespace gcs = ::google::cloud::storage;
+  using ::google::cloud::StatusOr;
+  [](gcs::Client client, std::string const& bucket_name) {
+    auto bucket =
+        client.CreateBucket(bucket_name, gcs::BucketMetadata()
+                                             .set_rpo(gcs::RpoAsyncTurbo())
+                                             .set_location("NAM4"));
+    if (!bucket) throw std::runtime_error(bucket.status().message());
+
+    std::cout << "Created bucket " << bucket->name() << " with RPO set to "
+              << bucket->rpo() << " in " << bucket->location() << ".\n";
+  }
+  // // [END storage_create_bucket_turbo_replication]
+  (std::move(client), argv.at(0));
+}
+
+void SetRpoAsyncTurbo(google::cloud::storage::Client client,
+                      std::vector<std::string> const& argv) {
+  // [START storage_set_turbo_replication_async_turbo]
+  namespace gcs = ::google::cloud::storage;
+  using ::google::cloud::StatusOr;
+  [](gcs::Client client, std::string const& bucket_name) {
+    auto updated = client.PatchBucket(
+        bucket_name,
+        gcs::BucketMetadataPatchBuilder().SetRpo(gcs::RpoAsyncTurbo()));
+    if (!updated) throw std::runtime_error(updated.status().message());
+
+    std::cout << "RPO is set to 'ASYNC_TURBO' for " << updated->name() << "\n";
+  }
+  // [END storage_set_turbo_replication_async_turbo]
+  (std::move(client), argv.at(0));
+}
+
+void SetRpoDefault(google::cloud::storage::Client client,
+                   std::vector<std::string> const& argv) {
+  // [START storage_set_turbo_replication_default]
+  namespace gcs = ::google::cloud::storage;
+  using ::google::cloud::StatusOr;
+  [](gcs::Client client, std::string const& bucket_name) {
+    auto updated = client.PatchBucket(
+        bucket_name,
+        gcs::BucketMetadataPatchBuilder().SetRpo(gcs::RpoDefault()));
+    if (!updated) throw std::runtime_error(updated.status().message());
+
+    std::cout << "RPO is set to 'default' for " << updated->name() << "\n";
+  }
+  // [END storage_set_turbo_replication_default]
+  (std::move(client), argv.at(0));
+}
+
+void GetRpo(google::cloud::storage::Client client,
+            std::vector<std::string> const& argv) {
+  // [START storage_get_turbo_replication]
+  namespace gcs = ::google::cloud::storage;
+  using ::google::cloud::StatusOr;
+  [](gcs::Client client, std::string const& bucket_name) {
+    auto metadata = client.GetBucketMetadata(bucket_name);
+    if (!metadata) throw std::runtime_error(metadata.status().message());
+
+    std::cout << "RPO is " << metadata->rpo() << " for bucket "
+              << metadata->name() << "\n";
+  }
+  // [END storage_get_turbo_replication]
+  (std::move(client), argv.at(0));
+}
+
 void AddBucketLabel(google::cloud::storage::Client client,
                     std::vector<std::string> const& argv) {
   //! [add bucket label] [START storage_add_bucket_label]
@@ -525,8 +594,10 @@ void RunAll(std::vector<std::string> const& argv) {
   });
   auto const project_id =
       google::cloud::internal::GetEnv("GOOGLE_CLOUD_PROJECT").value();
+
   auto generator = google::cloud::internal::DefaultPRNG(std::random_device{}());
   auto const bucket_name = examples::MakeRandomBucketName(generator);
+  auto const rpo_bucket_name = examples::MakeRandomBucketName(generator);
   auto client = gcs::Client();
 
   // This is the only example that cleans up stale buckets. The examples run in
@@ -582,6 +653,18 @@ void RunAll(std::vector<std::string> const& argv) {
   std::cout << "\nRunning GetPublicAccessPrevention() example" << std::endl;
   GetPublicAccessPrevention(client, {bucket_name});
 
+  std::cout << "\nRunning CreateBucketAsyncTurbo() example" << std::endl;
+  CreateBucketAsyncTurbo(client, {rpo_bucket_name});
+
+  std::cout << "\nRunning GetRpo() example" << std::endl;
+  GetRpo(client, {rpo_bucket_name});
+
+  std::cout << "\nRunning SetRpoDefault() example" << std::endl;
+  SetRpoDefault(client, {rpo_bucket_name});
+
+  std::cout << "\nRunning SetRpoAsyncTurbo() example" << std::endl;
+  SetRpoAsyncTurbo(client, {rpo_bucket_name});
+
   std::cout << "\nRunning AddBucketLabel() example" << std::endl;
   AddBucketLabel(client, {bucket_name, "test-label", "test-label-value"});
 
@@ -615,6 +698,9 @@ void RunAll(std::vector<std::string> const& argv) {
 
   std::cout << "\nRunning DeleteBucket() example [3]" << std::endl;
   DeleteBucket(client, {bucket_name});
+
+  std::cout << "\nRunning DeleteBucket() example [4]" << std::endl;
+  DeleteBucket(client, {rpo_bucket_name});
 }
 
 }  // anonymous namespace
@@ -659,6 +745,10 @@ int main(int argc, char* argv[]) {
       make_entry("set-public-access-prevention-enforced", {},
                  SetPublicAccessPreventionEnforced),
       make_entry("get-public-access-prevention", {}, GetPublicAccessPrevention),
+      make_entry("create-bucket-async-turbo", {}, CreateBucketAsyncTurbo),
+      make_entry("set-rpo-default", {}, SetRpoDefault),
+      make_entry("set-rpo-async-turn", {}, SetRpoAsyncTurbo),
+      make_entry("get-rpo", {}, GetRpo),
       make_entry("add-bucket-label", {"<label-key>", "<label-value>"},
                  AddBucketLabel),
       make_entry("get-bucket-labels", {}, GetBucketLabels),

--- a/google/cloud/storage/internal/bucket_metadata_parser.cc
+++ b/google/cloud/storage/internal/bucket_metadata_parser.cc
@@ -385,6 +385,10 @@ void ToJsonRetentionPolicy(nlohmann::json& json, BucketMetadata const& meta) {
       {"retentionPeriod", meta.retention_policy().retention_period.count()}};
 }
 
+void ToJsonRpo(nlohmann::json& json, BucketMetadata const& meta) {
+  SetIfNotEmpty(json, "rpo", meta.rpo());
+}
+
 void ToJsonStorageClass(nlohmann::json& json, BucketMetadata const& meta) {
   SetIfNotEmpty(json, "storageClass", meta.storage_class());
 }
@@ -461,6 +465,10 @@ StatusOr<BucketMetadata> BucketMetadataParser::FromJson(
         return ParseRetentionPolicy(meta.retention_policy_, json);
       },
       [](BucketMetadata& meta, nlohmann::json const& json) {
+        meta.rpo_ = json.value("rpo", "");
+        return Status{};
+      },
+      [](BucketMetadata& meta, nlohmann::json const& json) {
         return ParseVersioning(meta.versioning_, json);
       },
       [](BucketMetadata& meta, nlohmann::json const& json) {
@@ -498,6 +506,7 @@ std::string BucketMetadataToJsonString(BucketMetadata const& meta) {
   ToJsonLogging(json, meta);
   ToJsonName(json, meta);
   ToJsonRetentionPolicy(json, meta);
+  ToJsonRpo(json, meta);
   ToJsonStorageClass(json, meta);
   ToJsonVersioning(json, meta);
   ToJsonWebsite(json, meta);

--- a/google/cloud/storage/internal/bucket_requests.cc
+++ b/google/cloud/storage/internal/bucket_requests.cc
@@ -157,6 +157,11 @@ void DiffStorageClass(BucketMetadataPatchBuilder& builder,
   }
 }
 
+void DiffRpo(BucketMetadataPatchBuilder& builder, BucketMetadata const& o,
+             BucketMetadata const& u) {
+  if (o.rpo() != u.rpo()) builder.SetRpo(u.rpo());
+}
+
 void DiffVersioning(BucketMetadataPatchBuilder& builder,
                     BucketMetadata const& o, BucketMetadata const& u) {
   if (o.versioning() == u.versioning()) return;
@@ -193,6 +198,7 @@ BucketMetadataPatchBuilder DiffBucketMetadata(BucketMetadata const& original,
   DiffLogging(builder, original, updated);
   DiffName(builder, original, updated);
   DiffRetentionPolicy(builder, original, updated);
+  DiffRpo(builder, original, updated);
   DiffStorageClass(builder, original, updated);
   DiffVersioning(builder, original, updated);
   DiffWebsite(builder, original, updated);
@@ -340,7 +346,8 @@ StatusOr<IamPolicy> ParseIamPolicyFromString(std::string const& payload) {
   if (json.count("bindings") != 0) {
     if (!json["bindings"].is_array()) {
       std::ostringstream os;
-      os << "Invalid IamPolicy payload, expected array for 'bindings' field."
+      os << "Invalid IamPolicy payload, expected array for 'bindings' "
+            "field."
          << "  payload=" << payload;
       return Status(StatusCode::kInvalidArgument, os.str());
     }

--- a/google/cloud/storage/internal/bucket_requests_test.cc
+++ b/google/cloud/storage/internal/bucket_requests_test.cc
@@ -600,6 +600,18 @@ TEST(PatchBucketRequestTest, DiffResetRetentionPolicy) {
   EXPECT_EQ(expected, patch);
 }
 
+TEST(PatchBucketRequestTest, DiffSetRpo) {
+  BucketMetadata original = CreateBucketMetadataForTest();
+  original.set_rpo(RpoDefault());
+  BucketMetadata updated = original;
+  updated.set_rpo(RpoAsyncTurbo());
+  PatchBucketRequest request("test-bucket", original, updated);
+
+  auto patch = nlohmann::json::parse(request.payload());
+  auto expected = nlohmann::json::parse(R"""({"rpo": "ASYNC_TURBO"})""");
+  EXPECT_EQ(expected, patch);
+}
+
 TEST(PatchBucketRequestTest, DiffSetStorageClass) {
   BucketMetadata original = CreateBucketMetadataForTest();
   original.set_storage_class(storage_class::Standard());


### PR DESCRIPTION
Add support for the `rpo` (Recovery-Point Objective) attribute. Add a
new integration test and some examples to verify it works correctly.
Update the version of the storage testbench because it needed changes to
support this RPO feature too.

Fixes #7380 and fixes #7379

I will submit this after the imminent release.

/fyi: @ddelgrosso1

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7384)
<!-- Reviewable:end -->
