### PR TITLE
feat(GCS+gRPC): endpoint overrides with secure credentials

### DIFF
--- a/google/cloud/storage/internal/grpc_client.cc
+++ b/google/cloud/storage/internal/grpc_client.cc
@@ -72,10 +72,13 @@ Options DefaultOptionsGrpc(Options options) {
   if (!options.has<EndpointOption>()) {
     options.set<EndpointOption>("storage.googleapis.com");
   }
-  auto env = google::cloud::internal::GetEnv("CLOUD_STORAGE_GRPC_ENDPOINT");
-  if (env.has_value()) {
+  using google::cloud::internal::GetEnv;
+  auto env = GetEnv("CLOUD_STORAGE_GRPC_ENDPOINT");
+  if (env.has_value()) options.set<EndpointOption>(*env);
+  if (GetEnv("CLOUD_STORAGE_EMULATOR_ENDPOINT")) {
+    // The emulator does not support HTTPS or authentication, use insecure
+    // (sometimes called "anonymous") credentials, which disable SSL.
     options.set<UnifiedCredentialsOption>(MakeInsecureCredentials());
-    options.set<EndpointOption>(*env);
   }
   if (!options.has<GrpcNumChannelsOption>()) {
     options.set<GrpcNumChannelsOption>(DefaultGrpcNumChannels());


### PR DESCRIPTION
The `GOOGLE_STORAGE_GRPC_ENDPOINT` environment variable can be used to
override the default gRPC endpoint. This is mostly used for tests using
the testbench, and thus defaulted to also switching the credentials to
insecure credentials.  With this change the credentials are kept
unchanged unless you also set `CLOUD_STORAGE_EMULATOR_ENDPOINT`. If that
is set you definitely want to use the emulator and the credentials must
be changed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7572)
<!-- Reviewable:end -->
