### PR TITLE
test(storage): special cleanup for requester pay

### DIFF
--- a/google/cloud/storage/testing/remove_stale_buckets.h
+++ b/google/cloud/storage/testing/remove_stale_buckets.h
@@ -25,7 +25,12 @@ namespace cloud {
 namespace storage {
 namespace testing {
 
-/// Remove a bucket, including any objects in it
+/// Remove a bucket, including any objects in it.
+Status RemoveBucketAndContents(
+    google::cloud::storage::Client client,
+    google::cloud::storage::BucketMetadata const& bucket);
+
+/// Remove a bucket, including any objects in it.
 Status RemoveBucketAndContents(google::cloud::storage::Client client,
                                std::string const& bucket_name);
 

--- a/google/cloud/storage/testing/remove_stale_buckets_test.cc
+++ b/google/cloud/storage/testing/remove_stale_buckets_test.cc
@@ -69,6 +69,9 @@ TEST(CleanupStaleBucketsTest, RemoveBucketContents) {
         response.items.push_back(CreateObject("baz", 1));
         return response;
       });
+  EXPECT_CALL(*mock, GetBucketMetadata)
+      .WillOnce(
+          Return(make_status_or(BucketMetadata{}.set_name("fake-bucket"))));
   auto client = internal::ClientImplDetails::CreateWithoutDecorations(mock);
   auto const actual = RemoveBucketAndContents(client, "fake-bucket");
   EXPECT_STATUS_OK(actual);

--- a/google/cloud/storage/testing/storage_integration_test.cc
+++ b/google/cloud/storage/testing/storage_integration_test.cc
@@ -17,6 +17,7 @@
 #include "google/cloud/storage/grpc_plugin.h"
 #endif  // GOOGLE_CLOUD_CPP_STORAGE_HAVE_GRPC
 #include "google/cloud/storage/testing/random_names.h"
+#include "google/cloud/storage/testing/remove_stale_buckets.h"
 #include "google/cloud/internal/getenv.h"
 
 namespace google {
@@ -48,7 +49,7 @@ StorageIntegrationTest::~StorageIntegrationTest() {
                                Generation(o.generation()));
   }
   for (auto& b : buckets_to_delete_) {
-    (void)client->DeleteBucket(b.name());
+    (void)RemoveBucketAndContents(*client, b);
   }
 }
 


### PR DESCRIPTION
Cleaning up any buckets with the `requester_pays==true` attribute
requires passing the `UserProject` option.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7399)
<!-- Reviewable:end -->
