### PR TITLE
test(spanner): bump create-database timeout from ~300s to ~600s

### DIFF
--- a/google/cloud/spanner/integration_tests/rpc_failure_threshold_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/rpc_failure_threshold_integration_test.cc
@@ -65,10 +65,10 @@ class RpcFailureThresholdTest
                                       ) PRIMARY KEY (SingerId))""");
     auto database_future = admin_client.CreateDatabase(request);
     int i = 0;
-    int const timeout = 300;
+    int const timeout = 600;
     while (++i < timeout) {
       auto status = database_future.wait_for(std::chrono::seconds(1));
-      if (status == std::future_status::ready) break;
+      if (status != std::future_status::timeout) break;
       std::cout << '.' << std::flush;
     }
     if (i >= timeout) {

--- a/google/cloud/spanner/testing/database_integration_test.cc
+++ b/google/cloud/spanner/testing/database_integration_test.cc
@@ -121,10 +121,10 @@ void DatabaseIntegrationTest::SetUpTestSuite() {
   auto database_future = admin_client.CreateDatabase(request);
 
   int i = 0;
-  int const timeout = 300;
+  int const timeout = 600;
   while (++i < timeout) {
     auto status = database_future.wait_for(std::chrono::seconds(1));
-    if (status == std::future_status::ready) break;
+    if (status != std::future_status::timeout) break;
     std::cout << '.' << std::flush;
   }
   if (i >= timeout) {


### PR DESCRIPTION
Increase the time spent waiting for the creation of a test database
from 300 one-second polls to 600.  Indications are that the service
can just be slow on occasion.

See previous changes #7515 and #7536.  Related to #7510.

Also tweak the poll-loop termination condition to be more exacting.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7549)
<!-- Reviewable:end -->
