### PR TITLE
test(spanner): bump create-database timeout from ~120s to ~300s

### DIFF
--- a/google/cloud/spanner/integration_tests/rpc_failure_threshold_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/rpc_failure_threshold_integration_test.cc
@@ -65,7 +65,7 @@ class RpcFailureThresholdTest
                                       ) PRIMARY KEY (SingerId))""");
     auto database_future = admin_client.CreateDatabase(request);
     int i = 0;
-    int const timeout = 120;
+    int const timeout = 300;
     while (++i < timeout) {
       auto status = database_future.wait_for(std::chrono::seconds(1));
       if (status == std::future_status::ready) break;


### PR DESCRIPTION
Another instance of #7515.  Related to #7510.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7536)
<!-- Reviewable:end -->
