### PR TITLE
cleanup(bigtable): add ability to convert to common policies

### DIFF
--- a/google/cloud/bigtable/CMakeLists.txt
+++ b/google/cloud/bigtable/CMakeLists.txt
@@ -21,8 +21,8 @@ set(DOXYGEN_PROJECT_BRIEF "A C++ Client Library for Google Cloud Bigtable")
 set(DOXYGEN_PROJECT_NUMBER "${PROJECT_VERSION}")
 set(DOXYGEN_EXAMPLE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/examples"
                          "${CMAKE_CURRENT_SOURCE_DIR}/quickstart")
-set(DOXYGEN_EXCLUDE_SYMBOLS "benchmarks" "bigtable_admin_internal" "internal"
-                            "testing" "examples")
+set(DOXYGEN_EXCLUDE_SYMBOLS "benchmarks" "bigtable_admin_internal"
+                            "bigtable_internal" "internal" "testing" "examples")
 
 include(GoogleCloudCppCommon)
 

--- a/google/cloud/bigtable/polling_policy.cc
+++ b/google/cloud/bigtable/polling_policy.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/bigtable/polling_policy.h"
+#include "absl/memory/memory.h"
 
 namespace google {
 namespace cloud {

--- a/google/cloud/bigtable/polling_policy.cc
+++ b/google/cloud/bigtable/polling_policy.cc
@@ -18,6 +18,7 @@ namespace google {
 namespace cloud {
 namespace bigtable {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+
 std::unique_ptr<PollingPolicy> DefaultPollingPolicy(
     internal::RPCPolicyParameters defaults) {
   return std::unique_ptr<PollingPolicy>(new GenericPollingPolicy<>(defaults));
@@ -25,5 +26,35 @@ std::unique_ptr<PollingPolicy> DefaultPollingPolicy(
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigtable
+namespace bigtable_internal {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+
+std::unique_ptr<PollingPolicy> MakeCommonPollingPolicy(
+    std::unique_ptr<bigtable::PollingPolicy> policy) {
+  class CommonPollingPolicy : public PollingPolicy {
+   public:
+    explicit CommonPollingPolicy(std::unique_ptr<bigtable::PollingPolicy> impl)
+        : impl_(std::move(impl)) {}
+    ~CommonPollingPolicy() override = default;
+
+    std::unique_ptr<PollingPolicy> clone() const override {
+      return absl::make_unique<CommonPollingPolicy>(impl_->clone());
+    }
+    bool OnFailure(google::cloud::Status const& status) override {
+      return impl_->OnFailure(status);
+    }
+    std::chrono::milliseconds WaitPeriod() override {
+      return impl_->WaitPeriod();
+    }
+
+   private:
+    std::unique_ptr<bigtable::PollingPolicy> impl_;
+  };
+
+  return absl::make_unique<CommonPollingPolicy>(std::move(policy));
+}
+
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace bigtable_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/bigtable/polling_policy.h
+++ b/google/cloud/bigtable/polling_policy.h
@@ -19,6 +19,7 @@
 #include "google/cloud/bigtable/rpc_retry_policy.h"
 #include "google/cloud/bigtable/version.h"
 #include "google/cloud/grpc_error_delegate.h"
+#include "google/cloud/polling_policy.h"
 #include <grpcpp/grpcpp.h>
 #include <chrono>
 
@@ -148,6 +149,14 @@ std::unique_ptr<PollingPolicy> DefaultPollingPolicy(
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigtable
+namespace bigtable_internal {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+
+std::unique_ptr<PollingPolicy> MakeCommonPollingPolicy(
+    std::unique_ptr<bigtable::PollingPolicy> policy);
+
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace bigtable_internal
 }  // namespace cloud
 }  // namespace google
 

--- a/google/cloud/bigtable/rpc_backoff_policy.cc
+++ b/google/cloud/bigtable/rpc_backoff_policy.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/bigtable/rpc_backoff_policy.h"
+#include "absl/memory/memory.h"
 
 namespace google {
 namespace cloud {

--- a/google/cloud/bigtable/rpc_backoff_policy.cc
+++ b/google/cloud/bigtable/rpc_backoff_policy.cc
@@ -47,5 +47,33 @@ std::chrono::milliseconds ExponentialBackoffPolicy::OnCompletion(
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigtable
+namespace bigtable_internal {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+
+std::unique_ptr<internal::BackoffPolicy> MakeCommonBackoffPolicy(
+    std::unique_ptr<bigtable::RPCBackoffPolicy> policy) {
+  class CommonBackoffPolicy : public internal::BackoffPolicy {
+   public:
+    explicit CommonBackoffPolicy(
+        std::unique_ptr<bigtable::RPCBackoffPolicy> impl)
+        : impl_(std::move(impl)) {}
+    ~CommonBackoffPolicy() override = default;
+
+    std::unique_ptr<internal::BackoffPolicy> clone() const override {
+      return absl::make_unique<CommonBackoffPolicy>(impl_->clone());
+    }
+    std::chrono::milliseconds OnCompletion() override {
+      return impl_->OnCompletion();
+    }
+
+   private:
+    std::unique_ptr<bigtable::RPCBackoffPolicy> impl_;
+  };
+
+  return absl::make_unique<CommonBackoffPolicy>(std::move(policy));
+}
+
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace bigtable_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/bigtable/rpc_backoff_policy.h
+++ b/google/cloud/bigtable/rpc_backoff_policy.h
@@ -105,6 +105,14 @@ class ExponentialBackoffPolicy : public RPCBackoffPolicy {
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigtable
+namespace bigtable_internal {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+
+std::unique_ptr<internal::BackoffPolicy> MakeCommonBackoffPolicy(
+    std::unique_ptr<bigtable::RPCBackoffPolicy> policy);
+
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace bigtable_internal
 }  // namespace cloud
 }  // namespace google
 

--- a/google/cloud/bigtable/rpc_retry_policy.cc
+++ b/google/cloud/bigtable/rpc_retry_policy.cc
@@ -43,6 +43,10 @@ bool LimitedErrorCountRetryPolicy::OnFailure(grpc::Status const& status) {
   return impl_.OnFailure(MakeStatusFromRpcError(status));
 }
 
+bool LimitedErrorCountRetryPolicy::IsExhausted() const {
+  return impl_.IsExhausted();
+}
+
 LimitedTimeRetryPolicy::LimitedTimeRetryPolicy(
     internal::RPCPolicyParameters defaults)
     : impl_(defaults.maximum_retry_period) {}
@@ -64,6 +68,8 @@ bool LimitedTimeRetryPolicy::OnFailure(google::cloud::Status const& status) {
 bool LimitedTimeRetryPolicy::OnFailure(grpc::Status const& status) {
   return impl_.OnFailure(MakeStatusFromRpcError(status));
 }
+
+bool LimitedTimeRetryPolicy::IsExhausted() const { return impl_.IsExhausted(); }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigtable


### PR DESCRIPTION
Fixes #7529 

There is no `static_assert()` checking that the type  `T` passed to `MakeCommonRetryPolicy<T>();` is derived from `TraitBasedRetryPolicy<U>`. (I am not sure this is even possible). I think this is fine, because the function is not user facing.

I think it is best to leave the `grpc::Status`es in the tests, because that is the main way we pass errors to the policies. There is a separate issue to clean up these functions. (#2344)

This PR introduces `bigtable_internal`. I did this because it is easier to read `internal::Foo` than `google::cloud::internal::Foo`. I am allowed to convert everything else from `bigtable::internal` to `bigtable_internal` on Dec. 2nd.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7594)
<!-- Reviewable:end -->
