### PR TITLE
feat: enable the Pub/Sub Lite library

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -51,6 +51,20 @@ cc_library(
 )
 
 cc_library(
+    name = "experimental-pubsublite",
+    deps = [
+        "//google/cloud/pubsublite:google_cloud_cpp_pubsublite",
+    ],
+)
+
+cc_library(
+    name = "experimental-pubsublite-mocks",
+    deps = [
+        "//google/cloud/pubsublite:google_cloud_cpp_pubsublite_mocks",
+    ],
+)
+
+cc_library(
     name = "pubsub_client",
     deprecation = "this target will be removed on or around 2022-02-15, please use //:pubsub instead.",
     tags = ["manual"],

--- a/BUILD
+++ b/BUILD
@@ -58,7 +58,7 @@ cc_library(
 )
 
 cc_library(
-    name = "experimental-pubsublite-mocks",
+    name = "experimental-pubsublite_mocks",
     deps = [
         "//google/cloud/pubsublite:google_cloud_cpp_pubsublite_mocks",
     ],

--- a/ci/cloudbuild/builds/cmake-install.sh
+++ b/ci/cloudbuild/builds/cmake-install.sh
@@ -35,7 +35,6 @@ feature_list+=(
   spanner
   storage
   experimental-storage-grpc
-  pubsublite
 )
 features="$(printf ",%s" "${feature_list[@]}")"
 features="${features:1}"
@@ -79,8 +78,6 @@ expected_dirs+=(
   ./include/google/cloud/pubsub
   ./include/google/cloud/pubsub/internal
   ./include/google/cloud/pubsub/mocks
-  ./include/google/cloud/pubsublite
-  ./include/google/cloud/pubsublite/v1
   ./include/google/cloud/spanner/admin/mocks
   ./include/google/cloud/spanner/internal
   ./include/google/cloud/spanner/mocks
@@ -113,7 +110,6 @@ expected_dirs+=(
   ./lib64/cmake/google_cloud_cpp_googleapis
   ./lib64/cmake/google_cloud_cpp_grpc_utils
   ./lib64/cmake/google_cloud_cpp_pubsub
-  ./lib64/cmake/google_cloud_cpp_pubsublite
   ./lib64/cmake/google_cloud_cpp_spanner
   ./lib64/cmake/google_cloud_cpp_storage
   ./lib64/cmake/googleapis

--- a/ci/etc/expected_install_directories
+++ b/ci/etc/expected_install_directories
@@ -19,6 +19,10 @@
 ./include/google/cloud/logging
 ./include/google/cloud/logging/internal
 ./include/google/cloud/logging/mocks
+./include/google/cloud/pubsublite
+./include/google/cloud/pubsublite/internal
+./include/google/cloud/pubsublite/mocks
+./include/google/cloud/pubsublite/v1
 ./include/google/cloud/spanner
 ./include/google/cloud/spanner/admin
 ./include/google/cloud/spanner/admin/internal
@@ -40,3 +44,4 @@
 ./lib64/cmake/google_cloud_cpp_bigquery
 ./lib64/cmake/google_cloud_cpp_iam
 ./lib64/cmake/google_cloud_cpp_logging
+./lib64/cmake/google_cloud_cpp_pubsublite

--- a/ci/etc/full_feature_list
+++ b/ci/etc/full_feature_list
@@ -1,3 +1,4 @@
 bigquery
 iam
 logging
+pubsublite

--- a/doc/adding_new_libraries.md
+++ b/doc/adding_new_libraries.md
@@ -36,7 +36,8 @@ bazel query \
 
 ## Run the Scaffold Generator
 
-Manually edit `generator/generator_config.textproto` and add your new service.
+Manually edit `generator/generator_config.textproto` and add the new service.
+The run the micro-generator to create the scaffold and the C++ sources:
 
 ```shell
 bazel_output_base="$(bazel info output_base)"
@@ -51,11 +52,9 @@ bazel run \
 
 ## Manually add the C++ files to the CMakeLists.txt file
 
-Create the `google/cloud/$library/retry_traits.h` file, and add this file and
-any generated C++ files to the `CMakeLists.txt` file. There should be markers
-in the file, search for `EDIT HERE`.
-
-## Run the CI build to generate Bazel files
+Create the `google/cloud/$library/retry_traits.h` file, and add this file
+**and** any generated C++ files to the `CMakeLists.txt` file. There should be
+markers in the file, search for `EDIT HERE`.
 
 ```shell
 ci/cloudbuild/build.sh -t cmake-install-pr

--- a/doc/adding_new_libraries.md
+++ b/doc/adding_new_libraries.md
@@ -37,7 +37,7 @@ bazel query \
 ## Run the Scaffold Generator
 
 Manually edit `generator/generator_config.textproto` and add the new service.
-The run the micro-generator to create the scaffold and the C++ sources:
+Then run the micro-generator to create the scaffold and the C++ sources:
 
 ```shell
 bazel_output_base="$(bazel info output_base)"

--- a/generator/generator_config.textproto
+++ b/generator/generator_config.textproto
@@ -63,6 +63,13 @@ service {
   initial_copyright_year: "2021"
 }
 
+# Pub/Sub Lite
+service {
+  service_proto_path: "google/cloud/pubsublite/v1/admin.proto"
+  product_path: "google/cloud/pubsublite"
+  initial_copyright_year: "2021"
+}
+
 # Spanner
 service {
   service_proto_path: "google/spanner/admin/database/v1/spanner_database_admin.proto"

--- a/google/cloud/pubsublite/BUILD
+++ b/google/cloud/pubsublite/BUILD
@@ -1,0 +1,45 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+package(default_visibility = ["//visibility:private"])
+
+licenses(["notice"])  # Apache 2.0
+
+load(":google_cloud_cpp_pubsublite.bzl", "google_cloud_cpp_pubsublite_hdrs", "google_cloud_cpp_pubsublite_srcs")
+
+cc_library(
+    name = "google_cloud_cpp_pubsublite",
+    srcs = google_cloud_cpp_pubsublite_srcs,
+    hdrs = google_cloud_cpp_pubsublite_hdrs,
+    visibility = ["//:__pkg__"],
+    deps = [
+        "//google/cloud:google_cloud_cpp_common",
+        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "@com_google_googleapis//google/cloud/pubsublite/v1:pubsublite_cc_grpc",
+    ],
+)
+
+load(":google_cloud_cpp_pubsublite_mocks.bzl", "google_cloud_cpp_pubsublite_mocks_hdrs", "google_cloud_cpp_pubsublite_mocks_srcs")
+
+cc_library(
+    name = "google_cloud_cpp_pubsublite_mocks",
+    srcs = google_cloud_cpp_pubsublite_mocks_srcs,
+    hdrs = google_cloud_cpp_pubsublite_mocks_hdrs,
+    visibility = ["//:__pkg__"],
+    deps = [
+        ":google_cloud_cpp_pubsublite",
+        "//google/cloud:google_cloud_cpp_common",
+        "//google/cloud:google_cloud_cpp_grpc_utils",
+    ],
+)

--- a/google/cloud/pubsublite/CMakeLists.txt
+++ b/google/cloud/pubsublite/CMakeLists.txt
@@ -59,8 +59,28 @@ target_link_libraries(
            google-cloud-cpp::api_annotations_protos
            google-cloud-cpp::api_http_protos)
 
-add_library(google_cloud_cpp_pubsublite # cmake-format: sort
-            internal/placeholder.cc)
+add_library(
+    google_cloud_cpp_pubsublite # cmake-format: sort
+    admin_client.cc
+    admin_client.h
+    admin_connection.cc
+    admin_connection.h
+    admin_connection_idempotency_policy.cc
+    admin_connection_idempotency_policy.h
+    admin_options.h
+    internal/admin_auth_decorator.cc
+    internal/admin_auth_decorator.h
+    internal/admin_logging_decorator.cc
+    internal/admin_logging_decorator.h
+    internal/admin_metadata_decorator.cc
+    internal/admin_metadata_decorator.h
+    internal/admin_option_defaults.cc
+    internal/admin_option_defaults.h
+    internal/admin_stub.cc
+    internal/admin_stub.h
+    internal/admin_stub_factory.cc
+    internal/admin_stub_factory.h
+    retry_traits.h)
 target_include_directories(
     google_cloud_cpp_pubsublite
     PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
@@ -92,7 +112,9 @@ create_bazel_config(google_cloud_cpp_pubsublite YEAR "2021")
 # at least one .o file). Unfortunately INTERFACE libraries are a bit weird in
 # that they need absolute paths for their sources.
 add_library(google_cloud_cpp_pubsublite_mocks INTERFACE)
-target_sources(google_cloud_cpp_pubsublite_mocks INTERFACE)
+target_sources(
+    google_cloud_cpp_pubsublite_mocks
+    INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/mocks/mock_admin_connection.h)
 target_link_libraries(
     google_cloud_cpp_pubsublite_mocks
     INTERFACE google-cloud-cpp::experimental-pubsublite GTest::gmock_main

--- a/google/cloud/pubsublite/README.md
+++ b/google/cloud/pubsublite/README.md
@@ -4,7 +4,7 @@
 
 [Cloud Pub/Sub Lite](https://cloud.google.com/pubsub/lite/) is a high-volume
 messaging service built for very low cost of operation by offering zonal storage
-and pre-provisioned capacity
+and pre-provisioned capacity.
 
 This directory contains an idiomatic C++ client library for interacting with
 this service.

--- a/google/cloud/pubsublite/README.md
+++ b/google/cloud/pubsublite/README.md
@@ -2,7 +2,9 @@
 
 :construction:
 
-[Cloud Pub/Sub Lite](https://cloud.google.com/pubsublite/) TODO(...) - add description
+[Cloud Pub/Sub Lite](https://cloud.google.com/pubsub/lite/) is a high-volume
+messaging service built for very low cost of operation by offering zonal storage
+and pre-provisioned capacity
 
 This directory contains an idiomatic C++ client library for interacting with
 this service.

--- a/google/cloud/pubsublite/config.cmake.in
+++ b/google/cloud/pubsublite/config.cmake.in
@@ -19,4 +19,4 @@ find_dependency(google_cloud_cpp_common)
 find_dependency(google_cloud_cpp_grpc_utils)
 find_dependency(absl)
 
-include("${CMAKE_CURRENT_LIST_DIR}/google_cloud_cpp_@NAME@-targets.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/google_cloud_cpp_pubsublite-targets.cmake")

--- a/google/cloud/pubsublite/google_cloud_cpp_pubsublite.bzl
+++ b/google/cloud/pubsublite/google_cloud_cpp_pubsublite.bzl
@@ -17,8 +17,27 @@
 """Automatically generated source lists for google_cloud_cpp_pubsublite - DO NOT EDIT."""
 
 google_cloud_cpp_pubsublite_hdrs = [
+    "admin_client.h",
+    "admin_connection.h",
+    "admin_connection_idempotency_policy.h",
+    "admin_options.h",
+    "internal/admin_auth_decorator.h",
+    "internal/admin_logging_decorator.h",
+    "internal/admin_metadata_decorator.h",
+    "internal/admin_option_defaults.h",
+    "internal/admin_stub.h",
+    "internal/admin_stub_factory.h",
+    "retry_traits.h",
 ]
 
 google_cloud_cpp_pubsublite_srcs = [
-    "internal/placeholder.cc",
+    "admin_client.cc",
+    "admin_connection.cc",
+    "admin_connection_idempotency_policy.cc",
+    "internal/admin_auth_decorator.cc",
+    "internal/admin_logging_decorator.cc",
+    "internal/admin_metadata_decorator.cc",
+    "internal/admin_option_defaults.cc",
+    "internal/admin_stub.cc",
+    "internal/admin_stub_factory.cc",
 ]

--- a/google/cloud/pubsublite/google_cloud_cpp_pubsublite_mocks.bzl
+++ b/google/cloud/pubsublite/google_cloud_cpp_pubsublite_mocks.bzl
@@ -17,6 +17,7 @@
 """Automatically generated source lists for google_cloud_cpp_pubsublite_mocks - DO NOT EDIT."""
 
 google_cloud_cpp_pubsublite_mocks_hdrs = [
+    "mocks/mock_admin_connection.h",
 ]
 
 google_cloud_cpp_pubsublite_mocks_srcs = [

--- a/google/cloud/pubsublite/retry_traits.h
+++ b/google/cloud/pubsublite/retry_traits.h
@@ -12,19 +12,29 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PUBSUBLITE_RETRY_TRAITS_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PUBSUBLITE_RETRY_TRAITS_H
+
+#include "google/cloud/status.h"
 #include "google/cloud/version.h"
-#include <string>
 
 namespace google {
 namespace cloud {
 namespace pubsublite_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
-
-// Placeholder function so the library is non-empty and can be compiled
-// Can be removed after the library gains some real functions
-std::string placeholder() { return google::cloud::version_string(); }
+/// Define the gRPC status code semantics for retrying requests.
+struct AdminServiceRetryTraits {
+  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+    return status.code() != StatusCode::kOk &&
+           status.code() != StatusCode::kInternal &&
+           status.code() != StatusCode::kDeadlineExceeded &&
+           status.code() != StatusCode::kUnavailable;
+  }
+};
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace pubsublite_internal
 }  // namespace cloud
 }  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PUBSUBLITE_RETRY_TRAITS_H


### PR DESCRIPTION
This makes the Pub/Sub library usable, though it is still marked as
"experimental".

This grows my little script to create new libraries a little bit. I
think I will remove it soon (the script, `create_scaffold.cmake`), but I
want to unblock Pub/Sub Lite, so here we are.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7602)
<!-- Reviewable:end -->
