### PR TITLE
cleanup: explicitly list Doxygen sources

### DIFF
--- a/cmake/GoogleCloudCppCommon.cmake
+++ b/cmake/GoogleCloudCppCommon.cmake
@@ -38,10 +38,10 @@ if (${CMAKE_VERSION} VERSION_LESS "3.12")
     message(STATUS "Doxygen generation only enabled for cmake 3.9 and higher")
 elseif (GOOGLE_CLOUD_CPP_GENERATE_DOXYGEN)
     find_package(Doxygen REQUIRED)
-    set(DOXYGEN_RECURSIVE YES)
+    set(DOXYGEN_RECURSIVE NO)
     set(DOXYGEN_FILE_PATTERNS *.h *.cc *.dox)
-    set(DOXYGEN_EXAMPLE_RECURSIVE YES)
-    set(DOXYGEN_EXCLUDE "third_party" "cmake-build-debug" "cmake-out")
+    set(DOXYGEN_EXCLUDE_PATTERNS "*_test.cc")
+    set(DOXYGEN_EXAMPLE_RECURSIVE NO)
     set(DOXYGEN_EXCLUDE_SYMLINKS YES)
     set(DOXYGEN_QUIET YES)
     set(DOXYGEN_WARN_AS_ERROR YES)
@@ -108,9 +108,30 @@ elseif (GOOGLE_CLOUD_CPP_GENERATE_DOXYGEN)
         endif ()
     endif ()
 
+    set(GOOGLE_CLOUD_CPP_DOXYGEN_INPUTS)
+    set(GOOGLE_CLOUD_CPP_DOXYGEN_POSSIBLE_INPUTS
+        # Scan the current directory (duh)
+        "${CMAKE_CURRENT_SOURCE_DIR}"
+        # Many libraries export mock classes for public consumption
+        "${CMAKE_CURRENT_SOURCE_DIR}/mocks"
+        # The storage library has some public APIs in `oauth2`.
+        "${CMAKE_CURRENT_SOURCE_DIR}/oauth2"
+        # Scan the examples, the directory name depends on the library
+        "${CMAKE_CURRENT_SOURCE_DIR}/samples"
+        "${CMAKE_CURRENT_SOURCE_DIR}/examples"
+        # The landing page and other documentation is in the doc/
+        "${CMAKE_CURRENT_SOURCE_DIR}/doc")
+    foreach (input IN LISTS GOOGLE_CLOUD_CPP_DOXYGEN_POSSIBLE_INPUTS)
+        if (EXISTS "${input}")
+            list(APPEND GOOGLE_CLOUD_CPP_DOXYGEN_INPUTS "${input}")
+        endif ()
+    endforeach ()
     doxygen_add_docs(
-        ${GOOGLE_CLOUD_CPP_SUBPROJECT}-docs ${CMAKE_CURRENT_SOURCE_DIR}
-        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} COMMENT
+        ${GOOGLE_CLOUD_CPP_SUBPROJECT}-docs
+        "${GOOGLE_CLOUD_CPP_DOXYGEN_INPUTS}"
+        WORKING_DIRECTORY
+        ${CMAKE_CURRENT_SOURCE_DIR}
+        COMMENT
         "Generate ${GOOGLE_CLOUD_CPP_SUBPROJECT} HTML documentation")
     add_dependencies(doxygen-docs ${GOOGLE_CLOUD_CPP_SUBPROJECT}-docs)
 

--- a/cmake/GoogleCloudCppCommon.cmake
+++ b/cmake/GoogleCloudCppCommon.cmake
@@ -114,7 +114,9 @@ elseif (GOOGLE_CLOUD_CPP_GENERATE_DOXYGEN)
         "${CMAKE_CURRENT_SOURCE_DIR}"
         # Many libraries export mock classes for public consumption
         "${CMAKE_CURRENT_SOURCE_DIR}/mocks"
-        # The storage library has some public APIs in `oauth2`.
+        # The Bigtable and Spanner libraries have some public APIs in `admin`.
+        "${CMAKE_CURRENT_SOURCE_DIR}/admin"
+        # The Storage library has some public APIs in `oauth2`.
         "${CMAKE_CURRENT_SOURCE_DIR}/oauth2"
         # Scan the examples, the directory name depends on the library
         "${CMAKE_CURRENT_SOURCE_DIR}/samples"

