### PR TITLE
fix(spanner): GetSingularRow accepts by value

### DIFF
--- a/google/cloud/spanner/row.h
+++ b/google/cloud/spanner/row.h
@@ -463,17 +463,12 @@ TupleStream<Tuple> StreamOf(RowRange&& range) {
  * a loop.
  *
  * @snippet samples.cc get-singular-row
- *
- * @warning Due to the fact that a `RowStreamIterator` is an input iterator,
- *     this function may consume the first element in the range, even in cases
- *     where an error is returned. But again, this function should not be used
- *     if @p range might contain multiple rows.
  */
 template <typename RowRange>
-auto GetSingularRow(RowRange&& range) -> typename std::decay<
-    decltype(*std::forward<RowRange>(range).begin())>::type {
-  auto const e = std::forward<RowRange>(range).end();
-  auto it = std::forward<RowRange>(range).begin();
+auto GetSingularRow(RowRange range) ->
+    typename std::decay<decltype(*range.begin())>::type {
+  auto const e = range.end();
+  auto it = range.begin();
   if (it == e) return Status(StatusCode::kInvalidArgument, "no rows");
   auto row = std::move(*it);
   if (++it != e) return Status(StatusCode::kInvalidArgument, "too many rows");


### PR DESCRIPTION
`g::c::spanner::GetSingularRow` extracts and moves the singular row in
the given range, and so it should not take the argument by forwarding
reference, because the caller may pass an lvalue, and it
would be surprising if this function moved a value out of the named
lvalue in the calling function.

Accepting the range by value fixes this by either forcing a copy at the
call site if the caller has an lvalue that they don't want to be
modified, or else the caller can `std::move` the argument, in which case
no copies of the row will be performed -- only moves. I think this is
the best way to make the function unsurprising and allow the caller to
avoid all copies.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7589)
<!-- Reviewable:end -->
