### PR TITLE
feat(generator): has option to use compat namespace alias

### DIFF
--- a/generator/generator_config.proto
+++ b/generator/generator_config.proto
@@ -23,6 +23,7 @@ message ServiceConfiguration {
   repeated string omitted_rpcs = 4;
   string service_endpoint_env_var = 5;
   string emulator_endpoint_env_var = 6;
+  string compat_inline_namespace_alias = 7;
 }
 
 message GeneratorConfiguration {

--- a/generator/integration_tests/generator_integration_test.cc
+++ b/generator/integration_tests/generator_integration_test.cc
@@ -103,6 +103,7 @@ class GeneratorIntegrationTest : public testing::TestWithParam<std::string> {
     omit_rpc2_ = "Omitted2";
     service_endpoint_env_var_ = "GOLDEN_KITCHEN_SINK_ENDPOINT";
     emulator_endpoint_env_var_ = "GOLDEN_KITCHEN_SINK_EMULATOR_HOST";
+    compat_inline_namespace_alias_ = "compat_alias";
 
     std::vector<std::string> args;
     // empty arg keeps first real arg from being ignored.
@@ -121,6 +122,8 @@ class GeneratorIntegrationTest : public testing::TestWithParam<std::string> {
                       service_endpoint_env_var_);
     args.emplace_back("--cpp_codegen_opt=emulator_endpoint_env_var=" +
                       emulator_endpoint_env_var_);
+    args.emplace_back("--cpp_codegen_opt=compat_inline_namespace_alias=" +
+                      compat_inline_namespace_alias_);
     args.emplace_back("generator/integration_tests/test.proto");
 
     std::vector<char const*> c_args;
@@ -145,6 +148,7 @@ class GeneratorIntegrationTest : public testing::TestWithParam<std::string> {
   std::string omit_rpc2_;
   std::string service_endpoint_env_var_;
   std::string emulator_endpoint_env_var_;
+  std::string compat_inline_namespace_alias_;
 };
 
 TEST_P(GeneratorIntegrationTest, CompareGeneratedToGolden) {

--- a/generator/integration_tests/golden/golden_kitchen_sink_client.h
+++ b/generator/integration_tests/golden/golden_kitchen_sink_client.h
@@ -268,6 +268,11 @@ class GoldenKitchenSinkClient {
 };
 
 }  // namespace GOOGLE_CLOUD_CPP_NS
+/// @deprecated Do not spell the `compat_alias` inline namespace.
+///   Simply omit the inline namespace name instead.
+///   This alias will be removed after 2022-11. See
+///   https://github.com/googleapis/google-cloud-cpp/issues/5976.
+namespace compat_alias = GOOGLE_CLOUD_CPP_NS;
 }  // namespace golden
 }  // namespace cloud
 }  // namespace google

--- a/generator/integration_tests/golden/golden_kitchen_sink_connection.h
+++ b/generator/integration_tests/golden/golden_kitchen_sink_connection.h
@@ -76,6 +76,11 @@ std::shared_ptr<GoldenKitchenSinkConnection> MakeGoldenKitchenSinkConnection(
     Options options = {});
 
 }  // namespace GOOGLE_CLOUD_CPP_NS
+/// @deprecated Do not spell the `compat_alias` inline namespace.
+///   Simply omit the inline namespace name instead.
+///   This alias will be removed after 2022-11. See
+///   https://github.com/googleapis/google-cloud-cpp/issues/5976.
+namespace compat_alias = GOOGLE_CLOUD_CPP_NS;
 }  // namespace golden
 }  // namespace cloud
 }  // namespace google
@@ -91,6 +96,11 @@ MakeGoldenKitchenSinkConnection(
     Options options);
 
 }  // namespace GOOGLE_CLOUD_CPP_NS
+/// @deprecated Do not spell the `compat_alias` inline namespace.
+///   Simply omit the inline namespace name instead.
+///   This alias will be removed after 2022-11. See
+///   https://github.com/googleapis/google-cloud-cpp/issues/5976.
+namespace compat_alias = GOOGLE_CLOUD_CPP_NS;
 }  // namespace golden_internal
 }  // namespace cloud
 }  // namespace google

