### PR TITLE
feat: automatically update feature list

### DIFF
--- a/ci/cloudbuild/builds/cmake-install.sh
+++ b/ci/cloudbuild/builds/cmake-install.sh
@@ -27,12 +27,26 @@ export CXX=clang++
 INSTALL_PREFIX="$(mktemp -d)"
 readonly INSTALL_PREFIX
 
+mapfile -t feature_list < <(cat ci/etc/full_feature_list)
+# Add the hand-crafted libraries and custom features to the full list
+feature_list+=(
+  bigtable
+  pubsub
+  spanner
+  storage
+  experimental-storage-grpc
+  pubsublite
+)
+features="$(printf ",%s" "${feature_list[@]}")"
+features="${features:1}"
+readonly features
+
 # Compiles and installs all libraries and headers.
 cmake -GNinja \
   -DBUILD_TESTING=OFF \
   -DGOOGLE_CLOUD_CPP_ENABLE_EXAMPLES=OFF \
   -DCMAKE_INSTALL_PREFIX="${INSTALL_PREFIX}" \
-  -DGOOGLE_CLOUD_CPP_ENABLE="bigtable;bigquery;iam;logging;pubsub;spanner;storage;experimental-storage-grpc;pubsublite" \
+  -DGOOGLE_CLOUD_CPP_ENABLE="${features}" \
   -S . -B cmake-out
 cmake --build cmake-out
 cmake --install cmake-out --component google_cloud_cpp_development

--- a/ci/etc/full_feature_list
+++ b/ci/etc/full_feature_list
@@ -1,0 +1,3 @@
+bigquery
+iam
+logging


### PR DESCRIPTION
When adding new generated libraries we need to update the feature list
used by the CI builds (currently just `cmake-install`). With this change
that update is automated, reducing the work for each library.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7599)
<!-- Reviewable:end -->
