### PR TITLE
test(storage): speed up thread_integration_test

### DIFF
--- a/google/cloud/storage/tests/thread_integration_test.cc
+++ b/google/cloud/storage/tests/thread_integration_test.cc
@@ -20,6 +20,7 @@
 #include "google/cloud/testing_util/status_matchers.h"
 #include "absl/strings/str_split.h"
 #include <gmock/gmock.h>
+#include <algorithm>
 #include <future>
 #include <thread>
 
@@ -109,7 +110,10 @@ TEST_F(ThreadIntegrationTest, Unshared) {
   ASSERT_STATUS_OK(meta);
   EXPECT_EQ(bucket_name, meta->name());
 
-  auto const thread_count = (std::max)(std::thread::hardware_concurrency(), 8U);
+  // clamp the thread count to the [8, 16] range. Sadly, `std::clamp` is a C++17
+  // feature.
+  auto const thread_count =
+      (std::min)(32U, (std::max)(8U, std::thread::hardware_concurrency()));
   auto const object_count = 100 * thread_count;
   std::vector<std::string> objects(object_count);
   std::generate(objects.begin(), objects.end(),

--- a/google/cloud/storage/tests/thread_integration_test.cc
+++ b/google/cloud/storage/tests/thread_integration_test.cc
@@ -110,7 +110,7 @@ TEST_F(ThreadIntegrationTest, Unshared) {
   ASSERT_STATUS_OK(meta);
   EXPECT_EQ(bucket_name, meta->name());
 
-  // clamp the thread count to the [8, 16] range. Sadly, `std::clamp` is a C++17
+  // Clamp the thread count to the [8, 32] range. Sadly, `std::clamp` is a C++17
   // feature.
   auto const thread_count =
       (std::min)(32U, (std::max)(8U, std::thread::hardware_concurrency()));


### PR DESCRIPTION
The changes to make this test pass on macOS accidentally made it slower
on machines with lots of cores (such as my workstation).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7576)
<!-- Reviewable:end -->