--- a/generator/integration_tests/golden/golden_kitchen_sink_connection_idempotency_policy.h
+++ b/generator/integration_tests/golden/golden_kitchen_sink_connection_idempotency_policy.h
@@ -58,6 +58,11 @@ std::unique_ptr<GoldenKitchenSinkConnectionIdempotencyPolicy>
     MakeDefaultGoldenKitchenSinkConnectionIdempotencyPolicy();
 
 }  // namespace GOOGLE_CLOUD_CPP_NS
+/// @deprecated Do not spell the `compat_alias` inline namespace.
+///   Simply omit the inline namespace name instead.
+///   This alias will be removed after 2022-11. See
+///   https://github.com/googleapis/google-cloud-cpp/issues/5976.
+namespace compat_alias = GOOGLE_CLOUD_CPP_NS;
 }  // namespace golden
 }  // namespace cloud
 }  // namespace google

--- a/generator/integration_tests/golden/golden_kitchen_sink_options.h
+++ b/generator/integration_tests/golden/golden_kitchen_sink_options.h
@@ -52,6 +52,11 @@ using GoldenKitchenSinkPolicyOptionList =
                GoldenKitchenSinkConnectionIdempotencyPolicyOption>;
 
 }  // namespace GOOGLE_CLOUD_CPP_NS
+/// @deprecated Do not spell the `compat_alias` inline namespace.
+///   Simply omit the inline namespace name instead.
+///   This alias will be removed after 2022-11. See
+///   https://github.com/googleapis/google-cloud-cpp/issues/5976.
+namespace compat_alias = GOOGLE_CLOUD_CPP_NS;
 }  // namespace golden
 }  // namespace cloud
 }  // namespace google

--- a/generator/integration_tests/golden/golden_thing_admin_client.h
+++ b/generator/integration_tests/golden/golden_thing_admin_client.h
@@ -618,6 +618,11 @@ class GoldenThingAdminClient {
 };
 
 }  // namespace GOOGLE_CLOUD_CPP_NS
+/// @deprecated Do not spell the `compat_alias` inline namespace.
+///   Simply omit the inline namespace name instead.
+///   This alias will be removed after 2022-11. See
+///   https://github.com/googleapis/google-cloud-cpp/issues/5976.
+namespace compat_alias = GOOGLE_CLOUD_CPP_NS;
 }  // namespace golden
 }  // namespace cloud
 }  // namespace google

--- a/generator/integration_tests/golden/golden_thing_admin_connection.h
+++ b/generator/integration_tests/golden/golden_thing_admin_connection.h
@@ -108,6 +108,11 @@ std::shared_ptr<GoldenThingAdminConnection> MakeGoldenThingAdminConnection(
     Options options = {});
 
 }  // namespace GOOGLE_CLOUD_CPP_NS
+/// @deprecated Do not spell the `compat_alias` inline namespace.
+///   Simply omit the inline namespace name instead.
+///   This alias will be removed after 2022-11. See
+///   https://github.com/googleapis/google-cloud-cpp/issues/5976.
+namespace compat_alias = GOOGLE_CLOUD_CPP_NS;
 }  // namespace golden
 }  // namespace cloud
 }  // namespace google
@@ -123,6 +128,11 @@ MakeGoldenThingAdminConnection(
     Options options);
 
 }  // namespace GOOGLE_CLOUD_CPP_NS
+/// @deprecated Do not spell the `compat_alias` inline namespace.
+///   Simply omit the inline namespace name instead.
+///   This alias will be removed after 2022-11. See
+///   https://github.com/googleapis/google-cloud-cpp/issues/5976.
+namespace compat_alias = GOOGLE_CLOUD_CPP_NS;
 }  // namespace golden_internal
 }  // namespace cloud
 }  // namespace google

--- a/generator/integration_tests/golden/golden_thing_admin_connection_idempotency_policy.h
+++ b/generator/integration_tests/golden/golden_thing_admin_connection_idempotency_policy.h
@@ -95,6 +95,11 @@ std::unique_ptr<GoldenThingAdminConnectionIdempotencyPolicy>
     MakeDefaultGoldenThingAdminConnectionIdempotencyPolicy();
 
 }  // namespace GOOGLE_CLOUD_CPP_NS
