### PR TITLE
refactor(common): Status uses absl::Status

### DIFF
--- a/google/cloud/BUILD
+++ b/google/cloud/BUILD
@@ -40,6 +40,7 @@ cc_library(
     hdrs = google_cloud_cpp_common_hdrs,
     deps = [
         "@com_google_absl//absl/memory",
+        "@com_google_absl//absl/status",
         "@com_google_absl//absl/time",
         "@com_google_absl//absl/types:optional",
         "@com_google_absl//absl/types:variant",

--- a/google/cloud/CMakeLists.txt
+++ b/google/cloud/CMakeLists.txt
@@ -155,8 +155,8 @@ add_library(
     version.cc
     version.h)
 target_link_libraries(
-    google_cloud_cpp_common PUBLIC absl::memory absl::optional absl::time
-                                   absl::variant Threads::Threads)
+    google_cloud_cpp_common PUBLIC absl::memory absl::optional absl::status
+                                   absl::time absl::variant Threads::Threads)
 google_cloud_cpp_add_common_options(google_cloud_cpp_common)
 target_include_directories(
     google_cloud_cpp_common PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
@@ -306,7 +306,7 @@ set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
     "Common Components used by the Google Cloud C++ Client Libraries.")
 set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_common")
 string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "absl_memory" " absl_optional"
-              " absl_time")
+              " absl_status" " absl_time")
 
 # Create and install the pkg-config files.
 configure_file("${PROJECT_SOURCE_DIR}/google/cloud/config.pc.in"

--- a/google/cloud/status.cc
+++ b/google/cloud/status.cc
@@ -82,7 +82,7 @@ static_assert(static_cast<int>(StatusCode::kDataLoss) ==
               "");
 
 Status MakeStatus(absl::Status status) { return Status(std::move(status)); }
-absl::Status ToAbslStatus(Status status) { return std::move(status.status_); }
+absl::Status MakeAbslStatus(Status status) { return std::move(status.status_); }
 
 }  // namespace internal
 

--- a/google/cloud/status.cc
+++ b/google/cloud/status.cc
@@ -26,6 +26,66 @@ std::string StatusWhat(Status const& status) {
 }
 }  // namespace
 
