### PR TITLE
refactor: optimize Status moving error data to heap-allocated Impl

### DIFF
--- a/google/cloud/status.cc
+++ b/google/cloud/status.cc
@@ -107,7 +107,10 @@ class Status::Impl {
   PayloadType payload_;
 };
 
-Status::~Status() { delete impl_; }
+Status::Status() = default;
+Status::~Status() = default;
+Status::Status(Status&&) noexcept = default;
+Status& Status::operator=(Status&&) noexcept = default;
 
 // Deep copy
 Status::Status(Status const& other)
@@ -115,23 +118,7 @@ Status::Status(Status const& other)
 
 // Deep copy
 Status& Status::operator=(Status const& other) {
-  if (this != &other) {
-    delete impl_;
-    impl_ = other.ok() ? nullptr : new auto(*other.impl_);
-  }
-  return *this;
-}
-
-Status::Status(Status&& other) noexcept : impl_(other.impl_) {
-  other.impl_ = nullptr;
-}
-
-Status& Status::operator=(Status&& other) noexcept {
-  if (this != &other) {
-    delete impl_;
-    impl_ = other.impl_;
-    other.impl_ = nullptr;
-  }
+  impl_.reset(other.ok() ? nullptr : new auto(*other.impl_));
   return *this;
 }
 
@@ -151,8 +138,7 @@ std::string const& Status::message() const {
 }
 
 bool operator==(Status const& a, Status const& b) {
-  return (a.ok() && b.ok()) ||
-         (a.impl_ != nullptr && b.impl_ != nullptr && *a.impl_ == *b.impl_);
+  return (a.ok() && b.ok()) || (a.impl_ && b.impl_ && *a.impl_ == *b.impl_);
 }
 
 bool operator!=(Status const& a, Status const& b) { return !(a == b); }

--- a/google/cloud/status.cc
+++ b/google/cloud/status.cc
@@ -137,11 +137,9 @@ std::string const& Status::message() const {
   return impl_ ? impl_->message() : *kEmpty;
 }
 
