### PR TITLE
feat(generator): more stable googleapis proto links

### DIFF
--- a/ci/cloudbuild/builds/generate-libraries.sh
+++ b/ci/cloudbuild/builds/generate-libraries.sh
@@ -21,14 +21,10 @@ source module ci/cloudbuild/builds/lib/bazel.sh
 source module ci/cloudbuild/builds/lib/git.sh
 
 bazel_output_base="$(bazel info output_base)"
-googleapis_hash=$(bazel query \
-  'kind(http_archive, //external:com_google_googleapis)' --output=build |
-  sed -n 's/^.*strip_prefix = "googleapis-\(\S*\)"\,.*$/\1/p')
 
 io::log_h2 "Running generator"
 bazel run --action_env=GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes \
   //generator:google-cloud-cpp-codegen -- \
-  --googleapis_commit_hash="${googleapis_hash}" \
   --protobuf_proto_path="${bazel_output_base}"/external/com_google_protobuf/src \
   --googleapis_proto_path="${bazel_output_base}"/external/com_google_googleapis \
   --output_path="${PROJECT_ROOT}" \

--- a/cmake/GoogleapisConfig.cmake
+++ b/cmake/GoogleapisConfig.cmake
@@ -1,0 +1,30 @@
+# ~~~
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ~~~
+
+# Give application developers a hook to configure the version and hash
+# downloaded from GitHub.
+set(GOOGLE_CLOUD_CPP_GOOGLEAPIS_COMMIT_SHA
+    "53432afb877cb3c1920f73e6621daa8c24f86522"
+    CACHE STRING "Configure the commit SHA (or tag) for the googleapis protos.")
+mark_as_advanced(GOOGLE_CLOUD_CPP_GOOGLEAPIS_SHA)
+set(GOOGLE_CLOUD_CPP_GOOGLEAPIS_SHA256
+    "485631b0f2f54e344096263980f1ce8f357c72403da080a552df317eeda1ea7b"
+    CACHE STRING "Configure the SHA256 checksum of the googleapis tarball.")
+mark_as_advanced(GOOGLE_CLOUD_CPP_GOOGLEAPIS_SHA256)
+
+set(DOXYGEN_ALIASES
+    "googleapis_link{2}=\"[\\1](https://github.com/googleapis/googleapis/blob/${GOOGLE_CLOUD_CPP_GOOGLEAPIS_COMMIT_SHA}/\\2)\""
+)

--- a/external/googleapis/CMakeLists.txt
+++ b/external/googleapis/CMakeLists.txt
@@ -14,13 +14,11 @@
 # limitations under the License.
 # ~~~
 
-# Give application developers a hook to configure the version and hash
-# downloaded from GitHub.
+include(GoogleapisConfig)
+
 set(GOOGLE_CLOUD_CPP_GOOGLEAPIS_URL
-    "https://github.com/googleapis/googleapis/archive/53432afb877cb3c1920f73e6621daa8c24f86522.tar.gz"
+    "https://github.com/googleapis/googleapis/archive/${GOOGLE_CLOUD_CPP_GOOGLEAPIS_COMMIT_SHA}.tar.gz"
 )
-set(GOOGLE_CLOUD_CPP_GOOGLEAPIS_SHA256
-    "485631b0f2f54e344096263980f1ce8f357c72403da080a552df317eeda1ea7b")
 
 set(EXTERNAL_GOOGLEAPIS_SOURCE
     "${PROJECT_BINARY_DIR}/external/googleapis/src/googleapis_download")

--- a/generator/generator_test.cc
+++ b/generator/generator_test.cc
@@ -164,11 +164,9 @@ TEST_F(GeneratorTest, GenerateServicesSuccess) {
 
   std::string actual_error;
   Generator generator;
-  auto result = generator.Generate(
-      service_file_descriptor,
-      {"product_path=google/cloud/foo"
-       ",googleapis_commit_hash=59f97e6044a1275f83427ab7962a154c00d915b5"},
-      context_.get(), &actual_error);
+  auto result = generator.Generate(service_file_descriptor,
+                                   {"product_path=google/cloud/foo"},
+                                   context_.get(), &actual_error);
   EXPECT_TRUE(result);
   EXPECT_TRUE(actual_error.empty());
 }

--- a/generator/integration_tests/generator_integration_test.cc
+++ b/generator/integration_tests/generator_integration_test.cc
@@ -97,7 +97,6 @@ class GeneratorIntegrationTest : public testing::TestWithParam<std::string> {
                           "Codegen C++ Generator");
 
     product_path_ = "generator/integration_tests/golden/";
-    googleapis_commit_hash_ = "59f97e6044a1275f83427ab7962a154c00d915b5";
     copyright_year_ = CurrentCopyrightYear();
     omit_rpc1_ = "Omitted1";
     omit_rpc2_ = "GoldenKitchenSink.Omitted2";
