### PR TITLE
refactor(common): Status ignores message if code==OK

### DIFF
--- a/google/cloud/status.h
+++ b/google/cloud/status.h
@@ -89,9 +89,8 @@ class Status {
    * Ignores @p message if @p code is `StatusCode::kOk`.
    */
   explicit Status(StatusCode code, std::string message)
-      : code_(code), message_(std::move(message)) {
-    if (ok()) message_.clear();
-  }
+      : code_(code),
+        message_(code_ == StatusCode::kOk ? "" : std::move(message)) {}
 
   bool ok() const { return code_ == StatusCode::kOk; }
   StatusCode code() const { return code_; }

--- a/google/cloud/status.h
+++ b/google/cloud/status.h
@@ -68,11 +68,12 @@ absl::optional<std::string> GetPayload(Status const&, std::string const& key);
 
  * This class is typically used to indicate whether or not a function or other
  * operation completed successfully. Success is indicated by an "OK" status
- * (`StatusCode::kOk`), and the `.ok()` method will return true. Any non-OK
- * `Status` is considered an error. Users can inspect the error using the
- * `.code()` and `.message()` member functions, or they can simply stream the
- * `Status` object, and it will print itself in some human readable way (the
- * streamed format may change over time and you should *not* depend on the
+ * (`StatusCode::kOk`), and the `.ok()` method will return true. OK statuses
+ * will have an empty `.message()`, and all OK statuses are equivalent. Any
+ * non-OK `Status` is considered an error. Users can inspect the error using
+ * the `.code()` and `.message()` member functions, or they can simply stream
+ * the `Status` object, and it will print itself in some human readable way
+ * (the streamed format may change over time and you should *not* depend on the
  * specific format of a streamed `Status` object remaining unchanged).
  *
  * This is a regular value type that can be copied, moved, compared for
@@ -82,8 +83,15 @@ class Status {
  public:
   Status() = default;
 
-  explicit Status(StatusCode status_code, std::string message)
-      : code_(status_code), message_(std::move(message)) {}
+  /**
+   * Constructs a Status with the given @p code and @p message.
+   *
+   * Ignores @p message if @p code is `StatusCode::kOk`.
+   */
+  explicit Status(StatusCode code, std::string message)
+      : code_(code), message_(std::move(message)) {
+    if (ok()) message_.clear();
+  }
 
   bool ok() const { return code_ == StatusCode::kOk; }
   StatusCode code() const { return code_; }

--- a/google/cloud/status_test.cc
+++ b/google/cloud/status_test.cc
@@ -57,6 +57,12 @@ TEST(Status, Basics) {
   EXPECT_EQ(s.message(), "");
   EXPECT_EQ(s, Status());
 
+  // The message is ignored on OK statues.
+  auto ok = Status(StatusCode::kOk, "message ignored");
+  EXPECT_EQ(s, ok);
+  EXPECT_EQ("", ok.message());
+  EXPECT_EQ(StatusCode::kOk, ok.code());
+
   s = Status(StatusCode::kUnknown, "foo");
   EXPECT_FALSE(s.ok());
   EXPECT_EQ(s.code(), StatusCode::kUnknown);


### PR DESCRIPTION
With this PR, `google::cloud::Status` now ignores the `message` it's constructed with if the `code` is OK. This behavior matches `absl::Status` (which we don't use, but FWIW). We believe the previous behavior where the message was _not_ dropped on OK statuses was a bug, because that can result in "OK" Statuses being not equal. Consider:

```cc
Status ok1{StatusCode::kOk, ""};
Status ok2{StatusCode::kOk, "blah"};
assert(ok1.ok() && ok2.ok());
assert(ok1 != ok2);  // OLD BEHAVIOR -- CONSIDERED A BUG
assert(ok1 == ok2);  // NEW BEHAVIOR -- ALL OKs ARE EQUIVALENT
```
This new behavior differs from `grpc::Status`, which _does_ allow message strings on an OK status. But I imagine this is an oversight due to how it was implemented, and not actually desired behavior.

Requiring that all OK statuses are equivalent enables certain simplifications and optimizations, which we would like to enable.

Note: We (and Abseil) already disallow Status "payloads" on OK statuses.


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7622)
<!-- Reviewable:end -->