-bool operator==(Status const& a, Status const& b) {
+bool Status::Equals(Status const& a, Status const& b) {
   return (a.ok() && b.ok()) || (a.impl_ && b.impl_ && *a.impl_ == *b.impl_);
 }
-
-bool operator!=(Status const& a, Status const& b) { return !(a == b); }
 
 std::ostream& operator<<(std::ostream& os, Status const& s) {
   if (s.ok()) return os << StatusCode::kOk;

--- a/google/cloud/status.h
+++ b/google/cloud/status.h
@@ -18,8 +18,8 @@
 #include "google/cloud/version.h"
 #include "absl/types/optional.h"
 #include <iostream>
+#include <memory>
 #include <string>
-#include <tuple>
 #include <unordered_map>
 
 namespace google {
@@ -81,7 +81,7 @@ absl::optional<std::string> GetPayload(Status const&, std::string const& key);
  */
 class Status {
  public:
-  Status() = default;
+  Status();
   ~Status();
   Status(Status const&);
   Status& operator=(Status const&);
@@ -95,7 +95,7 @@ class Status {
    */
   explicit Status(StatusCode code, std::string message);
 
-  bool ok() const { return impl_ == nullptr; }
+  bool ok() const { return !impl_; }
   StatusCode code() const;
   std::string const& message() const;
 
@@ -110,7 +110,7 @@ class Status {
 
   class Impl;
   // A null `impl_` is an OK status. Only non-OK Statuses allocate an Impl.
-  Impl* impl_{nullptr};
+  std::unique_ptr<Impl> impl_;
 };
 
 /**

--- a/google/cloud/status.h
+++ b/google/cloud/status.h
@@ -99,11 +99,16 @@ class Status {
   StatusCode code() const;
   std::string const& message() const;
 
-  friend bool operator==(Status const& a, Status const& b);
-  friend bool operator!=(Status const& a, Status const& b);
+  friend inline bool operator==(Status const& a, Status const& b) {
+    return (a.ok() && b.ok()) || Equals(a, b);
+  }
+  friend inline bool operator!=(Status const& a, Status const& b) {
+    return !(a == b);
+  }
   friend std::ostream& operator<<(std::ostream& os, Status const& s);
 
  private:
+  static bool Equals(Status const& a, Status const& b);
   friend void internal::SetPayload(Status&, std::string, std::string);
   friend absl::optional<std::string> internal::GetPayload(Status const&,
                                                           std::string const&);

--- a/google/cloud/status_or.h
+++ b/google/cloud/status_or.h
@@ -98,14 +98,22 @@ class StatusOr final {
   /**
    * Initializes with an error status (UNKNOWN).
    */
-  StatusOr() : StatusOr(Status(StatusCode::kUnknown, "default")) {}
+  StatusOr() : StatusOr(MakeDefaultStatus()) {}
 
   StatusOr(StatusOr const&) = default;
   StatusOr& operator=(StatusOr const&) = default;
   // NOLINTNEXTLINE(performance-noexcept-move-constructor)
-  StatusOr(StatusOr&&) = default;
+  StatusOr(StatusOr&& other)
+      : status_(std::move(other.status_)), value_(std::move(other.value_)) {
+    other.status_ = MakeDefaultStatus();
+  }
   // NOLINTNEXTLINE(performance-noexcept-move-constructor)
-  StatusOr& operator=(StatusOr&&) = default;
+  StatusOr& operator=(StatusOr&& other) {
+    status_ = std::move(other.status_);
+    value_ = std::move(other.value_);
+    other.status_ = MakeDefaultStatus();
+    return *this;
+  }
 
   /**
    * Creates a new `StatusOr<T>` holding the error condition @p rhs.
@@ -246,6 +254,10 @@ class StatusOr final {
   //@}
 
  private:
+  static Status MakeDefaultStatus() {
+    return Status{StatusCode::kUnknown, "default"};
+  }
+
   void CheckHasValue() const& {
     if (!ok()) {
       internal::ThrowStatus(status_);

--- a/google/cloud/status_or_test.cc
+++ b/google/cloud/status_or_test.cc
@@ -242,7 +242,6 @@ TEST(StatusOrObservableTest, MoveAssignmentNoValueNoValue) {
 
   Observable::reset_counters();
   assigned = std::move(other);
-  EXPECT_FALSE(other.ok());  // NOLINT(bugprone-use-after-move)
   EXPECT_FALSE(assigned.ok());
   EXPECT_EQ(0, Observable::destructor());
   EXPECT_EQ(0, Observable::move_assignment());
@@ -298,7 +297,6 @@ TEST(StatusOrObservableTest, MoveAssignmentValueNoValue) {
 
   Observable::reset_counters();
   assigned = std::move(other);
-  EXPECT_FALSE(other.ok());  // NOLINT(bugprone-use-after-move)
   EXPECT_FALSE(assigned.ok());
   EXPECT_EQ(1, Observable::destructor());
   EXPECT_EQ(0, Observable::move_assignment());

--- a/google/cloud/status_test.cc
+++ b/google/cloud/status_test.cc
@@ -58,7 +58,7 @@ TEST(Status, Basics) {
   EXPECT_EQ(s.message(), "");
   EXPECT_EQ(s, Status());
 
-  // The message is ignored on OK statues.
+  // The message is ignored on OK statuses.
   auto ok = Status(StatusCode::kOk, "message ignored");
   EXPECT_EQ(s, ok);
   EXPECT_EQ("", ok.message());
@@ -72,6 +72,20 @@ TEST(Status, Basics) {
   EXPECT_NE(s, Status(StatusCode::kUnknown, ""));
   EXPECT_NE(s, Status(StatusCode::kUnknown, "bar"));
   EXPECT_EQ(s, Status(StatusCode::kUnknown, "foo"));
+}
+
+TEST(Status, SelfAssignWorks) {
+  auto s = Status(StatusCode::kUnknown, "foo");
+  auto& r = s;  // Hide the self-assign from linter.
+  s = r;
+  EXPECT_FALSE(s.ok());
+  EXPECT_EQ(s.code(), StatusCode::kUnknown);
+  EXPECT_EQ(s.message(), "foo");
+
+  s = std::move(r);
+  EXPECT_FALSE(s.ok());
+  EXPECT_EQ(s.code(), StatusCode::kUnknown);
+  EXPECT_EQ(s.message(), "foo");
 }
 
 TEST(Status, OperatorOutput) {


### PR DESCRIPTION
Related to: https://github.com/googleapis/google-cloud-cpp/issues/7429

Background: "OK" statuses are the common case, and they don't have message strings,
payload data, etc. Only non-OK Statuses need this extra data, so paying
the cost of these fields for OK statuses is wasteful.

This PR refactors `google::cloud::Status` to hold an opaque `Impl*` that
holds all the error data for non-OK statuses. OK statuses are
represented by `impl_ == nullptr`, which requires no allocations (again,
this is the common case). This allows us to associate whatever data we
need with non-OK Statuses without hurting the OK case.

**What's the moved-from state?** We continue to not define the moved-from state for
`Status`. It's a valid state, but unspecified. However, the implementation in this PR
is such that **all moved-from `Status` objects are "OK"**. This matches the default state
when a `Status{}` is constructed. Note that this is a **change in behavior** from the code
previously whereby a moved-from Status would retain its `code()` (and therefore `ok()`) state,
while losing its payload and message. 

Note: We will be attaching more "ErrorInfo" data with non-OK statuses in
an upcoming PR, so this refactoring will help with that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7639)
<!-- Reviewable:end -->
