### PR TITLE
fix(generator): more precise matching of directories

### DIFF
--- a/generator/internal/scaffold_generator.cc
+++ b/generator/internal/scaffold_generator.cc
@@ -91,7 +91,7 @@ std::map<std::string, std::string> ScaffoldVars(
   std::map<std::string, std::string> vars;
   for (auto const& api : index["apis"]) {
     if (!api.contains("directory")) continue;
-    auto const directory = api["directory"].get<std::string>();
+    auto const directory = api["directory"].get<std::string>() + "/";
     if (service.service_proto_path().rfind(directory, 0) != 0) continue;
     vars.emplace("title", api.value("title", ""));
     vars.emplace("description", api.value("description", ""));


### PR DESCRIPTION
Some services have multiple variants, like `google/cloud/tasks/v2` and
`google/cloud/tasks/v2beta3`. This change prevents the second directory
to match as we search the JSON object for the entry containing a given
proto file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7611)
<!-- Reviewable:end -->
