### PR TITLE
refactor: common set up for auth mocks

### DIFF
--- a/generator/integration_tests/golden/tests/golden_kitchen_sink_auth_decorator_test.cc
+++ b/generator/integration_tests/golden/tests/golden_kitchen_sink_auth_decorator_test.cc
@@ -27,25 +27,10 @@ namespace golden_internal {
 inline namespace GOOGLE_CLOUD_CPP_GENERATED_NS {
 namespace {
 
-using ::google::cloud::internal::GrpcAuthenticationStrategy;
 using ::google::cloud::internal::StreamingReadRpcError;
-using ::google::cloud::testing_util::MockAuthenticationStrategy;
+using ::google::cloud::testing_util::MakeTypicalMockAuth;
 using ::google::cloud::testing_util::StatusIs;
 using ::testing::IsNull;
-
-std::shared_ptr<GrpcAuthenticationStrategy> MakeMockAuth() {
-  auto auth = std::make_shared<MockAuthenticationStrategy>();
-  EXPECT_CALL(*auth, ConfigureContext)
-      .WillOnce([](grpc::ClientContext&) {
-        return Status(StatusCode::kInvalidArgument, "cannot-set-credentials");
-      })
-      .WillOnce([](grpc::ClientContext& context) {
-        context.set_credentials(
-            grpc::AccessTokenCredentials("test-only-invalid"));
-        return Status{};
-      });
-  return auth;
-}
 
 // The general pattern of these test is to make two requests, both of which
 // return an error. The first one because the auth strategy fails, the second
@@ -57,7 +42,7 @@ TEST(GoldenKitchenSinkAuthDecoratorTest, GenerateAccessToken) {
       .WillOnce(
           ::testing::Return(Status(StatusCode::kPermissionDenied, "uh-oh")));
 
-  auto under_test = GoldenKitchenSinkAuth(MakeMockAuth(), mock);
+  auto under_test = GoldenKitchenSinkAuth(MakeTypicalMockAuth(), mock);
   ::google::test::admin::database::v1::GenerateAccessTokenRequest request;
   grpc::ClientContext ctx;
   auto auth_failure = under_test.GenerateAccessToken(ctx, request);
@@ -75,7 +60,7 @@ TEST(GoldenKitchenSinkAuthDecoratorTest, GenerateIdToken) {
       .WillOnce(
           ::testing::Return(Status(StatusCode::kPermissionDenied, "uh-oh")));
 
-  auto under_test = GoldenKitchenSinkAuth(MakeMockAuth(), mock);
+  auto under_test = GoldenKitchenSinkAuth(MakeTypicalMockAuth(), mock);
   ::google::test::admin::database::v1::GenerateIdTokenRequest request;
   grpc::ClientContext ctx;
   auto auth_failure = under_test.GenerateIdToken(ctx, request);
@@ -93,7 +78,7 @@ TEST(GoldenKitchenSinkAuthDecoratorTest, WriteLogEntries) {
       .WillOnce(
           ::testing::Return(Status(StatusCode::kPermissionDenied, "uh-oh")));
 
-  auto under_test = GoldenKitchenSinkAuth(MakeMockAuth(), mock);
+  auto under_test = GoldenKitchenSinkAuth(MakeTypicalMockAuth(), mock);
   ::google::test::admin::database::v1::WriteLogEntriesRequest request;
   grpc::ClientContext ctx;
   auto auth_failure = under_test.WriteLogEntries(ctx, request);
@@ -111,7 +96,7 @@ TEST(GoldenKitchenSinkAuthDecoratorTest, ListLogs) {
       .WillOnce(
           ::testing::Return(Status(StatusCode::kPermissionDenied, "uh-oh")));
 
-  auto under_test = GoldenKitchenSinkAuth(MakeMockAuth(), mock);
+  auto under_test = GoldenKitchenSinkAuth(MakeTypicalMockAuth(), mock);
   ::google::test::admin::database::v1::ListLogsRequest request;
   grpc::ClientContext ctx;
   auto auth_failure = under_test.ListLogs(ctx, request);
@@ -134,7 +119,7 @@ TEST(GoldenKitchenSinkAuthDecoratorTest, TailLogEntries) {
             Status(StatusCode::kPermissionDenied, "uh-oh"));
       });
 
-  auto under_test = GoldenKitchenSinkAuth(MakeMockAuth(), mock);
+  auto under_test = GoldenKitchenSinkAuth(MakeTypicalMockAuth(), mock);
   ::google::test::admin::database::v1::TailLogEntriesRequest request;
   grpc::ClientContext ctx;
   auto auth_failure = under_test.TailLogEntries(
@@ -156,7 +141,7 @@ TEST(GoldenKitchenSinkAuthDecoratorTest, ListServiceAccountKeys) {
       .WillOnce(
           ::testing::Return(Status(StatusCode::kPermissionDenied, "uh-oh")));
 
-  auto under_test = GoldenKitchenSinkAuth(MakeMockAuth(), mock);
+  auto under_test = GoldenKitchenSinkAuth(MakeTypicalMockAuth(), mock);
   ::google::test::admin::database::v1::ListServiceAccountKeysRequest request;
   grpc::ClientContext ctx;
   auto auth_failure = under_test.ListServiceAccountKeys(ctx, request);

--- a/generator/integration_tests/golden/tests/golden_thing_admin_auth_decorator_test.cc
+++ b/generator/integration_tests/golden/tests/golden_thing_admin_auth_decorator_test.cc
@@ -25,43 +25,13 @@ namespace golden_internal {
 inline namespace GOOGLE_CLOUD_CPP_GENERATED_NS {
 namespace {
 
-using ::google::cloud::internal::GrpcAuthenticationStrategy;
-using ::google::cloud::testing_util::MockAuthenticationStrategy;
+using ::google::cloud::testing_util::MakeTypicalAsyncMockAuth;
+using ::google::cloud::testing_util::MakeTypicalMockAuth;
 using ::google::cloud::testing_util::StatusIs;
 using ::testing::ByMove;
 using ::testing::IsNull;
 using ::testing::Return;
 using ::testing::Unused;
-
-std::shared_ptr<GrpcAuthenticationStrategy> MakeAsyncMockAuth() {
-  using ReturnType = StatusOr<std::unique_ptr<grpc::ClientContext>>;
-  auto auth = std::make_shared<MockAuthenticationStrategy>();
-  EXPECT_CALL(*auth, AsyncConfigureContext)
-      .WillOnce([](std::unique_ptr<grpc::ClientContext>) {
-        return make_ready_future(ReturnType(
-            Status(StatusCode::kInvalidArgument, "cannot-set-credentials")));
-      })
-      .WillOnce([](std::unique_ptr<grpc::ClientContext> context) {
-        context->set_credentials(
-            grpc::AccessTokenCredentials("test-only-invalid"));
-        return make_ready_future(make_status_or(std::move(context)));
-      });
-  return auth;
-}
-
-std::shared_ptr<GrpcAuthenticationStrategy> MakeMockAuth() {
-  auto auth = std::make_shared<MockAuthenticationStrategy>();
-  EXPECT_CALL(*auth, ConfigureContext)
-      .WillOnce([](grpc::ClientContext&) {
-        return Status(StatusCode::kInvalidArgument, "cannot-set-credentials");
-      })
-      .WillOnce([](grpc::ClientContext& context) {
-        context.set_credentials(
-            grpc::AccessTokenCredentials("test-only-invalid"));
-        return Status{};
-      });
-  return auth;
-}
 
 future<StatusOr<google::longrunning::Operation>> LongrunningError(Unused,
                                                                   Unused,
@@ -79,7 +49,7 @@ TEST(GoldenThingAdminAuthDecoratorTest, ListDatabases) {
   EXPECT_CALL(*mock, ListDatabases)
       .WillOnce(Return(Status(StatusCode::kPermissionDenied, "uh-oh")));
 
-  auto under_test = GoldenThingAdminAuth(MakeMockAuth(), mock);
+  auto under_test = GoldenThingAdminAuth(MakeTypicalMockAuth(), mock);
   google::test::admin::database::v1::ListDatabasesRequest request;
   grpc::ClientContext ctx;
   auto auth_failure = under_test.ListDatabases(ctx, request);
@@ -95,7 +65,7 @@ TEST(GoldenThingAdminAuthDecoratorTest, AsyncCreateDatabase) {
   auto mock = std::make_shared<MockGoldenThingAdminStub>();
   EXPECT_CALL(*mock, AsyncCreateDatabase).WillOnce(LongrunningError);
 
-  auto under_test = GoldenThingAdminAuth(MakeAsyncMockAuth(), mock);
+  auto under_test = GoldenThingAdminAuth(MakeTypicalAsyncMockAuth(), mock);
   google::test::admin::database::v1::CreateDatabaseRequest request;
   CompletionQueue cq;
   auto auth_failure = under_test.AsyncCreateDatabase(
@@ -112,7 +82,7 @@ TEST(GoldenThingAdminAuthDecoratorTest, GetDatabase) {
   EXPECT_CALL(*mock, GetDatabase)
       .WillOnce(Return(Status(StatusCode::kPermissionDenied, "uh-oh")));
 
-  auto under_test = GoldenThingAdminAuth(MakeMockAuth(), mock);
+  auto under_test = GoldenThingAdminAuth(MakeTypicalMockAuth(), mock);
   google::test::admin::database::v1::GetDatabaseRequest request;
   grpc::ClientContext ctx;
   auto auth_failure = under_test.GetDatabase(ctx, request);
@@ -128,7 +98,7 @@ TEST(GoldenThingAdminAuthDecoratorTest, AsyncUpdateDatabaseDdl) {
   auto mock = std::make_shared<MockGoldenThingAdminStub>();
   EXPECT_CALL(*mock, AsyncUpdateDatabaseDdl).WillOnce(LongrunningError);
 
-  auto under_test = GoldenThingAdminAuth(MakeAsyncMockAuth(), mock);
+  auto under_test = GoldenThingAdminAuth(MakeTypicalAsyncMockAuth(), mock);
   google::test::admin::database::v1::UpdateDatabaseDdlRequest request;
   CompletionQueue cq;
   auto auth_failure = under_test.AsyncUpdateDatabaseDdl(
@@ -145,7 +115,7 @@ TEST(GoldenThingAdminAuthDecoratorTest, DropDatabase) {
   EXPECT_CALL(*mock, DropDatabase)
       .WillOnce(Return(Status(StatusCode::kPermissionDenied, "uh-oh")));
 
-  auto under_test = GoldenThingAdminAuth(MakeMockAuth(), mock);
+  auto under_test = GoldenThingAdminAuth(MakeTypicalMockAuth(), mock);
   google::test::admin::database::v1::DropDatabaseRequest request;
   grpc::ClientContext ctx;
   auto auth_failure = under_test.DropDatabase(ctx, request);
@@ -162,7 +132,7 @@ TEST(GoldenThingAdminAuthDecoratorTest, GetDatabaseDdl) {
   EXPECT_CALL(*mock, GetDatabaseDdl)
       .WillOnce(Return(Status(StatusCode::kPermissionDenied, "uh-oh")));
 
-  auto under_test = GoldenThingAdminAuth(MakeMockAuth(), mock);
+  auto under_test = GoldenThingAdminAuth(MakeTypicalMockAuth(), mock);
   google::test::admin::database::v1::GetDatabaseDdlRequest request;
   grpc::ClientContext ctx;
   auto auth_failure = under_test.GetDatabaseDdl(ctx, request);
@@ -179,7 +149,7 @@ TEST(GoldenThingAdminAuthDecoratorTest, SetIamPolicy) {
   EXPECT_CALL(*mock, SetIamPolicy)
       .WillOnce(Return(Status(StatusCode::kPermissionDenied, "uh-oh")));
 
-  auto under_test = GoldenThingAdminAuth(MakeMockAuth(), mock);
+  auto under_test = GoldenThingAdminAuth(MakeTypicalMockAuth(), mock);
   google::iam::v1::SetIamPolicyRequest request;
   grpc::ClientContext ctx;
   auto auth_failure = under_test.SetIamPolicy(ctx, request);
@@ -196,7 +166,7 @@ TEST(GoldenThingAdminAuthDecoratorTest, GetIamPolicy) {
   EXPECT_CALL(*mock, GetIamPolicy)
       .WillOnce(Return(Status(StatusCode::kPermissionDenied, "uh-oh")));
 
-  auto under_test = GoldenThingAdminAuth(MakeMockAuth(), mock);
+  auto under_test = GoldenThingAdminAuth(MakeTypicalMockAuth(), mock);
   google::iam::v1::GetIamPolicyRequest request;
   grpc::ClientContext ctx;
   auto auth_failure = under_test.GetIamPolicy(ctx, request);
@@ -213,7 +183,7 @@ TEST(GoldenThingAdminAuthDecoratorTest, TestIamPermissions) {
   EXPECT_CALL(*mock, TestIamPermissions)
       .WillOnce(Return(Status(StatusCode::kPermissionDenied, "uh-oh")));
 
-  auto under_test = GoldenThingAdminAuth(MakeMockAuth(), mock);
+  auto under_test = GoldenThingAdminAuth(MakeTypicalMockAuth(), mock);
   google::iam::v1::TestIamPermissionsRequest request;
   grpc::ClientContext ctx;
   auto auth_failure = under_test.TestIamPermissions(ctx, request);
@@ -229,7 +199,7 @@ TEST(GoldenThingAdminAuthDecoratorTest, AsyncCreateBackup) {
   auto mock = std::make_shared<MockGoldenThingAdminStub>();
   EXPECT_CALL(*mock, AsyncCreateBackup).WillOnce(LongrunningError);
 
-  auto under_test = GoldenThingAdminAuth(MakeAsyncMockAuth(), mock);
+  auto under_test = GoldenThingAdminAuth(MakeTypicalAsyncMockAuth(), mock);
   google::test::admin::database::v1::CreateBackupRequest request;
   CompletionQueue cq;
   auto auth_failure = under_test.AsyncCreateBackup(
@@ -246,7 +216,7 @@ TEST(GoldenThingAdminAuthDecoratorTest, GetBackup) {
   EXPECT_CALL(*mock, GetBackup)
       .WillOnce(Return(Status(StatusCode::kPermissionDenied, "uh-oh")));
 
-  auto under_test = GoldenThingAdminAuth(MakeMockAuth(), mock);
+  auto under_test = GoldenThingAdminAuth(MakeTypicalMockAuth(), mock);
   google::test::admin::database::v1::GetBackupRequest request;
   grpc::ClientContext ctx;
   auto auth_failure = under_test.GetBackup(ctx, request);
@@ -263,7 +233,7 @@ TEST(GoldenThingAdminAuthDecoratorTest, UpdateBackup) {
   EXPECT_CALL(*mock, UpdateBackup)
       .WillOnce(Return(Status(StatusCode::kPermissionDenied, "uh-oh")));
 
-  auto under_test = GoldenThingAdminAuth(MakeMockAuth(), mock);
+  auto under_test = GoldenThingAdminAuth(MakeTypicalMockAuth(), mock);
   google::test::admin::database::v1::UpdateBackupRequest request;
   grpc::ClientContext ctx;
   auto auth_failure = under_test.UpdateBackup(ctx, request);
@@ -280,7 +250,7 @@ TEST(GoldenThingAdminAuthDecoratorTest, DeleteBackup) {
   EXPECT_CALL(*mock, DeleteBackup)
       .WillOnce(Return(Status(StatusCode::kPermissionDenied, "uh-oh")));
 
-  auto under_test = GoldenThingAdminAuth(MakeMockAuth(), mock);
+  auto under_test = GoldenThingAdminAuth(MakeTypicalMockAuth(), mock);
   google::test::admin::database::v1::DeleteBackupRequest request;
   grpc::ClientContext ctx;
   auto auth_failure = under_test.DeleteBackup(ctx, request);
@@ -297,7 +267,7 @@ TEST(GoldenThingAdminAuthDecoratorTest, ListBackups) {
   EXPECT_CALL(*mock, ListBackups)
       .WillOnce(Return(Status(StatusCode::kPermissionDenied, "uh-oh")));
 
-  auto under_test = GoldenThingAdminAuth(MakeMockAuth(), mock);
+  auto under_test = GoldenThingAdminAuth(MakeTypicalMockAuth(), mock);
   google::test::admin::database::v1::ListBackupsRequest request;
   grpc::ClientContext ctx;
   auto auth_failure = under_test.ListBackups(ctx, request);
@@ -313,7 +283,7 @@ TEST(GoldenThingAdminAuthDecoratorTest, AsyncRestoreDatabase) {
   auto mock = std::make_shared<MockGoldenThingAdminStub>();
   EXPECT_CALL(*mock, AsyncRestoreDatabase).WillOnce(LongrunningError);
 
-  auto under_test = GoldenThingAdminAuth(MakeAsyncMockAuth(), mock);
+  auto under_test = GoldenThingAdminAuth(MakeTypicalAsyncMockAuth(), mock);
   google::test::admin::database::v1::RestoreDatabaseRequest request;
   CompletionQueue cq;
   auto auth_failure = under_test.AsyncRestoreDatabase(
@@ -330,7 +300,7 @@ TEST(GoldenThingAdminAuthDecoratorTest, ListDatabaseOperations) {
   EXPECT_CALL(*mock, ListDatabaseOperations)
       .WillOnce(Return(Status(StatusCode::kPermissionDenied, "uh-oh")));
 
-  auto under_test = GoldenThingAdminAuth(MakeMockAuth(), mock);
+  auto under_test = GoldenThingAdminAuth(MakeTypicalMockAuth(), mock);
   google::test::admin::database::v1::ListDatabaseOperationsRequest request;
   grpc::ClientContext ctx;
   auto auth_failure = under_test.ListDatabaseOperations(ctx, request);
@@ -347,7 +317,7 @@ TEST(GoldenThingAdminAuthDecoratorTest, ListBackupOperations) {
   EXPECT_CALL(*mock, ListBackupOperations)
       .WillOnce(Return(Status(StatusCode::kPermissionDenied, "uh-oh")));
 
-  auto under_test = GoldenThingAdminAuth(MakeMockAuth(), mock);
+  auto under_test = GoldenThingAdminAuth(MakeTypicalMockAuth(), mock);
   google::test::admin::database::v1::ListBackupOperationsRequest request;
   grpc::ClientContext ctx;
   auto auth_failure = under_test.ListBackupOperations(ctx, request);
@@ -363,7 +333,7 @@ TEST(GoldenThingAdminAuthDecoratorTest, AsyncGetOperation) {
   auto mock = std::make_shared<MockGoldenThingAdminStub>();
   EXPECT_CALL(*mock, AsyncGetOperation).WillOnce(LongrunningError);
 
-  auto under_test = GoldenThingAdminAuth(MakeAsyncMockAuth(), mock);
+  auto under_test = GoldenThingAdminAuth(MakeTypicalAsyncMockAuth(), mock);
   google::longrunning::GetOperationRequest request;
   CompletionQueue cq;
   auto auth_failure = under_test.AsyncGetOperation(
@@ -381,7 +351,7 @@ TEST(GoldenThingAdminAuthDecoratorTest, AsyncCancelOperation) {
       .WillOnce(Return(ByMove(
           make_ready_future(Status{StatusCode::kPermissionDenied, "uh-oh"}))));
 
-  auto under_test = GoldenThingAdminAuth(MakeAsyncMockAuth(), mock);
+  auto under_test = GoldenThingAdminAuth(MakeTypicalAsyncMockAuth(), mock);
   google::longrunning::CancelOperationRequest request;
   CompletionQueue cq;
   auto auth_failure = under_test.AsyncCancelOperation(

--- a/google/cloud/testing_util/CMakeLists.txt
+++ b/google/cloud/testing_util/CMakeLists.txt
@@ -102,6 +102,7 @@ if (BUILD_TESTING)
         is_proto_equal.h
         mock_async_response_reader.h
         mock_completion_queue_impl.h
+        mock_grpc_authentication_strategy.cc
         mock_grpc_authentication_strategy.h
         validate_metadata.cc
         validate_metadata.h)

--- a/google/cloud/testing_util/google_cloud_cpp_testing_grpc.bzl
+++ b/google/cloud/testing_util/google_cloud_cpp_testing_grpc.bzl
@@ -28,5 +28,6 @@ google_cloud_cpp_testing_grpc_hdrs = [
 google_cloud_cpp_testing_grpc_srcs = [
     "fake_completion_queue_impl.cc",
     "is_proto_equal.cc",
+    "mock_grpc_authentication_strategy.cc",
     "validate_metadata.cc",
 ]

--- a/google/cloud/testing_util/mock_grpc_authentication_strategy.cc
+++ b/google/cloud/testing_util/mock_grpc_authentication_strategy.cc
@@ -1,0 +1,56 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/testing_util/mock_grpc_authentication_strategy.h"
+#include <grpcpp/grpcpp.h>
+
+namespace google {
+namespace cloud {
+inline namespace GOOGLE_CLOUD_CPP_NS {
+namespace testing_util {
+
+std::shared_ptr<MockAuthenticationStrategy> MakeTypicalMockAuth() {
+  auto auth = std::make_shared<MockAuthenticationStrategy>();
+  EXPECT_CALL(*auth, ConfigureContext)
+      .WillOnce([](grpc::ClientContext&) {
+        return Status(StatusCode::kInvalidArgument, "cannot-set-credentials");
+      })
+      .WillOnce([](grpc::ClientContext& context) {
+        context.set_credentials(
+            grpc::AccessTokenCredentials("test-only-invalid"));
+        return Status{};
+      });
+  return auth;
+}
+
+std::shared_ptr<MockAuthenticationStrategy> MakeTypicalAsyncMockAuth() {
+  using ReturnType = StatusOr<std::unique_ptr<grpc::ClientContext>>;
+  auto auth = std::make_shared<MockAuthenticationStrategy>();
+  EXPECT_CALL(*auth, AsyncConfigureContext)
+      .WillOnce([](std::unique_ptr<grpc::ClientContext>) {
+        return make_ready_future(ReturnType(
+            Status(StatusCode::kInvalidArgument, "cannot-set-credentials")));
+      })
+      .WillOnce([](std::unique_ptr<grpc::ClientContext> context) {
+        context->set_credentials(
+            grpc::AccessTokenCredentials("test-only-invalid"));
+        return make_ready_future(make_status_or(std::move(context)));
+      });
+  return auth;
+}
+
+}  // namespace testing_util
+}  // namespace GOOGLE_CLOUD_CPP_NS
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/testing_util/mock_grpc_authentication_strategy.h
+++ b/google/cloud/testing_util/mock_grpc_authentication_strategy.h
@@ -35,6 +35,27 @@ class MockAuthenticationStrategy
               (override));
 };
 
+/**
+ * Create and set expectations a mock authentication strategy.
+ *
+ * Many of our tests initialize a MockAuthenticationStrategy and set up the same
+ * expectations, namely that the test will use the strategy twice, and the
+ * first time it will fail with `kInvalidArgument`, while the second time
+ * will set the call credentials in the client context.
+ *
+ * This function refactors that set up so we don't have to cut&paste it in too
+ * many tests.
+ */
+std::shared_ptr<MockAuthenticationStrategy> MakeTypicalMockAuth();
+
+/**
+ * Create and set expectations a mock authentication strategy.
+ *
+ * Like MakeTypicalMockAuth() but set the expectations for an asynchronous
+ * request.
+ */
+std::shared_ptr<MockAuthenticationStrategy> MakeTypicalAsyncMockAuth();
+
 }  // namespace testing_util
 }  // namespace GOOGLE_CLOUD_CPP_NS
 }  // namespace cloud


### PR DESCRIPTION
Our tests for the `*Auth` decorators tend to have the same structure,
and use the same set up, for the `GrpcAuthenticationStrategy` mock. This
change refactors the functions to create and initialize these mocks. I
am going to need them in the changes for Cloud Pub/Sub.

I think this will help with #6463 and similar changes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7421)
<!-- Reviewable:end -->