+namespace internal {
+
+// Asserts that Abseil's status codes match ours because we cast between them.
+static_assert(static_cast<int>(StatusCode::kOk) ==
+                  static_cast<int>(absl::StatusCode::kOk),
+              "");
+static_assert(static_cast<int>(StatusCode::kCancelled) ==
+                  static_cast<int>(absl::StatusCode::kCancelled),
+              "");
+static_assert(static_cast<int>(StatusCode::kUnknown) ==
+                  static_cast<int>(absl::StatusCode::kUnknown),
+              "");
+static_assert(static_cast<int>(StatusCode::kInvalidArgument) ==
+                  static_cast<int>(absl::StatusCode::kInvalidArgument),
+              "");
+static_assert(static_cast<int>(StatusCode::kDeadlineExceeded) ==
+                  static_cast<int>(absl::StatusCode::kDeadlineExceeded),
+              "");
+static_assert(static_cast<int>(StatusCode::kNotFound) ==
+                  static_cast<int>(absl::StatusCode::kNotFound),
+              "");
+static_assert(static_cast<int>(StatusCode::kAlreadyExists) ==
+                  static_cast<int>(absl::StatusCode::kAlreadyExists),
+              "");
+static_assert(static_cast<int>(StatusCode::kPermissionDenied) ==
+                  static_cast<int>(absl::StatusCode::kPermissionDenied),
+              "");
+static_assert(static_cast<int>(StatusCode::kUnauthenticated) ==
+                  static_cast<int>(absl::StatusCode::kUnauthenticated),
+              "");
+static_assert(static_cast<int>(StatusCode::kResourceExhausted) ==
+                  static_cast<int>(absl::StatusCode::kResourceExhausted),
+              "");
+static_assert(static_cast<int>(StatusCode::kFailedPrecondition) ==
+                  static_cast<int>(absl::StatusCode::kFailedPrecondition),
+              "");
+static_assert(static_cast<int>(StatusCode::kAborted) ==
+                  static_cast<int>(absl::StatusCode::kAborted),
+              "");
+static_assert(static_cast<int>(StatusCode::kOutOfRange) ==
+                  static_cast<int>(absl::StatusCode::kOutOfRange),
+              "");
+static_assert(static_cast<int>(StatusCode::kUnimplemented) ==
+                  static_cast<int>(absl::StatusCode::kUnimplemented),
+              "");
+static_assert(static_cast<int>(StatusCode::kInternal) ==
+                  static_cast<int>(absl::StatusCode::kInternal),
+              "");
+static_assert(static_cast<int>(StatusCode::kUnavailable) ==
+                  static_cast<int>(absl::StatusCode::kUnavailable),
+              "");
+static_assert(static_cast<int>(StatusCode::kDataLoss) ==
+                  static_cast<int>(absl::StatusCode::kDataLoss),
+              "");
+
+Status MakeStatus(absl::Status status) { return Status(std::move(status)); }
+absl::Status ToAbslStatus(Status status) { return std::move(status.status_); }
+
+}  // namespace internal
+
 std::string StatusCodeToString(StatusCode code) {
   switch (code) {
     case StatusCode::kOk:

--- a/google/cloud/status.h
+++ b/google/cloud/status.h
@@ -60,7 +60,7 @@ std::ostream& operator<<(std::ostream& os, StatusCode code);
 class Status;
 namespace internal {
 Status MakeStatus(absl::Status);
-absl::Status ToAbslStatus(Status);
+absl::Status MakeAbslStatus(Status);
 }  // namespace internal
 
 /**
@@ -102,7 +102,7 @@ class Status {
 
  private:
   friend Status internal::MakeStatus(absl::Status);
-  friend absl::Status internal::ToAbslStatus(Status);
+  friend absl::Status internal::MakeAbslStatus(Status);
 
   explicit Status(absl::Status status)
       : status_(std::move(status)), message_(status_.message()) {}

--- a/google/cloud/status_or_test.cc
+++ b/google/cloud/status_or_test.cc
@@ -312,7 +312,6 @@ TEST(StatusOrObservableTest, MoveAssignmentValueValue) {
 
   Observable::reset_counters();
   assigned = std::move(other);
-  EXPECT_STATUS_OK(other);  // NOLINT(bugprone-use-after-move)
   EXPECT_STATUS_OK(assigned);
   EXPECT_EQ(0, Observable::destructor());
   EXPECT_EQ(1, Observable::move_assignment());
@@ -320,7 +319,6 @@ TEST(StatusOrObservableTest, MoveAssignmentValueValue) {
   EXPECT_EQ(0, Observable::move_constructor());
   EXPECT_EQ(0, Observable::copy_constructor());
   EXPECT_EQ("foo", assigned->str());
-  EXPECT_EQ("moved-out", other->str());
 }
 
 /// @test A move-assigned status calls the right assignments and destructors.

--- a/google/cloud/status_or_test.cc
+++ b/google/cloud/status_or_test.cc
@@ -229,8 +229,6 @@ TEST(StatusOrObservableTest, MoveCopy) {
   EXPECT_EQ(1, Observable::move_constructor());
   EXPECT_STATUS_OK(copy);
   EXPECT_EQ("foo", copy->str());
-  EXPECT_STATUS_OK(other);  // NOLINT(bugprone-use-after-move)
-  EXPECT_EQ("moved-out", other->str());
 }
 
 /// @test A move-assigned status calls the right assignments and destructors.
@@ -260,10 +258,8 @@ TEST(StatusOrObservableTest, MoveAssignmentNoValueValue) {
 
   Observable::reset_counters();
   assigned = std::move(other);
-  EXPECT_STATUS_OK(other);  // NOLINT(bugprone-use-after-move)
   EXPECT_STATUS_OK(assigned);
   EXPECT_EQ("foo", assigned->str());
-  EXPECT_EQ("moved-out", other->str());
   EXPECT_EQ(0, Observable::destructor());
   EXPECT_EQ(0, Observable::move_assignment());
   EXPECT_EQ(0, Observable::copy_assignment());

--- a/google/cloud/status_test.cc
+++ b/google/cloud/status_test.cc
@@ -12,16 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "google/cloud/status.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/testing_util/expect_exception.h"
+#include "absl/status/status.h"
+#include "absl/strings/cord.h"
 #include <gmock/gmock.h>
+#include <unistd.h>
 
 namespace google {
 namespace cloud {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
-TEST(Status, StatusCodeToString) {
+TEST(StatusCode, StatusCodeToString) {
   EXPECT_EQ("OK", StatusCodeToString(StatusCode::kOk));
   EXPECT_EQ("CANCELLED", StatusCodeToString(StatusCode::kCancelled));
   EXPECT_EQ("UNKNOWN", StatusCodeToString(StatusCode::kUnknown));
@@ -47,6 +51,63 @@ TEST(Status, StatusCodeToString) {
   EXPECT_EQ("DATA_LOSS", StatusCodeToString(StatusCode::kDataLoss));
   EXPECT_EQ("UNEXPECTED_STATUS_CODE=42",
             StatusCodeToString(static_cast<StatusCode>(42)));
+}
+
+TEST(Status, Basics) {
+  Status s;
+  EXPECT_TRUE(s.ok());
+  EXPECT_EQ(s.code(), StatusCode::kOk);
+  EXPECT_EQ(s.message(), "");
+  EXPECT_EQ(s, Status());
+
+  s = Status(StatusCode::kUnknown, "foo");
+  EXPECT_FALSE(s.ok());
+  EXPECT_EQ(s.code(), StatusCode::kUnknown);
+  EXPECT_EQ(s.message(), "foo");
+  EXPECT_NE(s, Status());
+  EXPECT_NE(s, Status(StatusCode::kUnknown, ""));
+  EXPECT_NE(s, Status(StatusCode::kUnknown, "bar"));
+  EXPECT_EQ(s, Status(StatusCode::kUnknown, "foo"));
+}
+
+TEST(Status, ToAbseilStatus) {
+  Status s;
+  absl::Status a = internal::ToAbslStatus(s);
+  EXPECT_EQ(a.code(), absl::StatusCode::kOk);
+  EXPECT_EQ(a.message(), "");
+
+  s = Status{StatusCode::kUnknown, "foo"};
+  a = internal::ToAbslStatus(s);
+  EXPECT_EQ(a.code(), absl::StatusCode::kUnknown);
+  EXPECT_EQ(a.message(), "foo");
+}
+
+TEST(Status, FromAbseilStatus) {
+  absl::Status a;
+  Status s = internal::MakeStatus(a);
+  EXPECT_EQ(s.code(), StatusCode::kOk);
+  EXPECT_EQ(s.message(), "");
+
+  a = absl::Status{absl::StatusCode::kUnknown, "bar"};
+  s = internal::MakeStatus(a);
+  EXPECT_EQ(s.code(), StatusCode::kUnknown);
+  EXPECT_EQ(s.message(), "bar");
+}
+
+TEST(Status, RoundTripAbseil) {
+  absl::Status a;
+  EXPECT_EQ(a, internal::ToAbslStatus(internal::MakeStatus(a)));
+
+  a = absl::Status{absl::StatusCode::kUnknown, "bar"};
+  EXPECT_EQ(a, internal::ToAbslStatus(internal::MakeStatus(a)));
+
+  // Round tripping doesn't drop the payload.
+  a.SetPayload("key", absl::Cord("the payload"));
+  EXPECT_EQ(a, internal::ToAbslStatus(internal::MakeStatus(a)));
+  a = internal::ToAbslStatus(internal::MakeStatus(a));
+  absl::optional<absl::Cord> c = a.GetPayload("key");
+  EXPECT_TRUE(c.has_value());
+  EXPECT_EQ(*c, "the payload");
 }
 
 }  // namespace

--- a/google/cloud/status_test.cc
+++ b/google/cloud/status_test.cc
@@ -72,12 +72,12 @@ TEST(Status, Basics) {
 
 TEST(Status, ToAbseilStatus) {
   Status s;
-  absl::Status a = internal::ToAbslStatus(s);
+  absl::Status a = internal::MakeAbslStatus(s);
   EXPECT_EQ(a.code(), absl::StatusCode::kOk);
   EXPECT_EQ(a.message(), "");
 
   s = Status{StatusCode::kUnknown, "foo"};
-  a = internal::ToAbslStatus(s);
+  a = internal::MakeAbslStatus(s);
   EXPECT_EQ(a.code(), absl::StatusCode::kUnknown);
   EXPECT_EQ(a.message(), "foo");
 }
@@ -96,15 +96,15 @@ TEST(Status, FromAbseilStatus) {
 
 TEST(Status, RoundTripAbseil) {
   absl::Status a;
-  EXPECT_EQ(a, internal::ToAbslStatus(internal::MakeStatus(a)));
+  EXPECT_EQ(a, internal::MakeAbslStatus(internal::MakeStatus(a)));
 
   a = absl::Status{absl::StatusCode::kUnknown, "bar"};
-  EXPECT_EQ(a, internal::ToAbslStatus(internal::MakeStatus(a)));
+  EXPECT_EQ(a, internal::MakeAbslStatus(internal::MakeStatus(a)));
 
   // Round tripping doesn't drop the payload.
   a.SetPayload("key", absl::Cord("the payload"));
-  EXPECT_EQ(a, internal::ToAbslStatus(internal::MakeStatus(a)));
-  a = internal::ToAbslStatus(internal::MakeStatus(a));
+  EXPECT_EQ(a, internal::MakeAbslStatus(internal::MakeStatus(a)));
+  a = internal::MakeAbslStatus(internal::MakeStatus(a));
   absl::optional<absl::Cord> c = a.GetPayload("key");
   EXPECT_TRUE(c.has_value());
   EXPECT_EQ(*c, "the payload");


### PR DESCRIPTION
Related to: https://github.com/googleapis/google-cloud-cpp/issues/7429
Related to: https://github.com/googleapis/google-cloud-cpp/issues/4612
Related to: https://github.com/googleapis/google-cloud-cpp/issues/1912

There is no user-facing API change in this PR. This change only
_implements_ `g::c::Status` in terms of `absl::Status`. This will give
us the ability to do the following:

1. Easily convert between our Status and Abseil's.
2. Preserve grpc's `error_details()`.

One downside of this PR is that we still need to keep our own `message_`
data member, which is a copy of the one in contained `absl::Status`,
becuase our `g::c::Status::message()` function returns a `std::string
const&`. I can see no other way to do this, and it is a con.

Note: `absl::Status` does not like use-after-move, so I needed to remove a
couple tests that were relying on unspecified behavior.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7592)
<!-- Reviewable:end -->
