### PR TITLE
test(bigtable): convert admin integration tests to use generated code

### DIFF
--- a/google/cloud/bigtable/admin/integration_tests/admin_backup_integration_test.cc
+++ b/google/cloud/bigtable/admin/integration_tests/admin_backup_integration_test.cc
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "google/cloud/bigtable/instance_admin.h"
+#include "google/cloud/bigtable/admin/bigtable_instance_admin_client.h"
+#include "google/cloud/bigtable/admin/bigtable_table_admin_client.h"
 #include "google/cloud/bigtable/testing/table_integration_test.h"
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/internal/random.h"
@@ -28,7 +29,7 @@
 
 namespace google {
 namespace cloud {
-namespace bigtable {
+namespace bigtable_admin {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
@@ -37,42 +38,64 @@ using ::google::protobuf::util::TimeUtil;
 using ::testing::Contains;
 using ::testing::Not;
 namespace btadmin = ::google::bigtable::admin::v2;
-namespace bigtable = ::google::cloud::bigtable;
 
 class AdminBackupIntegrationTest
     : public bigtable::testing::TableIntegrationTest {
  protected:
-  std::unique_ptr<bigtable::TableAdmin> table_admin_;
-  std::unique_ptr<bigtable::InstanceAdmin> instance_admin_;
+  // Extract the backup names or return an error.
+  StatusOr<std::vector<std::string>> ListBackups() {
+    auto backups = client_.ListBackups(
+        bigtable::ClusterName(project_id(), instance_id(), "-"));
 
-  void SetUp() override {
-    TableIntegrationTest::SetUp();
-
-    std::shared_ptr<bigtable::AdminClient> admin_client =
-        bigtable::MakeAdminClient(
-            bigtable::testing::TableTestEnvironment::project_id());
-    table_admin_ = absl::make_unique<bigtable::TableAdmin>(
-        admin_client, bigtable::testing::TableTestEnvironment::instance_id());
-    auto instance_admin_client = bigtable::MakeInstanceAdminClient(
-        bigtable::testing::TableTestEnvironment::project_id());
-    instance_admin_ =
-        absl::make_unique<bigtable::InstanceAdmin>(instance_admin_client);
+    std::vector<std::string> names;
+    for (auto const& backup : backups) {
+      if (!backup) return backup.status();
+      names.push_back(backup->name());
+    }
+    return names;
   }
+
+  // Extract the table names or return an error.
+  StatusOr<std::vector<std::string>> ListTables() {
+    btadmin::ListTablesRequest r;
+    r.set_parent(bigtable::InstanceName(project_id(), instance_id()));
+    r.set_view(btadmin::Table::NAME_ONLY);
+    auto tables = client_.ListTables(std::move(r));
+
+    std::vector<std::string> names;
+    for (auto const& table : tables) {
+      if (!table) return table.status();
+      names.push_back(table->name());
+    }
+    return names;
+  }
+
+  BigtableTableAdminClient client_ =
+      BigtableTableAdminClient(MakeBigtableTableAdminConnection());
 };
+
+protobuf::FieldMask Mask(std::string const& path) {
+  protobuf::FieldMask mask;
+  mask.add_paths(path);
+  return mask;
+}
 
 /// @test Verify that `bigtable::TableAdmin` Backup CRUD operations work as
 /// expected.
 TEST_F(AdminBackupIntegrationTest, CreateListGetUpdateRestoreDeleteBackup) {
   auto const table_id = bigtable::testing::TableTestEnvironment::table_id();
+  auto const instance_name =
+      bigtable::InstanceName(project_id(), instance_id());
   auto const table_name =
       bigtable::TableName(project_id(), instance_id(), table_id);
 
-  auto clusters = instance_admin_->ListClusters(table_admin_->instance_id());
+  // Determine which cluster to make a backup of
+  auto instance_admin_client =
+      BigtableInstanceAdminClient(MakeBigtableInstanceAdminConnection());
+
+  auto clusters = instance_admin_client.ListClusters(instance_name);
   ASSERT_STATUS_OK(clusters);
-  auto const cluster_name = clusters->clusters.begin()->name();
-  auto const cluster_id =
-      cluster_name.substr(cluster_name.rfind('/') + 1,
-                          cluster_name.size() - cluster_name.rfind('/'));
+  auto const cluster_name = clusters->clusters().begin()->name();
   auto const backup_id = RandomBackupId();
   auto const backup_name = cluster_name + "/backups/" + backup_id;
 
@@ -80,59 +103,64 @@ TEST_F(AdminBackupIntegrationTest, CreateListGetUpdateRestoreDeleteBackup) {
   google::protobuf::Timestamp expire_time =
       TimeUtil::GetCurrentTime() + TimeUtil::HoursToDuration(12);
 
-  auto backup = table_admin_->CreateBackup(
-      {cluster_id, backup_id, table_id,
-       google::cloud::internal::ToChronoTimePoint(expire_time)});
+  btadmin::Backup b;
+  b.set_source_table(table_name);
+  *b.mutable_expire_time() = expire_time;
+  auto backup =
+      client_.CreateBackup(cluster_name, backup_id, std::move(b)).get();
   ASSERT_STATUS_OK(backup);
   EXPECT_EQ(backup->name(), backup_name);
 
   // List backups to verify new backup has been created
-  auto backups = table_admin_->ListBackups({});
+  auto backups = ListBackups();
   ASSERT_STATUS_OK(backups);
-  EXPECT_THAT(BackupNames(*backups), Contains(backup_name));
+  EXPECT_THAT(*backups, Contains(backup_name));
 
   // Get backup to verify create
-  backup = table_admin_->GetBackup(cluster_id, backup_id);
+  backup = client_.GetBackup(backup_name);
   ASSERT_STATUS_OK(backup);
   EXPECT_EQ(backup->name(), backup_name);
 
   // Update backup
   expire_time = expire_time + TimeUtil::HoursToDuration(12);
-  backup = table_admin_->UpdateBackup(
-      {cluster_id, backup_id,
-       google::cloud::internal::ToChronoTimePoint(expire_time)});
+  *backup->mutable_expire_time() = expire_time;
+  backup = client_.UpdateBackup(*backup, Mask("expire_time"));
   ASSERT_STATUS_OK(backup);
 
   // Verify the update
-  backup = table_admin_->GetBackup(cluster_id, backup_id);
+  backup = client_.GetBackup(backup_name);
   ASSERT_STATUS_OK(backup);
   EXPECT_EQ(backup->name(), backup_name);
   EXPECT_EQ(backup->expire_time(), expire_time);
 
   // Delete table
-  EXPECT_STATUS_OK(table_admin_->DeleteTable(table_id));
+  EXPECT_STATUS_OK(client_.DeleteTable(table_name));
 
   // Verify the delete
-  auto tables = table_admin_->ListTables(btadmin::Table::NAME_ONLY);
+  auto tables = ListTables();
   ASSERT_STATUS_OK(tables);
-  EXPECT_THAT(TableNames(*tables), Not(Contains(table_name)));
+  EXPECT_THAT(*tables, Not(Contains(table_name)));
 
   // Restore table
-  auto table = table_admin_->RestoreTable({table_id, cluster_id, backup_id});
+  btadmin::RestoreTableRequest r;
+  r.set_parent(instance_name);
+  r.set_table_id(table_id);
+  r.set_backup(backup_name);
+  auto table = client_.RestoreTable(std::move(r)).get();
   EXPECT_STATUS_OK(table);
 
   // Verify the restore
-  tables = table_admin_->ListTables(btadmin::Table::NAME_ONLY);
+  tables = ListTables();
   ASSERT_STATUS_OK(tables);
-  EXPECT_THAT(TableNames(*tables), ContainsOnce(table_name));
+  EXPECT_THAT(*tables, ContainsOnce(table_name));
 
   // Delete backup
-  EXPECT_STATUS_OK(table_admin_->DeleteBackup(cluster_id, backup_id));
+  EXPECT_STATUS_OK(client_.DeleteBackup(backup_name));
 }
 
 }  // namespace
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-}  // namespace bigtable
+}  // namespace bigtable_admin
 }  // namespace cloud
 }  // namespace google
 

--- a/google/cloud/bigtable/admin/integration_tests/instance_admin_integration_test.cc
+++ b/google/cloud/bigtable/admin/integration_tests/instance_admin_integration_test.cc
@@ -12,11 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "google/cloud/bigtable/instance_admin.h"
+#include "google/cloud/bigtable/admin/bigtable_instance_admin_client.h"
+#include "google/cloud/bigtable/iam_binding.h"
+#include "google/cloud/bigtable/iam_policy.h"
+#include "google/cloud/bigtable/resource_names.h"
+#include "google/cloud/common_options.h"
+#include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/algorithm.h"
 #include "google/cloud/internal/background_threads_impl.h"
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/internal/random.h"
+#include "google/cloud/project.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/testing_util/contains_once.h"
 #include "google/cloud/testing_util/integration_test.h"
@@ -31,12 +37,13 @@
 
 namespace google {
 namespace cloud {
-namespace bigtable {
+namespace bigtable_admin {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
 using ::google::cloud::internal::GetEnv;
 using ::google::cloud::testing_util::ContainsOnce;
+using ::google::cloud::testing_util::IsOk;
 using ::testing::Contains;
 using ::testing::HasSubstr;
 using ::testing::IsEmpty;
@@ -64,50 +71,77 @@ class InstanceAdminIntegrationTest
     service_account_ =
         GetEnv("GOOGLE_CLOUD_CPP_BIGTABLE_TEST_SERVICE_ACCOUNT").value_or("");
     ASSERT_FALSE(service_account_.empty());
+  }
 
-    auto instance_admin_client = bigtable::MakeInstanceAdminClient(project_id_);
-    instance_admin_ =
-        absl::make_unique<bigtable::InstanceAdmin>(instance_admin_client);
+  StatusOr<std::vector<std::string>> ListInstances(
+      BigtableInstanceAdminClient& client) {
+    auto const project_name = Project(project_id_).FullName();
+    auto sor = client.ListInstances(project_name);
+    if (!sor) return std::move(sor).status();
+    auto resp = std::move(sor).value();
+
+    std::vector<std::string> names;
+    names.reserve(resp.instances_size());
+    auto& instances = *resp.mutable_instances();
+    EXPECT_EQ(0, resp.failed_locations_size());
+    std::transform(instances.begin(), instances.end(),
+                   std::back_inserter(names),
+                   [](btadmin::Instance const& i) { return i.name(); });
+    return names;
+  }
+
+  StatusOr<std::vector<std::string>> ListClusters(
+      std::string const& instance_id) {
+    auto const instance_name = bigtable::InstanceName(project_id_, instance_id);
+    auto sor = client_.ListClusters(instance_name);
+    if (!sor) return std::move(sor).status();
+    auto resp = std::move(sor).value();
+
+    std::vector<std::string> names;
+    names.reserve(resp.clusters_size());
+    auto& clusters = *resp.mutable_clusters();
+    std::transform(clusters.begin(), clusters.end(), std::back_inserter(names),
+                   [](btadmin::Cluster const& c) { return c.name(); });
+    return names;
   }
 
   std::string project_id_;
   std::string zone_a_;
   std::string zone_b_;
   std::string service_account_;
-  std::unique_ptr<bigtable::InstanceAdmin> instance_admin_;
+  BigtableInstanceAdminClient client_ =
+      BigtableInstanceAdminClient(MakeBigtableInstanceAdminConnection());
   google::cloud::internal::DefaultPRNG generator_ =
       google::cloud::internal::MakeDefaultPRNG();
 };
 
-bool IsInstancePresent(std::vector<btadmin::Instance> const& instances,
-                       std::string const& instance_name) {
-  return google::cloud::internal::ContainsIf(
-      instances, [&instance_name](btadmin::Instance const& i) {
-        return i.name() == instance_name;
-      });
-}
-
-bool IsClusterPresent(std::vector<btadmin::Cluster> const& clusters,
-                      std::string const& cluster_name) {
-  return google::cloud::internal::ContainsIf(
-      clusters, [&cluster_name](btadmin::Cluster const& i) {
-        return i.name() == cluster_name;
-      });
-}
-
-bigtable::InstanceConfig IntegrationTestConfig(
-    std::string const& instance_id, std::string const& zone,
-    bigtable::InstanceConfig::InstanceType instance_type =
-        bigtable::InstanceConfig::DEVELOPMENT,
-    int32_t serve_node = 0) {
+btadmin::CreateInstanceRequest IntegrationTestConfig(
+    std::string const& project, std::string const& instance_id,
+    std::string const& location,
+    btadmin::Instance::Type type = btadmin::Instance::DEVELOPMENT,
+    int32_t serve_nodes = 0) {
   // The description cannot exceed 30 characters
   auto const display_name = ("IT " + instance_id).substr(0, 30);
-  auto cluster_config =
-      bigtable::ClusterConfig(zone, serve_node, bigtable::ClusterConfig::HDD);
-  bigtable::InstanceConfig config(instance_id, display_name,
-                                  {{instance_id + "-c1", cluster_config}});
-  config.set_type(instance_type);
-  return config;
+  auto const project_name = Project(project).FullName();
+
+  btadmin::Cluster c;
+  c.set_location(project_name + "/locations/" + location);
+  c.set_serve_nodes(serve_nodes);
+  c.set_default_storage_type(btadmin::StorageType::HDD);
+
+  btadmin::CreateInstanceRequest r;
+  r.set_parent(std::move(project_name));
+  r.set_instance_id(instance_id);
+  r.mutable_instance()->set_type(type);
+  r.mutable_instance()->set_display_name(std::move(display_name));
+  (*r.mutable_clusters())[instance_id + "-c1"] = std::move(c);
+  return r;
+}
+
+protobuf::FieldMask Mask(std::string const& path) {
+  protobuf::FieldMask mask;
+  mask.add_paths(path);
+  return mask;
 }
 
 /// @test Verify that default InstanceAdmin::ListClusters works as expected.
@@ -118,16 +152,17 @@ TEST_F(InstanceAdminIntegrationTest, ListAllClustersTest) {
   auto const id_2 =
       "it-" + google::cloud::internal::Sample(
                   generator_, 8, "abcdefghijklmnopqrstuvwxyz0123456789");
+  auto const project_name = Project(project_id_).FullName();
   auto const name_1 = bigtable::InstanceName(project_id_, id_1);
   auto const name_2 = bigtable::InstanceName(project_id_, id_2);
 
-  auto config_1 = IntegrationTestConfig(
-      id_1, zone_a_, bigtable::InstanceConfig::PRODUCTION, 3);
-  auto config_2 = IntegrationTestConfig(
-      id_2, zone_b_, bigtable::InstanceConfig::PRODUCTION, 3);
+  auto config_1 = IntegrationTestConfig(project_id_, id_1, zone_a_,
+                                        btadmin::Instance::PRODUCTION, 3);
+  auto config_2 = IntegrationTestConfig(project_id_, id_2, zone_b_,
+                                        btadmin::Instance::PRODUCTION, 3);
 
-  auto instance_1_fut = instance_admin_->CreateInstance(config_1);
-  auto instance_2_fut = instance_admin_->CreateInstance(config_2);
+  auto instance_1_fut = client_.CreateInstance(config_1);
+  auto instance_2_fut = client_.CreateInstance(config_2);
 
   // Wait for instance creation
   auto instance_1 = instance_1_fut.get();
@@ -138,16 +173,15 @@ TEST_F(InstanceAdminIntegrationTest, ListAllClustersTest) {
   EXPECT_EQ(instance_1->name(), name_1);
   EXPECT_EQ(instance_2->name(), name_2);
 
-  auto clusters = instance_admin_->ListClusters();
+  auto clusters = ListClusters("-");
   ASSERT_STATUS_OK(clusters);
-  for (auto const& cluster : clusters->clusters) {
-    EXPECT_NE(std::string::npos,
-              cluster.name().find(instance_admin_->project_name()));
+  for (auto const& cluster : *clusters) {
+    EXPECT_THAT(cluster, HasSubstr(project_name));
   }
-  EXPECT_FALSE(clusters->clusters.empty());
+  EXPECT_THAT(*clusters, Not(IsEmpty()));
 
-  EXPECT_STATUS_OK(instance_admin_->DeleteInstance(id_1));
-  EXPECT_STATUS_OK(instance_admin_->DeleteInstance(id_2));
+  EXPECT_STATUS_OK(client_.DeleteInstance(name_1));
+  EXPECT_STATUS_OK(client_.DeleteInstance(name_2));
 }
 
 /// @test Verify that AppProfile CRUD operations work as expected.
@@ -157,9 +191,9 @@ TEST_F(InstanceAdminIntegrationTest, CreateListGetDeleteAppProfile) {
                   generator_, 8, "abcdefghijklmnopqrstuvwxyz0123456789");
   auto const instance_name = bigtable::InstanceName(project_id_, instance_id);
 
-  auto config = IntegrationTestConfig(instance_id, zone_a_,
-                                      bigtable::InstanceConfig::PRODUCTION, 3);
-  auto instance_fut = instance_admin_->CreateInstance(config);
+  auto config = IntegrationTestConfig(project_id_, instance_id, zone_a_,
+                                      btadmin::Instance::PRODUCTION, 3);
+  auto instance_fut = client_.CreateInstance(config);
   // Wait for instance creation
   auto instance = instance_fut.get();
   ASSERT_STATUS_OK(instance);
@@ -171,71 +205,71 @@ TEST_F(InstanceAdminIntegrationTest, CreateListGetDeleteAppProfile) {
   auto const id_2 =
       "profile-" + google::cloud::internal::Sample(
                        generator_, 8, "abcdefghijklmnopqrstuvwxyz0123456789");
+
   auto const name_1 = bigtable::AppProfileName(project_id_, instance_id, id_1);
   auto const name_2 = bigtable::AppProfileName(project_id_, instance_id, id_2);
 
   // Simplify writing the rest of the test.
-  auto profile_names = [](std::vector<btadmin::AppProfile> const& list) {
-    std::vector<std::string> names(list.size());
-    std::transform(list.begin(), list.end(), names.begin(),
-                   [](btadmin::AppProfile const& x) { return x.name(); });
+  auto profile_names = [](StreamRange<btadmin::AppProfile> list)
+      -> StatusOr<std::vector<std::string>> {
+    std::vector<std::string> names;
+    for (auto const& profile : list) {
+      if (!profile) return profile.status();
+      names.push_back(profile->name());
+    }
     return names;
   };
 
-  auto profiles = instance_admin_->ListAppProfiles(instance_id);
+  auto profiles = profile_names(client_.ListAppProfiles(instance_name));
   ASSERT_STATUS_OK(profiles);
-  EXPECT_THAT(profile_names(*profiles), Not(Contains(name_1)));
-  EXPECT_THAT(profile_names(*profiles), Not(Contains(name_2)));
+  EXPECT_THAT(*profiles, Not(Contains(name_1)));
+  EXPECT_THAT(*profiles, Not(Contains(name_2)));
 
-  auto profile_1 = instance_admin_->CreateAppProfile(
-      instance_id, bigtable::AppProfileConfig::MultiClusterUseAny(id_1));
+  auto profile_1 = client_.CreateAppProfile(instance_name, id_1, {});
   ASSERT_STATUS_OK(profile_1);
   EXPECT_EQ(profile_1->name(), name_1);
 
-  auto profile_2 = instance_admin_->CreateAppProfile(
-      instance_id, bigtable::AppProfileConfig::MultiClusterUseAny(id_2));
+  auto profile_2 = client_.CreateAppProfile(instance_name, id_2, {});
   ASSERT_STATUS_OK(profile_2);
   EXPECT_EQ(profile_2->name(), name_2);
 
-  profiles = instance_admin_->ListAppProfiles(instance_id);
+  profiles = profile_names(client_.ListAppProfiles(instance_name));
   ASSERT_STATUS_OK(profiles);
-  EXPECT_THAT(profile_names(*profiles), ContainsOnce(name_1));
-  EXPECT_THAT(profile_names(*profiles), ContainsOnce(name_2));
+  EXPECT_THAT(*profiles, ContainsOnce(name_1));
+  EXPECT_THAT(*profiles, ContainsOnce(name_2));
 
-  profile_1 = instance_admin_->GetAppProfile(instance_id, id_1);
+  profile_1 = client_.GetAppProfile(name_1);
   ASSERT_STATUS_OK(profile_1);
   EXPECT_EQ(profile_1->name(), name_1);
 
-  profile_2 = instance_admin_->GetAppProfile(instance_id, id_2);
+  profile_2 = client_.GetAppProfile(name_2);
   ASSERT_STATUS_OK(profile_2);
   EXPECT_EQ(profile_2->name(), name_2);
 
+  profile_2->set_description("new description");
   profile_2 =
-      instance_admin_
-          ->UpdateAppProfile(instance_id, id_2,
-                             bigtable::AppProfileUpdateConfig().set_description(
-                                 "new description"))
+      client_.UpdateAppProfile(*std::move(profile_2), Mask("description"))
           .get();
   ASSERT_STATUS_OK(profile_2);
   EXPECT_EQ("new description", profile_2->description());
 
-  profile_2 = instance_admin_->GetAppProfile(instance_id, id_2);
+  profile_2 = client_.GetAppProfile(name_2);
   ASSERT_STATUS_OK(profile_2);
   EXPECT_EQ("new description", profile_2->description());
 
-  ASSERT_STATUS_OK(instance_admin_->DeleteAppProfile(instance_id, id_1, true));
-  profiles = instance_admin_->ListAppProfiles(instance_id);
+  ASSERT_STATUS_OK(client_.DeleteAppProfile(name_1));
+  profiles = profile_names(client_.ListAppProfiles(instance_name));
   ASSERT_STATUS_OK(profiles);
-  EXPECT_THAT(profile_names(*profiles), Not(Contains(name_1)));
-  EXPECT_THAT(profile_names(*profiles), ContainsOnce(name_2));
+  EXPECT_THAT(*profiles, Not(Contains(name_1)));
+  EXPECT_THAT(*profiles, ContainsOnce(name_2));
 
-  ASSERT_STATUS_OK(instance_admin_->DeleteAppProfile(instance_id, id_2, true));
-  profiles = instance_admin_->ListAppProfiles(instance_id);
+  ASSERT_STATUS_OK(client_.DeleteAppProfile(name_2));
+  profiles = profile_names(client_.ListAppProfiles(instance_name));
   ASSERT_STATUS_OK(profiles);
-  EXPECT_THAT(profile_names(*profiles), Not(Contains(name_1)));
-  EXPECT_THAT(profile_names(*profiles), Not(Contains(name_2)));
+  EXPECT_THAT(*profiles, Not(Contains(name_1)));
+  EXPECT_THAT(*profiles, Not(Contains(name_2)));
 
-  ASSERT_STATUS_OK(instance_admin_->DeleteInstance(instance_id));
+  ASSERT_STATUS_OK(client_.DeleteInstance(std::move(instance_name)));
 }
 
 /// @test Verify that Instance CRUD operations work as expected.
@@ -246,42 +280,40 @@ TEST_F(InstanceAdminIntegrationTest, CreateListGetDeleteInstanceTest) {
   auto const instance_name = bigtable::InstanceName(project_id_, instance_id);
 
   // Create instance
-  auto config = IntegrationTestConfig(instance_id, zone_a_);
-  auto instance = instance_admin_->CreateInstance(config).get();
+  auto config = IntegrationTestConfig(project_id_, instance_id, zone_a_);
+  auto instance = client_.CreateInstance(config).get();
   ASSERT_STATUS_OK(instance);
 
   // List instances
-  auto instances = instance_admin_->ListInstances();
+  auto instances = ListInstances(client_);
   ASSERT_STATUS_OK(instances);
-  ASSERT_TRUE(instances->failed_locations.empty());
-  EXPECT_TRUE(IsInstancePresent(instances->instances, instance->name()));
+  EXPECT_THAT(*instances, Contains(instance_name));
 
   // Get instance
-  instance = instance_admin_->GetInstance(instance_id);
+  instance = client_.GetInstance(instance_name);
   ASSERT_STATUS_OK(instance);
   EXPECT_EQ(instance->name(), instance_name);
 
   // Update instance
-  bigtable::InstanceUpdateConfig instance_update_config(std::move(*instance));
   auto const updated_display_name = instance_id + " updated";
-  instance_update_config.set_display_name(updated_display_name);
+  instance->set_display_name(updated_display_name);
   instance =
-      instance_admin_->UpdateInstance(std::move(instance_update_config)).get();
+      client_.PartialUpdateInstance(*std::move(instance), Mask("display_name"))
+          .get();
   ASSERT_STATUS_OK(instance);
 
   // Verify update
-  instance = instance_admin_->GetInstance(instance_id);
+  instance = client_.GetInstance(instance_name);
   ASSERT_STATUS_OK(instance);
   EXPECT_EQ(updated_display_name, instance->display_name());
 
   // Delete instance
-  ASSERT_STATUS_OK(instance_admin_->DeleteInstance(instance_id));
+  ASSERT_STATUS_OK(client_.DeleteInstance(instance_name));
 
   // Verify delete
-  instances = instance_admin_->ListInstances();
+  instances = ListInstances(client_);
   ASSERT_STATUS_OK(instances);
-  ASSERT_TRUE(instances->failed_locations.empty());
-  EXPECT_FALSE(IsInstancePresent(instances->instances, instance_name));
+  EXPECT_THAT(*instances, Not(Contains(instance_name)));
 }
 
 /// @test Verify that cluster CRUD operations work as expected.
@@ -290,57 +322,57 @@ TEST_F(InstanceAdminIntegrationTest, CreateListGetDeleteClusterTest) {
       "it-" + google::cloud::internal::Sample(
                   generator_, 8, "abcdefghijklmnopqrstuvwxyz0123456789");
   auto const cluster_id = instance_id + "-cl2";
+  auto const project_name = Project(project_id_).FullName();
+  auto const instance_name = bigtable::InstanceName(project_id_, instance_id);
   auto const cluster_name =
       bigtable::ClusterName(project_id_, instance_id, cluster_id);
 
   // Create instance prerequisites for cluster operations
-  auto config = IntegrationTestConfig(instance_id, zone_a_,
-                                      bigtable::InstanceConfig::PRODUCTION, 3);
-  auto instance = instance_admin_->CreateInstance(config).get();
+  auto config = IntegrationTestConfig(project_id_, instance_id, zone_a_,
+                                      btadmin::Instance::PRODUCTION, 3);
+  auto instance = client_.CreateInstance(config).get();
   ASSERT_STATUS_OK(instance);
 
   // Create cluster
-  auto cluster_config =
-      bigtable::ClusterConfig(zone_b_, 3, bigtable::ClusterConfig::HDD);
-  auto cluster =
-      instance_admin_->CreateCluster(cluster_config, instance_id, cluster_id)
-          .get();
+  btadmin::Cluster c;
+  c.set_location(project_name + "/locations/" + zone_b_);
+  c.set_serve_nodes(3);
+  c.set_default_storage_type(btadmin::StorageType::HDD);
+  auto cluster = client_.CreateCluster(instance_name, cluster_id, c).get();
   ASSERT_STATUS_OK(cluster);
   EXPECT_EQ(3, cluster->serve_nodes());
 
   // Verify create
-  auto clusters = instance_admin_->ListClusters(instance_id);
+  auto clusters = ListClusters(instance_id);
   ASSERT_STATUS_OK(clusters);
-  EXPECT_TRUE(IsClusterPresent(clusters->clusters, cluster->name()));
+  EXPECT_THAT(*clusters, Contains(cluster_name));
 
   // Get cluster
-  cluster = instance_admin_->GetCluster(instance_id, cluster_id);
+  cluster = client_.GetCluster(cluster_name);
   ASSERT_STATUS_OK(cluster);
   EXPECT_EQ(cluster_name, cluster->name());
 
   // Update cluster
   cluster->set_serve_nodes(4);
   cluster->clear_state();
-  bigtable::ClusterConfig updated_cluster_config(std::move(*cluster));
-  cluster =
-      instance_admin_->UpdateCluster(std::move(updated_cluster_config)).get();
+  cluster = client_.UpdateCluster(*std::move(cluster)).get();
   ASSERT_STATUS_OK(cluster);
 
   // Verify update
-  cluster = instance_admin_->GetCluster(instance_id, cluster_id);
+  cluster = client_.GetCluster(cluster_name);
   ASSERT_STATUS_OK(cluster);
   EXPECT_EQ(4, cluster->serve_nodes());
 
   // Delete cluster
-  ASSERT_STATUS_OK(instance_admin_->DeleteCluster(instance_id, cluster_id));
+  ASSERT_STATUS_OK(client_.DeleteCluster(cluster_name));
 
   // Verify delete
-  clusters = instance_admin_->ListClusters(instance_id);
+  clusters = ListClusters(instance_id);
   ASSERT_STATUS_OK(clusters);
-  EXPECT_FALSE(IsClusterPresent(clusters->clusters, cluster_name));
+  EXPECT_THAT(*clusters, Not(Contains(cluster_name)));
 
   // Delete instance
-  ASSERT_STATUS_OK(instance_admin_->DeleteInstance(instance_id));
+  ASSERT_STATUS_OK(client_.DeleteInstance(instance_name));
 }
 
 /// @test Verify that IAM Policy APIs work as expected.
@@ -348,62 +380,30 @@ TEST_F(InstanceAdminIntegrationTest, SetGetTestIamAPIsTest) {
   auto const instance_id =
       "it-" + google::cloud::internal::Sample(
                   generator_, 8, "abcdefghijklmnopqrstuvwxyz0123456789");
+  auto const instance_name = bigtable::InstanceName(project_id_, instance_id);
 
-  // Create instance prerequisites for cluster operations
-  auto config = IntegrationTestConfig(instance_id, zone_a_,
-                                      bigtable::InstanceConfig::PRODUCTION, 3);
-  ASSERT_STATUS_OK(instance_admin_->CreateInstance(config).get());
-
-  auto iam_bindings = google::cloud::IamBindings(
-      "roles/bigtable.reader", {"serviceAccount:" + service_account_});
-
-  auto initial_policy =
-      instance_admin_->SetIamPolicy(instance_id, iam_bindings);
-  ASSERT_STATUS_OK(initial_policy);
-
-  auto fetched_policy = instance_admin_->GetIamPolicy(instance_id);
-  ASSERT_STATUS_OK(fetched_policy);
-
-  EXPECT_EQ(initial_policy->version, fetched_policy->version);
-  EXPECT_EQ(initial_policy->etag, fetched_policy->etag);
-
-  auto permission_set = instance_admin_->TestIamPermissions(
-      instance_id, {"bigtable.tables.list", "bigtable.tables.delete"});
-  ASSERT_STATUS_OK(permission_set);
-
-  EXPECT_EQ(2, permission_set->size());
-  EXPECT_STATUS_OK(instance_admin_->DeleteInstance(instance_id));
-}
-
-/// @test Verify that IAM Policy Native APIs work as expected.
-TEST_F(InstanceAdminIntegrationTest, SetGetTestIamNativeAPIsTest) {
-  auto const instance_id =
-      "it-" + google::cloud::internal::Sample(
-                  generator_, 8, "abcdefghijklmnopqrstuvwxyz0123456789");
-
-  // create instance prerequisites for cluster operations
-  auto config = IntegrationTestConfig(instance_id, zone_a_,
-                                      bigtable::InstanceConfig::PRODUCTION, 3);
-  ASSERT_STATUS_OK(instance_admin_->CreateInstance(config).get());
+  // Create instance
+  auto config = IntegrationTestConfig(project_id_, instance_id, zone_a_);
+  ASSERT_STATUS_OK(client_.CreateInstance(config).get());
 
   auto iam_policy = bigtable::IamPolicy({bigtable::IamBinding(
       "roles/bigtable.reader", {"serviceAccount:" + service_account_})});
 
-  auto initial_policy = instance_admin_->SetIamPolicy(instance_id, iam_policy);
+  auto initial_policy = client_.SetIamPolicy(instance_id, iam_policy);
   ASSERT_STATUS_OK(initial_policy);
 
-  auto fetched_policy = instance_admin_->GetNativeIamPolicy(instance_id);
+  auto fetched_policy = client_.GetIamPolicy(instance_id);
   ASSERT_STATUS_OK(fetched_policy);
 
   EXPECT_EQ(initial_policy->version(), fetched_policy->version());
   EXPECT_EQ(initial_policy->etag(), fetched_policy->etag());
 
-  auto permission_set = instance_admin_->TestIamPermissions(
-      instance_id, {"bigtable.tables.list", "bigtable.tables.delete"});
+  auto permission_set = client_.TestIamPermissions(
+      instance_name, {"bigtable.tables.list", "bigtable.tables.delete"});
   ASSERT_STATUS_OK(permission_set);
 
-  EXPECT_EQ(2, permission_set->size());
-  EXPECT_STATUS_OK(instance_admin_->DeleteInstance(instance_id));
+  EXPECT_EQ(2, permission_set->permissions_size());
+  EXPECT_STATUS_OK(client_.DeleteInstance(instance_name));
 }
 
 /// @test Verify that Instance CRUD operations with logging work as expected.
@@ -418,79 +418,72 @@ TEST_F(InstanceAdminIntegrationTest,
   auto const instance_id =
       "it-" + google::cloud::internal::Sample(
                   generator_, 8, "abcdefghijklmnopqrstuvwxyz0123456789");
+  auto const project_name = Project(project_id_).FullName();
   auto const instance_name = bigtable::InstanceName(project_id_, instance_id);
 
-  auto instance_admin_client = bigtable::MakeInstanceAdminClient(
-      project_id_, Options{}.set<TracingComponentsOption>({"rpc"}));
-  auto instance_admin =
-      absl::make_unique<bigtable::InstanceAdmin>(instance_admin_client);
+  auto client = BigtableInstanceAdminClient(MakeBigtableInstanceAdminConnection(
+      Options{}.set<TracingComponentsOption>({"rpc"})));
 
   // Create instance
-  auto config = IntegrationTestConfig(instance_id, zone_a_);
-  auto instance = instance_admin->CreateInstance(config).get();
+  auto config = IntegrationTestConfig(project_id_, instance_id, zone_a_);
+  auto instance = client.CreateInstance(config).get();
   ASSERT_STATUS_OK(instance);
 
   // Verify create
-  auto instances = instance_admin->ListInstances();
+  auto instances = ListInstances(client);
   ASSERT_STATUS_OK(instances);
-  ASSERT_TRUE(instances->failed_locations.empty());
-  EXPECT_TRUE(IsInstancePresent(instances->instances, instance->name()));
+  EXPECT_THAT(*instances, Contains(instance_name));
 
   // Get instance
-  instance = instance_admin->GetInstance(instance_id);
+  instance = client.GetInstance(instance_name);
   ASSERT_STATUS_OK(instance);
   EXPECT_EQ(instance->name(), instance_name);
 
   // Update instance
-  bigtable::InstanceUpdateConfig instance_update_config(std::move(*instance));
   auto const updated_display_name = instance_id + " updated";
-  instance_update_config.set_display_name(updated_display_name);
+  instance->set_display_name(updated_display_name);
   instance =
-      instance_admin->UpdateInstance(std::move(instance_update_config)).get();
+      client.PartialUpdateInstance(*instance, Mask("display_name")).get();
   ASSERT_STATUS_OK(instance);
 
   // Verify update
-  instance = instance_admin->GetInstance(instance_id);
+  instance = client.GetInstance(instance_name);
   ASSERT_STATUS_OK(instance);
   EXPECT_EQ(updated_display_name, instance->display_name());
 
   // Delete instance
-  ASSERT_STATUS_OK(instance_admin->DeleteInstance(instance_id));
+  ASSERT_STATUS_OK(client.DeleteInstance(instance_name));
 
   // Verify delete
-  instances = instance_admin->ListInstances();
+  instances = ListInstances(client);
   ASSERT_STATUS_OK(instances);
-  ASSERT_TRUE(instances->failed_locations.empty());
-  EXPECT_FALSE(IsInstancePresent(instances->instances, instance_name));
+  EXPECT_THAT(*instances, Not(Contains(instance_name)));
 
   auto const log_lines = log.ExtractLines();
-  EXPECT_THAT(log_lines, Contains(HasSubstr("ListInstances")));
   EXPECT_THAT(log_lines, Contains(HasSubstr("AsyncCreateInstance")));
+  EXPECT_THAT(log_lines, Contains(HasSubstr("ListInstances")));
   EXPECT_THAT(log_lines, Contains(HasSubstr("GetInstance")));
-  EXPECT_THAT(log_lines, Contains(HasSubstr("AsyncUpdateInstance")));
+  EXPECT_THAT(log_lines, Contains(HasSubstr("AsyncPartialUpdateInstance")));
   EXPECT_THAT(log_lines, Contains(HasSubstr("DeleteInstance")));
 
   // Verify that a normal client does not log.
-  auto no_logging_client = InstanceAdmin(MakeInstanceAdminClient(project_id_));
-  (void)no_logging_client.ListInstances();
+  auto no_logging_client =
+      BigtableInstanceAdminClient(MakeBigtableInstanceAdminConnection());
+  (void)no_logging_client.ListInstances(project_name);
   EXPECT_THAT(log.ExtractLines(), IsEmpty());
 }
 
 TEST_F(InstanceAdminIntegrationTest, CustomWorkers) {
   CompletionQueue cq;
-  auto instance_admin_client = bigtable::MakeInstanceAdminClient(
-      project_id_, Options{}.set<GrpcCompletionQueueOption>(cq));
-  instance_admin_ = absl::make_unique<bigtable::InstanceAdmin>(
-      instance_admin_client,
-      *DefaultRPCRetryPolicy({std::chrono::seconds(1), std::chrono::seconds(1),
-                              std::chrono::seconds(1)}));
+  auto client = BigtableInstanceAdminClient(MakeBigtableInstanceAdminConnection(
+      Options{}.set<GrpcCompletionQueueOption>(cq)));
 
   // CompletionQueue `cq` is not being `Run()`, so this should never finish.
   auto const instance_id =
       "it-" + google::cloud::internal::Sample(
                   generator_, 8, "abcdefghijklmnopqrstuvwxyz0123456789");
-  auto instance_fut = instance_admin_->CreateInstance(IntegrationTestConfig(
-      instance_id, zone_a_, bigtable::InstanceConfig::PRODUCTION, 3));
+  auto instance_fut = client.CreateInstance(IntegrationTestConfig(
+      project_id_, instance_id, zone_a_, btadmin::Instance::PRODUCTION, 3));
 
   EXPECT_EQ(std::future_status::timeout,
             instance_fut.wait_for(std::chrono::milliseconds(100)));
@@ -498,7 +491,8 @@ TEST_F(InstanceAdminIntegrationTest, CustomWorkers) {
   std::thread t([cq]() mutable { cq.Run(); });
   auto instance = instance_fut.get();
   ASSERT_STATUS_OK(instance);
-  EXPECT_STATUS_OK(instance_admin_->DeleteInstance(instance_id));
+  EXPECT_STATUS_OK(
+      client.DeleteInstance(bigtable::InstanceName(project_id_, instance_id)));
 
   cq.CancelAll();
   cq.Shutdown();
@@ -507,6 +501,6 @@ TEST_F(InstanceAdminIntegrationTest, CustomWorkers) {
 
 }  // namespace
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-}  // namespace bigtable
+}  // namespace bigtable_admin
 }  // namespace cloud
 }  // namespace google


### PR DESCRIPTION
Fixes #7526 

Most of the changes in here involve methods that go from accepting an ID (e.g. `table-id` ) to accepting a full name (e.g. `projects/project-id/instances/instance-id/tables/table-id`)

There is also a change to the `WaitForConsistency` test in `table_admin_integration_test.cc`. Our generated clients do not have a method like `TableAdmin::WaitForConsistency`, so I implemented a simple version in a retry loop. I did not create an asynchronous retry loop, making asynchronous calls. It seemed too complicated, and I did not want to write a test to test the test.

Note that `bigtable/testing/table_integration_test.*` still uses the old APIs. That will be updated to the generated APIs in a future PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7571)
<!-- Reviewable:end -->
