### PR TITLE
test(GCS+gRPC): disable all production tests

### DIFF
--- a/ci/cloudbuild/builds/gcs-grpc.sh
+++ b/ci/cloudbuild/builds/gcs-grpc.sh
@@ -33,6 +33,7 @@ mapfile -t args < <(bazel::common_args)
 # Run as many of the integration tests as possible using production and gRPC:
 # "media" says to use the hybrid gRPC/REST client. For more details see
 # https://github.com/googleapis/google-cloud-cpp/issues/6268
-readonly GOOGLE_CLOUD_CPP_STORAGE_GRPC_CONFIG=media
+# TODO(#7257) - cleanup once production is fixed (again)
+#    readonly GOOGLE_CLOUD_CPP_STORAGE_GRPC_CONFIG=media
 mapfile -t integration_args < <(integration::bazel_args)
 bazel test "${args[@]}" "${integration_args[@]}" -- //google/cloud/storage/... "${excluded_rules[@]}"

--- a/google/cloud/storage/tests/grpc_integration_test.cc
+++ b/google/cloud/storage/tests/grpc_integration_test.cc
@@ -256,7 +256,7 @@ TEST_P(GrpcIntegrationTest, FieldFilter) {
 }
 
 INSTANTIATE_TEST_SUITE_P(GrpcIntegrationMediaTest, GrpcIntegrationTest,
-                         ::testing::Values("media"));
+                         ::testing::Values("none"));
 
 }  // namespace
 }  // namespace internal


### PR DESCRIPTION
GCS+gRPC just announced they will make incompatible changes before GA. I
am preemptively disabling all tests before things break.

Will need to undo these changes as part of #7257

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7424)
<!-- Reviewable:end -->
