### PR TITLE
test(spanner): relax an expectation about JSON keys in emulator

### DIFF
--- a/google/cloud/spanner/admin/integration_tests/database_admin_integration_test.cc
+++ b/google/cloud/spanner/admin/integration_tests/database_admin_integration_test.cc
@@ -275,8 +275,7 @@ TEST_F(DatabaseAdminClientTest, DatabaseBasicCRUD) {
                          AllOf(HasSubstr("Key has type JSON"),
                                HasSubstr("part of the primary key"))));
   } else {
-    EXPECT_THAT(metadata, StatusIs(StatusCode::kInvalidArgument,
-                                   HasSubstr("Encountered 'JSON'")));
+    EXPECT_THAT(metadata, Not(IsOk()));
   }
 
   EXPECT_TRUE(DatabaseExists()) << "Database " << database_;

--- a/google/cloud/spanner/integration_tests/database_admin_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/database_admin_integration_test.cc
@@ -268,8 +268,7 @@ TEST_F(DatabaseAdminClientTest, DatabaseBasicCRUD) {
                          AllOf(HasSubstr("Key has type JSON"),
                                HasSubstr("part of the primary key"))));
   } else {
-    EXPECT_THAT(metadata, StatusIs(StatusCode::kInvalidArgument,
-                                   HasSubstr("Encountered 'JSON'")));
+    EXPECT_THAT(metadata, Not(IsOk()));
   }
 
   EXPECT_TRUE(DatabaseExists()) << "Database " << database_;


### PR DESCRIPTION
The Spanner emulator is gaining support for JSON values, which means
we need to start changing some test expectations.  We were somewhat
particular about what errors to expect so that we could discern when
the emulator's behavior started to change.

In this test case, where we use a JSON column as a primary key (which
is always an error), we were expecting a parse error on the word
"JSON", but, for now, we're happy with any kind of error.  We might
still get the "INVALID_ARGUMENT" parsing error, or we could get the
true "INVALID_ARGUMENT" primary-key error, or we might even get
"UNIMPLEMENTED" if the emulator has JSON support dynamically disabled.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7517)
<!-- Reviewable:end -->
