### PR TITLE
ci: use CodeQL for security scans

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -5,8 +5,6 @@ on:
   # that much, start with a time that allows for easier troubleshooting.
   schedule:
     - cron: '00 22 * * *'
-  push:
-    branches: ['ci-experiment-codeql']
 
 jobs:
   analyze:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -30,10 +30,10 @@ jobs:
         with:
           path: "build/vcpkg"
           repository: "microsoft/vcpkg"
-      - name: Read vcpkg version
+          fetch-depth: 0
+      - name: Checkout pinned vcpkg version
         run: >
-          cat ci/etc/vcpkg-commit.txt;
-          git -C build/vcpkg checkout $(<ci/etc/vcpkg-commit.txt);
+          git -C build/vcpkg checkout -q $(<ci/etc/vcpkg-commit.txt)
       - name: cache-vcpkg
         id: cache-vcpkg
         uses: actions/cache@v2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,84 @@
+name: "CodeQL"
+
+on:
+  # Run the analysis once every 24 hours. The actual time does not matter
+  # that much, start with a time that allows for easier troubleshooting.
+  schedule:
+    - cron: '00 22 * * *'
+  push:
+    branches: ['ci-experiment-codeql']
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'cpp' ]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Checkout vcpkg
+        uses: actions/checkout@v2
+        with:
+          path: "build/vcpkg"
+          repository: "microsoft/vcpkg"
+          ref: "7e7bcf89171b7ed84ece845b1fa596a018e462f2"
+      - name: cache-vcpkg
+        id: cache-vcpkg
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cache/vcpkg
+            ~/.ccache
+          key: |
+            codeql-analysis-6-${{ hashFiles('vcpkg.json') }}-${{ hashFiles('build/vcpkg/versions/baseline.json') }}
+          restore-keys: |
+            codeql-analysis-
+      - name: install tools
+        run: sudo apt install ninja-build ccache
+      - name: bootstrap vcpkg
+        working-directory: "build/vcpkg"
+        run: |
+          CC="ccache gcc" CXX="ccache g++" ./bootstrap-vcpkg.sh -disableMetrics
+
+      # Compile the dependencies of `google-cloud-cpp` (if needed) before
+      # enabling the CodeQL scan, otherwise all the code in the deps would be
+      # scanned too. Note that most of the time this uses the vcpkg binary
+      # cache.
+      - name: bootstrap vcpkg packages
+        run: >
+          build/vcpkg/vcpkg install \
+            --x-manifest-root . \
+            --feature-flags=versions \
+            --clean-after-build
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v1
+        with:
+          languages: ${{ matrix.language }}
+
+      - name: Build
+        # The build configuration is specifically tweaked for CodeQL analysis:
+        #    - We disable the tests because I (coryan) think that any security
+        #      vulnerabilities in the tests are irrelevant *and* compiling with
+        #      the tests takes over 3h.
+        #    - We disable ccache because the CodeQL scan only scans the code
+        #      that is actually compiled. Any cached compilation would be
+        #      excluded from the DB
+        run: >
+          cmake -GNinja -S . -B build/output \
+            -DCMAKE_TOOLCHAIN_FILE=build/vcpkg/scripts/buildsystems/vcpkg.cmake \
+            -DBUILD_TESTING=OFF \
+            -DGOOGLE_CLOUD_CPP_ENABLE_CCACHE=OFF && \
+          cmake --build build/output
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v1

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -29,6 +29,9 @@ jobs:
         run: >
           GIT_SHA=$(<ci/etc/vcpkg-commit.txt);
           export GIT_SHA
+      - name: Debug vcpkg version
+        run: >
+          echo "GIT_SHA=${{env.GIT_SHA}}"
       - name: Checkout vcpkg
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -5,6 +5,8 @@ on:
   # that much, start with a time that allows for easier troubleshooting.
   schedule:
     - cron: '00 22 * * *'
+  push:
+    branches: ['ci-experiment-codeql']
 
 jobs:
   analyze:
@@ -23,12 +25,16 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
+      - name: Read vcpkg version
+        run: >
+          GIT_SHA=$(<ci/etc/vcpkg-commit.txt);
+          export GIT_SHA
       - name: Checkout vcpkg
         uses: actions/checkout@v2
         with:
           path: "build/vcpkg"
           repository: "microsoft/vcpkg"
-          ref: "7e7bcf89171b7ed84ece845b1fa596a018e462f2"
+          ref: "${{env.GIT_SHA}}"
       - name: cache-vcpkg
         id: cache-vcpkg
         uses: actions/cache@v2
@@ -51,32 +57,32 @@ jobs:
       # enabling the CodeQL scan, otherwise all the code in the deps would be
       # scanned too. Note that most of the time this uses the vcpkg binary
       # cache.
