### PR TITLE
fix(pubsub): do not overwrite ConnectionOptions

### DIFF
--- a/google/cloud/pubsub/internal/defaults.cc
+++ b/google/cloud/pubsub/internal/defaults.cc
@@ -85,8 +85,7 @@ Options DefaultCommonOptions(Options opts) {
 }
 
 Options DefaultPublisherOptions(Options opts) {
-  opts = DefaultPublisherOptionsOnly(std::move(opts));
-  return DefaultCommonOptions(std::move(opts));
+  return DefaultCommonOptions(DefaultPublisherOptionsOnly(std::move(opts)));
 }
 
 Options DefaultPublisherOptionsOnly(Options opts) {
@@ -119,8 +118,7 @@ Options DefaultPublisherOptionsOnly(Options opts) {
 }
 
 Options DefaultSubscriberOptions(Options opts) {
-  opts = DefaultSubscriberOptionsOnly(std::move(opts));
-  return DefaultCommonOptions(std::move(opts));
+  return DefaultCommonOptions(DefaultSubscriberOptionsOnly(std::move(opts)));
 }
 
 Options DefaultSubscriberOptionsOnly(Options opts) {

--- a/google/cloud/pubsub/internal/defaults.cc
+++ b/google/cloud/pubsub/internal/defaults.cc
@@ -85,6 +85,11 @@ Options DefaultCommonOptions(Options opts) {
 }
 
 Options DefaultPublisherOptions(Options opts) {
+  opts = DefaultPublisherOptionsOnly(std::move(opts));
+  return DefaultCommonOptions(std::move(opts));
+}
+
+Options DefaultPublisherOptionsOnly(Options opts) {
   if (!opts.has<pubsub::MaxHoldTimeOption>()) {
     opts.set<pubsub::MaxHoldTimeOption>(ms(10));
   }
@@ -110,10 +115,15 @@ Options DefaultPublisherOptions(Options opts) {
         pubsub::FullPublisherAction::kBlocks);
   }
 
-  return DefaultCommonOptions(std::move(opts));
+  return opts;
 }
 
 Options DefaultSubscriberOptions(Options opts) {
+  opts = DefaultSubscriberOptionsOnly(std::move(opts));
+  return DefaultCommonOptions(std::move(opts));
+}
+
+Options DefaultSubscriberOptionsOnly(Options opts) {
   if (!opts.has<pubsub::MaxDeadlineTimeOption>()) {
     opts.set<pubsub::MaxDeadlineTimeOption>(seconds(0));
   }
@@ -153,7 +163,7 @@ Options DefaultSubscriberOptions(Options opts) {
   auto& bytes = opts.lookup<pubsub::MaxOutstandingBytesOption>();
   bytes = std::max<std::int64_t>(0, bytes);
 
-  return DefaultCommonOptions(std::move(opts));
+  return opts;
 }
 
 }  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS

--- a/google/cloud/pubsub/internal/defaults.h
+++ b/google/cloud/pubsub/internal/defaults.h
@@ -29,7 +29,11 @@ Options DefaultCommonOptions(Options opts);
 
 Options DefaultPublisherOptions(Options opts);
 
+Options DefaultPublisherOptionsOnly(Options opts);
+
 Options DefaultSubscriberOptions(Options opts);
+
+Options DefaultSubscriberOptionsOnly(Options opts);
 
 }  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS
 }  // namespace pubsub_internal

--- a/google/cloud/pubsub/internal/defaults_test.cc
+++ b/google/cloud/pubsub/internal/defaults_test.cc
@@ -207,6 +207,55 @@ TEST(OptionsTest, UserSetSubscriberOptions) {
   EXPECT_EQ(6, opts.get<pubsub::MaxConcurrencyOption>());
 }
 
+TEST(OptionsTest, DefaultSubscriberOnly) {
+  // Ensure that we do not set common options
+  auto opts = DefaultSubscriberOptionsOnly(Options{});
+  EXPECT_FALSE(opts.has<GrpcCredentialOption>());
+  EXPECT_FALSE(opts.has<EndpointOption>());
+  EXPECT_FALSE(opts.has<GrpcCredentialOption>());
+  EXPECT_FALSE(opts.has<GrpcNumChannelsOption>());
+  EXPECT_FALSE(opts.has<TracingComponentsOption>());
+  EXPECT_FALSE(opts.has<GrpcTracingOptionsOption>());
+  EXPECT_FALSE(opts.has<pubsub::BackoffPolicyOption>());
+  EXPECT_FALSE(opts.has<GrpcBackgroundThreadPoolSizeOption>());
+  EXPECT_FALSE(opts.has<UserAgentProductsOption>());
+
+  // Ensure that we do set common options
+  opts = DefaultSubscriberOptions(Options{});
+  EXPECT_TRUE(opts.has<GrpcCredentialOption>());
+  EXPECT_TRUE(opts.has<EndpointOption>());
+  EXPECT_TRUE(opts.has<GrpcCredentialOption>());
+  EXPECT_TRUE(opts.has<GrpcNumChannelsOption>());
+  EXPECT_TRUE(opts.has<TracingComponentsOption>());
+  EXPECT_TRUE(opts.has<GrpcTracingOptionsOption>());
+  EXPECT_TRUE(opts.has<GrpcBackgroundThreadPoolSizeOption>());
+  EXPECT_TRUE(opts.has<UserAgentProductsOption>());
+}
+
+TEST(OptionsTest, DefaultPublisherOnly) {
+  // Ensure that we do not set common options
+  auto opts = DefaultPublisherOptionsOnly(Options{});
+  EXPECT_FALSE(opts.has<GrpcCredentialOption>());
+  EXPECT_FALSE(opts.has<EndpointOption>());
+  EXPECT_FALSE(opts.has<GrpcCredentialOption>());
+  EXPECT_FALSE(opts.has<GrpcNumChannelsOption>());
+  EXPECT_FALSE(opts.has<TracingComponentsOption>());
+  EXPECT_FALSE(opts.has<GrpcTracingOptionsOption>());
+  EXPECT_FALSE(opts.has<GrpcBackgroundThreadPoolSizeOption>());
+  EXPECT_FALSE(opts.has<UserAgentProductsOption>());
+
+  // Ensure that we do set common options
+  opts = DefaultPublisherOptions(Options{});
+  EXPECT_TRUE(opts.has<GrpcCredentialOption>());
+  EXPECT_TRUE(opts.has<EndpointOption>());
+  EXPECT_TRUE(opts.has<GrpcCredentialOption>());
+  EXPECT_TRUE(opts.has<GrpcNumChannelsOption>());
+  EXPECT_TRUE(opts.has<TracingComponentsOption>());
+  EXPECT_TRUE(opts.has<GrpcTracingOptionsOption>());
+  EXPECT_TRUE(opts.has<GrpcBackgroundThreadPoolSizeOption>());
+  EXPECT_TRUE(opts.has<UserAgentProductsOption>());
+}
+
 }  // namespace
 }  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS
 }  // namespace pubsub_internal

