### PR TITLE
feat(storage): default payload format for CreateNotification

### DIFF
--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -3027,6 +3027,44 @@ class Client {
    * @param topic_name the Google Cloud Pub/Sub topic that will receive the
    *     notifications. This requires the full name of the topic, i.e.:
    *     `projects/<PROJECT_ID>/topics/<TOPIC_ID>`.
+   * @param metadata define any optional parameters for the notification, such
+   *     as the list of event types, or any custom attributes.
+   * @param options a list of optional query parameters and/or request headers.
+   *     Valid types for this operation include `UserProject`.
+   *
+   * @par Idempotency
+   * This operation is only idempotent if restricted by pre-conditions. There
+   * are no pre-conditions for this operation that can make it idempotent.
+   *
+   * @par Example
+   * @snippet storage_notification_samples.cc create notification
+   *
+   * @see https://cloud.google.com/storage/docs/pubsub-notifications for general
+   *     information on Cloud Pub/Sub Notifications for Google Cloud Storage.
+   *
+   * @see https://cloud.google.com/pubsub/ for general information on Google
+   *     Cloud Pub/Sub service.
+   */
+  template <typename... Options>
+  StatusOr<NotificationMetadata> CreateNotification(
+      std::string const& bucket_name, std::string const& topic_name,
+      NotificationMetadata metadata, Options&&... options) {
+    return CreateNotification(bucket_name, topic_name,
+                              payload_format::JsonApiV1(), std::move(metadata),
+                              std::forward<Options>(options)...);
+  }
+
+  /**
+   * Creates a new notification config for a Bucket.
+   *
+   * Cloud Pub/Sub Notifications sends information about changes to objects
+   * in your buckets to Google Cloud Pub/Sub service. You can create multiple
+   * notifications per Bucket, with different topics and filtering options.
+   *
+   * @param bucket_name the name of the bucket.
+   * @param topic_name the Google Cloud Pub/Sub topic that will receive the
+   *     notifications. This requires the full name of the topic, i.e.:
+   *     `projects/<PROJECT_ID>/topics/<TOPIC_ID>`.
    * @param payload_format how will the data be formatted in the notifications,
    *     consider using the helpers in the `payload_format` namespace, or
    *     specify one of the valid formats defined in:

--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -3019,7 +3019,7 @@ class Client {
   /**
    * Creates a new notification config for a Bucket.
    *
-   * Cloud Pub/Sub Notifications sends information about changes to objects
+   * Cloud Pub/Sub Notifications send information about changes to objects
    * in your buckets to Google Cloud Pub/Sub service. You can create multiple
    * notifications per Bucket, with different topics and filtering options.
    *
@@ -3057,7 +3057,7 @@ class Client {
   /**
    * Creates a new notification config for a Bucket.
    *
-   * Cloud Pub/Sub Notifications sends information about changes to objects
+   * Cloud Pub/Sub Notifications send information about changes to objects
    * in your buckets to Google Cloud Pub/Sub service. You can create multiple
    * notifications per Bucket, with different topics and filtering options.
    *

--- a/google/cloud/storage/client_notifications_test.cc
+++ b/google/cloud/storage/client_notifications_test.cc
@@ -127,7 +127,6 @@ TEST_F(NotificationsTest, CreateNotificationTooManyFailures) {
       [](Client& client) {
         return client
             .CreateNotification("test-bucket-name", "test-topic-1",
-                                payload_format::JsonApiV1(),
                                 NotificationMetadata())
             .status();
       },
@@ -141,7 +140,6 @@ TEST_F(NotificationsTest, CreateNotificationPermanentFailure) {
       [](Client& client) {
         return client
             .CreateNotification("test-bucket-name", "test-topic-1",
-                                payload_format::JsonApiV1(),
                                 NotificationMetadata())
             .status();
       },

--- a/google/cloud/storage/examples/storage_notification_samples.cc
+++ b/google/cloud/storage/examples/storage_notification_samples.cc
@@ -48,7 +48,6 @@ void CreateNotification(google::cloud::storage::Client client,
      std::string const& topic_name) {
     StatusOr<gcs::NotificationMetadata> notification =
         client.CreateNotification(bucket_name, topic_name,
-                                  gcs::payload_format::JsonApiV1(),
                                   gcs::NotificationMetadata());
 
     if (!notification) {
@@ -151,14 +150,13 @@ void RunAll(std::vector<std::string> const& argv) {
   std::cout << "\nManually creating a notification [1]" << std::endl;
   auto n1 = client
                 .CreateNotification(
-                    bucket_name, topic_name, gcs::payload_format::JsonApiV1(),
+                    bucket_name, topic_name,
                     gcs::NotificationMetadata().set_object_name_prefix("foo/"))
                 .value();
 
   std::cout << "\nManually creating a notification [2]" << std::endl;
   auto n2 = client
                 .CreateNotification(bucket_name, topic_name,
-                                    gcs::payload_format::JsonApiV1(),
                                     gcs::NotificationMetadata())
                 .value();
 


### PR DESCRIPTION
Fixes #1098 

I tried to use `@copydoc` but it does not render correctly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7633)
<!-- Reviewable:end -->
