### PR TITLE
fix: update texttospeech proto library deps

### DIFF
--- a/external/googleapis/CMakeLists.txt
+++ b/external/googleapis/CMakeLists.txt
@@ -95,7 +95,6 @@ set(EXTERNAL_GOOGLEAPIS_PROTO_FILES
     "google/cloud/dialogflow/v2/validation_result.proto"
     "google/cloud/dialogflow/v2/webhook.proto"
     "google/cloud/speech/v1/cloud_speech.proto"
-    "google/cloud/texttospeech/v1/cloud_tts.proto"
     "google/logging/type/http_request.proto"
     "google/logging/type/log_severity.proto"
     "google/logging/v2/log_entry.proto"
@@ -150,19 +149,44 @@ set(EXTERNAL_GOOGLEAPIS_PROTO_FILES
     "google/type/quaternion.proto"
     "google/type/timeofday.proto")
 
-file(GLOB protolists "protolists/*.list")
-foreach (file IN LISTS protolists)
+function (google_cloud_cpp_load_protolist var file)
     file(READ "${file}" contents)
     string(REGEX REPLACE "\n" ";" contents "${contents}")
+    set(protos)
     foreach (line IN LISTS contents)
         string(REPLACE "@com_google_googleapis//" "" line "${line}")
         string(REPLACE ":" "/" line "${line}")
         if ("${line}" STREQUAL "")
             continue()
         endif ()
-        list(APPEND EXTERNAL_GOOGLEAPIS_PROTO_FILES "${line}")
+        list(APPEND protos "${EXTERNAL_GOOGLEAPIS_SOURCE}/${line}")
     endforeach ()
-endforeach ()
+    set(${var}
+        "${protos}"
+        PARENT_SCOPE)
+endfunction ()
+
+function (google_cloud_cpp_load_protodeps var file)
+    file(READ "${file}" contents)
+    string(REGEX REPLACE "\n" ";" contents "${contents}")
+    set(deps)
+    foreach (line IN LISTS contents)
+        if ("${line}" STREQUAL "")
+            continue()
+        endif ()
+        string(REPLACE ":" "_" line "${line}")
+        string(REPLACE "_proto" "_protos" line "${line}")
+        string(REPLACE "@com_google_googleapis//" "google-cloud-cpp::" line
+                       "${line}")
+        string(REPLACE "google-cloud-cpp::google/" "google-cloud-cpp::" line
+                       "${line}")
+        string(REPLACE "/" "_" line "${line}")
+        list(APPEND deps "${line}")
+    endforeach ()
+    set(${var}
+        "${deps}"
+        PARENT_SCOPE)
+endfunction ()
 
 include(EnableWerror)
 
@@ -170,6 +194,14 @@ set(EXTERNAL_GOOGLEAPIS_BYPRODUCTS)
 foreach (proto ${EXTERNAL_GOOGLEAPIS_PROTO_FILES})
     list(APPEND EXTERNAL_GOOGLEAPIS_BYPRODUCTS
          "${EXTERNAL_GOOGLEAPIS_SOURCE}/${proto}")
+endforeach ()
+
+file(GLOB protolists "protolists/*.list")
+foreach (file IN LISTS protolists)
+    google_cloud_cpp_load_protolist(protos "${file}")
+    foreach (proto IN LISTS protos)
+        list(APPEND EXTERNAL_GOOGLEAPIS_BYPRODUCTS "${proto}")
+    endforeach ()
 endforeach ()
 
 include(ExternalProject)
@@ -509,18 +541,17 @@ target_link_libraries(
            google-cloud-cpp::longrunning_operations_protos
            google-cloud-cpp::rpc_status_protos)
 
+google_cloud_cpp_load_protolist(cloud_texttospeech_list
+                                "protolists/texttospeech.list")
+google_cloud_cpp_load_protodeps(cloud_texttospeech_deps
+                                "protodeps/texttospeech.deps")
 google_cloud_cpp_grpcpp_library(
-    google_cloud_cpp_cloud_texttospeech_protos
-    "${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/texttospeech/v1/cloud_tts.proto"
-    PROTO_PATH_DIRECTORIES
-    "${EXTERNAL_GOOGLEAPIS_SOURCE}"
+    google_cloud_cpp_cloud_texttospeech_protos ${cloud_texttospeech_list}
+    PROTO_PATH_DIRECTORIES "${EXTERNAL_GOOGLEAPIS_SOURCE}"
     "${PROTO_INCLUDE_DIR}")
 external_googleapis_set_version_and_alias(cloud_texttospeech_protos)
-target_link_libraries(
-    google_cloud_cpp_cloud_texttospeech_protos
-    PUBLIC google-cloud-cpp::api_annotations_protos
-           google-cloud-cpp::api_client_protos
-           google-cloud-cpp::api_field_behavior_protos)
+target_link_libraries(google_cloud_cpp_cloud_texttospeech_protos
+                      PUBLIC ${cloud_texttospeech_deps})
 
 google_cloud_cpp_grpcpp_library(
     google_cloud_cpp_iam_protos

--- a/external/googleapis/protodeps/texttospeech.deps
+++ b/external/googleapis/protodeps/texttospeech.deps
@@ -1,0 +1,5 @@
+@com_google_googleapis//google/api:resource_proto
+@com_google_googleapis//google/api:field_behavior_proto
+@com_google_googleapis//google/api:client_proto
+@com_google_googleapis//google/api:annotations_proto
+@com_google_googleapis//google/api:http_proto

--- a/external/googleapis/protolists/texttospeech.list
+++ b/external/googleapis/protolists/texttospeech.list
@@ -1,0 +1,1 @@
+@com_google_googleapis//google/cloud/texttospeech/v1:cloud_tts.proto

--- a/external/googleapis/update_libraries.sh
+++ b/external/googleapis/update_libraries.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+declare -A -r LIBRARIES=(
+  ["texttospeech"]="@com_google_googleapis//google/cloud/texttospeech/v1:texttospeech_proto"
+)
+
+for library in "${!LIBRARIES[@]}"; do
+  IFS=',' read -r -a rules <<<"${LIBRARIES[$library]}"
+  : >"external/googleapis/protolists/${library}.list"
+  : >"external/googleapis/protodeps/${library}.deps"
+  for rule in "${rules[@]}"; do
+    path="${rule%:*}"
+    bazel --batch query --noshow_progress --noshow_loading_progress \
+      "deps(${rule})" |
+      grep "${path}" |
+      grep -E '\.proto$' \
+        >>"external/googleapis/protolists/${library}.list"
+    bazel --batch query --noshow_progress --noshow_loading_progress \
+      "deps(${rule})" |
+      grep "@com_google_googleapis//" | grep _proto |
+      grep -v "${path}" \
+        >>"external/googleapis/protodeps/${library}.deps"
+  done
+done


### PR DESCRIPTION
Use a script to generate the dependencies (as text files) and some CMake
functions to load them. Same format as we use for the generated
libraries scaffold.

I think this will fix the CI flakes.  Obviously it could be used to fix / automate
other libraries. I will do that later, I just want to get a fix out ASAP.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7643)
<!-- Reviewable:end -->