--- a/google/cloud/pubsub/publisher_options.cc
+++ b/google/cloud/pubsub/publisher_options.cc
@@ -22,7 +22,7 @@ inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
 
 PublisherOptions::PublisherOptions(Options opts) {
   internal::CheckExpectedOptions<PublisherOptionList>(opts, __func__);
-  opts_ = pubsub_internal::DefaultPublisherOptions(std::move(opts));
+  opts_ = pubsub_internal::DefaultPublisherOptionsOnly(std::move(opts));
 }
 
 }  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS

--- a/google/cloud/pubsub/publisher_options_test.cc
+++ b/google/cloud/pubsub/publisher_options_test.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/pubsub/publisher_options.h"
+#include "google/cloud/grpc_options.h"
 #include "google/cloud/testing_util/scoped_log.h"
 #include <gmock/gmock.h>
 
@@ -146,6 +147,9 @@ TEST(PublisherOptions, MakeOptions) {
   opts = pubsub_internal::MakeOptions(std::move(blocks));
   EXPECT_EQ(FullPublisherAction::kBlocks,
             opts.get<FullPublisherActionOption>());
+
+  // Ensure that we are not setting any extra options
+  EXPECT_FALSE(opts.has<GrpcCredentialOption>());
 }
 
 }  // namespace

--- a/google/cloud/pubsub/subscriber_options.cc
+++ b/google/cloud/pubsub/subscriber_options.cc
@@ -25,7 +25,7 @@ using seconds = std::chrono::seconds;
 
 SubscriberOptions::SubscriberOptions(Options opts) {
   internal::CheckExpectedOptions<SubscriberOptionList>(opts, __func__);
-  opts_ = pubsub_internal::DefaultSubscriberOptions(std::move(opts));
+  opts_ = pubsub_internal::DefaultSubscriberOptionsOnly(std::move(opts));
 }
 
 SubscriberOptions& SubscriberOptions::set_max_deadline_extension(

--- a/google/cloud/pubsub/subscriber_options_test.cc
+++ b/google/cloud/pubsub/subscriber_options_test.cc
@@ -14,6 +14,7 @@
 
 #include "google/cloud/pubsub/subscriber_options.h"
 #include "google/cloud/pubsub/options.h"
+#include "google/cloud/grpc_options.h"
 #include "google/cloud/testing_util/scoped_log.h"
 #include <gmock/gmock.h>
 #include <chrono>
@@ -112,6 +113,9 @@ TEST(SubscriberOptionsTest, MakeOptions) {
   EXPECT_EQ(4, opts.get<MaxOutstandingMessagesOption>());
   EXPECT_EQ(5, opts.get<MaxOutstandingBytesOption>());
   EXPECT_EQ(6, opts.get<MaxConcurrencyOption>());
+
+  // Ensure that we are not setting any extra options
+  EXPECT_FALSE(opts.has<GrpcCredentialOption>());
 }
 
 }  // namespace


### PR DESCRIPTION
When `PublisherOptions` is constructed, we default all options, including ones covered by `ConnectionOptions`, for example, `GrpcCredentialOption`.

https://github.com/googleapis/google-cloud-cpp/blob/c1a44cd759dcb0fd89293a558d759bdbb95c8f50/google/cloud/pubsub/publisher_options.cc#L25
https://github.com/googleapis/google-cloud-cpp/blob/c1a44cd759dcb0fd89293a558d759bdbb95c8f50/google/cloud/pubsub/internal/defaults.cc#L113

This means that when we merge options here ....
https://github.com/googleapis/google-cloud-cpp/blob/c1a44cd759dcb0fd89293a558d759bdbb95c8f50/google/cloud/pubsub/publisher_connection.cc#L94-L100
.... we try to merge user-set options contained in `ConnectionOptions` but ignore them because those options all have default values from `PublisherOptions`.

(I am saying we, but this is solely @dbolduc's fault)

This is a disaster if users try to authenticate with custom credentials passed to `ConnectionOptions`. Also, the same is true for the Subscriber version of things.

To fix the problem, I could have just switched the order of the merge so that the `PublisherOptions` are merged into the `ConnectionOptions`. But I decided it would be better (and easier to test) that `PublisherOptions` only defaults options from the `PublisherOptionList`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7406)
<!-- Reviewable:end -->