+/// @deprecated Do not spell the `compat_alias` inline namespace.
+///   Simply omit the inline namespace name instead.
+///   This alias will be removed after 2022-11. See
+///   https://github.com/googleapis/google-cloud-cpp/issues/5976.
+namespace compat_alias = GOOGLE_CLOUD_CPP_NS;
 }  // namespace golden
 }  // namespace cloud
 }  // namespace google

--- a/generator/integration_tests/golden/golden_thing_admin_options.h
+++ b/generator/integration_tests/golden/golden_thing_admin_options.h
@@ -58,6 +58,11 @@ using GoldenThingAdminPolicyOptionList =
                GoldenThingAdminConnectionIdempotencyPolicyOption>;
 
 }  // namespace GOOGLE_CLOUD_CPP_NS
+/// @deprecated Do not spell the `compat_alias` inline namespace.
+///   Simply omit the inline namespace name instead.
+///   This alias will be removed after 2022-11. See
+///   https://github.com/googleapis/google-cloud-cpp/issues/5976.
+namespace compat_alias = GOOGLE_CLOUD_CPP_NS;
 }  // namespace golden
 }  // namespace cloud
 }  // namespace google

--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_auth_decorator.h
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_auth_decorator.h
@@ -70,6 +70,11 @@ class GoldenKitchenSinkAuth : public GoldenKitchenSinkStub {
 };
 
 }  // namespace GOOGLE_CLOUD_CPP_NS
+/// @deprecated Do not spell the `compat_alias` inline namespace.
+///   Simply omit the inline namespace name instead.
+///   This alias will be removed after 2022-11. See
+///   https://github.com/googleapis/google-cloud-cpp/issues/5976.
+namespace compat_alias = GOOGLE_CLOUD_CPP_NS;
 }  // namespace golden_internal
 }  // namespace cloud
 }  // namespace google

--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_logging_decorator.h
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_logging_decorator.h
@@ -70,6 +70,11 @@ class GoldenKitchenSinkLogging : public GoldenKitchenSinkStub {
 };  // GoldenKitchenSinkLogging
 
 }  // namespace GOOGLE_CLOUD_CPP_NS
+/// @deprecated Do not spell the `compat_alias` inline namespace.
+///   Simply omit the inline namespace name instead.
+///   This alias will be removed after 2022-11. See
+///   https://github.com/googleapis/google-cloud-cpp/issues/5976.
+namespace compat_alias = GOOGLE_CLOUD_CPP_NS;
 }  // namespace golden_internal
 }  // namespace cloud
 }  // namespace google

--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_metadata_decorator.h
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_metadata_decorator.h
@@ -67,6 +67,11 @@ class GoldenKitchenSinkMetadata : public GoldenKitchenSinkStub {
 };  // GoldenKitchenSinkMetadata
 
 }  // namespace GOOGLE_CLOUD_CPP_NS
+/// @deprecated Do not spell the `compat_alias` inline namespace.
+///   Simply omit the inline namespace name instead.
+///   This alias will be removed after 2022-11. See
+///   https://github.com/googleapis/google-cloud-cpp/issues/5976.
+namespace compat_alias = GOOGLE_CLOUD_CPP_NS;
 }  // namespace golden_internal
 }  // namespace cloud
 }  // namespace google

--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_option_defaults.h
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_option_defaults.h
@@ -30,6 +30,11 @@ inline namespace GOOGLE_CLOUD_CPP_NS {
 Options GoldenKitchenSinkDefaultOptions(Options options);
 
 }  // namespace GOOGLE_CLOUD_CPP_NS
+/// @deprecated Do not spell the `compat_alias` inline namespace.
+///   Simply omit the inline namespace name instead.
+///   This alias will be removed after 2022-11. See
+///   https://github.com/googleapis/google-cloud-cpp/issues/5976.
+namespace compat_alias = GOOGLE_CLOUD_CPP_NS;
 }  // namespace golden_internal
 }  // namespace cloud
 }  // namespace google

--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_stub.h
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_stub.h
@@ -102,6 +102,11 @@ class DefaultGoldenKitchenSinkStub : public GoldenKitchenSinkStub {
 };
 
 }  // namespace GOOGLE_CLOUD_CPP_NS
