### PR TITLE
fix(common): fewer crashes with dynamic loading

### DIFF
--- a/google/cloud/BUILD
+++ b/google/cloud/BUILD
@@ -43,7 +43,6 @@ cc_library(
         "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/memory",
         "@com_google_absl//absl/time",
-        "@com_google_absl//absl/types:any",
         "@com_google_absl//absl/types:optional",
     ],
 )

--- a/google/cloud/CMakeLists.txt
+++ b/google/cloud/CMakeLists.txt
@@ -198,7 +198,7 @@ add_library(
     version.cc
     version.h)
 target_link_libraries(
-    google_cloud_cpp_common PUBLIC absl::any absl::flat_hash_map absl::memory
+    google_cloud_cpp_common PUBLIC absl::flat_hash_map absl::memory
                                    absl::optional absl::time Threads::Threads)
 google_cloud_cpp_add_common_options(google_cloud_cpp_common)
 target_include_directories(
@@ -348,8 +348,8 @@ set(GOOGLE_CLOUD_CPP_PC_NAME
 set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
     "Common Components used by the Google Cloud C++ Client Libraries.")
 set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_common")
-string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "absl_any absl_flat_hash_map"
-              " absl_memory" " absl_optional" " absl_time")
+string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "absl_flat_hash_map" " absl_memory"
+              " absl_optional" " absl_time")
 
 # Create and install the pkg-config files.
 configure_file("${PROJECT_SOURCE_DIR}/google/cloud/config.pc.in"

--- a/google/cloud/options.h
+++ b/google/cloud/options.h
@@ -17,7 +17,7 @@
 
 #include "google/cloud/internal/type_list.h"
 #include "google/cloud/version.h"
-#include "absl/types/any.h"
+#include "absl/memory/memory.h"
 #include <set>
 #include <typeindex>
 #include <typeinfo>
@@ -87,8 +87,14 @@ class Options {
   /// Constructs an empty instance.
   Options() = default;
 
-  Options(Options const&) = default;
-  Options& operator=(Options const&) = default;
+  Options(Options const& rhs) {
+    for (auto const& kv : rhs.m_) m_.emplace(kv.first, kv.second->clone());
+  }
+  Options& operator=(Options const& rhs) {
+    Options tmp(rhs);
+    std::swap(m_, tmp.m_);
+    return *this;
+  }
   Options(Options&&) = default;
   Options& operator=(Options&&) = default;
 
@@ -107,7 +113,7 @@ class Options {
    */
   template <typename T>
   Options& set(ValueTypeT<T> v) {
-    m_[typeid(T)] = Data<T>{std::move(v)};
+    m_[typeid(T)] = absl::make_unique<Data<T>>(std::move(v));
     return *this;
   }
 
@@ -158,8 +164,9 @@ class Options {
   ValueTypeT<T> const& get() const {
     static auto const* const kDefaultValue = new ValueTypeT<T>{};
     auto const it = m_.find(typeid(T));
-    if (it != m_.end()) return absl::any_cast<Data<T>>(&it->second)->value;
-    return *kDefaultValue;
+    if (it == m_.end()) return *kDefaultValue;
+    auto const* value = it->second->data_address();
+    return *reinterpret_cast<ValueTypeT<T> const*>(value);
   }
 
   /**
@@ -180,12 +187,17 @@ class Options {
    * @endcode
    *
    * @tparam T the option type
-   * @param init_value the initial value to use if `T` is not set (optional)
+   * @param value the initial value to use if `T` is not set (optional)
    */
   template <typename T>
-  ValueTypeT<T>& lookup(ValueTypeT<T> init_value = {}) {
-    auto const p = m_.emplace(typeid(T), Data<T>{std::move(init_value)});
-    return absl::any_cast<Data<T>>(&p.first->second)->value;
+  ValueTypeT<T>& lookup(ValueTypeT<T> value = {}) {
+    auto p = m_.find(typeid(T));
+    if (p == m_.end()) {
+      p = m_.emplace(typeid(T), absl::make_unique<Data<T>>(std::move(value)))
+              .first;
+    }
+    auto* v = p->second->data_address();
+    return *reinterpret_cast<ValueTypeT<T>*>(v);
   }
 
  private:
@@ -193,14 +205,33 @@ class Options {
   friend void internal::CheckExpectedOptionsImpl(
       std::set<std::type_index> const&, Options const&, char const*);
 
-  // The data holder for all the option values.
-  template <typename T>
-  struct Data {
-    ValueTypeT<T> value;
+  // The type-erased data holder of all the option values.
+  class DataHolder {
+   public:
+    virtual ~DataHolder() = default;
+    virtual void const* data_address() const = 0;
+    virtual void* data_address() = 0;
+    virtual std::unique_ptr<DataHolder> clone() const = 0;
   };
 
-  // The `absl::any` objects all hold a `Data<T>`
-  std::unordered_map<std::type_index, absl::any> m_;
+  // The data holder for all the option values.
+  template <typename T>
+  class Data : public DataHolder {
+   public:
+    explicit Data(ValueTypeT<T> v) : value_(std::move(v)) {}
+    ~Data() override = default;
+
+    void const* data_address() const override { return &value_; }
+    void* data_address() override { return &value_; }
+    std::unique_ptr<DataHolder> clone() const override {
+      return absl::make_unique<Data<T>>(*this);
+    }
+
+   private:
+    ValueTypeT<T> value_;
+  };
+
+  std::unordered_map<std::type_index, std::unique_ptr<DataHolder>> m_;
 };
 
 /**


### PR DESCRIPTION
`absl::any` does not support dynamically loaded libraries: it supports
`.so` libraries, it does not support libraries loaded with `dlopen()` or
a similar call. For our needs, it is easy to implement type-erasure in
`google::cloud::Options`.

Fixes #7505

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7512)
<!-- Reviewable:end -->
