### PR TITLE
fix: avoid use-after-move StatusOr

### DIFF
--- a/google/cloud/stream_range.h
+++ b/google/cloud/stream_range.h
@@ -178,16 +178,15 @@ class StreamRange {
       void operator()(Status&& status) {
         sr.is_end_ = status.ok();
         if (!status.ok()) sr.current_ = std::move(status);
-        sr.current_ok_ = sr.current_.ok();
       }
       void operator()(T&& t) {
         sr.is_end_ = false;
         sr.current_ = std::move(t);
-        sr.current_ok_ = sr.current_.ok();
       }
     };
     auto v = reader_();
     absl::visit(UnpackVariant{*this}, std::move(v));
+    current_ok_ = current_.ok();
   }
 
   template <typename U>

--- a/google/cloud/stream_range.h
+++ b/google/cloud/stream_range.h
@@ -169,7 +169,7 @@ class StreamRange {
  private:
   void Next() {
     // Jump to the end if we previously got an error.
-    if (!is_end_ && !current_) {
+    if (!is_end_ && !current_ok_) {
       is_end_ = true;
       return;
     }
@@ -178,10 +178,12 @@ class StreamRange {
       void operator()(Status&& status) {
         sr.is_end_ = status.ok();
         if (!status.ok()) sr.current_ = std::move(status);
+        sr.current_ok_ = sr.current_.ok();
       }
       void operator()(T&& t) {
         sr.is_end_ = false;
         sr.current_ = std::move(t);
+        sr.current_ok_ = sr.current_.ok();
       }
     };
     auto v = reader_();
@@ -224,6 +226,7 @@ class StreamRange {
 
   internal::StreamReader<T> reader_;
   StatusOr<T> current_;
+  bool current_ok_ = false;
   bool is_end_ = true;
 };
 

--- a/google/cloud/stream_range.h
+++ b/google/cloud/stream_range.h
@@ -177,16 +177,17 @@ class StreamRange {
       StreamRange& sr;
       void operator()(Status&& status) {
         sr.is_end_ = status.ok();
+        sr.current_ok_ = status.ok();
         if (!status.ok()) sr.current_ = std::move(status);
       }
       void operator()(T&& t) {
         sr.is_end_ = false;
+        sr.current_ok_ = true;
         sr.current_ = std::move(t);
       }
     };
     auto v = reader_();
     absl::visit(UnpackVariant{*this}, std::move(v));
-    current_ok_ = current_.ok();
   }
 
   template <typename U>


### PR DESCRIPTION
Similar to: #7588

This code allowed callers to (rightfully) move-out the `StatusOr` that
was held in `current_`. Therefore, it's a bug if we then consult the
status of `current_.ok()`, because it may be in a moved-from state.

The fix is to track the `current_ok_` bit separately, so that we only
ever assign to `current_` and never read it after it could have been
moved.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7635)
<!-- Reviewable:end -->
