### PR TITLE
doc: update patch release instructions 

### DIFF
--- a/release/README.md
+++ b/release/README.md
@@ -152,7 +152,13 @@ take several weeks.
 
 In your development fork:
 * Switch to the existing release branch, e.g. `git checkout v1.17.x`.
-* Create a new branch off the release branch.
+* Bump the version numbers for the patch release
+  * Create a new branch off the release branch
+  * Follow the instructions in the "Bump the version number in `main`"
+    instructions from above, but update the patch number, not the minor number.
+  * **Send this PR for review and merge it before continuing**
+* Create a new branch off the release branch, which now contains the new patch
+  version and baseline ABI dumps.
 * Create or cherry-pick commits with the desired changes.
 * Update `CHANELOG.md` to reflect the changes made.
 * Bump the minor version number in the top-level CMakeLists.txt and run the


### PR DESCRIPTION
Fixes: #7465

The instructions for creating a patch release needed to be updated since
we now use versioned inline namespaces that include the major, minor,
and patch numbers. The rule of thumb is that the ABI baseline files need
to be updated _everytime_ a version number changes. And these instructions
now have us updating the patch branch version number (and baseline)
**before** making the changes to that branch.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7525)
<!-- Reviewable:end -->
