### PR TITLE
test(spanner): bump create-database timeout from ~120s to ~300s

### DIFF
--- a/google/cloud/spanner/testing/database_integration_test.cc
+++ b/google/cloud/spanner/testing/database_integration_test.cc
@@ -121,7 +121,7 @@ void DatabaseIntegrationTest::SetUpTestSuite() {
   auto database_future = admin_client.CreateDatabase(request);
 
   int i = 0;
-  int const timeout = 120;
+  int const timeout = 300;
   while (++i < timeout) {
     auto status = database_future.wait_for(std::chrono::seconds(1));
     if (status == std::future_status::ready) break;


### PR DESCRIPTION
Increase the time spent waiting for the creation of a test database
from 120 one-second polls to 300.

While I have no evidence that whatever is stalling the backend will
clear up in that extra time, this just might forestall further failures.
At the very least it will give us new information.  Besides, this is
only a test that will timeout eventually anyway (with appropriate
cleanup measures in place).  Plus, the default admin LRO polling policy
is even longer, at 30 minutes.

Related to #7510.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7515)
<!-- Reviewable:end -->