--- a/generator/scaffold/CMakeLists.txt.in
+++ b/generator/scaffold/CMakeLists.txt.in
@@ -17,7 +17,6 @@
 set(DOXYGEN_PROJECT_NAME "@SERVICE_NAME@ C++ Client")
 set(DOXYGEN_PROJECT_BRIEF "A C++ Client Library for @SERVICE_NAME@")
 set(DOXYGEN_PROJECT_NUMBER "${PROJECT_VERSION} (Beta)")
-set(DOXYGEN_EXCLUDE_PATTERNS "*/*_test.cc")
 set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "@NAME@_internal" "@NAME@_testing"
                             "examples")
 

--- a/google/cloud/CMakeLists.txt
+++ b/google/cloud/CMakeLists.txt
@@ -23,23 +23,7 @@ configure_file(internal/version_info.h.in
 set(DOXYGEN_PROJECT_NAME "Google Cloud C++ Client")
 set(DOXYGEN_PROJECT_BRIEF "C++ Client Library for Google Cloud Platform")
 set(DOXYGEN_PROJECT_NUMBER "${PROJECT_VERSION}")
-set(DOXYGEN_EXCLUDE_PATTERNS
-    "*/generator/*"
-    "*/google/cloud/README.md"
-    "*/google/cloud/internal/*"
-    "*/google/cloud/examples/hello_world_grpc/*"
-    "*/google/cloud/examples/hello_world_http/*"
-    "*/google/cloud/testing_util/*"
-    "*/google/cloud/bigtable/*"
-    "*/google/cloud/bigquery/*"
-    "*/google/cloud/iam/*"
-    "*/google/cloud/logging/*"
-    "*/google/cloud/spanner/*"
-    "*/google/cloud/storage/*"
-    "*/google/cloud/pubsub/*"
-    "*/google/cloud/grpc_utils/*"
-    "*/google/cloud/*_test.cc")
-set(DOXYGEN_EXCLUDE_SYMBOLS "internal")
+set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "testing_util" "examples")
 
 # Creates the proto headers needed by doxygen.
 set(GOOGLE_CLOUD_CPP_DOXYGEN_DEPS google-cloud-cpp::rpc_status_protos

--- a/google/cloud/bigquery/CMakeLists.txt
+++ b/google/cloud/bigquery/CMakeLists.txt
@@ -19,7 +19,6 @@ set(DOXYGEN_PROJECT_BRIEF "A C++ Client Library for Google Cloud BigQuery")
 set(DOXYGEN_PROJECT_NUMBER "${PROJECT_VERSION}")
 set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/samples
                          ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
-set(DOXYGEN_EXCLUDE_PATTERNS "*/*_test.cc")
 set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "bigquery_internal" "bigquery_testing"
                             "examples")
 

--- a/google/cloud/bigtable/CMakeLists.txt
+++ b/google/cloud/bigtable/CMakeLists.txt
@@ -21,8 +21,6 @@ set(DOXYGEN_PROJECT_BRIEF "A C++ Client Library for Google Cloud Bigtable")
 set(DOXYGEN_PROJECT_NUMBER "${PROJECT_VERSION}")
 set(DOXYGEN_EXAMPLE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/examples"
                          "${CMAKE_CURRENT_SOURCE_DIR}/quickstart")
-set(DOXYGEN_EXCLUDE_PATTERNS "*/benchmarks/*" "*/internal/*" "*/testing/*"
-                             "*/tests/*" "*/*_test.cc")
 set(DOXYGEN_EXCLUDE_SYMBOLS "benchmarks" "bigtable_admin_internal" "internal"
                             "testing")
 

--- a/google/cloud/bigtable/CMakeLists.txt
+++ b/google/cloud/bigtable/CMakeLists.txt
@@ -22,7 +22,7 @@ set(DOXYGEN_PROJECT_NUMBER "${PROJECT_VERSION}")
 set(DOXYGEN_EXAMPLE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/examples"
                          "${CMAKE_CURRENT_SOURCE_DIR}/quickstart")
 set(DOXYGEN_EXCLUDE_SYMBOLS "benchmarks" "bigtable_admin_internal" "internal"
-                            "testing")
+                            "testing" "examples")
 
 include(GoogleCloudCppCommon)
 

--- a/google/cloud/iam/CMakeLists.txt
+++ b/google/cloud/iam/CMakeLists.txt
@@ -19,7 +19,6 @@ set(DOXYGEN_PROJECT_BRIEF "A C++ Client Library for Google Cloud IAM")
 set(DOXYGEN_PROJECT_NUMBER "${PROJECT_VERSION}")
 set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/samples
                          ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