-      - name: bootstrap vcpkg packages
-        run: >
-          build/vcpkg/vcpkg install \
-            --x-manifest-root . \
-            --feature-flags=versions \
-            --clean-after-build
+#      - name: bootstrap vcpkg packages
+#        run: >
+#          build/vcpkg/vcpkg install \
+#            --x-manifest-root . \
+#            --feature-flags=versions \
+#            --clean-after-build
 
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@v1
-        with:
-          languages: ${{ matrix.language }}
-
-      - name: Build
-        # The build configuration is specifically tweaked for CodeQL analysis:
-        #    - We disable the tests because I (coryan) think that any security
-        #      vulnerabilities in the tests are irrelevant *and* compiling with
-        #      the tests takes over 3h.
-        #    - We disable ccache because the CodeQL scan only scans the code
-        #      that is actually compiled. Any cached compilation would be
-        #      excluded from the DB
-        run: >
-          cmake -GNinja -S . -B build/output \
-            -DCMAKE_TOOLCHAIN_FILE=build/vcpkg/scripts/buildsystems/vcpkg.cmake \
-            -DBUILD_TESTING=OFF \
-            -DGOOGLE_CLOUD_CPP_ENABLE_CCACHE=OFF && \
-          cmake --build build/output
-
-      - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v1
+#      - name: Initialize CodeQL
+#        uses: github/codeql-action/init@v1
+#        with:
+#          languages: ${{ matrix.language }}
+#
+#      - name: Build
+#        # The build configuration is specifically tweaked for CodeQL analysis:
+#        #    - We disable the tests because I (coryan) think that any security
+#        #      vulnerabilities in the tests are irrelevant *and* compiling with
+#        #      the tests takes over 3h.
+#        #    - We disable ccache because the CodeQL scan only scans the code
+#        #      that is actually compiled. Any cached compilation would be
+#        #      excluded from the DB
+#        run: >
+#          cmake -GNinja -S . -B build/output \
+#            -DCMAKE_TOOLCHAIN_FILE=build/vcpkg/scripts/buildsystems/vcpkg.cmake \
+#            -DBUILD_TESTING=OFF \
+#            -DGOOGLE_CLOUD_CPP_ENABLE_CCACHE=OFF && \
+#          cmake --build build/output
+#
+#      - name: Perform CodeQL Analysis
+#        uses: github/codeql-action/analyze@v1

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -25,19 +25,15 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
-      - name: Read vcpkg version
-        run: >
-          GIT_SHA=$(<ci/etc/vcpkg-commit.txt);
-          export GIT_SHA
-      - name: Debug vcpkg version
-        run: >
-          echo "GIT_SHA=${{env.GIT_SHA}}"
       - name: Checkout vcpkg
         uses: actions/checkout@v2
         with:
           path: "build/vcpkg"
           repository: "microsoft/vcpkg"
-          ref: "${{env.GIT_SHA}}"
+      - name: Read vcpkg version
+        run: >
+          cat ci/etc/vcpkg-commit.txt;
+          git -C build/vcpkg checkout $(<ci/etc/vcpkg-commit.txt);
       - name: cache-vcpkg
         id: cache-vcpkg
         uses: actions/cache@v2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -5,8 +5,6 @@ on:
   # that much, start with a time that allows for easier troubleshooting.
   schedule:
     - cron: '00 22 * * *'
-  push:
-    branches: ['ci-experiment-codeql']
 
 jobs:
   analyze:
@@ -56,32 +54,32 @@ jobs:
       # enabling the CodeQL scan, otherwise all the code in the deps would be
       # scanned too. Note that most of the time this uses the vcpkg binary
       # cache.
-#      - name: bootstrap vcpkg packages
-#        run: >
-#          build/vcpkg/vcpkg install \
-#            --x-manifest-root . \
-#            --feature-flags=versions \
-#            --clean-after-build
+      - name: bootstrap vcpkg packages
+        run: >
+          build/vcpkg/vcpkg install \
+            --x-manifest-root . \
+            --feature-flags=versions \
+            --clean-after-build
 
-#      - name: Initialize CodeQL
-#        uses: github/codeql-action/init@v1
-#        with:
-#          languages: ${{ matrix.language }}
-#
-#      - name: Build
-#        # The build configuration is specifically tweaked for CodeQL analysis:
-#        #    - We disable the tests because I (coryan) think that any security
-#        #      vulnerabilities in the tests are irrelevant *and* compiling with
-#        #      the tests takes over 3h.
-#        #    - We disable ccache because the CodeQL scan only scans the code
-#        #      that is actually compiled. Any cached compilation would be
-#        #      excluded from the DB
-#        run: >
-#          cmake -GNinja -S . -B build/output \
-#            -DCMAKE_TOOLCHAIN_FILE=build/vcpkg/scripts/buildsystems/vcpkg.cmake \
-#            -DBUILD_TESTING=OFF \
-#            -DGOOGLE_CLOUD_CPP_ENABLE_CCACHE=OFF && \
-#          cmake --build build/output
-#
-#      - name: Perform CodeQL Analysis
-#        uses: github/codeql-action/analyze@v1
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v1
+        with:
+          languages: ${{ matrix.language }}
+
+      - name: Build
+        # The build configuration is specifically tweaked for CodeQL analysis:
+        #    - We disable the tests because I (coryan) think that any security
+        #      vulnerabilities in the tests are irrelevant *and* compiling with
+        #      the tests takes over 3h.
+        #    - We disable ccache because the CodeQL scan only scans the code
+        #      that is actually compiled. Any cached compilation would be
+        #      excluded from the DB
+        run: >
+          cmake -GNinja -S . -B build/output \
+            -DCMAKE_TOOLCHAIN_FILE=build/vcpkg/scripts/buildsystems/vcpkg.cmake \
+            -DBUILD_TESTING=OFF \
+            -DGOOGLE_CLOUD_CPP_ENABLE_CCACHE=OFF && \
+          cmake --build build/output
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v1


### PR DESCRIPTION
This sets up a GitHub action to run the CodeQL security scans. It only
runs once a day because it is too slow for PRs. It is unclear if this is
useful (beyond bragging rights), but it is worth testing for a while.

Previous results (no alerts) visible at:

https://github.com/coryan/google-cloud-cpp/runs/3792838206?check_suite_focus=true
https://github.com/coryan/google-cloud-cpp/security/code-scanning

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7398)
<!-- Reviewable:end -->
