### PR TITLE
feat(storage): `storage::Client` is a value type

### DIFF
--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -3235,7 +3235,6 @@ class Client {
       internal::PolicyDocumentV4Request request);
 
   std::shared_ptr<internal::RawClient> raw_client_;
-
 };
 
 /**

--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -294,6 +294,14 @@ class Client {
   explicit Client(std::shared_ptr<internal::RawClient> client, NoDecorations)
       : Client(InternalOnlyNoDecorations{}, std::move(client)) {}
 
+  //@{
+  // @name Equality
+  friend bool operator==(Client const& a, Client const& b) {
+    return a.raw_client_ == b.raw_client_;
+  }
+  friend bool operator!=(Client const& a, Client const& b) { return !(a == b); }
+  //@}
+
   /// Access the underlying `RawClient`.
   /// @deprecated Only intended for implementors, do not use.
   GOOGLE_CLOUD_CPP_DEPRECATED(
@@ -3132,6 +3140,8 @@ class Client {
   //@}
 
  private:
+  friend class internal::NonResumableParallelUploadState;
+  friend class internal::ResumableParallelUploadState;
   friend internal::ClientImplDetails;
 
   struct InternalOnly {};
@@ -3226,8 +3236,6 @@ class Client {
 
   std::shared_ptr<internal::RawClient> raw_client_;
 
-  friend class internal::NonResumableParallelUploadState;
-  friend class internal::ResumableParallelUploadState;
 };
 
 /**

--- a/google/cloud/storage/client_test.cc
+++ b/google/cloud/storage/client_test.cc
@@ -84,6 +84,16 @@ class ClientTest : public ::testing::Test {
   std::shared_ptr<testing::MockClient> mock_;
 };
 
+TEST_F(ClientTest, Equality) {
+  auto a = storage::Client(Options{}.set<google::cloud::UnifiedCredentialsOption>(google::cloud::MakeInsecureCredentials()));
+  auto b = storage::Client(Options{}.set<google::cloud::UnifiedCredentialsOption>(google::cloud::MakeInsecureCredentials()));
+  EXPECT_TRUE(a != b);
+  EXPECT_TRUE(a == a);
+  EXPECT_TRUE(b == b);
+  auto c = a;
+  EXPECT_TRUE(a == c);
+}
+
 TEST_F(ClientTest, OverrideRetryPolicy) {
   auto client = internal::ClientImplDetails::CreateClient(
       std::shared_ptr<internal::RawClient>(mock_), ObservableRetryPolicy(3));

--- a/google/cloud/storage/client_test.cc
+++ b/google/cloud/storage/client_test.cc
@@ -85,8 +85,12 @@ class ClientTest : public ::testing::Test {
 };
 
 TEST_F(ClientTest, Equality) {
-  auto a = storage::Client(Options{}.set<google::cloud::UnifiedCredentialsOption>(google::cloud::MakeInsecureCredentials()));
-  auto b = storage::Client(Options{}.set<google::cloud::UnifiedCredentialsOption>(google::cloud::MakeInsecureCredentials()));
+  auto a =
+      storage::Client(Options{}.set<google::cloud::UnifiedCredentialsOption>(
+          google::cloud::MakeInsecureCredentials()));
+  auto b =
+      storage::Client(Options{}.set<google::cloud::UnifiedCredentialsOption>(
+          google::cloud::MakeInsecureCredentials()));
   EXPECT_TRUE(a != b);
   EXPECT_TRUE(a == a);
   EXPECT_TRUE(b == b);

--- a/google/cloud/storage/client_test.cc
+++ b/google/cloud/storage/client_test.cc
@@ -94,8 +94,10 @@ TEST_F(ClientTest, Equality) {
   EXPECT_TRUE(a != b);
   EXPECT_TRUE(a == a);
   EXPECT_TRUE(b == b);
-  auto c = a;
+  auto c = a;  // NOLINT(performance-unnecessary-copy-initialization)
   EXPECT_TRUE(a == c);
+  b = std::move(a);
+  EXPECT_TRUE(b == c);
 }
 
 TEST_F(ClientTest, OverrideRetryPolicy) {


### PR DESCRIPTION
We did not have `operator==` and `operator!=` defined for this class.
Other `*Client` classes have this operator, and it will be useful when I
try to describe connection pooling.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7634)
<!-- Reviewable:end -->
