### PR TITLE
test(spanner): expand use of test instance labelling

### DIFF
--- a/google/cloud/spanner/admin/integration_tests/backup_extra_integration_test.cc
+++ b/google/cloud/spanner/admin/integration_tests/backup_extra_integration_test.cc
@@ -107,7 +107,8 @@ TEST_F(BackupExtraIntegrationTest, CreateBackupWithVersionTime) {
 
   auto instance_id = spanner_testing::PickRandomInstance(
       generator_, ProjectId(),
-      "labels.restore-database-partition:generated-extra");
+      "(labels.restore-database-partition:generated-extra OR"
+      " labels.restore-database-partition:all)");
   ASSERT_THAT(instance_id, IsOk()) << instance_id.status();
   Instance in(ProjectId(), *instance_id);
   Database db(in, spanner_testing::RandomDatabaseName(generator_));
@@ -352,8 +353,9 @@ TEST_F(BackupExtraIntegrationTest, BackupRestoreWithCMEK) {
 
   auto instance_id = spanner_testing::PickRandomInstance(
       generator_, ProjectId(),
-      "labels.restore-database-partition:generated-extra"
-      " NOT name:/instances/test-instance-mr-");
+      "(labels.restore-database-partition:generated-extra OR"
+      " labels.restore-database-partition:all)"
+      " AND NOT name:/instances/test-instance-mr-");
   ASSERT_STATUS_OK(instance_id);
   Instance in(ProjectId(), *instance_id);
 

--- a/google/cloud/spanner/admin/integration_tests/backup_integration_test.cc
+++ b/google/cloud/spanner/admin/integration_tests/backup_integration_test.cc
@@ -97,7 +97,8 @@ TEST_F(BackupIntegrationTest, BackupRestore) {
 
   auto instance_id = spanner_testing::PickRandomInstance(
       generator_, ProjectId(),
-      "labels.restore-database-partition:generated-core");
+      "(labels.restore-database-partition:generated-core OR"
+      " labels.restore-database-partition:all)");
   ASSERT_STATUS_OK(instance_id);
   Instance in(ProjectId(), *instance_id);
   Database db(in, spanner_testing::RandomDatabaseName(generator_));

--- a/google/cloud/spanner/integration_tests/backup_extra_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/backup_extra_integration_test.cc
@@ -98,7 +98,8 @@ TEST_F(BackupExtraIntegrationTest, BackupRestoreWithVersionTime) {
 
   auto instance_id = spanner_testing::PickRandomInstance(
       generator_, ProjectId(),
-      "labels.restore-database-partition:legacy-extra");
+      "(labels.restore-database-partition:legacy-extra OR"
+      " labels.restore-database-partition:all)");
   ASSERT_THAT(instance_id, IsOk()) << instance_id.status();
   Instance in(ProjectId(), *instance_id);
   Database db(in, spanner_testing::RandomDatabaseName(generator_));
@@ -315,8 +316,9 @@ TEST_F(BackupExtraIntegrationTest, BackupRestoreWithCMEK) {
 
   auto instance_id = spanner_testing::PickRandomInstance(
       generator_, ProjectId(),
-      "labels.restore-database-partition:legacy-extra"
-      " NOT name:/instances/test-instance-mr-");
+      "(labels.restore-database-partition:legacy-extra OR"
+      " labels.restore-database-partition:all)"
+      " AND NOT name:/instances/test-instance-mr-");
   ASSERT_STATUS_OK(instance_id);
   Instance in(ProjectId(), *instance_id);
 

--- a/google/cloud/spanner/integration_tests/backup_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/backup_integration_test.cc
@@ -87,7 +87,9 @@ TEST_F(BackupIntegrationTest, BackupRestore) {
   if (!RunSlowBackupTests() || Emulator()) GTEST_SKIP();
 
   auto instance_id = spanner_testing::PickRandomInstance(
-      generator_, ProjectId(), "labels.restore-database-partition:legacy-core");
+      generator_, ProjectId(),
+      "(labels.restore-database-partition:legacy-core OR"
+      " labels.restore-database-partition:all)");
   ASSERT_STATUS_OK(instance_id);
   Instance in(ProjectId(), *instance_id);
   Database db(in, spanner_testing::RandomDatabaseName(generator_));

--- a/google/cloud/spanner/samples/samples.cc
+++ b/google/cloud/spanner/samples/samples.cc
@@ -3817,7 +3817,8 @@ void RunAll(bool emulator) {
   auto generator = google::cloud::internal::MakeDefaultPRNG();
 
   auto random_instance = google::cloud::spanner_testing::PickRandomInstance(
-      generator, project_id, "NOT name:/instances/test-instance-mr-");
+      generator, project_id,
+      "labels.samples:yes AND NOT name:/instances/test-instance-mr-");
   if (!random_instance) {
     throw std::runtime_error("Cannot find an instance to run the samples: " +
                              random_instance.status().message());
@@ -4237,7 +4238,8 @@ void RunAll(bool emulator) {
   // TODO(#7144): Awaiting emulator support for default_leader.
   if (!emulator) {
     auto random_instance = google::cloud::spanner_testing::PickRandomInstance(
-        generator, project_id, "name:/instances/test-instance-mr-");
+        generator, project_id,
+        "labels.samples:yes AND name:/instances/test-instance-mr-");
     if (!random_instance) {
       throw std::runtime_error(
           "Cannot find an instance to run the multi-region samples: " +


### PR DESCRIPTION
Instance labels give us the flexibility to control where tests
are run through configuration, which we're using to temporarily
avoid regions with high contention.

* Use "samples:yes" for //google/cloud/spanner/samples:samples.

* Allow "restore-database-partition:all", mostly for the staging
  service where we don't have enough instance quota for the four
  `{generated,legacy}-{core,extra}` backup/restore partitions.

Also change to using explicit AND operators in the filters.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7626)
<!-- Reviewable:end -->
