### PR TITLE
fix(spanner): avoid use-after-move bugs

### DIFF
--- a/google/cloud/spanner/row.cc
+++ b/google/cloud/spanner/row.cc
@@ -80,16 +80,17 @@ bool operator==(Row const& a, Row const& b) {
 RowStreamIterator::RowStreamIterator() = default;
 
 RowStreamIterator::RowStreamIterator(Source source)
-    : row_(Row{}), source_(std::move(source)) {
+    : source_(std::move(source)) {
   ++*this;
 }
 
 RowStreamIterator& RowStreamIterator::operator++() {
-  if (!row_) {
+  if (!row_ok_) {
     source_ = nullptr;  // Last row was an error; become "end"
     return *this;
   }
   row_ = source_();
+  row_ok_ = row_.ok();
   if (row_ && row_->size() == 0) {
     source_ = nullptr;  // No more Rows to consume; become "end"
     return *this;

--- a/google/cloud/spanner/row.h
+++ b/google/cloud/spanner/row.h
@@ -290,7 +290,8 @@ class RowStreamIterator {
   friend bool operator!=(RowStreamIterator const&, RowStreamIterator const&);
 
  private:
-  value_type row_;
+  bool row_ok_{true};
+  value_type row_{Row{}};
   Source source_;  // nullptr means "end"
 };
 
@@ -343,7 +344,7 @@ class TupleStreamIterator {
   const_pointer operator->() const { return &tup_; }
 
   TupleStreamIterator& operator++() {
-    if (!tup_) {
+    if (!tup_ok_) {
       it_ = end_;
       return *this;
     }
@@ -372,8 +373,10 @@ class TupleStreamIterator {
   void ParseTuple() {
     if (it_ == end_) return;
     tup_ = *it_ ? std::move(*it_)->template get<Tuple>() : it_->status();
+    tup_ok_ = tup_.ok();
   }
 
+  bool tup_ok_{false};
   value_type tup_;
   RowStreamIterator it_;
   RowStreamIterator end_;

--- a/google/cloud/spanner/row_test.cc
+++ b/google/cloud/spanner/row_test.cc
@@ -330,13 +330,17 @@ TEST(RowStreamIterator, MovedFromValueOk) {
   EXPECT_NE(it, end);
   auto row = std::move(*it);
   EXPECT_STATUS_OK(row);
-  EXPECT_EQ(1, row->size());
+  auto val = row->get("num");
+  EXPECT_STATUS_OK(val);
+  EXPECT_EQ(Value(1), *val);
 
   ++it;
   EXPECT_NE(it, end);
   row = std::move(*it);
   EXPECT_STATUS_OK(row);
-  EXPECT_EQ(1, row->size());
+  val = row->get("num");
+  EXPECT_STATUS_OK(val);
+  EXPECT_EQ(Value(2), *val);
 
   ++it;
   EXPECT_EQ(it, end);
@@ -430,8 +434,8 @@ TEST(TupleStreamIterator, Error) {
 
 TEST(TupleStreamIterator, MovedFromValueOk) {
   std::vector<Row> rows;
-  rows.emplace_back(MakeTestRow({{"num", Value(42)}}));
-  rows.emplace_back(MakeTestRow({{"num", Value(42)}}));
+  rows.emplace_back(MakeTestRow({{"num", Value(1)}}));
+  rows.emplace_back(MakeTestRow({{"num", Value(2)}}));
 
   RowRange range(MakeRowStreamIteratorSource(rows));
   using RowType = std::tuple<std::int64_t>;
@@ -442,13 +446,13 @@ TEST(TupleStreamIterator, MovedFromValueOk) {
   EXPECT_NE(it, end);
   auto tup = std::move(*it);
   EXPECT_STATUS_OK(tup);
-  EXPECT_EQ(42, std::get<0>(*tup));
+  EXPECT_EQ(1, std::get<0>(*tup));
 
   ++it;
   EXPECT_NE(it, end);
   tup = std::move(*it);
   EXPECT_STATUS_OK(tup);
-  EXPECT_EQ(42, std::get<0>(*tup));
+  EXPECT_EQ(2, std::get<0>(*tup));
 
   ++it;
   EXPECT_EQ(it, end);


### PR DESCRIPTION
@devbww and I debugged a use-after move issue that boiled down to these
two Row iterators inspecting a data member (e.g., `row_` and `tup_`) on
subsequent invocations of `op++`, after a caller may have rightfully
moved the object. To avoid this issue, we keep an extra bool in both
iterators to avoid the need to inspect the StatusOr data member again.

Note: This issue didn't show up in our code or builds. It showed up only
when trying to make a different change to `Status`.

Kudos to @devbww for helping to track this down.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7588)
<!-- Reviewable:end -->
