### PR TITLE
feat(generator): support service-qualified names in RPC lists

### DIFF
--- a/generator/integration_tests/generator_integration_test.cc
+++ b/generator/integration_tests/generator_integration_test.cc
@@ -100,7 +100,7 @@ class GeneratorIntegrationTest : public testing::TestWithParam<std::string> {
     googleapis_commit_hash_ = "59f97e6044a1275f83427ab7962a154c00d915b5";
     copyright_year_ = CurrentCopyrightYear();
     omit_rpc1_ = "Omitted1";
-    omit_rpc2_ = "Omitted2";
+    omit_rpc2_ = "GoldenKitchenSink.Omitted2";
     service_endpoint_env_var_ = "GOLDEN_KITCHEN_SINK_ENDPOINT";
     emulator_endpoint_env_var_ = "GOLDEN_KITCHEN_SINK_EMULATOR_HOST";
     gen_async_rpc1_ = "GetDatabase";

--- a/generator/internal/service_code_generator.cc
+++ b/generator/internal/service_code_generator.cc
@@ -316,14 +316,18 @@ void ServiceCodeGenerator::SetMethods() {
   auto const omitted_rpcs = split_arg("omitted_rpcs");
   auto const gen_async_rpcs = split_arg("gen_async_rpcs");
 
+  auto service_name = service_descriptor_->name();
   for (int i = 0; i < service_descriptor_->method_count(); ++i) {
-    if (!internal::Contains(omitted_rpcs,
-                            service_descriptor_->method(i)->name())) {
-      methods_.emplace_back(*service_descriptor_->method(i));
+    auto const* method = service_descriptor_->method(i);
+    auto method_name = method->name();
+    auto qualified_method_name = absl::StrCat(service_name, ".", method_name);
+    if (!internal::Contains(omitted_rpcs, method_name) &&
+        !internal::Contains(omitted_rpcs, qualified_method_name)) {
+      methods_.emplace_back(*method);
     }
-    if (internal::Contains(gen_async_rpcs,
-                           service_descriptor_->method(i)->name())) {
-      async_methods_.emplace_back(*service_descriptor_->method(i));
+    if (internal::Contains(gen_async_rpcs, method_name) ||
+        internal::Contains(gen_async_rpcs, qualified_method_name)) {
+      async_methods_.emplace_back(*method);
     }
   }
 }


### PR DESCRIPTION
Allow `<service>.<method>` names in the `omitted_rpcs` and
`gen_async_rpcs` lists (in addition to just `<method>`) for
cases where two services defined in the same file share an
RPC name, but we want to treat the RPCs differently.

This isn't anything we need now, but is something I considered
during the recent `omitted_services` change, and it seemed best
to provide the groundwork while I had it in mind.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7586)
<!-- Reviewable:end -->