+/// @deprecated Do not spell the `compat_alias` inline namespace.
+///   Simply omit the inline namespace name instead.
+///   This alias will be removed after 2022-11. See
+///   https://github.com/googleapis/google-cloud-cpp/issues/5976.
+namespace compat_alias = GOOGLE_CLOUD_CPP_NS;
 }  // namespace golden_internal
 }  // namespace cloud
 }  // namespace google

--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_stub_factory.h
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_stub_factory.h
@@ -36,6 +36,11 @@ std::shared_ptr<GoldenKitchenSinkStub> CreateDefaultGoldenKitchenSinkStub(
     google::cloud::CompletionQueue cq, Options const& options);
 
 }  // namespace GOOGLE_CLOUD_CPP_NS
+/// @deprecated Do not spell the `compat_alias` inline namespace.
+///   Simply omit the inline namespace name instead.
+///   This alias will be removed after 2022-11. See
+///   https://github.com/googleapis/google-cloud-cpp/issues/5976.
+namespace compat_alias = GOOGLE_CLOUD_CPP_NS;
 }  // namespace golden_internal
 }  // namespace cloud
 }  // namespace google

--- a/generator/integration_tests/golden/internal/golden_thing_admin_auth_decorator.h
+++ b/generator/integration_tests/golden/internal/golden_thing_admin_auth_decorator.h
@@ -127,6 +127,11 @@ class GoldenThingAdminAuth : public GoldenThingAdminStub {
 };
 
 }  // namespace GOOGLE_CLOUD_CPP_NS
+/// @deprecated Do not spell the `compat_alias` inline namespace.
+///   Simply omit the inline namespace name instead.
+///   This alias will be removed after 2022-11. See
+///   https://github.com/googleapis/google-cloud-cpp/issues/5976.
+namespace compat_alias = GOOGLE_CLOUD_CPP_NS;
 }  // namespace golden_internal
 }  // namespace cloud
 }  // namespace google

--- a/generator/integration_tests/golden/internal/golden_thing_admin_logging_decorator.h
+++ b/generator/integration_tests/golden/internal/golden_thing_admin_logging_decorator.h
@@ -128,6 +128,11 @@ class GoldenThingAdminLogging : public GoldenThingAdminStub {
 };  // GoldenThingAdminLogging
 
 }  // namespace GOOGLE_CLOUD_CPP_NS
+/// @deprecated Do not spell the `compat_alias` inline namespace.
+///   Simply omit the inline namespace name instead.
+///   This alias will be removed after 2022-11. See
+///   https://github.com/googleapis/google-cloud-cpp/issues/5976.
+namespace compat_alias = GOOGLE_CLOUD_CPP_NS;
 }  // namespace golden_internal
 }  // namespace cloud
 }  // namespace google

--- a/generator/integration_tests/golden/internal/golden_thing_admin_metadata_decorator.h
+++ b/generator/integration_tests/golden/internal/golden_thing_admin_metadata_decorator.h
@@ -125,6 +125,11 @@ class GoldenThingAdminMetadata : public GoldenThingAdminStub {
 };  // GoldenThingAdminMetadata
 
 }  // namespace GOOGLE_CLOUD_CPP_NS
+/// @deprecated Do not spell the `compat_alias` inline namespace.
+///   Simply omit the inline namespace name instead.
+///   This alias will be removed after 2022-11. See
+///   https://github.com/googleapis/google-cloud-cpp/issues/5976.
+namespace compat_alias = GOOGLE_CLOUD_CPP_NS;
 }  // namespace golden_internal
 }  // namespace cloud
 }  // namespace google

--- a/generator/integration_tests/golden/internal/golden_thing_admin_option_defaults.h
+++ b/generator/integration_tests/golden/internal/golden_thing_admin_option_defaults.h
@@ -30,6 +30,11 @@ inline namespace GOOGLE_CLOUD_CPP_NS {
 Options GoldenThingAdminDefaultOptions(Options options);
 
 }  // namespace GOOGLE_CLOUD_CPP_NS