-set(DOXYGEN_EXCLUDE_PATTERNS "*/*_test.cc")
 set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "iam_internal" "iam_testing" "examples")
 
 # Creates the proto headers needed by doxygen.

--- a/google/cloud/logging/CMakeLists.txt
+++ b/google/cloud/logging/CMakeLists.txt
@@ -17,7 +17,6 @@
 set(DOXYGEN_PROJECT_NAME "Google Cloud Logging C++ Client")
 set(DOXYGEN_PROJECT_BRIEF "A C++ Client Library for Google Cloud Logging")
 set(DOXYGEN_PROJECT_NUMBER "${PROJECT_VERSION} (Beta)")
-set(DOXYGEN_EXCLUDE_PATTERNS "*/*_test.cc")
 set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "logging_internal" "logging_testing"
                             "examples")
 

--- a/google/cloud/pubsub/CMakeLists.txt
+++ b/google/cloud/pubsub/CMakeLists.txt
@@ -19,7 +19,6 @@ set(DOXYGEN_PROJECT_BRIEF "A C++ Client Library for Google Cloud Pub/Sub")
 set(DOXYGEN_PROJECT_NUMBER "${PROJECT_VERSION}")
 set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/samples
                          ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
-set(DOXYGEN_EXCLUDE_PATTERNS "*/*_test.cc")
 set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "pubsub_internal" "pubsub_testing"
                             "examples")
 

--- a/google/cloud/pubsublite/CMakeLists.txt
+++ b/google/cloud/pubsublite/CMakeLists.txt
@@ -17,7 +17,6 @@
 set(DOXYGEN_PROJECT_NAME "Cloud Pub/Sub Lite C++ Client")
 set(DOXYGEN_PROJECT_BRIEF "A C++ Client Library for Cloud Pub/Sub Lite")
 set(DOXYGEN_PROJECT_NUMBER "${PROJECT_VERSION} (Beta)")
-set(DOXYGEN_EXCLUDE_PATTERNS "*/*_test.cc")
 set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "pubsublite_internal"
                             "pubsublite_testing" "examples")
 

--- a/google/cloud/spanner/CMakeLists.txt
+++ b/google/cloud/spanner/CMakeLists.txt
@@ -22,11 +22,7 @@ set(DOXYGEN_PROJECT_NUMBER "${PROJECT_VERSION}")
 set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/samples
                          ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
 set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "spanner_admin_internal"
-                            "spanner_internal" "spanner_testing")
-set(DOXYGEN_EXCLUDE_PATTERNS
-    "*/google/cloud/spanner/README.md" "*/google/cloud/spanner/internal/*"
-    "*/google/cloud/spanner/benchmarks/*" "*/google/cloud/spanner/testing/*"
-    "*/google/cloud/spanner/*_test.cc")
+                            "spanner_internal" "spanner_testing" "examples")
 
 # Creates the proto headers needed by doxygen.
 set(GOOGLE_CLOUD_CPP_DOXYGEN_DEPS google-cloud-cpp::spanner_protos)

--- a/google/cloud/storage/CMakeLists.txt
+++ b/google/cloud/storage/CMakeLists.txt
@@ -21,15 +21,7 @@ set(DOXYGEN_PROJECT_BRIEF "A C++ Client Library for Google Cloud Storage")
 set(DOXYGEN_PROJECT_NUMBER "${PROJECT_VERSION}")
 set(DOXYGEN_EXAMPLE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/examples"
                          "${CMAKE_CURRENT_SOURCE_DIR}/quickstart")
-set(DOXYGEN_EXCLUDE_PATTERNS
-    "*/google/cloud/storage/README.md"
-    "*/google/cloud/storage/ci/*"
-    "*/google/cloud/storage/examples/*.md"
-    "*/google/cloud/storage/internal/*"
-    "*/google/cloud/storage/testing/*"
-    "*/google/cloud/storage/tests/*"
-    "*/google/cloud/storage/*_test.cc")
-set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "storage_benchmarks")
+set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "storage_benchmarks" "examples")
 
 # Creates the proto headers needed by doxygen.
 set(GOOGLE_CLOUD_CPP_DOXYGEN_DEPS google-cloud-cpp::storage_protos)


### PR DESCRIPTION
So far, we have been recursively scanning the source directory of each
library and then excluding some files. This is tedious, particularly in
the opt-level `google/cloud` directory. And also brittle, as adding a
new directory requires changes in multiple places.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7596)
<!-- Reviewable:end -->
