### PR TITLE
test(storage): ignore RPO on insert

### DIFF
--- a/google/cloud/storage/tests/bucket_integration_test.cc
+++ b/google/cloud/storage/tests/bucket_integration_test.cc
@@ -104,6 +104,10 @@ TEST_F(BucketIntegrationTest, BasicCRUD) {
 
   StatusOr<BucketMetadata> get_meta = client->GetBucketMetadata(bucket_name);
   ASSERT_STATUS_OK(get_meta);
+  // TODO(#....) - the default RPO value is changing and the code is rolling
+  //     out.
+  insert_meta->set_rpo("");
+  get_meta->set_rpo("");
   EXPECT_EQ(*insert_meta, *get_meta);
 
   // Create a request to update the metadata, change the storage class because

--- a/google/cloud/storage/tests/bucket_integration_test.cc
+++ b/google/cloud/storage/tests/bucket_integration_test.cc
@@ -104,8 +104,7 @@ TEST_F(BucketIntegrationTest, BasicCRUD) {
 
   StatusOr<BucketMetadata> get_meta = client->GetBucketMetadata(bucket_name);
   ASSERT_STATUS_OK(get_meta);
-  // TODO(#....) - the default RPO value is changing and the code is rolling
-  //     out.
+  // TODO(#7403) - the default RPO value is changing during initial rollouts.
   insert_meta->set_rpo("");
   get_meta->set_rpo("");
   EXPECT_EQ(*insert_meta, *get_meta);


### PR DESCRIPTION
Seems like there is a rollout ongoing, which changes the default RPO
value returned for multi-region and dual-region buckets.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7401)
<!-- Reviewable:end -->
