### PR TITLE
test(spanner): run the "slow" instance admin tests on the emulator

### DIFF
--- a/google/cloud/spanner/integration_tests/instance_admin_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/instance_admin_integration_test.cc
@@ -149,7 +149,11 @@ TEST_F(InstanceAdminClientTest, InstanceReadOperations) {
 
 /// @test Verify the basic CRUD operations for instances work.
 TEST_F(InstanceAdminClientTest, InstanceCRUDOperations) {
-  if (!RunSlowInstanceTests()) GTEST_SKIP();
+  if (!Emulator() && !RunSlowInstanceTests()) {
+    GTEST_SKIP() << "skipping slow instance tests; set "
+                 << "GOOGLE_CLOUD_CPP_SPANNER_SLOW_INTEGRATION_TESTS=instance"
+                 << " to override";
+  }
 
   std::string instance_id = spanner_testing::RandomInstanceName(generator_);
   Instance in(ProjectId(), instance_id);
@@ -174,9 +178,7 @@ TEST_F(InstanceAdminClientTest, InstanceCRUDOperations) {
   EXPECT_EQ(instance->display_name(), "test-display-name");
   EXPECT_NE(instance->node_count(), 0);
   EXPECT_EQ(instance->config(), instance_config);
-  if (!Emulator() || instance->labels_size() != 0) {
-    EXPECT_EQ(instance->labels().at("label-key"), "label-value");
-  }
+  EXPECT_EQ(instance->labels().at("label-key"), "label-value");
 
   // Then update the instance
   instance = client_
@@ -224,8 +226,6 @@ TEST_F(InstanceAdminClientTest, InstanceConfig) {
 }
 
 TEST_F(InstanceAdminClientTest, InstanceIam) {
-  if (Emulator()) GTEST_SKIP();
-
   Instance in(ProjectId(), InstanceId());
   ASSERT_FALSE(in.project_id().empty());
   ASSERT_FALSE(in.instance_id().empty());
@@ -235,6 +235,9 @@ TEST_F(InstanceAdminClientTest, InstanceIam) {
                    .empty());
 
   auto actual_policy = client_.GetIamPolicy(in);
+  if (Emulator() && actual_policy.status().code() == StatusCode::kUnimplemented) {
+    GTEST_SKIP() << "emulator does not support IAM policies";
+  }
   ASSERT_STATUS_OK(actual_policy);
   EXPECT_FALSE(actual_policy->etag().empty());
 
@@ -251,7 +254,7 @@ TEST_F(InstanceAdminClientTest, InstanceIam) {
     updated_policy =
         client_.SetIamPolicy(in, [](google::iam::v1::Policy p) { return p; });
     ASSERT_STATUS_OK(updated_policy);
-    EXPECT_FALSE(actual_policy->etag().empty());
+    EXPECT_FALSE(updated_policy->etag().empty());
   }
 
   auto actual = client_.TestIamPermissions(


### PR DESCRIPTION
Run (both versions of) `InstanceAdminClientTest.InstanceCRUDOperations` on
the emulator as they have sub-second execution times there.

Also change the unconditional skip of `InstanceAdminClientTest.InstanceIam`
on the emulator to instead only skip when `UNIMPLEMENTED` is returned from
`GetIamPolicy()`.

Remove the conditional expectation on labels as it seems it is no longer
needed.

Finally, provide messages about why a test is `GTEST_SKIP`ped.