### PR TITLE
ci: fix testbench install on linux

### DIFF
--- a/ci/cloudbuild/builds/lib/integration.sh
+++ b/ci/cloudbuild/builds/lib/integration.sh
@@ -28,7 +28,7 @@ source module ci/lib/io.sh
 
 # To run the integration tests we need to install the dependencies for the storage emulator
 export PATH="${HOME}/.local/bin:${PATH}"
-python3 -m pip install --quiet --user "git+git://github.com/googleapis/storage-testbench@v0.9.0"
+python3 -m pip install --quiet "git+https://github.com/googleapis/storage-testbench@v0.9.0"
 
 # Some of the tests will need a valid roots.pem file.
 rm -f /dev/shm/roots.pem


### PR DESCRIPTION
Some linux builds are failing with this error:
```
  ERROR: Command errored out with exit status 128:
   command: git clone --filter=blob:none -q git://github.com/googleapis/storage-testbench /tmp/pip-req-build-3egrh31a
       cwd: None
  Complete output (3 lines):
  fatal: remote error:
    The unauthenticated git protocol on port 9418 is no longer supported.
  Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
```

Link says: 
> If you’re having trouble cloning a repository, make sure the URL starts with `ssh://`, `https://`, or `git@github.com`

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7551)
<!-- Reviewable:end -->
