### PR TITLE
cleanup(pubsub): rename factory functions for *Connection tests

### DIFF
--- a/google/cloud/pubsub/publisher_connection.cc
+++ b/google/cloud/pubsub/publisher_connection.cc
@@ -169,7 +169,7 @@ std::shared_ptr<PublisherConnection> MakePublisherConnection(
 namespace pubsub_internal {
 inline namespace GOOGLE_CLOUD_CPP_NS {
 
-std::shared_ptr<pubsub::PublisherConnection> MakePublisherConnection(
+std::shared_ptr<pubsub::PublisherConnection> MakeTestPublisherConnection(
     pubsub::Topic topic, Options opts,
     std::vector<std::shared_ptr<PublisherStub>> stubs) {
   auto background = internal::MakeBackgroundThreadsFactory(opts)();

--- a/google/cloud/pubsub/publisher_connection.h
+++ b/google/cloud/pubsub/publisher_connection.h
@@ -164,7 +164,7 @@ std::shared_ptr<PublisherConnection> MakePublisherConnection(
 namespace pubsub_internal {
 inline namespace GOOGLE_CLOUD_CPP_NS {
 
-std::shared_ptr<pubsub::PublisherConnection> MakePublisherConnection(
+std::shared_ptr<pubsub::PublisherConnection> MakeTestPublisherConnection(
     pubsub::Topic topic, Options opts,
     std::vector<std::shared_ptr<PublisherStub>> stubs);
 

--- a/google/cloud/pubsub/publisher_connection_test.cc
+++ b/google/cloud/pubsub/publisher_connection_test.cc
@@ -42,7 +42,7 @@ std::shared_ptr<PublisherConnection> MakeTestPublisherConnection(
     Options opts = {}) {
   opts = pubsub_internal::DefaultPublisherOptions(
       pubsub_testing::MakeTestOptions(std::move(opts)));
-  return pubsub_internal::MakePublisherConnection(
+  return pubsub_internal::MakeTestPublisherConnection(
       std::move(topic), std::move(opts), {std::move(mock)});
 }
 

--- a/google/cloud/pubsub/schema_admin_connection.cc
+++ b/google/cloud/pubsub/schema_admin_connection.cc
@@ -206,11 +206,11 @@ std::shared_ptr<SchemaAdminConnection> MakeSchemaAdminConnection(
 namespace pubsub_internal {
 inline namespace GOOGLE_CLOUD_CPP_NS {
 
-std::shared_ptr<pubsub::SchemaAdminConnection> MakeSchemaAdminConnection(
+std::shared_ptr<pubsub::SchemaAdminConnection> MakeTestSchemaAdminConnection(
     Options const& opts, std::shared_ptr<SchemaStub> stub) {
   auto background = internal::MakeBackgroundThreadsFactory(opts)();
   auto auth = google::cloud::internal::CreateAuthenticationStrategy(
-      google::cloud::MakeInsecureCredentials(), background->cq(), opts);
+      background->cq(), opts);
   stub =
       pubsub::DecorateSchemaAdminStub(opts, std::move(auth), std::move(stub));
   return std::make_shared<pubsub::SchemaAdminConnectionImpl>(

--- a/google/cloud/pubsub/schema_admin_connection.h
+++ b/google/cloud/pubsub/schema_admin_connection.h
@@ -172,7 +172,7 @@ std::shared_ptr<SchemaAdminConnection> MakeSchemaAdminConnection(
 namespace pubsub_internal {
 inline namespace GOOGLE_CLOUD_CPP_NS {
 
-std::shared_ptr<pubsub::SchemaAdminConnection> MakeSchemaAdminConnection(
+std::shared_ptr<pubsub::SchemaAdminConnection> MakeTestSchemaAdminConnection(
     Options const& opts, std::shared_ptr<SchemaStub> stub);
 
 }  // namespace GOOGLE_CLOUD_CPP_NS

--- a/google/cloud/pubsub/schema_admin_connection_test.cc
+++ b/google/cloud/pubsub/schema_admin_connection_test.cc
@@ -43,8 +43,8 @@ std::shared_ptr<SchemaAdminConnection> MakeTestSchemaAdminConnection(
     std::shared_ptr<pubsub_internal::SchemaStub> mock, Options opts = {}) {
   opts = pubsub_internal::DefaultCommonOptions(
       pubsub_testing::MakeTestOptions(std::move(opts)));
-  return pubsub_internal::MakeSchemaAdminConnection(std::move(opts),
-                                                    std::move(mock));
+  return pubsub_internal::MakeTestSchemaAdminConnection(std::move(opts),
+                                                        std::move(mock));
 }
 
 TEST(SchemaAdminConnectionTest, Create) {

--- a/google/cloud/pubsub/subscriber_connection.cc
+++ b/google/cloud/pubsub/subscriber_connection.cc
@@ -148,7 +148,7 @@ std::shared_ptr<SubscriberConnection> MakeSubscriberConnection(
 namespace pubsub_internal {
 inline namespace GOOGLE_CLOUD_CPP_NS {
 
-std::shared_ptr<pubsub::SubscriberConnection> MakeSubscriberConnection(
+std::shared_ptr<pubsub::SubscriberConnection> MakeTestSubscriberConnection(
     pubsub::Subscription subscription, Options opts,
     std::vector<std::shared_ptr<SubscriberStub>> stubs) {
   auto background = internal::MakeBackgroundThreadsFactory(opts)();

--- a/google/cloud/pubsub/subscriber_connection.h
+++ b/google/cloud/pubsub/subscriber_connection.h
@@ -161,7 +161,7 @@ std::shared_ptr<SubscriberConnection> MakeSubscriberConnection(
 namespace pubsub_internal {
 inline namespace GOOGLE_CLOUD_CPP_NS {
 
-std::shared_ptr<pubsub::SubscriberConnection> MakeSubscriberConnection(
+std::shared_ptr<pubsub::SubscriberConnection> MakeTestSubscriberConnection(
     pubsub::Subscription subscription, Options opts,
     std::vector<std::shared_ptr<SubscriberStub>> stubs);
 

--- a/google/cloud/pubsub/subscriber_connection_test.cc
+++ b/google/cloud/pubsub/subscriber_connection_test.cc
@@ -46,8 +46,8 @@ std::shared_ptr<SubscriberConnection> MakeTestSubscriberConnection(
       pubsub_testing::MakeTestOptions(std::move(opts)));
   std::vector<std::shared_ptr<pubsub_internal::SubscriberStub>> children{
       std::move(mock)};
-  return MakeSubscriberConnection(std::move(subscription), std::move(opts),
-                                  std::move(children));
+  return MakeTestSubscriberConnection(std::move(subscription), std::move(opts),
+                                      std::move(children));
 }
 
 Options UserSuppliedThreadsOption(CompletionQueue const& cq) {

--- a/google/cloud/pubsub/subscription_admin_connection.cc
+++ b/google/cloud/pubsub/subscription_admin_connection.cc
@@ -379,11 +379,11 @@ namespace pubsub_internal {
 inline namespace GOOGLE_CLOUD_CPP_NS {
 
 std::shared_ptr<pubsub::SubscriptionAdminConnection>
-MakeSubscriptionAdminConnection(Options const& opts,
-                                std::shared_ptr<SubscriberStub> stub) {
+MakeTestSubscriptionAdminConnection(Options const& opts,
+                                    std::shared_ptr<SubscriberStub> stub) {
   auto background = internal::MakeBackgroundThreadsFactory(opts)();
   auto auth = google::cloud::internal::CreateAuthenticationStrategy(
-      google::cloud::MakeInsecureCredentials(), background->cq(), opts);
+      background->cq(), opts);
   stub = pubsub::DecorateSubscriptionAdminStub(opts, std::move(auth),
                                                std::move(stub));
   return std::make_shared<pubsub::SubscriptionAdminConnectionImpl>(

--- a/google/cloud/pubsub/subscription_admin_connection.h
+++ b/google/cloud/pubsub/subscription_admin_connection.h
@@ -267,8 +267,8 @@ namespace pubsub_internal {
 inline namespace GOOGLE_CLOUD_CPP_NS {
 
 std::shared_ptr<pubsub::SubscriptionAdminConnection>
-MakeSubscriptionAdminConnection(Options const& opts,
-                                std::shared_ptr<SubscriberStub> stub);
+MakeTestSubscriptionAdminConnection(Options const& opts,
+                                    std::shared_ptr<SubscriberStub> stub);
 
 }  // namespace GOOGLE_CLOUD_CPP_NS
 }  // namespace pubsub_internal

--- a/google/cloud/pubsub/subscription_admin_connection_test.cc
+++ b/google/cloud/pubsub/subscription_admin_connection_test.cc
@@ -44,8 +44,8 @@ MakeTestSubscriptionAdminConnection(
     std::shared_ptr<pubsub_internal::SubscriberStub> mock, Options opts = {}) {
   opts = pubsub_internal::DefaultCommonOptions(
       pubsub_testing::MakeTestOptions(std::move(opts)));
-  return pubsub_internal::MakeSubscriptionAdminConnection(std::move(opts),
-                                                          std::move(mock));
+  return pubsub_internal::MakeTestSubscriptionAdminConnection(std::move(opts),
+                                                              std::move(mock));
 }
 
 TEST(SubscriptionAdminConnectionTest, Create) {

--- a/google/cloud/pubsub/topic_admin_connection.cc
+++ b/google/cloud/pubsub/topic_admin_connection.cc
@@ -330,11 +330,11 @@ std::shared_ptr<TopicAdminConnection> MakeTopicAdminConnection(
 namespace pubsub_internal {
 inline namespace GOOGLE_CLOUD_CPP_NS {
 
-std::shared_ptr<pubsub::TopicAdminConnection> MakeTopicAdminConnection(
+std::shared_ptr<pubsub::TopicAdminConnection> MakeTestTopicAdminConnection(
     Options const& opts, std::shared_ptr<PublisherStub> stub) {
   auto background = internal::MakeBackgroundThreadsFactory(opts)();
   auto auth = google::cloud::internal::CreateAuthenticationStrategy(
-      google::cloud::MakeInsecureCredentials(), background->cq(), opts);
+      background->cq(), opts);
   stub = pubsub::DecorateTopicAdminStub(opts, std::move(auth), std::move(stub));
   return std::make_shared<pubsub::TopicAdminConnectionImpl>(
       std::move(background), std::move(stub),

--- a/google/cloud/pubsub/topic_admin_connection.h
+++ b/google/cloud/pubsub/topic_admin_connection.h
@@ -237,7 +237,7 @@ std::shared_ptr<TopicAdminConnection> MakeTopicAdminConnection(
 namespace pubsub_internal {
 inline namespace GOOGLE_CLOUD_CPP_NS {
 
-std::shared_ptr<pubsub::TopicAdminConnection> MakeTopicAdminConnection(
+std::shared_ptr<pubsub::TopicAdminConnection> MakeTestTopicAdminConnection(
     Options const& opts, std::shared_ptr<PublisherStub> stub);
 
 }  // namespace GOOGLE_CLOUD_CPP_NS

--- a/google/cloud/pubsub/topic_admin_connection_test.cc
+++ b/google/cloud/pubsub/topic_admin_connection_test.cc
@@ -40,8 +40,8 @@ std::shared_ptr<pubsub::TopicAdminConnection> MakeTestTopicAdminConnection(
     std::shared_ptr<pubsub_internal::PublisherStub> mock, Options opts = {}) {
   opts = pubsub_internal::DefaultCommonOptions(
       pubsub_testing::MakeTestOptions(std::move(opts)));
-  return pubsub_internal::MakeTopicAdminConnection(std::move(opts),
-                                                   std::move(mock));
+  return pubsub_internal::MakeTestTopicAdminConnection(std::move(opts),
+                                                       std::move(mock));
 }
 
 TEST(TopicAdminConnectionTest, Create) {


### PR DESCRIPTION
Fixes #6463 and fixes #7438 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7452)
<!-- Reviewable:end -->
