### PR TITLE
refactor: g::c::Status now logs code first then message

### DIFF
--- a/google/cloud/internal/throw_delegate_test.cc
+++ b/google/cloud/internal/throw_delegate_test.cc
@@ -101,7 +101,7 @@ TEST(ThrowDelegateTest, TestThrow) {
         EXPECT_EQ("NOT FOUND", ex.status().message());
       },
       "Aborting because exceptions are disabled: "
-      "NOT FOUND \\[NOT_FOUND\\]");
+      "NOT_FOUND: NOT FOUND");
 }
 
 }  // namespace

--- a/google/cloud/status.h
+++ b/google/cloud/status.h
@@ -104,7 +104,8 @@ class Status {
     return !(a == b);
   }
   friend inline std::ostream& operator<<(std::ostream& os, Status const& s) {
-    return os << s.message() << " [" << s.code() << "]";
+    if (s.ok()) return os << s.code();
+    return os << s.code() << ": " << s.message();
   }
 
  private:

--- a/google/cloud/status_or_test.cc
+++ b/google/cloud/status_or_test.cc
@@ -115,7 +115,7 @@ TEST(StatusOrTest, ValueAccessorNonConstThrows) {
         EXPECT_EQ(StatusCode::kInternal, ex.status().code());
         EXPECT_EQ("BAD", ex.status().message());
       },
