### PR TITLE
test(GCS+gRPC): enable MD5 integration tests

### DIFF
--- a/google/cloud/storage/tests/object_hash_integration_test.cc
+++ b/google/cloud/storage/tests/object_hash_integration_test.cc
@@ -85,8 +85,6 @@ TEST_P(ObjectHashIntegrationTest, InsertObjectExplicitDisable) {
 
 /// @test Verify that MD5 hashes can be explicitly enabled in InsertObject().
 TEST_P(ObjectHashIntegrationTest, InsertObjectExplicitEnable) {
-  // TODO(#7257) - restore this test when production is fixed
-  if (!UsingEmulator() && UsingGrpc()) GTEST_SKIP();
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
   auto object_name = MakeRandomObjectName();
@@ -106,8 +104,6 @@ TEST_P(ObjectHashIntegrationTest, InsertObjectExplicitEnable) {
 
 /// @test Verify that valid MD5 hash values work in InsertObject().
 TEST_P(ObjectHashIntegrationTest, InsertObjectWithValueSuccess) {
-  // TODO(#7257) - restore this test when production is fixed
-  if (!UsingEmulator() && UsingGrpc()) GTEST_SKIP();
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
   auto object_name = MakeRandomObjectName();
@@ -184,8 +180,6 @@ TEST_F(ObjectHashIntegrationTest, WriteObjectExplicitDisable) {
 
 /// @test Verify that MD5 hashes can be explicitly enabled in WriteObject().
 TEST_F(ObjectHashIntegrationTest, WriteObjectExplicitEnable) {
-  // TODO(#7257) - restore this test when production is fixed
-  if (!UsingEmulator() && UsingGrpc()) GTEST_SKIP();
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
   auto object_name = MakeRandomObjectName();
@@ -208,8 +202,6 @@ TEST_F(ObjectHashIntegrationTest, WriteObjectExplicitEnable) {
 
 /// @test Verify that valid MD5 hash values work in WriteObject().
 TEST_F(ObjectHashIntegrationTest, WriteObjectWithValueSuccess) {
-  // TODO(#7257) - restore this test when production is fixed
-  if (!UsingEmulator() && UsingGrpc()) GTEST_SKIP();
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
   auto object_name = MakeRandomObjectName();

--- a/google/cloud/storage/tests/object_insert_integration_test.cc
+++ b/google/cloud/storage/tests/object_insert_integration_test.cc
@@ -145,8 +145,6 @@ TEST_P(ObjectInsertIntegrationTest, MultipartInsertWithNonUrlSafeName) {
 }
 
 TEST_P(ObjectInsertIntegrationTest, InsertWithMD5) {
-  // TODO(#7257) - restore this test when production is fixed
-  if (!UsingEmulator() && UsingGrpc()) GTEST_SKIP();
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
@@ -170,8 +168,6 @@ TEST_P(ObjectInsertIntegrationTest, InsertWithMD5) {
 }
 
 TEST_P(ObjectInsertIntegrationTest, InsertWithComputedMD5) {
-  // TODO(#7257) - restore this test when production is fixed
-  if (!UsingEmulator() && UsingGrpc()) GTEST_SKIP();
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
@@ -195,8 +191,6 @@ TEST_P(ObjectInsertIntegrationTest, InsertWithComputedMD5) {
 }
 
 TEST_P(ObjectInsertIntegrationTest, XmlInsertWithMD5) {
-  // TODO(#7257) - restore this test when production is fixed
-  if (!UsingEmulator() && UsingGrpc()) GTEST_SKIP();
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 


### PR DESCRIPTION
Now that the fixes to support MD5 have rolled out we can enable the
integration tests against production once again.

Part of the work for #7257

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7412)
<!-- Reviewable:end -->
