### PR TITLE
fix(bigtable): retry internal errors known to be transient

### DIFF
--- a/google/cloud/bigtable/internal/bulk_mutator.cc
+++ b/google/cloud/bigtable/internal/bulk_mutator.cc
@@ -98,18 +98,17 @@ std::vector<int> BulkMutatorState::OnRead(
     auto const index = static_cast<std::size_t>(entry.index());
     auto& annotation = annotations_[index];
     annotation.has_mutation_result = true;
-    auto const& status = entry.status();
-    auto const code = static_cast<grpc::StatusCode>(status.code());
+    auto const& status = MakeStatusFromRpcError(entry.status());
     // Successful responses are not even recorded, this class only reports
     // the failures.  The data for successful responses is discarded, because
     // this class takes ownership in the constructor.
-    if (grpc::StatusCode::OK == code) {
+    if (status.ok()) {
       res.push_back(annotation.original_index);
       continue;
     }
     auto& original = *mutations_.mutable_entries(static_cast<int>(index));
     // Failed responses are handled according to the current policies.
-    if (SafeGrpcRetry::IsTransientFailure(code) &&
+    if (SafeGrpcRetry::IsTransientFailure(status) &&
         (annotation.idempotency == Idempotency::kIdempotent)) {
       // Retryable requests are saved in the pending mutations, along with the
       // mapping from their index in pending_mutations_ to the original

--- a/google/cloud/bigtable/rpc_retry_policy.h
+++ b/google/cloud/bigtable/rpc_retry_policy.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/bigtable/internal/rpc_policy_parameters.h"
 #include "google/cloud/bigtable/version.h"
+#include "google/cloud/grpc_error_delegate.h"
 #include "google/cloud/internal/retry_policy.h"
 #include "google/cloud/status.h"
 #include <grpcpp/grpcpp.h>
@@ -27,34 +28,31 @@ namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 namespace internal {
+/**
+ * Returns `true` for gRPC error messages, with status code: `kInternal`, that
+ * are known to be retryable across all services.
+ */
+bool IsTransientInternalError(Status const& status);
+
 /// An adapter to use `grpc::Status` with the `google::cloud::*Policies`.
 struct SafeGrpcRetry {
-  static inline bool IsTransientFailure(google::cloud::StatusCode code) {
-    return code == StatusCode::kAborted || code == StatusCode::kUnavailable ||
-           code == StatusCode::kDeadlineExceeded;
-  }
-
   static inline bool IsOk(google::cloud::Status const& status) {
     return status.ok();
   }
   static inline bool IsTransientFailure(google::cloud::Status const& status) {
-    return IsTransientFailure(status.code());
+    auto const code = status.code();
+    return code == StatusCode::kAborted || code == StatusCode::kUnavailable ||
+           code == StatusCode::kDeadlineExceeded ||
+           IsTransientInternalError(status);
   }
   static inline bool IsPermanentFailure(google::cloud::Status const& status) {
     return !IsOk(status) && !IsTransientFailure(status);
   }
 
   // TODO(#2344) - remove ::grpc::Status version.
-  // Sometimes we need to use google::protobuf::rpc::Status, in which case this
-  // is a easier function
-  static inline bool IsTransientFailure(grpc::StatusCode code) {
-    return code == grpc::StatusCode::ABORTED ||
-           code == grpc::StatusCode::UNAVAILABLE ||
-           code == grpc::StatusCode::DEADLINE_EXCEEDED;
-  }
   static inline bool IsOk(grpc::Status const& status) { return status.ok(); }
   static inline bool IsTransientFailure(grpc::Status const& status) {
-    return IsTransientFailure(status.error_code());
+    return IsTransientFailure(MakeStatusFromRpcError(status));
   }
   static inline bool IsPermanentFailure(grpc::Status const& status) {
     return !IsOk(status) && !IsTransientFailure(status);


### PR DESCRIPTION
The Bigtable part of #7394. 

I wanted to do it all at once, but I think it's best to just do the Bigtable piece and deliver value for that library now for known Bigtable error messages. (Instead of debating whether we can drop/change some spanner messages or debating which file the common function should go in).

The code and test for `IsTransientInternalError()` should be easy to refactor into common. (I decided to just have a redundant test specifically for RST_STREAM, for when we pluck out the Basic test)

I will consolidate what I have learned about the issue and share with the team offline when I have time, so we can decide how to address the rest of the issue.