@@ -114,8 +113,6 @@ class GeneratorIntegrationTest : public testing::TestWithParam<std::string> {
     args.emplace_back("--proto_path=" + code_path);
     args.emplace_back("--cpp_codegen_out=" + output_path_);
     args.emplace_back("--cpp_codegen_opt=product_path=" + product_path_);
-    args.emplace_back("--cpp_codegen_opt=googleapis_commit_hash=" +
-                      googleapis_commit_hash_);
     args.emplace_back("--cpp_codegen_opt=copyright_year=" + copyright_year_);
     args.emplace_back("--cpp_codegen_opt=omit_rpc=" + omit_rpc1_);
     args.emplace_back("--cpp_codegen_opt=omit_rpc=" + omit_rpc2_);
@@ -143,7 +140,6 @@ class GeneratorIntegrationTest : public testing::TestWithParam<std::string> {
   std::string product_path_;
   std::string output_path_;
   std::string golden_path_;
-  std::string googleapis_commit_hash_;
   std::string copyright_year_;
   std::string omit_rpc1_;
   std::string omit_rpc2_;

--- a/generator/integration_tests/golden/golden_kitchen_sink_client.h
+++ b/generator/integration_tests/golden/golden_kitchen_sink_client.h
@@ -91,7 +91,7 @@ class GoldenKitchenSinkClient {
    *  Must be set to a value less than or equal to 3600 (1 hour). If a value is
    *  not specified, the token's lifetime will be set to a default value of one
    *  hour.
-   * @return [google::test::admin::database::v1::GenerateAccessTokenResponse](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L872)
+   * @return @googleapis_link{google::test::admin::database::v1::GenerateAccessTokenResponse,generator/integration_tests/test.proto#L872}
    */
   StatusOr<google::test::admin::database::v1::GenerateAccessTokenResponse>
   GenerateAccessToken(std::string const& name, std::vector<std::string> const& delegates, std::vector<std::string> const& scope, google::protobuf::Duration const& lifetime);
@@ -116,7 +116,7 @@ class GoldenKitchenSinkClient {
    *  grants access to.
    * @param include_email  Include the service account email in the token. If set to `true`, the
    *  token will contain `email` and `email_verified` claims.
-   * @return [google::test::admin::database::v1::GenerateIdTokenResponse](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L914)
+   * @return @googleapis_link{google::test::admin::database::v1::GenerateIdTokenResponse,generator/integration_tests/test.proto#L914}
    */
   StatusOr<google::test::admin::database::v1::GenerateIdTokenResponse>
   GenerateIdToken(std::string const& name, std::vector<std::string> const& delegates, std::string const& audience, bool include_email);
@@ -147,7 +147,7 @@ class GoldenKitchenSinkClient {
    *  entries in `entries`. If a log entry already has a label with the same key
    *  as a label in this parameter, then the log entry's label is not changed.
    *  See [LogEntry][google.logging.v2.LogEntry]. Test delimiter$
-   * @return [google::test::admin::database::v1::WriteLogEntriesResponse](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L953)
+   * @return @googleapis_link{google::test::admin::database::v1::WriteLogEntriesResponse,generator/integration_tests/test.proto#L953}
    */
   StatusOr<google::test::admin::database::v1::WriteLogEntriesResponse>
   WriteLogEntries(std::string const& log_name, std::map<std::string, std::string> const& labels);
@@ -180,7 +180,7 @@ class GoldenKitchenSinkClient {
    *      "organization/[ORGANIZATION_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]"
    *      "billingAccounts/[BILLING_ACCOUNT_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]"
    *      "folders/[FOLDER_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]"
-   * @return [google::test::admin::database::v1::TailLogEntriesResponse](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L1214)
+   * @return @googleapis_link{google::test::admin::database::v1::TailLogEntriesResponse,generator/integration_tests/test.proto#L1214}
    */
   StreamRange<google::test::admin::database::v1::TailLogEntriesResponse>
   TailLogEntries(std::vector<std::string> const& resource_names);
@@ -196,7 +196,7 @@ class GoldenKitchenSinkClient {
    * @param key_types  Filters the types of keys the user wants to include in the list
    *  response. Duplicate key types are not allowed. If no key type
    *  is provided, all keys are returned.
-   * @return [google::test::admin::database::v1::ListServiceAccountKeysResponse](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L1286)
+   * @return @googleapis_link{google::test::admin::database::v1::ListServiceAccountKeysResponse,generator/integration_tests/test.proto#L1286}
    */
   StatusOr<google::test::admin::database::v1::ListServiceAccountKeysResponse>
   ListServiceAccountKeys(std::string const& name, std::vector<google::test::admin::database::v1::ListServiceAccountKeysRequest::KeyType> const& key_types);
@@ -204,8 +204,8 @@ class GoldenKitchenSinkClient {
   /**
    * Generates an OAuth 2.0 access token for a service account.
    *
-   * @param request [google::test::admin::database::v1::GenerateAccessTokenRequest](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L835)
-   * @return [google::test::admin::database::v1::GenerateAccessTokenResponse](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L872)
+   * @param request @googleapis_link{google::test::admin::database::v1::GenerateAccessTokenRequest,generator/integration_tests/test.proto#L835}
+   * @return @googleapis_link{google::test::admin::database::v1::GenerateAccessTokenResponse,generator/integration_tests/test.proto#L872}
    */
   StatusOr<google::test::admin::database::v1::GenerateAccessTokenResponse>
   GenerateAccessToken(google::test::admin::database::v1::GenerateAccessTokenRequest const& request);
@@ -213,8 +213,8 @@ class GoldenKitchenSinkClient {
   /**
    * Generates an OpenID Connect ID token for a service account.
    *
-   * @param request [google::test::admin::database::v1::GenerateIdTokenRequest](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L881)
-   * @return [google::test::admin::database::v1::GenerateIdTokenResponse](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L914)
+   * @param request @googleapis_link{google::test::admin::database::v1::GenerateIdTokenRequest,generator/integration_tests/test.proto#L881}
+   * @return @googleapis_link{google::test::admin::database::v1::GenerateIdTokenResponse,generator/integration_tests/test.proto#L914}
    */
   StatusOr<google::test::admin::database::v1::GenerateIdTokenResponse>
   GenerateIdToken(google::test::admin::database::v1::GenerateIdTokenRequest const& request);
@@ -228,8 +228,8 @@ class GoldenKitchenSinkClient {
    * different resources (projects, organizations, billing accounts or
    * folders)
    *
-   * @param request [google::test::admin::database::v1::WriteLogEntriesRequest](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L920)
-   * @return [google::test::admin::database::v1::WriteLogEntriesResponse](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L953)
+   * @param request @googleapis_link{google::test::admin::database::v1::WriteLogEntriesRequest,generator/integration_tests/test.proto#L920}
+   * @return @googleapis_link{google::test::admin::database::v1::WriteLogEntriesResponse,generator/integration_tests/test.proto#L953}
    */
   StatusOr<google::test::admin::database::v1::WriteLogEntriesResponse>
   WriteLogEntries(google::test::admin::database::v1::WriteLogEntriesRequest const& request);
@@ -238,7 +238,7 @@ class GoldenKitchenSinkClient {
    * Lists the logs in projects, organizations, folders, or billing accounts.
    * Only logs that have entries are listed.
    *
-   * @param request [google::test::admin::database::v1::ListLogsRequest](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L956)
+   * @param request @googleapis_link{google::test::admin::database::v1::ListLogsRequest,generator/integration_tests/test.proto#L956}
    * @return std::string
    */
   StreamRange<std::string>
@@ -248,8 +248,8 @@ class GoldenKitchenSinkClient {
    * Streaming read of log entries as they are ingested. Until the stream is
    * terminated, it will continue reading logs.
    *
-   * @param request [google::test::admin::database::v1::TailLogEntriesRequest](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L1182)
-   * @return [google::test::admin::database::v1::TailLogEntriesResponse](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L1214)
+   * @param request @googleapis_link{google::test::admin::database::v1::TailLogEntriesRequest,generator/integration_tests/test.proto#L1182}
+   * @return @googleapis_link{google::test::admin::database::v1::TailLogEntriesResponse,generator/integration_tests/test.proto#L1214}
    */
   StreamRange<google::test::admin::database::v1::TailLogEntriesResponse>
   TailLogEntries(google::test::admin::database::v1::TailLogEntriesRequest const& request);
@@ -257,8 +257,8 @@ class GoldenKitchenSinkClient {
   /**
    * Lists every [ServiceAccountKey][google.iam.admin.v1.ServiceAccountKey] for a service account.
    *
-   * @param request [google::test::admin::database::v1::ListServiceAccountKeysRequest](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L1254)
-   * @return [google::test::admin::database::v1::ListServiceAccountKeysResponse](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L1286)
+   * @param request @googleapis_link{google::test::admin::database::v1::ListServiceAccountKeysRequest,generator/integration_tests/test.proto#L1254}
+   * @return @googleapis_link{google::test::admin::database::v1::ListServiceAccountKeysResponse,generator/integration_tests/test.proto#L1286}
    */
   StatusOr<google::test::admin::database::v1::ListServiceAccountKeysResponse>
   ListServiceAccountKeys(google::test::admin::database::v1::ListServiceAccountKeysRequest const& request);

--- a/generator/integration_tests/golden/golden_thing_admin_client.h
+++ b/generator/integration_tests/golden/golden_thing_admin_client.h
@@ -70,7 +70,7 @@ class GoldenThingAdminClient {
    *
    * @param parent  Required. The instance whose databases should be listed.
    *  Values are of the form `projects/<project>/instances/<instance>`.
-   * @return [google::test::admin::database::v1::Database](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L329)
+   * @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
    */
   StreamRange<google::test::admin::database::v1::Database>
   ListDatabases(std::string const& parent);
@@ -92,7 +92,7 @@ class GoldenThingAdminClient {
    *  `[a-z][a-z0-9_\-]*[a-z0-9]` and be between 2 and 30 characters in length.
    *  If the database ID is a reserved word or if it contains a hyphen, the
    *  database ID must be enclosed in backticks (`` ` ``).
-   * @return [google::test::admin::database::v1::Database](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L329)
+   * @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
    */
   future<StatusOr<google::test::admin::database::v1::Database>>
   CreateDatabase(std::string const& parent, std::string const& create_statement);
@@ -102,7 +102,7 @@ class GoldenThingAdminClient {
    *
    * @param name  Required. The name of the requested database. Values are of the form
    *  `projects/<project>/instances/<instance>/databases/<database>`.
-   * @return [google::test::admin::database::v1::Database](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L329)
+   * @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
    */
   StatusOr<google::test::admin::database::v1::Database>
   GetDatabase(std::string const& name);
@@ -118,7 +118,7 @@ class GoldenThingAdminClient {
    *
    * @param database  Required. The database to update.
    * @param statements  Required. DDL statements to be applied to the database.
-   * @return [google::test::admin::database::v1::UpdateDatabaseDdlMetadata](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L506)
+   * @return @googleapis_link{google::test::admin::database::v1::UpdateDatabaseDdlMetadata,generator/integration_tests/test.proto#L506}
    */
   future<StatusOr<google::test::admin::database::v1::UpdateDatabaseDdlMetadata>>
   UpdateDatabaseDdl(std::string const& database, std::vector<std::string> const& statements);
@@ -139,7 +139,7 @@ class GoldenThingAdminClient {
    * be queried using the [Operations][google.longrunning.Operations] API.
    *
    * @param database  Required. The database whose schema we wish to get.
-   * @return [google::test::admin::database::v1::GetDatabaseDdlResponse](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L545)
+   * @return @googleapis_link{google::test::admin::database::v1::GetDatabaseDdlResponse,generator/integration_tests/test.proto#L545}
    */
   StatusOr<google::test::admin::database::v1::GetDatabaseDdlResponse>
   GetDatabaseDdl(std::string const& database);
@@ -159,7 +159,7 @@ class GoldenThingAdminClient {
    *  the policy is limited to a few 10s of KB. An empty policy is a
    *  valid policy but certain Cloud Platform services (such as Projects)
    *  might reject them.
-   * @return [google::iam::v1::Policy](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/google/iam/v1/policy.proto#L88)
+   * @return @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
    */
   StatusOr<google::iam::v1::Policy>
   SetIamPolicy(std::string const& resource, google::iam::v1::Policy const& policy);
@@ -200,7 +200,7 @@ class GoldenThingAdminClient {
    *
    * @param resource  REQUIRED: The resource for which the policy is being requested.
    *  See the operation documentation for the appropriate value for this field.
-   * @return [google::iam::v1::Policy](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/google/iam/v1/policy.proto#L88)
+   * @return @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
    */
   StatusOr<google::iam::v1::Policy>
   GetIamPolicy(std::string const& resource);
@@ -223,7 +223,7 @@ class GoldenThingAdminClient {
    *  wildcards (such as '*' or 'storage.*') are not allowed. For more
    *  information see
    *  [IAM Overview](https://cloud.google.com/iam/docs/overview#permissions).
-   * @return [google::iam::v1::TestIamPermissionsResponse](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/google/iam/v1/iam_policy.proto#L141)
+   * @return @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
    */
   StatusOr<google::iam::v1::TestIamPermissionsResponse>
   TestIamPermissions(std::string const& resource, std::vector<std::string> const& permissions);
@@ -252,7 +252,7 @@ class GoldenThingAdminClient {
    * @param backup_id  Required. The id of the backup to be created. The `backup_id` appended to
    *  `parent` forms the full backup name of the form
    *  `projects/<project>/instances/<instance>/backups/<backup_id>`.
-   * @return [google::test::admin::database::v1::Backup](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/backup.proto#L36)
+   * @return @googleapis_link{google::test::admin::database::v1::Backup,generator/integration_tests/backup.proto#L36}
    */
   future<StatusOr<google::test::admin::database::v1::Backup>>
   CreateBackup(std::string const& parent, google::test::admin::database::v1::Backup const& backup, std::string const& backup_id);
@@ -263,7 +263,7 @@ class GoldenThingAdminClient {
    * @param name  Required. Name of the backup.
    *  Values are of the form
    *  `projects/<project>/instances/<instance>/backups/<backup>`.
-   * @return [google::test::admin::database::v1::Backup](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/backup.proto#L36)
+   * @return @googleapis_link{google::test::admin::database::v1::Backup,generator/integration_tests/backup.proto#L36}
    */
   StatusOr<google::test::admin::database::v1::Backup>
   GetBackup(std::string const& name);
@@ -280,7 +280,7 @@ class GoldenThingAdminClient {
    *  resource, not to the request message. The field mask must always be
    *  specified; this prevents any future fields from being erased accidentally
    *  by clients that do not know about them.
-   * @return [google::test::admin::database::v1::Backup](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/backup.proto#L36)
+   * @return @googleapis_link{google::test::admin::database::v1::Backup,generator/integration_tests/backup.proto#L36}
    */
   StatusOr<google::test::admin::database::v1::Backup>
   UpdateBackup(google::test::admin::database::v1::Backup const& backup, google::protobuf::FieldMask const& update_mask);
@@ -302,7 +302,7 @@ class GoldenThingAdminClient {
    *
    * @param parent  Required. The instance to list backups from.  Values are of the
    *  form `projects/<project>/instances/<instance>`.
-   * @return [google::test::admin::database::v1::Backup](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/backup.proto#L36)
+   * @return @googleapis_link{google::test::admin::database::v1::Backup,generator/integration_tests/backup.proto#L36}
    */
   StreamRange<google::test::admin::database::v1::Backup>
   ListBackups(std::string const& parent);
@@ -337,7 +337,7 @@ class GoldenThingAdminClient {
    *  `projects/<project>/instances/<instance>/databases/<database_id>`.
    * @param backup  Name of the backup from which to restore.  Values are of the form
    *  `projects/<project>/instances/<instance>/backups/<backup>`.
-   * @return [google::test::admin::database::v1::Database](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L329)
+   * @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
    */
   future<StatusOr<google::test::admin::database::v1::Database>>
   RestoreDatabase(std::string const& parent, std::string const& database_id, std::string const& backup);
@@ -354,7 +354,7 @@ class GoldenThingAdminClient {
    *
    * @param parent  Required. The instance of the database operations.
    *  Values are of the form `projects/<project>/instances/<instance>`.
-   * @return [google::longrunning::Operation](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/google/longrunning/operations.proto#L128)
+   * @return @googleapis_link{google::longrunning::Operation,google/longrunning/operations.proto#L128}
    */
   StreamRange<google::longrunning::Operation>
   ListDatabaseOperations(std::string const& parent);
@@ -373,7 +373,7 @@ class GoldenThingAdminClient {
    *
    * @param parent  Required. The instance of the backup operations. Values are of
    *  the form `projects/<project>/instances/<instance>`.
-   * @return [google::longrunning::Operation](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/google/longrunning/operations.proto#L128)
+   * @return @googleapis_link{google::longrunning::Operation,google/longrunning/operations.proto#L128}
    */
   StreamRange<google::longrunning::Operation>
   ListBackupOperations(std::string const& parent);
@@ -383,7 +383,7 @@ class GoldenThingAdminClient {
    *
    * @param name  Required. The name of the requested database. Values are of the form
    *  `projects/<project>/instances/<instance>/databases/<database>`.
-   * @return [google::test::admin::database::v1::Database](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L329)
+   * @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
    */
   future<StatusOr<google::test::admin::database::v1::Database>>
   AsyncGetDatabase(std::string const& name);
@@ -401,8 +401,8 @@ class GoldenThingAdminClient {
   /**
    * Lists Cloud Test databases.
    *
-   * @param request [google::test::admin::database::v1::ListDatabasesRequest](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L377)
-   * @return [google::test::admin::database::v1::Database](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L329)
+   * @param request @googleapis_link{google::test::admin::database::v1::ListDatabasesRequest,generator/integration_tests/test.proto#L377}
+   * @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
    */
   StreamRange<google::test::admin::database::v1::Database>
   ListDatabases(google::test::admin::database::v1::ListDatabasesRequest request);
@@ -417,8 +417,8 @@ class GoldenThingAdminClient {
    * [response][google.longrunning.Operation.response] field type is
    * [Database][google.test.admin.database.v1.Database], if successful.
    *
-   * @param request [google::test::admin::database::v1::CreateDatabaseRequest](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L409)
-   * @return [google::test::admin::database::v1::Database](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L329)
+   * @param request @googleapis_link{google::test::admin::database::v1::CreateDatabaseRequest,generator/integration_tests/test.proto#L409}
+   * @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
    */
   future<StatusOr<google::test::admin::database::v1::Database>>
   CreateDatabase(google::test::admin::database::v1::CreateDatabaseRequest const& request);
@@ -426,8 +426,8 @@ class GoldenThingAdminClient {
   /**
    * Gets the state of a Cloud Test database.
    *
-   * @param request [google::test::admin::database::v1::GetDatabaseRequest](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L443)
-   * @return [google::test::admin::database::v1::Database](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L329)
+   * @param request @googleapis_link{google::test::admin::database::v1::GetDatabaseRequest,generator/integration_tests/test.proto#L443}
+   * @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
    */
   StatusOr<google::test::admin::database::v1::Database>
   GetDatabase(google::test::admin::database::v1::GetDatabaseRequest const& request);
@@ -441,8 +441,8 @@ class GoldenThingAdminClient {
    * [metadata][google.longrunning.Operation.metadata] field type is
    * [UpdateDatabaseDdlMetadata][google.test.admin.database.v1.UpdateDatabaseDdlMetadata].  The operation has no response.
    *
-   * @param request [google::test::admin::database::v1::UpdateDatabaseDdlRequest](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L470)
-   * @return [google::test::admin::database::v1::UpdateDatabaseDdlMetadata](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L506)
+   * @param request @googleapis_link{google::test::admin::database::v1::UpdateDatabaseDdlRequest,generator/integration_tests/test.proto#L470}
+   * @return @googleapis_link{google::test::admin::database::v1::UpdateDatabaseDdlMetadata,generator/integration_tests/test.proto#L506}
    */
   future<StatusOr<google::test::admin::database::v1::UpdateDatabaseDdlMetadata>>
   UpdateDatabaseDdl(google::test::admin::database::v1::UpdateDatabaseDdlRequest const& request);
@@ -452,7 +452,7 @@ class GoldenThingAdminClient {
    * Completed backups for the database will be retained according to their
    * `expire_time`.
    *
-   * @param request [google::test::admin::database::v1::DropDatabaseRequest](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L523)
+   * @param request @googleapis_link{google::test::admin::database::v1::DropDatabaseRequest,generator/integration_tests/test.proto#L523}
    */
   Status
   DropDatabase(google::test::admin::database::v1::DropDatabaseRequest const& request);
@@ -462,8 +462,8 @@ class GoldenThingAdminClient {
    * DDL statements. This method does not show pending schema updates, those may
    * be queried using the [Operations][google.longrunning.Operations] API.
    *
-   * @param request [google::test::admin::database::v1::GetDatabaseDdlRequest](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L534)
-   * @return [google::test::admin::database::v1::GetDatabaseDdlResponse](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L545)
+   * @param request @googleapis_link{google::test::admin::database::v1::GetDatabaseDdlRequest,generator/integration_tests/test.proto#L534}
+   * @return @googleapis_link{google::test::admin::database::v1::GetDatabaseDdlResponse,generator/integration_tests/test.proto#L545}
    */
   StatusOr<google::test::admin::database::v1::GetDatabaseDdlResponse>
   GetDatabaseDdl(google::test::admin::database::v1::GetDatabaseDdlRequest const& request);
@@ -477,8 +477,8 @@ class GoldenThingAdminClient {
    * For backups, authorization requires `test.backups.setIamPolicy`
    * permission on [resource][google.iam.v1.SetIamPolicyRequest.resource].
    *
-   * @param request [google::iam::v1::SetIamPolicyRequest](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/google/iam/v1/iam_policy.proto#L98)
-   * @return [google::iam::v1::Policy](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/google/iam/v1/policy.proto#L88)
+   * @param request @googleapis_link{google::iam::v1::SetIamPolicyRequest,google/iam/v1/iam_policy.proto#L98}
+   * @return @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
    */
   StatusOr<google::iam::v1::Policy>
   SetIamPolicy(google::iam::v1::SetIamPolicyRequest const& request);
@@ -493,8 +493,8 @@ class GoldenThingAdminClient {
    * For backups, authorization requires `test.backups.getIamPolicy`
    * permission on [resource][google.iam.v1.GetIamPolicyRequest.resource].
    *
-   * @param request [google::iam::v1::GetIamPolicyRequest](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/google/iam/v1/iam_policy.proto#L113)
-   * @return [google::iam::v1::Policy](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/google/iam/v1/policy.proto#L88)
+   * @param request @googleapis_link{google::iam::v1::GetIamPolicyRequest,google/iam/v1/iam_policy.proto#L113}
+   * @return @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
    */
   StatusOr<google::iam::v1::Policy>
   GetIamPolicy(google::iam::v1::GetIamPolicyRequest const& request);
@@ -511,8 +511,8 @@ class GoldenThingAdminClient {
    * result in a NOT_FOUND error if the user has
    * `test.backups.list` permission on the containing instance.
    *
-   * @param request [google::iam::v1::TestIamPermissionsRequest](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/google/iam/v1/iam_policy.proto#L126)
-   * @return [google::iam::v1::TestIamPermissionsResponse](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/google/iam/v1/iam_policy.proto#L141)
+   * @param request @googleapis_link{google::iam::v1::TestIamPermissionsRequest,google/iam/v1/iam_policy.proto#L126}
+   * @return @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
    */
   StatusOr<google::iam::v1::TestIamPermissionsResponse>
   TestIamPermissions(google::iam::v1::TestIamPermissionsRequest const& request);
@@ -531,8 +531,8 @@ class GoldenThingAdminClient {
    * There can be only one pending backup creation per database. Backup creation
    * of different databases can run concurrently.
    *
-   * @param request [google::test::admin::database::v1::CreateBackupRequest](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/backup.proto#L110)
-   * @return [google::test::admin::database::v1::Backup](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/backup.proto#L36)
+   * @param request @googleapis_link{google::test::admin::database::v1::CreateBackupRequest,generator/integration_tests/backup.proto#L110}
+   * @return @googleapis_link{google::test::admin::database::v1::Backup,generator/integration_tests/backup.proto#L36}
    */
   future<StatusOr<google::test::admin::database::v1::Backup>>
   CreateBackup(google::test::admin::database::v1::CreateBackupRequest const& request);
@@ -540,8 +540,8 @@ class GoldenThingAdminClient {
   /**
    * Gets metadata on a pending or completed [Backup][google.test.admin.database.v1.Backup].
    *
-   * @param request [google::test::admin::database::v1::GetBackupRequest](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/backup.proto#L177)
-   * @return [google::test::admin::database::v1::Backup](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/backup.proto#L36)
+   * @param request @googleapis_link{google::test::admin::database::v1::GetBackupRequest,generator/integration_tests/backup.proto#L177}
+   * @return @googleapis_link{google::test::admin::database::v1::Backup,generator/integration_tests/backup.proto#L36}
    */
   StatusOr<google::test::admin::database::v1::Backup>
   GetBackup(google::test::admin::database::v1::GetBackupRequest const& request);
@@ -549,8 +549,8 @@ class GoldenThingAdminClient {
   /**
    * Updates a pending or completed [Backup][google.test.admin.database.v1.Backup].
    *
-   * @param request [google::test::admin::database::v1::UpdateBackupRequest](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/backup.proto#L161)
-   * @return [google::test::admin::database::v1::Backup](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/backup.proto#L36)
+   * @param request @googleapis_link{google::test::admin::database::v1::UpdateBackupRequest,generator/integration_tests/backup.proto#L161}
+   * @return @googleapis_link{google::test::admin::database::v1::Backup,generator/integration_tests/backup.proto#L36}
    */
   StatusOr<google::test::admin::database::v1::Backup>
   UpdateBackup(google::test::admin::database::v1::UpdateBackupRequest const& request);
@@ -558,7 +558,7 @@ class GoldenThingAdminClient {
   /**
    * Deletes a pending or completed [Backup][google.test.admin.database.v1.Backup].
    *
-   * @param request [google::test::admin::database::v1::DeleteBackupRequest](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/backup.proto#L190)
+   * @param request @googleapis_link{google::test::admin::database::v1::DeleteBackupRequest,generator/integration_tests/backup.proto#L190}
    */
   Status
   DeleteBackup(google::test::admin::database::v1::DeleteBackupRequest const& request);
@@ -568,8 +568,8 @@ class GoldenThingAdminClient {
    * Backups returned are ordered by `create_time` in descending order,
    * starting from the most recent `create_time`.
    *
-   * @param request [google::test::admin::database::v1::ListBackupsRequest](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/backup.proto#L203)
-   * @return [google::test::admin::database::v1::Backup](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/backup.proto#L36)
+   * @param request @googleapis_link{google::test::admin::database::v1::ListBackupsRequest,generator/integration_tests/backup.proto#L203}
+   * @return @googleapis_link{google::test::admin::database::v1::Backup,generator/integration_tests/backup.proto#L36}
    */
   StreamRange<google::test::admin::database::v1::Backup>
   ListBackups(google::test::admin::database::v1::ListBackupsRequest request);
@@ -593,8 +593,8 @@ class GoldenThingAdminClient {
    * initiated, without waiting for the optimize operation associated with the
    * first restore to complete.
    *
-   * @param request [google::test::admin::database::v1::RestoreDatabaseRequest](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L634)
-   * @return [google::test::admin::database::v1::Database](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L329)
+   * @param request @googleapis_link{google::test::admin::database::v1::RestoreDatabaseRequest,generator/integration_tests/test.proto#L634}
+   * @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
    */
   future<StatusOr<google::test::admin::database::v1::Database>>
   RestoreDatabase(google::test::admin::database::v1::RestoreDatabaseRequest const& request);
@@ -609,8 +609,8 @@ class GoldenThingAdminClient {
    * include those that have completed/failed/canceled within the last 7 days,
    * and pending operations.
    *
-   * @param request [google::test::admin::database::v1::ListDatabaseOperationsRequest](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L553)
-   * @return [google::longrunning::Operation](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/google/longrunning/operations.proto#L128)
+   * @param request @googleapis_link{google::test::admin::database::v1::ListDatabaseOperationsRequest,generator/integration_tests/test.proto#L553}
+   * @return @googleapis_link{google::longrunning::Operation,google/longrunning/operations.proto#L128}
    */
   StreamRange<google::longrunning::Operation>
   ListDatabaseOperations(google::test::admin::database::v1::ListDatabaseOperationsRequest request);
@@ -627,8 +627,8 @@ class GoldenThingAdminClient {
    * `operation.metadata.value.progress.start_time` in descending order starting
    * from the most recently started operation.
    *
-   * @param request [google::test::admin::database::v1::ListBackupOperationsRequest](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/backup.proto#L274)
-   * @return [google::longrunning::Operation](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/google/longrunning/operations.proto#L128)
+   * @param request @googleapis_link{google::test::admin::database::v1::ListBackupOperationsRequest,generator/integration_tests/backup.proto#L274}
+   * @return @googleapis_link{google::longrunning::Operation,google/longrunning/operations.proto#L128}
    */
   StreamRange<google::longrunning::Operation>
   ListBackupOperations(google::test::admin::database::v1::ListBackupOperationsRequest request);
@@ -636,8 +636,8 @@ class GoldenThingAdminClient {
   /**
    * Gets the state of a Cloud Test database.
    *
-   * @param request [google::test::admin::database::v1::GetDatabaseRequest](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L443)
-   * @return [google::test::admin::database::v1::Database](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L329)
+   * @param request @googleapis_link{google::test::admin::database::v1::GetDatabaseRequest,generator/integration_tests/test.proto#L443}
+   * @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
    */
   future<StatusOr<google::test::admin::database::v1::Database>>
   AsyncGetDatabase(google::test::admin::database::v1::GetDatabaseRequest const& request);
@@ -647,7 +647,7 @@ class GoldenThingAdminClient {
    * Completed backups for the database will be retained according to their
    * `expire_time`.
    *
-   * @param request [google::test::admin::database::v1::DropDatabaseRequest](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L523)
+   * @param request @googleapis_link{google::test::admin::database::v1::DropDatabaseRequest,generator/integration_tests/test.proto#L523}
    */
   future<Status>
   AsyncDropDatabase(google::test::admin::database::v1::DropDatabaseRequest const& request);

--- a/generator/integration_tests/golden/internal/golden_thing_admin_auth_decorator.cc
+++ b/generator/integration_tests/golden/internal/golden_thing_admin_auth_decorator.cc
@@ -25,7 +25,6 @@ namespace cloud {
 namespace golden_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-
 GoldenThingAdminAuth::GoldenThingAdminAuth(
     std::shared_ptr<google::cloud::internal::GrpcAuthenticationStrategy> auth,
     std::shared_ptr<GoldenThingAdminStub> child)

--- a/generator/integration_tests/golden/internal/golden_thing_admin_auth_decorator.h
+++ b/generator/integration_tests/golden/internal/golden_thing_admin_auth_decorator.h
@@ -32,7 +32,6 @@ namespace cloud {
 namespace golden_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-
 class GoldenThingAdminAuth : public GoldenThingAdminStub {
  public:
   ~GoldenThingAdminAuth() override = default;

--- a/generator/internal/codegen_utils.cc
+++ b/generator/internal/codegen_utils.cc
@@ -57,22 +57,6 @@ Status ProcessArgProductPath(
   return {};
 }
 
-Status ProcessArgGoogleapisCommitHash(
-    std::vector<std::pair<std::string, std::string>>& command_line_args) {
-  auto googleapis_commit_hash =
-      std::find_if(command_line_args.begin(), command_line_args.end(),
-                   [](std::pair<std::string, std::string> const& p) {
-                     return p.first == "googleapis_commit_hash";
-                   });
-  if (googleapis_commit_hash == command_line_args.end() ||
-      googleapis_commit_hash->second.empty()) {
-    return Status(
-        StatusCode::kInvalidArgument,
-        "--cpp_codegen_opt=googleapis_commit_hash=<hash> must be specified.");
-  }
-  return {};
-}
-
 void ProcessArgCopyrightYear(
     std::vector<std::pair<std::string, std::string>>& command_line_args) {
   auto copyright_year =
@@ -227,9 +211,6 @@ ProcessCommandLineArgs(std::string const& parameters) {
   google::protobuf::compiler::ParseGeneratorParameter(parameters,
                                                       &command_line_args);
   auto status = ProcessArgProductPath(command_line_args);
-  if (!status.ok()) return status;
-
-  status = ProcessArgGoogleapisCommitHash(command_line_args);
   if (!status.ok()) return status;
 
   ProcessArgCopyrightYear(command_line_args);

--- a/generator/internal/codegen_utils_test.cc
+++ b/generator/internal/codegen_utils_test.cc
@@ -175,37 +175,19 @@ TEST(ProcessCommandLineArgs, EmptyProductPath) {
 }
 
 TEST(ProcessCommandLineArgs, ProductPathNeedsFormatting) {
-  auto result = ProcessCommandLineArgs(
-      "product_path=/google/cloud/pubsub,googleapis_commit_hash=foo");
+  auto result = ProcessCommandLineArgs("product_path=/google/cloud/pubsub");
   ASSERT_THAT(result, IsOk());
   EXPECT_THAT(*result, Contains(Pair("product_path", "google/cloud/pubsub/")));
 }
 
 TEST(ProcessCommandLineArgs, ProductPathAlreadyFormatted) {
-  auto result = ProcessCommandLineArgs(
-      "product_path=google/cloud/pubsub/,googleapis_commit_hash=foo");
+  auto result = ProcessCommandLineArgs("product_path=google/cloud/pubsub/");
   ASSERT_THAT(result, IsOk());
   EXPECT_THAT(*result, Contains(Pair("product_path", "google/cloud/pubsub/")));
 }
 
-TEST(ProcessCommandLineArgs, NoCommitHash) {
-  auto result = ProcessCommandLineArgs("product_path=/google/cloud/bar");
-  EXPECT_THAT(result, StatusIs(StatusCode::kInvalidArgument,
-                               "--cpp_codegen_opt=googleapis_commit_hash=<hash>"
-                               " must be specified."));
-}
-
-TEST(ProcessCommandLineArgs, EmptyCommitHash) {
-  auto result = ProcessCommandLineArgs(
-      "product_path=/google/cloud/bar,googleapis_commit_hash=");
-  EXPECT_THAT(result, StatusIs(StatusCode::kInvalidArgument,
-                               "--cpp_codegen_opt=googleapis_commit_hash=<hash>"
-                               " must be specified."));
-}
-
 TEST(ProcessCommandLineArgs, NoCopyrightYearParameterOrValue) {
-  auto result = ProcessCommandLineArgs(
-      "product_path=google/cloud/pubsub/,googleapis_commit_hash=foo");
+  auto result = ProcessCommandLineArgs("product_path=google/cloud/pubsub/");
   auto expected_year = CurrentCopyrightYear();
   ASSERT_THAT(result, IsOk());
   EXPECT_THAT(*result, Contains(Pair("copyright_year", expected_year)));
@@ -214,7 +196,7 @@ TEST(ProcessCommandLineArgs, NoCopyrightYearParameterOrValue) {
 TEST(ProcessCommandLineArgs, NoCopyrightYearValue) {
   auto result = ProcessCommandLineArgs(
       "product_path=google/cloud/pubsub/"
-      ",googleapis_commit_hash=foo,copyright_year=");
+      ",copyright_year=");
   auto expected_year = CurrentCopyrightYear();
   ASSERT_THAT(result, IsOk());
   EXPECT_THAT(*result, Contains(Pair("copyright_year", expected_year)));
@@ -223,14 +205,14 @@ TEST(ProcessCommandLineArgs, NoCopyrightYearValue) {
 TEST(ProcessCommandLineArgs, CopyrightYearWithValue) {
   auto result = ProcessCommandLineArgs(
       "product_path=google/cloud/pubsub/"
-      ",googleapis_commit_hash=foo,copyright_year=1995");
+      ",copyright_year=1995");
   ASSERT_THAT(result, IsOk());
   EXPECT_THAT(*result, Contains(Pair("copyright_year", "1995")));
 }
 
 TEST(ProcessCommandLineArgs, ServiceEndpointEnvVar) {
   auto result = ProcessCommandLineArgs(
-      "product_path=google/cloud/spanner/,googleapis_commit_hash=foo"
+      "product_path=google/cloud/spanner/"
       ",service_endpoint_env_var=GOOGLE_CLOUD_CPP_SPANNER_DEFAULT_ENDPOINT");
   ASSERT_THAT(result, IsOk());
   EXPECT_THAT(*result,
@@ -241,7 +223,7 @@ TEST(ProcessCommandLineArgs, ServiceEndpointEnvVar) {
 
 TEST(ProcessCommandLineArgs, EmulatorEndpointEnvVar) {
   auto result = ProcessCommandLineArgs(
-      "product_path=google/cloud/spanner/,googleapis_commit_hash=foo"
+      "product_path=google/cloud/spanner/"
       ",emulator_endpoint_env_var=SPANNER_EMULATOR_HOST");
   ASSERT_THAT(result, IsOk());
   EXPECT_THAT(*result, Contains(Pair("emulator_endpoint_env_var",
@@ -251,7 +233,7 @@ TEST(ProcessCommandLineArgs, EmulatorEndpointEnvVar) {
 
 TEST(ProcessCommandLineArgs, ProcessArgOmitService) {
   auto result = ProcessCommandLineArgs(
-      "product_path=google/cloud/spanner/,googleapis_commit_hash=foo"
+      "product_path=google/cloud/spanner/"
       ",omit_service=Omitted1"
       ",omit_service=Omitted2");
   ASSERT_THAT(result, IsOk());
@@ -262,7 +244,7 @@ TEST(ProcessCommandLineArgs, ProcessArgOmitService) {
 
 TEST(ProcessCommandLineArgs, ProcessArgOmitRpc) {
   auto result = ProcessCommandLineArgs(
-      "product_path=google/cloud/spanner/,googleapis_commit_hash=foo"
+      "product_path=google/cloud/spanner/"
       ",emulator_endpoint_env_var=SPANNER_EMULATOR_HOST"
       ",omit_rpc=Omitted1"
       ",omit_rpc=Omitted2");
@@ -275,7 +257,7 @@ TEST(ProcessCommandLineArgs, ProcessArgOmitRpc) {
 TEST(ProcessCommandLineArgs, ProcessArgGenAsyncRpc) {
   auto result = ProcessCommandLineArgs(
       "gen_async_rpc=Async1"
-      ",product_path=google/cloud/spanner/,googleapis_commit_hash=foo"
+      ",product_path=google/cloud/spanner/"
       ",emulator_endpoint_env_var=SPANNER_EMULATOR_HOST"
       ",gen_async_rpc=Async2");
   ASSERT_THAT(result, IsOk());
@@ -286,7 +268,7 @@ TEST(ProcessCommandLineArgs, ProcessArgGenAsyncRpc) {
 
 TEST(ProcessCommandLineArgs, ProcessArgAsyncOnlyRpc) {
   auto result = ProcessCommandLineArgs(
-      ",product_path=google/cloud/spanner/,googleapis_commit_hash=foo"
+      ",product_path=google/cloud/spanner/"
       ",emulator_endpoint_env_var=SPANNER_EMULATOR_HOST"
       ",omit_rpc=AsyncOnly"
       ",gen_async_rpc=AsyncOnly");
@@ -298,7 +280,7 @@ TEST(ProcessCommandLineArgs, ProcessArgAsyncOnlyRpc) {
 
 TEST(ProcessCommandLineArgs, ProcessArgNamespaceAlias) {
   auto result = ProcessCommandLineArgs(
-      ",product_path=google/cloud/spanner/,googleapis_commit_hash=foo"
+      ",product_path=google/cloud/spanner/"
       ",emulator_endpoint_env_var=SPANNER_EMULATOR_HOST"
       ",backwards_compatibility_namespace_alias=true");
   ASSERT_THAT(result, IsOk());

--- a/generator/internal/descriptor_utils_test.cc
+++ b/generator/internal/descriptor_utils_test.cc
@@ -149,7 +149,7 @@ class CreateServiceVarsTest
     // since our test file imports it
     FileDescriptorProto::descriptor()->file()->CopyTo(&file_proto_);
     simple_db_.Add(file_proto_);
-    service_vars_ = {{"googleapis_commit_hash", "foo"}};
+    service_vars_ = {};
   }
 
  private:
@@ -462,7 +462,7 @@ class CreateMethodVarsTest
     // since our test file imports it
     FileDescriptorProto::descriptor()->file()->CopyTo(&file_proto_);
     simple_db_.Add(file_proto_);
-    service_vars_ = {{"googleapis_commit_hash", "foo"}};
+    service_vars_ = {};
   }
 
  private:
@@ -499,8 +499,8 @@ TEST_F(CreateMethodVarsTest,
           MethodParameterStyle::kProtobufRequest),
       "  /**\n   * Leading comments about rpc Method0$$.\n   *\n   * @param "
       "request "
-      "[google::protobuf::Bar](https://github.com/googleapis/googleapis/blob/"
-      "$googleapis_commit_hash$/google/foo/v1/service.proto#L14)\n   */\n");
+      "@googleapis_link{google::protobuf::Bar,google/foo/v1/"
+      "service.proto#L14}\n   */\n");
 }
 
 TEST_F(CreateMethodVarsTest,
@@ -540,10 +540,10 @@ INSTANTIATE_TEST_SUITE_P(
                              "google::protobuf::Empty"),
         MethodVarsTestValues("google.protobuf.Service.Method0",
                              "default_idempotency", "kNonIdempotent"),
-        MethodVarsTestValues(
-            "google.protobuf.Service.Method0", "method_return_doxygen_link",
-            "[google::protobuf::Empty](https://github.com/googleapis/"
-            "googleapis/blob/foo/google/foo/v1/service.proto#L28)"),
+        MethodVarsTestValues("google.protobuf.Service.Method0",
+                             "method_return_doxygen_link",
+                             "@googleapis_link{google::protobuf::Empty,google/"
+                             "foo/v1/service.proto#L28}"),
         // Method1
         MethodVarsTestValues("google.protobuf.Service.Method1", "method_name",
                              "Method1"),
@@ -553,10 +553,10 @@ INSTANTIATE_TEST_SUITE_P(
                              "google::protobuf::Bar"),
         MethodVarsTestValues("google.protobuf.Service.Method1", "response_type",
                              "google::protobuf::Bar"),
-        MethodVarsTestValues(
-            "google.protobuf.Service.Method1", "method_return_doxygen_link",
-            "[google::protobuf::Bar](https://github.com/googleapis/"
-            "googleapis/blob/foo/google/foo/v1/service.proto#L14)"),
+        MethodVarsTestValues("google.protobuf.Service.Method1",
+                             "method_return_doxygen_link",
+                             "@googleapis_link{google::protobuf::Bar,google/"
+                             "foo/v1/service.proto#L14}"),
         // Method2
         MethodVarsTestValues("google.protobuf.Service.Method2",
                              "longrunning_metadata_type",
@@ -582,11 +582,10 @@ INSTANTIATE_TEST_SUITE_P(
                              "projects/*/instances/*"),
         MethodVarsTestValues("google.protobuf.Service.Method2",
                              "default_idempotency", "kNonIdempotent"),
-        MethodVarsTestValues(
-            "google.protobuf.Service.Method2",
-            "method_longrunning_deduced_return_doxygen_link",
-            "[google::protobuf::Bar](https://github.com/googleapis/"
-            "googleapis/blob/foo/google/foo/v1/service.proto#L14)"),
+        MethodVarsTestValues("google.protobuf.Service.Method2",
+                             "method_longrunning_deduced_return_doxygen_link",
+                             "@googleapis_link{google::protobuf::Bar,google/"
+                             "foo/v1/service.proto#L14}"),
         // Method3
         MethodVarsTestValues("google.protobuf.Service.Method3",
                              "longrunning_metadata_type",
@@ -700,11 +699,10 @@ INSTANTIATE_TEST_SUITE_P(
         MethodVarsTestValues("google.protobuf.Service.Method7",
                              "longrunning_deduced_response_type",
                              "google::protobuf::Bar"),
-        MethodVarsTestValues(
-            "google.protobuf.Service.Method7",
-            "method_longrunning_deduced_return_doxygen_link",
-            "[google::protobuf::Bar](https://github.com/googleapis/"
-            "googleapis/blob/foo/google/foo/v1/service.proto#L14)")),
+        MethodVarsTestValues("google.protobuf.Service.Method7",
+                             "method_longrunning_deduced_return_doxygen_link",
+                             "@googleapis_link{google::protobuf::Bar,google/"
+                             "foo/v1/service.proto#L14}")),
     [](testing::TestParamInfo<CreateMethodVarsTest::ParamType> const& info) {
       std::vector<std::string> pieces = absl::StrSplit(info.param.method, '.');
       return pieces.back() + "_" + info.param.vars_key;

--- a/generator/internal/scaffold_generator.cc
+++ b/generator/internal/scaffold_generator.cc
@@ -319,6 +319,7 @@ void GenerateCMakeLists(std::ostream& os,
 # limitations under the License.
 # ~~~
 
+include(GoogleapisConfig)
 set(DOXYGEN_PROJECT_NAME "$title$ C++ Client")
 set(DOXYGEN_PROJECT_BRIEF "A C++ Client Library for the $title$")
 set(DOXYGEN_PROJECT_NUMBER "$${PROJECT_VERSION} (Experimental)")

--- a/generator/standalone_main.cc
+++ b/generator/standalone_main.cc
@@ -29,8 +29,6 @@
 
 ABSL_FLAG(std::string, config_file, "",
           "Text proto configuration file specifying the code to be generated.");
-ABSL_FLAG(std::string, googleapis_commit_hash, "",
-          "Git commit hash of googleapis dependency.");
 ABSL_FLAG(std::string, protobuf_proto_path, "",
           "Path to root dir of protos distributed with protobuf.");
 ABSL_FLAG(std::string, googleapis_proto_path, "",
@@ -149,13 +147,11 @@ int WriteFeatureList(
  *
  * @par Command line arguments:
  *  --config-file=<path> REQUIRED should be a textproto file for
- * GeneratorConfiguration message.
- *  --googleapis_commit_hash=<hash> REQUIRED git commit hash of googleapis
- * dependency.
+ *      GeneratorConfiguration message.
  *  --protobuf_proto_path=<path> REQUIRED path to .proto files distributed with
- * protobuf.
+ *      protobuf.
  *  --googleapis_proto_path=<path> REQUIRED path to .proto files distributed
- * with googleapis repo.
+ *      with googleapis repo.
  *  --output_path=<path> OPTIONAL defaults to current directory.
  */
 int main(int argc, char** argv) {
@@ -165,15 +161,12 @@ int main(int argc, char** argv) {
 
   auto proto_path = absl::GetFlag(FLAGS_protobuf_proto_path);
   auto googleapis_path = absl::GetFlag(FLAGS_googleapis_proto_path);
-  auto googleapis_commit_hash = absl::GetFlag(FLAGS_googleapis_commit_hash);
   auto config_file = absl::GetFlag(FLAGS_config_file);
   auto output_path = absl::GetFlag(FLAGS_output_path);
   auto scaffold = absl::GetFlag(FLAGS_scaffold);
 
   GCP_LOG(INFO) << "proto_path = " << proto_path << "\n";
   GCP_LOG(INFO) << "googleapis_path = " << googleapis_path << "\n";
-  GCP_LOG(INFO) << "googleapis_commit_hash = " << googleapis_commit_hash
-                << "\n";
   GCP_LOG(INFO) << "config_file = " << config_file << "\n";
   GCP_LOG(INFO) << "output_path = " << output_path << "\n";
 
@@ -201,8 +194,6 @@ int main(int argc, char** argv) {
     args.emplace_back("--cpp_codegen_out=" + output_path);
     args.emplace_back("--cpp_codegen_opt=product_path=" +
                       service.product_path());
-    args.emplace_back("--cpp_codegen_opt=googleapis_commit_hash=" +
-                      googleapis_commit_hash);
     args.emplace_back("--cpp_codegen_opt=copyright_year=" +
                       service.initial_copyright_year());
     for (auto const& omit_service : service.omitted_services()) {

--- a/google/cloud/bigquery/CMakeLists.txt
+++ b/google/cloud/bigquery/CMakeLists.txt
@@ -14,6 +14,7 @@
 # limitations under the License.
 # ~~~
 
+include(GoogleapisConfig)
 set(DOXYGEN_PROJECT_NAME "Google Cloud BigQuery C++ Client")
 set(DOXYGEN_PROJECT_BRIEF "A C++ Client Library for Google Cloud BigQuery")
 set(DOXYGEN_PROJECT_NUMBER "${PROJECT_VERSION}")

--- a/google/cloud/bigquery/bigquery_read_client.h
+++ b/google/cloud/bigquery/bigquery_read_client.h
@@ -94,7 +94,7 @@ class BigQueryReadClient {
    * greater than the current system max limit of 1,000. Streams must be read
    * starting from offset 0.
    * @return
-   * [google::cloud::bigquery::storage::v1::ReadSession](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/cloud/bigquery/storage/v1/stream.proto#L47)
+   * @googleapis_link{google::cloud::bigquery::storage::v1::ReadSession,google/cloud/bigquery/storage/v1/stream.proto#L47}
    */
   StatusOr<google::cloud::bigquery::storage::v1::ReadSession> CreateReadSession(
       std::string const& parent,
@@ -115,7 +115,7 @@ class BigQueryReadClient {
    * from Read. Requesting a larger offset is undefined. If not specified, start
    * reading from offset zero.
    * @return
-   * [google::cloud::bigquery::storage::v1::ReadRowsResponse](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/cloud/bigquery/storage/v1/storage.proto#L304)
+   * @googleapis_link{google::cloud::bigquery::storage::v1::ReadRowsResponse,google/cloud/bigquery/storage/v1/storage.proto#L304}
    */
   StreamRange<google::cloud::bigquery::storage::v1::ReadRowsResponse> ReadRows(
       std::string const& read_stream, std::int64_t offset);
@@ -142,9 +142,9 @@ class BigQueryReadClient {
    * not require manual clean-up by the caller.
    *
    * @param request
-   * [google::cloud::bigquery::storage::v1::CreateReadSessionRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/cloud/bigquery/storage/v1/storage.proto#L229)
+   * @googleapis_link{google::cloud::bigquery::storage::v1::CreateReadSessionRequest,google/cloud/bigquery/storage/v1/storage.proto#L229}
    * @return
-   * [google::cloud::bigquery::storage::v1::ReadSession](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/cloud/bigquery/storage/v1/stream.proto#L47)
+   * @googleapis_link{google::cloud::bigquery::storage::v1::ReadSession,google/cloud/bigquery/storage/v1/stream.proto#L47}
    */
   StatusOr<google::cloud::bigquery::storage::v1::ReadSession> CreateReadSession(
       google::cloud::bigquery::storage::v1::CreateReadSessionRequest const&
@@ -160,9 +160,9 @@ class BigQueryReadClient {
    * state of the stream.
    *
    * @param request
-   * [google::cloud::bigquery::storage::v1::ReadRowsRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/cloud/bigquery/storage/v1/storage.proto#L254)
+   * @googleapis_link{google::cloud::bigquery::storage::v1::ReadRowsRequest,google/cloud/bigquery/storage/v1/storage.proto#L254}
    * @return
-   * [google::cloud::bigquery::storage::v1::ReadRowsResponse](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/cloud/bigquery/storage/v1/storage.proto#L304)
+   * @googleapis_link{google::cloud::bigquery::storage::v1::ReadRowsResponse,google/cloud/bigquery/storage/v1/storage.proto#L304}
    */
   StreamRange<google::cloud::bigquery::storage::v1::ReadRowsResponse> ReadRows(
       google::cloud::bigquery::storage::v1::ReadRowsRequest const& request);
@@ -182,9 +182,9 @@ class BigQueryReadClient {
    * completion.
    *
    * @param request
-   * [google::cloud::bigquery::storage::v1::SplitReadStreamRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/cloud/bigquery/storage/v1/storage.proto#L339)
+   * @googleapis_link{google::cloud::bigquery::storage::v1::SplitReadStreamRequest,google/cloud/bigquery/storage/v1/storage.proto#L339}
    * @return
-   * [google::cloud::bigquery::storage::v1::SplitReadStreamResponse](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/cloud/bigquery/storage/v1/storage.proto#L359)
+   * @googleapis_link{google::cloud::bigquery::storage::v1::SplitReadStreamResponse,google/cloud/bigquery/storage/v1/storage.proto#L359}
    */
   StatusOr<google::cloud::bigquery::storage::v1::SplitReadStreamResponse>
   SplitReadStream(

--- a/google/cloud/bigtable/CMakeLists.txt
+++ b/google/cloud/bigtable/CMakeLists.txt
@@ -16,6 +16,7 @@
 
 find_package(absl CONFIG REQUIRED)
 
+include(GoogleapisConfig)
 set(DOXYGEN_PROJECT_NAME "Google Cloud Bigtable C++ Client")
 set(DOXYGEN_PROJECT_BRIEF "A C++ Client Library for Google Cloud Bigtable")
 set(DOXYGEN_PROJECT_NUMBER "${PROJECT_VERSION}")

--- a/google/cloud/bigtable/admin/bigtable_instance_admin_client.h
+++ b/google/cloud/bigtable/admin/bigtable_instance_admin_client.h
@@ -84,7 +84,7 @@ class BigtableInstanceAdminClient {
    *  Fields marked `OutputOnly` must be left blank.
    *  Currently, at most four clusters can be specified.
    * @return
-   * [google::bigtable::admin::v2::Instance](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/bigtable/admin/v2/instance.proto#L41)
+   * @googleapis_link{google::bigtable::admin::v2::Instance,google/bigtable/admin/v2/instance.proto#L41}
    */
   future<StatusOr<google::bigtable::admin::v2::Instance>> CreateInstance(
       std::string const& parent, std::string const& instance_id,
@@ -98,7 +98,7 @@ class BigtableInstanceAdminClient {
    * @param name  Required. The unique name of the requested instance. Values
    * are of the form `projects/{project}/instances/{instance}`.
    * @return
-   * [google::bigtable::admin::v2::Instance](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/bigtable/admin/v2/instance.proto#L41)
+   * @googleapis_link{google::bigtable::admin::v2::Instance,google/bigtable/admin/v2/instance.proto#L41}
    */
   StatusOr<google::bigtable::admin::v2::Instance> GetInstance(
       std::string const& name);
@@ -109,7 +109,7 @@ class BigtableInstanceAdminClient {
    * @param parent  Required. The unique name of the project for which a list of
    * instances is requested. Values are of the form `projects/{project}`.
    * @return
-   * [google::bigtable::admin::v2::ListInstancesResponse](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/bigtable/admin/v2/bigtable_instance_admin.proto#L295)
+   * @googleapis_link{google::bigtable::admin::v2::ListInstancesResponse,google/bigtable/admin/v2/bigtable_instance_admin.proto#L295}
    */
   StatusOr<google::bigtable::admin::v2::ListInstancesResponse> ListInstances(
       std::string const& parent);
@@ -123,7 +123,7 @@ class BigtableInstanceAdminClient {
    * @param update_mask  Required. The subset of Instance fields which should be
    * replaced. Must be explicitly set.
    * @return
-   * [google::bigtable::admin::v2::Instance](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/bigtable/admin/v2/instance.proto#L41)
+   * @googleapis_link{google::bigtable::admin::v2::Instance,google/bigtable/admin/v2/instance.proto#L41}
    */
   future<StatusOr<google::bigtable::admin::v2::Instance>> PartialUpdateInstance(
       google::bigtable::admin::v2::Instance const& instance,
@@ -149,7 +149,7 @@ class BigtableInstanceAdminClient {
    * @param cluster  Required. The cluster to be created.
    *  Fields marked `OutputOnly` must be left blank.
    * @return
-   * [google::bigtable::admin::v2::Cluster](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/bigtable/admin/v2/instance.proto#L120)
+   * @googleapis_link{google::bigtable::admin::v2::Cluster,google/bigtable/admin/v2/instance.proto#L120}
    */
   future<StatusOr<google::bigtable::admin::v2::Cluster>> CreateCluster(
       std::string const& parent, std::string const& cluster_id,
@@ -161,7 +161,7 @@ class BigtableInstanceAdminClient {
    * @param name  Required. The unique name of the requested cluster. Values are
    * of the form `projects/{project}/instances/{instance}/clusters/{cluster}`.
    * @return
-   * [google::bigtable::admin::v2::Cluster](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/bigtable/admin/v2/instance.proto#L120)
+   * @googleapis_link{google::bigtable::admin::v2::Cluster,google/bigtable/admin/v2/instance.proto#L120}
    */
   StatusOr<google::bigtable::admin::v2::Cluster> GetCluster(
       std::string const& name);
@@ -175,7 +175,7 @@ class BigtableInstanceAdminClient {
    * Clusters for all Instances in a project, e.g.,
    * `projects/myproject/instances/-`.
    * @return
-   * [google::bigtable::admin::v2::ListClustersResponse](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/bigtable/admin/v2/bigtable_instance_admin.proto#L385)
+   * @googleapis_link{google::bigtable::admin::v2::ListClustersResponse,google/bigtable/admin/v2/bigtable_instance_admin.proto#L385}
    */
   StatusOr<google::bigtable::admin::v2::ListClustersResponse> ListClusters(
       std::string const& parent);
@@ -201,7 +201,7 @@ class BigtableInstanceAdminClient {
    * @param app_profile  Required. The app profile to be created.
    *  Fields marked `OutputOnly` will be ignored.
    * @return
-   * [google::bigtable::admin::v2::AppProfile](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/bigtable/admin/v2/instance.proto#L199)
+   * @googleapis_link{google::bigtable::admin::v2::AppProfile,google/bigtable/admin/v2/instance.proto#L199}
    */
   StatusOr<google::bigtable::admin::v2::AppProfile> CreateAppProfile(
       std::string const& parent, std::string const& app_profile_id,
@@ -214,7 +214,7 @@ class BigtableInstanceAdminClient {
    * are of the form
    *  `projects/{project}/instances/{instance}/appProfiles/{app_profile}`.
    * @return
-   * [google::bigtable::admin::v2::AppProfile](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/bigtable/admin/v2/instance.proto#L199)
+   * @googleapis_link{google::bigtable::admin::v2::AppProfile,google/bigtable/admin/v2/instance.proto#L199}
    */
   StatusOr<google::bigtable::admin::v2::AppProfile> GetAppProfile(
       std::string const& name);
@@ -228,7 +228,7 @@ class BigtableInstanceAdminClient {
    *  Use `{instance} = '-'` to list AppProfiles for all Instances in a project,
    *  e.g., `projects/myproject/instances/-`.
    * @return
-   * [google::bigtable::admin::v2::AppProfile](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/bigtable/admin/v2/instance.proto#L199)
+   * @googleapis_link{google::bigtable::admin::v2::AppProfile,google/bigtable/admin/v2/instance.proto#L199}
    */
   StreamRange<google::bigtable::admin::v2::AppProfile> ListAppProfiles(
       std::string const& parent);
@@ -241,7 +241,7 @@ class BigtableInstanceAdminClient {
    * @param update_mask  Required. The subset of app profile fields which should
    * be replaced. If unset, all fields will be replaced.
    * @return
-   * [google::bigtable::admin::v2::AppProfile](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/bigtable/admin/v2/instance.proto#L199)
+   * @googleapis_link{google::bigtable::admin::v2::AppProfile,google/bigtable/admin/v2/instance.proto#L199}
    */
   future<StatusOr<google::bigtable::admin::v2::AppProfile>> UpdateAppProfile(
       google::bigtable::admin::v2::AppProfile const& app_profile,
@@ -264,7 +264,7 @@ class BigtableInstanceAdminClient {
    * requested. See the operation documentation for the appropriate value for
    * this field.
    * @return
-   * [google::iam::v1::Policy](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/iam/v1/policy.proto#L88)
+   * @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
    */
   StatusOr<google::iam::v1::Policy> GetIamPolicy(std::string const& resource);
 
@@ -280,7 +280,7 @@ class BigtableInstanceAdminClient {
    * policy is a valid policy but certain Cloud Platform services (such as
    * Projects) might reject them.
    * @return
-   * [google::iam::v1::Policy](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/iam/v1/policy.proto#L88)
+   * @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
    */
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
       std::string const& resource, google::iam::v1::Policy const& policy);
@@ -321,7 +321,7 @@ class BigtableInstanceAdminClient {
    * For more information see [IAM
    * Overview](https://cloud.google.com/iam/docs/overview#permissions).
    * @return
-   * [google::iam::v1::TestIamPermissionsResponse](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/iam/v1/iam_policy.proto#L141)
+   * @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
    */
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
       std::string const& resource, std::vector<std::string> const& permissions);
@@ -330,9 +330,9 @@ class BigtableInstanceAdminClient {
    * Create an instance within a project.
    *
    * @param request
-   * [google::bigtable::admin::v2::CreateInstanceRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/bigtable/admin/v2/bigtable_instance_admin.proto#L240)
+   * @googleapis_link{google::bigtable::admin::v2::CreateInstanceRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L240}
    * @return
-   * [google::bigtable::admin::v2::Instance](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/bigtable/admin/v2/instance.proto#L41)
+   * @googleapis_link{google::bigtable::admin::v2::Instance,google/bigtable/admin/v2/instance.proto#L41}
    */
   future<StatusOr<google::bigtable::admin::v2::Instance>> CreateInstance(
       google::bigtable::admin::v2::CreateInstanceRequest const& request);
@@ -341,9 +341,9 @@ class BigtableInstanceAdminClient {
    * Gets information about an instance.
    *
    * @param request
-   * [google::bigtable::admin::v2::GetInstanceRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/bigtable/admin/v2/bigtable_instance_admin.proto#L268)
+   * @googleapis_link{google::bigtable::admin::v2::GetInstanceRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L268}
    * @return
-   * [google::bigtable::admin::v2::Instance](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/bigtable/admin/v2/instance.proto#L41)
+   * @googleapis_link{google::bigtable::admin::v2::Instance,google/bigtable/admin/v2/instance.proto#L41}
    */
   StatusOr<google::bigtable::admin::v2::Instance> GetInstance(
       google::bigtable::admin::v2::GetInstanceRequest const& request);
@@ -352,9 +352,9 @@ class BigtableInstanceAdminClient {
    * Lists information about instances in a project.
    *
    * @param request
-   * [google::bigtable::admin::v2::ListInstancesRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/bigtable/admin/v2/bigtable_instance_admin.proto#L280)
+   * @googleapis_link{google::bigtable::admin::v2::ListInstancesRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L280}
    * @return
-   * [google::bigtable::admin::v2::ListInstancesResponse](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/bigtable/admin/v2/bigtable_instance_admin.proto#L295)
+   * @googleapis_link{google::bigtable::admin::v2::ListInstancesResponse,google/bigtable/admin/v2/bigtable_instance_admin.proto#L295}
    */
   StatusOr<google::bigtable::admin::v2::ListInstancesResponse> ListInstances(
       google::bigtable::admin::v2::ListInstancesRequest const& request);
@@ -365,9 +365,9 @@ class BigtableInstanceAdminClient {
    * labels, use PartialUpdateInstance.
    *
    * @param request
-   * [google::bigtable::admin::v2::Instance](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/bigtable/admin/v2/instance.proto#L41)
+   * @googleapis_link{google::bigtable::admin::v2::Instance,google/bigtable/admin/v2/instance.proto#L41}
    * @return
-   * [google::bigtable::admin::v2::Instance](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/bigtable/admin/v2/instance.proto#L41)
+   * @googleapis_link{google::bigtable::admin::v2::Instance,google/bigtable/admin/v2/instance.proto#L41}
    */
   StatusOr<google::bigtable::admin::v2::Instance> UpdateInstance(
       google::bigtable::admin::v2::Instance const& request);
@@ -377,9 +377,9 @@ class BigtableInstanceAdminClient {
    * fields of an Instance and is the preferred way to update an Instance.
    *
    * @param request
-   * [google::bigtable::admin::v2::PartialUpdateInstanceRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/bigtable/admin/v2/bigtable_instance_admin.proto#L312)
+   * @googleapis_link{google::bigtable::admin::v2::PartialUpdateInstanceRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L312}
    * @return
-   * [google::bigtable::admin::v2::Instance](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/bigtable/admin/v2/instance.proto#L41)
+   * @googleapis_link{google::bigtable::admin::v2::Instance,google/bigtable/admin/v2/instance.proto#L41}
    */
   future<StatusOr<google::bigtable::admin::v2::Instance>> PartialUpdateInstance(
       google::bigtable::admin::v2::PartialUpdateInstanceRequest const& request);
@@ -388,7 +388,7 @@ class BigtableInstanceAdminClient {
    * Delete an instance from a project.
    *
    * @param request
-   * [google::bigtable::admin::v2::DeleteInstanceRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/bigtable/admin/v2/bigtable_instance_admin.proto#L322)
+   * @googleapis_link{google::bigtable::admin::v2::DeleteInstanceRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L322}
    */
   Status DeleteInstance(
       google::bigtable::admin::v2::DeleteInstanceRequest const& request);
@@ -397,9 +397,9 @@ class BigtableInstanceAdminClient {
    * Creates a cluster within an instance.
    *
    * @param request
-   * [google::bigtable::admin::v2::CreateClusterRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/bigtable/admin/v2/bigtable_instance_admin.proto#L334)
+   * @googleapis_link{google::bigtable::admin::v2::CreateClusterRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L334}
    * @return
-   * [google::bigtable::admin::v2::Cluster](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/bigtable/admin/v2/instance.proto#L120)
+   * @googleapis_link{google::bigtable::admin::v2::Cluster,google/bigtable/admin/v2/instance.proto#L120}
    */
   future<StatusOr<google::bigtable::admin::v2::Cluster>> CreateCluster(
       google::bigtable::admin::v2::CreateClusterRequest const& request);
@@ -408,9 +408,9 @@ class BigtableInstanceAdminClient {
    * Gets information about a cluster.
    *
    * @param request
-   * [google::bigtable::admin::v2::GetClusterRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/bigtable/admin/v2/bigtable_instance_admin.proto#L356)
+   * @googleapis_link{google::bigtable::admin::v2::GetClusterRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L356}
    * @return
-   * [google::bigtable::admin::v2::Cluster](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/bigtable/admin/v2/instance.proto#L120)
+   * @googleapis_link{google::bigtable::admin::v2::Cluster,google/bigtable/admin/v2/instance.proto#L120}
    */
   StatusOr<google::bigtable::admin::v2::Cluster> GetCluster(
       google::bigtable::admin::v2::GetClusterRequest const& request);
@@ -419,9 +419,9 @@ class BigtableInstanceAdminClient {
    * Lists information about clusters in an instance.
    *
    * @param request
-   * [google::bigtable::admin::v2::ListClustersRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/bigtable/admin/v2/bigtable_instance_admin.proto#L368)
+   * @googleapis_link{google::bigtable::admin::v2::ListClustersRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L368}
    * @return
-   * [google::bigtable::admin::v2::ListClustersResponse](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/bigtable/admin/v2/bigtable_instance_admin.proto#L385)
+   * @googleapis_link{google::bigtable::admin::v2::ListClustersResponse,google/bigtable/admin/v2/bigtable_instance_admin.proto#L385}
    */
   StatusOr<google::bigtable::admin::v2::ListClustersResponse> ListClusters(
       google::bigtable::admin::v2::ListClustersRequest const& request);
@@ -430,9 +430,9 @@ class BigtableInstanceAdminClient {
    * Updates a cluster within an instance.
    *
    * @param request
-   * [google::bigtable::admin::v2::Cluster](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/bigtable/admin/v2/instance.proto#L120)
+   * @googleapis_link{google::bigtable::admin::v2::Cluster,google/bigtable/admin/v2/instance.proto#L120}
    * @return
-   * [google::bigtable::admin::v2::Cluster](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/bigtable/admin/v2/instance.proto#L120)
+   * @googleapis_link{google::bigtable::admin::v2::Cluster,google/bigtable/admin/v2/instance.proto#L120}
    */
   future<StatusOr<google::bigtable::admin::v2::Cluster>> UpdateCluster(
       google::bigtable::admin::v2::Cluster const& request);
@@ -441,7 +441,7 @@ class BigtableInstanceAdminClient {
    * Deletes a cluster from an instance.
    *
    * @param request
-   * [google::bigtable::admin::v2::DeleteClusterRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/bigtable/admin/v2/bigtable_instance_admin.proto#L401)
+   * @googleapis_link{google::bigtable::admin::v2::DeleteClusterRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L401}
    */
   Status DeleteCluster(
       google::bigtable::admin::v2::DeleteClusterRequest const& request);
@@ -450,9 +450,9 @@ class BigtableInstanceAdminClient {
    * Creates an app profile within an instance.
    *
    * @param request
-   * [google::bigtable::admin::v2::CreateAppProfileRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/bigtable/admin/v2/bigtable_instance_admin.proto#L461)
+   * @googleapis_link{google::bigtable::admin::v2::CreateAppProfileRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L461}
    * @return
-   * [google::bigtable::admin::v2::AppProfile](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/bigtable/admin/v2/instance.proto#L199)
+   * @googleapis_link{google::bigtable::admin::v2::AppProfile,google/bigtable/admin/v2/instance.proto#L199}
    */
   StatusOr<google::bigtable::admin::v2::AppProfile> CreateAppProfile(
       google::bigtable::admin::v2::CreateAppProfileRequest const& request);
@@ -461,9 +461,9 @@ class BigtableInstanceAdminClient {
    * Gets information about an app profile.
    *
    * @param request
-   * [google::bigtable::admin::v2::GetAppProfileRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/bigtable/admin/v2/bigtable_instance_admin.proto#L486)
+   * @googleapis_link{google::bigtable::admin::v2::GetAppProfileRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L486}
    * @return
-   * [google::bigtable::admin::v2::AppProfile](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/bigtable/admin/v2/instance.proto#L199)
+   * @googleapis_link{google::bigtable::admin::v2::AppProfile,google/bigtable/admin/v2/instance.proto#L199}
    */
   StatusOr<google::bigtable::admin::v2::AppProfile> GetAppProfile(
       google::bigtable::admin::v2::GetAppProfileRequest const& request);
@@ -472,9 +472,9 @@ class BigtableInstanceAdminClient {
    * Lists information about app profiles in an instance.
    *
    * @param request
-   * [google::bigtable::admin::v2::ListAppProfilesRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/bigtable/admin/v2/bigtable_instance_admin.proto#L498)
+   * @googleapis_link{google::bigtable::admin::v2::ListAppProfilesRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L498}
    * @return
-   * [google::bigtable::admin::v2::AppProfile](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/bigtable/admin/v2/instance.proto#L199)
+   * @googleapis_link{google::bigtable::admin::v2::AppProfile,google/bigtable/admin/v2/instance.proto#L199}
    */
   StreamRange<google::bigtable::admin::v2::AppProfile> ListAppProfiles(
       google::bigtable::admin::v2::ListAppProfilesRequest request);
@@ -483,9 +483,9 @@ class BigtableInstanceAdminClient {
    * Updates an app profile within an instance.
    *
    * @param request
-   * [google::bigtable::admin::v2::UpdateAppProfileRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/bigtable/admin/v2/bigtable_instance_admin.proto#L544)
+   * @googleapis_link{google::bigtable::admin::v2::UpdateAppProfileRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L544}
    * @return
-   * [google::bigtable::admin::v2::AppProfile](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/bigtable/admin/v2/instance.proto#L199)
+   * @googleapis_link{google::bigtable::admin::v2::AppProfile,google/bigtable/admin/v2/instance.proto#L199}
    */
   future<StatusOr<google::bigtable::admin::v2::AppProfile>> UpdateAppProfile(
       google::bigtable::admin::v2::UpdateAppProfileRequest const& request);
@@ -494,7 +494,7 @@ class BigtableInstanceAdminClient {
    * Deletes an app profile from an instance.
    *
    * @param request
-   * [google::bigtable::admin::v2::DeleteAppProfileRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/bigtable/admin/v2/bigtable_instance_admin.proto#L557)
+   * @googleapis_link{google::bigtable::admin::v2::DeleteAppProfileRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L557}
    */
   Status DeleteAppProfile(
       google::bigtable::admin::v2::DeleteAppProfileRequest const& request);
@@ -504,9 +504,9 @@ class BigtableInstanceAdminClient {
    * policy if an instance exists but does not have a policy set.
    *
    * @param request
-   * [google::iam::v1::GetIamPolicyRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/iam/v1/iam_policy.proto#L113)
+   * @googleapis_link{google::iam::v1::GetIamPolicyRequest,google/iam/v1/iam_policy.proto#L113}
    * @return
-   * [google::iam::v1::Policy](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/iam/v1/policy.proto#L88)
+   * @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
    */
   StatusOr<google::iam::v1::Policy> GetIamPolicy(
       google::iam::v1::GetIamPolicyRequest const& request);
@@ -516,9 +516,9 @@ class BigtableInstanceAdminClient {
    * existing policy.
    *
    * @param request
-   * [google::iam::v1::SetIamPolicyRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/iam/v1/iam_policy.proto#L98)
+   * @googleapis_link{google::iam::v1::SetIamPolicyRequest,google/iam/v1/iam_policy.proto#L98}
    * @return
-   * [google::iam::v1::Policy](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/iam/v1/policy.proto#L88)
+   * @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
    */
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
       google::iam::v1::SetIamPolicyRequest const& request);
@@ -527,9 +527,9 @@ class BigtableInstanceAdminClient {
    * Returns permissions that the caller has on the specified instance resource.
    *
    * @param request
-   * [google::iam::v1::TestIamPermissionsRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/iam/v1/iam_policy.proto#L126)
+   * @googleapis_link{google::iam::v1::TestIamPermissionsRequest,google/iam/v1/iam_policy.proto#L126}
    * @return
-   * [google::iam::v1::TestIamPermissionsResponse](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/iam/v1/iam_policy.proto#L141)
+   * @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
    */
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
       google::iam::v1::TestIamPermissionsRequest const& request);

--- a/google/cloud/bigtable/admin/bigtable_table_admin_client.h
+++ b/google/cloud/bigtable/admin/bigtable_table_admin_client.h
@@ -82,7 +82,7 @@ class BigtableTableAdminClient {
    * `{parent}/tables/foobar`. Maximum 50 characters.
    * @param table  Required. The Table to create.
    * @return
-   * [google::bigtable::admin::v2::Table](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/bigtable/admin/v2/table.proto#L61)
+   * @googleapis_link{google::bigtable::admin::v2::Table,google/bigtable/admin/v2/table.proto#L61}
    */
   StatusOr<google::bigtable::admin::v2::Table> CreateTable(
       std::string const& parent, std::string const& table_id,
@@ -95,7 +95,7 @@ class BigtableTableAdminClient {
    * should be listed. Values are of the form
    * `projects/{project}/instances/{instance}`.
    * @return
-   * [google::bigtable::admin::v2::Table](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/bigtable/admin/v2/table.proto#L61)
+   * @googleapis_link{google::bigtable::admin::v2::Table,google/bigtable/admin/v2/table.proto#L61}
    */
   StreamRange<google::bigtable::admin::v2::Table> ListTables(
       std::string const& parent);
@@ -107,7 +107,7 @@ class BigtableTableAdminClient {
    *  Values are of the form
    *  `projects/{project}/instances/{instance}/tables/{table}`.
    * @return
-   * [google::bigtable::admin::v2::Table](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/bigtable/admin/v2/table.proto#L61)
+   * @googleapis_link{google::bigtable::admin::v2::Table,google/bigtable/admin/v2/table.proto#L61}
    */
   StatusOr<google::bigtable::admin::v2::Table> GetTable(
       std::string const& name);
@@ -135,7 +135,7 @@ class BigtableTableAdminClient {
    * earlier modifications can be masked by later ones (in the case of repeated
    * updates to the same family, for example).
    * @return
-   * [google::bigtable::admin::v2::Table](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/bigtable/admin/v2/table.proto#L61)
+   * @googleapis_link{google::bigtable::admin::v2::Table,google/bigtable/admin/v2/table.proto#L61}
    */
   StatusOr<google::bigtable::admin::v2::Table> ModifyColumnFamilies(
       std::string const& name,
@@ -152,7 +152,7 @@ class BigtableTableAdminClient {
    * consistency token. Values are of the form
    *  `projects/{project}/instances/{instance}/tables/{table}`.
    * @return
-   * [google::bigtable::admin::v2::GenerateConsistencyTokenResponse](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/bigtable/admin/v2/bigtable_table_admin.proto#L640)
+   * @googleapis_link{google::bigtable::admin::v2::GenerateConsistencyTokenResponse,google/bigtable/admin/v2/bigtable_table_admin.proto#L640}
    */
   StatusOr<google::bigtable::admin::v2::GenerateConsistencyTokenResponse>
   GenerateConsistencyToken(std::string const& name);
@@ -168,7 +168,7 @@ class BigtableTableAdminClient {
    * @param consistency_token  Required. The token created using
    * GenerateConsistencyToken for the Table.
    * @return
-   * [google::bigtable::admin::v2::CheckConsistencyResponse](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/bigtable/admin/v2/bigtable_table_admin.proto#L664)
+   * @googleapis_link{google::bigtable::admin::v2::CheckConsistencyResponse,google/bigtable/admin/v2/bigtable_table_admin.proto#L664}
    */
   StatusOr<google::bigtable::admin::v2::CheckConsistencyResponse>
   CheckConsistency(std::string const& name,
@@ -196,7 +196,7 @@ class BigtableTableAdminClient {
    *  regex [_a-zA-Z0-9][-_.a-zA-Z0-9]*.
    * @param backup  Required. The backup to create.
    * @return
-   * [google::bigtable::admin::v2::Backup](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/bigtable/admin/v2/table.proto#L317)
+   * @googleapis_link{google::bigtable::admin::v2::Backup,google/bigtable/admin/v2/table.proto#L317}
    */
   future<StatusOr<google::bigtable::admin::v2::Backup>> CreateBackup(
       std::string const& parent, std::string const& backup_id,
@@ -209,7 +209,7 @@ class BigtableTableAdminClient {
    *  Values are of the form
    *  `projects/{project}/instances/{instance}/clusters/{cluster}/backups/{backup}`.
    * @return
-   * [google::bigtable::admin::v2::Backup](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/bigtable/admin/v2/table.proto#L317)
+   * @googleapis_link{google::bigtable::admin::v2::Backup,google/bigtable/admin/v2/table.proto#L317}
    */
   StatusOr<google::bigtable::admin::v2::Backup> GetBackup(
       std::string const& name);
@@ -227,7 +227,7 @@ class BigtableTableAdminClient {
    * must always be specified; this prevents any future fields from being erased
    * accidentally by clients that do not know about them.
    * @return
-   * [google::bigtable::admin::v2::Backup](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/bigtable/admin/v2/table.proto#L317)
+   * @googleapis_link{google::bigtable::admin::v2::Backup,google/bigtable/admin/v2/table.proto#L317}
    */
   StatusOr<google::bigtable::admin::v2::Backup> UpdateBackup(
       google::bigtable::admin::v2::Backup const& backup,
@@ -251,7 +251,7 @@ class BigtableTableAdminClient {
    * `{cluster} = '-'` to list backups for all clusters in an instance, e.g.,
    * `projects/{project}/instances/{instance}/clusters/-`.
    * @return
-   * [google::bigtable::admin::v2::Backup](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/bigtable/admin/v2/table.proto#L317)
+   * @googleapis_link{google::bigtable::admin::v2::Backup,google/bigtable/admin/v2/table.proto#L317}
    */
   StreamRange<google::bigtable::admin::v2::Backup> ListBackups(
       std::string const& parent);
@@ -265,7 +265,7 @@ class BigtableTableAdminClient {
    * requested. See the operation documentation for the appropriate value for
    * this field.
    * @return
-   * [google::iam::v1::Policy](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/iam/v1/policy.proto#L88)
+   * @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
    */
   StatusOr<google::iam::v1::Policy> GetIamPolicy(std::string const& resource);
 
@@ -281,7 +281,7 @@ class BigtableTableAdminClient {
    * policy is a valid policy but certain Cloud Platform services (such as
    * Projects) might reject them.
    * @return
-   * [google::iam::v1::Policy](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/iam/v1/policy.proto#L88)
+   * @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
    */
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
       std::string const& resource, google::iam::v1::Policy const& policy);
@@ -323,7 +323,7 @@ class BigtableTableAdminClient {
    * For more information see [IAM
    * Overview](https://cloud.google.com/iam/docs/overview#permissions).
    * @return
-   * [google::iam::v1::TestIamPermissionsResponse](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/iam/v1/iam_policy.proto#L141)
+   * @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
    */
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
       std::string const& resource, std::vector<std::string> const& permissions);
@@ -339,7 +339,7 @@ class BigtableTableAdminClient {
    * @param consistency_token  Required. The token created using
    * GenerateConsistencyToken for the Table.
    * @return
-   * [google::bigtable::admin::v2::CheckConsistencyResponse](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/bigtable/admin/v2/bigtable_table_admin.proto#L664)
+   * @googleapis_link{google::bigtable::admin::v2::CheckConsistencyResponse,google/bigtable/admin/v2/bigtable_table_admin.proto#L664}
    */
   future<StatusOr<google::bigtable::admin::v2::CheckConsistencyResponse>>
   AsyncCheckConsistency(std::string const& name,
@@ -351,9 +351,9 @@ class BigtableTableAdminClient {
    * specified in the request.
    *
    * @param request
-   * [google::bigtable::admin::v2::CreateTableRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/bigtable/admin/v2/bigtable_table_admin.proto#L408)
+   * @googleapis_link{google::bigtable::admin::v2::CreateTableRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L408}
    * @return
-   * [google::bigtable::admin::v2::Table](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/bigtable/admin/v2/table.proto#L61)
+   * @googleapis_link{google::bigtable::admin::v2::Table,google/bigtable/admin/v2/table.proto#L61}
    */
   StatusOr<google::bigtable::admin::v2::Table> CreateTable(
       google::bigtable::admin::v2::CreateTableRequest const& request);
@@ -362,9 +362,9 @@ class BigtableTableAdminClient {
    * Lists all tables served from a specified instance.
    *
    * @param request
-   * [google::bigtable::admin::v2::ListTablesRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/bigtable/admin/v2/bigtable_table_admin.proto#L510)
+   * @googleapis_link{google::bigtable::admin::v2::ListTablesRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L510}
    * @return
-   * [google::bigtable::admin::v2::Table](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/bigtable/admin/v2/table.proto#L61)
+   * @googleapis_link{google::bigtable::admin::v2::Table,google/bigtable/admin/v2/table.proto#L61}
    */
   StreamRange<google::bigtable::admin::v2::Table> ListTables(
       google::bigtable::admin::v2::ListTablesRequest request);
@@ -373,9 +373,9 @@ class BigtableTableAdminClient {
    * Gets metadata information about the specified table.
    *
    * @param request
-   * [google::bigtable::admin::v2::GetTableRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/bigtable/admin/v2/bigtable_table_admin.proto#L553)
+   * @googleapis_link{google::bigtable::admin::v2::GetTableRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L553}
    * @return
-   * [google::bigtable::admin::v2::Table](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/bigtable/admin/v2/table.proto#L61)
+   * @googleapis_link{google::bigtable::admin::v2::Table,google/bigtable/admin/v2/table.proto#L61}
    */
   StatusOr<google::bigtable::admin::v2::Table> GetTable(
       google::bigtable::admin::v2::GetTableRequest const& request);
@@ -384,7 +384,7 @@ class BigtableTableAdminClient {
    * Permanently deletes a specified table and all of its data.
    *
    * @param request
-   * [google::bigtable::admin::v2::DeleteTableRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/bigtable/admin/v2/bigtable_table_admin.proto#L571)
+   * @googleapis_link{google::bigtable::admin::v2::DeleteTableRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L571}
    */
   Status DeleteTable(
       google::bigtable::admin::v2::DeleteTableRequest const& request);
@@ -396,9 +396,9 @@ class BigtableTableAdminClient {
    * where only some modifications have taken effect.
    *
    * @param request
-   * [google::bigtable::admin::v2::ModifyColumnFamiliesRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/bigtable/admin/v2/bigtable_table_admin.proto#L585)
+   * @googleapis_link{google::bigtable::admin::v2::ModifyColumnFamiliesRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L585}
    * @return
-   * [google::bigtable::admin::v2::Table](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/bigtable/admin/v2/table.proto#L61)
+   * @googleapis_link{google::bigtable::admin::v2::Table,google/bigtable/admin/v2/table.proto#L61}
    */
   StatusOr<google::bigtable::admin::v2::Table> ModifyColumnFamilies(
       google::bigtable::admin::v2::ModifyColumnFamiliesRequest const& request);
@@ -409,7 +409,7 @@ class BigtableTableAdminClient {
    * particular prefix.
    *
    * @param request
-   * [google::bigtable::admin::v2::DropRowRangeRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/bigtable/admin/v2/bigtable_table_admin.proto#L486)
+   * @googleapis_link{google::bigtable::admin::v2::DropRowRangeRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L486}
    */
   Status DropRowRange(
       google::bigtable::admin::v2::DropRowRangeRequest const& request);
@@ -421,9 +421,9 @@ class BigtableTableAdminClient {
    * for 90 days.
    *
    * @param request
-   * [google::bigtable::admin::v2::GenerateConsistencyTokenRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/bigtable/admin/v2/bigtable_table_admin.proto#L626)
+   * @googleapis_link{google::bigtable::admin::v2::GenerateConsistencyTokenRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L626}
    * @return
-   * [google::bigtable::admin::v2::GenerateConsistencyTokenResponse](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/bigtable/admin/v2/bigtable_table_admin.proto#L640)
+   * @googleapis_link{google::bigtable::admin::v2::GenerateConsistencyTokenResponse,google/bigtable/admin/v2/bigtable_table_admin.proto#L640}
    */
   StatusOr<google::bigtable::admin::v2::GenerateConsistencyTokenResponse>
   GenerateConsistencyToken(
@@ -436,9 +436,9 @@ class BigtableTableAdminClient {
    * and the check request.
    *
    * @param request
-   * [google::bigtable::admin::v2::CheckConsistencyRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/bigtable/admin/v2/bigtable_table_admin.proto#L647)
+   * @googleapis_link{google::bigtable::admin::v2::CheckConsistencyRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L647}
    * @return
-   * [google::bigtable::admin::v2::CheckConsistencyResponse](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/bigtable/admin/v2/bigtable_table_admin.proto#L664)
+   * @googleapis_link{google::bigtable::admin::v2::CheckConsistencyResponse,google/bigtable/admin/v2/bigtable_table_admin.proto#L664}
    */
   StatusOr<google::bigtable::admin::v2::CheckConsistencyResponse>
   CheckConsistency(
@@ -455,9 +455,9 @@ class BigtableTableAdminClient {
    * returned operation will stop the creation and delete the backup.
    *
    * @param request
-   * [google::bigtable::admin::v2::CreateBackupRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/bigtable/admin/v2/bigtable_table_admin.proto#L833)
+   * @googleapis_link{google::bigtable::admin::v2::CreateBackupRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L833}
    * @return
-   * [google::bigtable::admin::v2::Backup](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/bigtable/admin/v2/table.proto#L317)
+   * @googleapis_link{google::bigtable::admin::v2::Backup,google/bigtable/admin/v2/table.proto#L317}
    */
   future<StatusOr<google::bigtable::admin::v2::Backup>> CreateBackup(
       google::bigtable::admin::v2::CreateBackupRequest const& request);
@@ -466,9 +466,9 @@ class BigtableTableAdminClient {
    * Gets metadata on a pending or completed Cloud Bigtable Backup.
    *
    * @param request
-   * [google::bigtable::admin::v2::GetBackupRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/bigtable/admin/v2/bigtable_table_admin.proto#L889)
+   * @googleapis_link{google::bigtable::admin::v2::GetBackupRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L889}
    * @return
-   * [google::bigtable::admin::v2::Backup](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/bigtable/admin/v2/table.proto#L317)
+   * @googleapis_link{google::bigtable::admin::v2::Backup,google/bigtable/admin/v2/table.proto#L317}
    */
   StatusOr<google::bigtable::admin::v2::Backup> GetBackup(
       google::bigtable::admin::v2::GetBackupRequest const& request);
@@ -477,9 +477,9 @@ class BigtableTableAdminClient {
    * Updates a pending or completed Cloud Bigtable Backup.
    *
    * @param request
-   * [google::bigtable::admin::v2::UpdateBackupRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/bigtable/admin/v2/bigtable_table_admin.proto#L873)
+   * @googleapis_link{google::bigtable::admin::v2::UpdateBackupRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L873}
    * @return
-   * [google::bigtable::admin::v2::Backup](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/bigtable/admin/v2/table.proto#L317)
+   * @googleapis_link{google::bigtable::admin::v2::Backup,google/bigtable/admin/v2/table.proto#L317}
    */
   StatusOr<google::bigtable::admin::v2::Backup> UpdateBackup(
       google::bigtable::admin::v2::UpdateBackupRequest const& request);
@@ -488,7 +488,7 @@ class BigtableTableAdminClient {
    * Deletes a pending or completed Cloud Bigtable backup.
    *
    * @param request
-   * [google::bigtable::admin::v2::DeleteBackupRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/bigtable/admin/v2/bigtable_table_admin.proto#L902)
+   * @googleapis_link{google::bigtable::admin::v2::DeleteBackupRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L902}
    */
   Status DeleteBackup(
       google::bigtable::admin::v2::DeleteBackupRequest const& request);
@@ -498,9 +498,9 @@ class BigtableTableAdminClient {
    * backups.
    *
    * @param request
-   * [google::bigtable::admin::v2::ListBackupsRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/bigtable/admin/v2/bigtable_table_admin.proto#L915)
+   * @googleapis_link{google::bigtable::admin::v2::ListBackupsRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L915}
    * @return
-   * [google::bigtable::admin::v2::Backup](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/bigtable/admin/v2/table.proto#L317)
+   * @googleapis_link{google::bigtable::admin::v2::Backup,google/bigtable/admin/v2/table.proto#L317}
    */
   StreamRange<google::bigtable::admin::v2::Backup> ListBackups(
       google::bigtable::admin::v2::ListBackupsRequest request);
@@ -516,9 +516,9 @@ class BigtableTableAdminClient {
    * [Table][google.bigtable.admin.v2.Table], if successful.
    *
    * @param request
-   * [google::bigtable::admin::v2::RestoreTableRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/bigtable/admin/v2/bigtable_table_admin.proto#L336)
+   * @googleapis_link{google::bigtable::admin::v2::RestoreTableRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L336}
    * @return
-   * [google::bigtable::admin::v2::Table](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/bigtable/admin/v2/table.proto#L61)
+   * @googleapis_link{google::bigtable::admin::v2::Table,google/bigtable/admin/v2/table.proto#L61}
    */
   future<StatusOr<google::bigtable::admin::v2::Table>> RestoreTable(
       google::bigtable::admin::v2::RestoreTableRequest const& request);
@@ -529,9 +529,9 @@ class BigtableTableAdminClient {
    * set.
    *
    * @param request
-   * [google::iam::v1::GetIamPolicyRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/iam/v1/iam_policy.proto#L113)
+   * @googleapis_link{google::iam::v1::GetIamPolicyRequest,google/iam/v1/iam_policy.proto#L113}
    * @return
-   * [google::iam::v1::Policy](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/iam/v1/policy.proto#L88)
+   * @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
    */
   StatusOr<google::iam::v1::Policy> GetIamPolicy(
       google::iam::v1::GetIamPolicyRequest const& request);
@@ -541,9 +541,9 @@ class BigtableTableAdminClient {
    * Replaces any existing policy.
    *
    * @param request
-   * [google::iam::v1::SetIamPolicyRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/iam/v1/iam_policy.proto#L98)
+   * @googleapis_link{google::iam::v1::SetIamPolicyRequest,google/iam/v1/iam_policy.proto#L98}
    * @return
-   * [google::iam::v1::Policy](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/iam/v1/policy.proto#L88)
+   * @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
    */
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
       google::iam::v1::SetIamPolicyRequest const& request);
@@ -553,9 +553,9 @@ class BigtableTableAdminClient {
    * resource.
    *
    * @param request
-   * [google::iam::v1::TestIamPermissionsRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/iam/v1/iam_policy.proto#L126)
+   * @googleapis_link{google::iam::v1::TestIamPermissionsRequest,google/iam/v1/iam_policy.proto#L126}
    * @return
-   * [google::iam::v1::TestIamPermissionsResponse](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/iam/v1/iam_policy.proto#L141)
+   * @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
    */
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
       google::iam::v1::TestIamPermissionsRequest const& request);
@@ -566,9 +566,9 @@ class BigtableTableAdminClient {
    * and the check request.
    *
    * @param request
-   * [google::bigtable::admin::v2::CheckConsistencyRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/bigtable/admin/v2/bigtable_table_admin.proto#L647)
+   * @googleapis_link{google::bigtable::admin::v2::CheckConsistencyRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L647}
    * @return
-   * [google::bigtable::admin::v2::CheckConsistencyResponse](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/bigtable/admin/v2/bigtable_table_admin.proto#L664)
+   * @googleapis_link{google::bigtable::admin::v2::CheckConsistencyResponse,google/bigtable/admin/v2/bigtable_table_admin.proto#L664}
    */
   future<StatusOr<google::bigtable::admin::v2::CheckConsistencyResponse>>
   AsyncCheckConsistency(

--- a/google/cloud/iam/CMakeLists.txt
+++ b/google/cloud/iam/CMakeLists.txt
@@ -14,6 +14,7 @@
 # limitations under the License.
 # ~~~
 
+include(GoogleapisConfig)
 set(DOXYGEN_PROJECT_NAME "Google Cloud IAM C++ Client")
 set(DOXYGEN_PROJECT_BRIEF "A C++ Client Library for Google Cloud IAM")
 set(DOXYGEN_PROJECT_NUMBER "${PROJECT_VERSION}")

--- a/google/cloud/iam/iam_client.h
+++ b/google/cloud/iam/iam_client.h
@@ -84,7 +84,7 @@ class IAMClient {
    * @param name  Required. The resource name of the project associated with the
    * service accounts, such as `projects/my-project-123`.
    * @return
-   * [google::iam::admin::v1::ServiceAccount](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/iam/admin/v1/iam.proto#L461)
+   * @googleapis_link{google::iam::admin::v1::ServiceAccount,google/iam/admin/v1/iam.proto#L461}
    */
   StreamRange<google::iam::admin::v1::ServiceAccount> ListServiceAccounts(
       std::string const& name);
@@ -98,7 +98,7 @@ class IAMClient {
    * account. The `ACCOUNT` value can be the `email` address or the `unique_id`
    * of the service account.
    * @return
-   * [google::iam::admin::v1::ServiceAccount](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/iam/admin/v1/iam.proto#L461)
+   * @googleapis_link{google::iam::admin::v1::ServiceAccount,google/iam/admin/v1/iam.proto#L461}
    */
   StatusOr<google::iam::admin::v1::ServiceAccount> GetServiceAccount(
       std::string const& name);
@@ -117,7 +117,7 @@ class IAMClient {
    * Currently, only the following values are user assignable: `display_name`
    * and `description`.
    * @return
-   * [google::iam::admin::v1::ServiceAccount](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/iam/admin/v1/iam.proto#L461)
+   * @googleapis_link{google::iam::admin::v1::ServiceAccount,google/iam/admin/v1/iam.proto#L461}
    */
   StatusOr<google::iam::admin::v1::ServiceAccount> CreateServiceAccount(
       std::string const& name, std::string const& account_id,
@@ -164,7 +164,7 @@ class IAMClient {
    * the list response. Duplicate key types are not allowed. If no key type is
    * provided, all keys are returned.
    * @return
-   * [google::iam::admin::v1::ListServiceAccountKeysResponse](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/iam/admin/v1/iam.proto#L692)
+   * @googleapis_link{google::iam::admin::v1::ListServiceAccountKeysResponse,google/iam/admin/v1/iam.proto#L692}
    */
   StatusOr<google::iam::admin::v1::ListServiceAccountKeysResponse>
   ListServiceAccountKeys(
@@ -185,7 +185,7 @@ class IAMClient {
    * @param public_key_type  The output format of the public key requested.
    *  X509_PEM is the default output format.
    * @return
-   * [google::iam::admin::v1::ServiceAccountKey](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/iam/admin/v1/iam.proto#L741)
+   * @googleapis_link{google::iam::admin::v1::ServiceAccountKey,google/iam/admin/v1/iam.proto#L741}
    */
   StatusOr<google::iam::admin::v1::ServiceAccountKey> GetServiceAccountKey(
       std::string const& name,
@@ -206,7 +206,7 @@ class IAMClient {
    *  The default is currently a 2K RSA key.  However this may change in the
    *  future.
    * @return
-   * [google::iam::admin::v1::ServiceAccountKey](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/iam/admin/v1/iam.proto#L741)
+   * @googleapis_link{google::iam::admin::v1::ServiceAccountKey,google/iam/admin/v1/iam.proto#L741}
    */
   StatusOr<google::iam::admin::v1::ServiceAccountKey> CreateServiceAccountKey(
       std::string const& name,
@@ -244,7 +244,7 @@ class IAMClient {
    * requested. See the operation documentation for the appropriate value for
    * this field.
    * @return
-   * [google::iam::v1::Policy](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/iam/v1/policy.proto#L88)
+   * @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
    */
   StatusOr<google::iam::v1::Policy> GetIamPolicy(std::string const& resource);
 
@@ -276,7 +276,7 @@ class IAMClient {
    * policy is a valid policy but certain Cloud Platform services (such as
    * Projects) might reject them.
    * @return
-   * [google::iam::v1::Policy](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/iam/v1/policy.proto#L88)
+   * @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
    */
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
       std::string const& resource, google::iam::v1::Policy const& policy);
@@ -318,7 +318,7 @@ class IAMClient {
    * For more information see [IAM
    * Overview](https://cloud.google.com/iam/docs/overview#permissions).
    * @return
-   * [google::iam::v1::TestIamPermissionsResponse](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/iam/v1/iam_policy.proto#L141)
+   * @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
    */
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
       std::string const& resource, std::vector<std::string> const& permissions);
@@ -334,7 +334,7 @@ class IAMClient {
    * will be named
    *  `//cloudresourcemanager.googleapis.com/projects/my-project`.
    * @return
-   * [google::iam::admin::v1::Role](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/iam/admin/v1/iam.proto#L1004)
+   * @googleapis_link{google::iam::admin::v1::Role,google/iam/admin/v1/iam.proto#L1004}
    */
   StreamRange<google::iam::admin::v1::Role> QueryGrantableRoles(
       std::string const& full_resource_name);
@@ -344,9 +344,9 @@ class IAMClient {
    * belongs to a specific project.
    *
    * @param request
-   * [google::iam::admin::v1::ListServiceAccountsRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/iam/admin/v1/iam.proto#L544)
+   * @googleapis_link{google::iam::admin::v1::ListServiceAccountsRequest,google/iam/admin/v1/iam.proto#L544}
    * @return
-   * [google::iam::admin::v1::ServiceAccount](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/iam/admin/v1/iam.proto#L461)
+   * @googleapis_link{google::iam::admin::v1::ServiceAccount,google/iam/admin/v1/iam.proto#L461}
    */
   StreamRange<google::iam::admin::v1::ServiceAccount> ListServiceAccounts(
       google::iam::admin::v1::ListServiceAccountsRequest request);
@@ -355,9 +355,9 @@ class IAMClient {
    * Gets a [ServiceAccount][google.iam.admin.v1.ServiceAccount].
    *
    * @param request
-   * [google::iam::admin::v1::GetServiceAccountRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/iam/admin/v1/iam.proto#L579)
+   * @googleapis_link{google::iam::admin::v1::GetServiceAccountRequest,google/iam/admin/v1/iam.proto#L579}
    * @return
-   * [google::iam::admin::v1::ServiceAccount](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/iam/admin/v1/iam.proto#L461)
+   * @googleapis_link{google::iam::admin::v1::ServiceAccount,google/iam/admin/v1/iam.proto#L461}
    */
   StatusOr<google::iam::admin::v1::ServiceAccount> GetServiceAccount(
       google::iam::admin::v1::GetServiceAccountRequest const& request);
@@ -366,9 +366,9 @@ class IAMClient {
    * Creates a [ServiceAccount][google.iam.admin.v1.ServiceAccount].
    *
    * @param request
-   * [google::iam::admin::v1::CreateServiceAccountRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/iam/admin/v1/iam.proto#L521)
+   * @googleapis_link{google::iam::admin::v1::CreateServiceAccountRequest,google/iam/admin/v1/iam.proto#L521}
    * @return
-   * [google::iam::admin::v1::ServiceAccount](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/iam/admin/v1/iam.proto#L461)
+   * @googleapis_link{google::iam::admin::v1::ServiceAccount,google/iam/admin/v1/iam.proto#L461}
    */
   StatusOr<google::iam::admin::v1::ServiceAccount> CreateServiceAccount(
       google::iam::admin::v1::CreateServiceAccountRequest const& request);
@@ -377,9 +377,9 @@ class IAMClient {
    * Patches a [ServiceAccount][google.iam.admin.v1.ServiceAccount].
    *
    * @param request
-   * [google::iam::admin::v1::PatchServiceAccountRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/iam/admin/v1/iam.proto#L616)
+   * @googleapis_link{google::iam::admin::v1::PatchServiceAccountRequest,google/iam/admin/v1/iam.proto#L616}
    * @return
-   * [google::iam::admin::v1::ServiceAccount](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/iam/admin/v1/iam.proto#L461)
+   * @googleapis_link{google::iam::admin::v1::ServiceAccount,google/iam/admin/v1/iam.proto#L461}
    */
   StatusOr<google::iam::admin::v1::ServiceAccount> PatchServiceAccount(
       google::iam::admin::v1::PatchServiceAccountRequest const& request);
@@ -405,7 +405,7 @@ class IAMClient {
    * delete the service account.
    *
    * @param request
-   * [google::iam::admin::v1::DeleteServiceAccountRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/iam/admin/v1/iam.proto#L594)
+   * @googleapis_link{google::iam::admin::v1::DeleteServiceAccountRequest,google/iam/admin/v1/iam.proto#L594}
    */
   Status DeleteServiceAccount(
       google::iam::admin::v1::DeleteServiceAccountRequest const& request);
@@ -421,9 +421,9 @@ class IAMClient {
    * that has been permanently removed.
    *
    * @param request
-   * [google::iam::admin::v1::UndeleteServiceAccountRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/iam/admin/v1/iam.proto#L623)
+   * @googleapis_link{google::iam::admin::v1::UndeleteServiceAccountRequest,google/iam/admin/v1/iam.proto#L623}
    * @return
-   * [google::iam::admin::v1::UndeleteServiceAccountResponse](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/iam/admin/v1/iam.proto#L631)
+   * @googleapis_link{google::iam::admin::v1::UndeleteServiceAccountResponse,google/iam/admin/v1/iam.proto#L631}
    */
   StatusOr<google::iam::admin::v1::UndeleteServiceAccountResponse>
   UndeleteServiceAccount(
@@ -441,7 +441,7 @@ class IAMClient {
    * method to enable the service account.
    *
    * @param request
-   * [google::iam::admin::v1::EnableServiceAccountRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/iam/admin/v1/iam.proto#L637)
+   * @googleapis_link{google::iam::admin::v1::EnableServiceAccountRequest,google/iam/admin/v1/iam.proto#L637}
    */
   Status EnableServiceAccount(
       google::iam::admin::v1::EnableServiceAccountRequest const& request);
@@ -467,7 +467,7 @@ class IAMClient {
    * with [DeleteServiceAccount][google.iam.admin.v1.IAM.DeleteServiceAccount].
    *
    * @param request
-   * [google::iam::admin::v1::DisableServiceAccountRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/iam/admin/v1/iam.proto#L647)
+   * @googleapis_link{google::iam::admin::v1::DisableServiceAccountRequest,google/iam/admin/v1/iam.proto#L647}
    */
   Status DisableServiceAccount(
       google::iam::admin::v1::DisableServiceAccountRequest const& request);
@@ -477,9 +477,9 @@ class IAMClient {
    * a service account.
    *
    * @param request
-   * [google::iam::admin::v1::ListServiceAccountKeysRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/iam/admin/v1/iam.proto#L657)
+   * @googleapis_link{google::iam::admin::v1::ListServiceAccountKeysRequest,google/iam/admin/v1/iam.proto#L657}
    * @return
-   * [google::iam::admin::v1::ListServiceAccountKeysResponse](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/iam/admin/v1/iam.proto#L692)
+   * @googleapis_link{google::iam::admin::v1::ListServiceAccountKeysResponse,google/iam/admin/v1/iam.proto#L692}
    */
   StatusOr<google::iam::admin::v1::ListServiceAccountKeysResponse>
   ListServiceAccountKeys(
@@ -489,9 +489,9 @@ class IAMClient {
    * Gets a [ServiceAccountKey][google.iam.admin.v1.ServiceAccountKey].
    *
    * @param request
-   * [google::iam::admin::v1::GetServiceAccountKeyRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/iam/admin/v1/iam.proto#L698)
+   * @googleapis_link{google::iam::admin::v1::GetServiceAccountKeyRequest,google/iam/admin/v1/iam.proto#L698}
    * @return
-   * [google::iam::admin::v1::ServiceAccountKey](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/iam/admin/v1/iam.proto#L741)
+   * @googleapis_link{google::iam::admin::v1::ServiceAccountKey,google/iam/admin/v1/iam.proto#L741}
    */
   StatusOr<google::iam::admin::v1::ServiceAccountKey> GetServiceAccountKey(
       google::iam::admin::v1::GetServiceAccountKeyRequest const& request);
@@ -500,9 +500,9 @@ class IAMClient {
    * Creates a [ServiceAccountKey][google.iam.admin.v1.ServiceAccountKey].
    *
    * @param request
-   * [google::iam::admin::v1::CreateServiceAccountKeyRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/iam/admin/v1/iam.proto#L791)
+   * @googleapis_link{google::iam::admin::v1::CreateServiceAccountKeyRequest,google/iam/admin/v1/iam.proto#L791}
    * @return
-   * [google::iam::admin::v1::ServiceAccountKey](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/iam/admin/v1/iam.proto#L741)
+   * @googleapis_link{google::iam::admin::v1::ServiceAccountKey,google/iam/admin/v1/iam.proto#L741}
    */
   StatusOr<google::iam::admin::v1::ServiceAccountKey> CreateServiceAccountKey(
       google::iam::admin::v1::CreateServiceAccountKeyRequest const& request);
@@ -512,9 +512,9 @@ class IAMClient {
    * a public key that you provide.
    *
    * @param request
-   * [google::iam::admin::v1::UploadServiceAccountKeyRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/iam/admin/v1/iam.proto#L816)
+   * @googleapis_link{google::iam::admin::v1::UploadServiceAccountKeyRequest,google/iam/admin/v1/iam.proto#L816}
    * @return
-   * [google::iam::admin::v1::ServiceAccountKey](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/iam/admin/v1/iam.proto#L741)
+   * @googleapis_link{google::iam::admin::v1::ServiceAccountKey,google/iam/admin/v1/iam.proto#L741}
    */
   StatusOr<google::iam::admin::v1::ServiceAccountKey> UploadServiceAccountKey(
       google::iam::admin::v1::UploadServiceAccountKeyRequest const& request);
@@ -525,7 +525,7 @@ class IAMClient {
    * have been issued based on the service account key.
    *
    * @param request
-   * [google::iam::admin::v1::DeleteServiceAccountKeyRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/iam/admin/v1/iam.proto#L832)
+   * @googleapis_link{google::iam::admin::v1::DeleteServiceAccountKeyRequest,google/iam/admin/v1/iam.proto#L832}
    */
   Status DeleteServiceAccountKey(
       google::iam::admin::v1::DeleteServiceAccountKeyRequest const& request);
@@ -544,9 +544,9 @@ class IAMClient {
    * method.
    *
    * @param request
-   * [google::iam::v1::GetIamPolicyRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/iam/v1/iam_policy.proto#L113)
+   * @googleapis_link{google::iam::v1::GetIamPolicyRequest,google/iam/v1/iam_policy.proto#L113}
    * @return
-   * [google::iam::v1::Policy](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/iam/v1/policy.proto#L88)
+   * @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
    */
   StatusOr<google::iam::v1::Policy> GetIamPolicy(
       google::iam::v1::GetIamPolicyRequest const& request);
@@ -572,9 +572,9 @@ class IAMClient {
    * resources](https://cloud.google.com/iam/help/service-accounts/granting-access-to-service-accounts).
    *
    * @param request
-   * [google::iam::v1::SetIamPolicyRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/iam/v1/iam_policy.proto#L98)
+   * @googleapis_link{google::iam::v1::SetIamPolicyRequest,google/iam/v1/iam_policy.proto#L98}
    * @return
-   * [google::iam::v1::Policy](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/iam/v1/policy.proto#L88)
+   * @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
    */
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
       google::iam::v1::SetIamPolicyRequest const& request);
@@ -584,9 +584,9 @@ class IAMClient {
    * [ServiceAccount][google.iam.admin.v1.ServiceAccount].
    *
    * @param request
-   * [google::iam::v1::TestIamPermissionsRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/iam/v1/iam_policy.proto#L126)
+   * @googleapis_link{google::iam::v1::TestIamPermissionsRequest,google/iam/v1/iam_policy.proto#L126}
    * @return
-   * [google::iam::v1::TestIamPermissionsResponse](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/iam/v1/iam_policy.proto#L141)
+   * @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
    */
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
       google::iam::v1::TestIamPermissionsRequest const& request);
@@ -597,9 +597,9 @@ class IAMClient {
    * role.
    *
    * @param request
-   * [google::iam::admin::v1::QueryGrantableRolesRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/iam/admin/v1/iam.proto#L1062)
+   * @googleapis_link{google::iam::admin::v1::QueryGrantableRolesRequest,google/iam/admin/v1/iam.proto#L1062}
    * @return
-   * [google::iam::admin::v1::Role](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/iam/admin/v1/iam.proto#L1004)
+   * @googleapis_link{google::iam::admin::v1::Role,google/iam/admin/v1/iam.proto#L1004}
    */
   StreamRange<google::iam::admin::v1::Role> QueryGrantableRoles(
       google::iam::admin::v1::QueryGrantableRolesRequest request);
@@ -609,9 +609,9 @@ class IAMClient {
    * or every custom role that is defined for an organization or project.
    *
    * @param request
-   * [google::iam::admin::v1::ListRolesRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/iam/admin/v1/iam.proto#L1093)
+   * @googleapis_link{google::iam::admin::v1::ListRolesRequest,google/iam/admin/v1/iam.proto#L1093}
    * @return
-   * [google::iam::admin::v1::Role](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/iam/admin/v1/iam.proto#L1004)
+   * @googleapis_link{google::iam::admin::v1::Role,google/iam/admin/v1/iam.proto#L1004}
    */
   StreamRange<google::iam::admin::v1::Role> ListRoles(
       google::iam::admin::v1::ListRolesRequest request);
@@ -620,9 +620,9 @@ class IAMClient {
    * Gets the definition of a [Role][google.iam.admin.v1.Role].
    *
    * @param request
-   * [google::iam::admin::v1::GetRoleRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/iam/admin/v1/iam.proto#L1152)
+   * @googleapis_link{google::iam::admin::v1::GetRoleRequest,google/iam/admin/v1/iam.proto#L1152}
    * @return
-   * [google::iam::admin::v1::Role](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/iam/admin/v1/iam.proto#L1004)
+   * @googleapis_link{google::iam::admin::v1::Role,google/iam/admin/v1/iam.proto#L1004}
    */
   StatusOr<google::iam::admin::v1::Role> GetRole(
       google::iam::admin::v1::GetRoleRequest const& request);
@@ -631,9 +631,9 @@ class IAMClient {
    * Creates a new custom [Role][google.iam.admin.v1.Role].
    *
    * @param request
-   * [google::iam::admin::v1::CreateRoleRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/iam/admin/v1/iam.proto#L1184)
+   * @googleapis_link{google::iam::admin::v1::CreateRoleRequest,google/iam/admin/v1/iam.proto#L1184}
    * @return
-   * [google::iam::admin::v1::Role](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/iam/admin/v1/iam.proto#L1004)
+   * @googleapis_link{google::iam::admin::v1::Role,google/iam/admin/v1/iam.proto#L1004}
    */
   StatusOr<google::iam::admin::v1::Role> CreateRole(
       google::iam::admin::v1::CreateRoleRequest const& request);
@@ -642,9 +642,9 @@ class IAMClient {
    * Updates the definition of a custom [Role][google.iam.admin.v1.Role].
    *
    * @param request
-   * [google::iam::admin::v1::UpdateRoleRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/iam/admin/v1/iam.proto#L1219)
+   * @googleapis_link{google::iam::admin::v1::UpdateRoleRequest,google/iam/admin/v1/iam.proto#L1219}
    * @return
-   * [google::iam::admin::v1::Role](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/iam/admin/v1/iam.proto#L1004)
+   * @googleapis_link{google::iam::admin::v1::Role,google/iam/admin/v1/iam.proto#L1004}
    */
   StatusOr<google::iam::admin::v1::Role> UpdateRole(
       google::iam::admin::v1::UpdateRoleRequest const& request);
@@ -670,9 +670,9 @@ class IAMClient {
    * permanently removed.
    *
    * @param request
-   * [google::iam::admin::v1::DeleteRoleRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/iam/admin/v1/iam.proto#L1250)
+   * @googleapis_link{google::iam::admin::v1::DeleteRoleRequest,google/iam/admin/v1/iam.proto#L1250}
    * @return
-   * [google::iam::admin::v1::Role](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/iam/admin/v1/iam.proto#L1004)
+   * @googleapis_link{google::iam::admin::v1::Role,google/iam/admin/v1/iam.proto#L1004}
    */
   StatusOr<google::iam::admin::v1::Role> DeleteRole(
       google::iam::admin::v1::DeleteRoleRequest const& request);
@@ -681,9 +681,9 @@ class IAMClient {
    * Undeletes a custom [Role][google.iam.admin.v1.Role].
    *
    * @param request
-   * [google::iam::admin::v1::UndeleteRoleRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/iam/admin/v1/iam.proto#L1278)
+   * @googleapis_link{google::iam::admin::v1::UndeleteRoleRequest,google/iam/admin/v1/iam.proto#L1278}
    * @return
-   * [google::iam::admin::v1::Role](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/iam/admin/v1/iam.proto#L1004)
+   * @googleapis_link{google::iam::admin::v1::Role,google/iam/admin/v1/iam.proto#L1004}
    */
   StatusOr<google::iam::admin::v1::Role> UndeleteRole(
       google::iam::admin::v1::UndeleteRoleRequest const& request);
@@ -694,9 +694,9 @@ class IAMClient {
    * resource.
    *
    * @param request
-   * [google::iam::admin::v1::QueryTestablePermissionsRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/iam/admin/v1/iam.proto#L1361)
+   * @googleapis_link{google::iam::admin::v1::QueryTestablePermissionsRequest,google/iam/admin/v1/iam.proto#L1361}
    * @return
-   * [google::iam::admin::v1::Permission](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/iam/admin/v1/iam.proto#L1306)
+   * @googleapis_link{google::iam::admin::v1::Permission,google/iam/admin/v1/iam.proto#L1306}
    */
   StreamRange<google::iam::admin::v1::Permission> QueryTestablePermissions(
       google::iam::admin::v1::QueryTestablePermissionsRequest request);
@@ -709,9 +709,9 @@ class IAMClient {
    * documentation](https://cloud.google.com/logging/docs/audit).
    *
    * @param request
-   * [google::iam::admin::v1::QueryAuditableServicesRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/iam/admin/v1/iam.proto#L1391)
+   * @googleapis_link{google::iam::admin::v1::QueryAuditableServicesRequest,google/iam/admin/v1/iam.proto#L1391}
    * @return
-   * [google::iam::admin::v1::QueryAuditableServicesResponse](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/iam/admin/v1/iam.proto#L1402)
+   * @googleapis_link{google::iam::admin::v1::QueryAuditableServicesResponse,google/iam/admin/v1/iam.proto#L1402}
    */
   StatusOr<google::iam::admin::v1::QueryAuditableServicesResponse>
   QueryAuditableServices(
@@ -726,9 +726,9 @@ class IAMClient {
    * even if the linter detects an issue in the IAM policy.
    *
    * @param request
-   * [google::iam::admin::v1::LintPolicyRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/iam/admin/v1/iam.proto#L1415)
+   * @googleapis_link{google::iam::admin::v1::LintPolicyRequest,google/iam/admin/v1/iam.proto#L1415}
    * @return
-   * [google::iam::admin::v1::LintPolicyResponse](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/iam/admin/v1/iam.proto#L1513)
+   * @googleapis_link{google::iam::admin::v1::LintPolicyResponse,google/iam/admin/v1/iam.proto#L1513}
    */
   StatusOr<google::iam::admin::v1::LintPolicyResponse> LintPolicy(
       google::iam::admin::v1::LintPolicyRequest const& request);

--- a/google/cloud/iam/iam_credentials_client.h
+++ b/google/cloud/iam/iam_credentials_client.h
@@ -95,7 +95,7 @@ class IAMCredentialsClient {
    * value is not specified, the token's lifetime will be set to a default value
    * of one hour.
    * @return
-   * [google::iam::credentials::v1::GenerateAccessTokenResponse](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/iam/credentials/v1/common.proto#L72)
+   * @googleapis_link{google::iam::credentials::v1::GenerateAccessTokenResponse,google/iam/credentials/v1/common.proto#L72}
    */
   StatusOr<google::iam::credentials::v1::GenerateAccessTokenResponse>
   GenerateAccessToken(std::string const& name,
@@ -124,7 +124,7 @@ class IAMCredentialsClient {
    * @param include_email  Include the service account email in the token. If
    * set to `true`, the token will contain `email` and `email_verified` claims.
    * @return
-   * [google::iam::credentials::v1::GenerateIdTokenResponse](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/iam/credentials/v1/common.proto#L186)
+   * @googleapis_link{google::iam::credentials::v1::GenerateIdTokenResponse,google/iam/credentials/v1/common.proto#L186}
    */
   StatusOr<google::iam::credentials::v1::GenerateIdTokenResponse>
   GenerateIdToken(std::string const& name,
@@ -149,7 +149,7 @@ class IAMCredentialsClient {
    * invalid.
    * @param payload  Required. The bytes to sign.
    * @return
-   * [google::iam::credentials::v1::SignBlobResponse](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/iam/credentials/v1/common.proto#L109)
+   * @googleapis_link{google::iam::credentials::v1::SignBlobResponse,google/iam/credentials/v1/common.proto#L109}
    */
   StatusOr<google::iam::credentials::v1::SignBlobResponse> SignBlob(
       std::string const& name, std::vector<std::string> const& delegates,
@@ -174,7 +174,7 @@ class IAMCredentialsClient {
    * @param payload  Required. The JWT payload to sign: a JSON object that
    * contains a JWT Claims Set.
    * @return
-   * [google::iam::credentials::v1::SignJwtResponse](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/iam/credentials/v1/common.proto#L145)
+   * @googleapis_link{google::iam::credentials::v1::SignJwtResponse,google/iam/credentials/v1/common.proto#L145}
    */
   StatusOr<google::iam::credentials::v1::SignJwtResponse> SignJwt(
       std::string const& name, std::vector<std::string> const& delegates,
@@ -184,9 +184,9 @@ class IAMCredentialsClient {
    * Generates an OAuth 2.0 access token for a service account.
    *
    * @param request
-   * [google::iam::credentials::v1::GenerateAccessTokenRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/iam/credentials/v1/common.proto#L35)
+   * @googleapis_link{google::iam::credentials::v1::GenerateAccessTokenRequest,google/iam/credentials/v1/common.proto#L35}
    * @return
-   * [google::iam::credentials::v1::GenerateAccessTokenResponse](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/iam/credentials/v1/common.proto#L72)
+   * @googleapis_link{google::iam::credentials::v1::GenerateAccessTokenResponse,google/iam/credentials/v1/common.proto#L72}
    */
   StatusOr<google::iam::credentials::v1::GenerateAccessTokenResponse>
   GenerateAccessToken(
@@ -196,9 +196,9 @@ class IAMCredentialsClient {
    * Generates an OpenID Connect ID token for a service account.
    *
    * @param request
-   * [google::iam::credentials::v1::GenerateIdTokenRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/iam/credentials/v1/common.proto#L153)
+   * @googleapis_link{google::iam::credentials::v1::GenerateIdTokenRequest,google/iam/credentials/v1/common.proto#L153}
    * @return
-   * [google::iam::credentials::v1::GenerateIdTokenResponse](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/iam/credentials/v1/common.proto#L186)
+   * @googleapis_link{google::iam::credentials::v1::GenerateIdTokenResponse,google/iam/credentials/v1/common.proto#L186}
    */
   StatusOr<google::iam::credentials::v1::GenerateIdTokenResponse>
   GenerateIdToken(
@@ -208,9 +208,9 @@ class IAMCredentialsClient {
    * Signs a blob using a service account's system-managed private key.
    *
    * @param request
-   * [google::iam::credentials::v1::SignBlobRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/iam/credentials/v1/common.proto#L81)
+   * @googleapis_link{google::iam::credentials::v1::SignBlobRequest,google/iam/credentials/v1/common.proto#L81}
    * @return
-   * [google::iam::credentials::v1::SignBlobResponse](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/iam/credentials/v1/common.proto#L109)
+   * @googleapis_link{google::iam::credentials::v1::SignBlobResponse,google/iam/credentials/v1/common.proto#L109}
    */
   StatusOr<google::iam::credentials::v1::SignBlobResponse> SignBlob(
       google::iam::credentials::v1::SignBlobRequest const& request);
@@ -219,9 +219,9 @@ class IAMCredentialsClient {
    * Signs a JWT using a service account's system-managed private key.
    *
    * @param request
-   * [google::iam::credentials::v1::SignJwtRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/iam/credentials/v1/common.proto#L117)
+   * @googleapis_link{google::iam::credentials::v1::SignJwtRequest,google/iam/credentials/v1/common.proto#L117}
    * @return
-   * [google::iam::credentials::v1::SignJwtResponse](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/iam/credentials/v1/common.proto#L145)
+   * @googleapis_link{google::iam::credentials::v1::SignJwtResponse,google/iam/credentials/v1/common.proto#L145}
    */
   StatusOr<google::iam::credentials::v1::SignJwtResponse> SignJwt(
       google::iam::credentials::v1::SignJwtRequest const& request);

--- a/google/cloud/logging/CMakeLists.txt
+++ b/google/cloud/logging/CMakeLists.txt
@@ -14,6 +14,7 @@
 # limitations under the License.
 # ~~~
 
+include(GoogleapisConfig)
 set(DOXYGEN_PROJECT_NAME "Google Cloud Logging C++ Client")
 set(DOXYGEN_PROJECT_BRIEF "A C++ Client Library for Google Cloud Logging")
 set(DOXYGEN_PROJECT_NUMBER "${PROJECT_VERSION} (Beta)")

--- a/google/cloud/logging/logging_service_v2_client.h
+++ b/google/cloud/logging/logging_service_v2_client.h
@@ -133,7 +133,7 @@ class LoggingServiceV2Client {
    *  `entries.write`, you should try to include several log entries in this
    *  list, rather than calling this method for each individual log entry.
    * @return
-   * [google::logging::v2::WriteLogEntriesResponse](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/logging/v2/logging.proto#L243)
+   * @googleapis_link{google::logging::v2::WriteLogEntriesResponse,google/logging/v2/logging.proto#L243}
    */
   StatusOr<google::logging::v2::WriteLogEntriesResponse> WriteLogEntries(
       std::string const& log_name,
@@ -173,7 +173,7 @@ class LoggingServiceV2Client {
    *  in order of decreasing timestamps (newest first).  Entries with equal
    *  timestamps are returned in order of their `insert_id` values.
    * @return
-   * [google::logging::v2::LogEntry](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/logging/v2/log_entry.proto#L42)
+   * @googleapis_link{google::logging::v2::LogEntry,google/logging/v2/log_entry.proto#L42}
    */
   StreamRange<google::logging::v2::LogEntry> ListLogEntries(
       std::vector<std::string> const& resource_names, std::string const& filter,
@@ -199,7 +199,7 @@ class LoggingServiceV2Client {
    * before the operation will be deleted.
    *
    * @param request
-   * [google::logging::v2::DeleteLogRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/logging/v2/logging.proto#L140)
+   * @googleapis_link{google::logging::v2::DeleteLogRequest,google/logging/v2/logging.proto#L140}
    */
   Status DeleteLog(google::logging::v2::DeleteLogRequest const& request);
 
@@ -213,9 +213,9 @@ class LoggingServiceV2Client {
    * folders)
    *
    * @param request
-   * [google::logging::v2::WriteLogEntriesRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/logging/v2/logging.proto#L162)
+   * @googleapis_link{google::logging::v2::WriteLogEntriesRequest,google/logging/v2/logging.proto#L162}
    * @return
-   * [google::logging::v2::WriteLogEntriesResponse](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/logging/v2/logging.proto#L243)
+   * @googleapis_link{google::logging::v2::WriteLogEntriesResponse,google/logging/v2/logging.proto#L243}
    */
   StatusOr<google::logging::v2::WriteLogEntriesResponse> WriteLogEntries(
       google::logging::v2::WriteLogEntriesRequest const& request);
@@ -227,9 +227,9 @@ class LoggingServiceV2Client {
    * Logs](https://cloud.google.com/logging/docs/export).
    *
    * @param request
-   * [google::logging::v2::ListLogEntriesRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/logging/v2/logging.proto#L257)
+   * @googleapis_link{google::logging::v2::ListLogEntriesRequest,google/logging/v2/logging.proto#L257}
    * @return
-   * [google::logging::v2::LogEntry](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/logging/v2/log_entry.proto#L42)
+   * @googleapis_link{google::logging::v2::LogEntry,google/logging/v2/log_entry.proto#L42}
    */
   StreamRange<google::logging::v2::LogEntry> ListLogEntries(
       google::logging::v2::ListLogEntriesRequest request);
@@ -238,9 +238,9 @@ class LoggingServiceV2Client {
    * Lists the descriptors for monitored resource types used by Logging.
    *
    * @param request
-   * [google::logging::v2::ListMonitoredResourceDescriptorsRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/logging/v2/logging.proto#L331)
+   * @googleapis_link{google::logging::v2::ListMonitoredResourceDescriptorsRequest,google/logging/v2/logging.proto#L331}
    * @return
-   * [google::api::MonitoredResourceDescriptor](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/api/monitored_resource.proto#L40)
+   * @googleapis_link{google::api::MonitoredResourceDescriptor,google/api/monitored_resource.proto#L40}
    */
   StreamRange<google::api::MonitoredResourceDescriptor>
   ListMonitoredResourceDescriptors(
@@ -251,7 +251,7 @@ class LoggingServiceV2Client {
    * Only logs that have entries are listed.
    *
    * @param request
-   * [google::logging::v2::ListLogsRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/logging/v2/logging.proto#L356)
+   * @googleapis_link{google::logging::v2::ListLogsRequest,google/logging/v2/logging.proto#L356}
    * @return std::string
    */
   StreamRange<std::string> ListLogs(

--- a/google/cloud/pubsub/CMakeLists.txt
+++ b/google/cloud/pubsub/CMakeLists.txt
@@ -14,6 +14,7 @@
 # limitations under the License.
 # ~~~
 
+include(GoogleapisConfig)
 set(DOXYGEN_PROJECT_NAME "Google Cloud Pub/Sub C++ Client")
 set(DOXYGEN_PROJECT_BRIEF "A C++ Client Library for Google Cloud Pub/Sub")
 set(DOXYGEN_PROJECT_NUMBER "${PROJECT_VERSION}")

--- a/google/cloud/pubsublite/CMakeLists.txt
+++ b/google/cloud/pubsublite/CMakeLists.txt
@@ -14,6 +14,7 @@
 # limitations under the License.
 # ~~~
 
+include(GoogleapisConfig)
 set(DOXYGEN_PROJECT_NAME "Cloud Pub/Sub Lite C++ Client")
 set(DOXYGEN_PROJECT_BRIEF "A C++ Client Library for Cloud Pub/Sub Lite")
 set(DOXYGEN_PROJECT_NUMBER "${PROJECT_VERSION} (Beta)")

--- a/google/cloud/pubsublite/admin_client.h
+++ b/google/cloud/pubsublite/admin_client.h
@@ -73,7 +73,7 @@ class AdminServiceClient {
    * the final component of the topic's name. This value is structured like:
    * `my-topic-name`.
    * @return
-   * [google::cloud::pubsublite::v1::Topic](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/cloud/pubsublite/v1/common.proto#L102)
+   * [google::cloud::pubsublite::v1::Topic](@googleapis_link{google/cloud/pubsublite/v1/common.proto#L102})
    */
   StatusOr<google::cloud::pubsublite::v1::Topic> CreateTopic(
       std::string const& parent,
@@ -85,7 +85,7 @@ class AdminServiceClient {
    *
    * @param name  Required. The name of the topic whose configuration to return.
    * @return
-   * [google::cloud::pubsublite::v1::Topic](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/cloud/pubsublite/v1/common.proto#L102)
+   * [google::cloud::pubsublite::v1::Topic](@googleapis_link{google/cloud/pubsublite/v1/common.proto#L102})
    */
   StatusOr<google::cloud::pubsublite::v1::Topic> GetTopic(
       std::string const& name);
@@ -95,7 +95,7 @@ class AdminServiceClient {
    *
    * @param name  Required. The topic whose partition information to return.
    * @return
-   * [google::cloud::pubsublite::v1::TopicPartitions](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/cloud/pubsublite/v1/admin.proto#L270)
+   * [google::cloud::pubsublite::v1::TopicPartitions](@googleapis_link{google/cloud/pubsublite/v1/admin.proto#L270})
    */
   StatusOr<google::cloud::pubsublite::v1::TopicPartitions> GetTopicPartitions(
       std::string const& name);
@@ -106,7 +106,7 @@ class AdminServiceClient {
    * @param parent  Required. The parent whose topics are to be listed.
    *  Structured like `projects/{project_number}/locations/{location}`.
    * @return
-   * [google::cloud::pubsublite::v1::Topic](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/cloud/pubsublite/v1/common.proto#L102)
+   * [google::cloud::pubsublite::v1::Topic](@googleapis_link{google/cloud/pubsublite/v1/common.proto#L102})
    */
   StreamRange<google::cloud::pubsublite::v1::Topic> ListTopics(
       std::string const& parent);
@@ -118,7 +118,7 @@ class AdminServiceClient {
    * populated.
    * @param update_mask  Required. A mask specifying the topic fields to change.
    * @return
-   * [google::cloud::pubsublite::v1::Topic](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/cloud/pubsublite/v1/common.proto#L102)
+   * [google::cloud::pubsublite::v1::Topic](@googleapis_link{google/cloud/pubsublite/v1/common.proto#L102})
    */
   StatusOr<google::cloud::pubsublite::v1::Topic> UpdateTopic(
       google::cloud::pubsublite::v1::Topic const& topic,
@@ -151,7 +151,7 @@ class AdminServiceClient {
    * will become the final component of the subscription's name. This value is
    * structured like: `my-sub-name`.
    * @return
-   * [google::cloud::pubsublite::v1::Subscription](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/cloud/pubsublite/v1/common.proto#L186)
+   * [google::cloud::pubsublite::v1::Subscription](@googleapis_link{google/cloud/pubsublite/v1/common.proto#L186})
    */
   StatusOr<google::cloud::pubsublite::v1::Subscription> CreateSubscription(
       std::string const& parent,
@@ -164,7 +164,7 @@ class AdminServiceClient {
    * @param name  Required. The name of the subscription whose configuration to
    * return.
    * @return
-   * [google::cloud::pubsublite::v1::Subscription](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/cloud/pubsublite/v1/common.proto#L186)
+   * [google::cloud::pubsublite::v1::Subscription](@googleapis_link{google/cloud/pubsublite/v1/common.proto#L186})
    */
   StatusOr<google::cloud::pubsublite::v1::Subscription> GetSubscription(
       std::string const& name);
@@ -175,7 +175,7 @@ class AdminServiceClient {
    * @param parent  Required. The parent whose subscriptions are to be listed.
    *  Structured like `projects/{project_number}/locations/{location}`.
    * @return
-   * [google::cloud::pubsublite::v1::Subscription](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/cloud/pubsublite/v1/common.proto#L186)
+   * [google::cloud::pubsublite::v1::Subscription](@googleapis_link{google/cloud/pubsublite/v1/common.proto#L186})
    */
   StreamRange<google::cloud::pubsublite::v1::Subscription> ListSubscriptions(
       std::string const& parent);
@@ -188,7 +188,7 @@ class AdminServiceClient {
    * @param update_mask  Required. A mask specifying the subscription fields to
    * change.
    * @return
-   * [google::cloud::pubsublite::v1::Subscription](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/cloud/pubsublite/v1/common.proto#L186)
+   * [google::cloud::pubsublite::v1::Subscription](@googleapis_link{google/cloud/pubsublite/v1/common.proto#L186})
    */
   StatusOr<google::cloud::pubsublite::v1::Subscription> UpdateSubscription(
       google::cloud::pubsublite::v1::Subscription const& subscription,
@@ -213,7 +213,7 @@ class AdminServiceClient {
    * will become the final component of the reservation's name. This value is
    * structured like: `my-reservation-name`.
    * @return
-   * [google::cloud::pubsublite::v1::Reservation](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/cloud/pubsublite/v1/common.proto#L80)
+   * [google::cloud::pubsublite::v1::Reservation](@googleapis_link{google/cloud/pubsublite/v1/common.proto#L80})
    */
   StatusOr<google::cloud::pubsublite::v1::Reservation> CreateReservation(
       std::string const& parent,
@@ -227,7 +227,7 @@ class AdminServiceClient {
    * return. Structured like:
    *  projects/{project_number}/locations/{location}/reservations/{reservation_id}
    * @return
-   * [google::cloud::pubsublite::v1::Reservation](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/cloud/pubsublite/v1/common.proto#L80)
+   * [google::cloud::pubsublite::v1::Reservation](@googleapis_link{google/cloud/pubsublite/v1/common.proto#L80})
    */
   StatusOr<google::cloud::pubsublite::v1::Reservation> GetReservation(
       std::string const& name);
@@ -238,7 +238,7 @@ class AdminServiceClient {
    * @param parent  Required. The parent whose reservations are to be listed.
    *  Structured like `projects/{project_number}/locations/{location}`.
    * @return
-   * [google::cloud::pubsublite::v1::Reservation](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/cloud/pubsublite/v1/common.proto#L80)
+   * [google::cloud::pubsublite::v1::Reservation](@googleapis_link{google/cloud/pubsublite/v1/common.proto#L80})
    */
   StreamRange<google::cloud::pubsublite::v1::Reservation> ListReservations(
       std::string const& parent);
@@ -251,7 +251,7 @@ class AdminServiceClient {
    * @param update_mask  Required. A mask specifying the reservation fields to
    * change.
    * @return
-   * [google::cloud::pubsublite::v1::Reservation](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/cloud/pubsublite/v1/common.proto#L80)
+   * [google::cloud::pubsublite::v1::Reservation](@googleapis_link{google/cloud/pubsublite/v1/common.proto#L80})
    */
   StatusOr<google::cloud::pubsublite::v1::Reservation> UpdateReservation(
       google::cloud::pubsublite::v1::Reservation const& reservation,
@@ -280,9 +280,9 @@ class AdminServiceClient {
    * Creates a new topic.
    *
    * @param request
-   * [google::cloud::pubsublite::v1::CreateTopicRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/cloud/pubsublite/v1/admin.proto#L227)
+   * [google::cloud::pubsublite::v1::CreateTopicRequest](@googleapis_link{google/cloud/pubsublite/v1/admin.proto#L227})
    * @return
-   * [google::cloud::pubsublite::v1::Topic](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/cloud/pubsublite/v1/common.proto#L102)
+   * [google::cloud::pubsublite::v1::Topic](@googleapis_link{google/cloud/pubsublite/v1/common.proto#L102})
    */
   StatusOr<google::cloud::pubsublite::v1::Topic> CreateTopic(
       google::cloud::pubsublite::v1::CreateTopicRequest const& request);
@@ -291,9 +291,9 @@ class AdminServiceClient {
    * Returns the topic configuration.
    *
    * @param request
-   * [google::cloud::pubsublite::v1::GetTopicRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/cloud/pubsublite/v1/admin.proto#L248)
+   * [google::cloud::pubsublite::v1::GetTopicRequest](@googleapis_link{google/cloud/pubsublite/v1/admin.proto#L248})
    * @return
-   * [google::cloud::pubsublite::v1::Topic](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/cloud/pubsublite/v1/common.proto#L102)
+   * [google::cloud::pubsublite::v1::Topic](@googleapis_link{google/cloud/pubsublite/v1/common.proto#L102})
    */
   StatusOr<google::cloud::pubsublite::v1::Topic> GetTopic(
       google::cloud::pubsublite::v1::GetTopicRequest const& request);
@@ -302,9 +302,9 @@ class AdminServiceClient {
    * Returns the partition information for the requested topic.
    *
    * @param request
-   * [google::cloud::pubsublite::v1::GetTopicPartitionsRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/cloud/pubsublite/v1/admin.proto#L259)
+   * [google::cloud::pubsublite::v1::GetTopicPartitionsRequest](@googleapis_link{google/cloud/pubsublite/v1/admin.proto#L259})
    * @return
-   * [google::cloud::pubsublite::v1::TopicPartitions](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/cloud/pubsublite/v1/admin.proto#L270)
+   * [google::cloud::pubsublite::v1::TopicPartitions](@googleapis_link{google/cloud/pubsublite/v1/admin.proto#L270})
    */
   StatusOr<google::cloud::pubsublite::v1::TopicPartitions> GetTopicPartitions(
       google::cloud::pubsublite::v1::GetTopicPartitionsRequest const& request);
@@ -313,9 +313,9 @@ class AdminServiceClient {
    * Returns the list of topics for the given project.
    *
    * @param request
-   * [google::cloud::pubsublite::v1::ListTopicsRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/cloud/pubsublite/v1/admin.proto#L276)
+   * [google::cloud::pubsublite::v1::ListTopicsRequest](@googleapis_link{google/cloud/pubsublite/v1/admin.proto#L276})
    * @return
-   * [google::cloud::pubsublite::v1::Topic](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/cloud/pubsublite/v1/common.proto#L102)
+   * [google::cloud::pubsublite::v1::Topic](@googleapis_link{google/cloud/pubsublite/v1/common.proto#L102})
    */
   StreamRange<google::cloud::pubsublite::v1::Topic> ListTopics(
       google::cloud::pubsublite::v1::ListTopicsRequest request);
@@ -324,9 +324,9 @@ class AdminServiceClient {
    * Updates properties of the specified topic.
    *
    * @param request
-   * [google::cloud::pubsublite::v1::UpdateTopicRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/cloud/pubsublite/v1/admin.proto#L311)
+   * [google::cloud::pubsublite::v1::UpdateTopicRequest](@googleapis_link{google/cloud/pubsublite/v1/admin.proto#L311})
    * @return
-   * [google::cloud::pubsublite::v1::Topic](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/cloud/pubsublite/v1/common.proto#L102)
+   * [google::cloud::pubsublite::v1::Topic](@googleapis_link{google/cloud/pubsublite/v1/common.proto#L102})
    */
   StatusOr<google::cloud::pubsublite::v1::Topic> UpdateTopic(
       google::cloud::pubsublite::v1::UpdateTopicRequest const& request);
@@ -335,7 +335,7 @@ class AdminServiceClient {
    * Deletes the specified topic.
    *
    * @param request
-   * [google::cloud::pubsublite::v1::DeleteTopicRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/cloud/pubsublite/v1/admin.proto#L320)
+   * [google::cloud::pubsublite::v1::DeleteTopicRequest](@googleapis_link{google/cloud/pubsublite/v1/admin.proto#L320})
    */
   Status DeleteTopic(
       google::cloud::pubsublite::v1::DeleteTopicRequest const& request);
@@ -344,7 +344,7 @@ class AdminServiceClient {
    * Lists the subscriptions attached to the specified topic.
    *
    * @param request
-   * [google::cloud::pubsublite::v1::ListTopicSubscriptionsRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/cloud/pubsublite/v1/admin.proto#L331)
+   * [google::cloud::pubsublite::v1::ListTopicSubscriptionsRequest](@googleapis_link{google/cloud/pubsublite/v1/admin.proto#L331})
    * @return std::string
    */
   StreamRange<std::string> ListTopicSubscriptions(
@@ -354,9 +354,9 @@ class AdminServiceClient {
    * Creates a new subscription.
    *
    * @param request
-   * [google::cloud::pubsublite::v1::CreateSubscriptionRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/cloud/pubsublite/v1/admin.proto#L365)
+   * [google::cloud::pubsublite::v1::CreateSubscriptionRequest](@googleapis_link{google/cloud/pubsublite/v1/admin.proto#L365})
    * @return
-   * [google::cloud::pubsublite::v1::Subscription](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/cloud/pubsublite/v1/common.proto#L186)
+   * [google::cloud::pubsublite::v1::Subscription](@googleapis_link{google/cloud/pubsublite/v1/common.proto#L186})
    */
   StatusOr<google::cloud::pubsublite::v1::Subscription> CreateSubscription(
       google::cloud::pubsublite::v1::CreateSubscriptionRequest const& request);
@@ -365,9 +365,9 @@ class AdminServiceClient {
    * Returns the subscription configuration.
    *
    * @param request
-   * [google::cloud::pubsublite::v1::GetSubscriptionRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/cloud/pubsublite/v1/admin.proto#L391)
+   * [google::cloud::pubsublite::v1::GetSubscriptionRequest](@googleapis_link{google/cloud/pubsublite/v1/admin.proto#L391})
    * @return
-   * [google::cloud::pubsublite::v1::Subscription](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/cloud/pubsublite/v1/common.proto#L186)
+   * [google::cloud::pubsublite::v1::Subscription](@googleapis_link{google/cloud/pubsublite/v1/common.proto#L186})
    */
   StatusOr<google::cloud::pubsublite::v1::Subscription> GetSubscription(
       google::cloud::pubsublite::v1::GetSubscriptionRequest const& request);
@@ -376,9 +376,9 @@ class AdminServiceClient {
    * Returns the list of subscriptions for the given project.
    *
    * @param request
-   * [google::cloud::pubsublite::v1::ListSubscriptionsRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/cloud/pubsublite/v1/admin.proto#L402)
+   * [google::cloud::pubsublite::v1::ListSubscriptionsRequest](@googleapis_link{google/cloud/pubsublite/v1/admin.proto#L402})
    * @return
-   * [google::cloud::pubsublite::v1::Subscription](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/cloud/pubsublite/v1/common.proto#L186)
+   * [google::cloud::pubsublite::v1::Subscription](@googleapis_link{google/cloud/pubsublite/v1/common.proto#L186})
    */
   StreamRange<google::cloud::pubsublite::v1::Subscription> ListSubscriptions(
       google::cloud::pubsublite::v1::ListSubscriptionsRequest request);
@@ -387,9 +387,9 @@ class AdminServiceClient {
    * Updates properties of the specified subscription.
    *
    * @param request
-   * [google::cloud::pubsublite::v1::UpdateSubscriptionRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/cloud/pubsublite/v1/admin.proto#L437)
+   * [google::cloud::pubsublite::v1::UpdateSubscriptionRequest](@googleapis_link{google/cloud/pubsublite/v1/admin.proto#L437})
    * @return
-   * [google::cloud::pubsublite::v1::Subscription](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/cloud/pubsublite/v1/common.proto#L186)
+   * [google::cloud::pubsublite::v1::Subscription](@googleapis_link{google/cloud/pubsublite/v1/common.proto#L186})
    */
   StatusOr<google::cloud::pubsublite::v1::Subscription> UpdateSubscription(
       google::cloud::pubsublite::v1::UpdateSubscriptionRequest const& request);
@@ -398,7 +398,7 @@ class AdminServiceClient {
    * Deletes the specified subscription.
    *
    * @param request
-   * [google::cloud::pubsublite::v1::DeleteSubscriptionRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/cloud/pubsublite/v1/admin.proto#L447)
+   * [google::cloud::pubsublite::v1::DeleteSubscriptionRequest](@googleapis_link{google/cloud/pubsublite/v1/admin.proto#L447})
    */
   Status DeleteSubscription(
       google::cloud::pubsublite::v1::DeleteSubscriptionRequest const& request);
@@ -427,9 +427,9 @@ class AdminServiceClient {
    * and the new invocation of seek will supersede it.
    *
    * @param request
-   * [google::cloud::pubsublite::v1::SeekSubscriptionRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/cloud/pubsublite/v1/admin.proto#L458)
+   * [google::cloud::pubsublite::v1::SeekSubscriptionRequest](@googleapis_link{google/cloud/pubsublite/v1/admin.proto#L458})
    * @return
-   * [google::cloud::pubsublite::v1::SeekSubscriptionResponse](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/cloud/pubsublite/v1/admin.proto#L493)
+   * [google::cloud::pubsublite::v1::SeekSubscriptionResponse](@googleapis_link{google/cloud/pubsublite/v1/admin.proto#L493})
    */
   future<StatusOr<google::cloud::pubsublite::v1::SeekSubscriptionResponse>>
   SeekSubscription(
@@ -439,9 +439,9 @@ class AdminServiceClient {
    * Creates a new reservation.
    *
    * @param request
-   * [google::cloud::pubsublite::v1::CreateReservationRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/cloud/pubsublite/v1/admin.proto#L516)
+   * [google::cloud::pubsublite::v1::CreateReservationRequest](@googleapis_link{google/cloud/pubsublite/v1/admin.proto#L516})
    * @return
-   * [google::cloud::pubsublite::v1::Reservation](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/cloud/pubsublite/v1/common.proto#L80)
+   * [google::cloud::pubsublite::v1::Reservation](@googleapis_link{google/cloud/pubsublite/v1/common.proto#L80})
    */
   StatusOr<google::cloud::pubsublite::v1::Reservation> CreateReservation(
       google::cloud::pubsublite::v1::CreateReservationRequest const& request);
@@ -450,9 +450,9 @@ class AdminServiceClient {
    * Returns the reservation configuration.
    *
    * @param request
-   * [google::cloud::pubsublite::v1::GetReservationRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/cloud/pubsublite/v1/admin.proto#L537)
+   * [google::cloud::pubsublite::v1::GetReservationRequest](@googleapis_link{google/cloud/pubsublite/v1/admin.proto#L537})
    * @return
-   * [google::cloud::pubsublite::v1::Reservation](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/cloud/pubsublite/v1/common.proto#L80)
+   * [google::cloud::pubsublite::v1::Reservation](@googleapis_link{google/cloud/pubsublite/v1/common.proto#L80})
    */
   StatusOr<google::cloud::pubsublite::v1::Reservation> GetReservation(
       google::cloud::pubsublite::v1::GetReservationRequest const& request);
@@ -461,9 +461,9 @@ class AdminServiceClient {
    * Returns the list of reservations for the given project.
    *
    * @param request
-   * [google::cloud::pubsublite::v1::ListReservationsRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/cloud/pubsublite/v1/admin.proto#L550)
+   * [google::cloud::pubsublite::v1::ListReservationsRequest](@googleapis_link{google/cloud/pubsublite/v1/admin.proto#L550})
    * @return
-   * [google::cloud::pubsublite::v1::Reservation](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/cloud/pubsublite/v1/common.proto#L80)
+   * [google::cloud::pubsublite::v1::Reservation](@googleapis_link{google/cloud/pubsublite/v1/common.proto#L80})
    */
   StreamRange<google::cloud::pubsublite::v1::Reservation> ListReservations(
       google::cloud::pubsublite::v1::ListReservationsRequest request);
@@ -472,9 +472,9 @@ class AdminServiceClient {
    * Updates properties of the specified reservation.
    *
    * @param request
-   * [google::cloud::pubsublite::v1::UpdateReservationRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/cloud/pubsublite/v1/admin.proto#L585)
+   * [google::cloud::pubsublite::v1::UpdateReservationRequest](@googleapis_link{google/cloud/pubsublite/v1/admin.proto#L585})
    * @return
-   * [google::cloud::pubsublite::v1::Reservation](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/cloud/pubsublite/v1/common.proto#L80)
+   * [google::cloud::pubsublite::v1::Reservation](@googleapis_link{google/cloud/pubsublite/v1/common.proto#L80})
    */
   StatusOr<google::cloud::pubsublite::v1::Reservation> UpdateReservation(
       google::cloud::pubsublite::v1::UpdateReservationRequest const& request);
@@ -483,7 +483,7 @@ class AdminServiceClient {
    * Deletes the specified reservation.
    *
    * @param request
-   * [google::cloud::pubsublite::v1::DeleteReservationRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/cloud/pubsublite/v1/admin.proto#L594)
+   * [google::cloud::pubsublite::v1::DeleteReservationRequest](@googleapis_link{google/cloud/pubsublite/v1/admin.proto#L594})
    */
   Status DeleteReservation(
       google::cloud::pubsublite::v1::DeleteReservationRequest const& request);
@@ -492,7 +492,7 @@ class AdminServiceClient {
    * Lists the topics attached to the specified reservation.
    *
    * @param request
-   * [google::cloud::pubsublite::v1::ListReservationTopicsRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/cloud/pubsublite/v1/admin.proto#L607)
+   * [google::cloud::pubsublite::v1::ListReservationTopicsRequest](@googleapis_link{google/cloud/pubsublite/v1/admin.proto#L607})
    * @return std::string
    */
   StreamRange<std::string> ListReservationTopics(

--- a/google/cloud/spanner/CMakeLists.txt
+++ b/google/cloud/spanner/CMakeLists.txt
@@ -16,6 +16,7 @@
 
 find_package(absl CONFIG REQUIRED)
 
+include(GoogleapisConfig)
 set(DOXYGEN_PROJECT_NAME "Google Cloud Spanner C++ Client")
 set(DOXYGEN_PROJECT_BRIEF "A C++ Client Library for Google Cloud Spanner")
 set(DOXYGEN_PROJECT_NUMBER "${PROJECT_VERSION}")

--- a/google/cloud/spanner/admin/database_admin_client.h
+++ b/google/cloud/spanner/admin/database_admin_client.h
@@ -74,7 +74,7 @@ class DatabaseAdminClient {
    * @param parent  Required. The instance whose databases should be listed.
    *  Values are of the form `projects/<project>/instances/<instance>`.
    * @return
-   * [google::spanner::admin::database::v1::Database](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/spanner/admin/database/v1/spanner_database_admin.proto#L326)
+   * @googleapis_link{google::spanner::admin::database::v1::Database,google/spanner/admin/database/v1/spanner_database_admin.proto#L326}
    */
   StreamRange<google::spanner::admin::database::v1::Database> ListDatabases(
       std::string const& parent);
@@ -98,7 +98,7 @@ class DatabaseAdminClient {
    *  If the database ID is a reserved word or if it contains a hyphen, the
    *  database ID must be enclosed in backticks (`` ` ``).
    * @return
-   * [google::spanner::admin::database::v1::Database](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/spanner/admin/database/v1/spanner_database_admin.proto#L326)
+   * @googleapis_link{google::spanner::admin::database::v1::Database,google/spanner/admin/database/v1/spanner_database_admin.proto#L326}
    */
   future<StatusOr<google::spanner::admin::database::v1::Database>>
   CreateDatabase(std::string const& parent,
@@ -110,7 +110,7 @@ class DatabaseAdminClient {
    * @param name  Required. The name of the requested database. Values are of
    * the form `projects/<project>/instances/<instance>/databases/<database>`.
    * @return
-   * [google::spanner::admin::database::v1::Database](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/spanner/admin/database/v1/spanner_database_admin.proto#L326)
+   * @googleapis_link{google::spanner::admin::database::v1::Database,google/spanner/admin/database/v1/spanner_database_admin.proto#L326}
    */
   StatusOr<google::spanner::admin::database::v1::Database> GetDatabase(
       std::string const& name);
@@ -128,7 +128,7 @@ class DatabaseAdminClient {
    * @param database  Required. The database to update.
    * @param statements  Required. DDL statements to be applied to the database.
    * @return
-   * [google::spanner::admin::database::v1::UpdateDatabaseDdlMetadata](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/spanner/admin/database/v1/spanner_database_admin.proto#L547)
+   * @googleapis_link{google::spanner::admin::database::v1::UpdateDatabaseDdlMetadata,google/spanner/admin/database/v1/spanner_database_admin.proto#L547}
    */
   future<
       StatusOr<google::spanner::admin::database::v1::UpdateDatabaseDdlMetadata>>
@@ -153,7 +153,7 @@ class DatabaseAdminClient {
    *  Values are of the form
    *  `projects/<project>/instances/<instance>/databases/<database>`
    * @return
-   * [google::spanner::admin::database::v1::GetDatabaseDdlResponse](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/spanner/admin/database/v1/spanner_database_admin.proto#L603)
+   * @googleapis_link{google::spanner::admin::database::v1::GetDatabaseDdlResponse,google/spanner/admin/database/v1/spanner_database_admin.proto#L603}
    */
   StatusOr<google::spanner::admin::database::v1::GetDatabaseDdlResponse>
   GetDatabaseDdl(std::string const& database);
@@ -175,7 +175,7 @@ class DatabaseAdminClient {
    * policy is a valid policy but certain Cloud Platform services (such as
    * Projects) might reject them.
    * @return
-   * [google::iam::v1::Policy](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/iam/v1/policy.proto#L88)
+   * @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
    */
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
       std::string const& resource, google::iam::v1::Policy const& policy);
@@ -219,7 +219,7 @@ class DatabaseAdminClient {
    * requested. See the operation documentation for the appropriate value for
    * this field.
    * @return
-   * [google::iam::v1::Policy](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/iam/v1/policy.proto#L88)
+   * @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
    */
   StatusOr<google::iam::v1::Policy> GetIamPolicy(std::string const& resource);
 
@@ -243,7 +243,7 @@ class DatabaseAdminClient {
    * For more information see [IAM
    * Overview](https://cloud.google.com/iam/docs/overview#permissions).
    * @return
-   * [google::iam::v1::TestIamPermissionsResponse](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/iam/v1/iam_policy.proto#L141)
+   * @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
    */
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
       std::string const& resource, std::vector<std::string> const& permissions);
@@ -273,7 +273,7 @@ class DatabaseAdminClient {
    * `backup_id` appended to `parent` forms the full backup name of the form
    *  `projects/<project>/instances/<instance>/backups/<backup_id>`.
    * @return
-   * [google::spanner::admin::database::v1::Backup](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/spanner/admin/database/v1/backup.proto#L36)
+   * @googleapis_link{google::spanner::admin::database::v1::Backup,google/spanner/admin/database/v1/backup.proto#L36}
    */
   future<StatusOr<google::spanner::admin::database::v1::Backup>> CreateBackup(
       std::string const& parent,
@@ -288,7 +288,7 @@ class DatabaseAdminClient {
    *  Values are of the form
    *  `projects/<project>/instances/<instance>/backups/<backup>`.
    * @return
-   * [google::spanner::admin::database::v1::Backup](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/spanner/admin/database/v1/backup.proto#L36)
+   * @googleapis_link{google::spanner::admin::database::v1::Backup,google/spanner/admin/database/v1/backup.proto#L36}
    */
   StatusOr<google::spanner::admin::database::v1::Backup> GetBackup(
       std::string const& name);
@@ -307,7 +307,7 @@ class DatabaseAdminClient {
    * must always be specified; this prevents any future fields from being erased
    * accidentally by clients that do not know about them.
    * @return
-   * [google::spanner::admin::database::v1::Backup](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/spanner/admin/database/v1/backup.proto#L36)
+   * @googleapis_link{google::spanner::admin::database::v1::Backup,google/spanner/admin/database/v1/backup.proto#L36}
    */
   StatusOr<google::spanner::admin::database::v1::Backup> UpdateBackup(
       google::spanner::admin::database::v1::Backup const& backup,
@@ -331,7 +331,7 @@ class DatabaseAdminClient {
    * @param parent  Required. The instance to list backups from.  Values are of
    * the form `projects/<project>/instances/<instance>`.
    * @return
-   * [google::spanner::admin::database::v1::Backup](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/spanner/admin/database/v1/backup.proto#L36)
+   * @googleapis_link{google::spanner::admin::database::v1::Backup,google/spanner/admin/database/v1/backup.proto#L36}
    */
   StreamRange<google::spanner::admin::database::v1::Backup> ListBackups(
       std::string const& parent);
@@ -367,7 +367,7 @@ class DatabaseAdminClient {
    * @param backup  Name of the backup from which to restore.  Values are of the
    * form `projects/<project>/instances/<instance>/backups/<backup>`.
    * @return
-   * [google::spanner::admin::database::v1::Database](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/spanner/admin/database/v1/spanner_database_admin.proto#L326)
+   * @googleapis_link{google::spanner::admin::database::v1::Database,google/spanner/admin/database/v1/spanner_database_admin.proto#L326}
    */
   future<StatusOr<google::spanner::admin::database::v1::Database>>
   RestoreDatabase(std::string const& parent, std::string const& database_id,
@@ -386,7 +386,7 @@ class DatabaseAdminClient {
    * @param parent  Required. The instance of the database operations.
    *  Values are of the form `projects/<project>/instances/<instance>`.
    * @return
-   * [google::longrunning::Operation](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/longrunning/operations.proto#L128)
+   * @googleapis_link{google::longrunning::Operation,google/longrunning/operations.proto#L128}
    */
   StreamRange<google::longrunning::Operation> ListDatabaseOperations(
       std::string const& parent);
@@ -406,7 +406,7 @@ class DatabaseAdminClient {
    * @param parent  Required. The instance of the backup operations. Values are
    * of the form `projects/<project>/instances/<instance>`.
    * @return
-   * [google::longrunning::Operation](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/longrunning/operations.proto#L128)
+   * @googleapis_link{google::longrunning::Operation,google/longrunning/operations.proto#L128}
    */
   StreamRange<google::longrunning::Operation> ListBackupOperations(
       std::string const& parent);
@@ -415,9 +415,9 @@ class DatabaseAdminClient {
    * Lists Cloud Spanner databases.
    *
    * @param request
-   * [google::spanner::admin::database::v1::ListDatabasesRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/spanner/admin/database/v1/spanner_database_admin.proto#L413)
+   * @googleapis_link{google::spanner::admin::database::v1::ListDatabasesRequest,google/spanner/admin/database/v1/spanner_database_admin.proto#L413}
    * @return
-   * [google::spanner::admin::database::v1::Database](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/spanner/admin/database/v1/spanner_database_admin.proto#L326)
+   * @googleapis_link{google::spanner::admin::database::v1::Database,google/spanner/admin/database/v1/spanner_database_admin.proto#L326}
    */
   StreamRange<google::spanner::admin::database::v1::Database> ListDatabases(
       google::spanner::admin::database::v1::ListDatabasesRequest request);
@@ -433,9 +433,9 @@ class DatabaseAdminClient {
    * [Database][google.spanner.admin.database.v1.Database], if successful.
    *
    * @param request
-   * [google::spanner::admin::database::v1::CreateDatabaseRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/spanner/admin/database/v1/spanner_database_admin.proto#L445)
+   * @googleapis_link{google::spanner::admin::database::v1::CreateDatabaseRequest,google/spanner/admin/database/v1/spanner_database_admin.proto#L445}
    * @return
-   * [google::spanner::admin::database::v1::Database](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/spanner/admin/database/v1/spanner_database_admin.proto#L326)
+   * @googleapis_link{google::spanner::admin::database::v1::Database,google/spanner/admin/database/v1/spanner_database_admin.proto#L326}
    */
   future<StatusOr<google::spanner::admin::database::v1::Database>>
   CreateDatabase(
@@ -446,9 +446,9 @@ class DatabaseAdminClient {
    * Gets the state of a Cloud Spanner database.
    *
    * @param request
-   * [google::spanner::admin::database::v1::GetDatabaseRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/spanner/admin/database/v1/spanner_database_admin.proto#L484)
+   * @googleapis_link{google::spanner::admin::database::v1::GetDatabaseRequest,google/spanner/admin/database/v1/spanner_database_admin.proto#L484}
    * @return
-   * [google::spanner::admin::database::v1::Database](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/spanner/admin/database/v1/spanner_database_admin.proto#L326)
+   * @googleapis_link{google::spanner::admin::database::v1::Database,google/spanner/admin/database/v1/spanner_database_admin.proto#L326}
    */
   StatusOr<google::spanner::admin::database::v1::Database> GetDatabase(
       google::spanner::admin::database::v1::GetDatabaseRequest const& request);
@@ -464,9 +464,9 @@ class DatabaseAdminClient {
    * The operation has no response.
    *
    * @param request
-   * [google::spanner::admin::database::v1::UpdateDatabaseDdlRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/spanner/admin/database/v1/spanner_database_admin.proto#L511)
+   * @googleapis_link{google::spanner::admin::database::v1::UpdateDatabaseDdlRequest,google/spanner/admin/database/v1/spanner_database_admin.proto#L511}
    * @return
-   * [google::spanner::admin::database::v1::UpdateDatabaseDdlMetadata](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/spanner/admin/database/v1/spanner_database_admin.proto#L547)
+   * @googleapis_link{google::spanner::admin::database::v1::UpdateDatabaseDdlMetadata,google/spanner/admin/database/v1/spanner_database_admin.proto#L547}
    */
   future<
       StatusOr<google::spanner::admin::database::v1::UpdateDatabaseDdlMetadata>>
@@ -480,7 +480,7 @@ class DatabaseAdminClient {
    * `expire_time`.
    *
    * @param request
-   * [google::spanner::admin::database::v1::DropDatabaseRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/spanner/admin/database/v1/spanner_database_admin.proto#L579)
+   * @googleapis_link{google::spanner::admin::database::v1::DropDatabaseRequest,google/spanner/admin/database/v1/spanner_database_admin.proto#L579}
    */
   Status DropDatabase(
       google::spanner::admin::database::v1::DropDatabaseRequest const& request);
@@ -491,9 +491,9 @@ class DatabaseAdminClient {
    * be queried using the [Operations][google.longrunning.Operations] API.
    *
    * @param request
-   * [google::spanner::admin::database::v1::GetDatabaseDdlRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/spanner/admin/database/v1/spanner_database_admin.proto#L590)
+   * @googleapis_link{google::spanner::admin::database::v1::GetDatabaseDdlRequest,google/spanner/admin/database/v1/spanner_database_admin.proto#L590}
    * @return
-   * [google::spanner::admin::database::v1::GetDatabaseDdlResponse](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/spanner/admin/database/v1/spanner_database_admin.proto#L603)
+   * @googleapis_link{google::spanner::admin::database::v1::GetDatabaseDdlResponse,google/spanner/admin/database/v1/spanner_database_admin.proto#L603}
    */
   StatusOr<google::spanner::admin::database::v1::GetDatabaseDdlResponse>
   GetDatabaseDdl(
@@ -510,9 +510,9 @@ class DatabaseAdminClient {
    * permission on [resource][google.iam.v1.SetIamPolicyRequest.resource].
    *
    * @param request
-   * [google::iam::v1::SetIamPolicyRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/iam/v1/iam_policy.proto#L98)
+   * @googleapis_link{google::iam::v1::SetIamPolicyRequest,google/iam/v1/iam_policy.proto#L98}
    * @return
-   * [google::iam::v1::Policy](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/iam/v1/policy.proto#L88)
+   * @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
    */
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
       google::iam::v1::SetIamPolicyRequest const& request);
@@ -528,9 +528,9 @@ class DatabaseAdminClient {
    * permission on [resource][google.iam.v1.GetIamPolicyRequest.resource].
    *
    * @param request
-   * [google::iam::v1::GetIamPolicyRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/iam/v1/iam_policy.proto#L113)
+   * @googleapis_link{google::iam::v1::GetIamPolicyRequest,google/iam/v1/iam_policy.proto#L113}
    * @return
-   * [google::iam::v1::Policy](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/iam/v1/policy.proto#L88)
+   * @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
    */
   StatusOr<google::iam::v1::Policy> GetIamPolicy(
       google::iam::v1::GetIamPolicyRequest const& request);
@@ -548,9 +548,9 @@ class DatabaseAdminClient {
    * `spanner.backups.list` permission on the containing instance.
    *
    * @param request
-   * [google::iam::v1::TestIamPermissionsRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/iam/v1/iam_policy.proto#L126)
+   * @googleapis_link{google::iam::v1::TestIamPermissionsRequest,google/iam/v1/iam_policy.proto#L126}
    * @return
-   * [google::iam::v1::TestIamPermissionsResponse](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/iam/v1/iam_policy.proto#L141)
+   * @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
    */
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
       google::iam::v1::TestIamPermissionsRequest const& request);
@@ -570,9 +570,9 @@ class DatabaseAdminClient {
    * creation of different databases can run concurrently.
    *
    * @param request
-   * [google::spanner::admin::database::v1::CreateBackupRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/spanner/admin/database/v1/backup.proto#L123)
+   * @googleapis_link{google::spanner::admin::database::v1::CreateBackupRequest,google/spanner/admin/database/v1/backup.proto#L123}
    * @return
-   * [google::spanner::admin::database::v1::Backup](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/spanner/admin/database/v1/backup.proto#L36)
+   * @googleapis_link{google::spanner::admin::database::v1::Backup,google/spanner/admin/database/v1/backup.proto#L36}
    */
   future<StatusOr<google::spanner::admin::database::v1::Backup>> CreateBackup(
       google::spanner::admin::database::v1::CreateBackupRequest const& request);
@@ -582,9 +582,9 @@ class DatabaseAdminClient {
    * [Backup][google.spanner.admin.database.v1.Backup].
    *
    * @param request
-   * [google::spanner::admin::database::v1::GetBackupRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/spanner/admin/database/v1/backup.proto#L202)
+   * @googleapis_link{google::spanner::admin::database::v1::GetBackupRequest,google/spanner/admin/database/v1/backup.proto#L202}
    * @return
-   * [google::spanner::admin::database::v1::Backup](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/spanner/admin/database/v1/backup.proto#L36)
+   * @googleapis_link{google::spanner::admin::database::v1::Backup,google/spanner/admin/database/v1/backup.proto#L36}
    */
   StatusOr<google::spanner::admin::database::v1::Backup> GetBackup(
       google::spanner::admin::database::v1::GetBackupRequest const& request);
@@ -594,9 +594,9 @@ class DatabaseAdminClient {
    * [Backup][google.spanner.admin.database.v1.Backup].
    *
    * @param request
-   * [google::spanner::admin::database::v1::UpdateBackupRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/spanner/admin/database/v1/backup.proto#L186)
+   * @googleapis_link{google::spanner::admin::database::v1::UpdateBackupRequest,google/spanner/admin/database/v1/backup.proto#L186}
    * @return
-   * [google::spanner::admin::database::v1::Backup](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/spanner/admin/database/v1/backup.proto#L36)
+   * @googleapis_link{google::spanner::admin::database::v1::Backup,google/spanner/admin/database/v1/backup.proto#L36}
    */
   StatusOr<google::spanner::admin::database::v1::Backup> UpdateBackup(
       google::spanner::admin::database::v1::UpdateBackupRequest const& request);
@@ -606,7 +606,7 @@ class DatabaseAdminClient {
    * [Backup][google.spanner.admin.database.v1.Backup].
    *
    * @param request
-   * [google::spanner::admin::database::v1::DeleteBackupRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/spanner/admin/database/v1/backup.proto#L215)
+   * @googleapis_link{google::spanner::admin::database::v1::DeleteBackupRequest,google/spanner/admin/database/v1/backup.proto#L215}
    */
   Status DeleteBackup(
       google::spanner::admin::database::v1::DeleteBackupRequest const& request);
@@ -617,9 +617,9 @@ class DatabaseAdminClient {
    * starting from the most recent `create_time`.
    *
    * @param request
-   * [google::spanner::admin::database::v1::ListBackupsRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/spanner/admin/database/v1/backup.proto#L228)
+   * @googleapis_link{google::spanner::admin::database::v1::ListBackupsRequest,google/spanner/admin/database/v1/backup.proto#L228}
    * @return
-   * [google::spanner::admin::database::v1::Backup](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/spanner/admin/database/v1/backup.proto#L36)
+   * @googleapis_link{google::spanner::admin::database::v1::Backup,google/spanner/admin/database/v1/backup.proto#L36}
    */
   StreamRange<google::spanner::admin::database::v1::Backup> ListBackups(
       google::spanner::admin::database::v1::ListBackupsRequest request);
@@ -644,9 +644,9 @@ class DatabaseAdminClient {
    * first restore to complete.
    *
    * @param request
-   * [google::spanner::admin::database::v1::RestoreDatabaseRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/spanner/admin/database/v1/spanner_database_admin.proto#L692)
+   * @googleapis_link{google::spanner::admin::database::v1::RestoreDatabaseRequest,google/spanner/admin/database/v1/spanner_database_admin.proto#L692}
    * @return
-   * [google::spanner::admin::database::v1::Database](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/spanner/admin/database/v1/spanner_database_admin.proto#L326)
+   * @googleapis_link{google::spanner::admin::database::v1::Database,google/spanner/admin/database/v1/spanner_database_admin.proto#L326}
    */
   future<StatusOr<google::spanner::admin::database::v1::Database>>
   RestoreDatabase(
@@ -664,9 +664,9 @@ class DatabaseAdminClient {
    * and pending operations.
    *
    * @param request
-   * [google::spanner::admin::database::v1::ListDatabaseOperationsRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/spanner/admin/database/v1/spanner_database_admin.proto#L611)
+   * @googleapis_link{google::spanner::admin::database::v1::ListDatabaseOperationsRequest,google/spanner/admin/database/v1/spanner_database_admin.proto#L611}
    * @return
-   * [google::longrunning::Operation](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/longrunning/operations.proto#L128)
+   * @googleapis_link{google::longrunning::Operation,google/longrunning/operations.proto#L128}
    */
   StreamRange<google::longrunning::Operation> ListDatabaseOperations(
       google::spanner::admin::database::v1::ListDatabaseOperationsRequest
@@ -685,9 +685,9 @@ class DatabaseAdminClient {
    * from the most recently started operation.
    *
    * @param request
-   * [google::spanner::admin::database::v1::ListBackupOperationsRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/spanner/admin/database/v1/backup.proto#L300)
+   * @googleapis_link{google::spanner::admin::database::v1::ListBackupOperationsRequest,google/spanner/admin/database/v1/backup.proto#L300}
    * @return
-   * [google::longrunning::Operation](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/longrunning/operations.proto#L128)
+   * @googleapis_link{google::longrunning::Operation,google/longrunning/operations.proto#L128}
    */
   StreamRange<google::longrunning::Operation> ListBackupOperations(
       google::spanner::admin::database::v1::ListBackupOperationsRequest

--- a/google/cloud/spanner/admin/instance_admin_client.h
+++ b/google/cloud/spanner/admin/instance_admin_client.h
@@ -91,7 +91,7 @@ class InstanceAdminClient {
    * supported instance configurations is requested. Values are of the form
    *  `projects/<project>`.
    * @return
-   * [google::spanner::admin::instance::v1::InstanceConfig](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/spanner/admin/instance/v1/spanner_instance_admin.proto#L304)
+   * @googleapis_link{google::spanner::admin::instance::v1::InstanceConfig,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L304}
    */
   StreamRange<google::spanner::admin::instance::v1::InstanceConfig>
   ListInstanceConfigs(std::string const& parent);
@@ -102,7 +102,7 @@ class InstanceAdminClient {
    * @param name  Required. The name of the requested instance configuration.
    * Values are of the form `projects/<project>/instanceConfigs/<config>`.
    * @return
-   * [google::spanner::admin::instance::v1::InstanceConfig](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/spanner/admin/instance/v1/spanner_instance_admin.proto#L304)
+   * @googleapis_link{google::spanner::admin::instance::v1::InstanceConfig,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L304}
    */
   StatusOr<google::spanner::admin::instance::v1::InstanceConfig>
   GetInstanceConfig(std::string const& name);
@@ -113,7 +113,7 @@ class InstanceAdminClient {
    * @param parent  Required. The name of the project for which a list of
    * instances is requested. Values are of the form `projects/<project>`.
    * @return
-   * [google::spanner::admin::instance::v1::Instance](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328)
+   * @googleapis_link{google::spanner::admin::instance::v1::Instance,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328}
    */
   StreamRange<google::spanner::admin::instance::v1::Instance> ListInstances(
       std::string const& parent);
@@ -124,7 +124,7 @@ class InstanceAdminClient {
    * @param name  Required. The name of the requested instance. Values are of
    * the form `projects/<project>/instances/<instance>`.
    * @return
-   * [google::spanner::admin::instance::v1::Instance](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328)
+   * @googleapis_link{google::spanner::admin::instance::v1::Instance,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328}
    */
   StatusOr<google::spanner::admin::instance::v1::Instance> GetInstance(
       std::string const& name);
@@ -173,7 +173,7 @@ class InstanceAdminClient {
    * @param instance  Required. The instance to create.  The name may be
    * omitted, but if specified must be `<parent>/instances/<instance_id>`.
    * @return
-   * [google::spanner::admin::instance::v1::Instance](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328)
+   * @googleapis_link{google::spanner::admin::instance::v1::Instance,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328}
    */
   future<StatusOr<google::spanner::admin::instance::v1::Instance>>
   CreateInstance(
@@ -232,7 +232,7 @@ class InstanceAdminClient {
    * in [Instance][google.spanner.admin.instance.v1.Instance] from being erased
    * accidentally by clients that do not know about them.
    * @return
-   * [google::spanner::admin::instance::v1::Instance](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328)
+   * @googleapis_link{google::spanner::admin::instance::v1::Instance,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328}
    */
   future<StatusOr<google::spanner::admin::instance::v1::Instance>>
   UpdateInstance(google::spanner::admin::instance::v1::Instance const& instance,
@@ -271,7 +271,7 @@ class InstanceAdminClient {
    * policy is a valid policy but certain Cloud Platform services (such as
    * Projects) might reject them.
    * @return
-   * [google::iam::v1::Policy](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/iam/v1/policy.proto#L88)
+   * @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
    */
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
       std::string const& resource, google::iam::v1::Policy const& policy);
@@ -312,7 +312,7 @@ class InstanceAdminClient {
    * requested. See the operation documentation for the appropriate value for
    * this field.
    * @return
-   * [google::iam::v1::Policy](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/iam/v1/policy.proto#L88)
+   * @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
    */
   StatusOr<google::iam::v1::Policy> GetIamPolicy(std::string const& resource);
 
@@ -332,7 +332,7 @@ class InstanceAdminClient {
    * For more information see [IAM
    * Overview](https://cloud.google.com/iam/docs/overview#permissions).
    * @return
-   * [google::iam::v1::TestIamPermissionsResponse](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/iam/v1/iam_policy.proto#L141)
+   * @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
    */
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
       std::string const& resource, std::vector<std::string> const& permissions);
@@ -341,9 +341,9 @@ class InstanceAdminClient {
    * Lists the supported instance configurations for a given project.
    *
    * @param request
-   * [google::spanner::admin::instance::v1::ListInstanceConfigsRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/spanner/admin/instance/v1/spanner_instance_admin.proto#L415)
+   * @googleapis_link{google::spanner::admin::instance::v1::ListInstanceConfigsRequest,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L415}
    * @return
-   * [google::spanner::admin::instance::v1::InstanceConfig](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/spanner/admin/instance/v1/spanner_instance_admin.proto#L304)
+   * @googleapis_link{google::spanner::admin::instance::v1::InstanceConfig,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L304}
    */
   StreamRange<google::spanner::admin::instance::v1::InstanceConfig>
   ListInstanceConfigs(
@@ -353,9 +353,9 @@ class InstanceAdminClient {
    * Gets information about a particular instance configuration.
    *
    * @param request
-   * [google::spanner::admin::instance::v1::GetInstanceConfigRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/spanner/admin/instance/v1/spanner_instance_admin.proto#L449)
+   * @googleapis_link{google::spanner::admin::instance::v1::GetInstanceConfigRequest,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L449}
    * @return
-   * [google::spanner::admin::instance::v1::InstanceConfig](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/spanner/admin/instance/v1/spanner_instance_admin.proto#L304)
+   * @googleapis_link{google::spanner::admin::instance::v1::InstanceConfig,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L304}
    */
   StatusOr<google::spanner::admin::instance::v1::InstanceConfig>
   GetInstanceConfig(
@@ -366,9 +366,9 @@ class InstanceAdminClient {
    * Lists all instances in the given project.
    *
    * @param request
-   * [google::spanner::admin::instance::v1::ListInstancesRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/spanner/admin/instance/v1/spanner_instance_admin.proto#L499)
+   * @googleapis_link{google::spanner::admin::instance::v1::ListInstancesRequest,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L499}
    * @return
-   * [google::spanner::admin::instance::v1::Instance](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328)
+   * @googleapis_link{google::spanner::admin::instance::v1::Instance,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328}
    */
   StreamRange<google::spanner::admin::instance::v1::Instance> ListInstances(
       google::spanner::admin::instance::v1::ListInstancesRequest request);
@@ -377,9 +377,9 @@ class InstanceAdminClient {
    * Gets information about a particular instance.
    *
    * @param request
-   * [google::spanner::admin::instance::v1::GetInstanceRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/spanner/admin/instance/v1/spanner_instance_admin.proto#L461)
+   * @googleapis_link{google::spanner::admin::instance::v1::GetInstanceRequest,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L461}
    * @return
-   * [google::spanner::admin::instance::v1::Instance](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328)
+   * @googleapis_link{google::spanner::admin::instance::v1::Instance,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328}
    */
   StatusOr<google::spanner::admin::instance::v1::Instance> GetInstance(
       google::spanner::admin::instance::v1::GetInstanceRequest const& request);
@@ -421,9 +421,9 @@ class InstanceAdminClient {
    * [Instance][google.spanner.admin.instance.v1.Instance], if successful.
    *
    * @param request
-   * [google::spanner::admin::instance::v1::CreateInstanceRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/spanner/admin/instance/v1/spanner_instance_admin.proto#L478)
+   * @googleapis_link{google::spanner::admin::instance::v1::CreateInstanceRequest,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L478}
    * @return
-   * [google::spanner::admin::instance::v1::Instance](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328)
+   * @googleapis_link{google::spanner::admin::instance::v1::Instance,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328}
    */
   future<StatusOr<google::spanner::admin::instance::v1::Instance>>
   CreateInstance(
@@ -473,9 +473,9 @@ class InstanceAdminClient {
    * resource [name][google.spanner.admin.instance.v1.Instance.name].
    *
    * @param request
-   * [google::spanner::admin::instance::v1::UpdateInstanceRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/spanner/admin/instance/v1/spanner_instance_admin.proto#L552)
+   * @googleapis_link{google::spanner::admin::instance::v1::UpdateInstanceRequest,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L552}
    * @return
-   * [google::spanner::admin::instance::v1::Instance](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328)
+   * @googleapis_link{google::spanner::admin::instance::v1::Instance,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328}
    */
   future<StatusOr<google::spanner::admin::instance::v1::Instance>>
   UpdateInstance(
@@ -496,7 +496,7 @@ class InstanceAdminClient {
    *     is permanently deleted.
    *
    * @param request
-   * [google::spanner::admin::instance::v1::DeleteInstanceRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/spanner/admin/instance/v1/spanner_instance_admin.proto#L565)
+   * @googleapis_link{google::spanner::admin::instance::v1::DeleteInstanceRequest,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L565}
    */
   Status DeleteInstance(
       google::spanner::admin::instance::v1::DeleteInstanceRequest const&
@@ -510,9 +510,9 @@ class InstanceAdminClient {
    * [resource][google.iam.v1.SetIamPolicyRequest.resource].
    *
    * @param request
-   * [google::iam::v1::SetIamPolicyRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/iam/v1/iam_policy.proto#L98)
+   * @googleapis_link{google::iam::v1::SetIamPolicyRequest,google/iam/v1/iam_policy.proto#L98}
    * @return
-   * [google::iam::v1::Policy](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/iam/v1/policy.proto#L88)
+   * @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
    */
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
       google::iam::v1::SetIamPolicyRequest const& request);
@@ -525,9 +525,9 @@ class InstanceAdminClient {
    * [resource][google.iam.v1.GetIamPolicyRequest.resource].
    *
    * @param request
-   * [google::iam::v1::GetIamPolicyRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/iam/v1/iam_policy.proto#L113)
+   * @googleapis_link{google::iam::v1::GetIamPolicyRequest,google/iam/v1/iam_policy.proto#L113}
    * @return
-   * [google::iam::v1::Policy](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/iam/v1/policy.proto#L88)
+   * @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
    */
   StatusOr<google::iam::v1::Policy> GetIamPolicy(
       google::iam::v1::GetIamPolicyRequest const& request);
@@ -541,9 +541,9 @@ class InstanceAdminClient {
    * empty set of permissions.
    *
    * @param request
-   * [google::iam::v1::TestIamPermissionsRequest](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/iam/v1/iam_policy.proto#L126)
+   * @googleapis_link{google::iam::v1::TestIamPermissionsRequest,google/iam/v1/iam_policy.proto#L126}
    * @return
-   * [google::iam::v1::TestIamPermissionsResponse](https://github.com/googleapis/googleapis/blob/53432afb877cb3c1920f73e6621daa8c24f86522/google/iam/v1/iam_policy.proto#L141)
+   * @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
    */
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
       google::iam::v1::TestIamPermissionsRequest const& request);

--- a/google/cloud/storage/CMakeLists.txt
+++ b/google/cloud/storage/CMakeLists.txt
@@ -16,6 +16,7 @@
 
 find_package(absl CONFIG REQUIRED)
 
+include(GoogleapisConfig)
 set(DOXYGEN_PROJECT_NAME "Google Cloud Storage C++ Client")
 set(DOXYGEN_PROJECT_BRIEF "A C++ Client Library for Google Cloud Storage")
 set(DOXYGEN_PROJECT_NUMBER "${PROJECT_VERSION}")


### PR DESCRIPTION
We want to minimize the number of changes when we change the commit SHA
for googleapis/googleapis.  With this change we use a Doxygen custom
command in the header files. The CMake file defines this command to
include the embedded SHA. The arguments to the command *should* be more
stable, but will change when proto definitions are moved in their
`.proto` file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7606)
<!-- Reviewable:end -->
