### PR TITLE
cleanup(generator): new line in auth cc

### DIFF
--- a/generator/internal/auth_decorator_generator.cc
+++ b/generator/internal/auth_decorator_generator.cc
@@ -241,10 +241,10 @@ future<Status> $auth_class_name$::AsyncCancelOperation(
         return child->AsyncCancelOperation(cq, *std::move(context), request);
       });
 }
-
 )""");
   }
 
+  CcPrint("\n");
   CcCloseNamespaces();
   return {};
 }

--- a/google/cloud/bigquery/internal/bigquery_read_auth_decorator.cc
+++ b/google/cloud/bigquery/internal/bigquery_read_auth_decorator.cc
@@ -61,6 +61,7 @@ BigQueryReadAuth::SplitReadStream(
   if (!status.ok()) return status;
   return child_->SplitReadStream(context, request);
 }
+
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigquery_internal
 }  // namespace cloud

--- a/google/cloud/iam/internal/iam_auth_decorator.cc
+++ b/google/cloud/iam/internal/iam_auth_decorator.cc
@@ -247,6 +247,7 @@ StatusOr<google::iam::admin::v1::LintPolicyResponse> IAMAuth::LintPolicy(
   if (!status.ok()) return status;
   return child_->LintPolicy(context, request);
 }
+
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace iam_internal
 }  // namespace cloud

--- a/google/cloud/iam/internal/iam_credentials_auth_decorator.cc
+++ b/google/cloud/iam/internal/iam_credentials_auth_decorator.cc
@@ -65,6 +65,7 @@ IAMCredentialsAuth::SignJwt(
   if (!status.ok()) return status;
   return child_->SignJwt(context, request);
 }
+
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace iam_internal
 }  // namespace cloud

--- a/google/cloud/logging/internal/logging_service_v2_auth_decorator.cc
+++ b/google/cloud/logging/internal/logging_service_v2_auth_decorator.cc
@@ -73,6 +73,7 @@ StatusOr<google::logging::v2::ListLogsResponse> LoggingServiceV2Auth::ListLogs(
   if (!status.ok()) return status;
   return child_->ListLogs(context, request);
 }
+
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace logging_internal
 }  // namespace cloud


### PR DESCRIPTION
Auth decorators without a longrunning operations did not have a blank line before the closing namespace

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7543)
<!-- Reviewable:end -->
