### PR TITLE
fix(common): resume sending "v" in "gccl" component of API header

### DIFF
--- a/google/cloud/internal/api_client_header.cc
+++ b/google/cloud/internal/api_client_header.cc
@@ -22,11 +22,6 @@ namespace internal {
 
 std::string ApiClientVersion(std::string const& build_identifier) {
   auto client_library_version = version_string();
-  if (!client_library_version.empty() && client_library_version[0] == 'v') {
-    // Remove the leading 'v'. Without it, version_string() is a valid
-    // SemVer string: "<major>.<minor>.<patch>[-<prerelease>][+<build>]".
-    client_library_version.erase(0, 1);
-  }
   if (!build_identifier.empty()) {
     auto pos = client_library_version.find('+');
     client_library_version.append(1, pos == std::string::npos ? '+' : '.');


### PR DESCRIPTION
Resume sending the  leading "v" in the value of the "gccl" component
of the `X-Goog-Api-Client` header (see #7383).  The Cloud Spanner
frontend's route lookup service uses the version string in a semver
comparison to determine how the request should be routed, and it
currently expects to see a literal "v".  (For the record, the
minimal version supported by the route lookup service is "v1.17.1".)

Changing the route lookup service to not care about the leading "v"
is non-trivial (it uses a single-value map, indexed by language, to
store the minimum supported version, and the value comes from a flag),
and even then the fix will take some time to roll out, so, in the
meantime, we revert to sending the "v".

Eventually eliminating the "v" is still a goal because it makes the
header conform to the specification, and it also makes C++ behave
like the other languages.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7473)
<!-- Reviewable:end -->
