### PR TITLE
feat: allow super projects to override C++ version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,15 @@ set(GOOGLE_CLOUD_CPP_CXX_STANDARD
 mark_as_advanced(GOOGLE_CLOUD_CPP_CXX_STANDARD)
 
 # Allow applications to override the CMAKE_CXX_STANDARD, but if not set use 11.
-set(CMAKE_CXX_STANDARD 11)
+if (NOT CMAKE_CXX_STANDARD)
+    set(CMAKE_CXX_STANDARD 11)
+endif ()
+if (CMAKE_CXX_STANDARD VERSION_LESS 11)
+    message(
+        FATAL_ERROR
+            "CMAKE_CXX_STANDARD must be >= 11, was ${CMAKE_CXX_STANDARD}")
+endif ()
+
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 if (NOT ("${GOOGLE_CLOUD_CPP_CXX_STANDARD}" STREQUAL ""))


### PR DESCRIPTION
Previously application developers could override the C++ standard using
command-line options at CMake configuration time (e.g.
`-DCMAKE_CXX_STANDARD`). However, they could not set the standard when
including this project via `add_subdirectory()`. Conan, and possibly
other package managers, always use the `add_subdirectory()` approach,
and have to patch our code to package our project.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7478)
<!-- Reviewable:end -->
