### PR TITLE
feature(generator): add support for "omitted_services"

### DIFF
--- a/generator/generator_config.proto
+++ b/generator/generator_config.proto
@@ -23,6 +23,7 @@ message ServiceConfiguration {
   repeated string omitted_rpcs = 4;
   string service_endpoint_env_var = 5;
   string emulator_endpoint_env_var = 6;
+
   // Generating Async APIs is typically unnecessary for RPCs that are
   // non-streaming, non-paginated, and not longrunning operations. If we need
   // to generate an Async API for such an RPC, we can list it here.
@@ -30,6 +31,8 @@ message ServiceConfiguration {
   // Only the Async API will be generated for RPCs listed both here and in
   // `omitted_rpcs`.
   repeated string gen_async_rpcs = 7;
+
+  repeated string omitted_services = 8;
 }
 
 message GeneratorConfiguration {

--- a/generator/generator_config.textproto
+++ b/generator/generator_config.textproto
@@ -19,6 +19,7 @@ service {
   service_proto_path: "google/cloud/bigquery/storage/v1/storage.proto"
   product_path: "google/cloud/bigquery"
   initial_copyright_year: "2021"
+  omitted_services: ["BigQueryWrite"]
 }
 
 # Bigtable

--- a/generator/internal/codegen_utils.cc
+++ b/generator/internal/codegen_utils.cc
@@ -87,7 +87,7 @@ void ProcessArgCopyrightYear(
   }
 }
 
-void ProcessRepeatedRpcs(
+void ProcessRepeated(
     std::string const& single_arg, std::string const& grouped_arg,
     std::vector<std::pair<std::string, std::string>>& command_line_args) {
   using Pair = std::pair<std::string, std::string>;
@@ -105,9 +105,14 @@ void ProcessRepeatedRpcs(
   }
 }
 
+void ProcessArgOmitService(
+    std::vector<std::pair<std::string, std::string>>& command_line_args) {
+  ProcessRepeated("omit_service", "omitted_services", command_line_args);
+}
+
 void ProcessArgOmitRpc(
     std::vector<std::pair<std::string, std::string>>& command_line_args) {
-  ProcessRepeatedRpcs("omit_rpc", "omitted_rpcs", command_line_args);
+  ProcessRepeated("omit_rpc", "omitted_rpcs", command_line_args);
 }
 
 void ProcessArgServiceEndpointEnvVar(
@@ -136,7 +141,7 @@ void ProcessArgEmulatorEndpointEnvVar(
 
 void ProcessArgGenerateAsyncRpc(
     std::vector<std::pair<std::string, std::string>>& command_line_args) {
-  ProcessRepeatedRpcs("gen_async_rpc", "gen_async_rpcs", command_line_args);
+  ProcessRepeated("gen_async_rpc", "gen_async_rpcs", command_line_args);
 }
 
 }  // namespace
@@ -228,6 +233,7 @@ ProcessCommandLineArgs(std::string const& parameters) {
   if (!status.ok()) return status;
 
   ProcessArgCopyrightYear(command_line_args);
+  ProcessArgOmitService(command_line_args);
   ProcessArgOmitRpc(command_line_args);
   ProcessArgServiceEndpointEnvVar(command_line_args);
   ProcessArgEmulatorEndpointEnvVar(command_line_args);

--- a/generator/internal/codegen_utils_test.cc
+++ b/generator/internal/codegen_utils_test.cc
@@ -249,6 +249,17 @@ TEST(ProcessCommandLineArgs, EmulatorEndpointEnvVar) {
   EXPECT_THAT(*result, Contains(Pair("service_endpoint_env_var", "")));
 }
 
+TEST(ProcessCommandLineArgs, ProcessArgOmitService) {
+  auto result = ProcessCommandLineArgs(
+      "product_path=google/cloud/spanner/,googleapis_commit_hash=foo"
+      ",omit_service=Omitted1"
+      ",omit_service=Omitted2");
+  ASSERT_THAT(result, IsOk());
+  EXPECT_THAT(*result,
+              Contains(Pair("omitted_services", AllOf(HasSubstr("Omitted1"),
+                                                      HasSubstr("Omitted2")))));
+}
+
 TEST(ProcessCommandLineArgs, ProcessArgOmitRpc) {
   auto result = ProcessCommandLineArgs(
       "product_path=google/cloud/spanner/,googleapis_commit_hash=foo"

--- a/generator/standalone_main.cc
+++ b/generator/standalone_main.cc
@@ -103,6 +103,9 @@ int main(int argc, char** argv) {
                       googleapis_commit_hash);
     args.emplace_back("--cpp_codegen_opt=copyright_year=" +
                       service.initial_copyright_year());
+    for (auto const& omit_service : service.omitted_services()) {
+      args.emplace_back("--cpp_codegen_opt=omit_service=" + omit_service);
+    }
     for (auto const& omit_rpc : service.omitted_rpcs()) {
       args.emplace_back("--cpp_codegen_opt=omit_rpc=" + omit_rpc);
     }


### PR DESCRIPTION
Sometimes a single `service_proto_path` defines multiple
services, but we don't want to generate all of them.

Use this to omit generation of "BigQueryWrite".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7583)
<!-- Reviewable:end -->
