### PR TITLE
cleanup(bigtable): implement `TableIntegrationTest` using preferred API

### DIFF
--- a/google/cloud/bigtable/admin/integration_tests/admin_backup_integration_test.cc
+++ b/google/cloud/bigtable/admin/integration_tests/admin_backup_integration_test.cc
@@ -70,8 +70,7 @@ class AdminBackupIntegrationTest
     return names;
   }
 
-  BigtableTableAdminClient client_ =
-      BigtableTableAdminClient(MakeBigtableTableAdminConnection());
+  BigtableTableAdminClient client_ = bigtable::testing::TableAdminClient();
 };
 
 protobuf::FieldMask Mask(std::string const& path) {

--- a/google/cloud/bigtable/admin/integration_tests/admin_iam_policy_integration_test.cc
+++ b/google/cloud/bigtable/admin/integration_tests/admin_iam_policy_integration_test.cc
@@ -38,8 +38,7 @@ class AdminIAMPolicyIntegrationTest
   }
 
   std::string service_account_;
-  BigtableTableAdminClient client_ =
-      BigtableTableAdminClient(MakeBigtableTableAdminConnection());
+  BigtableTableAdminClient client_ = bigtable::testing::TableAdminClient();
 };
 
 /// @test Verify that IAM Policy APIs work as expected.

--- a/google/cloud/bigtable/admin/integration_tests/table_admin_integration_test.cc
+++ b/google/cloud/bigtable/admin/integration_tests/table_admin_integration_test.cc
@@ -64,8 +64,7 @@ class TableAdminIntegrationTest
     return names;
   }
 
-  BigtableTableAdminClient client_ =
-      BigtableTableAdminClient(MakeBigtableTableAdminConnection());
+  BigtableTableAdminClient client_ = bigtable::testing::TableAdminClient();
 };
 
 TEST_F(TableAdminIntegrationTest, TableListWithMultipleTables) {

--- a/google/cloud/bigtable/testing/table_integration_test.h
+++ b/google/cloud/bigtable/testing/table_integration_test.h
@@ -15,7 +15,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_TESTING_TABLE_INTEGRATION_TEST_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_TESTING_TABLE_INTEGRATION_TEST_H
 
-#include "google/cloud/bigtable/admin_client.h"
+#include "google/cloud/bigtable/admin/bigtable_table_admin_client.h"
 #include "google/cloud/bigtable/cell.h"
 #include "google/cloud/bigtable/data_client.h"
 #include "google/cloud/bigtable/table.h"
@@ -30,6 +30,8 @@ namespace google {
 namespace cloud {
 namespace bigtable {
 namespace testing {
+
+bigtable_admin::BigtableTableAdminClient TableAdminClient();
 
 /// Store the project and instance captured from the command-line arguments.
 class TableTestEnvironment : public ::testing::Environment {
@@ -177,8 +179,6 @@ class TableIntegrationTest
     return names;
   }
 
-  std::shared_ptr<bigtable::AdminClient> admin_client_;
-  std::unique_ptr<bigtable::TableAdmin> table_admin_;
   std::shared_ptr<bigtable::DataClient> data_client_;
 };
 


### PR DESCRIPTION
Part of the work for #7528 

Note that deleting the member variables for `admin_client_` and `table_admin_` does not affect the old tests, because the member variables are also defined in the derived classes like `AdminBackupIntegrationTest`.

(I probably should have included this change with the last PR)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7574)
<!-- Reviewable:end -->
