### PR TITLE
fix(GCS+gRPC): correct format Object ids

### DIFF
--- a/google/cloud/storage/internal/grpc_client.cc
+++ b/google/cloud/storage/internal/grpc_client.cc
@@ -727,7 +727,7 @@ ObjectMetadata GrpcClient::FromProto(google::storage::v2::Object object) {
   metadata.bucket_ = bucket_id(object);
   metadata.name_ = std::move(*object.mutable_name());
   metadata.generation_ = object.generation();
-  metadata.id_ = metadata.bucket() + "/" + metadata.name() + "#" +
+  metadata.id_ = metadata.bucket() + "/" + metadata.name() + "/" +
                  std::to_string(metadata.generation());
   metadata.metageneration_ = object.metageneration();
   if (object.has_owner()) {

--- a/google/cloud/storage/internal/grpc_client_test.cc
+++ b/google/cloud/storage/internal/grpc_client_test.cc
@@ -129,7 +129,7 @@ TEST(GrpcClientFromProto, ObjectSimple) {
     },
     "eventBasedHold": true,
     "name": "test-object-name",
-    "id": "test-bucket/test-object-name#2345",
+    "id": "test-bucket/test-object-name/2345",
     "kind": "storage#object",
     "bucket": "test-bucket",
     "generation": 2345,

--- a/google/cloud/storage/tests/object_basic_crud_integration_test.cc
+++ b/google/cloud/storage/tests/object_basic_crud_integration_test.cc
@@ -73,7 +73,6 @@ TEST_F(ObjectBasicCRUDIntegrationTest, BasicCRUD) {
       Projection("full"));
   ASSERT_STATUS_OK(get_meta);
 
-  // TODO(#7257) - cleanup after production is fixed.
   if (UsingGrpc()) {
     // The metadata returned by gRPC (InsertObject) doesn't contain the `acl`,
     // `etag`, `media_link`, or `self_link` fields. Just compare field by field:
@@ -89,7 +88,7 @@ TEST_F(ObjectBasicCRUDIntegrationTest, BasicCRUD) {
     EXPECT_EQ(get_meta->crc32c(), insert_meta->crc32c());
     EXPECT_EQ(get_meta->event_based_hold(), insert_meta->event_based_hold());
     EXPECT_EQ(get_meta->generation(), insert_meta->generation());
-    // EXPECT_EQ(get_meta->id(), insert_meta->id()); // b/198515640
+    EXPECT_EQ(get_meta->id(), insert_meta->id());
     EXPECT_EQ(get_meta->kind(), insert_meta->kind());
     EXPECT_EQ(get_meta->kms_key_name(), insert_meta->kms_key_name());
     EXPECT_EQ(get_meta->md5_hash(), insert_meta->md5_hash());


### PR DESCRIPTION
I was confused about the JSON format for Object ids the wrong synthetic values.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7559)
<!-- Reviewable:end -->