-      "exceptions are disabled: BAD \\[INTERNAL\\]");
+      "exceptions are disabled: INTERNAL: BAD");
 
   testing_util::ExpectException<RuntimeStatusError>(
       [&] { std::move(actual).value(); },
@@ -123,7 +123,7 @@ TEST(StatusOrTest, ValueAccessorNonConstThrows) {
         EXPECT_EQ(StatusCode::kInternal, ex.status().code());
         EXPECT_EQ("BAD", ex.status().message());
       },
-      "exceptions are disabled: BAD \\[INTERNAL\\]");
+      "exceptions are disabled: INTERNAL: BAD");
 }
 
 TEST(StatusOrTest, ValueAccessorConstThrows) {
@@ -135,7 +135,7 @@ TEST(StatusOrTest, ValueAccessorConstThrows) {
         EXPECT_EQ(StatusCode::kInternal, ex.status().code());
         EXPECT_EQ("BAD", ex.status().message());
       },
-      "exceptions are disabled: BAD \\[INTERNAL\\]");
+      "exceptions are disabled: INTERNAL: BAD");
 
   testing_util::ExpectException<RuntimeStatusError>(
       [&] { std::move(actual).value(); },
@@ -143,7 +143,7 @@ TEST(StatusOrTest, ValueAccessorConstThrows) {
         EXPECT_EQ(StatusCode::kInternal, ex.status().code());
         EXPECT_EQ("BAD", ex.status().message());
       },
-      "exceptions are disabled: BAD \\[INTERNAL\\]");
+      "exceptions are disabled: INTERNAL: BAD");
 }
 
 TEST(StatusOrTest, StatusConstAccessors) {

--- a/google/cloud/status_test.cc
+++ b/google/cloud/status_test.cc
@@ -16,6 +16,7 @@
 #include "google/cloud/status_or.h"
 #include "google/cloud/testing_util/expect_exception.h"
 #include <gmock/gmock.h>
+#include <sstream>
 
 namespace google {
 namespace cloud {
@@ -71,6 +72,18 @@ TEST(Status, Basics) {
   EXPECT_NE(s, Status(StatusCode::kUnknown, ""));
   EXPECT_NE(s, Status(StatusCode::kUnknown, "bar"));
   EXPECT_EQ(s, Status(StatusCode::kUnknown, "foo"));
+}
+
+TEST(Status, OperatorOutput) {
+  auto status = Status{};
+  auto ss = std::stringstream{};
+  ss << status;
+  EXPECT_EQ("OK", ss.str());
+
+  ss = std::stringstream{};
+  status = Status{StatusCode::kUnknown, "foo"};
+  ss << status;
+  EXPECT_EQ("UNKNOWN: foo", ss.str());
 }
 
 TEST(Status, PayloadIgnoredWithOk) {

--- a/google/cloud/storage/benchmarks/throughput_result_test.cc
+++ b/google/cloud/storage/benchmarks/throughput_result_test.cc
@@ -109,7 +109,7 @@ TEST(ThroughputResult, QuoteCsv) {
   result.status = Status{StatusCode::kInternal, R"(message, with comma)"};
   line = ToString(result);
   ASSERT_STATUS_OK(line);
-  EXPECT_THAT(*line, HasQuotedStatus(R"("message, with comma)"));
+  EXPECT_THAT(*line, HasQuotedStatus(R"(message, with comma)"));
 
   result.status = Status{StatusCode::kInternal, "message\nwith newline"};
   line = ToString(result);

--- a/google/cloud/storage/internal/logging_resumable_upload_session_test.cc
+++ b/google/cloud/storage/internal/logging_resumable_upload_session_test.cc
@@ -55,7 +55,7 @@ TEST_F(LoggingResumableUploadSessionTest, UploadChunk) {
   EXPECT_THAT(result, StatusIs(StatusCode::kUnavailable, "uh oh"));
 
   EXPECT_THAT(log_backend_.ExtractLines(),
-              ContainsOnce(HasSubstr("[UNAVAILABLE]")));
+              ContainsOnce(HasSubstr("UNAVAILABLE:")));
 }
 
 TEST_F(LoggingResumableUploadSessionTest, UploadFinalChunk) {
@@ -79,7 +79,7 @@ TEST_F(LoggingResumableUploadSessionTest, UploadFinalChunk) {
   auto const log_lines = log_backend_.ExtractLines();
   EXPECT_THAT(log_lines, ContainsOnce(HasSubstr("upload_size=" +
                                                 std::to_string(513 * 1024))));
-  EXPECT_THAT(log_lines, ContainsOnce(HasSubstr("[UNAVAILABLE]")));
+  EXPECT_THAT(log_lines, ContainsOnce(HasSubstr("UNAVAILABLE:")));
 }
 
 TEST_F(LoggingResumableUploadSessionTest, ResetSession) {
@@ -96,7 +96,7 @@ TEST_F(LoggingResumableUploadSessionTest, ResetSession) {
   EXPECT_THAT(result, StatusIs(StatusCode::kFailedPrecondition, "uh oh"));
 
   EXPECT_THAT(log_backend_.ExtractLines(),
-              ContainsOnce(HasSubstr("[FAILED_PRECONDITION]")));
+              ContainsOnce(HasSubstr("FAILED_PRECONDITION:")));
 }
 
 TEST_F(LoggingResumableUploadSessionTest, NextExpectedByte) {
@@ -145,7 +145,7 @@ TEST_F(LoggingResumableUploadSessionTest, LastResponseBadStatus) {
               StatusIs(StatusCode::kFailedPrecondition, "something bad"));
 
   EXPECT_THAT(log_backend_.ExtractLines(),
-              ContainsOnce(HasSubstr("[FAILED_PRECONDITION]")));
+              ContainsOnce(HasSubstr("FAILED_PRECONDITION:")));
 }
 
 }  // namespace

--- a/google/cloud/testing_util/status_matchers_test.cc
+++ b/google/cloud/testing_util/status_matchers_test.cc
@@ -56,7 +56,7 @@ TEST(AssertOkTest, AssertionFailed) {
         Status status(StatusCode::kInternal, "oh no!");
         ASSERT_STATUS_OK(status);
       },
-      "\n  Actual: oh no! [INTERNAL]");
+      "\n  Actual: INTERNAL: oh no!");
 }
 
 TEST(AssertOkTest, AssertionFailedStatusOr) {
@@ -65,7 +65,7 @@ TEST(AssertOkTest, AssertionFailedStatusOr) {
         StatusOr<int> status_or(Status(StatusCode::kInternal, "oh no!"));
         ASSERT_STATUS_OK(status_or);
       },
-      ", whose status is oh no! [INTERNAL]");
+      ", whose status is INTERNAL: oh no!");
 }
 
 TEST(AssertOkTest, AssertionFailedDescription) {
@@ -112,7 +112,7 @@ TEST(ExpectOkTest, ExpectationFailed) {
         Status status(StatusCode::kInternal, "oh no!");
         EXPECT_STATUS_OK(status);
       },
-      "\n  Actual: oh no! [INTERNAL]");
+      "\n  Actual: INTERNAL: oh no!");
 }
 
 TEST(ExpectOkTest, ExpectationFailedStatusOr) {
@@ -121,7 +121,7 @@ TEST(ExpectOkTest, ExpectationFailedStatusOr) {
         StatusOr<int> status_or(Status(StatusCode::kInternal, "oh no!"));
         EXPECT_STATUS_OK(status_or);
       },
-      ", whose status is oh no! [INTERNAL]");
+      ", whose status is INTERNAL: oh no!");
 }
 
 TEST(ExpectOkTest, ExpectationFailedDescription) {


### PR DESCRIPTION
Upcoming we are going to implement a change where we sometimes log
additional "error info" data when streaming a Status object. This
additional data will have newlines in it, and it would seem weird if
status code came last one the final line of the logged message. It
seems more natural for the streamed output to start with the code,
followed by the message, and any additional data. This format also
matches `absl::Status`, fwiw.

I'm not picky about the specific format syntax. I chose something like
`UNKNOWN: some message`, but I'd be just as happy to go back to using
square brackes around the code, with or without a colon.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7628)
<!-- Reviewable:end -->
