### PR TITLE
Revert "ci: print the CMake version in each build"

### DIFF
--- a/ci/cloudbuild/build.sh
+++ b/ci/cloudbuild/build.sh
@@ -215,7 +215,6 @@ if [[ "${LOCAL_FLAG}" = "true" ]]; then
   printf "%10s %s\n" "gcc:" "$(gcc --version 2>&1 | head -1)"
   printf "%10s %s\n" "clang:" "$(clang --version 2>&1 | head -1)"
   printf "%10s %s\n" "cc:" "$(cc --version 2>&1 | head -1)"
-  printf "%10s %s\n" "cmake:" "$(cmake --version 2>&1 | head -1)"
   io::log_h1 "Starting local build: ${BUILD_FLAG}"
   readonly TIMEFORMAT="==> 🕑 ${BUILD_FLAG} completed in %R seconds"
   time "${PROGRAM_DIR}/builds/${BUILD_FLAG}.sh"


### PR DESCRIPTION
Reverts googleapis/google-cloud-cpp#7480

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7483)
<!-- Reviewable:end -->
