### PR TITLE
feat(generator): reduce required editing on scaffold

### DIFF
--- a/doc/adding_new_libraries.md
+++ b/doc/adding_new_libraries.md
@@ -78,17 +78,30 @@ bazel run \
 ci/cloudbuild/build.sh -t checkers-pr
 ```
 
-## Manually add the C++ files to the CMakeLists.txt file
+## Create any custom source files
 
 If the `generator/generator_config.textproto` entry for the service does not
 enumerate the `retryable_status_codes`, you need to manually create the file as
-`google/cloud/$library/internal/<service_name>_retry_traits.h`. Add this file
-**and** any generated C++ files to the `CMakeLists.txt` file. There should
-be markers in the file, search for `EDIT HERE`.
+`google/cloud/$library/internal/<service_name>_retry_traits.h`.
+
+Likewise, for services using streaming operations you may need to implement the
+streaming `*Updater` function. Use `google/cloud/bigquery/streaming.cc` for
+inspiration.
+
+## Validate and Generate the `*.bzl` files
+
+Run the `cmake-install-pr` build.  This is one of the builds that compiles all
+the libraries, including the library you just added. It will also generate the
+`*.bzl` files for Bazel-based builds.
 
 ```shell
 ci/cloudbuild/build.sh -t cmake-install-pr
 ```
+
+## Update the README file
+
+The generated `README.md` file in `google/cloud/${library}` probably needs some
+light copy-editing to read less like it was written by a robot.
 
 ## Update the root `BUILD` file
 

--- a/generator/internal/scaffold_generator.cc
+++ b/generator/internal/scaffold_generator.cc
@@ -352,8 +352,11 @@ external_googleapis_set_version_and_alias($library$_protos)
 target_link_libraries(google_cloud_cpp_$library$_protos PUBLIC #
     $proto_deps$)
 
-add_library(google_cloud_cpp_$library$ # cmake-format: sort
-            $cpp_files$)
+file(GLOB source_files
+     RELATIVE "$${CMAKE_CURRENT_SOURCE_DIR}"
+     "*.h" "*.cc" "internal/*.h" "internal/*.cc")
+list(SORT source_files)
+add_library(google_cloud_cpp_$library$ $${source_files})
 target_include_directories(
     google_cloud_cpp_$library$
     PUBLIC $$<BUILD_INTERFACE:$${PROJECT_SOURCE_DIR}>
@@ -383,9 +386,16 @@ create_bazel_config(google_cloud_cpp_$library$ YEAR "2021")
 # for these, a regular library would not work on macOS (where the library needs
 # at least one .o file). Unfortunately INTERFACE libraries are a bit weird in
 # that they need absolute paths for their sources.
+file(GLOB relative_mock_files
+     RELATIVE "$${CMAKE_CURRENT_SOURCE_DIR}"
+     "mocks/*.h")
+list(SORT relative_mock_files)
+set(mock_files)
+foreach (file IN LISTS relative_mock_files)
+  list(APPEND mock_files "$${CMAKE_CURRENT_SOURCE_DIR}/$${file}")
+endforeach ()
 add_library(google_cloud_cpp_$library$_mocks INTERFACE)
-target_sources(google_cloud_cpp_$library$_mocks INTERFACE # cmake-format: sort
-               $mock_files$)
+target_sources(google_cloud_cpp_$library$_mocks INTERFACE $${mock_files})
 target_link_libraries(
     google_cloud_cpp_$library$_mocks
     INTERFACE google-cloud-cpp::experimental-$library$ GTest::gmock_main

--- a/generator/internal/scaffold_generator_test.cc
+++ b/generator/internal/scaffold_generator_test.cc
@@ -210,21 +210,6 @@ target_link_libraries(google_cloud_cpp_test_protos PUBLIC #
     google-cloud-cpp::api_annotations_protos
     google-cloud-cpp::api_http_protos)
 )"""));
-
-  EXPECT_THAT(actual, HasSubstr(R"""(
-add_library(google_cloud_cpp_test # cmake-format: sort
-            # EDIT HERE: add list of C++ files
-)
-target_include_directories(
-    google_cloud_cpp_test
-)"""));
-
-  EXPECT_THAT(actual, HasSubstr(R"""(
-add_library(google_cloud_cpp_test_mocks INTERFACE)
-target_sources(google_cloud_cpp_test_mocks INTERFACE # cmake-format: sort
-               # EDIT HERE: add list of mock headers
-)
-)"""));
 }
 
 }  // namespace

--- a/google/cloud/pubsublite/CMakeLists.txt
+++ b/google/cloud/pubsublite/CMakeLists.txt
@@ -15,9 +15,9 @@
 # ~~~
 
 include(GoogleapisConfig)
-set(DOXYGEN_PROJECT_NAME "Cloud Pub/Sub Lite C++ Client")
-set(DOXYGEN_PROJECT_BRIEF "A C++ Client Library for Cloud Pub/Sub Lite")
-set(DOXYGEN_PROJECT_NUMBER "${PROJECT_VERSION} (Beta)")
+set(DOXYGEN_PROJECT_NAME "Pub/Sub Lite API C++ Client")
+set(DOXYGEN_PROJECT_BRIEF "A C++ Client Library for the Pub/Sub Lite API")
+set(DOXYGEN_PROJECT_NUMBER "${PROJECT_VERSION} (Experimental)")
 set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "pubsublite_internal"
                             "pubsublite_testing" "examples")
 
@@ -40,6 +40,7 @@ endif ()
 include(CompileProtos)
 google_cloud_cpp_grpcpp_library(
     google_cloud_cpp_pubsublite_protos
+    # cmake-format: sort
     ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/pubsublite/v1/topic_stats.proto
     ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/pubsublite/v1/subscriber.proto
     ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/pubsublite/v1/publisher.proto
@@ -52,7 +53,8 @@ google_cloud_cpp_grpcpp_library(
 external_googleapis_set_version_and_alias(pubsublite_protos)
 target_link_libraries(
     google_cloud_cpp_pubsublite_protos
-    PUBLIC google-cloud-cpp::longrunning_operations_protos
+    PUBLIC #
+           google-cloud-cpp::longrunning_operations_protos
            google-cloud-cpp::rpc_status_protos
            google-cloud-cpp::api_resource_protos
            google-cloud-cpp::api_field_behavior_protos
@@ -60,28 +62,12 @@ target_link_libraries(
            google-cloud-cpp::api_annotations_protos
            google-cloud-cpp::api_http_protos)
 
-add_library(
-    google_cloud_cpp_pubsublite # cmake-format: sort
-    admin_client.cc
-    admin_client.h
-    admin_connection.cc
-    admin_connection.h
-    admin_connection_idempotency_policy.cc
-    admin_connection_idempotency_policy.h
-    admin_options.h
-    internal/admin_auth_decorator.cc
-    internal/admin_auth_decorator.h
-    internal/admin_logging_decorator.cc
-    internal/admin_logging_decorator.h
-    internal/admin_metadata_decorator.cc
-    internal/admin_metadata_decorator.h
-    internal/admin_option_defaults.cc
-    internal/admin_option_defaults.h
-    internal/admin_retry_traits.h
-    internal/admin_stub.cc
-    internal/admin_stub.h
-    internal/admin_stub_factory.cc
-    internal/admin_stub_factory.h)
+file(
+    GLOB source_files
+    RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}"
+    "*.h" "*.cc" "internal/*.h" "internal/*.cc")
+list(SORT source_files)
+add_library(google_cloud_cpp_pubsublite ${source_files})
 target_include_directories(
     google_cloud_cpp_pubsublite
     PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
@@ -112,10 +98,17 @@ create_bazel_config(google_cloud_cpp_pubsublite YEAR "2021")
 # for these, a regular library would not work on macOS (where the library needs
 # at least one .o file). Unfortunately INTERFACE libraries are a bit weird in
 # that they need absolute paths for their sources.
+file(
+    GLOB relative_mock_files
+    RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}"
+    "mocks/*.h")
+list(SORT relative_mock_files)
+set(mock_files)
+foreach (file IN LISTS relative_mock_files)
+    list(APPEND mock_files "${CMAKE_CURRENT_SOURCE_DIR}/${file}")
+endforeach ()
 add_library(google_cloud_cpp_pubsublite_mocks INTERFACE)
-target_sources(
-    google_cloud_cpp_pubsublite_mocks
-    INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/mocks/mock_admin_connection.h)
+target_sources(google_cloud_cpp_pubsublite_mocks INTERFACE ${mock_files})
 target_link_libraries(
     google_cloud_cpp_pubsublite_mocks
     INTERFACE google-cloud-cpp::experimental-pubsublite GTest::gmock_main
@@ -173,9 +166,8 @@ google_cloud_cpp_install_headers("google_cloud_cpp_pubsublite_mocks"
 set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
 set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
 set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
-set(GOOGLE_CLOUD_PC_NAME "The Cloud Pub/Sub Lite C++ Client Library")
-set(GOOGLE_CLOUD_PC_DESCRIPTION
-    "Provides C++ APIs to access Cloud Pub/Sub Lite.")
+set(GOOGLE_CLOUD_PC_NAME "The Pub/Sub Lite API C++ Client Library")
+set(GOOGLE_CLOUD_PC_DESCRIPTION "Provides C++ APIs to access Pub/Sub Lite API.")
 set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_pubsublite")
 string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common" " google_cloud_cpp_pubsublite_protos")

--- a/google/cloud/tasks/CMakeLists.txt
+++ b/google/cloud/tasks/CMakeLists.txt
@@ -63,28 +63,12 @@ target_link_libraries(
            google-cloud-cpp::api_annotations_protos
            google-cloud-cpp::api_http_protos)
 
-add_library(
-    google_cloud_cpp_tasks # cmake-format: sort
-    cloud_tasks_client.cc
-    cloud_tasks_client.h
-    cloud_tasks_connection.cc
-    cloud_tasks_connection.h
-    cloud_tasks_connection_idempotency_policy.cc
-    cloud_tasks_connection_idempotency_policy.h
-    cloud_tasks_options.h
-    internal/cloud_tasks_auth_decorator.cc
-    internal/cloud_tasks_auth_decorator.h
-    internal/cloud_tasks_logging_decorator.cc
-    internal/cloud_tasks_logging_decorator.h
-    internal/cloud_tasks_metadata_decorator.cc
-    internal/cloud_tasks_metadata_decorator.h
-    internal/cloud_tasks_option_defaults.cc
-    internal/cloud_tasks_option_defaults.h
-    internal/cloud_tasks_retry_traits.h
-    internal/cloud_tasks_stub.cc
-    internal/cloud_tasks_stub.h
-    internal/cloud_tasks_stub_factory.cc
-    internal/cloud_tasks_stub_factory.h)
+file(
+    GLOB source_files
+    RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}"
+    "*.h" "*.cc" "internal/*.h" "internal/*.cc")
+list(SORT source_files)
+add_library(google_cloud_cpp_tasks ${source_files})
 target_include_directories(
     google_cloud_cpp_tasks
     PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
@@ -114,11 +98,17 @@ create_bazel_config(google_cloud_cpp_tasks YEAR "2021")
 # for these, a regular library would not work on macOS (where the library needs
 # at least one .o file). Unfortunately INTERFACE libraries are a bit weird in
 # that they need absolute paths for their sources.
+file(
+    GLOB relative_mock_files
+    RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}"
+    "mocks/*.h")
+list(SORT relative_mock_files)
+set(mock_files)
+foreach (file IN LISTS relative_mock_files)
+    list(APPEND mock_files "${CMAKE_CURRENT_SOURCE_DIR}/${file}")
+endforeach ()
 add_library(google_cloud_cpp_tasks_mocks INTERFACE)
-target_sources(
-    google_cloud_cpp_tasks_mocks
-    INTERFACE # cmake-format: sort
-              ${CMAKE_CURRENT_SOURCE_DIR}/mocks/mock_cloud_tasks_connection.h)
+target_sources(google_cloud_cpp_tasks_mocks INTERFACE ${mock_files})
 target_link_libraries(
     google_cloud_cpp_tasks_mocks
     INTERFACE google-cloud-cpp::experimental-tasks GTest::gmock_main


### PR DESCRIPTION
The generated `CMakeLists.txt` files can use `file(GLOB)` to eliminate
the need to edit most generated files. We still can edit these files, of
course, but now it is not required in most cases.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7641)
<!-- Reviewable:end -->
