### PR TITLE
cleanup(bigtable): cleanup admin integration tests

### DIFF
--- a/google/cloud/bigtable/tests/admin_iam_policy_integration_test.cc
+++ b/google/cloud/bigtable/tests/admin_iam_policy_integration_test.cc
@@ -25,9 +25,6 @@ namespace bigtable {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
-namespace btadmin = ::google::bigtable::admin::v2;
-namespace bigtable = ::google::cloud::bigtable;
-
 class AdminIAMPolicyIntegrationTest
     : public bigtable::testing::TableIntegrationTest {
  protected:
@@ -53,11 +50,6 @@ class AdminIAMPolicyIntegrationTest
 /// @test Verify that IAM Policy APIs work as expected.
 TEST_F(AdminIAMPolicyIntegrationTest, SetGetTestIamAPIsTest) {
   auto const table_id = bigtable::testing::TableTestEnvironment::table_id();
-
-  // verify new table id in current table list
-  auto previous_table_list =
-      table_admin_->ListTables(btadmin::Table::NAME_ONLY);
-  ASSERT_STATUS_OK(previous_table_list);
 
   auto iam_policy = bigtable::IamPolicy({bigtable::IamBinding(
       "roles/bigtable.reader", {"serviceAccount:" + service_account_})});


### PR DESCRIPTION
I am going to copy the admin integration tests and convert them to test the generated API. This PR tidies up the tests so that the conversion step will be easier to grok.

Most of this is renaming. Some of it is functional.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7569)
<!-- Reviewable:end -->
