### PR TITLE
ci: ignore generated code in coverage build

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -5,5 +5,15 @@ coverage:
     project: off
     patch: off
 
+# Ignoring paths (see https://docs.codecov.com/docs/ignoring-paths)
+#
+# Ignore generated code, produced using...
+#   awk '/product_path:/ { print "  -", $2; }' \
+#     generator/generator_config.textproto | sort -u
+#
 ignore:
-  - "google/cloud/bigtable/admin/*"
+  - "google/cloud/bigquery"
+  - "google/cloud/bigtable/admin"
+  - "google/cloud/iam"
+  - "google/cloud/logging"
+  - "google/cloud/spanner/admin"


### PR DESCRIPTION
Ignore directories containing generated code.  This also ignores
some hand-written pieces like `integration_tests` and `samples`,
but we're not particularly interested in coverage data for those
either.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7585)
<!-- Reviewable:end -->