+/// @deprecated Do not spell the `compat_alias` inline namespace.
+///   Simply omit the inline namespace name instead.
+///   This alias will be removed after 2022-11. See
+///   https://github.com/googleapis/google-cloud-cpp/issues/5976.
+namespace compat_alias = GOOGLE_CLOUD_CPP_NS;
 }  // namespace golden_internal
 }  // namespace cloud
 }  // namespace google

--- a/generator/integration_tests/golden/internal/golden_thing_admin_stub.h
+++ b/generator/integration_tests/golden/internal/golden_thing_admin_stub.h
@@ -228,6 +228,11 @@ class DefaultGoldenThingAdminStub : public GoldenThingAdminStub {
 };
 
 }  // namespace GOOGLE_CLOUD_CPP_NS
+/// @deprecated Do not spell the `compat_alias` inline namespace.
+///   Simply omit the inline namespace name instead.
+///   This alias will be removed after 2022-11. See
+///   https://github.com/googleapis/google-cloud-cpp/issues/5976.
+namespace compat_alias = GOOGLE_CLOUD_CPP_NS;
 }  // namespace golden_internal
 }  // namespace cloud
 }  // namespace google

--- a/generator/integration_tests/golden/internal/golden_thing_admin_stub_factory.h
+++ b/generator/integration_tests/golden/internal/golden_thing_admin_stub_factory.h
@@ -36,6 +36,11 @@ std::shared_ptr<GoldenThingAdminStub> CreateDefaultGoldenThingAdminStub(
     google::cloud::CompletionQueue cq, Options const& options);
 
 }  // namespace GOOGLE_CLOUD_CPP_NS
+/// @deprecated Do not spell the `compat_alias` inline namespace.
+///   Simply omit the inline namespace name instead.
+///   This alias will be removed after 2022-11. See
+///   https://github.com/googleapis/google-cloud-cpp/issues/5976.
+namespace compat_alias = GOOGLE_CLOUD_CPP_NS;
 }  // namespace golden_internal
 }  // namespace cloud
 }  // namespace google

--- a/generator/integration_tests/golden/mocks/mock_golden_kitchen_sink_connection.h
+++ b/generator/integration_tests/golden/mocks/mock_golden_kitchen_sink_connection.h
@@ -56,6 +56,11 @@ class MockGoldenKitchenSinkConnection : public golden::GoldenKitchenSinkConnecti
 };
 
 }  // namespace GOOGLE_CLOUD_CPP_NS
+/// @deprecated Do not spell the `compat_alias` inline namespace.
+///   Simply omit the inline namespace name instead.
+///   This alias will be removed after 2022-11. See
+///   https://github.com/googleapis/google-cloud-cpp/issues/5976.
+namespace compat_alias = GOOGLE_CLOUD_CPP_NS;
 }  // namespace golden_mocks
 }  // namespace cloud
 }  // namespace google

--- a/generator/integration_tests/golden/mocks/mock_golden_kitchen_sink_stub.h
+++ b/generator/integration_tests/golden/mocks/mock_golden_kitchen_sink_stub.h
@@ -78,6 +78,11 @@ public:
 };
 
 }  // namespace GOOGLE_CLOUD_CPP_NS
+/// @deprecated Do not spell the `compat_alias` inline namespace.
+///   Simply omit the inline namespace name instead.
+///   This alias will be removed after 2022-11. See
+///   https://github.com/googleapis/google-cloud-cpp/issues/5976.
+namespace compat_alias = GOOGLE_CLOUD_CPP_NS;
 }  // namespace golden_internal
 }  // namespace cloud
 }  // namespace google

--- a/generator/integration_tests/golden/mocks/mock_golden_thing_admin_connection.h
+++ b/generator/integration_tests/golden/mocks/mock_golden_thing_admin_connection.h
@@ -100,6 +100,11 @@ class MockGoldenThingAdminConnection : public golden::GoldenThingAdminConnection
 };
 
 }  // namespace GOOGLE_CLOUD_CPP_NS
+/// @deprecated Do not spell the `compat_alias` inline namespace.
+///   Simply omit the inline namespace name instead.
+///   This alias will be removed after 2022-11. See
+///   https://github.com/googleapis/google-cloud-cpp/issues/5976.
+namespace compat_alias = GOOGLE_CLOUD_CPP_NS;
 }  // namespace golden_mocks
 }  // namespace cloud
 }  // namespace google

