### PR TITLE
ci: update quickstart build image

### DIFF
--- a/ci/cloudbuild/dockerfiles/ubuntu-focal.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/ubuntu-focal.Dockerfile
@@ -65,3 +65,7 @@ ENV CLOUD_SDK_LOCATION=/usr/local/google-cloud-sdk
 ENV PATH=${CLOUD_SDK_LOCATION}/bin:${PATH}
 # The Cloud Pub/Sub emulator needs Java :shrug:
 RUN apt update && (apt install -y openjdk-11-jre || apt install -y openjdk-9-jre)
+
+RUN curl -o /usr/bin/bazelisk -sSL "https://github.com/bazelbuild/bazelisk/releases/download/v1.10.1/bazelisk-linux-amd64" && \
+    chmod +x /usr/bin/bazelisk && \
+    ln -s /usr/bin/bazelisk /usr/bin/bazel

--- a/ci/cloudbuild/triggers/quickstart-bazel-ci.yaml
+++ b/ci/cloudbuild/triggers/quickstart-bazel-ci.yaml
@@ -7,7 +7,7 @@ github:
 name: quickstart-bazel-ci
 substitutions:
   _BUILD_NAME: quickstart-bazel
-  _DISTRO: ubuntu-bionic
+  _DISTRO: ubuntu-focal
   _TRIGGER_TYPE: ci
 tags:
 - ci

--- a/ci/cloudbuild/triggers/quickstart-bazel-pr.yaml
+++ b/ci/cloudbuild/triggers/quickstart-bazel-pr.yaml
@@ -8,7 +8,7 @@ github:
 name: quickstart-bazel-pr
 substitutions:
   _BUILD_NAME: quickstart-bazel
-  _DISTRO: ubuntu-bionic
+  _DISTRO: ubuntu-focal
   _TRIGGER_TYPE: pr
 tags:
 - pr

--- a/ci/cloudbuild/triggers/quickstart-cmake-ci.yaml
+++ b/ci/cloudbuild/triggers/quickstart-cmake-ci.yaml
@@ -7,7 +7,7 @@ github:
 name: quickstart-cmake-ci
 substitutions:
   _BUILD_NAME: quickstart-cmake
-  _DISTRO: ubuntu-bionic
+  _DISTRO: ubuntu-focal
   _TRIGGER_TYPE: ci
 tags:
 - ci

--- a/ci/cloudbuild/triggers/quickstart-cmake-pr.yaml
+++ b/ci/cloudbuild/triggers/quickstart-cmake-pr.yaml
@@ -8,7 +8,7 @@ github:
 name: quickstart-cmake-pr
 substitutions:
   _BUILD_NAME: quickstart-cmake
-  _DISTRO: ubuntu-bionic
+  _DISTRO: ubuntu-focal
   _TRIGGER_TYPE: pr
 tags:
 - pr


### PR DESCRIPTION
Update the docker image for `quickstart-*` builds to Ubuntu:20.04
(Focal). This includes a newer version of CMake that I want to use to
parallelize the CMake-based builds. I also upgraded the Bazel build for
consistency.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7647)
<!-- Reviewable:end -->
