### PR TITLE
test(spanner): use the last instance config as the PickConfig() default

### DIFF
--- a/google/cloud/spanner/samples/samples.cc
+++ b/google/cloud/spanner/samples/samples.cc
@@ -3607,14 +3607,14 @@ std::string PickConfig(google::cloud::spanner_admin::InstanceAdminClient client,
   std::cout << "\n" << __func__ << ":\n";
 
   std::string ret;
-  std::string first;
+  std::string last;
   int i = 0;
   for (auto const& instance_config :
        client.ListInstanceConfigs(project.FullName())) {
     if (!instance_config) break;
     if (instance_config->name().rfind(config_prefix, 0) != 0) continue;
     auto const config = instance_config->name().substr(config_prefix.size());
-    if (first.empty()) first = config;
+    last = config;
     if (config.rfind(included_prefix, 0) != 0) continue;
     if (std::find(excluded.begin(), excluded.end(), config) != excluded.end()) {
       continue;
@@ -3626,7 +3626,7 @@ std::string PickConfig(google::cloud::spanner_admin::InstanceAdminClient client,
     std::cout << "    " << i << " " << config << " " << selected << " " << ret
               << "\n";
   }
-  return ret.empty() ? first : ret;
+  return ret.empty() ? last : ret;
 }
 
 std::vector<std::string> LeaderOptions(


### PR DESCRIPTION
When no instance configs match our `included_prefix - excluded`
criteria, we return one anyway.  Previously we returned the first
one we saw during the enumeration, but now we return the last.
This only makes a practical difference when running against the
Spanner staging service, where we want to favor `us-central1`
over `cloud-devel-global-config`.

In the longer run we probably want to avoid having any criteria
or default favorites encoded in the source, and instead specify
our preferences using configuration data.  But in the short term
this restores the ability to test using the staging service.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7646)
<!-- Reviewable:end -->
