### PR TITLE
cleanup(generator): log unexpected options

### DIFF
--- a/generator/integration_tests/golden/golden_kitchen_sink_connection.cc
+++ b/generator/integration_tests/golden/golden_kitchen_sink_connection.cc
@@ -21,6 +21,7 @@
 #include "generator/integration_tests/golden/internal/golden_kitchen_sink_option_defaults.h"
 #include "generator/integration_tests/golden/internal/golden_kitchen_sink_stub_factory.h"
 #include "google/cloud/background_threads.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include "google/cloud/internal/resumable_streaming_read_rpc.h"
@@ -219,6 +220,8 @@ class GoldenKitchenSinkConnectionImpl : public GoldenKitchenSinkConnection {
 
 std::shared_ptr<GoldenKitchenSinkConnection> MakeGoldenKitchenSinkConnection(
     Options options) {
+  internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+      GoldenKitchenSinkPolicyOptionList>(options, __func__);
   options = golden_internal::GoldenKitchenSinkDefaultOptions(
       std::move(options));
   auto background = internal::MakeBackgroundThreadsFactory(options)();

--- a/generator/integration_tests/golden/golden_thing_admin_connection.cc
+++ b/generator/integration_tests/golden/golden_thing_admin_connection.cc
@@ -21,6 +21,7 @@
 #include "generator/integration_tests/golden/internal/golden_thing_admin_option_defaults.h"
 #include "generator/integration_tests/golden/internal/golden_thing_admin_stub_factory.h"
 #include "google/cloud/background_threads.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/async_long_running_operation.h"
 #include "google/cloud/internal/pagination_range.h"
@@ -591,6 +592,8 @@ class GoldenThingAdminConnectionImpl : public GoldenThingAdminConnection {
 
 std::shared_ptr<GoldenThingAdminConnection> MakeGoldenThingAdminConnection(
     Options options) {
+  internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+      GoldenThingAdminPolicyOptionList>(options, __func__);
   options = golden_internal::GoldenThingAdminDefaultOptions(
       std::move(options));
   auto background = internal::MakeBackgroundThreadsFactory(options)();

--- a/generator/integration_tests/golden/tests/golden_thing_admin_connection_test.cc
+++ b/generator/integration_tests/golden/tests/golden_thing_admin_connection_test.cc
@@ -16,6 +16,7 @@
 #include "google/cloud/polling_policy.h"
 #include "google/cloud/testing_util/async_sequencer.h"
 #include "google/cloud/testing_util/is_proto_equal.h"
+#include "google/cloud/testing_util/scoped_log.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include "generator/integration_tests/golden/golden_thing_admin_options.h"
 #include "generator/integration_tests/golden/mocks/mock_golden_thing_admin_stub.h"
@@ -35,6 +36,8 @@ using ::google::cloud::testing_util::IsProtoEqual;
 using ::google::cloud::testing_util::StatusIs;
 using ::google::protobuf::TextFormat;
 using ::testing::AtLeast;
+using ::testing::Contains;
+using ::testing::ContainsRegex;
 using ::testing::ElementsAre;
 using ::testing::HasSubstr;
 using ::testing::Return;
@@ -1325,6 +1328,17 @@ TEST(GoldenThingAdminClientTest, AsyncDropDatabaseCancel) {
                                AllOf(HasSubstr("Error in non-idempotent"),
                                      HasSubstr("AsyncDropDatabase"),
                                      HasSubstr("try again"))));
+}
+
+TEST(GoldenThingAdminConnectionTest, CheckExpectedOptions) {
+  struct UnexpectedOption {
+    using Type = int;
+  };
+  testing_util::ScopedLog log;
+  auto opts = Options{}.set<UnexpectedOption>({});
+  auto conn = MakeGoldenThingAdminConnection(std::move(opts));
+  EXPECT_THAT(log.ExtractLines(),
+              Contains(ContainsRegex("Unexpected option.+UnexpectedOption")));
 }
 
 }  // namespace

--- a/generator/internal/connection_generator.cc
+++ b/generator/internal/connection_generator.cc
@@ -205,7 +205,8 @@ Status ConnectionGenerator::GenerateCc() {
   CcLocalIncludes(
       {vars("connection_header_path"), vars("options_header_path"),
        vars("option_defaults_header_path"), vars("stub_factory_header_path"),
-       "google/cloud/background_threads.h", "google/cloud/grpc_options.h",
+       "google/cloud/background_threads.h", "google/cloud/common_options.h",
+       "google/cloud/grpc_options.h",
        HasPaginatedMethod() ? "google/cloud/internal/pagination_range.h" : "",
        HasLongrunningMethod()
            ? "google/cloud/internal/async_long_running_operation.h"
@@ -550,6 +551,8 @@ $connection_class_name$::Async$method_name$(
   CcPrint(R"""(
 std::shared_ptr<$connection_class_name$> Make$connection_class_name$(
     Options options) {
+  internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+      $service_name$PolicyOptionList>(options, __func__);
   options = $product_internal_namespace$::$service_name$DefaultOptions(
       std::move(options));
   auto background = internal::MakeBackgroundThreadsFactory(options)();

--- a/google/cloud/bigquery/bigquery_read_connection.cc
+++ b/google/cloud/bigquery/bigquery_read_connection.cc
@@ -21,6 +21,7 @@
 #include "google/cloud/bigquery/internal/bigquery_read_option_defaults.h"
 #include "google/cloud/bigquery/internal/bigquery_read_stub_factory.h"
 #include "google/cloud/background_threads.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/resumable_streaming_read_rpc.h"
 #include "google/cloud/internal/retry_loop.h"
@@ -144,6 +145,9 @@ class BigQueryReadConnectionImpl : public BigQueryReadConnection {
 
 std::shared_ptr<BigQueryReadConnection> MakeBigQueryReadConnection(
     Options options) {
+  internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 BigQueryReadPolicyOptionList>(options,
+                                                               __func__);
   options = bigquery_internal::BigQueryReadDefaultOptions(std::move(options));
   auto background = internal::MakeBackgroundThreadsFactory(options)();
   auto stub = bigquery_internal::CreateDefaultBigQueryReadStub(background->cq(),

--- a/google/cloud/bigtable/admin/bigtable_instance_admin_connection.cc
+++ b/google/cloud/bigtable/admin/bigtable_instance_admin_connection.cc
@@ -21,6 +21,7 @@
 #include "google/cloud/bigtable/admin/internal/bigtable_instance_admin_option_defaults.h"
 #include "google/cloud/bigtable/admin/internal/bigtable_instance_admin_stub_factory.h"
 #include "google/cloud/background_threads.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/async_long_running_operation.h"
 #include "google/cloud/internal/pagination_range.h"
@@ -549,6 +550,9 @@ class BigtableInstanceAdminConnectionImpl
 
 std::shared_ptr<BigtableInstanceAdminConnection>
 MakeBigtableInstanceAdminConnection(Options options) {
+  internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 BigtableInstanceAdminPolicyOptionList>(
+      options, __func__);
   options = bigtable_admin_internal::BigtableInstanceAdminDefaultOptions(
       std::move(options));
   auto background = internal::MakeBackgroundThreadsFactory(options)();

--- a/google/cloud/bigtable/admin/bigtable_table_admin_connection.cc
+++ b/google/cloud/bigtable/admin/bigtable_table_admin_connection.cc
@@ -21,6 +21,7 @@
 #include "google/cloud/bigtable/admin/internal/bigtable_table_admin_option_defaults.h"
 #include "google/cloud/bigtable/admin/internal/bigtable_table_admin_stub_factory.h"
 #include "google/cloud/background_threads.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/async_long_running_operation.h"
 #include "google/cloud/internal/pagination_range.h"
@@ -504,6 +505,9 @@ class BigtableTableAdminConnectionImpl : public BigtableTableAdminConnection {
 
 std::shared_ptr<BigtableTableAdminConnection> MakeBigtableTableAdminConnection(
     Options options) {
+  internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 BigtableTableAdminPolicyOptionList>(options,
+                                                                     __func__);
   options = bigtable_admin_internal::BigtableTableAdminDefaultOptions(
       std::move(options));
   auto background = internal::MakeBackgroundThreadsFactory(options)();

--- a/google/cloud/iam/iam_connection.cc
+++ b/google/cloud/iam/iam_connection.cc
@@ -21,6 +21,7 @@
 #include "google/cloud/iam/internal/iam_option_defaults.h"
 #include "google/cloud/iam/internal/iam_stub_factory.h"
 #include "google/cloud/background_threads.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include "google/cloud/internal/retry_loop.h"
@@ -658,6 +659,8 @@ class IAMConnectionImpl : public IAMConnection {
 }  // namespace
 
 std::shared_ptr<IAMConnection> MakeIAMConnection(Options options) {
+  internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 IAMPolicyOptionList>(options, __func__);
   options = iam_internal::IAMDefaultOptions(std::move(options));
   auto background = internal::MakeBackgroundThreadsFactory(options)();
   auto stub = iam_internal::CreateDefaultIAMStub(background->cq(), options);

--- a/google/cloud/iam/iam_credentials_connection.cc
+++ b/google/cloud/iam/iam_credentials_connection.cc
@@ -21,6 +21,7 @@
 #include "google/cloud/iam/internal/iam_credentials_option_defaults.h"
 #include "google/cloud/iam/internal/iam_credentials_stub_factory.h"
 #include "google/cloud/background_threads.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/retry_loop.h"
 #include <memory>
@@ -140,6 +141,9 @@ class IAMCredentialsConnectionImpl : public IAMCredentialsConnection {
 
 std::shared_ptr<IAMCredentialsConnection> MakeIAMCredentialsConnection(
     Options options) {
+  internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 IAMCredentialsPolicyOptionList>(options,
+                                                                 __func__);
   options = iam_internal::IAMCredentialsDefaultOptions(std::move(options));
   auto background = internal::MakeBackgroundThreadsFactory(options)();
   auto stub =

--- a/google/cloud/logging/logging_service_v2_connection.cc
+++ b/google/cloud/logging/logging_service_v2_connection.cc
@@ -21,6 +21,7 @@
 #include "google/cloud/logging/internal/logging_service_v2_stub_factory.h"
 #include "google/cloud/logging/logging_service_v2_options.h"
 #include "google/cloud/background_threads.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include "google/cloud/internal/retry_loop.h"
@@ -241,6 +242,9 @@ class LoggingServiceV2ConnectionImpl : public LoggingServiceV2Connection {
 
 std::shared_ptr<LoggingServiceV2Connection> MakeLoggingServiceV2Connection(
     Options options) {
+  internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 LoggingServiceV2PolicyOptionList>(options,
+                                                                   __func__);
   options =
       logging_internal::LoggingServiceV2DefaultOptions(std::move(options));
   auto background = internal::MakeBackgroundThreadsFactory(options)();

--- a/google/cloud/spanner/admin/database_admin_connection.cc
+++ b/google/cloud/spanner/admin/database_admin_connection.cc
@@ -21,6 +21,7 @@
 #include "google/cloud/spanner/admin/internal/database_admin_option_defaults.h"
 #include "google/cloud/spanner/admin/internal/database_admin_stub_factory.h"
 #include "google/cloud/background_threads.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/async_long_running_operation.h"
 #include "google/cloud/internal/pagination_range.h"
@@ -592,6 +593,9 @@ class DatabaseAdminConnectionImpl : public DatabaseAdminConnection {
 
 std::shared_ptr<DatabaseAdminConnection> MakeDatabaseAdminConnection(
     Options options) {
+  internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 DatabaseAdminPolicyOptionList>(options,
+                                                                __func__);
   options =
       spanner_admin_internal::DatabaseAdminDefaultOptions(std::move(options));
   auto background = internal::MakeBackgroundThreadsFactory(options)();

--- a/google/cloud/spanner/admin/instance_admin_connection.cc
+++ b/google/cloud/spanner/admin/instance_admin_connection.cc
@@ -21,6 +21,7 @@
 #include "google/cloud/spanner/admin/internal/instance_admin_option_defaults.h"
 #include "google/cloud/spanner/admin/internal/instance_admin_stub_factory.h"
 #include "google/cloud/background_threads.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/async_long_running_operation.h"
 #include "google/cloud/internal/pagination_range.h"
@@ -361,6 +362,9 @@ class InstanceAdminConnectionImpl : public InstanceAdminConnection {
 
 std::shared_ptr<InstanceAdminConnection> MakeInstanceAdminConnection(
     Options options) {
+  internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 InstanceAdminPolicyOptionList>(options,
+                                                                __func__);
   options =
       spanner_admin_internal::InstanceAdminDefaultOptions(std::move(options));
   auto background = internal::MakeBackgroundThreadsFactory(options)();


### PR DESCRIPTION
Check expected options passed to the `Connection`

I don't think it is necessary to add a checks in the `internal::MakeConnection` methods

Note that the test in `golden_thing_admin_connection_test.cc` has a different name than other tests in the file. There is a [separate PR](https://github.com/googleapis/google-cloud-cpp/pull/7590) to change the current test names to be `GoldenThingAdminConnectionTest`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7591)
<!-- Reviewable:end -->
