### PR TITLE
cleanup(bigtable): make default clients conform

### DIFF
--- a/google/cloud/bigtable/admin_client.cc
+++ b/google/cloud/bigtable/admin_client.cc
@@ -22,101 +22,92 @@ namespace google {
 namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
-grpc::Status AdminClient::CreateBackup(
-    grpc::ClientContext*,
-    google::bigtable::admin::v2::CreateBackupRequest const&,
-    google::longrunning::Operation*) {
+
+namespace btadmin = ::google::bigtable::admin::v2;
+
+grpc::Status AdminClient::CreateBackup(grpc::ClientContext*,
+                                       btadmin::CreateBackupRequest const&,
+                                       google::longrunning::Operation*) {
   return {grpc::StatusCode::UNIMPLEMENTED, "Not implemented"};
 }
 
-grpc::Status AdminClient::GetBackup(
-    grpc::ClientContext*, google::bigtable::admin::v2::GetBackupRequest const&,
-    google::bigtable::admin::v2::Backup*) {
+grpc::Status AdminClient::GetBackup(grpc::ClientContext*,
+                                    btadmin::GetBackupRequest const&,
+                                    btadmin::Backup*) {
   return {grpc::StatusCode::UNIMPLEMENTED, "Not implemented"};
 }
 
-grpc::Status AdminClient::UpdateBackup(
-    grpc::ClientContext*,
-    google::bigtable::admin::v2::UpdateBackupRequest const&,
-    google::bigtable::admin::v2::Backup*) {
+grpc::Status AdminClient::UpdateBackup(grpc::ClientContext*,
+                                       btadmin::UpdateBackupRequest const&,
+                                       btadmin::Backup*) {
   return {grpc::StatusCode::UNIMPLEMENTED, "Not implemented"};
 }
 
-grpc::Status AdminClient::DeleteBackup(
-    grpc::ClientContext*,
-    google::bigtable::admin::v2::DeleteBackupRequest const&,
-    google::protobuf::Empty*) {
+grpc::Status AdminClient::DeleteBackup(grpc::ClientContext*,
+                                       btadmin::DeleteBackupRequest const&,
+                                       google::protobuf::Empty*) {
   return {grpc::StatusCode::UNIMPLEMENTED, "Not implemented"};
 }
 
-grpc::Status AdminClient::ListBackups(
-    grpc::ClientContext*,
-    google::bigtable::admin::v2::ListBackupsRequest const&,
-    google::bigtable::admin::v2::ListBackupsResponse*) {
+grpc::Status AdminClient::ListBackups(grpc::ClientContext*,
+                                      btadmin::ListBackupsRequest const&,
+                                      btadmin::ListBackupsResponse*) {
   return {grpc::StatusCode::UNIMPLEMENTED, "Not implemented"};
 }
 
-grpc::Status AdminClient::RestoreTable(
-    grpc::ClientContext*,
-    google::bigtable::admin::v2::RestoreTableRequest const&,
-    google::longrunning::Operation*) {
+grpc::Status AdminClient::RestoreTable(grpc::ClientContext*,
+                                       btadmin::RestoreTableRequest const&,
+                                       google::longrunning::Operation*) {
   return {grpc::StatusCode::UNIMPLEMENTED, "Not implemented"};
 }
 
 std::unique_ptr<
     grpc::ClientAsyncResponseReaderInterface<google::longrunning::Operation>>
-AdminClient::AsyncCreateBackup(
-    grpc::ClientContext*,
-    google::bigtable::admin::v2::CreateBackupRequest const&,
-    grpc::CompletionQueue*) {
+AdminClient::AsyncCreateBackup(grpc::ClientContext*,
+                               btadmin::CreateBackupRequest const&,
+                               grpc::CompletionQueue*) {
   return {};
 }
 
-std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<
-    google::bigtable::admin::v2::Backup>>
-AdminClient::AsyncGetBackup(
-    grpc::ClientContext*, google::bigtable::admin::v2::GetBackupRequest const&,
-    grpc::CompletionQueue*) {
+std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<btadmin::Backup>>
+AdminClient::AsyncGetBackup(grpc::ClientContext*,
+                            btadmin::GetBackupRequest const&,
+                            grpc::CompletionQueue*) {
   return {};
 }
 
-std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<
-    google::bigtable::admin::v2::Backup>>
-AdminClient::AsyncUpdateBackup(
-    grpc::ClientContext*,
-    google::bigtable::admin::v2::UpdateBackupRequest const&,
-    grpc::CompletionQueue*) {
+std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<btadmin::Backup>>
+AdminClient::AsyncUpdateBackup(grpc::ClientContext*,
+                               btadmin::UpdateBackupRequest const&,
+                               grpc::CompletionQueue*) {
   return {};
 }
 
 std::unique_ptr<
     grpc::ClientAsyncResponseReaderInterface<google::protobuf::Empty>>
-AdminClient::AsyncDeleteBackup(
-    grpc::ClientContext*,
-    google::bigtable::admin::v2::DeleteBackupRequest const&,
-    grpc::CompletionQueue*) {
+AdminClient::AsyncDeleteBackup(grpc::ClientContext*,
+                               btadmin::DeleteBackupRequest const&,
+                               grpc::CompletionQueue*) {
   return {};
 }
 
-std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<
-    google::bigtable::admin::v2::ListBackupsResponse>>
-AdminClient::AsyncListBackups(
-    grpc::ClientContext*,
-    google::bigtable::admin::v2::ListBackupsRequest const&,
-    grpc::CompletionQueue*) {
+std::unique_ptr<
+    grpc::ClientAsyncResponseReaderInterface<btadmin::ListBackupsResponse>>
+AdminClient::AsyncListBackups(grpc::ClientContext*,
+                              btadmin::ListBackupsRequest const&,
+                              grpc::CompletionQueue*) {
   return {};
 }
 
 std::unique_ptr<
     grpc::ClientAsyncResponseReaderInterface<google::longrunning::Operation>>
-AdminClient::AsyncRestoreTable(
-    grpc::ClientContext*,
-    google::bigtable::admin::v2::RestoreTableRequest const&,
-    grpc::CompletionQueue*) {
+AdminClient::AsyncRestoreTable(grpc::ClientContext*,
+                               btadmin::RestoreTableRequest const&,
+                               grpc::CompletionQueue*) {
   return {};
 }
 
-namespace btadmin = ::google::bigtable::admin::v2;
+namespace {
 
 /**
  * An AdminClient for single-threaded programs that refreshes credentials on all
@@ -166,10 +157,10 @@ class DefaultAdminClient : public google::cloud::bigtable::AdminClient {
     return impl_.Stub()->ListTables(context, request, response);
   }
 
-  std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<
-      google::bigtable::admin::v2::ListTablesResponse>>
+  std::unique_ptr<
+      grpc::ClientAsyncResponseReaderInterface<btadmin::ListTablesResponse>>
   AsyncListTables(grpc::ClientContext* context,
-                  google::bigtable::admin::v2::ListTablesRequest const& request,
+                  btadmin::ListTablesRequest const& request,
                   grpc::CompletionQueue* cq) override {
     return impl_.Stub()->AsyncListTables(context, request, cq);
   }
@@ -180,10 +171,9 @@ class DefaultAdminClient : public google::cloud::bigtable::AdminClient {
     return impl_.Stub()->GetTable(context, request, response);
   }
 
-  std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<
-      google::bigtable::admin::v2::Table>>
+  std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<btadmin::Table>>
   AsyncGetTable(grpc::ClientContext* context,
-                google::bigtable::admin::v2::GetTableRequest const& request,
+                btadmin::GetTableRequest const& request,
                 grpc::CompletionQueue* cq) override {
     return impl_.Stub()->AsyncGetTable(context, request, cq);
   }
@@ -194,45 +184,39 @@ class DefaultAdminClient : public google::cloud::bigtable::AdminClient {
     return impl_.Stub()->DeleteTable(context, request, response);
   }
 
-  grpc::Status CreateBackup(
-      grpc::ClientContext* context,
-      google::bigtable::admin::v2::CreateBackupRequest const& request,
-      google::longrunning::Operation* response) override {
+  grpc::Status CreateBackup(grpc::ClientContext* context,
+                            btadmin::CreateBackupRequest const& request,
+                            google::longrunning::Operation* response) override {
     return impl_.Stub()->CreateBackup(context, request, response);
   }
 
-  grpc::Status GetBackup(
-      grpc::ClientContext* context,
-      google::bigtable::admin::v2::GetBackupRequest const& request,
-      google::bigtable::admin::v2::Backup* response) override {
+  grpc::Status GetBackup(grpc::ClientContext* context,
+                         btadmin::GetBackupRequest const& request,
+                         btadmin::Backup* response) override {
     return impl_.Stub()->GetBackup(context, request, response);
   }
 
-  grpc::Status UpdateBackup(
-      grpc::ClientContext* context,
-      google::bigtable::admin::v2::UpdateBackupRequest const& request,
-      google::bigtable::admin::v2::Backup* response) override {
+  grpc::Status UpdateBackup(grpc::ClientContext* context,
+                            btadmin::UpdateBackupRequest const& request,
+                            btadmin::Backup* response) override {
     return impl_.Stub()->UpdateBackup(context, request, response);
   }
 
-  grpc::Status DeleteBackup(
-      grpc::ClientContext* context,
-      google::bigtable::admin::v2::DeleteBackupRequest const& request,
-      google::protobuf::Empty* response) override {
+  grpc::Status DeleteBackup(grpc::ClientContext* context,
+                            btadmin::DeleteBackupRequest const& request,
+                            google::protobuf::Empty* response) override {
     return impl_.Stub()->DeleteBackup(context, request, response);
   }
 
-  grpc::Status ListBackups(
-      grpc::ClientContext* context,
-      google::bigtable::admin::v2::ListBackupsRequest const& request,
-      google::bigtable::admin::v2::ListBackupsResponse* response) override {
+  grpc::Status ListBackups(grpc::ClientContext* context,
+                           btadmin::ListBackupsRequest const& request,
+                           btadmin::ListBackupsResponse* response) override {
     return impl_.Stub()->ListBackups(context, request, response);
   }
 
-  grpc::Status RestoreTable(
-      grpc::ClientContext* context,
-      google::bigtable::admin::v2::RestoreTableRequest const& request,
-      google::longrunning::Operation* response) override {
+  grpc::Status RestoreTable(grpc::ClientContext* context,
+                            btadmin::RestoreTableRequest const& request,
+                            google::longrunning::Operation* response) override {
     return impl_.Stub()->RestoreTable(context, request, response);
   }
 
@@ -290,111 +274,96 @@ class DefaultAdminClient : public google::cloud::bigtable::AdminClient {
     return impl_.Stub()->TestIamPermissions(context, request, response);
   }
 
-  std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<
-      google::bigtable::admin::v2::Table>>
-  AsyncCreateTable(
-      grpc::ClientContext* context,
-      google::bigtable::admin::v2::CreateTableRequest const& request,
-      grpc::CompletionQueue* cq) override {
+  std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<btadmin::Table>>
+  AsyncCreateTable(grpc::ClientContext* context,
+                   btadmin::CreateTableRequest const& request,
+                   grpc::CompletionQueue* cq) override {
     return impl_.Stub()->AsyncCreateTable(context, request, cq);
   }
 
   std::unique_ptr<
-      ::grpc::ClientAsyncResponseReaderInterface<::google::protobuf::Empty>>
-  AsyncDeleteTable(
-      grpc::ClientContext* context,
-      google::bigtable::admin::v2::DeleteTableRequest const& request,
-      grpc::CompletionQueue* cq) override {
+      grpc::ClientAsyncResponseReaderInterface<::google::protobuf::Empty>>
+  AsyncDeleteTable(grpc::ClientContext* context,
+                   btadmin::DeleteTableRequest const& request,
+                   grpc::CompletionQueue* cq) override {
     return impl_.Stub()->AsyncDeleteTable(context, request, cq);
   }
 
   std::unique_ptr<
       grpc::ClientAsyncResponseReaderInterface<google::longrunning::Operation>>
-  AsyncCreateBackup(
-      grpc::ClientContext* context,
-      google::bigtable::admin::v2::CreateBackupRequest const& request,
-      grpc::CompletionQueue* cq) override {
+  AsyncCreateBackup(grpc::ClientContext* context,
+                    btadmin::CreateBackupRequest const& request,
+                    grpc::CompletionQueue* cq) override {
     return impl_.Stub()->AsyncCreateBackup(context, request, cq);
   }
 
-  std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<
-      google::bigtable::admin::v2::Backup>>
+  std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<btadmin::Backup>>
   AsyncGetBackup(grpc::ClientContext* context,
-                 google::bigtable::admin::v2::GetBackupRequest const& request,
+                 btadmin::GetBackupRequest const& request,
                  grpc::CompletionQueue* cq) override {
     return impl_.Stub()->AsyncGetBackup(context, request, cq);
   }
 
-  std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<
-      google::bigtable::admin::v2::Backup>>
-  AsyncUpdateBackup(
-      grpc::ClientContext* context,
-      google::bigtable::admin::v2::UpdateBackupRequest const& request,
-      grpc::CompletionQueue* cq) override {
+  std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<btadmin::Backup>>
+  AsyncUpdateBackup(grpc::ClientContext* context,
+                    btadmin::UpdateBackupRequest const& request,
+                    grpc::CompletionQueue* cq) override {
     return impl_.Stub()->AsyncUpdateBackup(context, request, cq);
   }
 
   std::unique_ptr<
       grpc::ClientAsyncResponseReaderInterface<google::protobuf::Empty>>
-  AsyncDeleteBackup(
-      grpc::ClientContext* context,
-      google::bigtable::admin::v2::DeleteBackupRequest const& request,
-      grpc::CompletionQueue* cq) override {
+  AsyncDeleteBackup(grpc::ClientContext* context,
+                    btadmin::DeleteBackupRequest const& request,
+                    grpc::CompletionQueue* cq) override {
     return impl_.Stub()->AsyncDeleteBackup(context, request, cq);
   }
 
-  std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<
-      google::bigtable::admin::v2::ListBackupsResponse>>
-  AsyncListBackups(
-      grpc::ClientContext* context,
-      google::bigtable::admin::v2::ListBackupsRequest const& request,
-      grpc::CompletionQueue* cq) override {
+  std::unique_ptr<
+      grpc::ClientAsyncResponseReaderInterface<btadmin::ListBackupsResponse>>
+  AsyncListBackups(grpc::ClientContext* context,
+                   btadmin::ListBackupsRequest const& request,
+                   grpc::CompletionQueue* cq) override {
     return impl_.Stub()->AsyncListBackups(context, request, cq);
   }
 
   std::unique_ptr<
       grpc::ClientAsyncResponseReaderInterface<google::longrunning::Operation>>
-  AsyncRestoreTable(
-      grpc::ClientContext* context,
-      google::bigtable::admin::v2::RestoreTableRequest const& request,
-      grpc::CompletionQueue* cq) override {
+  AsyncRestoreTable(grpc::ClientContext* context,
+                    btadmin::RestoreTableRequest const& request,
+                    grpc::CompletionQueue* cq) override {
     return impl_.Stub()->AsyncRestoreTable(context, request, cq);
   }
 
-  std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<
-      google::bigtable::admin::v2::Table>>
-  AsyncModifyColumnFamilies(
-      grpc::ClientContext* context,
-      google::bigtable::admin::v2::ModifyColumnFamiliesRequest const& request,
-      grpc::CompletionQueue* cq) override {
+  std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<btadmin::Table>>
+  AsyncModifyColumnFamilies(grpc::ClientContext* context,
+                            btadmin::ModifyColumnFamiliesRequest const& request,
+                            grpc::CompletionQueue* cq) override {
     return impl_.Stub()->AsyncModifyColumnFamilies(context, request, cq);
   }
 
   std::unique_ptr<
       grpc::ClientAsyncResponseReaderInterface<google::protobuf::Empty>>
-  AsyncDropRowRange(
-      grpc::ClientContext* context,
-      google::bigtable::admin::v2::DropRowRangeRequest const& request,
-      grpc::CompletionQueue* cq) override {
+  AsyncDropRowRange(grpc::ClientContext* context,
+                    btadmin::DropRowRangeRequest const& request,
+                    grpc::CompletionQueue* cq) override {
     return impl_.Stub()->AsyncDropRowRange(context, request, cq);
   };
 
   std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<
-      google::bigtable::admin::v2::GenerateConsistencyTokenResponse>>
+      btadmin::GenerateConsistencyTokenResponse>>
   AsyncGenerateConsistencyToken(
       grpc::ClientContext* context,
-      google::bigtable::admin::v2::GenerateConsistencyTokenRequest const&
-          request,
+      btadmin::GenerateConsistencyTokenRequest const& request,
       grpc::CompletionQueue* cq) override {
     return impl_.Stub()->AsyncGenerateConsistencyToken(context, request, cq);
   }
 
   std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<
-      google::bigtable::admin::v2::CheckConsistencyResponse>>
-  AsyncCheckConsistency(
-      grpc::ClientContext* context,
-      google::bigtable::admin::v2::CheckConsistencyRequest const& request,
-      grpc::CompletionQueue* cq) override {
+      btadmin::CheckConsistencyResponse>>
+  AsyncCheckConsistency(grpc::ClientContext* context,
+                        btadmin::CheckConsistencyRequest const& request,
+                        grpc::CompletionQueue* cq) override {
     return impl_.Stub()->AsyncCheckConsistency(context, request, cq);
   }
 
@@ -442,6 +411,8 @@ class DefaultAdminClient : public google::cloud::bigtable::AdminClient {
   std::string project_;
   Impl impl_;
 };
+
+}  // namespace
 
 std::shared_ptr<AdminClient> MakeAdminClient(std::string project,
                                              Options options) {

--- a/google/cloud/bigtable/admin_client.cc
+++ b/google/cloud/bigtable/admin_client.cc
@@ -124,8 +124,6 @@ namespace {
  */
 class DefaultAdminClient : public google::cloud::bigtable::AdminClient {
  private:
-  // Introduce an early `private:` section because this type is used to define
-  // the public interface, it should not be part of the public interface.
   struct AdminTraits {
     static std::string const& Endpoint(Options const& options) {
       return options.get<AdminEndpointOption>();
@@ -136,8 +134,6 @@ class DefaultAdminClient : public google::cloud::bigtable::AdminClient {
       AdminTraits, btadmin::BigtableTableAdmin>;
 
  public:
-  using AdminStubPtr = Impl::StubPtr;
-
   DefaultAdminClient(std::string project, Options options)
       : project_(std::move(project)), impl_(std::move(options)) {}
 

--- a/google/cloud/bigtable/admin_client.cc
+++ b/google/cloud/bigtable/admin_client.cc
@@ -123,16 +123,6 @@ namespace {
  * connections need refreshing.
  */
 class DefaultAdminClient : public google::cloud::bigtable::AdminClient {
- private:
-  struct AdminTraits {
-    static std::string const& Endpoint(Options const& options) {
-      return options.get<AdminEndpointOption>();
-    }
-  };
-
-  using Impl = ::google::cloud::bigtable::internal::CommonClient<
-      AdminTraits, btadmin::BigtableTableAdmin>;
-
  public:
   DefaultAdminClient(std::string project, Options options)
       : project_(std::move(project)), impl_(std::move(options)) {}
@@ -404,8 +394,14 @@ class DefaultAdminClient : public google::cloud::bigtable::AdminClient {
     return impl_.BackgroundThreadsFactory();
   }
 
+  struct Traits {
+    static std::string const& Endpoint(Options const& options) {
+      return options.get<AdminEndpointOption>();
+    }
+  };
+
   std::string project_;
-  Impl impl_;
+  internal::CommonClient<Traits, btadmin::BigtableTableAdmin> impl_;
 };
 
 }  // namespace

--- a/google/cloud/bigtable/client_options.h
+++ b/google/cloud/bigtable/client_options.h
@@ -38,7 +38,6 @@ namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 class ClientOptions;
 namespace internal {
-struct InstanceAdminTraits;
 Options&& MakeOptions(ClientOptions&& o);
 }  // namespace internal
 
@@ -465,7 +464,6 @@ class ClientOptions {
   BackgroundThreadsFactory background_threads_factory() const;
 
  private:
-  friend struct internal::InstanceAdminTraits;
   friend struct ClientOptionsTestTraits;
   friend Options&& internal::MakeOptions(ClientOptions&&);
 

--- a/google/cloud/bigtable/data_client.cc
+++ b/google/cloud/bigtable/data_client.cc
@@ -18,21 +18,23 @@
 #include "google/cloud/internal/log_wrapper.h"
 #include "google/cloud/log.h"
 
-namespace btproto = ::google::bigtable::v2;
-
 namespace google {
 namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 
-std::unique_ptr<::grpc::ClientAsyncReaderInterface<
-    ::google::bigtable::v2::SampleRowKeysResponse>>
+namespace btproto = ::google::bigtable::v2;
+
+std::unique_ptr<
+    ::grpc::ClientAsyncReaderInterface<btproto::SampleRowKeysResponse>>
 // NOLINTNEXTLINE(performance-unnecessary-value-param)
-DataClient::PrepareAsyncSampleRowKeys(
-    ::grpc::ClientContext*, ::google::bigtable::v2::SampleRowKeysRequest const&,
-    ::grpc::CompletionQueue*) {
+DataClient::PrepareAsyncSampleRowKeys(grpc::ClientContext*,
+                                      btproto::SampleRowKeysRequest const&,
+                                      grpc::CompletionQueue*) {
   return nullptr;
 }
+
+namespace {
 
 /**
  * Implement a simple DataClient.
@@ -50,7 +52,9 @@ class DefaultDataClient : public DataClient {
     }
   };
 
-  using Impl = bigtable::internal::CommonClient<DataTraits, btproto::Bigtable>;
+  using Impl =
+      ::google::cloud::bigtable::internal::CommonClient<DataTraits,
+                                                        btproto::Bigtable>;
 
  public:
   DefaultDataClient(std::string project, std::string instance,
@@ -59,8 +63,8 @@ class DefaultDataClient : public DataClient {
         instance_(std::move(instance)),
         impl_(std::move(options)) {}
 
-  std::string const& project_id() const override;
-  std::string const& instance_id() const override;
+  std::string const& project_id() const override { return project_; };
+  std::string const& instance_id() const override { return instance_; };
 
   std::shared_ptr<grpc::Channel> Channel() override { return impl_.Channel(); }
   void reset() override { impl_.reset(); }
@@ -87,11 +91,10 @@ class DefaultDataClient : public DataClient {
   }
 
   std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<
-      google::bigtable::v2::CheckAndMutateRowResponse>>
-  AsyncCheckAndMutateRow(
-      grpc::ClientContext* context,
-      google::bigtable::v2::CheckAndMutateRowRequest const& request,
-      grpc::CompletionQueue* cq) override {
+      btproto::CheckAndMutateRowResponse>>
+  AsyncCheckAndMutateRow(grpc::ClientContext* context,
+                         btproto::CheckAndMutateRowRequest const& request,
+                         grpc::CompletionQueue* cq) override {
     return impl_.Stub()->AsyncCheckAndMutateRow(context, request, cq);
   }
 
@@ -103,11 +106,10 @@ class DefaultDataClient : public DataClient {
   }
 
   std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<
-      google::bigtable::v2::ReadModifyWriteRowResponse>>
-  AsyncReadModifyWriteRow(
-      grpc::ClientContext* context,
-      google::bigtable::v2::ReadModifyWriteRowRequest const& request,
-      grpc::CompletionQueue* cq) override {
+      btproto::ReadModifyWriteRowResponse>>
+  AsyncReadModifyWriteRow(grpc::ClientContext* context,
+                          btproto::ReadModifyWriteRowRequest const& request,
+                          grpc::CompletionQueue* cq) override {
     return impl_.Stub()->AsyncReadModifyWriteRow(context, request, cq);
   }
 
@@ -119,16 +121,15 @@ class DefaultDataClient : public DataClient {
 
   std::unique_ptr<grpc::ClientAsyncReaderInterface<btproto::ReadRowsResponse>>
   AsyncReadRows(grpc::ClientContext* context,
-                google::bigtable::v2::ReadRowsRequest const& request,
+                btproto::ReadRowsRequest const& request,
                 grpc::CompletionQueue* cq, void* tag) override {
     return impl_.Stub()->AsyncReadRows(context, request, cq, tag);
   }
 
-  std::unique_ptr<::grpc::ClientAsyncReaderInterface<
-      ::google::bigtable::v2::ReadRowsResponse>>
-  PrepareAsyncReadRows(::grpc::ClientContext* context,
-                       ::google::bigtable::v2::ReadRowsRequest const& request,
-                       ::grpc::CompletionQueue* cq) override {
+  std::unique_ptr<::grpc::ClientAsyncReaderInterface<btproto::ReadRowsResponse>>
+  PrepareAsyncReadRows(grpc::ClientContext* context,
+                       btproto::ReadRowsRequest const& request,
+                       grpc::CompletionQueue* cq) override {
     return impl_.Stub()->PrepareAsyncReadRows(context, request, cq);
   }
 
@@ -138,21 +139,19 @@ class DefaultDataClient : public DataClient {
     return impl_.Stub()->SampleRowKeys(context, request);
   }
 
-  std::unique_ptr<::grpc::ClientAsyncReaderInterface<
-      ::google::bigtable::v2::SampleRowKeysResponse>>
-  AsyncSampleRowKeys(
-      ::grpc::ClientContext* context,
-      ::google::bigtable::v2::SampleRowKeysRequest const& request,
-      ::grpc::CompletionQueue* cq, void* tag) override {
+  std::unique_ptr<
+      ::grpc::ClientAsyncReaderInterface<btproto::SampleRowKeysResponse>>
+  AsyncSampleRowKeys(grpc::ClientContext* context,
+                     btproto::SampleRowKeysRequest const& request,
+                     grpc::CompletionQueue* cq, void* tag) override {
     return impl_.Stub()->AsyncSampleRowKeys(context, request, cq, tag);
   }
 
-  std::unique_ptr<::grpc::ClientAsyncReaderInterface<
-      ::google::bigtable::v2::SampleRowKeysResponse>>
-  PrepareAsyncSampleRowKeys(
-      ::grpc::ClientContext* context,
-      ::google::bigtable::v2::SampleRowKeysRequest const& request,
-      ::grpc::CompletionQueue* cq) override {
+  std::unique_ptr<
+      ::grpc::ClientAsyncReaderInterface<btproto::SampleRowKeysResponse>>
+  PrepareAsyncSampleRowKeys(grpc::ClientContext* context,
+                            btproto::SampleRowKeysRequest const& request,
+                            grpc::CompletionQueue* cq) override {
     return impl_.Stub()->PrepareAsyncSampleRowKeys(context, request, cq);
   }
 
@@ -162,20 +161,19 @@ class DefaultDataClient : public DataClient {
     return impl_.Stub()->MutateRows(context, request);
   }
 
-  std::unique_ptr<::grpc::ClientAsyncReaderInterface<
-      ::google::bigtable::v2::MutateRowsResponse>>
-  AsyncMutateRows(::grpc::ClientContext* context,
-                  ::google::bigtable::v2::MutateRowsRequest const& request,
-                  ::grpc::CompletionQueue* cq, void* tag) override {
+  std::unique_ptr<
+      ::grpc::ClientAsyncReaderInterface<btproto::MutateRowsResponse>>
+  AsyncMutateRows(grpc::ClientContext* context,
+                  btproto::MutateRowsRequest const& request,
+                  grpc::CompletionQueue* cq, void* tag) override {
     return impl_.Stub()->AsyncMutateRows(context, request, cq, tag);
   }
 
-  std::unique_ptr<::grpc::ClientAsyncReaderInterface<
-      ::google::bigtable::v2::MutateRowsResponse>>
-  PrepareAsyncMutateRows(
-      ::grpc::ClientContext* context,
-      ::google::bigtable::v2::MutateRowsRequest const& request,
-      ::grpc::CompletionQueue* cq) override {
+  std::unique_ptr<
+      ::grpc::ClientAsyncReaderInterface<btproto::MutateRowsResponse>>
+  PrepareAsyncMutateRows(grpc::ClientContext* context,
+                         btproto::MutateRowsRequest const& request,
+                         grpc::CompletionQueue* cq) override {
     return impl_.Stub()->PrepareAsyncMutateRows(context, request, cq);
   }
 
@@ -189,9 +187,7 @@ class DefaultDataClient : public DataClient {
   Impl impl_;
 };
 
-std::string const& DefaultDataClient::project_id() const { return project_; }
-
-std::string const& DefaultDataClient::instance_id() const { return instance_; }
+}  // namespace
 
 std::shared_ptr<DataClient> MakeDataClient(std::string project_id,
                                            std::string instance_id,

--- a/google/cloud/bigtable/data_client.cc
+++ b/google/cloud/bigtable/data_client.cc
@@ -44,8 +44,6 @@ namespace {
  */
 class DefaultDataClient : public DataClient {
  private:
-  // Introduce an early `private:` section because this type is used to define
-  // the public interface, it should not be part of the public interface.
   struct DataTraits {
     static std::string const& Endpoint(Options const& options) {
       return options.get<DataEndpointOption>();

--- a/google/cloud/bigtable/data_client.cc
+++ b/google/cloud/bigtable/data_client.cc
@@ -43,17 +43,6 @@ namespace {
  * authorization tokens.  In other words, it is extremely bare bones.
  */
 class DefaultDataClient : public DataClient {
- private:
-  struct DataTraits {
-    static std::string const& Endpoint(Options const& options) {
-      return options.get<DataEndpointOption>();
-    }
-  };
-
-  using Impl =
-      ::google::cloud::bigtable::internal::CommonClient<DataTraits,
-                                                        btproto::Bigtable>;
-
  public:
   DefaultDataClient(std::string project, std::string instance,
                     Options options = {})
@@ -180,9 +169,15 @@ class DefaultDataClient : public DataClient {
     return impl_.BackgroundThreadsFactory();
   }
 
+  struct Traits {
+    static std::string const& Endpoint(Options const& options) {
+      return options.get<DataEndpointOption>();
+    }
+  };
+
   std::string project_;
   std::string instance_;
-  Impl impl_;
+  internal::CommonClient<Traits, btproto::Bigtable> impl_;
 };
 
 }  // namespace

--- a/google/cloud/bigtable/data_client.h
+++ b/google/cloud/bigtable/data_client.h
@@ -138,41 +138,39 @@ class DataClient {
                 google::bigtable::v2::ReadRowsRequest const& request,
                 grpc::CompletionQueue* cq, void* tag) = 0;
   virtual std::unique_ptr<::grpc::ClientAsyncReaderInterface<
-      ::google::bigtable::v2::ReadRowsResponse>>
+      google::bigtable::v2::ReadRowsResponse>>
   PrepareAsyncReadRows(::grpc::ClientContext* context,
-                       ::google::bigtable::v2::ReadRowsRequest const& request,
-                       ::grpc::CompletionQueue* cq) = 0;
+                       google::bigtable::v2::ReadRowsRequest const& request,
+                       grpc::CompletionQueue* cq) = 0;
   virtual std::unique_ptr<
       grpc::ClientReaderInterface<google::bigtable::v2::SampleRowKeysResponse>>
   SampleRowKeys(grpc::ClientContext* context,
                 google::bigtable::v2::SampleRowKeysRequest const& request) = 0;
   virtual std::unique_ptr<::grpc::ClientAsyncReaderInterface<
-      ::google::bigtable::v2::SampleRowKeysResponse>>
-  AsyncSampleRowKeys(
-      ::grpc::ClientContext* context,
-      ::google::bigtable::v2::SampleRowKeysRequest const& request,
-      ::grpc::CompletionQueue* cq, void* tag) = 0;
+      google::bigtable::v2::SampleRowKeysResponse>>
+  AsyncSampleRowKeys(grpc::ClientContext* context,
+                     google::bigtable::v2::SampleRowKeysRequest const& request,
+                     grpc::CompletionQueue* cq, void* tag) = 0;
   virtual std::unique_ptr<::grpc::ClientAsyncReaderInterface<
-      ::google::bigtable::v2::SampleRowKeysResponse>>
+      google::bigtable::v2::SampleRowKeysResponse>>
   PrepareAsyncSampleRowKeys(
-      ::grpc::ClientContext* context,
-      ::google::bigtable::v2::SampleRowKeysRequest const& request,
-      ::grpc::CompletionQueue* cq);
+      grpc::ClientContext* context,
+      google::bigtable::v2::SampleRowKeysRequest const& request,
+      grpc::CompletionQueue* cq);
   virtual std::unique_ptr<
       grpc::ClientReaderInterface<google::bigtable::v2::MutateRowsResponse>>
   MutateRows(grpc::ClientContext* context,
              google::bigtable::v2::MutateRowsRequest const& request) = 0;
   virtual std::unique_ptr<::grpc::ClientAsyncReaderInterface<
-      ::google::bigtable::v2::MutateRowsResponse>>
+      google::bigtable::v2::MutateRowsResponse>>
   AsyncMutateRows(::grpc::ClientContext* context,
-                  ::google::bigtable::v2::MutateRowsRequest const& request,
-                  ::grpc::CompletionQueue* cq, void* tag) = 0;
+                  google::bigtable::v2::MutateRowsRequest const& request,
+                  grpc::CompletionQueue* cq, void* tag) = 0;
   virtual std::unique_ptr<::grpc::ClientAsyncReaderInterface<
-      ::google::bigtable::v2::MutateRowsResponse>>
-  PrepareAsyncMutateRows(
-      ::grpc::ClientContext* context,
-      ::google::bigtable::v2::MutateRowsRequest const& request,
-      ::grpc::CompletionQueue* cq) = 0;
+      google::bigtable::v2::MutateRowsResponse>>
+  PrepareAsyncMutateRows(grpc::ClientContext* context,
+                         google::bigtable::v2::MutateRowsRequest const& request,
+                         grpc::CompletionQueue* cq) = 0;
   //@}
 };
 

--- a/google/cloud/bigtable/instance_admin_client.cc
+++ b/google/cloud/bigtable/instance_admin_client.cc
@@ -31,6 +31,9 @@ struct InstanceAdminTraits {
 }  // namespace internal
 
 namespace {
+
+namespace btadmin = ::google::bigtable::admin::v2;
+
 /**
  * An AdminClient for single-threaded programs that refreshes credentials on all
  * gRPC errors.
@@ -48,9 +51,8 @@ class DefaultInstanceAdminClient : public InstanceAdminClient {
  private:
   // Introduce an early `private:` section because this type is used to define
   // the public interface, it should not be part of the public interface.
-  using Impl = internal::CommonClient<
-      internal::InstanceAdminTraits,
-      ::google::bigtable::admin::v2::BigtableInstanceAdmin>;
+  using Impl = internal::CommonClient<internal::InstanceAdminTraits,
+                                      btadmin::BigtableInstanceAdmin>;
 
  public:
   using AdminStubPtr = Impl::StubPtr;
@@ -64,21 +66,21 @@ class DefaultInstanceAdminClient : public InstanceAdminClient {
 
   grpc::Status ListInstances(
       grpc::ClientContext* context,
-      google::bigtable::admin::v2::ListInstancesRequest const& request,
-      google::bigtable::admin::v2::ListInstancesResponse* response) override {
+      btadmin::ListInstancesRequest const& request,
+      btadmin::ListInstancesResponse* response) override {
     return impl_.Stub()->ListInstances(context, request, response);
   }
 
   grpc::Status CreateInstance(
       grpc::ClientContext* context,
-      google::bigtable::admin::v2::CreateInstanceRequest const& request,
+      btadmin::CreateInstanceRequest const& request,
       google::longrunning::Operation* response) override {
     return impl_.Stub()->CreateInstance(context, request, response);
   }
 
   grpc::Status UpdateInstance(
       grpc::ClientContext* context,
-      google::bigtable::admin::v2::PartialUpdateInstanceRequest const& request,
+      btadmin::PartialUpdateInstanceRequest const& request,
       google::longrunning::Operation* response) override {
     return impl_.Stub()->PartialUpdateInstance(context, request, response);
   }
@@ -91,87 +93,78 @@ class DefaultInstanceAdminClient : public InstanceAdminClient {
     return stub->GetOperation(context, request, response);
   }
 
-  grpc::Status GetInstance(
-      grpc::ClientContext* context,
-      google::bigtable::admin::v2::GetInstanceRequest const& request,
-      google::bigtable::admin::v2::Instance* response) override {
+  grpc::Status GetInstance(grpc::ClientContext* context,
+                           btadmin::GetInstanceRequest const& request,
+                           btadmin::Instance* response) override {
     return impl_.Stub()->GetInstance(context, request, response);
   }
 
-  grpc::Status DeleteInstance(
-      grpc::ClientContext* context,
-      google::bigtable::admin::v2::DeleteInstanceRequest const& request,
-      google::protobuf::Empty* response) override {
+  grpc::Status DeleteInstance(grpc::ClientContext* context,
+                              btadmin::DeleteInstanceRequest const& request,
+                              google::protobuf::Empty* response) override {
     return impl_.Stub()->DeleteInstance(context, request, response);
   }
 
-  grpc::Status ListClusters(
-      grpc::ClientContext* context,
-      google::bigtable::admin::v2::ListClustersRequest const& request,
-      google::bigtable::admin::v2::ListClustersResponse* response) override {
+  grpc::Status ListClusters(grpc::ClientContext* context,
+                            btadmin::ListClustersRequest const& request,
+                            btadmin::ListClustersResponse* response) override {
     return impl_.Stub()->ListClusters(context, request, response);
   }
 
-  grpc::Status GetCluster(
-      grpc::ClientContext* context,
-      google::bigtable::admin::v2::GetClusterRequest const& request,
-      google::bigtable::admin::v2::Cluster* response) override {
+  grpc::Status GetCluster(grpc::ClientContext* context,
+                          btadmin::GetClusterRequest const& request,
+                          btadmin::Cluster* response) override {
     return impl_.Stub()->GetCluster(context, request, response);
   }
 
-  grpc::Status DeleteCluster(
-      grpc::ClientContext* context,
-      google::bigtable::admin::v2::DeleteClusterRequest const& request,
-      google::protobuf::Empty* response) override {
+  grpc::Status DeleteCluster(grpc::ClientContext* context,
+                             btadmin::DeleteClusterRequest const& request,
+                             google::protobuf::Empty* response) override {
     return impl_.Stub()->DeleteCluster(context, request, response);
   }
 
   grpc::Status CreateCluster(
       grpc::ClientContext* context,
-      google::bigtable::admin::v2::CreateClusterRequest const& request,
+      btadmin::CreateClusterRequest const& request,
       google::longrunning::Operation* response) override {
     return impl_.Stub()->CreateCluster(context, request, response);
   }
 
   grpc::Status UpdateCluster(
-      grpc::ClientContext* context,
-      google::bigtable::admin::v2::Cluster const& request,
+      grpc::ClientContext* context, btadmin::Cluster const& request,
       google::longrunning::Operation* response) override {
     return impl_.Stub()->UpdateCluster(context, request, response);
   }
 
-  grpc::Status CreateAppProfile(
-      grpc::ClientContext* context,
-      google::bigtable::admin::v2::CreateAppProfileRequest const& request,
-      google::bigtable::admin::v2::AppProfile* response) override {
+  grpc::Status CreateAppProfile(grpc::ClientContext* context,
+                                btadmin::CreateAppProfileRequest const& request,
+                                btadmin::AppProfile* response) override {
     return impl_.Stub()->CreateAppProfile(context, request, response);
   }
 
-  grpc::Status GetAppProfile(
-      grpc::ClientContext* context,
-      google::bigtable::admin::v2::GetAppProfileRequest const& request,
-      google::bigtable::admin::v2::AppProfile* response) override {
+  grpc::Status GetAppProfile(grpc::ClientContext* context,
+                             btadmin::GetAppProfileRequest const& request,
+                             btadmin::AppProfile* response) override {
     return impl_.Stub()->GetAppProfile(context, request, response);
   }
 
   grpc::Status ListAppProfiles(
       grpc::ClientContext* context,
-      google::bigtable::admin::v2::ListAppProfilesRequest const& request,
-      google::bigtable::admin::v2::ListAppProfilesResponse* response) override {
+      btadmin::ListAppProfilesRequest const& request,
+      btadmin::ListAppProfilesResponse* response) override {
     return impl_.Stub()->ListAppProfiles(context, request, response);
   }
 
   grpc::Status UpdateAppProfile(
       grpc::ClientContext* context,
-      google::bigtable::admin::v2::UpdateAppProfileRequest const& request,
+      btadmin::UpdateAppProfileRequest const& request,
       google::longrunning::Operation* response) override {
     return impl_.Stub()->UpdateAppProfile(context, request, response);
   }
 
-  grpc::Status DeleteAppProfile(
-      grpc::ClientContext* context,
-      google::bigtable::admin::v2::DeleteAppProfileRequest const& request,
-      google::protobuf::Empty* response) override {
+  grpc::Status DeleteAppProfile(grpc::ClientContext* context,
+                                btadmin::DeleteAppProfileRequest const& request,
+                                google::protobuf::Empty* response) override {
     return impl_.Stub()->DeleteAppProfile(context, request, response);
   }
 
@@ -194,136 +187,119 @@ class DefaultInstanceAdminClient : public InstanceAdminClient {
     return impl_.Stub()->TestIamPermissions(context, request, response);
   }
 
-  std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<
-      google::bigtable::admin::v2::ListInstancesResponse>>
-  AsyncListInstances(
-      grpc::ClientContext* context,
-      google::bigtable::admin::v2::ListInstancesRequest const& request,
-      grpc::CompletionQueue* cq) override {
+  std::unique_ptr<
+      grpc::ClientAsyncResponseReaderInterface<btadmin::ListInstancesResponse>>
+  AsyncListInstances(grpc::ClientContext* context,
+                     btadmin::ListInstancesRequest const& request,
+                     grpc::CompletionQueue* cq) override {
     return impl_.Stub()->AsyncListInstances(context, request, cq);
   }
 
-  std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<
-      google::bigtable::admin::v2::Instance>>
-  AsyncGetInstance(
-      grpc::ClientContext* context,
-      google::bigtable::admin::v2::GetInstanceRequest const& request,
-      grpc::CompletionQueue* cq) override {
+  std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<btadmin::Instance>>
+  AsyncGetInstance(grpc::ClientContext* context,
+                   btadmin::GetInstanceRequest const& request,
+                   grpc::CompletionQueue* cq) override {
     return impl_.Stub()->AsyncGetInstance(context, request, cq);
   }
 
-  std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<
-      google::bigtable::admin::v2::Cluster>>
+  std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<btadmin::Cluster>>
   AsyncGetCluster(grpc::ClientContext* context,
-                  google::bigtable::admin::v2::GetClusterRequest const& request,
+                  btadmin::GetClusterRequest const& request,
                   grpc::CompletionQueue* cq) override {
     return impl_.Stub()->AsyncGetCluster(context, request, cq);
   }
 
   std::unique_ptr<
       grpc::ClientAsyncResponseReaderInterface<google::protobuf::Empty>>
-  AsyncDeleteCluster(
-      grpc::ClientContext* context,
-      google::bigtable::admin::v2::DeleteClusterRequest const& request,
-      grpc::CompletionQueue* cq) override {
+  AsyncDeleteCluster(grpc::ClientContext* context,
+                     btadmin::DeleteClusterRequest const& request,
+                     grpc::CompletionQueue* cq) override {
     return impl_.Stub()->AsyncDeleteCluster(context, request, cq);
   }
 
   std::unique_ptr<
       grpc::ClientAsyncResponseReaderInterface<google::longrunning::Operation>>
-  AsyncCreateCluster(
-      grpc::ClientContext* context,
-      google::bigtable::admin::v2::CreateClusterRequest const& request,
-      grpc::CompletionQueue* cq) override {
+  AsyncCreateCluster(grpc::ClientContext* context,
+                     btadmin::CreateClusterRequest const& request,
+                     grpc::CompletionQueue* cq) override {
     return impl_.Stub()->AsyncCreateCluster(context, request, cq);
   }
 
   std::unique_ptr<
       grpc::ClientAsyncResponseReaderInterface<google::longrunning::Operation>>
-  AsyncCreateInstance(
-      grpc::ClientContext* context,
-      google::bigtable::admin::v2::CreateInstanceRequest const& request,
-      grpc::CompletionQueue* cq) override {
+  AsyncCreateInstance(grpc::ClientContext* context,
+                      btadmin::CreateInstanceRequest const& request,
+                      grpc::CompletionQueue* cq) override {
     return impl_.Stub()->AsyncCreateInstance(context, request, cq);
   }
 
   std::unique_ptr<
       grpc::ClientAsyncResponseReaderInterface<google::longrunning::Operation>>
-  AsyncUpdateInstance(
-      grpc::ClientContext* context,
-      google::bigtable::admin::v2::PartialUpdateInstanceRequest const& request,
-      grpc::CompletionQueue* cq) override {
+  AsyncUpdateInstance(grpc::ClientContext* context,
+                      btadmin::PartialUpdateInstanceRequest const& request,
+                      grpc::CompletionQueue* cq) override {
     return impl_.Stub()->AsyncPartialUpdateInstance(context, request, cq);
   }
 
   std::unique_ptr<
       grpc::ClientAsyncResponseReaderInterface<google::longrunning::Operation>>
   AsyncUpdateCluster(grpc::ClientContext* context,
-                     google::bigtable::admin::v2::Cluster const& request,
+                     btadmin::Cluster const& request,
                      grpc::CompletionQueue* cq) override {
     return impl_.Stub()->AsyncUpdateCluster(context, request, cq);
   }
 
   std::unique_ptr<
       grpc::ClientAsyncResponseReaderInterface<google::protobuf::Empty>>
-  AsyncDeleteInstance(
-      grpc::ClientContext* context,
-      google::bigtable::admin::v2::DeleteInstanceRequest const& request,
-      grpc::CompletionQueue* cq) override {
+  AsyncDeleteInstance(grpc::ClientContext* context,
+                      btadmin::DeleteInstanceRequest const& request,
+                      grpc::CompletionQueue* cq) override {
     return impl_.Stub()->AsyncDeleteInstance(context, request, cq);
   }
 
-  std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<
-      google::bigtable::admin::v2::ListClustersResponse>>
-  AsyncListClusters(
-      grpc::ClientContext* context,
-      google::bigtable::admin::v2::ListClustersRequest const& request,
-      grpc::CompletionQueue* cq) override {
+  std::unique_ptr<
+      grpc::ClientAsyncResponseReaderInterface<btadmin::ListClustersResponse>>
+  AsyncListClusters(grpc::ClientContext* context,
+                    btadmin::ListClustersRequest const& request,
+                    grpc::CompletionQueue* cq) override {
     return impl_.Stub()->AsyncListClusters(context, request, cq);
   }
 
-  std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<
-      google::bigtable::admin::v2::AppProfile>>
-  AsyncGetAppProfile(
-      grpc::ClientContext* context,
-      google::bigtable::admin::v2::GetAppProfileRequest const& request,
-      grpc::CompletionQueue* cq) override {
+  std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<btadmin::AppProfile>>
+  AsyncGetAppProfile(grpc::ClientContext* context,
+                     btadmin::GetAppProfileRequest const& request,
+                     grpc::CompletionQueue* cq) override {
     return impl_.Stub()->AsyncGetAppProfile(context, request, cq);
   }
 
   std::unique_ptr<
       grpc::ClientAsyncResponseReaderInterface<google::protobuf::Empty>>
-  AsyncDeleteAppProfile(
-      grpc::ClientContext* context,
-      google::bigtable::admin::v2::DeleteAppProfileRequest const& request,
-      grpc::CompletionQueue* cq) override {
+  AsyncDeleteAppProfile(grpc::ClientContext* context,
+                        btadmin::DeleteAppProfileRequest const& request,
+                        grpc::CompletionQueue* cq) override {
     return impl_.Stub()->AsyncDeleteAppProfile(context, request, cq);
   }
 
-  std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<
-      google::bigtable::admin::v2::AppProfile>>
-  AsyncCreateAppProfile(
-      grpc::ClientContext* context,
-      google::bigtable::admin::v2::CreateAppProfileRequest const& request,
-      grpc::CompletionQueue* cq) override {
+  std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<btadmin::AppProfile>>
+  AsyncCreateAppProfile(grpc::ClientContext* context,
+                        btadmin::CreateAppProfileRequest const& request,
+                        grpc::CompletionQueue* cq) override {
     return impl_.Stub()->AsyncCreateAppProfile(context, request, cq);
   }
 
   std::unique_ptr<
       grpc::ClientAsyncResponseReaderInterface<google::longrunning::Operation>>
-  AsyncUpdateAppProfile(
-      grpc::ClientContext* context,
-      google::bigtable::admin::v2::UpdateAppProfileRequest const& request,
-      grpc::CompletionQueue* cq) override {
+  AsyncUpdateAppProfile(grpc::ClientContext* context,
+                        btadmin::UpdateAppProfileRequest const& request,
+                        grpc::CompletionQueue* cq) override {
     return impl_.Stub()->AsyncUpdateAppProfile(context, request, cq);
   }
 
   std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<
-      google::bigtable::admin::v2::ListAppProfilesResponse>>
-  AsyncListAppProfiles(
-      grpc::ClientContext* context,
-      google::bigtable::admin::v2::ListAppProfilesRequest const& request,
-      grpc::CompletionQueue* cq) override {
+      btadmin::ListAppProfilesResponse>>
+  AsyncListAppProfiles(grpc::ClientContext* context,
+                       btadmin::ListAppProfilesRequest const& request,
+                       grpc::CompletionQueue* cq) override {
     return impl_.Stub()->AsyncListAppProfiles(context, request, cq);
   }
 

--- a/google/cloud/bigtable/instance_admin_client.cc
+++ b/google/cloud/bigtable/instance_admin_client.cc
@@ -39,16 +39,6 @@ namespace btadmin = ::google::bigtable::admin::v2;
  * connections need refreshing.
  */
 class DefaultInstanceAdminClient : public InstanceAdminClient {
- private:
-  struct InstanceAdminTraits {
-    static std::string const& Endpoint(Options const& options) {
-      return options.get<InstanceAdminEndpointOption>();
-    }
-  };
-
-  using Impl = ::google::cloud::bigtable::internal::CommonClient<
-      InstanceAdminTraits, btadmin::BigtableInstanceAdmin>;
-
  public:
   DefaultInstanceAdminClient(std::string project, Options options)
       : project_(std::move(project)), impl_(std::move(options)) {}
@@ -337,8 +327,14 @@ class DefaultInstanceAdminClient : public InstanceAdminClient {
     return impl_.BackgroundThreadsFactory();
   }
 
+  struct Traits {
+    static std::string const& Endpoint(Options const& options) {
+      return options.get<InstanceAdminEndpointOption>();
+    }
+  };
+
   std::string project_;
-  Impl impl_;
+  internal::CommonClient<Traits, btadmin::BigtableInstanceAdmin> impl_;
 };
 
 }  // anonymous namespace


### PR DESCRIPTION
The main point of this change was to define `DefaultDataClient` and `DefaultAdminClient` in an anonymous namespace so they don't show up in our [docs](https://googleapis.dev/cpp/google-cloud-bigtable/latest/annotated.html). 
![image](https://user-images.githubusercontent.com/23088558/135730582-5e0e6ccc-c44c-4fc4-bafd-b6667cd7d571.png)

But then I got carried away making the clients conform. This means:
* moving `InstanceAdminTraits` definition into class
* removing untrue comment about early private section
* `(::)google::bigtable::v2` -> `btproto`
* `(::)google::bigtable::admin::v2` -> `btadmin`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7397)
<!-- Reviewable:end -->