--- a/generator/integration_tests/golden/mocks/mock_golden_thing_admin_stub.h
+++ b/generator/integration_tests/golden/mocks/mock_golden_thing_admin_stub.h
@@ -134,6 +134,11 @@ class MockGoldenThingAdminStub
 };
 
 }  // namespace GOOGLE_CLOUD_CPP_NS
+/// @deprecated Do not spell the `compat_alias` inline namespace.
+///   Simply omit the inline namespace name instead.
+///   This alias will be removed after 2022-11. See
+///   https://github.com/googleapis/google-cloud-cpp/issues/5976.
+namespace compat_alias = GOOGLE_CLOUD_CPP_NS;
 }  // namespace golden_internal
 }  // namespace cloud
 }  // namespace google

--- a/generator/integration_tests/golden/retry_traits.h
+++ b/generator/integration_tests/golden/retry_traits.h
@@ -40,6 +40,11 @@ struct GoldenKitchenSinkRetryTraits {
 };
 
 }  // namespace GOOGLE_CLOUD_CPP_NS
+/// @deprecated Do not spell the `compat_alias` inline namespace.
+///   Simply omit the inline namespace name instead.
+///   This alias will be removed after 2022-11. See
+///   https://github.com/googleapis/google-cloud-cpp/issues/5976.
+namespace compat_alias = GOOGLE_CLOUD_CPP_NS;
 }  // namespace golden_internal
 }  // namespace cloud
 }  // namespace google

--- a/generator/internal/codegen_utils_test.cc
+++ b/generator/internal/codegen_utils_test.cc
@@ -247,6 +247,15 @@ TEST(ProcessCommandLineArgs, EmulatorEndpointEnvVar) {
   EXPECT_THAT(*result, Contains(Pair("service_endpoint_env_var", "")));
 }
 
+TEST(ProcessCommandLineArgs, CompatInlineNamespaceAlias) {
+  auto result = ProcessCommandLineArgs(
+      "product_path=google/cloud/spanner/,googleapis_commit_hash=foo"
+      ",compat_inline_namespace_alias=oldname");
+  ASSERT_THAT(result, IsOk());
+  EXPECT_THAT(*result,
+              Contains(Pair("compat_inline_namespace_alias", "oldname")));
+}
+
 }  // namespace
 }  // namespace generator_internal
 }  // namespace cloud

--- a/generator/internal/service_code_generator.h
+++ b/generator/internal/service_code_generator.h
@@ -128,7 +128,7 @@ class ServiceCodeGenerator : public GeneratorInterface {
 
   Status OpenNamespaces(Printer& p,
                         NamespaceType ns_type = NamespaceType::kNormal);
-  void CloseNamespaces(Printer& p);
+  void CloseNamespaces(Printer& p, std::string const& compat_alias = "");
 
   google::protobuf::ServiceDescriptor const* service_descriptor_;
   VarsDictionary service_vars_;

--- a/generator/standalone_main.cc
+++ b/generator/standalone_main.cc
@@ -110,6 +110,10 @@ int main(int argc, char** argv) {
                       service.service_endpoint_env_var());
     args.emplace_back("--cpp_codegen_opt=emulator_endpoint_env_var=" +
                       service.emulator_endpoint_env_var());
+    if (!service.compat_inline_namespace_alias().empty()) {
+      args.emplace_back("--cpp_codegen_opt=compat_inline_namespace_alias=" +
+                        service.compat_inline_namespace_alias());
+    }
     args.emplace_back(service.service_proto_path());
     GCP_LOG(INFO) << "Generating service code using: "
                   << absl::StrJoin(args, ";") << "\n";


### PR DESCRIPTION
Related to: https://github.com/googleapis/google-cloud-cpp/issues/5976

This PR teaches the generator how to generate backward compatibility
aliases for the `GOOGLE_CLOUD_CPP_NS` inline namespace. This is
configured by an option, and it's off by default. When enabled, it will
generate an alias to keep old code working that may have been spelling a
previous inline namespace.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7454)
<!-- Reviewable:end -->
