### PR TITLE
ci: remove macOS root CA workaround

### DIFF
--- a/ci/kokoro/macos/build.sh
+++ b/ci/kokoro/macos/build.sh
@@ -103,10 +103,6 @@ rm -f "${GRPC_DEFAULT_SSL_ROOTS_FILE_PATH}"
 curl -sSL --retry 10 -o "${GRPC_DEFAULT_SSL_ROOTS_FILE_PATH}" \
   https://pki.google.com/roots.pem
 
-# The CA roots are outdated in some Kokoro macOS machines. Use Google's
-# `root.pem` file for any remaining downloads.
-echo "cacert ${GRPC_DEFAULT_SSL_ROOTS_FILE_PATH}" >>"${HOME}/.curlrc"
-
 io::log_h1 "Downloading cache"
 readonly CACHE_BUCKET="${GOOGLE_CLOUD_CPP_KOKORO_RESULTS:-cloud-cpp-kokoro-results}"
 readonly CACHE_FOLDER="${CACHE_BUCKET}/build-cache/google-cloud-cpp/${BRANCH}"


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7487)
<!-- Reviewable:end -->
