### PR TITLE
feat: expose and log ErrorInfo if present 

### DIFF
--- a/google/cloud/BUILD
+++ b/google/cloud/BUILD
@@ -98,6 +98,7 @@ cc_library(
         "@com_google_googleapis//:googleapis_system_includes",
         "@com_google_googleapis//google/iam/credentials/v1:credentials_cc_grpc",
         "@com_google_googleapis//google/longrunning:longrunning_cc_grpc",
+        "@com_google_googleapis//google/rpc:error_details_cc_proto",
         "@com_google_googleapis//google/rpc:status_cc_proto",
     ],
 )

--- a/google/cloud/CMakeLists.txt
+++ b/google/cloud/CMakeLists.txt
@@ -394,6 +394,7 @@ if (GOOGLE_CLOUD_CPP_ENABLE_GRPC)
                absl::variant
                google-cloud-cpp::iam_protos
                google-cloud-cpp::longrunning_operations_protos
+               google-cloud-cpp::rpc_error_details_protos
                google-cloud-cpp::rpc_status_protos
                google-cloud-cpp::common
                gRPC::grpc++

--- a/google/cloud/grpc_error_delegate_test.cc
+++ b/google/cloud/grpc_error_delegate_test.cc
@@ -14,6 +14,7 @@
 
 #include "google/cloud/grpc_error_delegate.h"
 #include "google/cloud/internal/status_payload_keys.h"
