### PR TITLE
test: enable codecov for bigtable/admin

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -4,6 +4,3 @@ coverage:
   status:
     project: off
     patch: off
-
-ignore:
-  - "google/cloud/bigtable/admin/*"


### PR DESCRIPTION
Unsurprisingly, I forgot to re-enable codecov for `bigtable/admin/` after the integration tests were converted.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7579)
<!-- Reviewable:end -->
