### PR TITLE
feat(bigtable): add multi-cluster routing for specific clusters

### DIFF
--- a/google/cloud/bigtable/app_profile_config.cc
+++ b/google/cloud/bigtable/app_profile_config.cc
@@ -19,12 +19,15 @@ namespace google {
 namespace cloud {
 namespace bigtable {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
-AppProfileConfig AppProfileConfig::MultiClusterUseAny(std::string profile_id) {
+AppProfileConfig AppProfileConfig::MultiClusterUseAny(
+    std::string profile_id, std::vector<std::string> cluster_ids) {
   AppProfileConfig tmp;
   tmp.proto_.set_app_profile_id(std::move(profile_id));
-  tmp.proto_.mutable_app_profile()
-      ->mutable_multi_cluster_routing_use_any()
-      ->Clear();
+  auto& mc_routing = *tmp.proto_.mutable_app_profile()
+                          ->mutable_multi_cluster_routing_use_any();
+  for (auto&& cluster_id : cluster_ids) {
+    mc_routing.add_cluster_ids(std::move(cluster_id));
+  }
   return tmp;
 }
 

--- a/google/cloud/bigtable/app_profile_config.h
+++ b/google/cloud/bigtable/app_profile_config.h
@@ -30,7 +30,37 @@ class AppProfileConfig {
       google::bigtable::admin::v2::CreateAppProfileRequest proto)
       : proto_(std::move(proto)) {}
 
-  static AppProfileConfig MultiClusterUseAny(std::string profile_id);
+  /**
+   * Create an AppProfile that uses multi-cluster routing.
+   *
+   * Read/write requests are routed to the nearest cluster in the instance,
+   * and will fail over to the nearest cluster that is available in the event of
+   * transient errors or delays. Clusters in a region are considered
+   * equidistant. Choosing this option sacrifices read-your-writes consistency
+   * to improve availability.
+   *
+   * @param profile_id The unique name of the AppProfile.
+   * @param cluster_ids The set of clusters to route to. The order is
+   *     ignored; clusters will be tried in order of distance. If left empty,
+   *     all clusters are eligible.
+   */
+  static AppProfileConfig MultiClusterUseAny(
+      std::string profile_id, std::vector<std::string> cluster_ids = {});
+
+  /**
+   * Create an AppProfile that uses single cluster routing.
+   *
+   * Unconditionally routes all read/write requests to a specific cluster. This
+   * option preserves read-your-writes consistency but does not improve
+   * availability.
+   *
+   * @param profile_id The unique name of the AppProfile.
+   * @param cluster_id The cluster to which read/write requests are routed.
+   * @param allow_transactional_writes Whether or not `CheckAndMutateRow` and
+   *     `ReadModifyWriteRow` requests are allowed by this app profile. It is
+   *     unsafe to send these requests to the same table/row/column in multiple
+   *     clusters.
+   */
   static AppProfileConfig SingleClusterRouting(
       std::string profile_id, std::string cluster_id,
       bool allow_transactional_writes = false);
@@ -84,8 +114,13 @@ class AppProfileUpdateConfig {
     AddPathIfNotPresent("etag");
     return *this;
   }
-  AppProfileUpdateConfig& set_multi_cluster_use_any() {
-    *proto_.mutable_app_profile()->mutable_multi_cluster_routing_use_any() = {};
+  AppProfileUpdateConfig& set_multi_cluster_use_any(
+      std::vector<std::string> cluster_ids = {}) {
+    auto& mc_routing =
+        *proto_.mutable_app_profile()->mutable_multi_cluster_routing_use_any();
+    for (auto&& cluster_id : cluster_ids) {
+      mc_routing.add_cluster_ids(std::move(cluster_id));
+    }
     RemoveIfPresent("single_cluster_routing");
     AddPathIfNotPresent("multi_cluster_routing_use_any");
     return *this;


### PR DESCRIPTION
I needed an easy win today, so add support for [multi-cluster routing](https://cloud.google.com/bigtable/docs/app-profiles#routing) in Bigtable, in accordance with [this proto change](https://github.com/googleapis/googleapis/commit/5f761138c64054797b7e25164798d573ff4c1c62#diff-712127d2a900984d269e05e237ccc6552f798034cd7d97256374e12cfb8da77cR198-R202).

Now you can specify an exact subset of clusters to route to when using multi-cluster routing. Providing no clusters to the multi-cluster routing remains the same, routing to the nearest cluster in the instance.

As far as I can tell, there are no snippets needed for this update.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7636)
<!-- Reviewable:end -->