+#include <google/rpc/error_details.pb.h>
 #include <gtest/gtest.h>
 
 namespace google {
@@ -29,6 +30,23 @@ std::string MakeErrorDetails(grpc::StatusCode code, std::string message) {
   google::rpc::Status proto;
   proto.set_code(static_cast<std::int32_t>(code));
   proto.set_message(std::move(message));
+  return MakeErrorDetails(proto);
+}
+
+std::string MakeErrorDetails(grpc::StatusCode code, std::string message,
+                             ErrorInfo const& error_info) {
+  google::rpc::Status proto;
+  proto.set_code(static_cast<std::int32_t>(code));
+  proto.set_message(std::move(message));
+
+  google::rpc::ErrorInfo error_info_proto;
+  error_info_proto.set_reason(error_info.reason());
+  error_info_proto.set_domain(error_info.domain());
+  for (auto const& e : error_info.metadata()) {
+    (*error_info_proto.mutable_metadata())[e.first] = e.second;
+  }
+
+  proto.add_details()->PackFrom(error_info_proto);
   return MakeErrorDetails(proto);
 }
 
@@ -104,6 +122,58 @@ TEST(MakeStatusFromRpcError, AllCodesWithPayload) {
 
     auto const actual = MakeStatusFromRpcError(original);
     EXPECT_EQ(expected, actual);
+    EXPECT_EQ(message, actual.message());
+    EXPECT_EQ(ErrorInfo{}, actual.error_info());
+
+    // Make sure the actual payload is what we expect.
+    auto actual_payload = google::cloud::internal::GetPayload(
+        actual, google::cloud::internal::kStatusPayloadGrpcProto);
+    EXPECT_TRUE(actual_payload.has_value());
+    EXPECT_EQ(payload, actual_payload.value());
+  }
+}
+
+TEST(MakeStatusFromRpcError, AllCodesWithPayloadAndErrorDetails) {
+  using ::google::cloud::StatusCode;
+
+  struct {
+    grpc::StatusCode grpc;
+    StatusCode expected;
+  } expected_codes[]{
+      // We skip OK because that cannot have a payload.
+      {grpc::StatusCode::CANCELLED, StatusCode::kCancelled},
+      {grpc::StatusCode::UNKNOWN, StatusCode::kUnknown},
+      {grpc::StatusCode::INVALID_ARGUMENT, StatusCode::kInvalidArgument},
+      {grpc::StatusCode::DEADLINE_EXCEEDED, StatusCode::kDeadlineExceeded},
+      {grpc::StatusCode::NOT_FOUND, StatusCode::kNotFound},
+      {grpc::StatusCode::ALREADY_EXISTS, StatusCode::kAlreadyExists},
+      {grpc::StatusCode::PERMISSION_DENIED, StatusCode::kPermissionDenied},
+      {grpc::StatusCode::UNAUTHENTICATED, StatusCode::kUnauthenticated},
+      {grpc::StatusCode::RESOURCE_EXHAUSTED, StatusCode::kResourceExhausted},
+      {grpc::StatusCode::FAILED_PRECONDITION, StatusCode::kFailedPrecondition},
+      {grpc::StatusCode::ABORTED, StatusCode::kAborted},
+      {grpc::StatusCode::OUT_OF_RANGE, StatusCode::kOutOfRange},
+      {grpc::StatusCode::UNIMPLEMENTED, StatusCode::kUnimplemented},
+      {grpc::StatusCode::INTERNAL, StatusCode::kInternal},
+      {grpc::StatusCode::UNAVAILABLE, StatusCode::kUnavailable},
+      {grpc::StatusCode::DATA_LOSS, StatusCode::kDataLoss},
+  };
+
+  for (auto const& codes : expected_codes) {
+    std::string const message = "test message";
+    ErrorInfo const error_info{"reason", "domain", {{"key", "val"}}};
+    std::string const payload =
+        MakeErrorDetails(codes.grpc, message, error_info);
+    auto const original = grpc::Status(codes.grpc, message, payload);
+
+    auto expected = google::cloud::Status(codes.expected, message, error_info);
+    google::cloud::internal::SetPayload(
+        expected, google::cloud::internal::kStatusPayloadGrpcProto, payload);
+
+    auto const actual = MakeStatusFromRpcError(original);
+    EXPECT_EQ(expected, actual);
+    EXPECT_EQ(message, actual.message());
+    EXPECT_EQ(error_info, actual.error_info());
 
     // Make sure the actual payload is what we expect.
     auto actual_payload = google::cloud::internal::GetPayload(

--- a/google/cloud/status.cc
+++ b/google/cloud/status.cc
@@ -162,8 +162,9 @@ std::ostream& operator<<(std::ostream& os, Status const& s) {
   if (s.ok()) return os << StatusCode::kOk;
   os << s.code() << ": " << s.message();
   auto const& e = s.error_info();
-  if (e.reason().empty() && e.domain().empty() && e.metadata().empty())
+  if (e.reason().empty() && e.domain().empty() && e.metadata().empty()) {
     return os;
+  }
   os << " error_info={reason=" << e.reason();
   os << ", domain=" << e.domain();
   os << ", metadata={";

--- a/google/cloud/status.cc
+++ b/google/cloud/status.cc
@@ -76,9 +76,9 @@ std::ostream& operator<<(std::ostream& os, StatusCode code) {
 // case of OK Statuses. This class holds all the data associated with a non-OK
 // Status so we don't have to worry about bloating the common OK case.
 class Status::Impl {
+ public:
   using PayloadType = std::unordered_map<std::string, std::string>;
 
- public:
   explicit Impl(StatusCode code, std::string message, ErrorInfo info,
                 PayloadType payload)
       : code_(code),

--- a/google/cloud/status.h
+++ b/google/cloud/status.h
@@ -66,8 +66,7 @@ absl::optional<std::string> GetPayload(Status const&, std::string const& key);
 /**
  * Describes the cause of the error with structured details.
  *
- * @see
- * https://github.com/googleapis/googleapis/blob/master/google/rpc/error_details.proto
+ * @see https://cloud.google.com/apis/design/errors#error_info
  */
 class ErrorInfo {
  public:

--- a/google/cloud/status.h
+++ b/google/cloud/status.h
@@ -83,13 +83,8 @@ class ErrorInfo {
     return metadata_;
   }
 
-  friend inline bool operator==(ErrorInfo const& a, ErrorInfo const& b) {
-    return a.reason_ == b.reason_ && a.domain_ == b.domain_ &&
-           a.metadata_ == b.metadata_;
-  }
-  friend inline bool operator!=(ErrorInfo const& a, ErrorInfo const& b) {
-    return !(a == b);
-  }
+  friend bool operator==(ErrorInfo const&, ErrorInfo const&);
+  friend bool operator!=(ErrorInfo const&, ErrorInfo const&);
 
  private:
   std::string reason_;

--- a/google/cloud/status_test.cc
+++ b/google/cloud/status_test.cc
@@ -124,13 +124,10 @@ TEST(Status, OperatorOutputWithErrorInfo) {
   ErrorInfo error_info{"the reason", "the domain", {{"key", "val"}}};
   auto status = Status{StatusCode::kUnknown, "foo", error_info};
   auto ss = std::stringstream{};
-  ss << "\n" << status;
+  ss << status;
   EXPECT_EQ(ss.str(),
-            R"(
-UNKNOWN: foo
-    reason: the reason
-    domain: the domain
-    metadata[key]: val)");
+            "UNKNOWN: foo error_info={reason=the reason, "
+            "domain=the domain, metadata={key=val}}");
 }
 
 TEST(Status, PayloadIgnoredWithOk) {


### PR DESCRIPTION
Fixes: https://github.com/googleapis/google-cloud-cpp/issues/7429

This PR adds a `google::cloud::ErrorInfo` class, which mirrors
[ErrorInfo][error-info-proto], and can also work with an equivalent
type in a REST world. We expose programmatic access to this via the
`g::c::Status::error_info()` accessor. We also log this data when
streaming a `g::c::Status` if it's present.

As of today, very few (if any) GCP services actually return this proto,
so I don't expect to see it much yet.

Alternative options:
* We could move `ErrorInfo` into it's own `error_info.h` file. It's pretty closely related to `Status`, so I'm OK w/ it where it is, but I'm also happy to move it if people think that's preferable.
* We can discuss the logging format that we want to use when streaming the `ErrorInfo`. I chose something in this PR, but we can certainly consider other output formats.

[error-info-proto]: https://github.com/googleapis/googleapis/blob/2e680c6be4b8e48c12f006b945b93edd41be8653/google/rpc/error_details.proto#L112

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7640)
<!-- Reviewable:end -->
