### PR TITLE
fix(storage): prevent crashes on double Close()

### DIFF
--- a/google/cloud/storage/internal/object_write_streambuf.cc
+++ b/google/cloud/storage/internal/object_write_streambuf.cc
@@ -75,6 +75,7 @@ bool ObjectWriteStreambuf::ValidateHash(ObjectMetadata const& meta) {
     auto function = std::move(hash_function_);
     hash_values_ = std::move(*function).Finish();
   }
+  if (!hash_validator_) return !hash_validator_result_.is_mismatch;
   auto validator = std::move(hash_validator_);
   validator->ProcessMetadata(meta);
   hash_validator_result_ = std::move(*validator).Finish(hash_values_);

--- a/google/cloud/storage/tests/object_write_stream_integration_test.cc
+++ b/google/cloud/storage/tests/object_write_stream_integration_test.cc
@@ -74,6 +74,30 @@ TEST_F(ObjectWriteStreamIntegrationTest, MoveWorkingStream) {
   EXPECT_EQ(w3.metadata()->size(), 3 * kBlockSize);
 }
 
+TEST_F(ObjectWriteStreamIntegrationTest, DoubleClose) {
+  StatusOr<Client> client = MakeIntegrationTestClient();
+  ASSERT_STATUS_OK(client);
+
+  auto const object_name = MakeRandomObjectName();
+  auto constexpr kBlockSize = 256 * 1024;
+  auto const block = MakeRandomData(kBlockSize);
+  auto w1 =
+      client->WriteObject(bucket_name(), object_name, IfGenerationMatch(0));
+  ASSERT_TRUE(w1.good());
+
+  EXPECT_TRUE(w1.write(block.data(), kBlockSize));
+  EXPECT_TRUE(w1.flush());
+  ASSERT_STATUS_OK(w1.last_status());
+
+  w1.Close();
+  ASSERT_STATUS_OK(w1.metadata());
+  ScheduleForDelete(*w1.metadata());
+  EXPECT_EQ(w1.metadata()->size(), kBlockSize);
+
+  w1.Close();
+  ASSERT_STATUS_OK(w1.metadata());
+}
+
 }  // anonymous namespace
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage


### PR DESCRIPTION
The library was crashing if the application called `.Close()` twice on a
`storage::ObjectWriteStream`. Arguably one should not do that, but I
think a crash is really sad behavior in this case, and it is trivial to
return the status from the previous `.Close()`.

I think @devbww asked me about this in the original review, and I had
convinced myself the pre-conditions prevented the code from running
twice. I was wrong.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7390)
<!-- Reviewable:end -->
