### PR TITLE
feat(GCS+gRPC): synthetic object metadata links

### DIFF
--- a/google/cloud/storage/internal/grpc_client.h
+++ b/google/cloud/storage/internal/grpc_client.h
@@ -69,6 +69,8 @@ class GrpcClient : public RawClient,
                                std::string const& upload_url);
   //@}
 
+  Options const& options() const { return options_; }
+
   ClientOptions const& client_options() const override;
 
   StatusOr<ListBucketsResponse> ListBuckets(
@@ -184,7 +186,8 @@ class GrpcClient : public RawClient,
   static CustomerEncryption FromProto(
       google::storage::v2::Object::CustomerEncryption rhs);
 
-  static ObjectMetadata FromProto(google::storage::v2::Object object);
+  static ObjectMetadata FromProto(google::storage::v2::Object object,
+                                  Options const& options);
 
   static google::storage::v2::ObjectAccessControl ToProto(
       ObjectAccessControl const& acl);
@@ -202,7 +205,8 @@ class GrpcClient : public RawClient,
   static StatusOr<google::storage::v2::WriteObjectRequest> ToProto(
       InsertObjectMediaRequest const& request);
   static ResumableUploadResponse FromProto(
-      google::storage::v2::WriteObjectResponse const&);
+      google::storage::v2::WriteObjectResponse const& p,
+      Options const& options);
   static StatusOr<google::storage::v2::StartResumableWriteRequest> ToProto(
       ResumableUploadRequest const& request);
   static google::storage::v2::QueryWriteStatusRequest ToProto(

--- a/google/cloud/storage/internal/grpc_client_test.cc
+++ b/google/cloud/storage/internal/grpc_client_test.cc
@@ -133,6 +133,8 @@ TEST(GrpcClientFromProto, ObjectSimple) {
     "kind": "storage#object",
     "bucket": "test-bucket",
     "generation": 2345,
+    "selfLink":  "https://www.googleapis.com/storage/v1/b/test-bucket/o/test-object-name",
+    "mediaLink": "https://storage.googleapis.com/download/storage/v1/b/test-bucket/o/test-object-name?generation=2345&alt=media",
     "owner": {
       "entity": "test-entity",
       "entityId": "test-entity-id"
@@ -144,7 +146,9 @@ TEST(GrpcClientFromProto, ObjectSimple) {
 })""");
   EXPECT_STATUS_OK(expected);
 
-  auto actual = GrpcClient::FromProto(input);
+  auto actual = GrpcClient::FromProto(
+      input,
+      Options{}.set<RestEndpointOption>("https://storage.googleapis.com"));
   EXPECT_EQ(actual, *expected);
 }
 

--- a/google/cloud/storage/internal/grpc_resumable_upload_session.cc
+++ b/google/cloud/storage/internal/grpc_resumable_upload_session.cc
@@ -141,7 +141,8 @@ StatusOr<ResumableUploadResponse> GrpcResumableUploadSession::UploadGeneric(
       return last_response_;
     }
     done_ = final_chunk;
-    last_response_ = GrpcClient::FromProto(*std::move(result));
+    last_response_ =
+        GrpcClient::FromProto(*std::move(result), client_->options());
     return last_response_;
   };
 

--- a/google/cloud/storage/object_metadata.cc
+++ b/google/cloud/storage/object_metadata.cc
@@ -71,7 +71,8 @@ std::ostream& operator<<(std::ostream& os, ObjectMetadata const& rhs) {
      << rhs.event_based_hold() << ", generation=" << rhs.generation()
      << ", id=" << rhs.id() << ", kind=" << rhs.kind()
      << ", kms_key_name=" << rhs.kms_key_name()
-     << ", md5_hash=" << rhs.md5_hash() << ", media_link=" << rhs.media_link();
+     << ", md5_hash=" << rhs.md5_hash() << ", media_link=" << rhs.media_link()
+     << ", ";
   if (!rhs.metadata_.empty()) {
     os << "metadata."
        << absl::StrJoin(rhs.metadata_, ", metadata.", absl::PairFormatter("="));

--- a/google/cloud/storage/tests/object_basic_crud_integration_test.cc
+++ b/google/cloud/storage/tests/object_basic_crud_integration_test.cc
@@ -92,12 +92,12 @@ TEST_F(ObjectBasicCRUDIntegrationTest, BasicCRUD) {
     EXPECT_EQ(get_meta->kind(), insert_meta->kind());
     EXPECT_EQ(get_meta->kms_key_name(), insert_meta->kms_key_name());
     EXPECT_EQ(get_meta->md5_hash(), insert_meta->md5_hash());
-    // EXPECT_EQ(get_meta->media_link(), insert_meta->media_link());
+    EXPECT_EQ(get_meta->media_link(), insert_meta->media_link());
     EXPECT_EQ(get_meta->metageneration(), insert_meta->metageneration());
     // EXPECT_EQ(get_meta->owner(), insert_meta->owner());
     EXPECT_EQ(get_meta->retention_expiration_time(),
               insert_meta->retention_expiration_time());
-    // EXPECT_EQ(get_meta->self_link(), insert_meta->self_link());
+    EXPECT_EQ(get_meta->self_link(), insert_meta->self_link());
     EXPECT_EQ(get_meta->size(), insert_meta->size());
     EXPECT_EQ(get_meta->storage_class(), insert_meta->storage_class());
     EXPECT_EQ(get_meta->temporary_hold(), insert_meta->temporary_hold());


### PR DESCRIPTION
The JSON API provides links to the media and metadata contents of each
object as part of the object metadata. The gRPC API does not provide
such links. While not strictly necessary, I think it is nice to create
synthetic versions of these links.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7563)
<!-- Reviewable:end -->
