### PR TITLE
refactor: use inline namespace macros in version.{h,cc} files

### DIFF
--- a/google/cloud/bigtable/version.cc
+++ b/google/cloud/bigtable/version.cc
@@ -19,9 +19,9 @@
 namespace google {
 namespace cloud {
 namespace bigtable {
-inline namespace GOOGLE_CLOUD_CPP_NS {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 std::string version_string() { return ::google::cloud::version_string(); }
-}  // namespace GOOGLE_CLOUD_CPP_NS
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigtable
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/bigtable/version.h
+++ b/google/cloud/bigtable/version.h
@@ -38,19 +38,7 @@ namespace cloud {
  * Contains all the Cloud Bigtable C++ client APIs.
  */
 namespace bigtable {
-/**
- * Versioned inline namespace that users should generally avoid spelling.
- *
- * Applications may need to link multiple versions of the Cloud Bigtable C++
- * client, for example, if they link a library that uses an older version of
- * the client than they do.  This namespace is inlined, so applications can use
- * `bigtable::Foo` in their source, but the symbols are versioned, i.e., the
- * symbol becomes `bigtable::v1::Foo`.
- *
- * Note that, consistent with the semver.org guidelines, the v0 version makes
- * no guarantees with respect to backwards compatibility.
- */
-inline namespace GOOGLE_CLOUD_CPP_NS {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 /**
  * The Cloud Bigtable C++ Client major version.
  *
@@ -78,7 +66,7 @@ int constexpr version() { return google::cloud::version(); }
 /// The version as a string, in MAJOR.MINOR.PATCH+gitrev format.
 std::string version_string();
 
-}  // namespace GOOGLE_CLOUD_CPP_NS
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigtable
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/grpc_utils/version.h
+++ b/google/cloud/grpc_utils/version.h
@@ -23,14 +23,13 @@ namespace cloud {
  * Contains all the Cloud C++ gRPC Utilities APIs.
  */
 namespace grpc_utils {
-/// Versioned inline namespace that users should generally avoid spelling.
-inline namespace GOOGLE_CLOUD_CPP_NS {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 using ::google::cloud::version;
 using ::google::cloud::version_major;
 using ::google::cloud::version_minor;
 using ::google::cloud::version_patch;
 using ::google::cloud::version_string;
-}  // namespace GOOGLE_CLOUD_CPP_NS
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace grpc_utils
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/pubsub/version.h
+++ b/google/cloud/pubsub/version.h
@@ -31,18 +31,7 @@ namespace cloud {
 /**
  * Contains all the Cloud Pubsub C++ client types and functions.
  */
-namespace pubsub {
-/**
- * Versioned inline namespace that users should generally avoid spelling.
- *
- * Applications may need to link multiple versions of the Cloud pubsub C++
- * client, for example, if they link a library that uses an older version of
- * the client than they do.  This namespace is inlined, so applications can use
- * `pubsub::Foo` in their source, but the symbols are versioned, i.e., the
- * symbol becomes `pubsub::v1::Foo`.
- */
-inline namespace GOOGLE_CLOUD_CPP_NS {}  // namespace GOOGLE_CLOUD_CPP_NS
-}  // namespace pubsub
+namespace pubsub {}  // namespace pubsub
 }  // namespace cloud
 }  // namespace google
 

--- a/google/cloud/spanner/version.cc
+++ b/google/cloud/spanner/version.cc
@@ -19,9 +19,9 @@
 namespace google {
 namespace cloud {
 namespace spanner {
-inline namespace GOOGLE_CLOUD_CPP_NS {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 std::string VersionString() { return ::google::cloud::version_string(); }
-}  // namespace GOOGLE_CLOUD_CPP_NS
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace spanner
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/spanner/version.h
+++ b/google/cloud/spanner/version.h
@@ -41,16 +41,7 @@ namespace cloud {
  * Contains all the Cloud Spanner C++ client types and functions.
  */
 namespace spanner {
-/**
- * Versioned inline namespace that users should generally avoid spelling.
- *
- * Applications may need to link multiple versions of the Cloud spanner C++
- * client, for example, if they link a library that uses an older version of
- * the client than they do.  This namespace is inlined, so applications can use
- * `spanner::Foo` in their source, but the symbols are versioned, i.e., the
- * symbol becomes `spanner::v1::Foo`.
- */
-inline namespace GOOGLE_CLOUD_CPP_NS {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 /**
  * The Cloud spanner C++ Client major version.
  */
@@ -72,7 +63,7 @@ int constexpr Version() { return google::cloud::version(); }
 /// The version as a string, in MAJOR.MINOR.PATCH+gitrev format.
 std::string VersionString();
 
-}  // namespace GOOGLE_CLOUD_CPP_NS
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace spanner
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/storage/version.cc
+++ b/google/cloud/storage/version.cc
@@ -19,7 +19,7 @@
 namespace google {
 namespace cloud {
 namespace storage {
-inline namespace GOOGLE_CLOUD_CPP_NS {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 std::string version_string() { return ::google::cloud::version_string(); }
 
 std::string x_goog_api_client() {
@@ -36,7 +36,7 @@ static_assert(
     "    https://github.com/googleapis/google-cloud-cpp/issues\n"
     "describing your platform details to request support for it.");
 
-}  // namespace GOOGLE_CLOUD_CPP_NS
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace storage
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/storage/version.h
+++ b/google/cloud/storage/version.h
@@ -49,19 +49,7 @@ namespace cloud {
  * Contains all the Google Cloud Storage C++ client APIs.
  */
 namespace storage {
-/**
- * Versioned inline namespace that users should generally avoid spelling.
- *
- * Applications may need to link multiple versions of the Google Cloud Storage
- * C++ client, for example, if they link a library that uses an older version of
- * the client than they do.  This namespace is inlined, so applications can use
- * `storage::Foo` in their source, but the symbols are versioned, i.e., the
- * symbol becomes `storage::v1::Foo`.
- *
- * Note that, consistent with the semver.org guidelines, the v0 version makes
- * no guarantees with respect to backwards compatibility.
- */
-inline namespace GOOGLE_CLOUD_CPP_NS {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 /**
  * Returns the Google Cloud Storage C++ Client major version.
  *
@@ -92,7 +80,7 @@ std::string version_string();
 /// Returns the value for `x-goog-api-client` header.
 std::string x_goog_api_client();
 
-}  // namespace GOOGLE_CLOUD_CPP_NS
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace storage
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/version.cc
+++ b/google/cloud/version.cc
@@ -18,7 +18,7 @@
 
 namespace google {
 namespace cloud {
-inline namespace GOOGLE_CLOUD_CPP_NS {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 std::string version_string() {
   static auto const* const kVersion = new auto([] {
     std::ostringstream os;
@@ -32,6 +32,6 @@ std::string version_string() {
   }());
   return *kVersion;
 }
-}  // namespace GOOGLE_CLOUD_CPP_NS
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/version.h
+++ b/google/cloud/version.h
@@ -61,19 +61,7 @@ namespace google {
  * Contains all the Google Cloud C++ Library APIs.
  */
 namespace cloud {
-/**
- * Versioned inline namespace that users should generally avoid spelling.
- *
- * Applications may need to link multiple versions of the Google Cloud C++
- * Libraries, for example, if they link a library that uses an older version of
- * the libraries than they do.  This namespace is inlined, so applications can
- * use `google::cloud::Foo` in their source, but the symbols are versioned,
- * i.e., the symbol becomes `google::cloud::v1::Foo`.
- *
- * Note that, consistent with the semver.org guidelines, the v0 version makes
- * no guarantees with respect to backwards compatibility.
- */
-inline namespace GOOGLE_CLOUD_CPP_NS {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 /**
  * The Google Cloud Storage C++ Client major version.
  *
@@ -114,7 +102,7 @@ int constexpr version() {
 /// The version as a string, in MAJOR.MINOR.PATCH+gitrev format.
 std::string version_string();
 
-}  // namespace GOOGLE_CLOUD_CPP_NS
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace cloud
 }  // namespace google
 


### PR DESCRIPTION
Part of: #5976
Part of: #7453

I'm sending these edits separately because these are hand edits, not
mechanical search-n-replace edits. In these cases, I'm removing the
doxygen documentation on the inline namespace for each product because
we're going to change our Doxygen build (follow-up PR) to omit the
inline namespaces completely anyway. The documentation about the inline
namespace now lives in one location: `google/cloud/version.h` with the
macro.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7459)
<!-- Reviewable:end -->
