### PR TITLE
chore(generator): change doxygen commnent character sequence

### DIFF
--- a/generator/integration_tests/golden/golden_kitchen_sink_client.h
+++ b/generator/integration_tests/golden/golden_kitchen_sink_client.h
@@ -33,17 +33,17 @@ namespace cloud {
 namespace golden {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-/**
- * A service account is a special type of Google account that belongs to your
- * application or a virtual machine (VM), instead of to an individual end user.
- * Your application assumes the identity of the service account to call Google
- * APIs, so that the users aren't directly involved.
- *
- * Service account credentials are used to temporarily assume the identity
- * of the service account. Supported credential types include OAuth 2.0 access
- * tokens, OpenID Connect ID tokens, self-signed JSON Web Tokens (JWTs), and
- * more.
- */
+///
+/// A service account is a special type of Google account that belongs to your
+/// application or a virtual machine (VM), instead of to an individual end user.
+/// Your application assumes the identity of the service account to call Google
+/// APIs, so that the users aren't directly involved.
+///
+/// Service account credentials are used to temporarily assume the identity
+/// of the service account. Supported credential types include OAuth 2.0 access
+/// tokens, OpenID Connect ID tokens, self-signed JSON Web Tokens (JWTs), and
+/// more.
+///
 class GoldenKitchenSinkClient {
  public:
   explicit GoldenKitchenSinkClient(std::shared_ptr<GoldenKitchenSinkConnection> connection);
@@ -67,199 +67,199 @@ class GoldenKitchenSinkClient {
   }
   //@}
 
-  /**
-   * Generates an OAuth 2.0 access token for a service account.
-   *
-   * @param name  Required. The resource name of the service account for which the credentials
-   *  are requested, in the following format:
-   *  `projects/-/serviceAccounts/{ACCOUNT_EMAIL_OR_UNIQUEID}`. The `-` wildcard
-   *  character is required; replacing it with a project ID is invalid.
-   * @param delegates  The sequence of service accounts in a delegation chain. Each service
-   *  account must be granted the `roles/iam.serviceAccountTokenCreator` role
-   *  on its next service account in the chain. The last service account in the
-   *  chain must be granted the `roles/iam.serviceAccountTokenCreator` role
-   *  on the service account that is specified in the `name` field of the
-   *  request.
-   *  The delegates must have the following format:
-   *  `projects/-/serviceAccounts/{ACCOUNT_EMAIL_OR_UNIQUEID}`. The `-` wildcard
-   *  character is required; replacing it with a project ID is invalid.
-   * @param scope  Required. Code to identify the scopes to be included in the OAuth 2.0 access token.
-   *  See https://developers.google.com/identity/protocols/googlescopes for more
-   *  information.
-   *  At least one value required.
-   * @param lifetime  The desired lifetime duration of the access token in seconds.
-   *  Must be set to a value less than or equal to 3600 (1 hour). If a value is
-   *  not specified, the token's lifetime will be set to a default value of one
-   *  hour.
-   * @return @googleapis_link{google::test::admin::database::v1::GenerateAccessTokenResponse,generator/integration_tests/test.proto#L872}
-   */
+  ///
+  /// Generates an OAuth 2.0 access token for a service account.
+  ///
+  /// @param name  Required. The resource name of the service account for which the credentials
+  ///  are requested, in the following format:
+  ///  `projects/-/serviceAccounts/{ACCOUNT_EMAIL_OR_UNIQUEID}`. The `-` wildcard
+  ///  character is required; replacing it with a project ID is invalid.
+  /// @param delegates  The sequence of service accounts in a delegation chain. Each service
+  ///  account must be granted the `roles/iam.serviceAccountTokenCreator` role
+  ///  on its next service account in the chain. The last service account in the
+  ///  chain must be granted the `roles/iam.serviceAccountTokenCreator` role
+  ///  on the service account that is specified in the `name` field of the
+  ///  request.
+  ///  The delegates must have the following format:
+  ///  `projects/-/serviceAccounts/{ACCOUNT_EMAIL_OR_UNIQUEID}`. The `-` wildcard
+  ///  character is required; replacing it with a project ID is invalid.
+  /// @param scope  Required. Code to identify the scopes to be included in the OAuth 2.0 access token.
+  ///  See https://developers.google.com/identity/protocols/googlescopes for more
+  ///  information.
+  ///  At least one value required.
+  /// @param lifetime  The desired lifetime duration of the access token in seconds.
+  ///  Must be set to a value less than or equal to 3600 (1 hour). If a value is
+  ///  not specified, the token's lifetime will be set to a default value of one
+  ///  hour.
+  /// @return @googleapis_link{google::test::admin::database::v1::GenerateAccessTokenResponse,generator/integration_tests/test.proto#L872}
+  ///
   StatusOr<google::test::admin::database::v1::GenerateAccessTokenResponse>
   GenerateAccessToken(std::string const& name, std::vector<std::string> const& delegates, std::vector<std::string> const& scope, google::protobuf::Duration const& lifetime);
 
-  /**
-   * Generates an OpenID Connect ID token for a service account.
-   *
-   * @param name  Required. The resource name of the service account for which the credentials
-   *  are requested, in the following format:
-   *  `projects/-/serviceAccounts/{ACCOUNT_EMAIL_OR_UNIQUEID}`. The `-` wildcard
-   *  character is required; replacing it with a project ID is invalid.
-   * @param delegates  The sequence of service accounts in a delegation chain. Each service
-   *  account must be granted the `roles/iam.serviceAccountTokenCreator` role
-   *  on its next service account in the chain. The last service account in the
-   *  chain must be granted the `roles/iam.serviceAccountTokenCreator` role
-   *  on the service account that is specified in the `name` field of the
-   *  request.
-   *  The delegates must have the following format:
-   *  `projects/-/serviceAccounts/{ACCOUNT_EMAIL_OR_UNIQUEID}`. The `-` wildcard
-   *  character is required; replacing it with a project ID is invalid.
-   * @param audience  Required. The audience for the token, such as the API or account that this token
-   *  grants access to.
-   * @param include_email  Include the service account email in the token. If set to `true`, the
-   *  token will contain `email` and `email_verified` claims.
-   * @return @googleapis_link{google::test::admin::database::v1::GenerateIdTokenResponse,generator/integration_tests/test.proto#L914}
-   */
+  ///
+  /// Generates an OpenID Connect ID token for a service account.
+  ///
+  /// @param name  Required. The resource name of the service account for which the credentials
+  ///  are requested, in the following format:
+  ///  `projects/-/serviceAccounts/{ACCOUNT_EMAIL_OR_UNIQUEID}`. The `-` wildcard
+  ///  character is required; replacing it with a project ID is invalid.
+  /// @param delegates  The sequence of service accounts in a delegation chain. Each service
+  ///  account must be granted the `roles/iam.serviceAccountTokenCreator` role
+  ///  on its next service account in the chain. The last service account in the
+  ///  chain must be granted the `roles/iam.serviceAccountTokenCreator` role
+  ///  on the service account that is specified in the `name` field of the
+  ///  request.
+  ///  The delegates must have the following format:
+  ///  `projects/-/serviceAccounts/{ACCOUNT_EMAIL_OR_UNIQUEID}`. The `-` wildcard
+  ///  character is required; replacing it with a project ID is invalid.
+  /// @param audience  Required. The audience for the token, such as the API or account that this token
+  ///  grants access to.
+  /// @param include_email  Include the service account email in the token. If set to `true`, the
+  ///  token will contain `email` and `email_verified` claims.
+  /// @return @googleapis_link{google::test::admin::database::v1::GenerateIdTokenResponse,generator/integration_tests/test.proto#L914}
+  ///
   StatusOr<google::test::admin::database::v1::GenerateIdTokenResponse>
   GenerateIdToken(std::string const& name, std::vector<std::string> const& delegates, std::string const& audience, bool include_email);
 
-  /**
-   * Writes log entries to Logging. This API method is the
-   * only way to send log entries to Logging. This method
-   * is used, directly or indirectly, by the Logging agent
-   * (fluentd) and all logging libraries configured to use Logging.
-   * A single request may contain log entries for a maximum of 1000
-   * different resources (projects, organizations, billing accounts or
-   * folders)
-   *
-   * @param log_name  Optional. A default log resource name that is assigned to all log entries
-   *  in `entries` that do not specify a value for `log_name`:
-   *      "projects/[PROJECT_ID]/logs/[LOG_ID]"
-   *      "organizations/[ORGANIZATION_ID]/logs/[LOG_ID]"
-   *      "billingAccounts/[BILLING_ACCOUNT_ID]/logs/[LOG_ID]"
-   *      "folders/[FOLDER_ID]/logs/[LOG_ID]"
-   *  `[LOG_ID]` must be URL-encoded. For example:
-   *      "projects/my-project-id/logs/syslog"
-   *      "organizations/1234567890/logs/cloudresourcemanager.googleapis.com%2Factivity"
-   *  The permission `logging.logEntries.create` is needed on each project,
-   *  organization, billing account, or folder that is receiving new log
-   *  entries, whether the resource is specified in `logName` or in an
-   *  individual log entry. $Test delimiter.
-   * @param labels  Optional. Default labels that are added to the `labels` field of all log
-   *  entries in `entries`. If a log entry already has a label with the same key
-   *  as a label in this parameter, then the log entry's label is not changed.
-   *  See [LogEntry][google.logging.v2.LogEntry]. Test delimiter$
-   * @return @googleapis_link{google::test::admin::database::v1::WriteLogEntriesResponse,generator/integration_tests/test.proto#L953}
-   */
+  ///
+  /// Writes log entries to Logging. This API method is the
+  /// only way to send log entries to Logging. This method
+  /// is used, directly or indirectly, by the Logging agent
+  /// (fluentd) and all logging libraries configured to use Logging.
+  /// A single request may contain log entries for a maximum of 1000
+  /// different resources (projects, organizations, billing accounts or
+  /// folders)
+  ///
+  /// @param log_name  Optional. A default log resource name that is assigned to all log entries
+  ///  in `entries` that do not specify a value for `log_name`:
+  ///      "projects/[PROJECT_ID]/logs/[LOG_ID]"
+  ///      "organizations/[ORGANIZATION_ID]/logs/[LOG_ID]"
+  ///      "billingAccounts/[BILLING_ACCOUNT_ID]/logs/[LOG_ID]"
+  ///      "folders/[FOLDER_ID]/logs/[LOG_ID]"
+  ///  `[LOG_ID]` must be URL-encoded. For example:
+  ///      "projects/my-project-id/logs/syslog"
+  ///      "organizations/1234567890/logs/cloudresourcemanager.googleapis.com%2Factivity"
+  ///  The permission `logging.logEntries.create` is needed on each project,
+  ///  organization, billing account, or folder that is receiving new log
+  ///  entries, whether the resource is specified in `logName` or in an
+  ///  individual log entry. $Test delimiter.
+  /// @param labels  Optional. Default labels that are added to the `labels` field of all log
+  ///  entries in `entries`. If a log entry already has a label with the same key
+  ///  as a label in this parameter, then the log entry's label is not changed.
+  ///  See [LogEntry][google.logging.v2.LogEntry]. Test delimiter$
+  /// @return @googleapis_link{google::test::admin::database::v1::WriteLogEntriesResponse,generator/integration_tests/test.proto#L953}
+  ///
   StatusOr<google::test::admin::database::v1::WriteLogEntriesResponse>
   WriteLogEntries(std::string const& log_name, std::map<std::string, std::string> const& labels);
 
-  /**
-   * Lists the logs in projects, organizations, folders, or billing accounts.
-   * Only logs that have entries are listed.
-   *
-   * @param parent  Required. The resource name that owns the logs:
-   *      "projects/[PROJECT_ID]"
-   *      "organizations/[ORGANIZATION_ID]"
-   *      "billingAccounts/[BILLING_ACCOUNT_ID]"
-   *      "folders/[FOLDER_ID]"
-   * @return std::string
-   */
+  ///
+  /// Lists the logs in projects, organizations, folders, or billing accounts.
+  /// Only logs that have entries are listed.
+  ///
+  /// @param parent  Required. The resource name that owns the logs:
+  ///      "projects/[PROJECT_ID]"
+  ///      "organizations/[ORGANIZATION_ID]"
+  ///      "billingAccounts/[BILLING_ACCOUNT_ID]"
+  ///      "folders/[FOLDER_ID]"
+  /// @return std::string
+  ///
   StreamRange<std::string>
   ListLogs(std::string const& parent);
 
-  /**
-   * Streaming read of log entries as they are ingested. Until the stream is
-   * terminated, it will continue reading logs.
-   *
-   * @param resource_names  Required. Name of a parent resource from which to retrieve log entries:
-   *      "projects/[PROJECT_ID]"
-   *      "organizations/[ORGANIZATION_ID]"
-   *      "billingAccounts/[BILLING_ACCOUNT_ID]"
-   *      "folders/[FOLDER_ID]"
-   *  May alternatively be one or more views:
-   *      "projects/[PROJECT_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]"
-   *      "organization/[ORGANIZATION_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]"
-   *      "billingAccounts/[BILLING_ACCOUNT_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]"
-   *      "folders/[FOLDER_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]"
-   * @return @googleapis_link{google::test::admin::database::v1::TailLogEntriesResponse,generator/integration_tests/test.proto#L1214}
-   */
+  ///
+  /// Streaming read of log entries as they are ingested. Until the stream is
+  /// terminated, it will continue reading logs.
+  ///
+  /// @param resource_names  Required. Name of a parent resource from which to retrieve log entries:
+  ///      "projects/[PROJECT_ID]"
+  ///      "organizations/[ORGANIZATION_ID]"
+  ///      "billingAccounts/[BILLING_ACCOUNT_ID]"
+  ///      "folders/[FOLDER_ID]"
+  ///  May alternatively be one or more views:
+  ///      "projects/[PROJECT_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]"
+  ///      "organization/[ORGANIZATION_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]"
+  ///      "billingAccounts/[BILLING_ACCOUNT_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]"
+  ///      "folders/[FOLDER_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]"
+  /// @return @googleapis_link{google::test::admin::database::v1::TailLogEntriesResponse,generator/integration_tests/test.proto#L1214}
+  ///
   StreamRange<google::test::admin::database::v1::TailLogEntriesResponse>
   TailLogEntries(std::vector<std::string> const& resource_names);
 
-  /**
-   * Lists every [ServiceAccountKey][google.iam.admin.v1.ServiceAccountKey] for a service account.
-   *
-   * @param name  Required. The resource name of the service account in the following format:
-   *  `projects/{PROJECT_ID}/serviceAccounts/{ACCOUNT}`.
-   *  Using `-` as a wildcard for the `PROJECT_ID`, will infer the project from
-   *  the account. The `ACCOUNT` value can be the `email` address or the
-   *  `unique_id` of the service account.
-   * @param key_types  Filters the types of keys the user wants to include in the list
-   *  response. Duplicate key types are not allowed. If no key type
-   *  is provided, all keys are returned.
-   * @return @googleapis_link{google::test::admin::database::v1::ListServiceAccountKeysResponse,generator/integration_tests/test.proto#L1286}
-   */
+  ///
+  /// Lists every [ServiceAccountKey][google.iam.admin.v1.ServiceAccountKey] for a service account.
+  ///
+  /// @param name  Required. The resource name of the service account in the following format:
+  ///  `projects/{PROJECT_ID}/serviceAccounts/{ACCOUNT}`.
+  ///  Using `-` as a wildcard for the `PROJECT_ID`, will infer the project from
+  ///  the account. The `ACCOUNT` value can be the `email` address or the
+  ///  `unique_id` of the service account.
+  /// @param key_types  Filters the types of keys the user wants to include in the list
+  ///  response. Duplicate key types are not allowed. If no key type
+  ///  is provided, all keys are returned.
+  /// @return @googleapis_link{google::test::admin::database::v1::ListServiceAccountKeysResponse,generator/integration_tests/test.proto#L1286}
+  ///
   StatusOr<google::test::admin::database::v1::ListServiceAccountKeysResponse>
   ListServiceAccountKeys(std::string const& name, std::vector<google::test::admin::database::v1::ListServiceAccountKeysRequest::KeyType> const& key_types);
 
-  /**
-   * Generates an OAuth 2.0 access token for a service account.
-   *
-   * @param request @googleapis_link{google::test::admin::database::v1::GenerateAccessTokenRequest,generator/integration_tests/test.proto#L835}
-   * @return @googleapis_link{google::test::admin::database::v1::GenerateAccessTokenResponse,generator/integration_tests/test.proto#L872}
-   */
+  ///
+  /// Generates an OAuth 2.0 access token for a service account.
+  ///
+  /// @param request @googleapis_link{google::test::admin::database::v1::GenerateAccessTokenRequest,generator/integration_tests/test.proto#L835}
+  /// @return @googleapis_link{google::test::admin::database::v1::GenerateAccessTokenResponse,generator/integration_tests/test.proto#L872}
+  ///
   StatusOr<google::test::admin::database::v1::GenerateAccessTokenResponse>
   GenerateAccessToken(google::test::admin::database::v1::GenerateAccessTokenRequest const& request);
 
-  /**
-   * Generates an OpenID Connect ID token for a service account.
-   *
-   * @param request @googleapis_link{google::test::admin::database::v1::GenerateIdTokenRequest,generator/integration_tests/test.proto#L881}
-   * @return @googleapis_link{google::test::admin::database::v1::GenerateIdTokenResponse,generator/integration_tests/test.proto#L914}
-   */
+  ///
+  /// Generates an OpenID Connect ID token for a service account.
+  ///
+  /// @param request @googleapis_link{google::test::admin::database::v1::GenerateIdTokenRequest,generator/integration_tests/test.proto#L881}
+  /// @return @googleapis_link{google::test::admin::database::v1::GenerateIdTokenResponse,generator/integration_tests/test.proto#L914}
+  ///
   StatusOr<google::test::admin::database::v1::GenerateIdTokenResponse>
   GenerateIdToken(google::test::admin::database::v1::GenerateIdTokenRequest const& request);
 
-  /**
-   * Writes log entries to Logging. This API method is the
-   * only way to send log entries to Logging. This method
-   * is used, directly or indirectly, by the Logging agent
-   * (fluentd) and all logging libraries configured to use Logging.
-   * A single request may contain log entries for a maximum of 1000
-   * different resources (projects, organizations, billing accounts or
-   * folders)
-   *
-   * @param request @googleapis_link{google::test::admin::database::v1::WriteLogEntriesRequest,generator/integration_tests/test.proto#L920}
-   * @return @googleapis_link{google::test::admin::database::v1::WriteLogEntriesResponse,generator/integration_tests/test.proto#L953}
-   */
+  ///
+  /// Writes log entries to Logging. This API method is the
+  /// only way to send log entries to Logging. This method
+  /// is used, directly or indirectly, by the Logging agent
+  /// (fluentd) and all logging libraries configured to use Logging.
+  /// A single request may contain log entries for a maximum of 1000
+  /// different resources (projects, organizations, billing accounts or
+  /// folders)
+  ///
+  /// @param request @googleapis_link{google::test::admin::database::v1::WriteLogEntriesRequest,generator/integration_tests/test.proto#L920}
+  /// @return @googleapis_link{google::test::admin::database::v1::WriteLogEntriesResponse,generator/integration_tests/test.proto#L953}
+  ///
   StatusOr<google::test::admin::database::v1::WriteLogEntriesResponse>
   WriteLogEntries(google::test::admin::database::v1::WriteLogEntriesRequest const& request);
 
-  /**
-   * Lists the logs in projects, organizations, folders, or billing accounts.
-   * Only logs that have entries are listed.
-   *
-   * @param request @googleapis_link{google::test::admin::database::v1::ListLogsRequest,generator/integration_tests/test.proto#L956}
-   * @return std::string
-   */
+  ///
+  /// Lists the logs in projects, organizations, folders, or billing accounts.
+  /// Only logs that have entries are listed.
+  ///
+  /// @param request @googleapis_link{google::test::admin::database::v1::ListLogsRequest,generator/integration_tests/test.proto#L956}
+  /// @return std::string
+  ///
   StreamRange<std::string>
   ListLogs(google::test::admin::database::v1::ListLogsRequest request);
 
-  /**
-   * Streaming read of log entries as they are ingested. Until the stream is
-   * terminated, it will continue reading logs.
-   *
-   * @param request @googleapis_link{google::test::admin::database::v1::TailLogEntriesRequest,generator/integration_tests/test.proto#L1182}
-   * @return @googleapis_link{google::test::admin::database::v1::TailLogEntriesResponse,generator/integration_tests/test.proto#L1214}
-   */
+  ///
+  /// Streaming read of log entries as they are ingested. Until the stream is
+  /// terminated, it will continue reading logs.
+  ///
+  /// @param request @googleapis_link{google::test::admin::database::v1::TailLogEntriesRequest,generator/integration_tests/test.proto#L1182}
+  /// @return @googleapis_link{google::test::admin::database::v1::TailLogEntriesResponse,generator/integration_tests/test.proto#L1214}
+  ///
   StreamRange<google::test::admin::database::v1::TailLogEntriesResponse>
   TailLogEntries(google::test::admin::database::v1::TailLogEntriesRequest const& request);
 
-  /**
-   * Lists every [ServiceAccountKey][google.iam.admin.v1.ServiceAccountKey] for a service account.
-   *
-   * @param request @googleapis_link{google::test::admin::database::v1::ListServiceAccountKeysRequest,generator/integration_tests/test.proto#L1254}
-   * @return @googleapis_link{google::test::admin::database::v1::ListServiceAccountKeysResponse,generator/integration_tests/test.proto#L1286}
-   */
+  ///
+  /// Lists every [ServiceAccountKey][google.iam.admin.v1.ServiceAccountKey] for a service account.
+  ///
+  /// @param request @googleapis_link{google::test::admin::database::v1::ListServiceAccountKeysRequest,generator/integration_tests/test.proto#L1254}
+  /// @return @googleapis_link{google::test::admin::database::v1::ListServiceAccountKeysResponse,generator/integration_tests/test.proto#L1286}
+  ///
   StatusOr<google::test::admin::database::v1::ListServiceAccountKeysResponse>
   ListServiceAccountKeys(google::test::admin::database::v1::ListServiceAccountKeysRequest const& request);
 

--- a/generator/integration_tests/golden/golden_thing_admin_client.h
+++ b/generator/integration_tests/golden/golden_thing_admin_client.h
@@ -34,14 +34,14 @@ namespace cloud {
 namespace golden {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-/**
- * Cloud Test Database Admin API
- *
- * The Cloud Test Database Admin API can be used to create, drop, and
- * list databases. It also enables updating the schema of pre-existing
- * databases. It can be also used to create, delete and list backups for a
- * database and to restore from an existing backup.
- */
+///
+/// Cloud Test Database Admin API
+///
+/// The Cloud Test Database Admin API can be used to create, drop, and
+/// list databases. It also enables updating the schema of pre-existing
+/// databases. It can be also used to create, delete and list backups for a
+/// database and to restore from an existing backup.
+///
 class GoldenThingAdminClient {
  public:
   explicit GoldenThingAdminClient(std::shared_ptr<GoldenThingAdminConnection> connection);
@@ -65,102 +65,102 @@ class GoldenThingAdminClient {
   }
   //@}
 
-  /**
-   * Lists Cloud Test databases.
-   *
-   * @param parent  Required. The instance whose databases should be listed.
-   *  Values are of the form `projects/<project>/instances/<instance>`.
-   * @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
-   */
+  ///
+  /// Lists Cloud Test databases.
+  ///
+  /// @param parent  Required. The instance whose databases should be listed.
+  ///  Values are of the form `projects/<project>/instances/<instance>`.
+  /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
+  ///
   StreamRange<google::test::admin::database::v1::Database>
   ListDatabases(std::string const& parent);
 
-  /**
-   * Creates a new Cloud Test database and starts to prepare it for serving.
-   * The returned [long-running operation][google.longrunning.Operation] will
-   * have a name of the format `<database_name>/operations/<operation_id>` and
-   * can be used to track preparation of the database. The
-   * [metadata][google.longrunning.Operation.metadata] field type is
-   * [CreateDatabaseMetadata][google.test.admin.database.v1.CreateDatabaseMetadata]. The
-   * [response][google.longrunning.Operation.response] field type is
-   * [Database][google.test.admin.database.v1.Database], if successful.
-   *
-   * @param parent  Required. The name of the instance that will serve the new database.
-   *  Values are of the form `projects/<project>/instances/<instance>`.
-   * @param create_statement  Required. A `CREATE DATABASE` statement, which specifies the ID of the
-   *  new database.  The database ID must conform to the regular expression
-   *  `[a-z][a-z0-9_\-]*[a-z0-9]` and be between 2 and 30 characters in length.
-   *  If the database ID is a reserved word or if it contains a hyphen, the
-   *  database ID must be enclosed in backticks (`` ` ``).
-   * @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
-   */
+  ///
+  /// Creates a new Cloud Test database and starts to prepare it for serving.
+  /// The returned [long-running operation][google.longrunning.Operation] will
+  /// have a name of the format `<database_name>/operations/<operation_id>` and
+  /// can be used to track preparation of the database. The
+  /// [metadata][google.longrunning.Operation.metadata] field type is
+  /// [CreateDatabaseMetadata][google.test.admin.database.v1.CreateDatabaseMetadata]. The
+  /// [response][google.longrunning.Operation.response] field type is
+  /// [Database][google.test.admin.database.v1.Database], if successful.
+  ///
+  /// @param parent  Required. The name of the instance that will serve the new database.
+  ///  Values are of the form `projects/<project>/instances/<instance>`.
+  /// @param create_statement  Required. A `CREATE DATABASE` statement, which specifies the ID of the
+  ///  new database.  The database ID must conform to the regular expression
+  ///  `[a-z][a-z0-9_\-]*[a-z0-9]` and be between 2 and 30 characters in length.
+  ///  If the database ID is a reserved word or if it contains a hyphen, the
+  ///  database ID must be enclosed in backticks (`` ` ``).
+  /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
+  ///
   future<StatusOr<google::test::admin::database::v1::Database>>
   CreateDatabase(std::string const& parent, std::string const& create_statement);
 
-  /**
-   * Gets the state of a Cloud Test database.
-   *
-   * @param name  Required. The name of the requested database. Values are of the form
-   *  `projects/<project>/instances/<instance>/databases/<database>`.
-   * @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
-   */
+  ///
+  /// Gets the state of a Cloud Test database.
+  ///
+  /// @param name  Required. The name of the requested database. Values are of the form
+  ///  `projects/<project>/instances/<instance>/databases/<database>`.
+  /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
+  ///
   StatusOr<google::test::admin::database::v1::Database>
   GetDatabase(std::string const& name);
 
-  /**
-   * Updates the schema of a Cloud Test database by
-   * creating/altering/dropping tables, columns, indexes, etc. The returned
-   * [long-running operation][google.longrunning.Operation] will have a name of
-   * the format `<database_name>/operations/<operation_id>` and can be used to
-   * track execution of the schema change(s). The
-   * [metadata][google.longrunning.Operation.metadata] field type is
-   * [UpdateDatabaseDdlMetadata][google.test.admin.database.v1.UpdateDatabaseDdlMetadata].  The operation has no response.
-   *
-   * @param database  Required. The database to update.
-   * @param statements  Required. DDL statements to be applied to the database.
-   * @return @googleapis_link{google::test::admin::database::v1::UpdateDatabaseDdlMetadata,generator/integration_tests/test.proto#L506}
-   */
+  ///
+  /// Updates the schema of a Cloud Test database by
+  /// creating/altering/dropping tables, columns, indexes, etc. The returned
+  /// [long-running operation][google.longrunning.Operation] will have a name of
+  /// the format `<database_name>/operations/<operation_id>` and can be used to
+  /// track execution of the schema change(s). The
+  /// [metadata][google.longrunning.Operation.metadata] field type is
+  /// [UpdateDatabaseDdlMetadata][google.test.admin.database.v1.UpdateDatabaseDdlMetadata].  The operation has no response.
+  ///
+  /// @param database  Required. The database to update.
+  /// @param statements  Required. DDL statements to be applied to the database.
+  /// @return @googleapis_link{google::test::admin::database::v1::UpdateDatabaseDdlMetadata,generator/integration_tests/test.proto#L506}
+  ///
   future<StatusOr<google::test::admin::database::v1::UpdateDatabaseDdlMetadata>>
   UpdateDatabaseDdl(std::string const& database, std::vector<std::string> const& statements);
 
-  /**
-   * Drops (aka deletes) a Cloud Test database.
-   * Completed backups for the database will be retained according to their
-   * `expire_time`.
-   *
-   * @param database  Required. The database to be dropped.
-   */
+  ///
+  /// Drops (aka deletes) a Cloud Test database.
+  /// Completed backups for the database will be retained according to their
+  /// `expire_time`.
+  ///
+  /// @param database  Required. The database to be dropped.
+  ///
   Status
   DropDatabase(std::string const& database);
 
-  /**
-   * Returns the schema of a Cloud Test database as a list of formatted
-   * DDL statements. This method does not show pending schema updates, those may
-   * be queried using the [Operations][google.longrunning.Operations] API.
-   *
-   * @param database  Required. The database whose schema we wish to get.
-   * @return @googleapis_link{google::test::admin::database::v1::GetDatabaseDdlResponse,generator/integration_tests/test.proto#L545}
-   */
+  ///
+  /// Returns the schema of a Cloud Test database as a list of formatted
+  /// DDL statements. This method does not show pending schema updates, those may
+  /// be queried using the [Operations][google.longrunning.Operations] API.
+  ///
+  /// @param database  Required. The database whose schema we wish to get.
+  /// @return @googleapis_link{google::test::admin::database::v1::GetDatabaseDdlResponse,generator/integration_tests/test.proto#L545}
+  ///
   StatusOr<google::test::admin::database::v1::GetDatabaseDdlResponse>
   GetDatabaseDdl(std::string const& database);
 
-  /**
-   * Sets the access control policy on a database or backup resource.
-   * Replaces any existing policy.
-   *
-   * Authorization requires `test.databases.setIamPolicy`
-   * permission on [resource][google.iam.v1.SetIamPolicyRequest.resource].
-   * For backups, authorization requires `test.backups.setIamPolicy`
-   * permission on [resource][google.iam.v1.SetIamPolicyRequest.resource].
-   *
-   * @param resource  REQUIRED: The resource for which the policy is being specified.
-   *  See the operation documentation for the appropriate value for this field.
-   * @param policy  REQUIRED: The complete policy to be applied to the `resource`. The size of
-   *  the policy is limited to a few 10s of KB. An empty policy is a
-   *  valid policy but certain Cloud Platform services (such as Projects)
-   *  might reject them.
-   * @return @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
-   */
+  ///
+  /// Sets the access control policy on a database or backup resource.
+  /// Replaces any existing policy.
+  ///
+  /// Authorization requires `test.databases.setIamPolicy`
+  /// permission on [resource][google.iam.v1.SetIamPolicyRequest.resource].
+  /// For backups, authorization requires `test.backups.setIamPolicy`
+  /// permission on [resource][google.iam.v1.SetIamPolicyRequest.resource].
+  ///
+  /// @param resource  REQUIRED: The resource for which the policy is being specified.
+  ///  See the operation documentation for the appropriate value for this field.
+  /// @param policy  REQUIRED: The complete policy to be applied to the `resource`. The size of
+  ///  the policy is limited to a few 10s of KB. An empty policy is a
+  ///  valid policy but certain Cloud Platform services (such as Projects)
+  ///  might reject them.
+  /// @return @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
+  ///
   StatusOr<google::iam::v1::Policy>
   SetIamPolicy(std::string const& resource, google::iam::v1::Policy const& policy);
 
@@ -188,467 +188,467 @@ class GoldenThingAdminClient {
   StatusOr<google::iam::v1::Policy>
   SetIamPolicy(std::string const& resource, IamUpdater const& updater, Options options = {});
 
-  /**
-   * Gets the access control policy for a database or backup resource.
-   * Returns an empty policy if a database or backup exists but does not have a
-   * policy set.
-   *
-   * Authorization requires `test.databases.getIamPolicy` permission on
-   * [resource][google.iam.v1.GetIamPolicyRequest.resource].
-   * For backups, authorization requires `test.backups.getIamPolicy`
-   * permission on [resource][google.iam.v1.GetIamPolicyRequest.resource].
-   *
-   * @param resource  REQUIRED: The resource for which the policy is being requested.
-   *  See the operation documentation for the appropriate value for this field.
-   * @return @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
-   */
+  ///
+  /// Gets the access control policy for a database or backup resource.
+  /// Returns an empty policy if a database or backup exists but does not have a
+  /// policy set.
+  ///
+  /// Authorization requires `test.databases.getIamPolicy` permission on
+  /// [resource][google.iam.v1.GetIamPolicyRequest.resource].
+  /// For backups, authorization requires `test.backups.getIamPolicy`
+  /// permission on [resource][google.iam.v1.GetIamPolicyRequest.resource].
+  ///
+  /// @param resource  REQUIRED: The resource for which the policy is being requested.
+  ///  See the operation documentation for the appropriate value for this field.
+  /// @return @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
+  ///
   StatusOr<google::iam::v1::Policy>
   GetIamPolicy(std::string const& resource);
 
-  /**
-   * Returns permissions that the caller has on the specified database or backup
-   * resource.
-   *
-   * Attempting this RPC on a non-existent Cloud Test database will
-   * result in a NOT_FOUND error if the user has
-   * `test.databases.list` permission on the containing Cloud
-   * Test instance. Otherwise returns an empty set of permissions.
-   * Calling this method on a backup that does not exist will
-   * result in a NOT_FOUND error if the user has
-   * `test.backups.list` permission on the containing instance.
-   *
-   * @param resource  REQUIRED: The resource for which the policy detail is being requested.
-   *  See the operation documentation for the appropriate value for this field.
-   * @param permissions  The set of permissions to check for the `resource`. Permissions with
-   *  wildcards (such as '*' or 'storage.*') are not allowed. For more
-   *  information see
-   *  [IAM Overview](https://cloud.google.com/iam/docs/overview#permissions).
-   * @return @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
-   */
+  ///
+  /// Returns permissions that the caller has on the specified database or backup
+  /// resource.
+  ///
+  /// Attempting this RPC on a non-existent Cloud Test database will
+  /// result in a NOT_FOUND error if the user has
+  /// `test.databases.list` permission on the containing Cloud
+  /// Test instance. Otherwise returns an empty set of permissions.
+  /// Calling this method on a backup that does not exist will
+  /// result in a NOT_FOUND error if the user has
+  /// `test.backups.list` permission on the containing instance.
+  ///
+  /// @param resource  REQUIRED: The resource for which the policy detail is being requested.
+  ///  See the operation documentation for the appropriate value for this field.
+  /// @param permissions  The set of permissions to check for the `resource`. Permissions with
+  ///  wildcards (such as '*' or 'storage.*') are not allowed. For more
+  ///  information see
+  ///  [IAM Overview](https://cloud.google.com/iam/docs/overview#permissions).
+  /// @return @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
+  ///
   StatusOr<google::iam::v1::TestIamPermissionsResponse>
   TestIamPermissions(std::string const& resource, std::vector<std::string> const& permissions);
 
-  /**
-   * Starts creating a new Cloud Test Backup.
-   * The returned backup [long-running operation][google.longrunning.Operation]
-   * will have a name of the format
-   * `projects/<project>/instances/<instance>/backups/<backup>/operations/<operation_id>`
-   * and can be used to track creation of the backup. The
-   * [metadata][google.longrunning.Operation.metadata] field type is
-   * [CreateBackupMetadata][google.test.admin.database.v1.CreateBackupMetadata]. The
-   * [response][google.longrunning.Operation.response] field type is
-   * [Backup][google.test.admin.database.v1.Backup], if successful. Cancelling the returned operation will stop the
-   * creation and delete the backup.
-   * There can be only one pending backup creation per database. Backup creation
-   * of different databases can run concurrently.
-   *
-   * @param parent  Required. The name of the instance in which the backup will be
-   *  created. This must be the same instance that contains the database the
-   *  backup will be created from. The backup will be stored in the
-   *  location(s) specified in the instance configuration of this
-   *  instance. Values are of the form
-   *  `projects/<project>/instances/<instance>`.
-   * @param backup  Required. The backup to create.
-   * @param backup_id  Required. The id of the backup to be created. The `backup_id` appended to
-   *  `parent` forms the full backup name of the form
-   *  `projects/<project>/instances/<instance>/backups/<backup_id>`.
-   * @return @googleapis_link{google::test::admin::database::v1::Backup,generator/integration_tests/backup.proto#L36}
-   */
+  ///
+  /// Starts creating a new Cloud Test Backup.
+  /// The returned backup [long-running operation][google.longrunning.Operation]
+  /// will have a name of the format
+  /// `projects/<project>/instances/<instance>/backups/<backup>/operations/<operation_id>`
+  /// and can be used to track creation of the backup. The
+  /// [metadata][google.longrunning.Operation.metadata] field type is
+  /// [CreateBackupMetadata][google.test.admin.database.v1.CreateBackupMetadata]. The
+  /// [response][google.longrunning.Operation.response] field type is
+  /// [Backup][google.test.admin.database.v1.Backup], if successful. Cancelling the returned operation will stop the
+  /// creation and delete the backup.
+  /// There can be only one pending backup creation per database. Backup creation
+  /// of different databases can run concurrently.
+  ///
+  /// @param parent  Required. The name of the instance in which the backup will be
+  ///  created. This must be the same instance that contains the database the
+  ///  backup will be created from. The backup will be stored in the
+  ///  location(s) specified in the instance configuration of this
+  ///  instance. Values are of the form
+  ///  `projects/<project>/instances/<instance>`.
+  /// @param backup  Required. The backup to create.
+  /// @param backup_id  Required. The id of the backup to be created. The `backup_id` appended to
+  ///  `parent` forms the full backup name of the form
+  ///  `projects/<project>/instances/<instance>/backups/<backup_id>`.
+  /// @return @googleapis_link{google::test::admin::database::v1::Backup,generator/integration_tests/backup.proto#L36}
+  ///
   future<StatusOr<google::test::admin::database::v1::Backup>>
   CreateBackup(std::string const& parent, google::test::admin::database::v1::Backup const& backup, std::string const& backup_id);
 
-  /**
-   * Gets metadata on a pending or completed [Backup][google.test.admin.database.v1.Backup].
-   *
-   * @param name  Required. Name of the backup.
-   *  Values are of the form
-   *  `projects/<project>/instances/<instance>/backups/<backup>`.
-   * @return @googleapis_link{google::test::admin::database::v1::Backup,generator/integration_tests/backup.proto#L36}
-   */
+  ///
+  /// Gets metadata on a pending or completed [Backup][google.test.admin.database.v1.Backup].
+  ///
+  /// @param name  Required. Name of the backup.
+  ///  Values are of the form
+  ///  `projects/<project>/instances/<instance>/backups/<backup>`.
+  /// @return @googleapis_link{google::test::admin::database::v1::Backup,generator/integration_tests/backup.proto#L36}
+  ///
   StatusOr<google::test::admin::database::v1::Backup>
   GetBackup(std::string const& name);
 
-  /**
-   * Updates a pending or completed [Backup][google.test.admin.database.v1.Backup].
-   *
-   * @param backup  Required. The backup to update. `backup.name`, and the fields to be updated
-   *  as specified by `update_mask` are required. Other fields are ignored.
-   *  Update is only supported for the following fields:
-   *   * `backup.expire_time`.
-   * @param update_mask  Required. A mask specifying which fields (e.g. `expire_time`) in the
-   *  Backup resource should be updated. This mask is relative to the Backup
-   *  resource, not to the request message. The field mask must always be
-   *  specified; this prevents any future fields from being erased accidentally
-   *  by clients that do not know about them.
-   * @return @googleapis_link{google::test::admin::database::v1::Backup,generator/integration_tests/backup.proto#L36}
-   */
+  ///
+  /// Updates a pending or completed [Backup][google.test.admin.database.v1.Backup].
+  ///
+  /// @param backup  Required. The backup to update. `backup.name`, and the fields to be updated
+  ///  as specified by `update_mask` are required. Other fields are ignored.
+  ///  Update is only supported for the following fields:
+  ///   * `backup.expire_time`.
+  /// @param update_mask  Required. A mask specifying which fields (e.g. `expire_time`) in the
+  ///  Backup resource should be updated. This mask is relative to the Backup
+  ///  resource, not to the request message. The field mask must always be
+  ///  specified; this prevents any future fields from being erased accidentally
+  ///  by clients that do not know about them.
+  /// @return @googleapis_link{google::test::admin::database::v1::Backup,generator/integration_tests/backup.proto#L36}
+  ///
   StatusOr<google::test::admin::database::v1::Backup>
   UpdateBackup(google::test::admin::database::v1::Backup const& backup, google::protobuf::FieldMask const& update_mask);
 
-  /**
-   * Deletes a pending or completed [Backup][google.test.admin.database.v1.Backup].
-   *
-   * @param name  Required. Name of the backup to delete.
-   *  Values are of the form
-   *  `projects/<project>/instances/<instance>/backups/<backup>`.
-   */
+  ///
+  /// Deletes a pending or completed [Backup][google.test.admin.database.v1.Backup].
+  ///
+  /// @param name  Required. Name of the backup to delete.
+  ///  Values are of the form
+  ///  `projects/<project>/instances/<instance>/backups/<backup>`.
+  ///
   Status
   DeleteBackup(std::string const& name);
 
-  /**
-   * Lists completed and pending backups.
-   * Backups returned are ordered by `create_time` in descending order,
-   * starting from the most recent `create_time`.
-   *
-   * @param parent  Required. The instance to list backups from.  Values are of the
-   *  form `projects/<project>/instances/<instance>`.
-   * @return @googleapis_link{google::test::admin::database::v1::Backup,generator/integration_tests/backup.proto#L36}
-   */
+  ///
+  /// Lists completed and pending backups.
+  /// Backups returned are ordered by `create_time` in descending order,
+  /// starting from the most recent `create_time`.
+  ///
+  /// @param parent  Required. The instance to list backups from.  Values are of the
+  ///  form `projects/<project>/instances/<instance>`.
+  /// @return @googleapis_link{google::test::admin::database::v1::Backup,generator/integration_tests/backup.proto#L36}
+  ///
   StreamRange<google::test::admin::database::v1::Backup>
   ListBackups(std::string const& parent);
 
-  /**
-   * Create a new database by restoring from a completed backup. The new
-   * database must be in the same project and in an instance with the same
-   * instance configuration as the instance containing
-   * the backup. The returned database [long-running
-   * operation][google.longrunning.Operation] has a name of the format
-   * `projects/<project>/instances/<instance>/databases/<database>/operations/<operation_id>`,
-   * and can be used to track the progress of the operation, and to cancel it.
-   * The [metadata][google.longrunning.Operation.metadata] field type is
-   * [RestoreDatabaseMetadata][google.test.admin.database.v1.RestoreDatabaseMetadata].
-   * The [response][google.longrunning.Operation.response] type
-   * is [Database][google.test.admin.database.v1.Database], if
-   * successful. Cancelling the returned operation will stop the restore and
-   * delete the database.
-   * There can be only one database being restored into an instance at a time.
-   * Once the restore operation completes, a new restore operation can be
-   * initiated, without waiting for the optimize operation associated with the
-   * first restore to complete.
-   *
-   * @param parent  Required. The name of the instance in which to create the
-   *  restored database. This instance must be in the same project and
-   *  have the same instance configuration as the instance containing
-   *  the source backup. Values are of the form
-   *  `projects/<project>/instances/<instance>`.
-   * @param database_id  Required. The id of the database to create and restore to. This
-   *  database must not already exist. The `database_id` appended to
-   *  `parent` forms the full database name of the form
-   *  `projects/<project>/instances/<instance>/databases/<database_id>`.
-   * @param backup  Name of the backup from which to restore.  Values are of the form
-   *  `projects/<project>/instances/<instance>/backups/<backup>`.
-   * @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
-   */
+  ///
+  /// Create a new database by restoring from a completed backup. The new
+  /// database must be in the same project and in an instance with the same
+  /// instance configuration as the instance containing
+  /// the backup. The returned database [long-running
+  /// operation][google.longrunning.Operation] has a name of the format
+  /// `projects/<project>/instances/<instance>/databases/<database>/operations/<operation_id>`,
+  /// and can be used to track the progress of the operation, and to cancel it.
+  /// The [metadata][google.longrunning.Operation.metadata] field type is
+  /// [RestoreDatabaseMetadata][google.test.admin.database.v1.RestoreDatabaseMetadata].
+  /// The [response][google.longrunning.Operation.response] type
+  /// is [Database][google.test.admin.database.v1.Database], if
+  /// successful. Cancelling the returned operation will stop the restore and
+  /// delete the database.
+  /// There can be only one database being restored into an instance at a time.
+  /// Once the restore operation completes, a new restore operation can be
+  /// initiated, without waiting for the optimize operation associated with the
+  /// first restore to complete.
+  ///
+  /// @param parent  Required. The name of the instance in which to create the
+  ///  restored database. This instance must be in the same project and
+  ///  have the same instance configuration as the instance containing
+  ///  the source backup. Values are of the form
+  ///  `projects/<project>/instances/<instance>`.
+  /// @param database_id  Required. The id of the database to create and restore to. This
+  ///  database must not already exist. The `database_id` appended to
+  ///  `parent` forms the full database name of the form
+  ///  `projects/<project>/instances/<instance>/databases/<database_id>`.
+  /// @param backup  Name of the backup from which to restore.  Values are of the form
+  ///  `projects/<project>/instances/<instance>/backups/<backup>`.
+  /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
+  ///
   future<StatusOr<google::test::admin::database::v1::Database>>
   RestoreDatabase(std::string const& parent, std::string const& database_id, std::string const& backup);
 
-  /**
-   * Lists database [longrunning-operations][google.longrunning.Operation].
-   * A database operation has a name of the form
-   * `projects/<project>/instances/<instance>/databases/<database>/operations/<operation>`.
-   * The long-running operation
-   * [metadata][google.longrunning.Operation.metadata] field type
-   * `metadata.type_url` describes the type of the metadata. Operations returned
-   * include those that have completed/failed/canceled within the last 7 days,
-   * and pending operations.
-   *
-   * @param parent  Required. The instance of the database operations.
-   *  Values are of the form `projects/<project>/instances/<instance>`.
-   * @return @googleapis_link{google::longrunning::Operation,google/longrunning/operations.proto#L128}
-   */
+  ///
+  /// Lists database [longrunning-operations][google.longrunning.Operation].
+  /// A database operation has a name of the form
+  /// `projects/<project>/instances/<instance>/databases/<database>/operations/<operation>`.
+  /// The long-running operation
+  /// [metadata][google.longrunning.Operation.metadata] field type
+  /// `metadata.type_url` describes the type of the metadata. Operations returned
+  /// include those that have completed/failed/canceled within the last 7 days,
+  /// and pending operations.
+  ///
+  /// @param parent  Required. The instance of the database operations.
+  ///  Values are of the form `projects/<project>/instances/<instance>`.
+  /// @return @googleapis_link{google::longrunning::Operation,google/longrunning/operations.proto#L128}
+  ///
   StreamRange<google::longrunning::Operation>
   ListDatabaseOperations(std::string const& parent);
 
-  /**
-   * Lists the backup [long-running operations][google.longrunning.Operation] in
-   * the given instance. A backup operation has a name of the form
-   * `projects/<project>/instances/<instance>/backups/<backup>/operations/<operation>`.
-   * The long-running operation
-   * [metadata][google.longrunning.Operation.metadata] field type
-   * `metadata.type_url` describes the type of the metadata. Operations returned
-   * include those that have completed/failed/canceled within the last 7 days,
-   * and pending operations. Operations returned are ordered by
-   * `operation.metadata.value.progress.start_time` in descending order starting
-   * from the most recently started operation.
-   *
-   * @param parent  Required. The instance of the backup operations. Values are of
-   *  the form `projects/<project>/instances/<instance>`.
-   * @return @googleapis_link{google::longrunning::Operation,google/longrunning/operations.proto#L128}
-   */
+  ///
+  /// Lists the backup [long-running operations][google.longrunning.Operation] in
+  /// the given instance. A backup operation has a name of the form
+  /// `projects/<project>/instances/<instance>/backups/<backup>/operations/<operation>`.
+  /// The long-running operation
+  /// [metadata][google.longrunning.Operation.metadata] field type
+  /// `metadata.type_url` describes the type of the metadata. Operations returned
+  /// include those that have completed/failed/canceled within the last 7 days,
+  /// and pending operations. Operations returned are ordered by
+  /// `operation.metadata.value.progress.start_time` in descending order starting
+  /// from the most recently started operation.
+  ///
+  /// @param parent  Required. The instance of the backup operations. Values are of
+  ///  the form `projects/<project>/instances/<instance>`.
+  /// @return @googleapis_link{google::longrunning::Operation,google/longrunning/operations.proto#L128}
+  ///
   StreamRange<google::longrunning::Operation>
   ListBackupOperations(std::string const& parent);
 
-  /**
-   * Gets the state of a Cloud Test database.
-   *
-   * @param name  Required. The name of the requested database. Values are of the form
-   *  `projects/<project>/instances/<instance>/databases/<database>`.
-   * @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
-   */
+  ///
+  /// Gets the state of a Cloud Test database.
+  ///
+  /// @param name  Required. The name of the requested database. Values are of the form
+  ///  `projects/<project>/instances/<instance>/databases/<database>`.
+  /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
+  ///
   future<StatusOr<google::test::admin::database::v1::Database>>
   AsyncGetDatabase(std::string const& name);
 
-  /**
-   * Drops (aka deletes) a Cloud Test database.
-   * Completed backups for the database will be retained according to their
-   * `expire_time`.
-   *
-   * @param database  Required. The database to be dropped.
-   */
+  ///
+  /// Drops (aka deletes) a Cloud Test database.
+  /// Completed backups for the database will be retained according to their
+  /// `expire_time`.
+  ///
+  /// @param database  Required. The database to be dropped.
+  ///
   future<Status>
   AsyncDropDatabase(std::string const& database);
 
-  /**
-   * Lists Cloud Test databases.
-   *
-   * @param request @googleapis_link{google::test::admin::database::v1::ListDatabasesRequest,generator/integration_tests/test.proto#L377}
-   * @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
-   */
+  ///
+  /// Lists Cloud Test databases.
+  ///
+  /// @param request @googleapis_link{google::test::admin::database::v1::ListDatabasesRequest,generator/integration_tests/test.proto#L377}
+  /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
+  ///
   StreamRange<google::test::admin::database::v1::Database>
   ListDatabases(google::test::admin::database::v1::ListDatabasesRequest request);
 
-  /**
-   * Creates a new Cloud Test database and starts to prepare it for serving.
-   * The returned [long-running operation][google.longrunning.Operation] will
-   * have a name of the format `<database_name>/operations/<operation_id>` and
-   * can be used to track preparation of the database. The
-   * [metadata][google.longrunning.Operation.metadata] field type is
-   * [CreateDatabaseMetadata][google.test.admin.database.v1.CreateDatabaseMetadata]. The
-   * [response][google.longrunning.Operation.response] field type is
-   * [Database][google.test.admin.database.v1.Database], if successful.
-   *
-   * @param request @googleapis_link{google::test::admin::database::v1::CreateDatabaseRequest,generator/integration_tests/test.proto#L409}
-   * @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
-   */
+  ///
+  /// Creates a new Cloud Test database and starts to prepare it for serving.
+  /// The returned [long-running operation][google.longrunning.Operation] will
+  /// have a name of the format `<database_name>/operations/<operation_id>` and
+  /// can be used to track preparation of the database. The
+  /// [metadata][google.longrunning.Operation.metadata] field type is
+  /// [CreateDatabaseMetadata][google.test.admin.database.v1.CreateDatabaseMetadata]. The
+  /// [response][google.longrunning.Operation.response] field type is
+  /// [Database][google.test.admin.database.v1.Database], if successful.
+  ///
+  /// @param request @googleapis_link{google::test::admin::database::v1::CreateDatabaseRequest,generator/integration_tests/test.proto#L409}
+  /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
+  ///
   future<StatusOr<google::test::admin::database::v1::Database>>
   CreateDatabase(google::test::admin::database::v1::CreateDatabaseRequest const& request);
 
-  /**
-   * Gets the state of a Cloud Test database.
-   *
-   * @param request @googleapis_link{google::test::admin::database::v1::GetDatabaseRequest,generator/integration_tests/test.proto#L443}
-   * @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
-   */
+  ///
+  /// Gets the state of a Cloud Test database.
+  ///
+  /// @param request @googleapis_link{google::test::admin::database::v1::GetDatabaseRequest,generator/integration_tests/test.proto#L443}
+  /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
+  ///
   StatusOr<google::test::admin::database::v1::Database>
   GetDatabase(google::test::admin::database::v1::GetDatabaseRequest const& request);
 
-  /**
-   * Updates the schema of a Cloud Test database by
-   * creating/altering/dropping tables, columns, indexes, etc. The returned
-   * [long-running operation][google.longrunning.Operation] will have a name of
-   * the format `<database_name>/operations/<operation_id>` and can be used to
-   * track execution of the schema change(s). The
-   * [metadata][google.longrunning.Operation.metadata] field type is
-   * [UpdateDatabaseDdlMetadata][google.test.admin.database.v1.UpdateDatabaseDdlMetadata].  The operation has no response.
-   *
-   * @param request @googleapis_link{google::test::admin::database::v1::UpdateDatabaseDdlRequest,generator/integration_tests/test.proto#L470}
-   * @return @googleapis_link{google::test::admin::database::v1::UpdateDatabaseDdlMetadata,generator/integration_tests/test.proto#L506}
-   */
+  ///
+  /// Updates the schema of a Cloud Test database by
+  /// creating/altering/dropping tables, columns, indexes, etc. The returned
+  /// [long-running operation][google.longrunning.Operation] will have a name of
+  /// the format `<database_name>/operations/<operation_id>` and can be used to
+  /// track execution of the schema change(s). The
+  /// [metadata][google.longrunning.Operation.metadata] field type is
+  /// [UpdateDatabaseDdlMetadata][google.test.admin.database.v1.UpdateDatabaseDdlMetadata].  The operation has no response.
+  ///
+  /// @param request @googleapis_link{google::test::admin::database::v1::UpdateDatabaseDdlRequest,generator/integration_tests/test.proto#L470}
+  /// @return @googleapis_link{google::test::admin::database::v1::UpdateDatabaseDdlMetadata,generator/integration_tests/test.proto#L506}
+  ///
   future<StatusOr<google::test::admin::database::v1::UpdateDatabaseDdlMetadata>>
   UpdateDatabaseDdl(google::test::admin::database::v1::UpdateDatabaseDdlRequest const& request);
 
-  /**
-   * Drops (aka deletes) a Cloud Test database.
-   * Completed backups for the database will be retained according to their
-   * `expire_time`.
-   *
-   * @param request @googleapis_link{google::test::admin::database::v1::DropDatabaseRequest,generator/integration_tests/test.proto#L523}
-   */
+  ///
+  /// Drops (aka deletes) a Cloud Test database.
+  /// Completed backups for the database will be retained according to their
+  /// `expire_time`.
+  ///
+  /// @param request @googleapis_link{google::test::admin::database::v1::DropDatabaseRequest,generator/integration_tests/test.proto#L523}
+  ///
   Status
   DropDatabase(google::test::admin::database::v1::DropDatabaseRequest const& request);
 
-  /**
-   * Returns the schema of a Cloud Test database as a list of formatted
-   * DDL statements. This method does not show pending schema updates, those may
-   * be queried using the [Operations][google.longrunning.Operations] API.
-   *
-   * @param request @googleapis_link{google::test::admin::database::v1::GetDatabaseDdlRequest,generator/integration_tests/test.proto#L534}
-   * @return @googleapis_link{google::test::admin::database::v1::GetDatabaseDdlResponse,generator/integration_tests/test.proto#L545}
-   */
+  ///
+  /// Returns the schema of a Cloud Test database as a list of formatted
+  /// DDL statements. This method does not show pending schema updates, those may
+  /// be queried using the [Operations][google.longrunning.Operations] API.
+  ///
+  /// @param request @googleapis_link{google::test::admin::database::v1::GetDatabaseDdlRequest,generator/integration_tests/test.proto#L534}
+  /// @return @googleapis_link{google::test::admin::database::v1::GetDatabaseDdlResponse,generator/integration_tests/test.proto#L545}
+  ///
   StatusOr<google::test::admin::database::v1::GetDatabaseDdlResponse>
   GetDatabaseDdl(google::test::admin::database::v1::GetDatabaseDdlRequest const& request);
 
-  /**
-   * Sets the access control policy on a database or backup resource.
-   * Replaces any existing policy.
-   *
-   * Authorization requires `test.databases.setIamPolicy`
-   * permission on [resource][google.iam.v1.SetIamPolicyRequest.resource].
-   * For backups, authorization requires `test.backups.setIamPolicy`
-   * permission on [resource][google.iam.v1.SetIamPolicyRequest.resource].
-   *
-   * @param request @googleapis_link{google::iam::v1::SetIamPolicyRequest,google/iam/v1/iam_policy.proto#L98}
-   * @return @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
-   */
+  ///
+  /// Sets the access control policy on a database or backup resource.
+  /// Replaces any existing policy.
+  ///
+  /// Authorization requires `test.databases.setIamPolicy`
+  /// permission on [resource][google.iam.v1.SetIamPolicyRequest.resource].
+  /// For backups, authorization requires `test.backups.setIamPolicy`
+  /// permission on [resource][google.iam.v1.SetIamPolicyRequest.resource].
+  ///
+  /// @param request @googleapis_link{google::iam::v1::SetIamPolicyRequest,google/iam/v1/iam_policy.proto#L98}
+  /// @return @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
+  ///
   StatusOr<google::iam::v1::Policy>
   SetIamPolicy(google::iam::v1::SetIamPolicyRequest const& request);
 
-  /**
-   * Gets the access control policy for a database or backup resource.
-   * Returns an empty policy if a database or backup exists but does not have a
-   * policy set.
-   *
-   * Authorization requires `test.databases.getIamPolicy` permission on
-   * [resource][google.iam.v1.GetIamPolicyRequest.resource].
-   * For backups, authorization requires `test.backups.getIamPolicy`
-   * permission on [resource][google.iam.v1.GetIamPolicyRequest.resource].
-   *
-   * @param request @googleapis_link{google::iam::v1::GetIamPolicyRequest,google/iam/v1/iam_policy.proto#L113}
-   * @return @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
-   */
+  ///
+  /// Gets the access control policy for a database or backup resource.
+  /// Returns an empty policy if a database or backup exists but does not have a
+  /// policy set.
+  ///
+  /// Authorization requires `test.databases.getIamPolicy` permission on
+  /// [resource][google.iam.v1.GetIamPolicyRequest.resource].
+  /// For backups, authorization requires `test.backups.getIamPolicy`
+  /// permission on [resource][google.iam.v1.GetIamPolicyRequest.resource].
+  ///
+  /// @param request @googleapis_link{google::iam::v1::GetIamPolicyRequest,google/iam/v1/iam_policy.proto#L113}
+  /// @return @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
+  ///
   StatusOr<google::iam::v1::Policy>
   GetIamPolicy(google::iam::v1::GetIamPolicyRequest const& request);
 
-  /**
-   * Returns permissions that the caller has on the specified database or backup
-   * resource.
-   *
-   * Attempting this RPC on a non-existent Cloud Test database will
-   * result in a NOT_FOUND error if the user has
-   * `test.databases.list` permission on the containing Cloud
-   * Test instance. Otherwise returns an empty set of permissions.
-   * Calling this method on a backup that does not exist will
-   * result in a NOT_FOUND error if the user has
-   * `test.backups.list` permission on the containing instance.
-   *
-   * @param request @googleapis_link{google::iam::v1::TestIamPermissionsRequest,google/iam/v1/iam_policy.proto#L126}
-   * @return @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
-   */
+  ///
+  /// Returns permissions that the caller has on the specified database or backup
+  /// resource.
+  ///
+  /// Attempting this RPC on a non-existent Cloud Test database will
+  /// result in a NOT_FOUND error if the user has
+  /// `test.databases.list` permission on the containing Cloud
+  /// Test instance. Otherwise returns an empty set of permissions.
+  /// Calling this method on a backup that does not exist will
+  /// result in a NOT_FOUND error if the user has
+  /// `test.backups.list` permission on the containing instance.
+  ///
+  /// @param request @googleapis_link{google::iam::v1::TestIamPermissionsRequest,google/iam/v1/iam_policy.proto#L126}
+  /// @return @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
+  ///
   StatusOr<google::iam::v1::TestIamPermissionsResponse>
   TestIamPermissions(google::iam::v1::TestIamPermissionsRequest const& request);
 
-  /**
-   * Starts creating a new Cloud Test Backup.
-   * The returned backup [long-running operation][google.longrunning.Operation]
-   * will have a name of the format
-   * `projects/<project>/instances/<instance>/backups/<backup>/operations/<operation_id>`
-   * and can be used to track creation of the backup. The
-   * [metadata][google.longrunning.Operation.metadata] field type is
-   * [CreateBackupMetadata][google.test.admin.database.v1.CreateBackupMetadata]. The
-   * [response][google.longrunning.Operation.response] field type is
-   * [Backup][google.test.admin.database.v1.Backup], if successful. Cancelling the returned operation will stop the
-   * creation and delete the backup.
-   * There can be only one pending backup creation per database. Backup creation
-   * of different databases can run concurrently.
-   *
-   * @param request @googleapis_link{google::test::admin::database::v1::CreateBackupRequest,generator/integration_tests/backup.proto#L110}
-   * @return @googleapis_link{google::test::admin::database::v1::Backup,generator/integration_tests/backup.proto#L36}
-   */
+  ///
+  /// Starts creating a new Cloud Test Backup.
+  /// The returned backup [long-running operation][google.longrunning.Operation]
+  /// will have a name of the format
+  /// `projects/<project>/instances/<instance>/backups/<backup>/operations/<operation_id>`
+  /// and can be used to track creation of the backup. The
+  /// [metadata][google.longrunning.Operation.metadata] field type is
+  /// [CreateBackupMetadata][google.test.admin.database.v1.CreateBackupMetadata]. The
+  /// [response][google.longrunning.Operation.response] field type is
+  /// [Backup][google.test.admin.database.v1.Backup], if successful. Cancelling the returned operation will stop the
+  /// creation and delete the backup.
+  /// There can be only one pending backup creation per database. Backup creation
+  /// of different databases can run concurrently.
+  ///
+  /// @param request @googleapis_link{google::test::admin::database::v1::CreateBackupRequest,generator/integration_tests/backup.proto#L110}
+  /// @return @googleapis_link{google::test::admin::database::v1::Backup,generator/integration_tests/backup.proto#L36}
+  ///
   future<StatusOr<google::test::admin::database::v1::Backup>>
   CreateBackup(google::test::admin::database::v1::CreateBackupRequest const& request);
 
-  /**
-   * Gets metadata on a pending or completed [Backup][google.test.admin.database.v1.Backup].
-   *
-   * @param request @googleapis_link{google::test::admin::database::v1::GetBackupRequest,generator/integration_tests/backup.proto#L177}
-   * @return @googleapis_link{google::test::admin::database::v1::Backup,generator/integration_tests/backup.proto#L36}
-   */
+  ///
+  /// Gets metadata on a pending or completed [Backup][google.test.admin.database.v1.Backup].
+  ///
+  /// @param request @googleapis_link{google::test::admin::database::v1::GetBackupRequest,generator/integration_tests/backup.proto#L177}
+  /// @return @googleapis_link{google::test::admin::database::v1::Backup,generator/integration_tests/backup.proto#L36}
+  ///
   StatusOr<google::test::admin::database::v1::Backup>
   GetBackup(google::test::admin::database::v1::GetBackupRequest const& request);
 
-  /**
-   * Updates a pending or completed [Backup][google.test.admin.database.v1.Backup].
-   *
-   * @param request @googleapis_link{google::test::admin::database::v1::UpdateBackupRequest,generator/integration_tests/backup.proto#L161}
-   * @return @googleapis_link{google::test::admin::database::v1::Backup,generator/integration_tests/backup.proto#L36}
-   */
+  ///
+  /// Updates a pending or completed [Backup][google.test.admin.database.v1.Backup].
+  ///
+  /// @param request @googleapis_link{google::test::admin::database::v1::UpdateBackupRequest,generator/integration_tests/backup.proto#L161}
+  /// @return @googleapis_link{google::test::admin::database::v1::Backup,generator/integration_tests/backup.proto#L36}
+  ///
   StatusOr<google::test::admin::database::v1::Backup>
   UpdateBackup(google::test::admin::database::v1::UpdateBackupRequest const& request);
 
-  /**
-   * Deletes a pending or completed [Backup][google.test.admin.database.v1.Backup].
-   *
-   * @param request @googleapis_link{google::test::admin::database::v1::DeleteBackupRequest,generator/integration_tests/backup.proto#L190}
-   */
+  ///
+  /// Deletes a pending or completed [Backup][google.test.admin.database.v1.Backup].
+  ///
+  /// @param request @googleapis_link{google::test::admin::database::v1::DeleteBackupRequest,generator/integration_tests/backup.proto#L190}
+  ///
   Status
   DeleteBackup(google::test::admin::database::v1::DeleteBackupRequest const& request);
 
-  /**
-   * Lists completed and pending backups.
-   * Backups returned are ordered by `create_time` in descending order,
-   * starting from the most recent `create_time`.
-   *
-   * @param request @googleapis_link{google::test::admin::database::v1::ListBackupsRequest,generator/integration_tests/backup.proto#L203}
-   * @return @googleapis_link{google::test::admin::database::v1::Backup,generator/integration_tests/backup.proto#L36}
-   */
+  ///
+  /// Lists completed and pending backups.
+  /// Backups returned are ordered by `create_time` in descending order,
+  /// starting from the most recent `create_time`.
+  ///
+  /// @param request @googleapis_link{google::test::admin::database::v1::ListBackupsRequest,generator/integration_tests/backup.proto#L203}
+  /// @return @googleapis_link{google::test::admin::database::v1::Backup,generator/integration_tests/backup.proto#L36}
+  ///
   StreamRange<google::test::admin::database::v1::Backup>
   ListBackups(google::test::admin::database::v1::ListBackupsRequest request);
 
-  /**
-   * Create a new database by restoring from a completed backup. The new
-   * database must be in the same project and in an instance with the same
-   * instance configuration as the instance containing
-   * the backup. The returned database [long-running
-   * operation][google.longrunning.Operation] has a name of the format
-   * `projects/<project>/instances/<instance>/databases/<database>/operations/<operation_id>`,
-   * and can be used to track the progress of the operation, and to cancel it.
-   * The [metadata][google.longrunning.Operation.metadata] field type is
-   * [RestoreDatabaseMetadata][google.test.admin.database.v1.RestoreDatabaseMetadata].
-   * The [response][google.longrunning.Operation.response] type
-   * is [Database][google.test.admin.database.v1.Database], if
-   * successful. Cancelling the returned operation will stop the restore and
-   * delete the database.
-   * There can be only one database being restored into an instance at a time.
-   * Once the restore operation completes, a new restore operation can be
-   * initiated, without waiting for the optimize operation associated with the
-   * first restore to complete.
-   *
-   * @param request @googleapis_link{google::test::admin::database::v1::RestoreDatabaseRequest,generator/integration_tests/test.proto#L634}
-   * @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
-   */
+  ///
+  /// Create a new database by restoring from a completed backup. The new
+  /// database must be in the same project and in an instance with the same
+  /// instance configuration as the instance containing
+  /// the backup. The returned database [long-running
+  /// operation][google.longrunning.Operation] has a name of the format
+  /// `projects/<project>/instances/<instance>/databases/<database>/operations/<operation_id>`,
+  /// and can be used to track the progress of the operation, and to cancel it.
+  /// The [metadata][google.longrunning.Operation.metadata] field type is
+  /// [RestoreDatabaseMetadata][google.test.admin.database.v1.RestoreDatabaseMetadata].
+  /// The [response][google.longrunning.Operation.response] type
+  /// is [Database][google.test.admin.database.v1.Database], if
+  /// successful. Cancelling the returned operation will stop the restore and
+  /// delete the database.
+  /// There can be only one database being restored into an instance at a time.
+  /// Once the restore operation completes, a new restore operation can be
+  /// initiated, without waiting for the optimize operation associated with the
+  /// first restore to complete.
+  ///
+  /// @param request @googleapis_link{google::test::admin::database::v1::RestoreDatabaseRequest,generator/integration_tests/test.proto#L634}
+  /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
+  ///
   future<StatusOr<google::test::admin::database::v1::Database>>
   RestoreDatabase(google::test::admin::database::v1::RestoreDatabaseRequest const& request);
 
-  /**
-   * Lists database [longrunning-operations][google.longrunning.Operation].
-   * A database operation has a name of the form
-   * `projects/<project>/instances/<instance>/databases/<database>/operations/<operation>`.
-   * The long-running operation
-   * [metadata][google.longrunning.Operation.metadata] field type
-   * `metadata.type_url` describes the type of the metadata. Operations returned
-   * include those that have completed/failed/canceled within the last 7 days,
-   * and pending operations.
-   *
-   * @param request @googleapis_link{google::test::admin::database::v1::ListDatabaseOperationsRequest,generator/integration_tests/test.proto#L553}
-   * @return @googleapis_link{google::longrunning::Operation,google/longrunning/operations.proto#L128}
-   */
+  ///
+  /// Lists database [longrunning-operations][google.longrunning.Operation].
+  /// A database operation has a name of the form
+  /// `projects/<project>/instances/<instance>/databases/<database>/operations/<operation>`.
+  /// The long-running operation
+  /// [metadata][google.longrunning.Operation.metadata] field type
+  /// `metadata.type_url` describes the type of the metadata. Operations returned
+  /// include those that have completed/failed/canceled within the last 7 days,
+  /// and pending operations.
+  ///
+  /// @param request @googleapis_link{google::test::admin::database::v1::ListDatabaseOperationsRequest,generator/integration_tests/test.proto#L553}
+  /// @return @googleapis_link{google::longrunning::Operation,google/longrunning/operations.proto#L128}
+  ///
   StreamRange<google::longrunning::Operation>
   ListDatabaseOperations(google::test::admin::database::v1::ListDatabaseOperationsRequest request);
 
-  /**
-   * Lists the backup [long-running operations][google.longrunning.Operation] in
-   * the given instance. A backup operation has a name of the form
-   * `projects/<project>/instances/<instance>/backups/<backup>/operations/<operation>`.
-   * The long-running operation
-   * [metadata][google.longrunning.Operation.metadata] field type
-   * `metadata.type_url` describes the type of the metadata. Operations returned
-   * include those that have completed/failed/canceled within the last 7 days,
-   * and pending operations. Operations returned are ordered by
-   * `operation.metadata.value.progress.start_time` in descending order starting
-   * from the most recently started operation.
-   *
-   * @param request @googleapis_link{google::test::admin::database::v1::ListBackupOperationsRequest,generator/integration_tests/backup.proto#L274}
-   * @return @googleapis_link{google::longrunning::Operation,google/longrunning/operations.proto#L128}
-   */
+  ///
+  /// Lists the backup [long-running operations][google.longrunning.Operation] in
+  /// the given instance. A backup operation has a name of the form
+  /// `projects/<project>/instances/<instance>/backups/<backup>/operations/<operation>`.
+  /// The long-running operation
+  /// [metadata][google.longrunning.Operation.metadata] field type
+  /// `metadata.type_url` describes the type of the metadata. Operations returned
+  /// include those that have completed/failed/canceled within the last 7 days,
+  /// and pending operations. Operations returned are ordered by
+  /// `operation.metadata.value.progress.start_time` in descending order starting
+  /// from the most recently started operation.
+  ///
+  /// @param request @googleapis_link{google::test::admin::database::v1::ListBackupOperationsRequest,generator/integration_tests/backup.proto#L274}
+  /// @return @googleapis_link{google::longrunning::Operation,google/longrunning/operations.proto#L128}
+  ///
   StreamRange<google::longrunning::Operation>
   ListBackupOperations(google::test::admin::database::v1::ListBackupOperationsRequest request);
 
-  /**
-   * Gets the state of a Cloud Test database.
-   *
-   * @param request @googleapis_link{google::test::admin::database::v1::GetDatabaseRequest,generator/integration_tests/test.proto#L443}
-   * @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
-   */
+  ///
+  /// Gets the state of a Cloud Test database.
+  ///
+  /// @param request @googleapis_link{google::test::admin::database::v1::GetDatabaseRequest,generator/integration_tests/test.proto#L443}
+  /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
+  ///
   future<StatusOr<google::test::admin::database::v1::Database>>
   AsyncGetDatabase(google::test::admin::database::v1::GetDatabaseRequest const& request);
 
-  /**
-   * Drops (aka deletes) a Cloud Test database.
-   * Completed backups for the database will be retained according to their
-   * `expire_time`.
-   *
-   * @param request @googleapis_link{google::test::admin::database::v1::DropDatabaseRequest,generator/integration_tests/test.proto#L523}
-   */
+  ///
+  /// Drops (aka deletes) a Cloud Test database.
+  /// Completed backups for the database will be retained according to their
+  /// `expire_time`.
+  ///
+  /// @param request @googleapis_link{google::test::admin::database::v1::DropDatabaseRequest,generator/integration_tests/test.proto#L523}
+  ///
   future<Status>
   AsyncDropDatabase(google::test::admin::database::v1::DropDatabaseRequest const& request);
 

--- a/generator/internal/descriptor_utils.cc
+++ b/generator/internal/descriptor_utils.cc
@@ -268,12 +268,12 @@ std::string FormatClassCommentsFromServiceComments(
                    << " no leading_comments to format";
   }
   std::string doxygen_formatted_comments =
-      absl::StrCat("/**\n *",
+      absl::StrCat("///\n///",
                    absl::StrReplaceAll(
                        ChompByValue(service_source_location.leading_comments),
-                       {{"\n\n", "\n *\n * "}, {"\n", "\n * "}}),
-                   "\n */");
-  return absl::StrReplaceAll(doxygen_formatted_comments, {{"*  ", "* "}});
+                       {{"\n\n", "\n///\n/// "}, {"\n", "\n/// "}}),
+                   "\n///");
+  return absl::StrReplaceAll(doxygen_formatted_comments, {{"///  ", "/// "}});
 }
 
 std::string FormatApiMethodSignatureParameters(
@@ -293,13 +293,13 @@ std::string FormatApiMethodSignatureParameters(
           parameter,
           absl::StrReplaceAll(
               EscapePrinterDelimiter(ChompByValue(loc.leading_comments)),
-              {{"\n\n", "\n   * "}, {"\n", "\n   * "}}));
+              {{"\n\n", "\n  /// "}, {"\n", "\n  /// "}}));
     }
   }
   std::string parameter_comment_string;
   for (auto const& param : parameter_comments) {
     parameter_comment_string +=
-        absl::StrFormat("   * @param %s %s\n", param.first, param.second);
+        absl::StrFormat("  /// @param %s %s\n", param.first, param.second);
   }
 
   return parameter_comment_string;
@@ -316,7 +316,7 @@ std::string FormatProtobufRequestParameters(
   std::string parameter_comment_string;
   for (auto const& param : parameter_comments) {
     parameter_comment_string +=
-        absl::StrFormat("   * @param %s %s\n", param.first, param.second);
+        absl::StrFormat("  /// @param %s %s\n", param.first, param.second);
   }
 
   return parameter_comment_string;
@@ -401,22 +401,22 @@ std::string FormatMethodCommentsFromRpcComments(
 
   std::string doxygen_formatted_function_comments = absl::StrReplaceAll(
       EscapePrinterDelimiter(method_source_location.leading_comments),
-      {{"\n", "\n   *"}});
+      {{"\n", "\n  ///"}});
 
   std::string return_comment_string;
   if (IsLongrunningOperation(method)) {
     return_comment_string =
-        "   * @return $method_longrunning_deduced_return_doxygen_link$\n";
+        "  /// @return $method_longrunning_deduced_return_doxygen_link$\n";
   } else if (!IsResponseTypeEmpty(method) && !IsPaginated(method)) {
-    return_comment_string = "   * @return $method_return_doxygen_link$\n";
+    return_comment_string = "  /// @return $method_return_doxygen_link$\n";
   } else if (IsPaginated(method)) {
     return_comment_string =
-        "   * @return $method_paginated_return_doxygen_link$\n";
+        "  /// @return $method_paginated_return_doxygen_link$\n";
   }
 
-  return absl::StrCat("  /**\n   *", doxygen_formatted_function_comments, "\n",
+  return absl::StrCat("  ///\n  ///", doxygen_formatted_function_comments, "\n",
                       parameter_comment_string, return_comment_string,
-                      "   */\n");
+                      "  ///\n");
 }
 
 VarsDictionary CreateServiceVars(

--- a/generator/internal/descriptor_utils_test.cc
+++ b/generator/internal/descriptor_utils_test.cc
@@ -190,8 +190,8 @@ INSTANTIATE_TEST_SUITE_P(
     ServiceVars, CreateServiceVarsTest,
     testing::Values(
         std::make_pair("class_comment_block",
-                       "/**\n * Leading comments about service "
-                       "FrobberService.\n * $Delimiter escapes$ $\n */"),
+                       "///\n/// Leading comments about service "
+                       "FrobberService.\n/// $Delimiter escapes$ $\n///"),
         std::make_pair("client_class_name", "FrobberServiceClient"),
         std::make_pair("client_cc_path",
                        "google/cloud/frobber/"
@@ -500,10 +500,10 @@ TEST_F(CreateMethodVarsTest,
       FormatMethodCommentsFromRpcComments(
           *service_file_descriptor->service(0)->method(0),
           MethodParameterStyle::kProtobufRequest),
-      "  /**\n   * Leading comments about rpc Method0$$.\n   *\n   * @param "
+      "  ///\n  /// Leading comments about rpc Method0$$.\n  ///\n  /// @param "
       "request "
       "@googleapis_link{google::protobuf::Bar,google/foo/v1/"
-      "service.proto#L14}\n   */\n");
+      "service.proto#L14}\n  ///\n");
 }
 
 TEST_F(CreateMethodVarsTest,
@@ -513,8 +513,8 @@ TEST_F(CreateMethodVarsTest,
   EXPECT_EQ(FormatMethodCommentsFromRpcComments(
                 *service_file_descriptor->service(0)->method(6),
                 MethodParameterStyle::kApiMethodSignature),
-            "  /**\n   * Leading comments about rpc $$Method6.\n   *\n   * "
-            "@param labels  labels $$field comment.\n   */\n");
+            "  ///\n  /// Leading comments about rpc $$Method6.\n  ///\n  /// "
+            "@param labels  labels $$field comment.\n  ///\n");
 }
 
 TEST_P(CreateMethodVarsTest, KeySetCorrectly) {

--- a/google/cloud/bigquery/bigquery_read_client.h
+++ b/google/cloud/bigquery/bigquery_read_client.h
@@ -31,11 +31,11 @@ namespace cloud {
 namespace bigquery {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-/**
- * BigQuery Read API.
- *
- * The Read API can be used to read data from BigQuery.
- */
+///
+/// BigQuery Read API.
+///
+/// The Read API can be used to read data from BigQuery.
+///
 class BigQueryReadClient {
  public:
   explicit BigQueryReadClient(
@@ -62,130 +62,133 @@ class BigQueryReadClient {
   }
   //@}
 
-  /**
-   * Creates a new read session. A read session divides the contents of a
-   * BigQuery table into one or more streams, which can then be used to read
-   * data from the table. The read session also specifies properties of the
-   * data to be read, such as a list of columns or a push-down filter describing
-   * the rows to be returned.
-   *
-   * A particular row can be read by at most one stream. When the caller has
-   * reached the end of each stream in the session, then all the data in the
-   * table has been read.
-   *
-   * Data is assigned to each stream such that roughly the same number of
-   * rows can be read from each stream. Because the server-side unit for
-   * assigning data is collections of rows, the API does not guarantee that
-   * each stream will return the same number or rows. Additionally, the
-   * limits are enforced based on the number of pre-filtered rows, so some
-   * filters can lead to lopsided assignments.
-   *
-   * Read sessions automatically expire 6 hours after they are created and do
-   * not require manual clean-up by the caller.
-   *
-   * @param parent  Required. The request project that owns the session, in the
-   * form of `projects/{project_id}`.
-   * @param read_session  Required. Session to be created.
-   * @param max_stream_count  Max initial number of streams. If unset or zero,
-   * the server will provide a value of streams so as to produce reasonable
-   * throughput. Must be non-negative. The number of streams may be lower than
-   * the requested number, depending on the amount parallelism that is
-   * reasonable for the table. Error will be returned if the max count is
-   * greater than the current system max limit of 1,000. Streams must be read
-   * starting from offset 0.
-   * @return
-   * @googleapis_link{google::cloud::bigquery::storage::v1::ReadSession,google/cloud/bigquery/storage/v1/stream.proto#L47}
-   */
+  ///
+  /// Creates a new read session. A read session divides the contents of a
+  /// BigQuery table into one or more streams, which can then be used to read
+  /// data from the table. The read session also specifies properties of the
+  /// data to be read, such as a list of columns or a push-down filter
+  /// describing the rows to be returned.
+  ///
+  /// A particular row can be read by at most one stream. When the caller has
+  /// reached the end of each stream in the session, then all the data in the
+  /// table has been read.
+  ///
+  /// Data is assigned to each stream such that roughly the same number of
+  /// rows can be read from each stream. Because the server-side unit for
+  /// assigning data is collections of rows, the API does not guarantee that
+  /// each stream will return the same number or rows. Additionally, the
+  /// limits are enforced based on the number of pre-filtered rows, so some
+  /// filters can lead to lopsided assignments.
+  ///
+  /// Read sessions automatically expire 6 hours after they are created and do
+  /// not require manual clean-up by the caller.
+  ///
+  /// @param parent  Required. The request project that owns the session, in the
+  /// form of
+  ///  `projects/{project_id}`.
+  /// @param read_session  Required. Session to be created.
+  /// @param max_stream_count  Max initial number of streams. If unset or zero,
+  /// the server will
+  ///  provide a value of streams so as to produce reasonable throughput. Must
+  ///  be non-negative. The number of streams may be lower than the requested
+  ///  number, depending on the amount parallelism that is reasonable for the
+  ///  table. Error will be returned if the max count is greater than the
+  ///  current system max limit of 1,000. Streams must be read starting from
+  ///  offset 0.
+  /// @return
+  /// @googleapis_link{google::cloud::bigquery::storage::v1::ReadSession,google/cloud/bigquery/storage/v1/stream.proto#L47}
+  ///
   StatusOr<google::cloud::bigquery::storage::v1::ReadSession> CreateReadSession(
       std::string const& parent,
       google::cloud::bigquery::storage::v1::ReadSession const& read_session,
       std::int32_t max_stream_count);
 
-  /**
-   * Reads rows from the stream in the format prescribed by the ReadSession.
-   * Each response contains one or more table rows, up to a maximum of 100 MiB
-   * per response; read requests which attempt to read individual rows larger
-   * than 100 MiB will fail.
-   *
-   * Each request also returns a set of stream statistics reflecting the current
-   * state of the stream.
-   *
-   * @param read_stream  Required. Stream to read rows from.
-   * @param offset  The offset requested must be less than the last row read
-   * from Read. Requesting a larger offset is undefined. If not specified, start
-   * reading from offset zero.
-   * @return
-   * @googleapis_link{google::cloud::bigquery::storage::v1::ReadRowsResponse,google/cloud/bigquery/storage/v1/storage.proto#L304}
-   */
+  ///
+  /// Reads rows from the stream in the format prescribed by the ReadSession.
+  /// Each response contains one or more table rows, up to a maximum of 100 MiB
+  /// per response; read requests which attempt to read individual rows larger
+  /// than 100 MiB will fail.
+  ///
+  /// Each request also returns a set of stream statistics reflecting the
+  /// current state of the stream.
+  ///
+  /// @param read_stream  Required. Stream to read rows from.
+  /// @param offset  The offset requested must be less than the last row read
+  /// from Read.
+  ///  Requesting a larger offset is undefined. If not specified, start reading
+  ///  from offset zero.
+  /// @return
+  /// @googleapis_link{google::cloud::bigquery::storage::v1::ReadRowsResponse,google/cloud/bigquery/storage/v1/storage.proto#L304}
+  ///
   StreamRange<google::cloud::bigquery::storage::v1::ReadRowsResponse> ReadRows(
       std::string const& read_stream, std::int64_t offset);
 
-  /**
-   * Creates a new read session. A read session divides the contents of a
-   * BigQuery table into one or more streams, which can then be used to read
-   * data from the table. The read session also specifies properties of the
-   * data to be read, such as a list of columns or a push-down filter describing
-   * the rows to be returned.
-   *
-   * A particular row can be read by at most one stream. When the caller has
-   * reached the end of each stream in the session, then all the data in the
-   * table has been read.
-   *
-   * Data is assigned to each stream such that roughly the same number of
-   * rows can be read from each stream. Because the server-side unit for
-   * assigning data is collections of rows, the API does not guarantee that
-   * each stream will return the same number or rows. Additionally, the
-   * limits are enforced based on the number of pre-filtered rows, so some
-   * filters can lead to lopsided assignments.
-   *
-   * Read sessions automatically expire 6 hours after they are created and do
-   * not require manual clean-up by the caller.
-   *
-   * @param request
-   * @googleapis_link{google::cloud::bigquery::storage::v1::CreateReadSessionRequest,google/cloud/bigquery/storage/v1/storage.proto#L229}
-   * @return
-   * @googleapis_link{google::cloud::bigquery::storage::v1::ReadSession,google/cloud/bigquery/storage/v1/stream.proto#L47}
-   */
+  ///
+  /// Creates a new read session. A read session divides the contents of a
+  /// BigQuery table into one or more streams, which can then be used to read
+  /// data from the table. The read session also specifies properties of the
+  /// data to be read, such as a list of columns or a push-down filter
+  /// describing the rows to be returned.
+  ///
+  /// A particular row can be read by at most one stream. When the caller has
+  /// reached the end of each stream in the session, then all the data in the
+  /// table has been read.
+  ///
+  /// Data is assigned to each stream such that roughly the same number of
+  /// rows can be read from each stream. Because the server-side unit for
+  /// assigning data is collections of rows, the API does not guarantee that
+  /// each stream will return the same number or rows. Additionally, the
+  /// limits are enforced based on the number of pre-filtered rows, so some
+  /// filters can lead to lopsided assignments.
+  ///
+  /// Read sessions automatically expire 6 hours after they are created and do
+  /// not require manual clean-up by the caller.
+  ///
+  /// @param request
+  /// @googleapis_link{google::cloud::bigquery::storage::v1::CreateReadSessionRequest,google/cloud/bigquery/storage/v1/storage.proto#L229}
+  /// @return
+  /// @googleapis_link{google::cloud::bigquery::storage::v1::ReadSession,google/cloud/bigquery/storage/v1/stream.proto#L47}
+  ///
   StatusOr<google::cloud::bigquery::storage::v1::ReadSession> CreateReadSession(
       google::cloud::bigquery::storage::v1::CreateReadSessionRequest const&
           request);
 
-  /**
-   * Reads rows from the stream in the format prescribed by the ReadSession.
-   * Each response contains one or more table rows, up to a maximum of 100 MiB
-   * per response; read requests which attempt to read individual rows larger
-   * than 100 MiB will fail.
-   *
-   * Each request also returns a set of stream statistics reflecting the current
-   * state of the stream.
-   *
-   * @param request
-   * @googleapis_link{google::cloud::bigquery::storage::v1::ReadRowsRequest,google/cloud/bigquery/storage/v1/storage.proto#L254}
-   * @return
-   * @googleapis_link{google::cloud::bigquery::storage::v1::ReadRowsResponse,google/cloud/bigquery/storage/v1/storage.proto#L304}
-   */
+  ///
+  /// Reads rows from the stream in the format prescribed by the ReadSession.
+  /// Each response contains one or more table rows, up to a maximum of 100 MiB
+  /// per response; read requests which attempt to read individual rows larger
+  /// than 100 MiB will fail.
+  ///
+  /// Each request also returns a set of stream statistics reflecting the
+  /// current state of the stream.
+  ///
+  /// @param request
+  /// @googleapis_link{google::cloud::bigquery::storage::v1::ReadRowsRequest,google/cloud/bigquery/storage/v1/storage.proto#L254}
+  /// @return
+  /// @googleapis_link{google::cloud::bigquery::storage::v1::ReadRowsResponse,google/cloud/bigquery/storage/v1/storage.proto#L304}
+  ///
   StreamRange<google::cloud::bigquery::storage::v1::ReadRowsResponse> ReadRows(
       google::cloud::bigquery::storage::v1::ReadRowsRequest const& request);
 
-  /**
-   * Splits a given `ReadStream` into two `ReadStream` objects. These
-   * `ReadStream` objects are referred to as the primary and the residual
-   * streams of the split. The original `ReadStream` can still be read from in
-   * the same manner as before. Both of the returned `ReadStream` objects can
-   * also be read from, and the rows returned by both child streams will be
-   * the same as the rows read from the original stream.
-   *
-   * Moreover, the two child streams will be allocated back-to-back in the
-   * original `ReadStream`. Concretely, it is guaranteed that for streams
-   * original, primary, and residual, that original[0-j] = primary[0-j] and
-   * original[j-n] = residual[0-m] once the streams have been read to
-   * completion.
-   *
-   * @param request
-   * @googleapis_link{google::cloud::bigquery::storage::v1::SplitReadStreamRequest,google/cloud/bigquery/storage/v1/storage.proto#L339}
-   * @return
-   * @googleapis_link{google::cloud::bigquery::storage::v1::SplitReadStreamResponse,google/cloud/bigquery/storage/v1/storage.proto#L359}
-   */
+  ///
+  /// Splits a given `ReadStream` into two `ReadStream` objects. These
+  /// `ReadStream` objects are referred to as the primary and the residual
+  /// streams of the split. The original `ReadStream` can still be read from in
+  /// the same manner as before. Both of the returned `ReadStream` objects can
+  /// also be read from, and the rows returned by both child streams will be
+  /// the same as the rows read from the original stream.
+  ///
+  /// Moreover, the two child streams will be allocated back-to-back in the
+  /// original `ReadStream`. Concretely, it is guaranteed that for streams
+  /// original, primary, and residual, that original[0-j] = primary[0-j] and
+  /// original[j-n] = residual[0-m] once the streams have been read to
+  /// completion.
+  ///
+  /// @param request
+  /// @googleapis_link{google::cloud::bigquery::storage::v1::SplitReadStreamRequest,google/cloud/bigquery/storage/v1/storage.proto#L339}
+  /// @return
+  /// @googleapis_link{google::cloud::bigquery::storage::v1::SplitReadStreamResponse,google/cloud/bigquery/storage/v1/storage.proto#L359}
+  ///
   StatusOr<google::cloud::bigquery::storage::v1::SplitReadStreamResponse>
   SplitReadStream(
       google::cloud::bigquery::storage::v1::SplitReadStreamRequest const&

--- a/google/cloud/bigtable/admin/bigtable_instance_admin_client.h
+++ b/google/cloud/bigtable/admin/bigtable_instance_admin_client.h
@@ -35,11 +35,11 @@ namespace cloud {
 namespace bigtable_admin {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-/**
- * Service for creating, configuring, and deleting Cloud Bigtable Instances and
- * Clusters. Provides access to the Instance and Cluster schemas only, not the
- * tables' metadata or data stored in those tables.
- */
+///
+/// Service for creating, configuring, and deleting Cloud Bigtable Instances and
+/// Clusters. Provides access to the Instance and Cluster schemas only, not the
+/// tables' metadata or data stored in those tables.
+///
 class BigtableInstanceAdminClient {
  public:
   explicit BigtableInstanceAdminClient(
@@ -68,257 +68,272 @@ class BigtableInstanceAdminClient {
   }
   //@}
 
-  /**
-   * Create an instance within a project.
-   *
-   * Note that exactly one of Cluster.serve_nodes and
-   * Cluster.cluster_config.cluster_autoscaling_config can be set. If
-   * serve_nodes is set to non-zero, then the cluster is manually scaled. If
-   * cluster_config.cluster_autoscaling_config is non-empty, then autoscaling is
-   * enabled.
-   *
-   * @param parent  Required. The unique name of the project in which to create
-   * the new instance. Values are of the form `projects/{project}`.
-   * @param instance_id  Required. The ID to be used when referring to the new
-   * instance within its project, e.g., just `myinstance` rather than
-   *  `projects/myproject/instances/myinstance`.
-   * @param instance  Required. The instance to create.
-   *  Fields marked `OutputOnly` must be left blank.
-   * @param clusters  Required. The clusters to be created within the instance,
-   * mapped by desired cluster ID, e.g., just `mycluster` rather than
-   *  `projects/myproject/instances/myinstance/clusters/mycluster`.
-   *  Fields marked `OutputOnly` must be left blank.
-   *  Currently, at most four clusters can be specified.
-   * @return
-   * @googleapis_link{google::bigtable::admin::v2::Instance,google/bigtable/admin/v2/instance.proto#L41}
-   */
+  ///
+  /// Create an instance within a project.
+  ///
+  /// Note that exactly one of Cluster.serve_nodes and
+  /// Cluster.cluster_config.cluster_autoscaling_config can be set. If
+  /// serve_nodes is set to non-zero, then the cluster is manually scaled. If
+  /// cluster_config.cluster_autoscaling_config is non-empty, then autoscaling
+  /// is enabled.
+  ///
+  /// @param parent  Required. The unique name of the project in which to create
+  /// the new instance.
+  ///  Values are of the form `projects/{project}`.
+  /// @param instance_id  Required. The ID to be used when referring to the new
+  /// instance within its project,
+  ///  e.g., just `myinstance` rather than
+  ///  `projects/myproject/instances/myinstance`.
+  /// @param instance  Required. The instance to create.
+  ///  Fields marked `OutputOnly` must be left blank.
+  /// @param clusters  Required. The clusters to be created within the instance,
+  /// mapped by desired
+  ///  cluster ID, e.g., just `mycluster` rather than
+  ///  `projects/myproject/instances/myinstance/clusters/mycluster`.
+  ///  Fields marked `OutputOnly` must be left blank.
+  ///  Currently, at most four clusters can be specified.
+  /// @return
+  /// @googleapis_link{google::bigtable::admin::v2::Instance,google/bigtable/admin/v2/instance.proto#L41}
+  ///
   future<StatusOr<google::bigtable::admin::v2::Instance>> CreateInstance(
       std::string const& parent, std::string const& instance_id,
       google::bigtable::admin::v2::Instance const& instance,
       std::map<std::string, google::bigtable::admin::v2::Cluster> const&
           clusters);
 
-  /**
-   * Gets information about an instance.
-   *
-   * @param name  Required. The unique name of the requested instance. Values
-   * are of the form `projects/{project}/instances/{instance}`.
-   * @return
-   * @googleapis_link{google::bigtable::admin::v2::Instance,google/bigtable/admin/v2/instance.proto#L41}
-   */
+  ///
+  /// Gets information about an instance.
+  ///
+  /// @param name  Required. The unique name of the requested instance. Values
+  /// are of the form
+  ///  `projects/{project}/instances/{instance}`.
+  /// @return
+  /// @googleapis_link{google::bigtable::admin::v2::Instance,google/bigtable/admin/v2/instance.proto#L41}
+  ///
   StatusOr<google::bigtable::admin::v2::Instance> GetInstance(
       std::string const& name);
 
-  /**
-   * Lists information about instances in a project.
-   *
-   * @param parent  Required. The unique name of the project for which a list of
-   * instances is requested. Values are of the form `projects/{project}`.
-   * @return
-   * @googleapis_link{google::bigtable::admin::v2::ListInstancesResponse,google/bigtable/admin/v2/bigtable_instance_admin.proto#L335}
-   */
+  ///
+  /// Lists information about instances in a project.
+  ///
+  /// @param parent  Required. The unique name of the project for which a list
+  /// of instances is requested.
+  ///  Values are of the form `projects/{project}`.
+  /// @return
+  /// @googleapis_link{google::bigtable::admin::v2::ListInstancesResponse,google/bigtable/admin/v2/bigtable_instance_admin.proto#L335}
+  ///
   StatusOr<google::bigtable::admin::v2::ListInstancesResponse> ListInstances(
       std::string const& parent);
 
-  /**
-   * Partially updates an instance within a project. This method can modify all
-   * fields of an Instance and is the preferred way to update an Instance.
-   *
-   * @param instance  Required. The Instance which will (partially) replace the
-   * current value.
-   * @param update_mask  Required. The subset of Instance fields which should be
-   * replaced. Must be explicitly set.
-   * @return
-   * @googleapis_link{google::bigtable::admin::v2::Instance,google/bigtable/admin/v2/instance.proto#L41}
-   */
+  ///
+  /// Partially updates an instance within a project. This method can modify all
+  /// fields of an Instance and is the preferred way to update an Instance.
+  ///
+  /// @param instance  Required. The Instance which will (partially) replace the
+  /// current value.
+  /// @param update_mask  Required. The subset of Instance fields which should
+  /// be replaced.
+  ///  Must be explicitly set.
+  /// @return
+  /// @googleapis_link{google::bigtable::admin::v2::Instance,google/bigtable/admin/v2/instance.proto#L41}
+  ///
   future<StatusOr<google::bigtable::admin::v2::Instance>> PartialUpdateInstance(
       google::bigtable::admin::v2::Instance const& instance,
       google::protobuf::FieldMask const& update_mask);
 
-  /**
-   * Delete an instance from a project.
-   *
-   * @param name  Required. The unique name of the instance to be deleted.
-   *  Values are of the form `projects/{project}/instances/{instance}`.
-   */
+  ///
+  /// Delete an instance from a project.
+  ///
+  /// @param name  Required. The unique name of the instance to be deleted.
+  ///  Values are of the form `projects/{project}/instances/{instance}`.
+  ///
   Status DeleteInstance(std::string const& name);
 
-  /**
-   * Creates a cluster within an instance.
-   *
-   * Note that exactly one of Cluster.serve_nodes and
-   * Cluster.cluster_config.cluster_autoscaling_config can be set. If
-   * serve_nodes is set to non-zero, then the cluster is manually scaled. If
-   * cluster_config.cluster_autoscaling_config is non-empty, then autoscaling is
-   * enabled.
-   *
-   * @param parent  Required. The unique name of the instance in which to create
-   * the new cluster. Values are of the form
-   *  `projects/{project}/instances/{instance}`.
-   * @param cluster_id  Required. The ID to be used when referring to the new
-   * cluster within its instance, e.g., just `mycluster` rather than
-   *  `projects/myproject/instances/myinstance/clusters/mycluster`.
-   * @param cluster  Required. The cluster to be created.
-   *  Fields marked `OutputOnly` must be left blank.
-   * @return
-   * @googleapis_link{google::bigtable::admin::v2::Cluster,google/bigtable/admin/v2/instance.proto#L137}
-   */
+  ///
+  /// Creates a cluster within an instance.
+  ///
+  /// Note that exactly one of Cluster.serve_nodes and
+  /// Cluster.cluster_config.cluster_autoscaling_config can be set. If
+  /// serve_nodes is set to non-zero, then the cluster is manually scaled. If
+  /// cluster_config.cluster_autoscaling_config is non-empty, then autoscaling
+  /// is enabled.
+  ///
+  /// @param parent  Required. The unique name of the instance in which to
+  /// create the new cluster.
+  ///  Values are of the form
+  ///  `projects/{project}/instances/{instance}`.
+  /// @param cluster_id  Required. The ID to be used when referring to the new
+  /// cluster within its instance,
+  ///  e.g., just `mycluster` rather than
+  ///  `projects/myproject/instances/myinstance/clusters/mycluster`.
+  /// @param cluster  Required. The cluster to be created.
+  ///  Fields marked `OutputOnly` must be left blank.
+  /// @return
+  /// @googleapis_link{google::bigtable::admin::v2::Cluster,google/bigtable/admin/v2/instance.proto#L137}
+  ///
   future<StatusOr<google::bigtable::admin::v2::Cluster>> CreateCluster(
       std::string const& parent, std::string const& cluster_id,
       google::bigtable::admin::v2::Cluster const& cluster);
 
-  /**
-   * Gets information about a cluster.
-   *
-   * @param name  Required. The unique name of the requested cluster. Values are
-   * of the form `projects/{project}/instances/{instance}/clusters/{cluster}`.
-   * @return
-   * @googleapis_link{google::bigtable::admin::v2::Cluster,google/bigtable/admin/v2/instance.proto#L137}
-   */
+  ///
+  /// Gets information about a cluster.
+  ///
+  /// @param name  Required. The unique name of the requested cluster. Values
+  /// are of the form
+  ///  `projects/{project}/instances/{instance}/clusters/{cluster}`.
+  /// @return
+  /// @googleapis_link{google::bigtable::admin::v2::Cluster,google/bigtable/admin/v2/instance.proto#L137}
+  ///
   StatusOr<google::bigtable::admin::v2::Cluster> GetCluster(
       std::string const& name);
 
-  /**
-   * Lists information about clusters in an instance.
-   *
-   * @param parent  Required. The unique name of the instance for which a list
-   * of clusters is requested. Values are of the form
-   * `projects/{project}/instances/{instance}`. Use `{instance} = '-'` to list
-   * Clusters for all Instances in a project, e.g.,
-   * `projects/myproject/instances/-`.
-   * @return
-   * @googleapis_link{google::bigtable::admin::v2::ListClustersResponse,google/bigtable/admin/v2/bigtable_instance_admin.proto#L425}
-   */
+  ///
+  /// Lists information about clusters in an instance.
+  ///
+  /// @param parent  Required. The unique name of the instance for which a list
+  /// of clusters is requested.
+  ///  Values are of the form `projects/{project}/instances/{instance}`.
+  ///  Use `{instance} = '-'` to list Clusters for all Instances in a project,
+  ///  e.g., `projects/myproject/instances/-`.
+  /// @return
+  /// @googleapis_link{google::bigtable::admin::v2::ListClustersResponse,google/bigtable/admin/v2/bigtable_instance_admin.proto#L425}
+  ///
   StatusOr<google::bigtable::admin::v2::ListClustersResponse> ListClusters(
       std::string const& parent);
 
-  /**
-   * Partially updates a cluster within a project. This method is the preferred
-   * way to update a Cluster.
-   *
-   * To enable and update autoscaling, set
-   * cluster_config.cluster_autoscaling_config. When autoscaling is enabled,
-   * serve_nodes is treated as an OUTPUT_ONLY field, meaning that updates to it
-   * are ignored. Note that an update cannot simultaneously set serve_nodes to
-   * non-zero and cluster_config.cluster_autoscaling_config to non-empty, and
-   * also specify both in the update_mask.
-   *
-   * To disable autoscaling, clear cluster_config.cluster_autoscaling_config,
-   * and explicitly set a serve_node count via the update_mask.
-   *
-   * @param cluster  Required. The Cluster which contains the partial updates to
-   * be applied, subject to the update_mask.
-   * @param update_mask  Required. The subset of Cluster fields which should be
-   * replaced.
-   * @return
-   * @googleapis_link{google::bigtable::admin::v2::Cluster,google/bigtable/admin/v2/instance.proto#L137}
-   */
+  ///
+  /// Partially updates a cluster within a project. This method is the preferred
+  /// way to update a Cluster.
+  ///
+  /// To enable and update autoscaling, set
+  /// cluster_config.cluster_autoscaling_config. When autoscaling is enabled,
+  /// serve_nodes is treated as an OUTPUT_ONLY field, meaning that updates to it
+  /// are ignored. Note that an update cannot simultaneously set serve_nodes to
+  /// non-zero and cluster_config.cluster_autoscaling_config to non-empty, and
+  /// also specify both in the update_mask.
+  ///
+  /// To disable autoscaling, clear cluster_config.cluster_autoscaling_config,
+  /// and explicitly set a serve_node count via the update_mask.
+  ///
+  /// @param cluster  Required. The Cluster which contains the partial updates
+  /// to be applied, subject to
+  ///  the update_mask.
+  /// @param update_mask  Required. The subset of Cluster fields which should be
+  /// replaced.
+  /// @return
+  /// @googleapis_link{google::bigtable::admin::v2::Cluster,google/bigtable/admin/v2/instance.proto#L137}
+  ///
   future<StatusOr<google::bigtable::admin::v2::Cluster>> PartialUpdateCluster(
       google::bigtable::admin::v2::Cluster const& cluster,
       google::protobuf::FieldMask const& update_mask);
 
-  /**
-   * Deletes a cluster from an instance.
-   *
-   * @param name  Required. The unique name of the cluster to be deleted. Values
-   * are of the form
-   *  `projects/{project}/instances/{instance}/clusters/{cluster}`.
-   */
+  ///
+  /// Deletes a cluster from an instance.
+  ///
+  /// @param name  Required. The unique name of the cluster to be deleted.
+  /// Values are of the form
+  ///  `projects/{project}/instances/{instance}/clusters/{cluster}`.
+  ///
   Status DeleteCluster(std::string const& name);
 
-  /**
-   * Creates an app profile within an instance.
-   *
-   * @param parent  Required. The unique name of the instance in which to create
-   * the new app profile. Values are of the form
-   *  `projects/{project}/instances/{instance}`.
-   * @param app_profile_id  Required. The ID to be used when referring to the
-   * new app profile within its instance, e.g., just `myprofile` rather than
-   *  `projects/myproject/instances/myinstance/appProfiles/myprofile`.
-   * @param app_profile  Required. The app profile to be created.
-   *  Fields marked `OutputOnly` will be ignored.
-   * @return
-   * @googleapis_link{google::bigtable::admin::v2::AppProfile,google/bigtable/admin/v2/instance.proto#L236}
-   */
+  ///
+  /// Creates an app profile within an instance.
+  ///
+  /// @param parent  Required. The unique name of the instance in which to
+  /// create the new app profile.
+  ///  Values are of the form
+  ///  `projects/{project}/instances/{instance}`.
+  /// @param app_profile_id  Required. The ID to be used when referring to the
+  /// new app profile within its
+  ///  instance, e.g., just `myprofile` rather than
+  ///  `projects/myproject/instances/myinstance/appProfiles/myprofile`.
+  /// @param app_profile  Required. The app profile to be created.
+  ///  Fields marked `OutputOnly` will be ignored.
+  /// @return
+  /// @googleapis_link{google::bigtable::admin::v2::AppProfile,google/bigtable/admin/v2/instance.proto#L236}
+  ///
   StatusOr<google::bigtable::admin::v2::AppProfile> CreateAppProfile(
       std::string const& parent, std::string const& app_profile_id,
       google::bigtable::admin::v2::AppProfile const& app_profile);
 
-  /**
-   * Gets information about an app profile.
-   *
-   * @param name  Required. The unique name of the requested app profile. Values
-   * are of the form
-   *  `projects/{project}/instances/{instance}/appProfiles/{app_profile}`.
-   * @return
-   * @googleapis_link{google::bigtable::admin::v2::AppProfile,google/bigtable/admin/v2/instance.proto#L236}
-   */
+  ///
+  /// Gets information about an app profile.
+  ///
+  /// @param name  Required. The unique name of the requested app profile.
+  /// Values are of the form
+  ///  `projects/{project}/instances/{instance}/appProfiles/{app_profile}`.
+  /// @return
+  /// @googleapis_link{google::bigtable::admin::v2::AppProfile,google/bigtable/admin/v2/instance.proto#L236}
+  ///
   StatusOr<google::bigtable::admin::v2::AppProfile> GetAppProfile(
       std::string const& name);
 
-  /**
-   * Lists information about app profiles in an instance.
-   *
-   * @param parent  Required. The unique name of the instance for which a list
-   * of app profiles is requested. Values are of the form
-   *  `projects/{project}/instances/{instance}`.
-   *  Use `{instance} = '-'` to list AppProfiles for all Instances in a project,
-   *  e.g., `projects/myproject/instances/-`.
-   * @return
-   * @googleapis_link{google::bigtable::admin::v2::AppProfile,google/bigtable/admin/v2/instance.proto#L236}
-   */
+  ///
+  /// Lists information about app profiles in an instance.
+  ///
+  /// @param parent  Required. The unique name of the instance for which a list
+  /// of app profiles is
+  ///  requested. Values are of the form
+  ///  `projects/{project}/instances/{instance}`.
+  ///  Use `{instance} = '-'` to list AppProfiles for all Instances in a
+  ///  project, e.g., `projects/myproject/instances/-`.
+  /// @return
+  /// @googleapis_link{google::bigtable::admin::v2::AppProfile,google/bigtable/admin/v2/instance.proto#L236}
+  ///
   StreamRange<google::bigtable::admin::v2::AppProfile> ListAppProfiles(
       std::string const& parent);
 
-  /**
-   * Updates an app profile within an instance.
-   *
-   * @param app_profile  Required. The app profile which will (partially)
-   * replace the current value.
-   * @param update_mask  Required. The subset of app profile fields which should
-   * be replaced. If unset, all fields will be replaced.
-   * @return
-   * @googleapis_link{google::bigtable::admin::v2::AppProfile,google/bigtable/admin/v2/instance.proto#L236}
-   */
+  ///
+  /// Updates an app profile within an instance.
+  ///
+  /// @param app_profile  Required. The app profile which will (partially)
+  /// replace the current value.
+  /// @param update_mask  Required. The subset of app profile fields which
+  /// should be replaced.
+  ///  If unset, all fields will be replaced.
+  /// @return
+  /// @googleapis_link{google::bigtable::admin::v2::AppProfile,google/bigtable/admin/v2/instance.proto#L236}
+  ///
   future<StatusOr<google::bigtable::admin::v2::AppProfile>> UpdateAppProfile(
       google::bigtable::admin::v2::AppProfile const& app_profile,
       google::protobuf::FieldMask const& update_mask);
 
-  /**
-   * Deletes an app profile from an instance.
-   *
-   * @param name  Required. The unique name of the app profile to be deleted.
-   * Values are of the form
-   *  `projects/{project}/instances/{instance}/appProfiles/{app_profile}`.
-   */
+  ///
+  /// Deletes an app profile from an instance.
+  ///
+  /// @param name  Required. The unique name of the app profile to be deleted.
+  /// Values are of the form
+  ///  `projects/{project}/instances/{instance}/appProfiles/{app_profile}`.
+  ///
   Status DeleteAppProfile(std::string const& name);
 
-  /**
-   * Gets the access control policy for an instance resource. Returns an empty
-   * policy if an instance exists but does not have a policy set.
-   *
-   * @param resource  REQUIRED: The resource for which the policy is being
-   * requested. See the operation documentation for the appropriate value for
-   * this field.
-   * @return
-   * @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
-   */
+  ///
+  /// Gets the access control policy for an instance resource. Returns an empty
+  /// policy if an instance exists but does not have a policy set.
+  ///
+  /// @param resource  REQUIRED: The resource for which the policy is being
+  /// requested.
+  ///  See the operation documentation for the appropriate value for this field.
+  /// @return
+  /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
+  ///
   StatusOr<google::iam::v1::Policy> GetIamPolicy(std::string const& resource);
 
-  /**
-   * Sets the access control policy on an instance resource. Replaces any
-   * existing policy.
-   *
-   * @param resource  REQUIRED: The resource for which the policy is being
-   * specified. See the operation documentation for the appropriate value for
-   * this field.
-   * @param policy  REQUIRED: The complete policy to be applied to the
-   * `resource`. The size of the policy is limited to a few 10s of KB. An empty
-   * policy is a valid policy but certain Cloud Platform services (such as
-   * Projects) might reject them.
-   * @return
-   * @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
-   */
+  ///
+  /// Sets the access control policy on an instance resource. Replaces any
+  /// existing policy.
+  ///
+  /// @param resource  REQUIRED: The resource for which the policy is being
+  /// specified.
+  ///  See the operation documentation for the appropriate value for this field.
+  /// @param policy  REQUIRED: The complete policy to be applied to the
+  /// `resource`. The size of
+  ///  the policy is limited to a few 10s of KB. An empty policy is a
+  ///  valid policy but certain Cloud Platform services (such as Projects)
+  ///  might reject them.
+  /// @return
+  /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
+  ///
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
       std::string const& resource, google::iam::v1::Policy const& policy);
 
@@ -347,265 +362,268 @@ class BigtableInstanceAdminClient {
                                                  IamUpdater const& updater,
                                                  Options options = {});
 
-  /**
-   * Returns permissions that the caller has on the specified instance resource.
-   *
-   * @param resource  REQUIRED: The resource for which the policy detail is
-   * being requested. See the operation documentation for the appropriate value
-   * for this field.
-   * @param permissions  The set of permissions to check for the `resource`.
-   * Permissions with wildcards (such as '*' or 'storage.*') are not allowed.
-   * For more information see [IAM
-   * Overview](https://cloud.google.com/iam/docs/overview#permissions).
-   * @return
-   * @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
-   */
+  ///
+  /// Returns permissions that the caller has on the specified instance
+  /// resource.
+  ///
+  /// @param resource  REQUIRED: The resource for which the policy detail is
+  /// being requested.
+  ///  See the operation documentation for the appropriate value for this field.
+  /// @param permissions  The set of permissions to check for the `resource`.
+  /// Permissions with
+  ///  wildcards (such as '*' or 'storage.*') are not allowed. For more
+  ///  information see
+  ///  [IAM Overview](https://cloud.google.com/iam/docs/overview#permissions).
+  /// @return
+  /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
+  ///
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
       std::string const& resource, std::vector<std::string> const& permissions);
 
-  /**
-   * Create an instance within a project.
-   *
-   * Note that exactly one of Cluster.serve_nodes and
-   * Cluster.cluster_config.cluster_autoscaling_config can be set. If
-   * serve_nodes is set to non-zero, then the cluster is manually scaled. If
-   * cluster_config.cluster_autoscaling_config is non-empty, then autoscaling is
-   * enabled.
-   *
-   * @param request
-   * @googleapis_link{google::bigtable::admin::v2::CreateInstanceRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L280}
-   * @return
-   * @googleapis_link{google::bigtable::admin::v2::Instance,google/bigtable/admin/v2/instance.proto#L41}
-   */
+  ///
+  /// Create an instance within a project.
+  ///
+  /// Note that exactly one of Cluster.serve_nodes and
+  /// Cluster.cluster_config.cluster_autoscaling_config can be set. If
+  /// serve_nodes is set to non-zero, then the cluster is manually scaled. If
+  /// cluster_config.cluster_autoscaling_config is non-empty, then autoscaling
+  /// is enabled.
+  ///
+  /// @param request
+  /// @googleapis_link{google::bigtable::admin::v2::CreateInstanceRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L280}
+  /// @return
+  /// @googleapis_link{google::bigtable::admin::v2::Instance,google/bigtable/admin/v2/instance.proto#L41}
+  ///
   future<StatusOr<google::bigtable::admin::v2::Instance>> CreateInstance(
       google::bigtable::admin::v2::CreateInstanceRequest const& request);
 
-  /**
-   * Gets information about an instance.
-   *
-   * @param request
-   * @googleapis_link{google::bigtable::admin::v2::GetInstanceRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L308}
-   * @return
-   * @googleapis_link{google::bigtable::admin::v2::Instance,google/bigtable/admin/v2/instance.proto#L41}
-   */
+  ///
+  /// Gets information about an instance.
+  ///
+  /// @param request
+  /// @googleapis_link{google::bigtable::admin::v2::GetInstanceRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L308}
+  /// @return
+  /// @googleapis_link{google::bigtable::admin::v2::Instance,google/bigtable/admin/v2/instance.proto#L41}
+  ///
   StatusOr<google::bigtable::admin::v2::Instance> GetInstance(
       google::bigtable::admin::v2::GetInstanceRequest const& request);
 
-  /**
-   * Lists information about instances in a project.
-   *
-   * @param request
-   * @googleapis_link{google::bigtable::admin::v2::ListInstancesRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L320}
-   * @return
-   * @googleapis_link{google::bigtable::admin::v2::ListInstancesResponse,google/bigtable/admin/v2/bigtable_instance_admin.proto#L335}
-   */
+  ///
+  /// Lists information about instances in a project.
+  ///
+  /// @param request
+  /// @googleapis_link{google::bigtable::admin::v2::ListInstancesRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L320}
+  /// @return
+  /// @googleapis_link{google::bigtable::admin::v2::ListInstancesResponse,google/bigtable/admin/v2/bigtable_instance_admin.proto#L335}
+  ///
   StatusOr<google::bigtable::admin::v2::ListInstancesResponse> ListInstances(
       google::bigtable::admin::v2::ListInstancesRequest const& request);
 
-  /**
-   * Updates an instance within a project. This method updates only the display
-   * name and type for an Instance. To update other Instance properties, such as
-   * labels, use PartialUpdateInstance.
-   *
-   * @param request
-   * @googleapis_link{google::bigtable::admin::v2::Instance,google/bigtable/admin/v2/instance.proto#L41}
-   * @return
-   * @googleapis_link{google::bigtable::admin::v2::Instance,google/bigtable/admin/v2/instance.proto#L41}
-   */
+  ///
+  /// Updates an instance within a project. This method updates only the display
+  /// name and type for an Instance. To update other Instance properties, such
+  /// as labels, use PartialUpdateInstance.
+  ///
+  /// @param request
+  /// @googleapis_link{google::bigtable::admin::v2::Instance,google/bigtable/admin/v2/instance.proto#L41}
+  /// @return
+  /// @googleapis_link{google::bigtable::admin::v2::Instance,google/bigtable/admin/v2/instance.proto#L41}
+  ///
   StatusOr<google::bigtable::admin::v2::Instance> UpdateInstance(
       google::bigtable::admin::v2::Instance const& request);
 
-  /**
-   * Partially updates an instance within a project. This method can modify all
-   * fields of an Instance and is the preferred way to update an Instance.
-   *
-   * @param request
-   * @googleapis_link{google::bigtable::admin::v2::PartialUpdateInstanceRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L352}
-   * @return
-   * @googleapis_link{google::bigtable::admin::v2::Instance,google/bigtable/admin/v2/instance.proto#L41}
-   */
+  ///
+  /// Partially updates an instance within a project. This method can modify all
+  /// fields of an Instance and is the preferred way to update an Instance.
+  ///
+  /// @param request
+  /// @googleapis_link{google::bigtable::admin::v2::PartialUpdateInstanceRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L352}
+  /// @return
+  /// @googleapis_link{google::bigtable::admin::v2::Instance,google/bigtable/admin/v2/instance.proto#L41}
+  ///
   future<StatusOr<google::bigtable::admin::v2::Instance>> PartialUpdateInstance(
       google::bigtable::admin::v2::PartialUpdateInstanceRequest const& request);
 
-  /**
-   * Delete an instance from a project.
-   *
-   * @param request
-   * @googleapis_link{google::bigtable::admin::v2::DeleteInstanceRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L362}
-   */
+  ///
+  /// Delete an instance from a project.
+  ///
+  /// @param request
+  /// @googleapis_link{google::bigtable::admin::v2::DeleteInstanceRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L362}
+  ///
   Status DeleteInstance(
       google::bigtable::admin::v2::DeleteInstanceRequest const& request);
 
-  /**
-   * Creates a cluster within an instance.
-   *
-   * Note that exactly one of Cluster.serve_nodes and
-   * Cluster.cluster_config.cluster_autoscaling_config can be set. If
-   * serve_nodes is set to non-zero, then the cluster is manually scaled. If
-   * cluster_config.cluster_autoscaling_config is non-empty, then autoscaling is
-   * enabled.
-   *
-   * @param request
-   * @googleapis_link{google::bigtable::admin::v2::CreateClusterRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L374}
-   * @return
-   * @googleapis_link{google::bigtable::admin::v2::Cluster,google/bigtable/admin/v2/instance.proto#L137}
-   */
+  ///
+  /// Creates a cluster within an instance.
+  ///
+  /// Note that exactly one of Cluster.serve_nodes and
+  /// Cluster.cluster_config.cluster_autoscaling_config can be set. If
+  /// serve_nodes is set to non-zero, then the cluster is manually scaled. If
+  /// cluster_config.cluster_autoscaling_config is non-empty, then autoscaling
+  /// is enabled.
+  ///
+  /// @param request
+  /// @googleapis_link{google::bigtable::admin::v2::CreateClusterRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L374}
+  /// @return
+  /// @googleapis_link{google::bigtable::admin::v2::Cluster,google/bigtable/admin/v2/instance.proto#L137}
+  ///
   future<StatusOr<google::bigtable::admin::v2::Cluster>> CreateCluster(
       google::bigtable::admin::v2::CreateClusterRequest const& request);
 
-  /**
-   * Gets information about a cluster.
-   *
-   * @param request
-   * @googleapis_link{google::bigtable::admin::v2::GetClusterRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L396}
-   * @return
-   * @googleapis_link{google::bigtable::admin::v2::Cluster,google/bigtable/admin/v2/instance.proto#L137}
-   */
+  ///
+  /// Gets information about a cluster.
+  ///
+  /// @param request
+  /// @googleapis_link{google::bigtable::admin::v2::GetClusterRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L396}
+  /// @return
+  /// @googleapis_link{google::bigtable::admin::v2::Cluster,google/bigtable/admin/v2/instance.proto#L137}
+  ///
   StatusOr<google::bigtable::admin::v2::Cluster> GetCluster(
       google::bigtable::admin::v2::GetClusterRequest const& request);
 
-  /**
-   * Lists information about clusters in an instance.
-   *
-   * @param request
-   * @googleapis_link{google::bigtable::admin::v2::ListClustersRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L408}
-   * @return
-   * @googleapis_link{google::bigtable::admin::v2::ListClustersResponse,google/bigtable/admin/v2/bigtable_instance_admin.proto#L425}
-   */
+  ///
+  /// Lists information about clusters in an instance.
+  ///
+  /// @param request
+  /// @googleapis_link{google::bigtable::admin::v2::ListClustersRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L408}
+  /// @return
+  /// @googleapis_link{google::bigtable::admin::v2::ListClustersResponse,google/bigtable/admin/v2/bigtable_instance_admin.proto#L425}
+  ///
   StatusOr<google::bigtable::admin::v2::ListClustersResponse> ListClusters(
       google::bigtable::admin::v2::ListClustersRequest const& request);
 
-  /**
-   * Updates a cluster within an instance.
-   *
-   * Note that UpdateCluster does not support updating
-   * cluster_config.cluster_autoscaling_config. In order to update it, you
-   * must use PartialUpdateCluster.
-   *
-   * @param request
-   * @googleapis_link{google::bigtable::admin::v2::Cluster,google/bigtable/admin/v2/instance.proto#L137}
-   * @return
-   * @googleapis_link{google::bigtable::admin::v2::Cluster,google/bigtable/admin/v2/instance.proto#L137}
-   */
+  ///
+  /// Updates a cluster within an instance.
+  ///
+  /// Note that UpdateCluster does not support updating
+  /// cluster_config.cluster_autoscaling_config. In order to update it, you
+  /// must use PartialUpdateCluster.
+  ///
+  /// @param request
+  /// @googleapis_link{google::bigtable::admin::v2::Cluster,google/bigtable/admin/v2/instance.proto#L137}
+  /// @return
+  /// @googleapis_link{google::bigtable::admin::v2::Cluster,google/bigtable/admin/v2/instance.proto#L137}
+  ///
   future<StatusOr<google::bigtable::admin::v2::Cluster>> UpdateCluster(
       google::bigtable::admin::v2::Cluster const& request);
 
-  /**
-   * Partially updates a cluster within a project. This method is the preferred
-   * way to update a Cluster.
-   *
-   * To enable and update autoscaling, set
-   * cluster_config.cluster_autoscaling_config. When autoscaling is enabled,
-   * serve_nodes is treated as an OUTPUT_ONLY field, meaning that updates to it
-   * are ignored. Note that an update cannot simultaneously set serve_nodes to
-   * non-zero and cluster_config.cluster_autoscaling_config to non-empty, and
-   * also specify both in the update_mask.
-   *
-   * To disable autoscaling, clear cluster_config.cluster_autoscaling_config,
-   * and explicitly set a serve_node count via the update_mask.
-   *
-   * @param request
-   * @googleapis_link{google::bigtable::admin::v2::PartialUpdateClusterRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L513}
-   * @return
-   * @googleapis_link{google::bigtable::admin::v2::Cluster,google/bigtable/admin/v2/instance.proto#L137}
-   */
+  ///
+  /// Partially updates a cluster within a project. This method is the preferred
+  /// way to update a Cluster.
+  ///
+  /// To enable and update autoscaling, set
+  /// cluster_config.cluster_autoscaling_config. When autoscaling is enabled,
+  /// serve_nodes is treated as an OUTPUT_ONLY field, meaning that updates to it
+  /// are ignored. Note that an update cannot simultaneously set serve_nodes to
+  /// non-zero and cluster_config.cluster_autoscaling_config to non-empty, and
+  /// also specify both in the update_mask.
+  ///
+  /// To disable autoscaling, clear cluster_config.cluster_autoscaling_config,
+  /// and explicitly set a serve_node count via the update_mask.
+  ///
+  /// @param request
+  /// @googleapis_link{google::bigtable::admin::v2::PartialUpdateClusterRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L513}
+  /// @return
+  /// @googleapis_link{google::bigtable::admin::v2::Cluster,google/bigtable/admin/v2/instance.proto#L137}
+  ///
   future<StatusOr<google::bigtable::admin::v2::Cluster>> PartialUpdateCluster(
       google::bigtable::admin::v2::PartialUpdateClusterRequest const& request);
 
-  /**
-   * Deletes a cluster from an instance.
-   *
-   * @param request
-   * @googleapis_link{google::bigtable::admin::v2::DeleteClusterRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L441}
-   */
+  ///
+  /// Deletes a cluster from an instance.
+  ///
+  /// @param request
+  /// @googleapis_link{google::bigtable::admin::v2::DeleteClusterRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L441}
+  ///
   Status DeleteCluster(
       google::bigtable::admin::v2::DeleteClusterRequest const& request);
 
-  /**
-   * Creates an app profile within an instance.
-   *
-   * @param request
-   * @googleapis_link{google::bigtable::admin::v2::CreateAppProfileRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L523}
-   * @return
-   * @googleapis_link{google::bigtable::admin::v2::AppProfile,google/bigtable/admin/v2/instance.proto#L236}
-   */
+  ///
+  /// Creates an app profile within an instance.
+  ///
+  /// @param request
+  /// @googleapis_link{google::bigtable::admin::v2::CreateAppProfileRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L523}
+  /// @return
+  /// @googleapis_link{google::bigtable::admin::v2::AppProfile,google/bigtable/admin/v2/instance.proto#L236}
+  ///
   StatusOr<google::bigtable::admin::v2::AppProfile> CreateAppProfile(
       google::bigtable::admin::v2::CreateAppProfileRequest const& request);
 
-  /**
-   * Gets information about an app profile.
-   *
-   * @param request
-   * @googleapis_link{google::bigtable::admin::v2::GetAppProfileRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L548}
-   * @return
-   * @googleapis_link{google::bigtable::admin::v2::AppProfile,google/bigtable/admin/v2/instance.proto#L236}
-   */
+  ///
+  /// Gets information about an app profile.
+  ///
+  /// @param request
+  /// @googleapis_link{google::bigtable::admin::v2::GetAppProfileRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L548}
+  /// @return
+  /// @googleapis_link{google::bigtable::admin::v2::AppProfile,google/bigtable/admin/v2/instance.proto#L236}
+  ///
   StatusOr<google::bigtable::admin::v2::AppProfile> GetAppProfile(
       google::bigtable::admin::v2::GetAppProfileRequest const& request);
 
-  /**
-   * Lists information about app profiles in an instance.
-   *
-   * @param request
-   * @googleapis_link{google::bigtable::admin::v2::ListAppProfilesRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L560}
-   * @return
-   * @googleapis_link{google::bigtable::admin::v2::AppProfile,google/bigtable/admin/v2/instance.proto#L236}
-   */
+  ///
+  /// Lists information about app profiles in an instance.
+  ///
+  /// @param request
+  /// @googleapis_link{google::bigtable::admin::v2::ListAppProfilesRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L560}
+  /// @return
+  /// @googleapis_link{google::bigtable::admin::v2::AppProfile,google/bigtable/admin/v2/instance.proto#L236}
+  ///
   StreamRange<google::bigtable::admin::v2::AppProfile> ListAppProfiles(
       google::bigtable::admin::v2::ListAppProfilesRequest request);
 
-  /**
-   * Updates an app profile within an instance.
-   *
-   * @param request
-   * @googleapis_link{google::bigtable::admin::v2::UpdateAppProfileRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L606}
-   * @return
-   * @googleapis_link{google::bigtable::admin::v2::AppProfile,google/bigtable/admin/v2/instance.proto#L236}
-   */
+  ///
+  /// Updates an app profile within an instance.
+  ///
+  /// @param request
+  /// @googleapis_link{google::bigtable::admin::v2::UpdateAppProfileRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L606}
+  /// @return
+  /// @googleapis_link{google::bigtable::admin::v2::AppProfile,google/bigtable/admin/v2/instance.proto#L236}
+  ///
   future<StatusOr<google::bigtable::admin::v2::AppProfile>> UpdateAppProfile(
       google::bigtable::admin::v2::UpdateAppProfileRequest const& request);
 
-  /**
-   * Deletes an app profile from an instance.
-   *
-   * @param request
-   * @googleapis_link{google::bigtable::admin::v2::DeleteAppProfileRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L619}
-   */
+  ///
+  /// Deletes an app profile from an instance.
+  ///
+  /// @param request
+  /// @googleapis_link{google::bigtable::admin::v2::DeleteAppProfileRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L619}
+  ///
   Status DeleteAppProfile(
       google::bigtable::admin::v2::DeleteAppProfileRequest const& request);
 
-  /**
-   * Gets the access control policy for an instance resource. Returns an empty
-   * policy if an instance exists but does not have a policy set.
-   *
-   * @param request
-   * @googleapis_link{google::iam::v1::GetIamPolicyRequest,google/iam/v1/iam_policy.proto#L113}
-   * @return
-   * @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
-   */
+  ///
+  /// Gets the access control policy for an instance resource. Returns an empty
+  /// policy if an instance exists but does not have a policy set.
+  ///
+  /// @param request
+  /// @googleapis_link{google::iam::v1::GetIamPolicyRequest,google/iam/v1/iam_policy.proto#L113}
+  /// @return
+  /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
+  ///
   StatusOr<google::iam::v1::Policy> GetIamPolicy(
       google::iam::v1::GetIamPolicyRequest const& request);
 
-  /**
-   * Sets the access control policy on an instance resource. Replaces any
-   * existing policy.
-   *
-   * @param request
-   * @googleapis_link{google::iam::v1::SetIamPolicyRequest,google/iam/v1/iam_policy.proto#L98}
-   * @return
-   * @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
-   */
+  ///
+  /// Sets the access control policy on an instance resource. Replaces any
+  /// existing policy.
+  ///
+  /// @param request
+  /// @googleapis_link{google::iam::v1::SetIamPolicyRequest,google/iam/v1/iam_policy.proto#L98}
+  /// @return
+  /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
+  ///
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
       google::iam::v1::SetIamPolicyRequest const& request);
 
-  /**
-   * Returns permissions that the caller has on the specified instance resource.
-   *
-   * @param request
-   * @googleapis_link{google::iam::v1::TestIamPermissionsRequest,google/iam/v1/iam_policy.proto#L126}
-   * @return
-   * @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
-   */
+  ///
+  /// Returns permissions that the caller has on the specified instance
+  /// resource.
+  ///
+  /// @param request
+  /// @googleapis_link{google::iam::v1::TestIamPermissionsRequest,google/iam/v1/iam_policy.proto#L126}
+  /// @return
+  /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
+  ///
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
       google::iam::v1::TestIamPermissionsRequest const& request);
 

--- a/google/cloud/bigtable/admin/bigtable_table_admin_client.h
+++ b/google/cloud/bigtable/admin/bigtable_table_admin_client.h
@@ -35,13 +35,13 @@ namespace cloud {
 namespace bigtable_admin {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-/**
- * Service for creating, configuring, and deleting Cloud Bigtable tables.
- *
- *
- * Provides access to the table schemas only, not the data stored within
- * the tables.
- */
+///
+/// Service for creating, configuring, and deleting Cloud Bigtable tables.
+///
+///
+/// Provides access to the table schemas only, not the data stored within
+/// the tables.
+///
 class BigtableTableAdminClient {
  public:
   explicit BigtableTableAdminClient(
@@ -69,220 +69,230 @@ class BigtableTableAdminClient {
   }
   //@}
 
-  /**
-   * Creates a new table in the specified instance.
-   * The table can be created with a full set of initial column families,
-   * specified in the request.
-   *
-   * @param parent  Required. The unique name of the instance in which to create
-   * the table. Values are of the form
-   * `projects/{project}/instances/{instance}`.
-   * @param table_id  Required. The name by which the new table should be
-   * referred to within the parent instance, e.g., `foobar` rather than
-   * `{parent}/tables/foobar`. Maximum 50 characters.
-   * @param table  Required. The Table to create.
-   * @return
-   * @googleapis_link{google::bigtable::admin::v2::Table,google/bigtable/admin/v2/table.proto#L61}
-   */
+  ///
+  /// Creates a new table in the specified instance.
+  /// The table can be created with a full set of initial column families,
+  /// specified in the request.
+  ///
+  /// @param parent  Required. The unique name of the instance in which to
+  /// create the table.
+  ///  Values are of the form `projects/{project}/instances/{instance}`.
+  /// @param table_id  Required. The name by which the new table should be
+  /// referred to within the parent
+  ///  instance, e.g., `foobar` rather than `{parent}/tables/foobar`.
+  ///  Maximum 50 characters.
+  /// @param table  Required. The Table to create.
+  /// @return
+  /// @googleapis_link{google::bigtable::admin::v2::Table,google/bigtable/admin/v2/table.proto#L61}
+  ///
   StatusOr<google::bigtable::admin::v2::Table> CreateTable(
       std::string const& parent, std::string const& table_id,
       google::bigtable::admin::v2::Table const& table);
 
-  /**
-   * Lists all tables served from a specified instance.
-   *
-   * @param parent  Required. The unique name of the instance for which tables
-   * should be listed. Values are of the form
-   * `projects/{project}/instances/{instance}`.
-   * @return
-   * @googleapis_link{google::bigtable::admin::v2::Table,google/bigtable/admin/v2/table.proto#L61}
-   */
+  ///
+  /// Lists all tables served from a specified instance.
+  ///
+  /// @param parent  Required. The unique name of the instance for which tables
+  /// should be listed.
+  ///  Values are of the form `projects/{project}/instances/{instance}`.
+  /// @return
+  /// @googleapis_link{google::bigtable::admin::v2::Table,google/bigtable/admin/v2/table.proto#L61}
+  ///
   StreamRange<google::bigtable::admin::v2::Table> ListTables(
       std::string const& parent);
 
-  /**
-   * Gets metadata information about the specified table.
-   *
-   * @param name  Required. The unique name of the requested table.
-   *  Values are of the form
-   *  `projects/{project}/instances/{instance}/tables/{table}`.
-   * @return
-   * @googleapis_link{google::bigtable::admin::v2::Table,google/bigtable/admin/v2/table.proto#L61}
-   */
+  ///
+  /// Gets metadata information about the specified table.
+  ///
+  /// @param name  Required. The unique name of the requested table.
+  ///  Values are of the form
+  ///  `projects/{project}/instances/{instance}/tables/{table}`.
+  /// @return
+  /// @googleapis_link{google::bigtable::admin::v2::Table,google/bigtable/admin/v2/table.proto#L61}
+  ///
   StatusOr<google::bigtable::admin::v2::Table> GetTable(
       std::string const& name);
 
-  /**
-   * Permanently deletes a specified table and all of its data.
-   *
-   * @param name  Required. The unique name of the table to be deleted.
-   *  Values are of the form
-   *  `projects/{project}/instances/{instance}/tables/{table}`.
-   */
+  ///
+  /// Permanently deletes a specified table and all of its data.
+  ///
+  /// @param name  Required. The unique name of the table to be deleted.
+  ///  Values are of the form
+  ///  `projects/{project}/instances/{instance}/tables/{table}`.
+  ///
   Status DeleteTable(std::string const& name);
 
-  /**
-   * Performs a series of column family modifications on the specified table.
-   * Either all or none of the modifications will occur before this method
-   * returns, but data requests received prior to that point may see a table
-   * where only some modifications have taken effect.
-   *
-   * @param name  Required. The unique name of the table whose families should
-   * be modified. Values are of the form
-   *  `projects/{project}/instances/{instance}/tables/{table}`.
-   * @param modifications  Required. Modifications to be atomically applied to
-   * the specified table's families. Entries are applied in order, meaning that
-   * earlier modifications can be masked by later ones (in the case of repeated
-   * updates to the same family, for example).
-   * @return
-   * @googleapis_link{google::bigtable::admin::v2::Table,google/bigtable/admin/v2/table.proto#L61}
-   */
+  ///
+  /// Performs a series of column family modifications on the specified table.
+  /// Either all or none of the modifications will occur before this method
+  /// returns, but data requests received prior to that point may see a table
+  /// where only some modifications have taken effect.
+  ///
+  /// @param name  Required. The unique name of the table whose families should
+  /// be modified.
+  ///  Values are of the form
+  ///  `projects/{project}/instances/{instance}/tables/{table}`.
+  /// @param modifications  Required. Modifications to be atomically applied to
+  /// the specified table's families.
+  ///  Entries are applied in order, meaning that earlier modifications can be
+  ///  masked by later ones (in the case of repeated updates to the same family,
+  ///  for example).
+  /// @return
+  /// @googleapis_link{google::bigtable::admin::v2::Table,google/bigtable/admin/v2/table.proto#L61}
+  ///
   StatusOr<google::bigtable::admin::v2::Table> ModifyColumnFamilies(
       std::string const& name,
       std::vector<google::bigtable::admin::v2::ModifyColumnFamiliesRequest::
                       Modification> const& modifications);
 
-  /**
-   * Generates a consistency token for a Table, which can be used in
-   * CheckConsistency to check whether mutations to the table that finished
-   * before this call started have been replicated. The tokens will be available
-   * for 90 days.
-   *
-   * @param name  Required. The unique name of the Table for which to create a
-   * consistency token. Values are of the form
-   *  `projects/{project}/instances/{instance}/tables/{table}`.
-   * @return
-   * @googleapis_link{google::bigtable::admin::v2::GenerateConsistencyTokenResponse,google/bigtable/admin/v2/bigtable_table_admin.proto#L640}
-   */
+  ///
+  /// Generates a consistency token for a Table, which can be used in
+  /// CheckConsistency to check whether mutations to the table that finished
+  /// before this call started have been replicated. The tokens will be
+  /// available for 90 days.
+  ///
+  /// @param name  Required. The unique name of the Table for which to create a
+  /// consistency token.
+  ///  Values are of the form
+  ///  `projects/{project}/instances/{instance}/tables/{table}`.
+  /// @return
+  /// @googleapis_link{google::bigtable::admin::v2::GenerateConsistencyTokenResponse,google/bigtable/admin/v2/bigtable_table_admin.proto#L640}
+  ///
   StatusOr<google::bigtable::admin::v2::GenerateConsistencyTokenResponse>
   GenerateConsistencyToken(std::string const& name);
 
-  /**
-   * Checks replication consistency based on a consistency token, that is, if
-   * replication has caught up based on the conditions specified in the token
-   * and the check request.
-   *
-   * @param name  Required. The unique name of the Table for which to check
-   * replication consistency. Values are of the form
-   *  `projects/{project}/instances/{instance}/tables/{table}`.
-   * @param consistency_token  Required. The token created using
-   * GenerateConsistencyToken for the Table.
-   * @return
-   * @googleapis_link{google::bigtable::admin::v2::CheckConsistencyResponse,google/bigtable/admin/v2/bigtable_table_admin.proto#L664}
-   */
+  ///
+  /// Checks replication consistency based on a consistency token, that is, if
+  /// replication has caught up based on the conditions specified in the token
+  /// and the check request.
+  ///
+  /// @param name  Required. The unique name of the Table for which to check
+  /// replication consistency.
+  ///  Values are of the form
+  ///  `projects/{project}/instances/{instance}/tables/{table}`.
+  /// @param consistency_token  Required. The token created using
+  /// GenerateConsistencyToken for the Table.
+  /// @return
+  /// @googleapis_link{google::bigtable::admin::v2::CheckConsistencyResponse,google/bigtable/admin/v2/bigtable_table_admin.proto#L664}
+  ///
   StatusOr<google::bigtable::admin::v2::CheckConsistencyResponse>
   CheckConsistency(std::string const& name,
                    std::string const& consistency_token);
 
-  /**
-   * Starts creating a new Cloud Bigtable Backup.  The returned backup
-   * [long-running operation][google.longrunning.Operation] can be used to
-   * track creation of the backup. The
-   * [metadata][google.longrunning.Operation.metadata] field type is
-   * [CreateBackupMetadata][google.bigtable.admin.v2.CreateBackupMetadata]. The
-   * [response][google.longrunning.Operation.response] field type is
-   * [Backup][google.bigtable.admin.v2.Backup], if successful. Cancelling the
-   * returned operation will stop the creation and delete the backup.
-   *
-   * @param parent  Required. This must be one of the clusters in the instance
-   * in which this table is located. The backup will be stored in this cluster.
-   * Values are of the form
-   * `projects/{project}/instances/{instance}/clusters/{cluster}`.
-   * @param backup_id  Required. The id of the backup to be created. The
-   * `backup_id` along with the parent `parent` are combined as
-   * {parent}/backups/{backup_id} to create the full backup name, of the form:
-   *  `projects/{project}/instances/{instance}/clusters/{cluster}/backups/{backup_id}`.
-   *  This string must be between 1 and 50 characters in length and match the
-   *  regex [_a-zA-Z0-9][-_.a-zA-Z0-9]*.
-   * @param backup  Required. The backup to create.
-   * @return
-   * @googleapis_link{google::bigtable::admin::v2::Backup,google/bigtable/admin/v2/table.proto#L317}
-   */
+  ///
+  /// Starts creating a new Cloud Bigtable Backup.  The returned backup
+  /// [long-running operation][google.longrunning.Operation] can be used to
+  /// track creation of the backup. The
+  /// [metadata][google.longrunning.Operation.metadata] field type is
+  /// [CreateBackupMetadata][google.bigtable.admin.v2.CreateBackupMetadata]. The
+  /// [response][google.longrunning.Operation.response] field type is
+  /// [Backup][google.bigtable.admin.v2.Backup], if successful. Cancelling the
+  /// returned operation will stop the creation and delete the backup.
+  ///
+  /// @param parent  Required. This must be one of the clusters in the instance
+  /// in which this
+  ///  table is located. The backup will be stored in this cluster. Values are
+  ///  of the form `projects/{project}/instances/{instance}/clusters/{cluster}`.
+  /// @param backup_id  Required. The id of the backup to be created. The
+  /// `backup_id` along with
+  ///  the parent `parent` are combined as {parent}/backups/{backup_id} to
+  ///  create the full backup name, of the form:
+  ///  `projects/{project}/instances/{instance}/clusters/{cluster}/backups/{backup_id}`.
+  ///  This string must be between 1 and 50 characters in length and match the
+  ///  regex [_a-zA-Z0-9][-_.a-zA-Z0-9]*.
+  /// @param backup  Required. The backup to create.
+  /// @return
+  /// @googleapis_link{google::bigtable::admin::v2::Backup,google/bigtable/admin/v2/table.proto#L317}
+  ///
   future<StatusOr<google::bigtable::admin::v2::Backup>> CreateBackup(
       std::string const& parent, std::string const& backup_id,
       google::bigtable::admin::v2::Backup const& backup);
 
-  /**
-   * Gets metadata on a pending or completed Cloud Bigtable Backup.
-   *
-   * @param name  Required. Name of the backup.
-   *  Values are of the form
-   *  `projects/{project}/instances/{instance}/clusters/{cluster}/backups/{backup}`.
-   * @return
-   * @googleapis_link{google::bigtable::admin::v2::Backup,google/bigtable/admin/v2/table.proto#L317}
-   */
+  ///
+  /// Gets metadata on a pending or completed Cloud Bigtable Backup.
+  ///
+  /// @param name  Required. Name of the backup.
+  ///  Values are of the form
+  ///  `projects/{project}/instances/{instance}/clusters/{cluster}/backups/{backup}`.
+  /// @return
+  /// @googleapis_link{google::bigtable::admin::v2::Backup,google/bigtable/admin/v2/table.proto#L317}
+  ///
   StatusOr<google::bigtable::admin::v2::Backup> GetBackup(
       std::string const& name);
 
-  /**
-   * Updates a pending or completed Cloud Bigtable Backup.
-   *
-   * @param backup  Required. The backup to update. `backup.name`, and the
-   * fields to be updated as specified by `update_mask` are required. Other
-   * fields are ignored. Update is only supported for the following fields:
-   *   * `backup.expire_time`.
-   * @param update_mask  Required. A mask specifying which fields (e.g.
-   * `expire_time`) in the Backup resource should be updated. This mask is
-   * relative to the Backup resource, not to the request message. The field mask
-   * must always be specified; this prevents any future fields from being erased
-   * accidentally by clients that do not know about them.
-   * @return
-   * @googleapis_link{google::bigtable::admin::v2::Backup,google/bigtable/admin/v2/table.proto#L317}
-   */
+  ///
+  /// Updates a pending or completed Cloud Bigtable Backup.
+  ///
+  /// @param backup  Required. The backup to update. `backup.name`, and the
+  /// fields to be updated
+  ///  as specified by `update_mask` are required. Other fields are ignored.
+  ///  Update is only supported for the following fields:
+  ///   * `backup.expire_time`.
+  /// @param update_mask  Required. A mask specifying which fields (e.g.
+  /// `expire_time`) in the
+  ///  Backup resource should be updated. This mask is relative to the Backup
+  ///  resource, not to the request message. The field mask must always be
+  ///  specified; this prevents any future fields from being erased accidentally
+  ///  by clients that do not know about them.
+  /// @return
+  /// @googleapis_link{google::bigtable::admin::v2::Backup,google/bigtable/admin/v2/table.proto#L317}
+  ///
   StatusOr<google::bigtable::admin::v2::Backup> UpdateBackup(
       google::bigtable::admin::v2::Backup const& backup,
       google::protobuf::FieldMask const& update_mask);
 
-  /**
-   * Deletes a pending or completed Cloud Bigtable backup.
-   *
-   * @param name  Required. Name of the backup to delete.
-   *  Values are of the form
-   *  `projects/{project}/instances/{instance}/clusters/{cluster}/backups/{backup}`.
-   */
+  ///
+  /// Deletes a pending or completed Cloud Bigtable backup.
+  ///
+  /// @param name  Required. Name of the backup to delete.
+  ///  Values are of the form
+  ///  `projects/{project}/instances/{instance}/clusters/{cluster}/backups/{backup}`.
+  ///
   Status DeleteBackup(std::string const& name);
 
-  /**
-   * Lists Cloud Bigtable backups. Returns both completed and pending
-   * backups.
-   *
-   * @param parent  Required. The cluster to list backups from.  Values are of
-   * the form `projects/{project}/instances/{instance}/clusters/{cluster}`. Use
-   * `{cluster} = '-'` to list backups for all clusters in an instance, e.g.,
-   * `projects/{project}/instances/{instance}/clusters/-`.
-   * @return
-   * @googleapis_link{google::bigtable::admin::v2::Backup,google/bigtable/admin/v2/table.proto#L317}
-   */
+  ///
+  /// Lists Cloud Bigtable backups. Returns both completed and pending
+  /// backups.
+  ///
+  /// @param parent  Required. The cluster to list backups from.  Values are of
+  /// the
+  ///  form `projects/{project}/instances/{instance}/clusters/{cluster}`.
+  ///  Use `{cluster} = '-'` to list backups for all clusters in an instance,
+  ///  e.g., `projects/{project}/instances/{instance}/clusters/-`.
+  /// @return
+  /// @googleapis_link{google::bigtable::admin::v2::Backup,google/bigtable/admin/v2/table.proto#L317}
+  ///
   StreamRange<google::bigtable::admin::v2::Backup> ListBackups(
       std::string const& parent);
 
-  /**
-   * Gets the access control policy for a Table or Backup resource.
-   * Returns an empty policy if the resource exists but does not have a policy
-   * set.
-   *
-   * @param resource  REQUIRED: The resource for which the policy is being
-   * requested. See the operation documentation for the appropriate value for
-   * this field.
-   * @return
-   * @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
-   */
+  ///
+  /// Gets the access control policy for a Table or Backup resource.
+  /// Returns an empty policy if the resource exists but does not have a policy
+  /// set.
+  ///
+  /// @param resource  REQUIRED: The resource for which the policy is being
+  /// requested.
+  ///  See the operation documentation for the appropriate value for this field.
+  /// @return
+  /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
+  ///
   StatusOr<google::iam::v1::Policy> GetIamPolicy(std::string const& resource);
 
-  /**
-   * Sets the access control policy on a Table or Backup resource.
-   * Replaces any existing policy.
-   *
-   * @param resource  REQUIRED: The resource for which the policy is being
-   * specified. See the operation documentation for the appropriate value for
-   * this field.
-   * @param policy  REQUIRED: The complete policy to be applied to the
-   * `resource`. The size of the policy is limited to a few 10s of KB. An empty
-   * policy is a valid policy but certain Cloud Platform services (such as
-   * Projects) might reject them.
-   * @return
-   * @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
-   */
+  ///
+  /// Sets the access control policy on a Table or Backup resource.
+  /// Replaces any existing policy.
+  ///
+  /// @param resource  REQUIRED: The resource for which the policy is being
+  /// specified.
+  ///  See the operation documentation for the appropriate value for this field.
+  /// @param policy  REQUIRED: The complete policy to be applied to the
+  /// `resource`. The size of
+  ///  the policy is limited to a few 10s of KB. An empty policy is a
+  ///  valid policy but certain Cloud Platform services (such as Projects)
+  ///  might reject them.
+  /// @return
+  /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
+  ///
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
       std::string const& resource, google::iam::v1::Policy const& policy);
 
@@ -311,265 +321,267 @@ class BigtableTableAdminClient {
                                                  IamUpdater const& updater,
                                                  Options options = {});
 
-  /**
-   * Returns permissions that the caller has on the specified Table or Backup
-   * resource.
-   *
-   * @param resource  REQUIRED: The resource for which the policy detail is
-   * being requested. See the operation documentation for the appropriate value
-   * for this field.
-   * @param permissions  The set of permissions to check for the `resource`.
-   * Permissions with wildcards (such as '*' or 'storage.*') are not allowed.
-   * For more information see [IAM
-   * Overview](https://cloud.google.com/iam/docs/overview#permissions).
-   * @return
-   * @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
-   */
+  ///
+  /// Returns permissions that the caller has on the specified Table or Backup
+  /// resource.
+  ///
+  /// @param resource  REQUIRED: The resource for which the policy detail is
+  /// being requested.
+  ///  See the operation documentation for the appropriate value for this field.
+  /// @param permissions  The set of permissions to check for the `resource`.
+  /// Permissions with
+  ///  wildcards (such as '*' or 'storage.*') are not allowed. For more
+  ///  information see
+  ///  [IAM Overview](https://cloud.google.com/iam/docs/overview#permissions).
+  /// @return
+  /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
+  ///
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
       std::string const& resource, std::vector<std::string> const& permissions);
 
-  /**
-   * Checks replication consistency based on a consistency token, that is, if
-   * replication has caught up based on the conditions specified in the token
-   * and the check request.
-   *
-   * @param name  Required. The unique name of the Table for which to check
-   * replication consistency. Values are of the form
-   *  `projects/{project}/instances/{instance}/tables/{table}`.
-   * @param consistency_token  Required. The token created using
-   * GenerateConsistencyToken for the Table.
-   * @return
-   * @googleapis_link{google::bigtable::admin::v2::CheckConsistencyResponse,google/bigtable/admin/v2/bigtable_table_admin.proto#L664}
-   */
+  ///
+  /// Checks replication consistency based on a consistency token, that is, if
+  /// replication has caught up based on the conditions specified in the token
+  /// and the check request.
+  ///
+  /// @param name  Required. The unique name of the Table for which to check
+  /// replication consistency.
+  ///  Values are of the form
+  ///  `projects/{project}/instances/{instance}/tables/{table}`.
+  /// @param consistency_token  Required. The token created using
+  /// GenerateConsistencyToken for the Table.
+  /// @return
+  /// @googleapis_link{google::bigtable::admin::v2::CheckConsistencyResponse,google/bigtable/admin/v2/bigtable_table_admin.proto#L664}
+  ///
   future<StatusOr<google::bigtable::admin::v2::CheckConsistencyResponse>>
   AsyncCheckConsistency(std::string const& name,
                         std::string const& consistency_token);
 
-  /**
-   * Creates a new table in the specified instance.
-   * The table can be created with a full set of initial column families,
-   * specified in the request.
-   *
-   * @param request
-   * @googleapis_link{google::bigtable::admin::v2::CreateTableRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L408}
-   * @return
-   * @googleapis_link{google::bigtable::admin::v2::Table,google/bigtable/admin/v2/table.proto#L61}
-   */
+  ///
+  /// Creates a new table in the specified instance.
+  /// The table can be created with a full set of initial column families,
+  /// specified in the request.
+  ///
+  /// @param request
+  /// @googleapis_link{google::bigtable::admin::v2::CreateTableRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L408}
+  /// @return
+  /// @googleapis_link{google::bigtable::admin::v2::Table,google/bigtable/admin/v2/table.proto#L61}
+  ///
   StatusOr<google::bigtable::admin::v2::Table> CreateTable(
       google::bigtable::admin::v2::CreateTableRequest const& request);
 
-  /**
-   * Lists all tables served from a specified instance.
-   *
-   * @param request
-   * @googleapis_link{google::bigtable::admin::v2::ListTablesRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L510}
-   * @return
-   * @googleapis_link{google::bigtable::admin::v2::Table,google/bigtable/admin/v2/table.proto#L61}
-   */
+  ///
+  /// Lists all tables served from a specified instance.
+  ///
+  /// @param request
+  /// @googleapis_link{google::bigtable::admin::v2::ListTablesRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L510}
+  /// @return
+  /// @googleapis_link{google::bigtable::admin::v2::Table,google/bigtable/admin/v2/table.proto#L61}
+  ///
   StreamRange<google::bigtable::admin::v2::Table> ListTables(
       google::bigtable::admin::v2::ListTablesRequest request);
 
-  /**
-   * Gets metadata information about the specified table.
-   *
-   * @param request
-   * @googleapis_link{google::bigtable::admin::v2::GetTableRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L553}
-   * @return
-   * @googleapis_link{google::bigtable::admin::v2::Table,google/bigtable/admin/v2/table.proto#L61}
-   */
+  ///
+  /// Gets metadata information about the specified table.
+  ///
+  /// @param request
+  /// @googleapis_link{google::bigtable::admin::v2::GetTableRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L553}
+  /// @return
+  /// @googleapis_link{google::bigtable::admin::v2::Table,google/bigtable/admin/v2/table.proto#L61}
+  ///
   StatusOr<google::bigtable::admin::v2::Table> GetTable(
       google::bigtable::admin::v2::GetTableRequest const& request);
 
-  /**
-   * Permanently deletes a specified table and all of its data.
-   *
-   * @param request
-   * @googleapis_link{google::bigtable::admin::v2::DeleteTableRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L571}
-   */
+  ///
+  /// Permanently deletes a specified table and all of its data.
+  ///
+  /// @param request
+  /// @googleapis_link{google::bigtable::admin::v2::DeleteTableRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L571}
+  ///
   Status DeleteTable(
       google::bigtable::admin::v2::DeleteTableRequest const& request);
 
-  /**
-   * Performs a series of column family modifications on the specified table.
-   * Either all or none of the modifications will occur before this method
-   * returns, but data requests received prior to that point may see a table
-   * where only some modifications have taken effect.
-   *
-   * @param request
-   * @googleapis_link{google::bigtable::admin::v2::ModifyColumnFamiliesRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L585}
-   * @return
-   * @googleapis_link{google::bigtable::admin::v2::Table,google/bigtable/admin/v2/table.proto#L61}
-   */
+  ///
+  /// Performs a series of column family modifications on the specified table.
+  /// Either all or none of the modifications will occur before this method
+  /// returns, but data requests received prior to that point may see a table
+  /// where only some modifications have taken effect.
+  ///
+  /// @param request
+  /// @googleapis_link{google::bigtable::admin::v2::ModifyColumnFamiliesRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L585}
+  /// @return
+  /// @googleapis_link{google::bigtable::admin::v2::Table,google/bigtable/admin/v2/table.proto#L61}
+  ///
   StatusOr<google::bigtable::admin::v2::Table> ModifyColumnFamilies(
       google::bigtable::admin::v2::ModifyColumnFamiliesRequest const& request);
 
-  /**
-   * Permanently drop/delete a row range from a specified table. The request can
-   * specify whether to delete all rows in a table, or only those that match a
-   * particular prefix.
-   *
-   * @param request
-   * @googleapis_link{google::bigtable::admin::v2::DropRowRangeRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L486}
-   */
+  ///
+  /// Permanently drop/delete a row range from a specified table. The request
+  /// can specify whether to delete all rows in a table, or only those that
+  /// match a particular prefix.
+  ///
+  /// @param request
+  /// @googleapis_link{google::bigtable::admin::v2::DropRowRangeRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L486}
+  ///
   Status DropRowRange(
       google::bigtable::admin::v2::DropRowRangeRequest const& request);
 
-  /**
-   * Generates a consistency token for a Table, which can be used in
-   * CheckConsistency to check whether mutations to the table that finished
-   * before this call started have been replicated. The tokens will be available
-   * for 90 days.
-   *
-   * @param request
-   * @googleapis_link{google::bigtable::admin::v2::GenerateConsistencyTokenRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L626}
-   * @return
-   * @googleapis_link{google::bigtable::admin::v2::GenerateConsistencyTokenResponse,google/bigtable/admin/v2/bigtable_table_admin.proto#L640}
-   */
+  ///
+  /// Generates a consistency token for a Table, which can be used in
+  /// CheckConsistency to check whether mutations to the table that finished
+  /// before this call started have been replicated. The tokens will be
+  /// available for 90 days.
+  ///
+  /// @param request
+  /// @googleapis_link{google::bigtable::admin::v2::GenerateConsistencyTokenRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L626}
+  /// @return
+  /// @googleapis_link{google::bigtable::admin::v2::GenerateConsistencyTokenResponse,google/bigtable/admin/v2/bigtable_table_admin.proto#L640}
+  ///
   StatusOr<google::bigtable::admin::v2::GenerateConsistencyTokenResponse>
   GenerateConsistencyToken(
       google::bigtable::admin::v2::GenerateConsistencyTokenRequest const&
           request);
 
-  /**
-   * Checks replication consistency based on a consistency token, that is, if
-   * replication has caught up based on the conditions specified in the token
-   * and the check request.
-   *
-   * @param request
-   * @googleapis_link{google::bigtable::admin::v2::CheckConsistencyRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L647}
-   * @return
-   * @googleapis_link{google::bigtable::admin::v2::CheckConsistencyResponse,google/bigtable/admin/v2/bigtable_table_admin.proto#L664}
-   */
+  ///
+  /// Checks replication consistency based on a consistency token, that is, if
+  /// replication has caught up based on the conditions specified in the token
+  /// and the check request.
+  ///
+  /// @param request
+  /// @googleapis_link{google::bigtable::admin::v2::CheckConsistencyRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L647}
+  /// @return
+  /// @googleapis_link{google::bigtable::admin::v2::CheckConsistencyResponse,google/bigtable/admin/v2/bigtable_table_admin.proto#L664}
+  ///
   StatusOr<google::bigtable::admin::v2::CheckConsistencyResponse>
   CheckConsistency(
       google::bigtable::admin::v2::CheckConsistencyRequest const& request);
 
-  /**
-   * Starts creating a new Cloud Bigtable Backup.  The returned backup
-   * [long-running operation][google.longrunning.Operation] can be used to
-   * track creation of the backup. The
-   * [metadata][google.longrunning.Operation.metadata] field type is
-   * [CreateBackupMetadata][google.bigtable.admin.v2.CreateBackupMetadata]. The
-   * [response][google.longrunning.Operation.response] field type is
-   * [Backup][google.bigtable.admin.v2.Backup], if successful. Cancelling the
-   * returned operation will stop the creation and delete the backup.
-   *
-   * @param request
-   * @googleapis_link{google::bigtable::admin::v2::CreateBackupRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L833}
-   * @return
-   * @googleapis_link{google::bigtable::admin::v2::Backup,google/bigtable/admin/v2/table.proto#L317}
-   */
+  ///
+  /// Starts creating a new Cloud Bigtable Backup.  The returned backup
+  /// [long-running operation][google.longrunning.Operation] can be used to
+  /// track creation of the backup. The
+  /// [metadata][google.longrunning.Operation.metadata] field type is
+  /// [CreateBackupMetadata][google.bigtable.admin.v2.CreateBackupMetadata]. The
+  /// [response][google.longrunning.Operation.response] field type is
+  /// [Backup][google.bigtable.admin.v2.Backup], if successful. Cancelling the
+  /// returned operation will stop the creation and delete the backup.
+  ///
+  /// @param request
+  /// @googleapis_link{google::bigtable::admin::v2::CreateBackupRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L833}
+  /// @return
+  /// @googleapis_link{google::bigtable::admin::v2::Backup,google/bigtable/admin/v2/table.proto#L317}
+  ///
   future<StatusOr<google::bigtable::admin::v2::Backup>> CreateBackup(
       google::bigtable::admin::v2::CreateBackupRequest const& request);
 
-  /**
-   * Gets metadata on a pending or completed Cloud Bigtable Backup.
-   *
-   * @param request
-   * @googleapis_link{google::bigtable::admin::v2::GetBackupRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L889}
-   * @return
-   * @googleapis_link{google::bigtable::admin::v2::Backup,google/bigtable/admin/v2/table.proto#L317}
-   */
+  ///
+  /// Gets metadata on a pending or completed Cloud Bigtable Backup.
+  ///
+  /// @param request
+  /// @googleapis_link{google::bigtable::admin::v2::GetBackupRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L889}
+  /// @return
+  /// @googleapis_link{google::bigtable::admin::v2::Backup,google/bigtable/admin/v2/table.proto#L317}
+  ///
   StatusOr<google::bigtable::admin::v2::Backup> GetBackup(
       google::bigtable::admin::v2::GetBackupRequest const& request);
 
-  /**
-   * Updates a pending or completed Cloud Bigtable Backup.
-   *
-   * @param request
-   * @googleapis_link{google::bigtable::admin::v2::UpdateBackupRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L873}
-   * @return
-   * @googleapis_link{google::bigtable::admin::v2::Backup,google/bigtable/admin/v2/table.proto#L317}
-   */
+  ///
+  /// Updates a pending or completed Cloud Bigtable Backup.
+  ///
+  /// @param request
+  /// @googleapis_link{google::bigtable::admin::v2::UpdateBackupRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L873}
+  /// @return
+  /// @googleapis_link{google::bigtable::admin::v2::Backup,google/bigtable/admin/v2/table.proto#L317}
+  ///
   StatusOr<google::bigtable::admin::v2::Backup> UpdateBackup(
       google::bigtable::admin::v2::UpdateBackupRequest const& request);
 
-  /**
-   * Deletes a pending or completed Cloud Bigtable backup.
-   *
-   * @param request
-   * @googleapis_link{google::bigtable::admin::v2::DeleteBackupRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L902}
-   */
+  ///
+  /// Deletes a pending or completed Cloud Bigtable backup.
+  ///
+  /// @param request
+  /// @googleapis_link{google::bigtable::admin::v2::DeleteBackupRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L902}
+  ///
   Status DeleteBackup(
       google::bigtable::admin::v2::DeleteBackupRequest const& request);
 
-  /**
-   * Lists Cloud Bigtable backups. Returns both completed and pending
-   * backups.
-   *
-   * @param request
-   * @googleapis_link{google::bigtable::admin::v2::ListBackupsRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L915}
-   * @return
-   * @googleapis_link{google::bigtable::admin::v2::Backup,google/bigtable/admin/v2/table.proto#L317}
-   */
+  ///
+  /// Lists Cloud Bigtable backups. Returns both completed and pending
+  /// backups.
+  ///
+  /// @param request
+  /// @googleapis_link{google::bigtable::admin::v2::ListBackupsRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L915}
+  /// @return
+  /// @googleapis_link{google::bigtable::admin::v2::Backup,google/bigtable/admin/v2/table.proto#L317}
+  ///
   StreamRange<google::bigtable::admin::v2::Backup> ListBackups(
       google::bigtable::admin::v2::ListBackupsRequest request);
 
-  /**
-   * Create a new table by restoring from a completed backup. The new table
-   * must be in the same project as the instance containing the backup.  The
-   * returned table [long-running operation][google.longrunning.Operation] can
-   * be used to track the progress of the operation, and to cancel it.  The
-   * [metadata][google.longrunning.Operation.metadata] field type is
-   * [RestoreTableMetadata][google.bigtable.admin.RestoreTableMetadata].  The
-   * [response][google.longrunning.Operation.response] type is
-   * [Table][google.bigtable.admin.v2.Table], if successful.
-   *
-   * @param request
-   * @googleapis_link{google::bigtable::admin::v2::RestoreTableRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L336}
-   * @return
-   * @googleapis_link{google::bigtable::admin::v2::Table,google/bigtable/admin/v2/table.proto#L61}
-   */
+  ///
+  /// Create a new table by restoring from a completed backup. The new table
+  /// must be in the same project as the instance containing the backup.  The
+  /// returned table [long-running operation][google.longrunning.Operation] can
+  /// be used to track the progress of the operation, and to cancel it.  The
+  /// [metadata][google.longrunning.Operation.metadata] field type is
+  /// [RestoreTableMetadata][google.bigtable.admin.RestoreTableMetadata].  The
+  /// [response][google.longrunning.Operation.response] type is
+  /// [Table][google.bigtable.admin.v2.Table], if successful.
+  ///
+  /// @param request
+  /// @googleapis_link{google::bigtable::admin::v2::RestoreTableRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L336}
+  /// @return
+  /// @googleapis_link{google::bigtable::admin::v2::Table,google/bigtable/admin/v2/table.proto#L61}
+  ///
   future<StatusOr<google::bigtable::admin::v2::Table>> RestoreTable(
       google::bigtable::admin::v2::RestoreTableRequest const& request);
 
-  /**
-   * Gets the access control policy for a Table or Backup resource.
-   * Returns an empty policy if the resource exists but does not have a policy
-   * set.
-   *
-   * @param request
-   * @googleapis_link{google::iam::v1::GetIamPolicyRequest,google/iam/v1/iam_policy.proto#L113}
-   * @return
-   * @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
-   */
+  ///
+  /// Gets the access control policy for a Table or Backup resource.
+  /// Returns an empty policy if the resource exists but does not have a policy
+  /// set.
+  ///
+  /// @param request
+  /// @googleapis_link{google::iam::v1::GetIamPolicyRequest,google/iam/v1/iam_policy.proto#L113}
+  /// @return
+  /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
+  ///
   StatusOr<google::iam::v1::Policy> GetIamPolicy(
       google::iam::v1::GetIamPolicyRequest const& request);
 
-  /**
-   * Sets the access control policy on a Table or Backup resource.
-   * Replaces any existing policy.
-   *
-   * @param request
-   * @googleapis_link{google::iam::v1::SetIamPolicyRequest,google/iam/v1/iam_policy.proto#L98}
-   * @return
-   * @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
-   */
+  ///
+  /// Sets the access control policy on a Table or Backup resource.
+  /// Replaces any existing policy.
+  ///
+  /// @param request
+  /// @googleapis_link{google::iam::v1::SetIamPolicyRequest,google/iam/v1/iam_policy.proto#L98}
+  /// @return
+  /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
+  ///
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
       google::iam::v1::SetIamPolicyRequest const& request);
 
-  /**
-   * Returns permissions that the caller has on the specified Table or Backup
-   * resource.
-   *
-   * @param request
-   * @googleapis_link{google::iam::v1::TestIamPermissionsRequest,google/iam/v1/iam_policy.proto#L126}
-   * @return
-   * @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
-   */
+  ///
+  /// Returns permissions that the caller has on the specified Table or Backup
+  /// resource.
+  ///
+  /// @param request
+  /// @googleapis_link{google::iam::v1::TestIamPermissionsRequest,google/iam/v1/iam_policy.proto#L126}
+  /// @return
+  /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
+  ///
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
       google::iam::v1::TestIamPermissionsRequest const& request);
 
-  /**
-   * Checks replication consistency based on a consistency token, that is, if
-   * replication has caught up based on the conditions specified in the token
-   * and the check request.
-   *
-   * @param request
-   * @googleapis_link{google::bigtable::admin::v2::CheckConsistencyRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L647}
-   * @return
-   * @googleapis_link{google::bigtable::admin::v2::CheckConsistencyResponse,google/bigtable/admin/v2/bigtable_table_admin.proto#L664}
-   */
+  ///
+  /// Checks replication consistency based on a consistency token, that is, if
+  /// replication has caught up based on the conditions specified in the token
+  /// and the check request.
+  ///
+  /// @param request
+  /// @googleapis_link{google::bigtable::admin::v2::CheckConsistencyRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L647}
+  /// @return
+  /// @googleapis_link{google::bigtable::admin::v2::CheckConsistencyResponse,google/bigtable/admin/v2/bigtable_table_admin.proto#L664}
+  ///
   future<StatusOr<google::bigtable::admin::v2::CheckConsistencyResponse>>
   AsyncCheckConsistency(
       google::bigtable::admin::v2::CheckConsistencyRequest const& request);

--- a/google/cloud/iam/iam_client.h
+++ b/google/cloud/iam/iam_client.h
@@ -33,27 +33,27 @@ namespace cloud {
 namespace iam {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-/**
- * Creates and manages Identity and Access Management (IAM) resources.
- *
- * You can use this service to work with all of the following resources:
- *
- * * **Service accounts**, which identify an application or a virtual machine
- *   (VM) instance rather than a person
- * * **Service account keys**, which service accounts use to authenticate with
- *   Google APIs
- * * **IAM policies for service accounts**, which specify the roles that a
- *   member has for the service account
- * * **IAM custom roles**, which help you limit the number of permissions that
- *   you grant to members
- *
- * In addition, you can use this service to complete the following tasks, among
- * others:
- *
- * * Test whether a service account can use specific permissions
- * * Check which roles you can grant for a specific resource
- * * Lint, or validate, condition expressions in an IAM policy
- */
+///
+/// Creates and manages Identity and Access Management (IAM) resources.
+///
+/// You can use this service to work with all of the following resources:
+///
+/// * **Service accounts**, which identify an application or a virtual machine
+///   (VM) instance rather than a person
+/// * **Service account keys**, which service accounts use to authenticate with
+///   Google APIs
+/// * **IAM policies for service accounts**, which specify the roles that a
+///   member has for the service account
+/// * **IAM custom roles**, which help you limit the number of permissions that
+///   you grant to members
+///
+/// In addition, you can use this service to complete the following tasks, among
+/// others:
+///
+/// * Test whether a service account can use specific permissions
+/// * Check which roles you can grant for a specific resource
+/// * Lint, or validate, condition expressions in an IAM policy
+///
 class IAMClient {
  public:
   explicit IAMClient(std::shared_ptr<IAMConnection> connection);
@@ -77,95 +77,102 @@ class IAMClient {
   }
   //@}
 
-  /**
-   * Lists every [ServiceAccount][google.iam.admin.v1.ServiceAccount] that
-   * belongs to a specific project.
-   *
-   * @param name  Required. The resource name of the project associated with the
-   * service accounts, such as `projects/my-project-123`.
-   * @return
-   * @googleapis_link{google::iam::admin::v1::ServiceAccount,google/iam/admin/v1/iam.proto#L461}
-   */
+  ///
+  /// Lists every [ServiceAccount][google.iam.admin.v1.ServiceAccount] that
+  /// belongs to a specific project.
+  ///
+  /// @param name  Required. The resource name of the project associated with
+  /// the service
+  ///  accounts, such as `projects/my-project-123`.
+  /// @return
+  /// @googleapis_link{google::iam::admin::v1::ServiceAccount,google/iam/admin/v1/iam.proto#L461}
+  ///
   StreamRange<google::iam::admin::v1::ServiceAccount> ListServiceAccounts(
       std::string const& name);
 
-  /**
-   * Gets a [ServiceAccount][google.iam.admin.v1.ServiceAccount].
-   *
-   * @param name  Required. The resource name of the service account in the
-   * following format: `projects/{PROJECT_ID}/serviceAccounts/{ACCOUNT}`. Using
-   * `-` as a wildcard for the `PROJECT_ID` will infer the project from the
-   * account. The `ACCOUNT` value can be the `email` address or the `unique_id`
-   * of the service account.
-   * @return
-   * @googleapis_link{google::iam::admin::v1::ServiceAccount,google/iam/admin/v1/iam.proto#L461}
-   */
+  ///
+  /// Gets a [ServiceAccount][google.iam.admin.v1.ServiceAccount].
+  ///
+  /// @param name  Required. The resource name of the service account in the
+  /// following format:
+  ///  `projects/{PROJECT_ID}/serviceAccounts/{ACCOUNT}`.
+  ///  Using `-` as a wildcard for the `PROJECT_ID` will infer the project from
+  ///  the account. The `ACCOUNT` value can be the `email` address or the
+  ///  `unique_id` of the service account.
+  /// @return
+  /// @googleapis_link{google::iam::admin::v1::ServiceAccount,google/iam/admin/v1/iam.proto#L461}
+  ///
   StatusOr<google::iam::admin::v1::ServiceAccount> GetServiceAccount(
       std::string const& name);
 
-  /**
-   * Creates a [ServiceAccount][google.iam.admin.v1.ServiceAccount].
-   *
-   * @param name  Required. The resource name of the project associated with the
-   * service accounts, such as `projects/my-project-123`.
-   * @param account_id  Required. The account id that is used to generate the
-   * service account email address and a stable unique id. It is unique within a
-   * project, must be 6-30 characters long, and match the regular expression
-   *  `[a-z]([-a-z0-9]*[a-z0-9])` to comply with RFC1035.
-   * @param service_account  The
-   * [ServiceAccount][google.iam.admin.v1.ServiceAccount] resource to create.
-   * Currently, only the following values are user assignable: `display_name`
-   * and `description`.
-   * @return
-   * @googleapis_link{google::iam::admin::v1::ServiceAccount,google/iam/admin/v1/iam.proto#L461}
-   */
+  ///
+  /// Creates a [ServiceAccount][google.iam.admin.v1.ServiceAccount].
+  ///
+  /// @param name  Required. The resource name of the project associated with
+  /// the service
+  ///  accounts, such as `projects/my-project-123`.
+  /// @param account_id  Required. The account id that is used to generate the
+  /// service account
+  ///  email address and a stable unique id. It is unique within a project,
+  ///  must be 6-30 characters long, and match the regular expression
+  ///  `[a-z]([-a-z0-9]*[a-z0-9])` to comply with RFC1035.
+  /// @param service_account  The
+  /// [ServiceAccount][google.iam.admin.v1.ServiceAccount] resource to
+  ///  create. Currently, only the following values are user assignable:
+  ///  `display_name` and `description`.
+  /// @return
+  /// @googleapis_link{google::iam::admin::v1::ServiceAccount,google/iam/admin/v1/iam.proto#L461}
+  ///
   StatusOr<google::iam::admin::v1::ServiceAccount> CreateServiceAccount(
       std::string const& name, std::string const& account_id,
       google::iam::admin::v1::ServiceAccount const& service_account);
 
-  /**
-   * Deletes a [ServiceAccount][google.iam.admin.v1.ServiceAccount].
-   *
-   * **Warning:** After you delete a service account, you might not be able to
-   * undelete it. If you know that you need to re-enable the service account in
-   * the future, use
-   * [DisableServiceAccount][google.iam.admin.v1.IAM.DisableServiceAccount]
-   * instead.
-   *
-   * If you delete a service account, IAM permanently removes the service
-   * account 30 days later. Google Cloud cannot recover the service account
-   * after it is permanently removed, even if you file a support request.
-   *
-   * To help avoid unplanned outages, we recommend that you disable the service
-   * account before you delete it. Use
-   * [DisableServiceAccount][google.iam.admin.v1.IAM.DisableServiceAccount] to
-   * disable the service account, then wait at least 24 hours and watch for
-   * unintended consequences. If there are no unintended consequences, you can
-   * delete the service account.
-   *
-   * @param name  Required. The resource name of the service account in the
-   * following format: `projects/{PROJECT_ID}/serviceAccounts/{ACCOUNT}`. Using
-   * `-` as a wildcard for the `PROJECT_ID` will infer the project from the
-   * account. The `ACCOUNT` value can be the `email` address or the `unique_id`
-   * of the service account.
-   */
+  ///
+  /// Deletes a [ServiceAccount][google.iam.admin.v1.ServiceAccount].
+  ///
+  /// **Warning:** After you delete a service account, you might not be able to
+  /// undelete it. If you know that you need to re-enable the service account in
+  /// the future, use
+  /// [DisableServiceAccount][google.iam.admin.v1.IAM.DisableServiceAccount]
+  /// instead.
+  ///
+  /// If you delete a service account, IAM permanently removes the service
+  /// account 30 days later. Google Cloud cannot recover the service account
+  /// after it is permanently removed, even if you file a support request.
+  ///
+  /// To help avoid unplanned outages, we recommend that you disable the service
+  /// account before you delete it. Use
+  /// [DisableServiceAccount][google.iam.admin.v1.IAM.DisableServiceAccount] to
+  /// disable the service account, then wait at least 24 hours and watch for
+  /// unintended consequences. If there are no unintended consequences, you can
+  /// delete the service account.
+  ///
+  /// @param name  Required. The resource name of the service account in the
+  /// following format:
+  ///  `projects/{PROJECT_ID}/serviceAccounts/{ACCOUNT}`.
+  ///  Using `-` as a wildcard for the `PROJECT_ID` will infer the project from
+  ///  the account. The `ACCOUNT` value can be the `email` address or the
+  ///  `unique_id` of the service account.
+  ///
   Status DeleteServiceAccount(std::string const& name);
 
-  /**
-   * Lists every [ServiceAccountKey][google.iam.admin.v1.ServiceAccountKey] for
-   * a service account.
-   *
-   * @param name  Required. The resource name of the service account in the
-   * following format: `projects/{PROJECT_ID}/serviceAccounts/{ACCOUNT}`. Using
-   * `-` as a wildcard for the `PROJECT_ID`, will infer the project from the
-   * account. The `ACCOUNT` value can be the `email` address or the `unique_id`
-   * of the service account.
-   * @param key_types  Filters the types of keys the user wants to include in
-   * the list response. Duplicate key types are not allowed. If no key type is
-   * provided, all keys are returned.
-   * @return
-   * @googleapis_link{google::iam::admin::v1::ListServiceAccountKeysResponse,google/iam/admin/v1/iam.proto#L692}
-   */
+  ///
+  /// Lists every [ServiceAccountKey][google.iam.admin.v1.ServiceAccountKey] for
+  /// a service account.
+  ///
+  /// @param name  Required. The resource name of the service account in the
+  /// following format:
+  ///  `projects/{PROJECT_ID}/serviceAccounts/{ACCOUNT}`.
+  ///  Using `-` as a wildcard for the `PROJECT_ID`, will infer the project from
+  ///  the account. The `ACCOUNT` value can be the `email` address or the
+  ///  `unique_id` of the service account.
+  /// @param key_types  Filters the types of keys the user wants to include in
+  /// the list
+  ///  response. Duplicate key types are not allowed. If no key type
+  ///  is provided, all keys are returned.
+  /// @return
+  /// @googleapis_link{google::iam::admin::v1::ListServiceAccountKeysResponse,google/iam/admin/v1/iam.proto#L692}
+  ///
   StatusOr<google::iam::admin::v1::ListServiceAccountKeysResponse>
   ListServiceAccountKeys(
       std::string const& name,
@@ -173,111 +180,115 @@ class IAMClient {
           google::iam::admin::v1::ListServiceAccountKeysRequest::KeyType> const&
           key_types);
 
-  /**
-   * Gets a [ServiceAccountKey][google.iam.admin.v1.ServiceAccountKey].
-   *
-   * @param name  Required. The resource name of the service account key in the
-   * following format:
-   *  `projects/{PROJECT_ID}/serviceAccounts/{ACCOUNT}/keys/{key}`.
-   *  Using `-` as a wildcard for the `PROJECT_ID` will infer the project from
-   *  the account. The `ACCOUNT` value can be the `email` address or the
-   *  `unique_id` of the service account.
-   * @param public_key_type  The output format of the public key requested.
-   *  X509_PEM is the default output format.
-   * @return
-   * @googleapis_link{google::iam::admin::v1::ServiceAccountKey,google/iam/admin/v1/iam.proto#L741}
-   */
+  ///
+  /// Gets a [ServiceAccountKey][google.iam.admin.v1.ServiceAccountKey].
+  ///
+  /// @param name  Required. The resource name of the service account key in the
+  /// following format:
+  ///  `projects/{PROJECT_ID}/serviceAccounts/{ACCOUNT}/keys/{key}`.
+  ///  Using `-` as a wildcard for the `PROJECT_ID` will infer the project from
+  ///  the account. The `ACCOUNT` value can be the `email` address or the
+  ///  `unique_id` of the service account.
+  /// @param public_key_type  The output format of the public key requested.
+  ///  X509_PEM is the default output format.
+  /// @return
+  /// @googleapis_link{google::iam::admin::v1::ServiceAccountKey,google/iam/admin/v1/iam.proto#L741}
+  ///
   StatusOr<google::iam::admin::v1::ServiceAccountKey> GetServiceAccountKey(
       std::string const& name,
       google::iam::admin::v1::ServiceAccountPublicKeyType public_key_type);
 
-  /**
-   * Creates a [ServiceAccountKey][google.iam.admin.v1.ServiceAccountKey].
-   *
-   * @param name  Required. The resource name of the service account in the
-   * following format: `projects/{PROJECT_ID}/serviceAccounts/{ACCOUNT}`. Using
-   * `-` as a wildcard for the `PROJECT_ID` will infer the project from the
-   * account. The `ACCOUNT` value can be the `email` address or the `unique_id`
-   * of the service account.
-   * @param private_key_type  The output format of the private key. The default
-   * value is `TYPE_GOOGLE_CREDENTIALS_FILE`, which is the Google Credentials
-   * File format.
-   * @param key_algorithm  Which type of key and algorithm to use for the key.
-   *  The default is currently a 2K RSA key.  However this may change in the
-   *  future.
-   * @return
-   * @googleapis_link{google::iam::admin::v1::ServiceAccountKey,google/iam/admin/v1/iam.proto#L741}
-   */
+  ///
+  /// Creates a [ServiceAccountKey][google.iam.admin.v1.ServiceAccountKey].
+  ///
+  /// @param name  Required. The resource name of the service account in the
+  /// following format:
+  ///  `projects/{PROJECT_ID}/serviceAccounts/{ACCOUNT}`.
+  ///  Using `-` as a wildcard for the `PROJECT_ID` will infer the project from
+  ///  the account. The `ACCOUNT` value can be the `email` address or the
+  ///  `unique_id` of the service account.
+  /// @param private_key_type  The output format of the private key. The default
+  /// value is
+  ///  `TYPE_GOOGLE_CREDENTIALS_FILE`, which is the Google Credentials File
+  ///  format.
+  /// @param key_algorithm  Which type of key and algorithm to use for the key.
+  ///  The default is currently a 2K RSA key.  However this may change in the
+  ///  future.
+  /// @return
+  /// @googleapis_link{google::iam::admin::v1::ServiceAccountKey,google/iam/admin/v1/iam.proto#L741}
+  ///
   StatusOr<google::iam::admin::v1::ServiceAccountKey> CreateServiceAccountKey(
       std::string const& name,
       google::iam::admin::v1::ServiceAccountPrivateKeyType private_key_type,
       google::iam::admin::v1::ServiceAccountKeyAlgorithm key_algorithm);
 
-  /**
-   * Deletes a [ServiceAccountKey][google.iam.admin.v1.ServiceAccountKey].
-   * Deleting a service account key does not revoke short-lived credentials that
-   * have been issued based on the service account key.
-   *
-   * @param name  Required. The resource name of the service account key in the
-   * following format:
-   *  `projects/{PROJECT_ID}/serviceAccounts/{ACCOUNT}/keys/{key}`.
-   *  Using `-` as a wildcard for the `PROJECT_ID` will infer the project from
-   *  the account. The `ACCOUNT` value can be the `email` address or the
-   *  `unique_id` of the service account.
-   */
+  ///
+  /// Deletes a [ServiceAccountKey][google.iam.admin.v1.ServiceAccountKey].
+  /// Deleting a service account key does not revoke short-lived credentials
+  /// that have been issued based on the service account key.
+  ///
+  /// @param name  Required. The resource name of the service account key in the
+  /// following format:
+  ///  `projects/{PROJECT_ID}/serviceAccounts/{ACCOUNT}/keys/{key}`.
+  ///  Using `-` as a wildcard for the `PROJECT_ID` will infer the project from
+  ///  the account. The `ACCOUNT` value can be the `email` address or the
+  ///  `unique_id` of the service account.
+  ///
   Status DeleteServiceAccountKey(std::string const& name);
 
-  /**
-   * Gets the IAM policy that is attached to a
-   * [ServiceAccount][google.iam.admin.v1.ServiceAccount]. This IAM policy
-   * specifies which members have access to the service account.
-   *
-   * This method does not tell you whether the service account has been granted
-   * any roles on other resources. To check whether a service account has role
-   * grants on a resource, use the `getIamPolicy` method for that resource. For
-   * example, to view the role grants for a project, call the Resource Manager
-   * API's
-   * [`projects.getIamPolicy`](https://cloud.google.com/resource-manager/reference/rest/v1/projects/getIamPolicy)
-   * method.
-   *
-   * @param resource  REQUIRED: The resource for which the policy is being
-   * requested. See the operation documentation for the appropriate value for
-   * this field.
-   * @return
-   * @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
-   */
+  ///
+  /// Gets the IAM policy that is attached to a
+  /// [ServiceAccount][google.iam.admin.v1.ServiceAccount]. This IAM policy
+  /// specifies which members have access to the service account.
+  ///
+  /// This method does not tell you whether the service account has been granted
+  /// any roles on other resources. To check whether a service account has role
+  /// grants on a resource, use the `getIamPolicy` method for that resource. For
+  /// example, to view the role grants for a project, call the Resource Manager
+  /// API's
+  /// [`projects.getIamPolicy`](https://cloud.google.com/resource-manager/reference/rest/v1/projects/getIamPolicy)
+  /// method.
+  ///
+  /// @param resource  REQUIRED: The resource for which the policy is being
+  /// requested.
+  ///  See the operation documentation for the appropriate value for this field.
+  /// @return
+  /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
+  ///
   StatusOr<google::iam::v1::Policy> GetIamPolicy(std::string const& resource);
 
-  /**
-   * Sets the IAM policy that is attached to a
-   * [ServiceAccount][google.iam.admin.v1.ServiceAccount].
-   *
-   * Use this method to grant or revoke access to the service account. For
-   * example, you could grant a member the ability to impersonate the service
-   * account.
-   *
-   * This method does not enable the service account to access other resources.
-   * To grant roles to a service account on a resource, follow these steps:
-   *
-   * 1. Call the resource's `getIamPolicy` method to get its current IAM policy.
-   * 2. Edit the policy so that it binds the service account to an IAM role for
-   * the resource.
-   * 3. Call the resource's `setIamPolicy` method to update its IAM policy.
-   *
-   * For detailed instructions, see
-   * [Granting roles to a service account for specific
-   * resources](https://cloud.google.com/iam/help/service-accounts/granting-access-to-service-accounts).
-   *
-   * @param resource  REQUIRED: The resource for which the policy is being
-   * specified. See the operation documentation for the appropriate value for
-   * this field.
-   * @param policy  REQUIRED: The complete policy to be applied to the
-   * `resource`. The size of the policy is limited to a few 10s of KB. An empty
-   * policy is a valid policy but certain Cloud Platform services (such as
-   * Projects) might reject them.
-   * @return
-   * @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
-   */
+  ///
+  /// Sets the IAM policy that is attached to a
+  /// [ServiceAccount][google.iam.admin.v1.ServiceAccount].
+  ///
+  /// Use this method to grant or revoke access to the service account. For
+  /// example, you could grant a member the ability to impersonate the service
+  /// account.
+  ///
+  /// This method does not enable the service account to access other resources.
+  /// To grant roles to a service account on a resource, follow these steps:
+  ///
+  /// 1. Call the resource's `getIamPolicy` method to get its current IAM
+  /// policy.
+  /// 2. Edit the policy so that it binds the service account to an IAM role for
+  /// the resource.
+  /// 3. Call the resource's `setIamPolicy` method to update its IAM policy.
+  ///
+  /// For detailed instructions, see
+  /// [Granting roles to a service account for specific
+  /// resources](https://cloud.google.com/iam/help/service-accounts/granting-access-to-service-accounts).
+  ///
+  /// @param resource  REQUIRED: The resource for which the policy is being
+  /// specified.
+  ///  See the operation documentation for the appropriate value for this field.
+  /// @param policy  REQUIRED: The complete policy to be applied to the
+  /// `resource`. The size of
+  ///  the policy is limited to a few 10s of KB. An empty policy is a
+  ///  valid policy but certain Cloud Platform services (such as Projects)
+  ///  might reject them.
+  /// @return
+  /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
+  ///
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
       std::string const& resource, google::iam::v1::Policy const& policy);
 
@@ -306,430 +317,433 @@ class IAMClient {
                                                  IamUpdater const& updater,
                                                  Options options = {});
 
-  /**
-   * Tests whether the caller has the specified permissions on a
-   * [ServiceAccount][google.iam.admin.v1.ServiceAccount].
-   *
-   * @param resource  REQUIRED: The resource for which the policy detail is
-   * being requested. See the operation documentation for the appropriate value
-   * for this field.
-   * @param permissions  The set of permissions to check for the `resource`.
-   * Permissions with wildcards (such as '*' or 'storage.*') are not allowed.
-   * For more information see [IAM
-   * Overview](https://cloud.google.com/iam/docs/overview#permissions).
-   * @return
-   * @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
-   */
+  ///
+  /// Tests whether the caller has the specified permissions on a
+  /// [ServiceAccount][google.iam.admin.v1.ServiceAccount].
+  ///
+  /// @param resource  REQUIRED: The resource for which the policy detail is
+  /// being requested.
+  ///  See the operation documentation for the appropriate value for this field.
+  /// @param permissions  The set of permissions to check for the `resource`.
+  /// Permissions with
+  ///  wildcards (such as '*' or 'storage.*') are not allowed. For more
+  ///  information see
+  ///  [IAM Overview](https://cloud.google.com/iam/docs/overview#permissions).
+  /// @return
+  /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
+  ///
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
       std::string const& resource, std::vector<std::string> const& permissions);
 
-  /**
-   * Lists roles that can be granted on a Google Cloud resource. A role is
-   * grantable if the IAM policy for the resource can contain bindings to the
-   * role.
-   *
-   * @param full_resource_name  Required. The full resource name to query from
-   * the list of grantable roles. The name follows the Google Cloud Platform
-   * resource format. For example, a Cloud Platform project with id `my-project`
-   * will be named
-   *  `//cloudresourcemanager.googleapis.com/projects/my-project`.
-   * @return
-   * @googleapis_link{google::iam::admin::v1::Role,google/iam/admin/v1/iam.proto#L1004}
-   */
+  ///
+  /// Lists roles that can be granted on a Google Cloud resource. A role is
+  /// grantable if the IAM policy for the resource can contain bindings to the
+  /// role.
+  ///
+  /// @param full_resource_name  Required. The full resource name to query from
+  /// the list of grantable roles.
+  ///  The name follows the Google Cloud Platform resource format.
+  ///  For example, a Cloud Platform project with id `my-project` will be named
+  ///  `//cloudresourcemanager.googleapis.com/projects/my-project`.
+  /// @return
+  /// @googleapis_link{google::iam::admin::v1::Role,google/iam/admin/v1/iam.proto#L1004}
+  ///
   StreamRange<google::iam::admin::v1::Role> QueryGrantableRoles(
       std::string const& full_resource_name);
 
-  /**
-   * Lists every [ServiceAccount][google.iam.admin.v1.ServiceAccount] that
-   * belongs to a specific project.
-   *
-   * @param request
-   * @googleapis_link{google::iam::admin::v1::ListServiceAccountsRequest,google/iam/admin/v1/iam.proto#L544}
-   * @return
-   * @googleapis_link{google::iam::admin::v1::ServiceAccount,google/iam/admin/v1/iam.proto#L461}
-   */
+  ///
+  /// Lists every [ServiceAccount][google.iam.admin.v1.ServiceAccount] that
+  /// belongs to a specific project.
+  ///
+  /// @param request
+  /// @googleapis_link{google::iam::admin::v1::ListServiceAccountsRequest,google/iam/admin/v1/iam.proto#L544}
+  /// @return
+  /// @googleapis_link{google::iam::admin::v1::ServiceAccount,google/iam/admin/v1/iam.proto#L461}
+  ///
   StreamRange<google::iam::admin::v1::ServiceAccount> ListServiceAccounts(
       google::iam::admin::v1::ListServiceAccountsRequest request);
 
-  /**
-   * Gets a [ServiceAccount][google.iam.admin.v1.ServiceAccount].
-   *
-   * @param request
-   * @googleapis_link{google::iam::admin::v1::GetServiceAccountRequest,google/iam/admin/v1/iam.proto#L579}
-   * @return
-   * @googleapis_link{google::iam::admin::v1::ServiceAccount,google/iam/admin/v1/iam.proto#L461}
-   */
+  ///
+  /// Gets a [ServiceAccount][google.iam.admin.v1.ServiceAccount].
+  ///
+  /// @param request
+  /// @googleapis_link{google::iam::admin::v1::GetServiceAccountRequest,google/iam/admin/v1/iam.proto#L579}
+  /// @return
+  /// @googleapis_link{google::iam::admin::v1::ServiceAccount,google/iam/admin/v1/iam.proto#L461}
+  ///
   StatusOr<google::iam::admin::v1::ServiceAccount> GetServiceAccount(
       google::iam::admin::v1::GetServiceAccountRequest const& request);
 
-  /**
-   * Creates a [ServiceAccount][google.iam.admin.v1.ServiceAccount].
-   *
-   * @param request
-   * @googleapis_link{google::iam::admin::v1::CreateServiceAccountRequest,google/iam/admin/v1/iam.proto#L521}
-   * @return
-   * @googleapis_link{google::iam::admin::v1::ServiceAccount,google/iam/admin/v1/iam.proto#L461}
-   */
+  ///
+  /// Creates a [ServiceAccount][google.iam.admin.v1.ServiceAccount].
+  ///
+  /// @param request
+  /// @googleapis_link{google::iam::admin::v1::CreateServiceAccountRequest,google/iam/admin/v1/iam.proto#L521}
+  /// @return
+  /// @googleapis_link{google::iam::admin::v1::ServiceAccount,google/iam/admin/v1/iam.proto#L461}
+  ///
   StatusOr<google::iam::admin::v1::ServiceAccount> CreateServiceAccount(
       google::iam::admin::v1::CreateServiceAccountRequest const& request);
 
-  /**
-   * Patches a [ServiceAccount][google.iam.admin.v1.ServiceAccount].
-   *
-   * @param request
-   * @googleapis_link{google::iam::admin::v1::PatchServiceAccountRequest,google/iam/admin/v1/iam.proto#L616}
-   * @return
-   * @googleapis_link{google::iam::admin::v1::ServiceAccount,google/iam/admin/v1/iam.proto#L461}
-   */
+  ///
+  /// Patches a [ServiceAccount][google.iam.admin.v1.ServiceAccount].
+  ///
+  /// @param request
+  /// @googleapis_link{google::iam::admin::v1::PatchServiceAccountRequest,google/iam/admin/v1/iam.proto#L616}
+  /// @return
+  /// @googleapis_link{google::iam::admin::v1::ServiceAccount,google/iam/admin/v1/iam.proto#L461}
+  ///
   StatusOr<google::iam::admin::v1::ServiceAccount> PatchServiceAccount(
       google::iam::admin::v1::PatchServiceAccountRequest const& request);
 
-  /**
-   * Deletes a [ServiceAccount][google.iam.admin.v1.ServiceAccount].
-   *
-   * **Warning:** After you delete a service account, you might not be able to
-   * undelete it. If you know that you need to re-enable the service account in
-   * the future, use
-   * [DisableServiceAccount][google.iam.admin.v1.IAM.DisableServiceAccount]
-   * instead.
-   *
-   * If you delete a service account, IAM permanently removes the service
-   * account 30 days later. Google Cloud cannot recover the service account
-   * after it is permanently removed, even if you file a support request.
-   *
-   * To help avoid unplanned outages, we recommend that you disable the service
-   * account before you delete it. Use
-   * [DisableServiceAccount][google.iam.admin.v1.IAM.DisableServiceAccount] to
-   * disable the service account, then wait at least 24 hours and watch for
-   * unintended consequences. If there are no unintended consequences, you can
-   * delete the service account.
-   *
-   * @param request
-   * @googleapis_link{google::iam::admin::v1::DeleteServiceAccountRequest,google/iam/admin/v1/iam.proto#L594}
-   */
+  ///
+  /// Deletes a [ServiceAccount][google.iam.admin.v1.ServiceAccount].
+  ///
+  /// **Warning:** After you delete a service account, you might not be able to
+  /// undelete it. If you know that you need to re-enable the service account in
+  /// the future, use
+  /// [DisableServiceAccount][google.iam.admin.v1.IAM.DisableServiceAccount]
+  /// instead.
+  ///
+  /// If you delete a service account, IAM permanently removes the service
+  /// account 30 days later. Google Cloud cannot recover the service account
+  /// after it is permanently removed, even if you file a support request.
+  ///
+  /// To help avoid unplanned outages, we recommend that you disable the service
+  /// account before you delete it. Use
+  /// [DisableServiceAccount][google.iam.admin.v1.IAM.DisableServiceAccount] to
+  /// disable the service account, then wait at least 24 hours and watch for
+  /// unintended consequences. If there are no unintended consequences, you can
+  /// delete the service account.
+  ///
+  /// @param request
+  /// @googleapis_link{google::iam::admin::v1::DeleteServiceAccountRequest,google/iam/admin/v1/iam.proto#L594}
+  ///
   Status DeleteServiceAccount(
       google::iam::admin::v1::DeleteServiceAccountRequest const& request);
 
-  /**
-   * Restores a deleted [ServiceAccount][google.iam.admin.v1.ServiceAccount].
-   *
-   * **Important:** It is not always possible to restore a deleted service
-   * account. Use this method only as a last resort.
-   *
-   * After you delete a service account, IAM permanently removes the service
-   * account 30 days later. There is no way to restore a deleted service account
-   * that has been permanently removed.
-   *
-   * @param request
-   * @googleapis_link{google::iam::admin::v1::UndeleteServiceAccountRequest,google/iam/admin/v1/iam.proto#L623}
-   * @return
-   * @googleapis_link{google::iam::admin::v1::UndeleteServiceAccountResponse,google/iam/admin/v1/iam.proto#L631}
-   */
+  ///
+  /// Restores a deleted [ServiceAccount][google.iam.admin.v1.ServiceAccount].
+  ///
+  /// **Important:** It is not always possible to restore a deleted service
+  /// account. Use this method only as a last resort.
+  ///
+  /// After you delete a service account, IAM permanently removes the service
+  /// account 30 days later. There is no way to restore a deleted service
+  /// account that has been permanently removed.
+  ///
+  /// @param request
+  /// @googleapis_link{google::iam::admin::v1::UndeleteServiceAccountRequest,google/iam/admin/v1/iam.proto#L623}
+  /// @return
+  /// @googleapis_link{google::iam::admin::v1::UndeleteServiceAccountResponse,google/iam/admin/v1/iam.proto#L631}
+  ///
   StatusOr<google::iam::admin::v1::UndeleteServiceAccountResponse>
   UndeleteServiceAccount(
       google::iam::admin::v1::UndeleteServiceAccountRequest const& request);
 
-  /**
-   * Enables a [ServiceAccount][google.iam.admin.v1.ServiceAccount] that was
-   * disabled by
-   * [DisableServiceAccount][google.iam.admin.v1.IAM.DisableServiceAccount].
-   *
-   * If the service account is already enabled, then this method has no effect.
-   *
-   * If the service account was disabled by other means—for example, if Google
-   * disabled the service account because it was compromised—you cannot use this
-   * method to enable the service account.
-   *
-   * @param request
-   * @googleapis_link{google::iam::admin::v1::EnableServiceAccountRequest,google/iam/admin/v1/iam.proto#L637}
-   */
+  ///
+  /// Enables a [ServiceAccount][google.iam.admin.v1.ServiceAccount] that was
+  /// disabled by
+  /// [DisableServiceAccount][google.iam.admin.v1.IAM.DisableServiceAccount].
+  ///
+  /// If the service account is already enabled, then this method has no effect.
+  ///
+  /// If the service account was disabled by other means—for example, if Google
+  /// disabled the service account because it was compromised—you cannot use
+  /// this method to enable the service account.
+  ///
+  /// @param request
+  /// @googleapis_link{google::iam::admin::v1::EnableServiceAccountRequest,google/iam/admin/v1/iam.proto#L637}
+  ///
   Status EnableServiceAccount(
       google::iam::admin::v1::EnableServiceAccountRequest const& request);
 
-  /**
-   * Disables a [ServiceAccount][google.iam.admin.v1.ServiceAccount]
-   * immediately.
-   *
-   * If an application uses the service account to authenticate, that
-   * application can no longer call Google APIs or access Google Cloud
-   * resources. Existing access tokens for the service account are rejected, and
-   * requests for new access tokens will fail.
-   *
-   * To re-enable the service account, use
-   * [EnableServiceAccount][google.iam.admin.v1.IAM.EnableServiceAccount]. After
-   * you re-enable the service account, its existing access tokens will be
-   * accepted, and you can request new access tokens.
-   *
-   * To help avoid unplanned outages, we recommend that you disable the service
-   * account before you delete it. Use this method to disable the service
-   * account, then wait at least 24 hours and watch for unintended consequences.
-   * If there are no unintended consequences, you can delete the service account
-   * with [DeleteServiceAccount][google.iam.admin.v1.IAM.DeleteServiceAccount].
-   *
-   * @param request
-   * @googleapis_link{google::iam::admin::v1::DisableServiceAccountRequest,google/iam/admin/v1/iam.proto#L647}
-   */
+  ///
+  /// Disables a [ServiceAccount][google.iam.admin.v1.ServiceAccount]
+  /// immediately.
+  ///
+  /// If an application uses the service account to authenticate, that
+  /// application can no longer call Google APIs or access Google Cloud
+  /// resources. Existing access tokens for the service account are rejected,
+  /// and requests for new access tokens will fail.
+  ///
+  /// To re-enable the service account, use
+  /// [EnableServiceAccount][google.iam.admin.v1.IAM.EnableServiceAccount].
+  /// After you re-enable the service account, its existing access tokens will
+  /// be accepted, and you can request new access tokens.
+  ///
+  /// To help avoid unplanned outages, we recommend that you disable the service
+  /// account before you delete it. Use this method to disable the service
+  /// account, then wait at least 24 hours and watch for unintended
+  /// consequences. If there are no unintended consequences, you can delete the
+  /// service account with
+  /// [DeleteServiceAccount][google.iam.admin.v1.IAM.DeleteServiceAccount].
+  ///
+  /// @param request
+  /// @googleapis_link{google::iam::admin::v1::DisableServiceAccountRequest,google/iam/admin/v1/iam.proto#L647}
+  ///
   Status DisableServiceAccount(
       google::iam::admin::v1::DisableServiceAccountRequest const& request);
 
-  /**
-   * Lists every [ServiceAccountKey][google.iam.admin.v1.ServiceAccountKey] for
-   * a service account.
-   *
-   * @param request
-   * @googleapis_link{google::iam::admin::v1::ListServiceAccountKeysRequest,google/iam/admin/v1/iam.proto#L657}
-   * @return
-   * @googleapis_link{google::iam::admin::v1::ListServiceAccountKeysResponse,google/iam/admin/v1/iam.proto#L692}
-   */
+  ///
+  /// Lists every [ServiceAccountKey][google.iam.admin.v1.ServiceAccountKey] for
+  /// a service account.
+  ///
+  /// @param request
+  /// @googleapis_link{google::iam::admin::v1::ListServiceAccountKeysRequest,google/iam/admin/v1/iam.proto#L657}
+  /// @return
+  /// @googleapis_link{google::iam::admin::v1::ListServiceAccountKeysResponse,google/iam/admin/v1/iam.proto#L692}
+  ///
   StatusOr<google::iam::admin::v1::ListServiceAccountKeysResponse>
   ListServiceAccountKeys(
       google::iam::admin::v1::ListServiceAccountKeysRequest const& request);
 
-  /**
-   * Gets a [ServiceAccountKey][google.iam.admin.v1.ServiceAccountKey].
-   *
-   * @param request
-   * @googleapis_link{google::iam::admin::v1::GetServiceAccountKeyRequest,google/iam/admin/v1/iam.proto#L698}
-   * @return
-   * @googleapis_link{google::iam::admin::v1::ServiceAccountKey,google/iam/admin/v1/iam.proto#L741}
-   */
+  ///
+  /// Gets a [ServiceAccountKey][google.iam.admin.v1.ServiceAccountKey].
+  ///
+  /// @param request
+  /// @googleapis_link{google::iam::admin::v1::GetServiceAccountKeyRequest,google/iam/admin/v1/iam.proto#L698}
+  /// @return
+  /// @googleapis_link{google::iam::admin::v1::ServiceAccountKey,google/iam/admin/v1/iam.proto#L741}
+  ///
   StatusOr<google::iam::admin::v1::ServiceAccountKey> GetServiceAccountKey(
       google::iam::admin::v1::GetServiceAccountKeyRequest const& request);
 
-  /**
-   * Creates a [ServiceAccountKey][google.iam.admin.v1.ServiceAccountKey].
-   *
-   * @param request
-   * @googleapis_link{google::iam::admin::v1::CreateServiceAccountKeyRequest,google/iam/admin/v1/iam.proto#L791}
-   * @return
-   * @googleapis_link{google::iam::admin::v1::ServiceAccountKey,google/iam/admin/v1/iam.proto#L741}
-   */
+  ///
+  /// Creates a [ServiceAccountKey][google.iam.admin.v1.ServiceAccountKey].
+  ///
+  /// @param request
+  /// @googleapis_link{google::iam::admin::v1::CreateServiceAccountKeyRequest,google/iam/admin/v1/iam.proto#L791}
+  /// @return
+  /// @googleapis_link{google::iam::admin::v1::ServiceAccountKey,google/iam/admin/v1/iam.proto#L741}
+  ///
   StatusOr<google::iam::admin::v1::ServiceAccountKey> CreateServiceAccountKey(
       google::iam::admin::v1::CreateServiceAccountKeyRequest const& request);
 
-  /**
-   * Creates a [ServiceAccountKey][google.iam.admin.v1.ServiceAccountKey], using
-   * a public key that you provide.
-   *
-   * @param request
-   * @googleapis_link{google::iam::admin::v1::UploadServiceAccountKeyRequest,google/iam/admin/v1/iam.proto#L816}
-   * @return
-   * @googleapis_link{google::iam::admin::v1::ServiceAccountKey,google/iam/admin/v1/iam.proto#L741}
-   */
+  ///
+  /// Creates a [ServiceAccountKey][google.iam.admin.v1.ServiceAccountKey],
+  /// using a public key that you provide.
+  ///
+  /// @param request
+  /// @googleapis_link{google::iam::admin::v1::UploadServiceAccountKeyRequest,google/iam/admin/v1/iam.proto#L816}
+  /// @return
+  /// @googleapis_link{google::iam::admin::v1::ServiceAccountKey,google/iam/admin/v1/iam.proto#L741}
+  ///
   StatusOr<google::iam::admin::v1::ServiceAccountKey> UploadServiceAccountKey(
       google::iam::admin::v1::UploadServiceAccountKeyRequest const& request);
 
-  /**
-   * Deletes a [ServiceAccountKey][google.iam.admin.v1.ServiceAccountKey].
-   * Deleting a service account key does not revoke short-lived credentials that
-   * have been issued based on the service account key.
-   *
-   * @param request
-   * @googleapis_link{google::iam::admin::v1::DeleteServiceAccountKeyRequest,google/iam/admin/v1/iam.proto#L832}
-   */
+  ///
+  /// Deletes a [ServiceAccountKey][google.iam.admin.v1.ServiceAccountKey].
+  /// Deleting a service account key does not revoke short-lived credentials
+  /// that have been issued based on the service account key.
+  ///
+  /// @param request
+  /// @googleapis_link{google::iam::admin::v1::DeleteServiceAccountKeyRequest,google/iam/admin/v1/iam.proto#L832}
+  ///
   Status DeleteServiceAccountKey(
       google::iam::admin::v1::DeleteServiceAccountKeyRequest const& request);
 
-  /**
-   * Gets the IAM policy that is attached to a
-   * [ServiceAccount][google.iam.admin.v1.ServiceAccount]. This IAM policy
-   * specifies which members have access to the service account.
-   *
-   * This method does not tell you whether the service account has been granted
-   * any roles on other resources. To check whether a service account has role
-   * grants on a resource, use the `getIamPolicy` method for that resource. For
-   * example, to view the role grants for a project, call the Resource Manager
-   * API's
-   * [`projects.getIamPolicy`](https://cloud.google.com/resource-manager/reference/rest/v1/projects/getIamPolicy)
-   * method.
-   *
-   * @param request
-   * @googleapis_link{google::iam::v1::GetIamPolicyRequest,google/iam/v1/iam_policy.proto#L113}
-   * @return
-   * @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
-   */
+  ///
+  /// Gets the IAM policy that is attached to a
+  /// [ServiceAccount][google.iam.admin.v1.ServiceAccount]. This IAM policy
+  /// specifies which members have access to the service account.
+  ///
+  /// This method does not tell you whether the service account has been granted
+  /// any roles on other resources. To check whether a service account has role
+  /// grants on a resource, use the `getIamPolicy` method for that resource. For
+  /// example, to view the role grants for a project, call the Resource Manager
+  /// API's
+  /// [`projects.getIamPolicy`](https://cloud.google.com/resource-manager/reference/rest/v1/projects/getIamPolicy)
+  /// method.
+  ///
+  /// @param request
+  /// @googleapis_link{google::iam::v1::GetIamPolicyRequest,google/iam/v1/iam_policy.proto#L113}
+  /// @return
+  /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
+  ///
   StatusOr<google::iam::v1::Policy> GetIamPolicy(
       google::iam::v1::GetIamPolicyRequest const& request);
 
-  /**
-   * Sets the IAM policy that is attached to a
-   * [ServiceAccount][google.iam.admin.v1.ServiceAccount].
-   *
-   * Use this method to grant or revoke access to the service account. For
-   * example, you could grant a member the ability to impersonate the service
-   * account.
-   *
-   * This method does not enable the service account to access other resources.
-   * To grant roles to a service account on a resource, follow these steps:
-   *
-   * 1. Call the resource's `getIamPolicy` method to get its current IAM policy.
-   * 2. Edit the policy so that it binds the service account to an IAM role for
-   * the resource.
-   * 3. Call the resource's `setIamPolicy` method to update its IAM policy.
-   *
-   * For detailed instructions, see
-   * [Granting roles to a service account for specific
-   * resources](https://cloud.google.com/iam/help/service-accounts/granting-access-to-service-accounts).
-   *
-   * @param request
-   * @googleapis_link{google::iam::v1::SetIamPolicyRequest,google/iam/v1/iam_policy.proto#L98}
-   * @return
-   * @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
-   */
+  ///
+  /// Sets the IAM policy that is attached to a
+  /// [ServiceAccount][google.iam.admin.v1.ServiceAccount].
+  ///
+  /// Use this method to grant or revoke access to the service account. For
+  /// example, you could grant a member the ability to impersonate the service
+  /// account.
+  ///
+  /// This method does not enable the service account to access other resources.
+  /// To grant roles to a service account on a resource, follow these steps:
+  ///
+  /// 1. Call the resource's `getIamPolicy` method to get its current IAM
+  /// policy.
+  /// 2. Edit the policy so that it binds the service account to an IAM role for
+  /// the resource.
+  /// 3. Call the resource's `setIamPolicy` method to update its IAM policy.
+  ///
+  /// For detailed instructions, see
+  /// [Granting roles to a service account for specific
+  /// resources](https://cloud.google.com/iam/help/service-accounts/granting-access-to-service-accounts).
+  ///
+  /// @param request
+  /// @googleapis_link{google::iam::v1::SetIamPolicyRequest,google/iam/v1/iam_policy.proto#L98}
+  /// @return
+  /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
+  ///
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
       google::iam::v1::SetIamPolicyRequest const& request);
 
-  /**
-   * Tests whether the caller has the specified permissions on a
-   * [ServiceAccount][google.iam.admin.v1.ServiceAccount].
-   *
-   * @param request
-   * @googleapis_link{google::iam::v1::TestIamPermissionsRequest,google/iam/v1/iam_policy.proto#L126}
-   * @return
-   * @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
-   */
+  ///
+  /// Tests whether the caller has the specified permissions on a
+  /// [ServiceAccount][google.iam.admin.v1.ServiceAccount].
+  ///
+  /// @param request
+  /// @googleapis_link{google::iam::v1::TestIamPermissionsRequest,google/iam/v1/iam_policy.proto#L126}
+  /// @return
+  /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
+  ///
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
       google::iam::v1::TestIamPermissionsRequest const& request);
 
-  /**
-   * Lists roles that can be granted on a Google Cloud resource. A role is
-   * grantable if the IAM policy for the resource can contain bindings to the
-   * role.
-   *
-   * @param request
-   * @googleapis_link{google::iam::admin::v1::QueryGrantableRolesRequest,google/iam/admin/v1/iam.proto#L1062}
-   * @return
-   * @googleapis_link{google::iam::admin::v1::Role,google/iam/admin/v1/iam.proto#L1004}
-   */
+  ///
+  /// Lists roles that can be granted on a Google Cloud resource. A role is
+  /// grantable if the IAM policy for the resource can contain bindings to the
+  /// role.
+  ///
+  /// @param request
+  /// @googleapis_link{google::iam::admin::v1::QueryGrantableRolesRequest,google/iam/admin/v1/iam.proto#L1062}
+  /// @return
+  /// @googleapis_link{google::iam::admin::v1::Role,google/iam/admin/v1/iam.proto#L1004}
+  ///
   StreamRange<google::iam::admin::v1::Role> QueryGrantableRoles(
       google::iam::admin::v1::QueryGrantableRolesRequest request);
 
-  /**
-   * Lists every predefined [Role][google.iam.admin.v1.Role] that IAM supports,
-   * or every custom role that is defined for an organization or project.
-   *
-   * @param request
-   * @googleapis_link{google::iam::admin::v1::ListRolesRequest,google/iam/admin/v1/iam.proto#L1093}
-   * @return
-   * @googleapis_link{google::iam::admin::v1::Role,google/iam/admin/v1/iam.proto#L1004}
-   */
+  ///
+  /// Lists every predefined [Role][google.iam.admin.v1.Role] that IAM supports,
+  /// or every custom role that is defined for an organization or project.
+  ///
+  /// @param request
+  /// @googleapis_link{google::iam::admin::v1::ListRolesRequest,google/iam/admin/v1/iam.proto#L1093}
+  /// @return
+  /// @googleapis_link{google::iam::admin::v1::Role,google/iam/admin/v1/iam.proto#L1004}
+  ///
   StreamRange<google::iam::admin::v1::Role> ListRoles(
       google::iam::admin::v1::ListRolesRequest request);
 
-  /**
-   * Gets the definition of a [Role][google.iam.admin.v1.Role].
-   *
-   * @param request
-   * @googleapis_link{google::iam::admin::v1::GetRoleRequest,google/iam/admin/v1/iam.proto#L1152}
-   * @return
-   * @googleapis_link{google::iam::admin::v1::Role,google/iam/admin/v1/iam.proto#L1004}
-   */
+  ///
+  /// Gets the definition of a [Role][google.iam.admin.v1.Role].
+  ///
+  /// @param request
+  /// @googleapis_link{google::iam::admin::v1::GetRoleRequest,google/iam/admin/v1/iam.proto#L1152}
+  /// @return
+  /// @googleapis_link{google::iam::admin::v1::Role,google/iam/admin/v1/iam.proto#L1004}
+  ///
   StatusOr<google::iam::admin::v1::Role> GetRole(
       google::iam::admin::v1::GetRoleRequest const& request);
 
-  /**
-   * Creates a new custom [Role][google.iam.admin.v1.Role].
-   *
-   * @param request
-   * @googleapis_link{google::iam::admin::v1::CreateRoleRequest,google/iam/admin/v1/iam.proto#L1184}
-   * @return
-   * @googleapis_link{google::iam::admin::v1::Role,google/iam/admin/v1/iam.proto#L1004}
-   */
+  ///
+  /// Creates a new custom [Role][google.iam.admin.v1.Role].
+  ///
+  /// @param request
+  /// @googleapis_link{google::iam::admin::v1::CreateRoleRequest,google/iam/admin/v1/iam.proto#L1184}
+  /// @return
+  /// @googleapis_link{google::iam::admin::v1::Role,google/iam/admin/v1/iam.proto#L1004}
+  ///
   StatusOr<google::iam::admin::v1::Role> CreateRole(
       google::iam::admin::v1::CreateRoleRequest const& request);
 
-  /**
-   * Updates the definition of a custom [Role][google.iam.admin.v1.Role].
-   *
-   * @param request
-   * @googleapis_link{google::iam::admin::v1::UpdateRoleRequest,google/iam/admin/v1/iam.proto#L1219}
-   * @return
-   * @googleapis_link{google::iam::admin::v1::Role,google/iam/admin/v1/iam.proto#L1004}
-   */
+  ///
+  /// Updates the definition of a custom [Role][google.iam.admin.v1.Role].
+  ///
+  /// @param request
+  /// @googleapis_link{google::iam::admin::v1::UpdateRoleRequest,google/iam/admin/v1/iam.proto#L1219}
+  /// @return
+  /// @googleapis_link{google::iam::admin::v1::Role,google/iam/admin/v1/iam.proto#L1004}
+  ///
   StatusOr<google::iam::admin::v1::Role> UpdateRole(
       google::iam::admin::v1::UpdateRoleRequest const& request);
 
-  /**
-   * Deletes a custom [Role][google.iam.admin.v1.Role].
-   *
-   * When you delete a custom role, the following changes occur immediately:
-   *
-   * * You cannot bind a member to the custom role in an IAM
-   * [Policy][google.iam.v1.Policy].
-   * * Existing bindings to the custom role are not changed, but they have no
-   * effect.
-   * * By default, the response from
-   * [ListRoles][google.iam.admin.v1.IAM.ListRoles] does not include the custom
-   * role.
-   *
-   * You have 7 days to undelete the custom role. After 7 days, the following
-   * changes occur:
-   *
-   * * The custom role is permanently deleted and cannot be recovered.
-   * * If an IAM policy contains a binding to the custom role, the binding is
-   * permanently removed.
-   *
-   * @param request
-   * @googleapis_link{google::iam::admin::v1::DeleteRoleRequest,google/iam/admin/v1/iam.proto#L1250}
-   * @return
-   * @googleapis_link{google::iam::admin::v1::Role,google/iam/admin/v1/iam.proto#L1004}
-   */
+  ///
+  /// Deletes a custom [Role][google.iam.admin.v1.Role].
+  ///
+  /// When you delete a custom role, the following changes occur immediately:
+  ///
+  /// * You cannot bind a member to the custom role in an IAM
+  /// [Policy][google.iam.v1.Policy].
+  /// * Existing bindings to the custom role are not changed, but they have no
+  /// effect.
+  /// * By default, the response from
+  /// [ListRoles][google.iam.admin.v1.IAM.ListRoles] does not include the custom
+  /// role.
+  ///
+  /// You have 7 days to undelete the custom role. After 7 days, the following
+  /// changes occur:
+  ///
+  /// * The custom role is permanently deleted and cannot be recovered.
+  /// * If an IAM policy contains a binding to the custom role, the binding is
+  /// permanently removed.
+  ///
+  /// @param request
+  /// @googleapis_link{google::iam::admin::v1::DeleteRoleRequest,google/iam/admin/v1/iam.proto#L1250}
+  /// @return
+  /// @googleapis_link{google::iam::admin::v1::Role,google/iam/admin/v1/iam.proto#L1004}
+  ///
   StatusOr<google::iam::admin::v1::Role> DeleteRole(
       google::iam::admin::v1::DeleteRoleRequest const& request);
 
-  /**
-   * Undeletes a custom [Role][google.iam.admin.v1.Role].
-   *
-   * @param request
-   * @googleapis_link{google::iam::admin::v1::UndeleteRoleRequest,google/iam/admin/v1/iam.proto#L1278}
-   * @return
-   * @googleapis_link{google::iam::admin::v1::Role,google/iam/admin/v1/iam.proto#L1004}
-   */
+  ///
+  /// Undeletes a custom [Role][google.iam.admin.v1.Role].
+  ///
+  /// @param request
+  /// @googleapis_link{google::iam::admin::v1::UndeleteRoleRequest,google/iam/admin/v1/iam.proto#L1278}
+  /// @return
+  /// @googleapis_link{google::iam::admin::v1::Role,google/iam/admin/v1/iam.proto#L1004}
+  ///
   StatusOr<google::iam::admin::v1::Role> UndeleteRole(
       google::iam::admin::v1::UndeleteRoleRequest const& request);
 
-  /**
-   * Lists every permission that you can test on a resource. A permission is
-   * testable if you can check whether a member has that permission on the
-   * resource.
-   *
-   * @param request
-   * @googleapis_link{google::iam::admin::v1::QueryTestablePermissionsRequest,google/iam/admin/v1/iam.proto#L1361}
-   * @return
-   * @googleapis_link{google::iam::admin::v1::Permission,google/iam/admin/v1/iam.proto#L1306}
-   */
+  ///
+  /// Lists every permission that you can test on a resource. A permission is
+  /// testable if you can check whether a member has that permission on the
+  /// resource.
+  ///
+  /// @param request
+  /// @googleapis_link{google::iam::admin::v1::QueryTestablePermissionsRequest,google/iam/admin/v1/iam.proto#L1361}
+  /// @return
+  /// @googleapis_link{google::iam::admin::v1::Permission,google/iam/admin/v1/iam.proto#L1306}
+  ///
   StreamRange<google::iam::admin::v1::Permission> QueryTestablePermissions(
       google::iam::admin::v1::QueryTestablePermissionsRequest request);
 
-  /**
-   * Returns a list of services that allow you to opt into audit logs that are
-   * not generated by default.
-   *
-   * To learn more about audit logs, see the [Logging
-   * documentation](https://cloud.google.com/logging/docs/audit).
-   *
-   * @param request
-   * @googleapis_link{google::iam::admin::v1::QueryAuditableServicesRequest,google/iam/admin/v1/iam.proto#L1391}
-   * @return
-   * @googleapis_link{google::iam::admin::v1::QueryAuditableServicesResponse,google/iam/admin/v1/iam.proto#L1402}
-   */
+  ///
+  /// Returns a list of services that allow you to opt into audit logs that are
+  /// not generated by default.
+  ///
+  /// To learn more about audit logs, see the [Logging
+  /// documentation](https://cloud.google.com/logging/docs/audit).
+  ///
+  /// @param request
+  /// @googleapis_link{google::iam::admin::v1::QueryAuditableServicesRequest,google/iam/admin/v1/iam.proto#L1391}
+  /// @return
+  /// @googleapis_link{google::iam::admin::v1::QueryAuditableServicesResponse,google/iam/admin/v1/iam.proto#L1402}
+  ///
   StatusOr<google::iam::admin::v1::QueryAuditableServicesResponse>
   QueryAuditableServices(
       google::iam::admin::v1::QueryAuditableServicesRequest const& request);
 
-  /**
-   * Lints, or validates, an IAM policy. Currently checks the
-   * [google.iam.v1.Binding.condition][google.iam.v1.Binding.condition] field,
-   * which contains a condition expression for a role binding.
-   *
-   * Successful calls to this method always return an HTTP `200 OK` status code,
-   * even if the linter detects an issue in the IAM policy.
-   *
-   * @param request
-   * @googleapis_link{google::iam::admin::v1::LintPolicyRequest,google/iam/admin/v1/iam.proto#L1415}
-   * @return
-   * @googleapis_link{google::iam::admin::v1::LintPolicyResponse,google/iam/admin/v1/iam.proto#L1513}
-   */
+  ///
+  /// Lints, or validates, an IAM policy. Currently checks the
+  /// [google.iam.v1.Binding.condition][google.iam.v1.Binding.condition] field,
+  /// which contains a condition expression for a role binding.
+  ///
+  /// Successful calls to this method always return an HTTP `200 OK` status
+  /// code, even if the linter detects an issue in the IAM policy.
+  ///
+  /// @param request
+  /// @googleapis_link{google::iam::admin::v1::LintPolicyRequest,google/iam/admin/v1/iam.proto#L1415}
+  /// @return
+  /// @googleapis_link{google::iam::admin::v1::LintPolicyResponse,google/iam/admin/v1/iam.proto#L1513}
+  ///
   StatusOr<google::iam::admin::v1::LintPolicyResponse> LintPolicy(
       google::iam::admin::v1::LintPolicyRequest const& request);
 

--- a/google/cloud/iam/iam_credentials_client.h
+++ b/google/cloud/iam/iam_credentials_client.h
@@ -32,17 +32,17 @@ namespace cloud {
 namespace iam {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-/**
- * A service account is a special type of Google account that belongs to your
- * application or a virtual machine (VM), instead of to an individual end user.
- * Your application assumes the identity of the service account to call Google
- * APIs, so that the users aren't directly involved.
- *
- * Service account credentials are used to temporarily assume the identity
- * of the service account. Supported credential types include OAuth 2.0 access
- * tokens, OpenID Connect ID tokens, self-signed JSON Web Tokens (JWTs), and
- * more.
- */
+///
+/// A service account is a special type of Google account that belongs to your
+/// application or a virtual machine (VM), instead of to an individual end user.
+/// Your application assumes the identity of the service account to call Google
+/// APIs, so that the users aren't directly involved.
+///
+/// Service account credentials are used to temporarily assume the identity
+/// of the service account. Supported credential types include OAuth 2.0 access
+/// tokens, OpenID Connect ID tokens, self-signed JSON Web Tokens (JWTs), and
+/// more.
+///
 class IAMCredentialsClient {
  public:
   explicit IAMCredentialsClient(
@@ -69,160 +69,178 @@ class IAMCredentialsClient {
   }
   //@}
 
-  /**
-   * Generates an OAuth 2.0 access token for a service account.
-   *
-   * @param name  Required. The resource name of the service account for which
-   * the credentials are requested, in the following format:
-   *  `projects/-/serviceAccounts/{ACCOUNT_EMAIL_OR_UNIQUEID}`. The `-` wildcard
-   *  character is required; replacing it with a project ID is invalid.
-   * @param delegates  The sequence of service accounts in a delegation chain.
-   * Each service account must be granted the
-   * `roles/iam.serviceAccountTokenCreator` role on its next service account in
-   * the chain. The last service account in the chain must be granted the
-   * `roles/iam.serviceAccountTokenCreator` role on the service account that is
-   * specified in the `name` field of the request. The delegates must have the
-   * following format: `projects/-/serviceAccounts/{ACCOUNT_EMAIL_OR_UNIQUEID}`.
-   * The `-` wildcard character is required; replacing it with a project ID is
-   * invalid.
-   * @param scope  Required. Code to identify the scopes to be included in the
-   * OAuth 2.0 access token. See
-   * https://developers.google.com/identity/protocols/googlescopes for more
-   *  information.
-   *  At least one value required.
-   * @param lifetime  The desired lifetime duration of the access token in
-   * seconds. Must be set to a value less than or equal to 3600 (1 hour). If a
-   * value is not specified, the token's lifetime will be set to a default value
-   * of one hour.
-   * @return
-   * @googleapis_link{google::iam::credentials::v1::GenerateAccessTokenResponse,google/iam/credentials/v1/common.proto#L72}
-   */
+  ///
+  /// Generates an OAuth 2.0 access token for a service account.
+  ///
+  /// @param name  Required. The resource name of the service account for which
+  /// the credentials
+  ///  are requested, in the following format:
+  ///  `projects/-/serviceAccounts/{ACCOUNT_EMAIL_OR_UNIQUEID}`. The `-`
+  ///  wildcard character is required; replacing it with a project ID is
+  ///  invalid.
+  /// @param delegates  The sequence of service accounts in a delegation chain.
+  /// Each service
+  ///  account must be granted the `roles/iam.serviceAccountTokenCreator` role
+  ///  on its next service account in the chain. The last service account in the
+  ///  chain must be granted the `roles/iam.serviceAccountTokenCreator` role
+  ///  on the service account that is specified in the `name` field of the
+  ///  request.
+  ///  The delegates must have the following format:
+  ///  `projects/-/serviceAccounts/{ACCOUNT_EMAIL_OR_UNIQUEID}`. The `-`
+  ///  wildcard character is required; replacing it with a project ID is
+  ///  invalid.
+  /// @param scope  Required. Code to identify the scopes to be included in the
+  /// OAuth 2.0 access token.
+  ///  See https://developers.google.com/identity/protocols/googlescopes for
+  ///  more information. At least one value required.
+  /// @param lifetime  The desired lifetime duration of the access token in
+  /// seconds.
+  ///  Must be set to a value less than or equal to 3600 (1 hour). If a value is
+  ///  not specified, the token's lifetime will be set to a default value of one
+  ///  hour.
+  /// @return
+  /// @googleapis_link{google::iam::credentials::v1::GenerateAccessTokenResponse,google/iam/credentials/v1/common.proto#L72}
+  ///
   StatusOr<google::iam::credentials::v1::GenerateAccessTokenResponse>
   GenerateAccessToken(std::string const& name,
                       std::vector<std::string> const& delegates,
                       std::vector<std::string> const& scope,
                       google::protobuf::Duration const& lifetime);
 
-  /**
-   * Generates an OpenID Connect ID token for a service account.
-   *
-   * @param name  Required. The resource name of the service account for which
-   * the credentials are requested, in the following format:
-   *  `projects/-/serviceAccounts/{ACCOUNT_EMAIL_OR_UNIQUEID}`. The `-` wildcard
-   *  character is required; replacing it with a project ID is invalid.
-   * @param delegates  The sequence of service accounts in a delegation chain.
-   * Each service account must be granted the
-   * `roles/iam.serviceAccountTokenCreator` role on its next service account in
-   * the chain. The last service account in the chain must be granted the
-   * `roles/iam.serviceAccountTokenCreator` role on the service account that is
-   * specified in the `name` field of the request. The delegates must have the
-   * following format: `projects/-/serviceAccounts/{ACCOUNT_EMAIL_OR_UNIQUEID}`.
-   * The `-` wildcard character is required; replacing it with a project ID is
-   * invalid.
-   * @param audience  Required. The audience for the token, such as the API or
-   * account that this token grants access to.
-   * @param include_email  Include the service account email in the token. If
-   * set to `true`, the token will contain `email` and `email_verified` claims.
-   * @return
-   * @googleapis_link{google::iam::credentials::v1::GenerateIdTokenResponse,google/iam/credentials/v1/common.proto#L186}
-   */
+  ///
+  /// Generates an OpenID Connect ID token for a service account.
+  ///
+  /// @param name  Required. The resource name of the service account for which
+  /// the credentials
+  ///  are requested, in the following format:
+  ///  `projects/-/serviceAccounts/{ACCOUNT_EMAIL_OR_UNIQUEID}`. The `-`
+  ///  wildcard character is required; replacing it with a project ID is
+  ///  invalid.
+  /// @param delegates  The sequence of service accounts in a delegation chain.
+  /// Each service
+  ///  account must be granted the `roles/iam.serviceAccountTokenCreator` role
+  ///  on its next service account in the chain. The last service account in the
+  ///  chain must be granted the `roles/iam.serviceAccountTokenCreator` role
+  ///  on the service account that is specified in the `name` field of the
+  ///  request.
+  ///  The delegates must have the following format:
+  ///  `projects/-/serviceAccounts/{ACCOUNT_EMAIL_OR_UNIQUEID}`. The `-`
+  ///  wildcard character is required; replacing it with a project ID is
+  ///  invalid.
+  /// @param audience  Required. The audience for the token, such as the API or
+  /// account that this token
+  ///  grants access to.
+  /// @param include_email  Include the service account email in the token. If
+  /// set to `true`, the
+  ///  token will contain `email` and `email_verified` claims.
+  /// @return
+  /// @googleapis_link{google::iam::credentials::v1::GenerateIdTokenResponse,google/iam/credentials/v1/common.proto#L186}
+  ///
   StatusOr<google::iam::credentials::v1::GenerateIdTokenResponse>
   GenerateIdToken(std::string const& name,
                   std::vector<std::string> const& delegates,
                   std::string const& audience, bool include_email);
 
-  /**
-   * Signs a blob using a service account's system-managed private key.
-   *
-   * @param name  Required. The resource name of the service account for which
-   * the credentials are requested, in the following format:
-   *  `projects/-/serviceAccounts/{ACCOUNT_EMAIL_OR_UNIQUEID}`. The `-` wildcard
-   *  character is required; replacing it with a project ID is invalid.
-   * @param delegates  The sequence of service accounts in a delegation chain.
-   * Each service account must be granted the
-   * `roles/iam.serviceAccountTokenCreator` role on its next service account in
-   * the chain. The last service account in the chain must be granted the
-   * `roles/iam.serviceAccountTokenCreator` role on the service account that is
-   * specified in the `name` field of the request. The delegates must have the
-   * following format: `projects/-/serviceAccounts/{ACCOUNT_EMAIL_OR_UNIQUEID}`.
-   * The `-` wildcard character is required; replacing it with a project ID is
-   * invalid.
-   * @param payload  Required. The bytes to sign.
-   * @return
-   * @googleapis_link{google::iam::credentials::v1::SignBlobResponse,google/iam/credentials/v1/common.proto#L109}
-   */
+  ///
+  /// Signs a blob using a service account's system-managed private key.
+  ///
+  /// @param name  Required. The resource name of the service account for which
+  /// the credentials
+  ///  are requested, in the following format:
+  ///  `projects/-/serviceAccounts/{ACCOUNT_EMAIL_OR_UNIQUEID}`. The `-`
+  ///  wildcard character is required; replacing it with a project ID is
+  ///  invalid.
+  /// @param delegates  The sequence of service accounts in a delegation chain.
+  /// Each service
+  ///  account must be granted the `roles/iam.serviceAccountTokenCreator` role
+  ///  on its next service account in the chain. The last service account in the
+  ///  chain must be granted the `roles/iam.serviceAccountTokenCreator` role
+  ///  on the service account that is specified in the `name` field of the
+  ///  request.
+  ///  The delegates must have the following format:
+  ///  `projects/-/serviceAccounts/{ACCOUNT_EMAIL_OR_UNIQUEID}`. The `-`
+  ///  wildcard character is required; replacing it with a project ID is
+  ///  invalid.
+  /// @param payload  Required. The bytes to sign.
+  /// @return
+  /// @googleapis_link{google::iam::credentials::v1::SignBlobResponse,google/iam/credentials/v1/common.proto#L109}
+  ///
   StatusOr<google::iam::credentials::v1::SignBlobResponse> SignBlob(
       std::string const& name, std::vector<std::string> const& delegates,
       std::string const& payload);
 
-  /**
-   * Signs a JWT using a service account's system-managed private key.
-   *
-   * @param name  Required. The resource name of the service account for which
-   * the credentials are requested, in the following format:
-   *  `projects/-/serviceAccounts/{ACCOUNT_EMAIL_OR_UNIQUEID}`. The `-` wildcard
-   *  character is required; replacing it with a project ID is invalid.
-   * @param delegates  The sequence of service accounts in a delegation chain.
-   * Each service account must be granted the
-   * `roles/iam.serviceAccountTokenCreator` role on its next service account in
-   * the chain. The last service account in the chain must be granted the
-   * `roles/iam.serviceAccountTokenCreator` role on the service account that is
-   * specified in the `name` field of the request. The delegates must have the
-   * following format: `projects/-/serviceAccounts/{ACCOUNT_EMAIL_OR_UNIQUEID}`.
-   * The `-` wildcard character is required; replacing it with a project ID is
-   * invalid.
-   * @param payload  Required. The JWT payload to sign: a JSON object that
-   * contains a JWT Claims Set.
-   * @return
-   * @googleapis_link{google::iam::credentials::v1::SignJwtResponse,google/iam/credentials/v1/common.proto#L145}
-   */
+  ///
+  /// Signs a JWT using a service account's system-managed private key.
+  ///
+  /// @param name  Required. The resource name of the service account for which
+  /// the credentials
+  ///  are requested, in the following format:
+  ///  `projects/-/serviceAccounts/{ACCOUNT_EMAIL_OR_UNIQUEID}`. The `-`
+  ///  wildcard character is required; replacing it with a project ID is
+  ///  invalid.
+  /// @param delegates  The sequence of service accounts in a delegation chain.
+  /// Each service
+  ///  account must be granted the `roles/iam.serviceAccountTokenCreator` role
+  ///  on its next service account in the chain. The last service account in the
+  ///  chain must be granted the `roles/iam.serviceAccountTokenCreator` role
+  ///  on the service account that is specified in the `name` field of the
+  ///  request.
+  ///  The delegates must have the following format:
+  ///  `projects/-/serviceAccounts/{ACCOUNT_EMAIL_OR_UNIQUEID}`. The `-`
+  ///  wildcard character is required; replacing it with a project ID is
+  ///  invalid.
+  /// @param payload  Required. The JWT payload to sign: a JSON object that
+  /// contains a JWT Claims Set.
+  /// @return
+  /// @googleapis_link{google::iam::credentials::v1::SignJwtResponse,google/iam/credentials/v1/common.proto#L145}
+  ///
   StatusOr<google::iam::credentials::v1::SignJwtResponse> SignJwt(
       std::string const& name, std::vector<std::string> const& delegates,
       std::string const& payload);
 
-  /**
-   * Generates an OAuth 2.0 access token for a service account.
-   *
-   * @param request
-   * @googleapis_link{google::iam::credentials::v1::GenerateAccessTokenRequest,google/iam/credentials/v1/common.proto#L35}
-   * @return
-   * @googleapis_link{google::iam::credentials::v1::GenerateAccessTokenResponse,google/iam/credentials/v1/common.proto#L72}
-   */
+  ///
+  /// Generates an OAuth 2.0 access token for a service account.
+  ///
+  /// @param request
+  /// @googleapis_link{google::iam::credentials::v1::GenerateAccessTokenRequest,google/iam/credentials/v1/common.proto#L35}
+  /// @return
+  /// @googleapis_link{google::iam::credentials::v1::GenerateAccessTokenResponse,google/iam/credentials/v1/common.proto#L72}
+  ///
   StatusOr<google::iam::credentials::v1::GenerateAccessTokenResponse>
   GenerateAccessToken(
       google::iam::credentials::v1::GenerateAccessTokenRequest const& request);
 
-  /**
-   * Generates an OpenID Connect ID token for a service account.
-   *
-   * @param request
-   * @googleapis_link{google::iam::credentials::v1::GenerateIdTokenRequest,google/iam/credentials/v1/common.proto#L153}
-   * @return
-   * @googleapis_link{google::iam::credentials::v1::GenerateIdTokenResponse,google/iam/credentials/v1/common.proto#L186}
-   */
+  ///
+  /// Generates an OpenID Connect ID token for a service account.
+  ///
+  /// @param request
+  /// @googleapis_link{google::iam::credentials::v1::GenerateIdTokenRequest,google/iam/credentials/v1/common.proto#L153}
+  /// @return
+  /// @googleapis_link{google::iam::credentials::v1::GenerateIdTokenResponse,google/iam/credentials/v1/common.proto#L186}
+  ///
   StatusOr<google::iam::credentials::v1::GenerateIdTokenResponse>
   GenerateIdToken(
       google::iam::credentials::v1::GenerateIdTokenRequest const& request);
 
-  /**
-   * Signs a blob using a service account's system-managed private key.
-   *
-   * @param request
-   * @googleapis_link{google::iam::credentials::v1::SignBlobRequest,google/iam/credentials/v1/common.proto#L81}
-   * @return
-   * @googleapis_link{google::iam::credentials::v1::SignBlobResponse,google/iam/credentials/v1/common.proto#L109}
-   */
+  ///
+  /// Signs a blob using a service account's system-managed private key.
+  ///
+  /// @param request
+  /// @googleapis_link{google::iam::credentials::v1::SignBlobRequest,google/iam/credentials/v1/common.proto#L81}
+  /// @return
+  /// @googleapis_link{google::iam::credentials::v1::SignBlobResponse,google/iam/credentials/v1/common.proto#L109}
+  ///
   StatusOr<google::iam::credentials::v1::SignBlobResponse> SignBlob(
       google::iam::credentials::v1::SignBlobRequest const& request);
 
-  /**
-   * Signs a JWT using a service account's system-managed private key.
-   *
-   * @param request
-   * @googleapis_link{google::iam::credentials::v1::SignJwtRequest,google/iam/credentials/v1/common.proto#L117}
-   * @return
-   * @googleapis_link{google::iam::credentials::v1::SignJwtResponse,google/iam/credentials/v1/common.proto#L145}
-   */
+  ///
+  /// Signs a JWT using a service account's system-managed private key.
+  ///
+  /// @param request
+  /// @googleapis_link{google::iam::credentials::v1::SignJwtRequest,google/iam/credentials/v1/common.proto#L117}
+  /// @return
+  /// @googleapis_link{google::iam::credentials::v1::SignJwtResponse,google/iam/credentials/v1/common.proto#L145}
+  ///
   StatusOr<google::iam::credentials::v1::SignJwtResponse> SignJwt(
       google::iam::credentials::v1::SignJwtRequest const& request);
 

--- a/google/cloud/logging/logging_service_v2_client.h
+++ b/google/cloud/logging/logging_service_v2_client.h
@@ -32,9 +32,9 @@ namespace cloud {
 namespace logging {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-/**
- * Service for ingesting and querying logs.
- */
+///
+/// Service for ingesting and querying logs.
+///
 class LoggingServiceV2Client {
  public:
   explicit LoggingServiceV2Client(
@@ -61,199 +61,208 @@ class LoggingServiceV2Client {
   }
   //@}
 
-  /**
-   * Deletes all the log entries in a log. The log reappears if it receives new
-   * entries. Log entries written shortly before the delete operation might not
-   * be deleted. Entries received after the delete operation with a timestamp
-   * before the operation will be deleted.
-   *
-   * @param log_name  Required. The resource name of the log to delete:
-   *      "projects/[PROJECT_ID]/logs/[LOG_ID]"
-   *      "organizations/[ORGANIZATION_ID]/logs/[LOG_ID]"
-   *      "billingAccounts/[BILLING_ACCOUNT_ID]/logs/[LOG_ID]"
-   *      "folders/[FOLDER_ID]/logs/[LOG_ID]"
-   *  `[LOG_ID]` must be URL-encoded. For example,
-   *  `"projects/my-project-id/logs/syslog"`,
-   *  `"organizations/1234567890/logs/cloudresourcemanager.googleapis.com%2Factivity"`.
-   *  For more information about log names, see
-   *  [LogEntry][google.logging.v2.LogEntry].
-   */
+  ///
+  /// Deletes all the log entries in a log. The log reappears if it receives new
+  /// entries. Log entries written shortly before the delete operation might not
+  /// be deleted. Entries received after the delete operation with a timestamp
+  /// before the operation will be deleted.
+  ///
+  /// @param log_name  Required. The resource name of the log to delete:
+  ///      "projects/[PROJECT_ID]/logs/[LOG_ID]"
+  ///      "organizations/[ORGANIZATION_ID]/logs/[LOG_ID]"
+  ///      "billingAccounts/[BILLING_ACCOUNT_ID]/logs/[LOG_ID]"
+  ///      "folders/[FOLDER_ID]/logs/[LOG_ID]"
+  ///  `[LOG_ID]` must be URL-encoded. For example,
+  ///  `"projects/my-project-id/logs/syslog"`,
+  ///  `"organizations/1234567890/logs/cloudresourcemanager.googleapis.com%2Factivity"`.
+  ///  For more information about log names, see
+  ///  [LogEntry][google.logging.v2.LogEntry].
+  ///
   Status DeleteLog(std::string const& log_name);
 
-  /**
-   * Writes log entries to Logging. This API method is the
-   * only way to send log entries to Logging. This method
-   * is used, directly or indirectly, by the Logging agent
-   * (fluentd) and all logging libraries configured to use Logging.
-   * A single request may contain log entries for a maximum of 1000
-   * different resources (projects, organizations, billing accounts or
-   * folders)
-   *
-   * @param log_name  Optional. A default log resource name that is assigned to
-   * all log entries in `entries` that do not specify a value for `log_name`:
-   *      "projects/[PROJECT_ID]/logs/[LOG_ID]"
-   *      "organizations/[ORGANIZATION_ID]/logs/[LOG_ID]"
-   *      "billingAccounts/[BILLING_ACCOUNT_ID]/logs/[LOG_ID]"
-   *      "folders/[FOLDER_ID]/logs/[LOG_ID]"
-   *  `[LOG_ID]` must be URL-encoded. For example:
-   *      "projects/my-project-id/logs/syslog"
-   *      "organizations/1234567890/logs/cloudresourcemanager.googleapis.com%2Factivity"
-   *  The permission `logging.logEntries.create` is needed on each project,
-   *  organization, billing account, or folder that is receiving new log
-   *  entries, whether the resource is specified in `logName` or in an
-   *  individual log entry.
-   * @param resource  Optional. A default monitored resource object that is
-   * assigned to all log entries in `entries` that do not specify a value for
-   * `resource`. Example: { "type": "gce_instance", "labels": { "zone":
-   * "us-central1-a", "instance_id": "00000000000000000000" }} See
-   * [LogEntry][google.logging.v2.LogEntry].
-   * @param labels  Optional. Default labels that are added to the `labels`
-   * field of all log entries in `entries`. If a log entry already has a label
-   * with the same key as a label in this parameter, then the log entry's label
-   * is not changed. See [LogEntry][google.logging.v2.LogEntry].
-   * @param entries  Required. The log entries to send to Logging. The order of
-   * log entries in this list does not matter. Values supplied in this method's
-   *  `log_name`, `resource`, and `labels` fields are copied into those log
-   *  entries in this list that do not include values for their corresponding
-   *  fields. For more information, see the
-   *  [LogEntry][google.logging.v2.LogEntry] type.
-   *  If the `timestamp` or `insert_id` fields are missing in log entries, then
-   *  this method supplies the current time or a unique identifier,
-   * respectively. The supplied values are chosen so that, among the log entries
-   * that did not supply their own values, the entries earlier in the list will
-   * sort before the entries later in the list. See the `entries.list` method.
-   *  Log entries with timestamps that are more than the
-   *  [logs retention period](https://cloud.google.com/logging/quota-policy) in
-   *  the past or more than 24 hours in the future will not be available when
-   *  calling `entries.list`. However, those log entries can still be [exported
-   *  with
-   *  LogSinks](https://cloud.google.com/logging/docs/api/tasks/exporting-logs).
-   *  To improve throughput and to avoid exceeding the
-   *  [quota limit](https://cloud.google.com/logging/quota-policy) for calls to
-   *  `entries.write`, you should try to include several log entries in this
-   *  list, rather than calling this method for each individual log entry.
-   * @return
-   * @googleapis_link{google::logging::v2::WriteLogEntriesResponse,google/logging/v2/logging.proto#L243}
-   */
+  ///
+  /// Writes log entries to Logging. This API method is the
+  /// only way to send log entries to Logging. This method
+  /// is used, directly or indirectly, by the Logging agent
+  /// (fluentd) and all logging libraries configured to use Logging.
+  /// A single request may contain log entries for a maximum of 1000
+  /// different resources (projects, organizations, billing accounts or
+  /// folders)
+  ///
+  /// @param log_name  Optional. A default log resource name that is assigned to
+  /// all log entries
+  ///  in `entries` that do not specify a value for `log_name`:
+  ///      "projects/[PROJECT_ID]/logs/[LOG_ID]"
+  ///      "organizations/[ORGANIZATION_ID]/logs/[LOG_ID]"
+  ///      "billingAccounts/[BILLING_ACCOUNT_ID]/logs/[LOG_ID]"
+  ///      "folders/[FOLDER_ID]/logs/[LOG_ID]"
+  ///  `[LOG_ID]` must be URL-encoded. For example:
+  ///      "projects/my-project-id/logs/syslog"
+  ///      "organizations/1234567890/logs/cloudresourcemanager.googleapis.com%2Factivity"
+  ///  The permission `logging.logEntries.create` is needed on each project,
+  ///  organization, billing account, or folder that is receiving new log
+  ///  entries, whether the resource is specified in `logName` or in an
+  ///  individual log entry.
+  /// @param resource  Optional. A default monitored resource object that is
+  /// assigned to all log
+  ///  entries in `entries` that do not specify a value for `resource`. Example:
+  ///      { "type": "gce_instance",
+  ///        "labels": {
+  ///          "zone": "us-central1-a", "instance_id": "00000000000000000000" }}
+  ///  See [LogEntry][google.logging.v2.LogEntry].
+  /// @param labels  Optional. Default labels that are added to the `labels`
+  /// field of all log
+  ///  entries in `entries`. If a log entry already has a label with the same
+  ///  key as a label in this parameter, then the log entry's label is not
+  ///  changed. See [LogEntry][google.logging.v2.LogEntry].
+  /// @param entries  Required. The log entries to send to Logging. The order of
+  /// log
+  ///  entries in this list does not matter. Values supplied in this method's
+  ///  `log_name`, `resource`, and `labels` fields are copied into those log
+  ///  entries in this list that do not include values for their corresponding
+  ///  fields. For more information, see the
+  ///  [LogEntry][google.logging.v2.LogEntry] type.
+  ///  If the `timestamp` or `insert_id` fields are missing in log entries, then
+  ///  this method supplies the current time or a unique identifier,
+  ///  respectively. The supplied values are chosen so that, among the log
+  ///  entries that did not supply their own values, the entries earlier in the
+  ///  list will sort before the entries later in the list. See the
+  ///  `entries.list` method. Log entries with timestamps that are more than the
+  ///  [logs retention period](https://cloud.google.com/logging/quota-policy) in
+  ///  the past or more than 24 hours in the future will not be available when
+  ///  calling `entries.list`. However, those log entries can still be [exported
+  ///  with
+  ///  LogSinks](https://cloud.google.com/logging/docs/api/tasks/exporting-logs).
+  ///  To improve throughput and to avoid exceeding the
+  ///  [quota limit](https://cloud.google.com/logging/quota-policy) for calls to
+  ///  `entries.write`, you should try to include several log entries in this
+  ///  list, rather than calling this method for each individual log entry.
+  /// @return
+  /// @googleapis_link{google::logging::v2::WriteLogEntriesResponse,google/logging/v2/logging.proto#L243}
+  ///
   StatusOr<google::logging::v2::WriteLogEntriesResponse> WriteLogEntries(
       std::string const& log_name,
       google::api::MonitoredResource const& resource,
       std::map<std::string, std::string> const& labels,
       std::vector<google::logging::v2::LogEntry> const& entries);
 
-  /**
-   * Lists log entries.  Use this method to retrieve log entries that originated
-   * from a project/folder/organization/billing account.  For ways to export log
-   * entries, see [Exporting
-   * Logs](https://cloud.google.com/logging/docs/export).
-   *
-   * @param resource_names  Required. Names of one or more parent resources from
-   * which to retrieve log entries: "projects/[PROJECT_ID]"
-   *      "organizations/[ORGANIZATION_ID]"
-   *      "billingAccounts/[BILLING_ACCOUNT_ID]"
-   *      "folders/[FOLDER_ID]"
-   *  May alternatively be one or more views
-   *    projects/[PROJECT_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]
-   *    organization/[ORGANIZATION_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]
-   *    billingAccounts/[BILLING_ACCOUNT_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]
-   *    folders/[FOLDER_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]
-   *  Projects listed in the `project_ids` field are added to this list.
-   * @param filter  Optional. A filter that chooses which log entries to return.
-   * See [Advanced Logs
-   * Queries](https://cloud.google.com/logging/docs/view/advanced-queries). Only
-   * log entries that match the filter are returned.  An empty filter matches
-   * all log entries in the resources listed in `resource_names`. Referencing a
-   * parent resource that is not listed in `resource_names` will cause the
-   * filter to return no results. The maximum length of the filter is 20000
-   * characters.
-   * @param order_by  Optional. How the results should be sorted.  Presently,
-   * the only permitted values are `"timestamp asc"` (default) and `"timestamp
-   * desc"`. The first option returns entries in order of increasing values of
-   *  `LogEntry.timestamp` (oldest first), and the second option returns entries
-   *  in order of decreasing timestamps (newest first).  Entries with equal
-   *  timestamps are returned in order of their `insert_id` values.
-   * @return
-   * @googleapis_link{google::logging::v2::LogEntry,google/logging/v2/log_entry.proto#L42}
-   */
+  ///
+  /// Lists log entries.  Use this method to retrieve log entries that
+  /// originated from a project/folder/organization/billing account.  For ways
+  /// to export log entries, see [Exporting
+  /// Logs](https://cloud.google.com/logging/docs/export).
+  ///
+  /// @param resource_names  Required. Names of one or more parent resources
+  /// from which to
+  ///  retrieve log entries:
+  ///      "projects/[PROJECT_ID]"
+  ///      "organizations/[ORGANIZATION_ID]"
+  ///      "billingAccounts/[BILLING_ACCOUNT_ID]"
+  ///      "folders/[FOLDER_ID]"
+  ///  May alternatively be one or more views
+  ///    projects/[PROJECT_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]
+  ///    organization/[ORGANIZATION_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]
+  ///    billingAccounts/[BILLING_ACCOUNT_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]
+  ///    folders/[FOLDER_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]
+  ///  Projects listed in the `project_ids` field are added to this list.
+  /// @param filter  Optional. A filter that chooses which log entries to
+  /// return.  See [Advanced
+  ///  Logs
+  ///  Queries](https://cloud.google.com/logging/docs/view/advanced-queries).
+  ///  Only log entries that match the filter are returned.  An empty filter
+  ///  matches all log entries in the resources listed in `resource_names`.
+  ///  Referencing a parent resource that is not listed in `resource_names` will
+  ///  cause the filter to return no results. The maximum length of the filter
+  ///  is 20000 characters.
+  /// @param order_by  Optional. How the results should be sorted.  Presently,
+  /// the only permitted
+  ///  values are `"timestamp asc"` (default) and `"timestamp desc"`. The first
+  ///  option returns entries in order of increasing values of
+  ///  `LogEntry.timestamp` (oldest first), and the second option returns
+  ///  entries in order of decreasing timestamps (newest first).  Entries with
+  ///  equal timestamps are returned in order of their `insert_id` values.
+  /// @return
+  /// @googleapis_link{google::logging::v2::LogEntry,google/logging/v2/log_entry.proto#L42}
+  ///
   StreamRange<google::logging::v2::LogEntry> ListLogEntries(
       std::vector<std::string> const& resource_names, std::string const& filter,
       std::string const& order_by);
 
-  /**
-   * Lists the logs in projects, organizations, folders, or billing accounts.
-   * Only logs that have entries are listed.
-   *
-   * @param parent  Required. The resource name that owns the logs:
-   *      "projects/[PROJECT_ID]"
-   *      "organizations/[ORGANIZATION_ID]"
-   *      "billingAccounts/[BILLING_ACCOUNT_ID]"
-   *      "folders/[FOLDER_ID]"
-   * @return std::string
-   */
+  ///
+  /// Lists the logs in projects, organizations, folders, or billing accounts.
+  /// Only logs that have entries are listed.
+  ///
+  /// @param parent  Required. The resource name that owns the logs:
+  ///      "projects/[PROJECT_ID]"
+  ///      "organizations/[ORGANIZATION_ID]"
+  ///      "billingAccounts/[BILLING_ACCOUNT_ID]"
+  ///      "folders/[FOLDER_ID]"
+  /// @return std::string
+  ///
   StreamRange<std::string> ListLogs(std::string const& parent);
 
-  /**
-   * Deletes all the log entries in a log. The log reappears if it receives new
-   * entries. Log entries written shortly before the delete operation might not
-   * be deleted. Entries received after the delete operation with a timestamp
-   * before the operation will be deleted.
-   *
-   * @param request
-   * @googleapis_link{google::logging::v2::DeleteLogRequest,google/logging/v2/logging.proto#L140}
-   */
+  ///
+  /// Deletes all the log entries in a log. The log reappears if it receives new
+  /// entries. Log entries written shortly before the delete operation might not
+  /// be deleted. Entries received after the delete operation with a timestamp
+  /// before the operation will be deleted.
+  ///
+  /// @param request
+  /// @googleapis_link{google::logging::v2::DeleteLogRequest,google/logging/v2/logging.proto#L140}
+  ///
   Status DeleteLog(google::logging::v2::DeleteLogRequest const& request);
 
-  /**
-   * Writes log entries to Logging. This API method is the
-   * only way to send log entries to Logging. This method
-   * is used, directly or indirectly, by the Logging agent
-   * (fluentd) and all logging libraries configured to use Logging.
-   * A single request may contain log entries for a maximum of 1000
-   * different resources (projects, organizations, billing accounts or
-   * folders)
-   *
-   * @param request
-   * @googleapis_link{google::logging::v2::WriteLogEntriesRequest,google/logging/v2/logging.proto#L162}
-   * @return
-   * @googleapis_link{google::logging::v2::WriteLogEntriesResponse,google/logging/v2/logging.proto#L243}
-   */
+  ///
+  /// Writes log entries to Logging. This API method is the
+  /// only way to send log entries to Logging. This method
+  /// is used, directly or indirectly, by the Logging agent
+  /// (fluentd) and all logging libraries configured to use Logging.
+  /// A single request may contain log entries for a maximum of 1000
+  /// different resources (projects, organizations, billing accounts or
+  /// folders)
+  ///
+  /// @param request
+  /// @googleapis_link{google::logging::v2::WriteLogEntriesRequest,google/logging/v2/logging.proto#L162}
+  /// @return
+  /// @googleapis_link{google::logging::v2::WriteLogEntriesResponse,google/logging/v2/logging.proto#L243}
+  ///
   StatusOr<google::logging::v2::WriteLogEntriesResponse> WriteLogEntries(
       google::logging::v2::WriteLogEntriesRequest const& request);
 
-  /**
-   * Lists log entries.  Use this method to retrieve log entries that originated
-   * from a project/folder/organization/billing account.  For ways to export log
-   * entries, see [Exporting
-   * Logs](https://cloud.google.com/logging/docs/export).
-   *
-   * @param request
-   * @googleapis_link{google::logging::v2::ListLogEntriesRequest,google/logging/v2/logging.proto#L257}
-   * @return
-   * @googleapis_link{google::logging::v2::LogEntry,google/logging/v2/log_entry.proto#L42}
-   */
+  ///
+  /// Lists log entries.  Use this method to retrieve log entries that
+  /// originated from a project/folder/organization/billing account.  For ways
+  /// to export log entries, see [Exporting
+  /// Logs](https://cloud.google.com/logging/docs/export).
+  ///
+  /// @param request
+  /// @googleapis_link{google::logging::v2::ListLogEntriesRequest,google/logging/v2/logging.proto#L257}
+  /// @return
+  /// @googleapis_link{google::logging::v2::LogEntry,google/logging/v2/log_entry.proto#L42}
+  ///
   StreamRange<google::logging::v2::LogEntry> ListLogEntries(
       google::logging::v2::ListLogEntriesRequest request);
 
-  /**
-   * Lists the descriptors for monitored resource types used by Logging.
-   *
-   * @param request
-   * @googleapis_link{google::logging::v2::ListMonitoredResourceDescriptorsRequest,google/logging/v2/logging.proto#L331}
-   * @return
-   * @googleapis_link{google::api::MonitoredResourceDescriptor,google/api/monitored_resource.proto#L40}
-   */
+  ///
+  /// Lists the descriptors for monitored resource types used by Logging.
+  ///
+  /// @param request
+  /// @googleapis_link{google::logging::v2::ListMonitoredResourceDescriptorsRequest,google/logging/v2/logging.proto#L331}
+  /// @return
+  /// @googleapis_link{google::api::MonitoredResourceDescriptor,google/api/monitored_resource.proto#L40}
+  ///
   StreamRange<google::api::MonitoredResourceDescriptor>
   ListMonitoredResourceDescriptors(
       google::logging::v2::ListMonitoredResourceDescriptorsRequest request);
 
-  /**
-   * Lists the logs in projects, organizations, folders, or billing accounts.
-   * Only logs that have entries are listed.
-   *
-   * @param request
-   * @googleapis_link{google::logging::v2::ListLogsRequest,google/logging/v2/logging.proto#L356}
-   * @return std::string
-   */
+  ///
+  /// Lists the logs in projects, organizations, folders, or billing accounts.
+  /// Only logs that have entries are listed.
+  ///
+  /// @param request
+  /// @googleapis_link{google::logging::v2::ListLogsRequest,google/logging/v2/logging.proto#L356}
+  /// @return std::string
+  ///
   StreamRange<std::string> ListLogs(
       google::logging::v2::ListLogsRequest request);
 

--- a/google/cloud/pubsublite/admin_client.h
+++ b/google/cloud/pubsublite/admin_client.h
@@ -32,10 +32,11 @@ namespace cloud {
 namespace pubsublite {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-/**
- * The service that a client application uses to manage topics and
- * subscriptions, such creating, listing, and deleting topics and subscriptions.
- */
+///
+/// The service that a client application uses to manage topics and
+/// subscriptions, such creating, listing, and deleting topics and
+/// subscriptions.
+///
 class AdminServiceClient {
  public:
   explicit AdminServiceClient(
@@ -62,439 +63,446 @@ class AdminServiceClient {
   }
   //@}
 
-  /**
-   * Creates a new topic.
-   *
-   * @param parent  Required. The parent location in which to create the topic.
-   *  Structured like `projects/{project_number}/locations/{location}`.
-   * @param topic  Required. Configuration of the topic to create. Its `name`
-   * field is ignored.
-   * @param topic_id  Required. The ID to use for the topic, which will become
-   * the final component of the topic's name. This value is structured like:
-   * `my-topic-name`.
-   * @return
-   * @googleapis_link{google::cloud::pubsublite::v1::Topic,google/cloud/pubsublite/v1/common.proto#L102}
-   */
+  ///
+  /// Creates a new topic.
+  ///
+  /// @param parent  Required. The parent location in which to create the topic.
+  ///  Structured like `projects/{project_number}/locations/{location}`.
+  /// @param topic  Required. Configuration of the topic to create. Its `name`
+  /// field is ignored.
+  /// @param topic_id  Required. The ID to use for the topic, which will become
+  /// the final component of
+  ///  the topic's name.
+  ///  This value is structured like: `my-topic-name`.
+  /// @return
+  /// @googleapis_link{google::cloud::pubsublite::v1::Topic,google/cloud/pubsublite/v1/common.proto#L102}
+  ///
   StatusOr<google::cloud::pubsublite::v1::Topic> CreateTopic(
       std::string const& parent,
       google::cloud::pubsublite::v1::Topic const& topic,
       std::string const& topic_id);
 
-  /**
-   * Returns the topic configuration.
-   *
-   * @param name  Required. The name of the topic whose configuration to return.
-   * @return
-   * @googleapis_link{google::cloud::pubsublite::v1::Topic,google/cloud/pubsublite/v1/common.proto#L102}
-   */
+  ///
+  /// Returns the topic configuration.
+  ///
+  /// @param name  Required. The name of the topic whose configuration to
+  /// return.
+  /// @return
+  /// @googleapis_link{google::cloud::pubsublite::v1::Topic,google/cloud/pubsublite/v1/common.proto#L102}
+  ///
   StatusOr<google::cloud::pubsublite::v1::Topic> GetTopic(
       std::string const& name);
 
-  /**
-   * Returns the partition information for the requested topic.
-   *
-   * @param name  Required. The topic whose partition information to return.
-   * @return
-   * @googleapis_link{google::cloud::pubsublite::v1::TopicPartitions,google/cloud/pubsublite/v1/admin.proto#L270}
-   */
+  ///
+  /// Returns the partition information for the requested topic.
+  ///
+  /// @param name  Required. The topic whose partition information to return.
+  /// @return
+  /// @googleapis_link{google::cloud::pubsublite::v1::TopicPartitions,google/cloud/pubsublite/v1/admin.proto#L270}
+  ///
   StatusOr<google::cloud::pubsublite::v1::TopicPartitions> GetTopicPartitions(
       std::string const& name);
 
-  /**
-   * Returns the list of topics for the given project.
-   *
-   * @param parent  Required. The parent whose topics are to be listed.
-   *  Structured like `projects/{project_number}/locations/{location}`.
-   * @return
-   * @googleapis_link{google::cloud::pubsublite::v1::Topic,google/cloud/pubsublite/v1/common.proto#L102}
-   */
+  ///
+  /// Returns the list of topics for the given project.
+  ///
+  /// @param parent  Required. The parent whose topics are to be listed.
+  ///  Structured like `projects/{project_number}/locations/{location}`.
+  /// @return
+  /// @googleapis_link{google::cloud::pubsublite::v1::Topic,google/cloud/pubsublite/v1/common.proto#L102}
+  ///
   StreamRange<google::cloud::pubsublite::v1::Topic> ListTopics(
       std::string const& parent);
 
-  /**
-   * Updates properties of the specified topic.
-   *
-   * @param topic  Required. The topic to update. Its `name` field must be
-   * populated.
-   * @param update_mask  Required. A mask specifying the topic fields to change.
-   * @return
-   * @googleapis_link{google::cloud::pubsublite::v1::Topic,google/cloud/pubsublite/v1/common.proto#L102}
-   */
+  ///
+  /// Updates properties of the specified topic.
+  ///
+  /// @param topic  Required. The topic to update. Its `name` field must be
+  /// populated.
+  /// @param update_mask  Required. A mask specifying the topic fields to
+  /// change.
+  /// @return
+  /// @googleapis_link{google::cloud::pubsublite::v1::Topic,google/cloud/pubsublite/v1/common.proto#L102}
+  ///
   StatusOr<google::cloud::pubsublite::v1::Topic> UpdateTopic(
       google::cloud::pubsublite::v1::Topic const& topic,
       google::protobuf::FieldMask const& update_mask);
 
-  /**
-   * Deletes the specified topic.
-   *
-   * @param name  Required. The name of the topic to delete.
-   */
+  ///
+  /// Deletes the specified topic.
+  ///
+  /// @param name  Required. The name of the topic to delete.
+  ///
   Status DeleteTopic(std::string const& name);
 
-  /**
-   * Lists the subscriptions attached to the specified topic.
-   *
-   * @param name  Required. The name of the topic whose subscriptions to list.
-   * @return std::string
-   */
+  ///
+  /// Lists the subscriptions attached to the specified topic.
+  ///
+  /// @param name  Required. The name of the topic whose subscriptions to list.
+  /// @return std::string
+  ///
   StreamRange<std::string> ListTopicSubscriptions(std::string const& name);
 
-  /**
-   * Creates a new subscription.
-   *
-   * @param parent  Required. The parent location in which to create the
-   * subscription. Structured like
-   * `projects/{project_number}/locations/{location}`.
-   * @param subscription  Required. Configuration of the subscription to create.
-   * Its `name` field is ignored.
-   * @param subscription_id  Required. The ID to use for the subscription, which
-   * will become the final component of the subscription's name. This value is
-   * structured like: `my-sub-name`.
-   * @return
-   * @googleapis_link{google::cloud::pubsublite::v1::Subscription,google/cloud/pubsublite/v1/common.proto#L186}
-   */
+  ///
+  /// Creates a new subscription.
+  ///
+  /// @param parent  Required. The parent location in which to create the
+  /// subscription.
+  ///  Structured like `projects/{project_number}/locations/{location}`.
+  /// @param subscription  Required. Configuration of the subscription to
+  /// create. Its `name` field is ignored.
+  /// @param subscription_id  Required. The ID to use for the subscription,
+  /// which will become the final component
+  ///  of the subscription's name.
+  ///  This value is structured like: `my-sub-name`.
+  /// @return
+  /// @googleapis_link{google::cloud::pubsublite::v1::Subscription,google/cloud/pubsublite/v1/common.proto#L186}
+  ///
   StatusOr<google::cloud::pubsublite::v1::Subscription> CreateSubscription(
       std::string const& parent,
       google::cloud::pubsublite::v1::Subscription const& subscription,
       std::string const& subscription_id);
 
-  /**
-   * Returns the subscription configuration.
-   *
-   * @param name  Required. The name of the subscription whose configuration to
-   * return.
-   * @return
-   * @googleapis_link{google::cloud::pubsublite::v1::Subscription,google/cloud/pubsublite/v1/common.proto#L186}
-   */
+  ///
+  /// Returns the subscription configuration.
+  ///
+  /// @param name  Required. The name of the subscription whose configuration to
+  /// return.
+  /// @return
+  /// @googleapis_link{google::cloud::pubsublite::v1::Subscription,google/cloud/pubsublite/v1/common.proto#L186}
+  ///
   StatusOr<google::cloud::pubsublite::v1::Subscription> GetSubscription(
       std::string const& name);
 
-  /**
-   * Returns the list of subscriptions for the given project.
-   *
-   * @param parent  Required. The parent whose subscriptions are to be listed.
-   *  Structured like `projects/{project_number}/locations/{location}`.
-   * @return
-   * @googleapis_link{google::cloud::pubsublite::v1::Subscription,google/cloud/pubsublite/v1/common.proto#L186}
-   */
+  ///
+  /// Returns the list of subscriptions for the given project.
+  ///
+  /// @param parent  Required. The parent whose subscriptions are to be listed.
+  ///  Structured like `projects/{project_number}/locations/{location}`.
+  /// @return
+  /// @googleapis_link{google::cloud::pubsublite::v1::Subscription,google/cloud/pubsublite/v1/common.proto#L186}
+  ///
   StreamRange<google::cloud::pubsublite::v1::Subscription> ListSubscriptions(
       std::string const& parent);
 
-  /**
-   * Updates properties of the specified subscription.
-   *
-   * @param subscription  Required. The subscription to update. Its `name` field
-   * must be populated. Topic field must not be populated.
-   * @param update_mask  Required. A mask specifying the subscription fields to
-   * change.
-   * @return
-   * @googleapis_link{google::cloud::pubsublite::v1::Subscription,google/cloud/pubsublite/v1/common.proto#L186}
-   */
+  ///
+  /// Updates properties of the specified subscription.
+  ///
+  /// @param subscription  Required. The subscription to update. Its `name`
+  /// field must be populated.
+  ///  Topic field must not be populated.
+  /// @param update_mask  Required. A mask specifying the subscription fields to
+  /// change.
+  /// @return
+  /// @googleapis_link{google::cloud::pubsublite::v1::Subscription,google/cloud/pubsublite/v1/common.proto#L186}
+  ///
   StatusOr<google::cloud::pubsublite::v1::Subscription> UpdateSubscription(
       google::cloud::pubsublite::v1::Subscription const& subscription,
       google::protobuf::FieldMask const& update_mask);
 
-  /**
-   * Deletes the specified subscription.
-   *
-   * @param name  Required. The name of the subscription to delete.
-   */
+  ///
+  /// Deletes the specified subscription.
+  ///
+  /// @param name  Required. The name of the subscription to delete.
+  ///
   Status DeleteSubscription(std::string const& name);
 
-  /**
-   * Creates a new reservation.
-   *
-   * @param parent  Required. The parent location in which to create the
-   * reservation. Structured like
-   * `projects/{project_number}/locations/{location}`.
-   * @param reservation  Required. Configuration of the reservation to create.
-   * Its `name` field is ignored.
-   * @param reservation_id  Required. The ID to use for the reservation, which
-   * will become the final component of the reservation's name. This value is
-   * structured like: `my-reservation-name`.
-   * @return
-   * @googleapis_link{google::cloud::pubsublite::v1::Reservation,google/cloud/pubsublite/v1/common.proto#L80}
-   */
+  ///
+  /// Creates a new reservation.
+  ///
+  /// @param parent  Required. The parent location in which to create the
+  /// reservation.
+  ///  Structured like `projects/{project_number}/locations/{location}`.
+  /// @param reservation  Required. Configuration of the reservation to create.
+  /// Its `name` field is ignored.
+  /// @param reservation_id  Required. The ID to use for the reservation, which
+  /// will become the final component of
+  ///  the reservation's name.
+  ///  This value is structured like: `my-reservation-name`.
+  /// @return
+  /// @googleapis_link{google::cloud::pubsublite::v1::Reservation,google/cloud/pubsublite/v1/common.proto#L80}
+  ///
   StatusOr<google::cloud::pubsublite::v1::Reservation> CreateReservation(
       std::string const& parent,
       google::cloud::pubsublite::v1::Reservation const& reservation,
       std::string const& reservation_id);
 
-  /**
-   * Returns the reservation configuration.
-   *
-   * @param name  Required. The name of the reservation whose configuration to
-   * return. Structured like:
-   *  projects/{project_number}/locations/{location}/reservations/{reservation_id}
-   * @return
-   * @googleapis_link{google::cloud::pubsublite::v1::Reservation,google/cloud/pubsublite/v1/common.proto#L80}
-   */
+  ///
+  /// Returns the reservation configuration.
+  ///
+  /// @param name  Required. The name of the reservation whose configuration to
+  /// return.
+  ///  Structured like:
+  ///  projects/{project_number}/locations/{location}/reservations/{reservation_id}
+  /// @return
+  /// @googleapis_link{google::cloud::pubsublite::v1::Reservation,google/cloud/pubsublite/v1/common.proto#L80}
+  ///
   StatusOr<google::cloud::pubsublite::v1::Reservation> GetReservation(
       std::string const& name);
 
-  /**
-   * Returns the list of reservations for the given project.
-   *
-   * @param parent  Required. The parent whose reservations are to be listed.
-   *  Structured like `projects/{project_number}/locations/{location}`.
-   * @return
-   * @googleapis_link{google::cloud::pubsublite::v1::Reservation,google/cloud/pubsublite/v1/common.proto#L80}
-   */
+  ///
+  /// Returns the list of reservations for the given project.
+  ///
+  /// @param parent  Required. The parent whose reservations are to be listed.
+  ///  Structured like `projects/{project_number}/locations/{location}`.
+  /// @return
+  /// @googleapis_link{google::cloud::pubsublite::v1::Reservation,google/cloud/pubsublite/v1/common.proto#L80}
+  ///
   StreamRange<google::cloud::pubsublite::v1::Reservation> ListReservations(
       std::string const& parent);
 
-  /**
-   * Updates properties of the specified reservation.
-   *
-   * @param reservation  Required. The reservation to update. Its `name` field
-   * must be populated.
-   * @param update_mask  Required. A mask specifying the reservation fields to
-   * change.
-   * @return
-   * @googleapis_link{google::cloud::pubsublite::v1::Reservation,google/cloud/pubsublite/v1/common.proto#L80}
-   */
+  ///
+  /// Updates properties of the specified reservation.
+  ///
+  /// @param reservation  Required. The reservation to update. Its `name` field
+  /// must be populated.
+  /// @param update_mask  Required. A mask specifying the reservation fields to
+  /// change.
+  /// @return
+  /// @googleapis_link{google::cloud::pubsublite::v1::Reservation,google/cloud/pubsublite/v1/common.proto#L80}
+  ///
   StatusOr<google::cloud::pubsublite::v1::Reservation> UpdateReservation(
       google::cloud::pubsublite::v1::Reservation const& reservation,
       google::protobuf::FieldMask const& update_mask);
 
-  /**
-   * Deletes the specified reservation.
-   *
-   * @param name  Required. The name of the reservation to delete.
-   *  Structured like:
-   *  projects/{project_number}/locations/{location}/reservations/{reservation_id}
-   */
+  ///
+  /// Deletes the specified reservation.
+  ///
+  /// @param name  Required. The name of the reservation to delete.
+  ///  Structured like:
+  ///  projects/{project_number}/locations/{location}/reservations/{reservation_id}
+  ///
   Status DeleteReservation(std::string const& name);
 
-  /**
-   * Lists the topics attached to the specified reservation.
-   *
-   * @param name  Required. The name of the reservation whose topics to list.
-   *  Structured like:
-   *  projects/{project_number}/locations/{location}/reservations/{reservation_id}
-   * @return std::string
-   */
+  ///
+  /// Lists the topics attached to the specified reservation.
+  ///
+  /// @param name  Required. The name of the reservation whose topics to list.
+  ///  Structured like:
+  ///  projects/{project_number}/locations/{location}/reservations/{reservation_id}
+  /// @return std::string
+  ///
   StreamRange<std::string> ListReservationTopics(std::string const& name);
 
-  /**
-   * Creates a new topic.
-   *
-   * @param request
-   * @googleapis_link{google::cloud::pubsublite::v1::CreateTopicRequest,google/cloud/pubsublite/v1/admin.proto#L227}
-   * @return
-   * @googleapis_link{google::cloud::pubsublite::v1::Topic,google/cloud/pubsublite/v1/common.proto#L102}
-   */
+  ///
+  /// Creates a new topic.
+  ///
+  /// @param request
+  /// @googleapis_link{google::cloud::pubsublite::v1::CreateTopicRequest,google/cloud/pubsublite/v1/admin.proto#L227}
+  /// @return
+  /// @googleapis_link{google::cloud::pubsublite::v1::Topic,google/cloud/pubsublite/v1/common.proto#L102}
+  ///
   StatusOr<google::cloud::pubsublite::v1::Topic> CreateTopic(
       google::cloud::pubsublite::v1::CreateTopicRequest const& request);
 
-  /**
-   * Returns the topic configuration.
-   *
-   * @param request
-   * @googleapis_link{google::cloud::pubsublite::v1::GetTopicRequest,google/cloud/pubsublite/v1/admin.proto#L248}
-   * @return
-   * @googleapis_link{google::cloud::pubsublite::v1::Topic,google/cloud/pubsublite/v1/common.proto#L102}
-   */
+  ///
+  /// Returns the topic configuration.
+  ///
+  /// @param request
+  /// @googleapis_link{google::cloud::pubsublite::v1::GetTopicRequest,google/cloud/pubsublite/v1/admin.proto#L248}
+  /// @return
+  /// @googleapis_link{google::cloud::pubsublite::v1::Topic,google/cloud/pubsublite/v1/common.proto#L102}
+  ///
   StatusOr<google::cloud::pubsublite::v1::Topic> GetTopic(
       google::cloud::pubsublite::v1::GetTopicRequest const& request);
 
-  /**
-   * Returns the partition information for the requested topic.
-   *
-   * @param request
-   * @googleapis_link{google::cloud::pubsublite::v1::GetTopicPartitionsRequest,google/cloud/pubsublite/v1/admin.proto#L259}
-   * @return
-   * @googleapis_link{google::cloud::pubsublite::v1::TopicPartitions,google/cloud/pubsublite/v1/admin.proto#L270}
-   */
+  ///
+  /// Returns the partition information for the requested topic.
+  ///
+  /// @param request
+  /// @googleapis_link{google::cloud::pubsublite::v1::GetTopicPartitionsRequest,google/cloud/pubsublite/v1/admin.proto#L259}
+  /// @return
+  /// @googleapis_link{google::cloud::pubsublite::v1::TopicPartitions,google/cloud/pubsublite/v1/admin.proto#L270}
+  ///
   StatusOr<google::cloud::pubsublite::v1::TopicPartitions> GetTopicPartitions(
       google::cloud::pubsublite::v1::GetTopicPartitionsRequest const& request);
 
-  /**
-   * Returns the list of topics for the given project.
-   *
-   * @param request
-   * @googleapis_link{google::cloud::pubsublite::v1::ListTopicsRequest,google/cloud/pubsublite/v1/admin.proto#L276}
-   * @return
-   * @googleapis_link{google::cloud::pubsublite::v1::Topic,google/cloud/pubsublite/v1/common.proto#L102}
-   */
+  ///
+  /// Returns the list of topics for the given project.
+  ///
+  /// @param request
+  /// @googleapis_link{google::cloud::pubsublite::v1::ListTopicsRequest,google/cloud/pubsublite/v1/admin.proto#L276}
+  /// @return
+  /// @googleapis_link{google::cloud::pubsublite::v1::Topic,google/cloud/pubsublite/v1/common.proto#L102}
+  ///
   StreamRange<google::cloud::pubsublite::v1::Topic> ListTopics(
       google::cloud::pubsublite::v1::ListTopicsRequest request);
 
-  /**
-   * Updates properties of the specified topic.
-   *
-   * @param request
-   * @googleapis_link{google::cloud::pubsublite::v1::UpdateTopicRequest,google/cloud/pubsublite/v1/admin.proto#L311}
-   * @return
-   * @googleapis_link{google::cloud::pubsublite::v1::Topic,google/cloud/pubsublite/v1/common.proto#L102}
-   */
+  ///
+  /// Updates properties of the specified topic.
+  ///
+  /// @param request
+  /// @googleapis_link{google::cloud::pubsublite::v1::UpdateTopicRequest,google/cloud/pubsublite/v1/admin.proto#L311}
+  /// @return
+  /// @googleapis_link{google::cloud::pubsublite::v1::Topic,google/cloud/pubsublite/v1/common.proto#L102}
+  ///
   StatusOr<google::cloud::pubsublite::v1::Topic> UpdateTopic(
       google::cloud::pubsublite::v1::UpdateTopicRequest const& request);
 
-  /**
-   * Deletes the specified topic.
-   *
-   * @param request
-   * @googleapis_link{google::cloud::pubsublite::v1::DeleteTopicRequest,google/cloud/pubsublite/v1/admin.proto#L320}
-   */
+  ///
+  /// Deletes the specified topic.
+  ///
+  /// @param request
+  /// @googleapis_link{google::cloud::pubsublite::v1::DeleteTopicRequest,google/cloud/pubsublite/v1/admin.proto#L320}
+  ///
   Status DeleteTopic(
       google::cloud::pubsublite::v1::DeleteTopicRequest const& request);
 
-  /**
-   * Lists the subscriptions attached to the specified topic.
-   *
-   * @param request
-   * @googleapis_link{google::cloud::pubsublite::v1::ListTopicSubscriptionsRequest,google/cloud/pubsublite/v1/admin.proto#L331}
-   * @return std::string
-   */
+  ///
+  /// Lists the subscriptions attached to the specified topic.
+  ///
+  /// @param request
+  /// @googleapis_link{google::cloud::pubsublite::v1::ListTopicSubscriptionsRequest,google/cloud/pubsublite/v1/admin.proto#L331}
+  /// @return std::string
+  ///
   StreamRange<std::string> ListTopicSubscriptions(
       google::cloud::pubsublite::v1::ListTopicSubscriptionsRequest request);
 
-  /**
-   * Creates a new subscription.
-   *
-   * @param request
-   * @googleapis_link{google::cloud::pubsublite::v1::CreateSubscriptionRequest,google/cloud/pubsublite/v1/admin.proto#L365}
-   * @return
-   * @googleapis_link{google::cloud::pubsublite::v1::Subscription,google/cloud/pubsublite/v1/common.proto#L186}
-   */
+  ///
+  /// Creates a new subscription.
+  ///
+  /// @param request
+  /// @googleapis_link{google::cloud::pubsublite::v1::CreateSubscriptionRequest,google/cloud/pubsublite/v1/admin.proto#L365}
+  /// @return
+  /// @googleapis_link{google::cloud::pubsublite::v1::Subscription,google/cloud/pubsublite/v1/common.proto#L186}
+  ///
   StatusOr<google::cloud::pubsublite::v1::Subscription> CreateSubscription(
       google::cloud::pubsublite::v1::CreateSubscriptionRequest const& request);
 
-  /**
-   * Returns the subscription configuration.
-   *
-   * @param request
-   * @googleapis_link{google::cloud::pubsublite::v1::GetSubscriptionRequest,google/cloud/pubsublite/v1/admin.proto#L391}
-   * @return
-   * @googleapis_link{google::cloud::pubsublite::v1::Subscription,google/cloud/pubsublite/v1/common.proto#L186}
-   */
+  ///
+  /// Returns the subscription configuration.
+  ///
+  /// @param request
+  /// @googleapis_link{google::cloud::pubsublite::v1::GetSubscriptionRequest,google/cloud/pubsublite/v1/admin.proto#L391}
+  /// @return
+  /// @googleapis_link{google::cloud::pubsublite::v1::Subscription,google/cloud/pubsublite/v1/common.proto#L186}
+  ///
   StatusOr<google::cloud::pubsublite::v1::Subscription> GetSubscription(
       google::cloud::pubsublite::v1::GetSubscriptionRequest const& request);
 
-  /**
-   * Returns the list of subscriptions for the given project.
-   *
-   * @param request
-   * @googleapis_link{google::cloud::pubsublite::v1::ListSubscriptionsRequest,google/cloud/pubsublite/v1/admin.proto#L402}
-   * @return
-   * @googleapis_link{google::cloud::pubsublite::v1::Subscription,google/cloud/pubsublite/v1/common.proto#L186}
-   */
+  ///
+  /// Returns the list of subscriptions for the given project.
+  ///
+  /// @param request
+  /// @googleapis_link{google::cloud::pubsublite::v1::ListSubscriptionsRequest,google/cloud/pubsublite/v1/admin.proto#L402}
+  /// @return
+  /// @googleapis_link{google::cloud::pubsublite::v1::Subscription,google/cloud/pubsublite/v1/common.proto#L186}
+  ///
   StreamRange<google::cloud::pubsublite::v1::Subscription> ListSubscriptions(
       google::cloud::pubsublite::v1::ListSubscriptionsRequest request);
 
-  /**
-   * Updates properties of the specified subscription.
-   *
-   * @param request
-   * @googleapis_link{google::cloud::pubsublite::v1::UpdateSubscriptionRequest,google/cloud/pubsublite/v1/admin.proto#L437}
-   * @return
-   * @googleapis_link{google::cloud::pubsublite::v1::Subscription,google/cloud/pubsublite/v1/common.proto#L186}
-   */
+  ///
+  /// Updates properties of the specified subscription.
+  ///
+  /// @param request
+  /// @googleapis_link{google::cloud::pubsublite::v1::UpdateSubscriptionRequest,google/cloud/pubsublite/v1/admin.proto#L437}
+  /// @return
+  /// @googleapis_link{google::cloud::pubsublite::v1::Subscription,google/cloud/pubsublite/v1/common.proto#L186}
+  ///
   StatusOr<google::cloud::pubsublite::v1::Subscription> UpdateSubscription(
       google::cloud::pubsublite::v1::UpdateSubscriptionRequest const& request);
 
-  /**
-   * Deletes the specified subscription.
-   *
-   * @param request
-   * @googleapis_link{google::cloud::pubsublite::v1::DeleteSubscriptionRequest,google/cloud/pubsublite/v1/admin.proto#L447}
-   */
+  ///
+  /// Deletes the specified subscription.
+  ///
+  /// @param request
+  /// @googleapis_link{google::cloud::pubsublite::v1::DeleteSubscriptionRequest,google/cloud/pubsublite/v1/admin.proto#L447}
+  ///
   Status DeleteSubscription(
       google::cloud::pubsublite::v1::DeleteSubscriptionRequest const& request);
 
-  /**
-   * Performs an out-of-band seek for a subscription to a specified target,
-   * which may be timestamps or named positions within the message backlog.
-   * Seek translates these targets to cursors for each partition and
-   * orchestrates subscribers to start consuming messages from these seek
-   * cursors.
-   *
-   * If an operation is returned, the seek has been registered and subscribers
-   * will eventually receive messages from the seek cursors (i.e. eventual
-   * consistency), as long as they are using a minimum supported client library
-   * version and not a system that tracks cursors independently of Pub/Sub Lite
-   * (e.g. Apache Beam, Dataflow, Spark). The seek operation will fail for
-   * unsupported clients.
-   *
-   * If clients would like to know when subscribers react to the seek (or not),
-   * they can poll the operation. The seek operation will succeed and complete
-   * once subscribers are ready to receive messages from the seek cursors for
-   * all partitions of the topic. This means that the seek operation will not
-   * complete until all subscribers come online.
-   *
-   * If the previous seek operation has not yet completed, it will be aborted
-   * and the new invocation of seek will supersede it.
-   *
-   * @param request
-   * @googleapis_link{google::cloud::pubsublite::v1::SeekSubscriptionRequest,google/cloud/pubsublite/v1/admin.proto#L458}
-   * @return
-   * @googleapis_link{google::cloud::pubsublite::v1::SeekSubscriptionResponse,google/cloud/pubsublite/v1/admin.proto#L493}
-   */
+  ///
+  /// Performs an out-of-band seek for a subscription to a specified target,
+  /// which may be timestamps or named positions within the message backlog.
+  /// Seek translates these targets to cursors for each partition and
+  /// orchestrates subscribers to start consuming messages from these seek
+  /// cursors.
+  ///
+  /// If an operation is returned, the seek has been registered and subscribers
+  /// will eventually receive messages from the seek cursors (i.e. eventual
+  /// consistency), as long as they are using a minimum supported client library
+  /// version and not a system that tracks cursors independently of Pub/Sub Lite
+  /// (e.g. Apache Beam, Dataflow, Spark). The seek operation will fail for
+  /// unsupported clients.
+  ///
+  /// If clients would like to know when subscribers react to the seek (or not),
+  /// they can poll the operation. The seek operation will succeed and complete
+  /// once subscribers are ready to receive messages from the seek cursors for
+  /// all partitions of the topic. This means that the seek operation will not
+  /// complete until all subscribers come online.
+  ///
+  /// If the previous seek operation has not yet completed, it will be aborted
+  /// and the new invocation of seek will supersede it.
+  ///
+  /// @param request
+  /// @googleapis_link{google::cloud::pubsublite::v1::SeekSubscriptionRequest,google/cloud/pubsublite/v1/admin.proto#L458}
+  /// @return
+  /// @googleapis_link{google::cloud::pubsublite::v1::SeekSubscriptionResponse,google/cloud/pubsublite/v1/admin.proto#L493}
+  ///
   future<StatusOr<google::cloud::pubsublite::v1::SeekSubscriptionResponse>>
   SeekSubscription(
       google::cloud::pubsublite::v1::SeekSubscriptionRequest const& request);
 
-  /**
-   * Creates a new reservation.
-   *
-   * @param request
-   * @googleapis_link{google::cloud::pubsublite::v1::CreateReservationRequest,google/cloud/pubsublite/v1/admin.proto#L516}
-   * @return
-   * @googleapis_link{google::cloud::pubsublite::v1::Reservation,google/cloud/pubsublite/v1/common.proto#L80}
-   */
+  ///
+  /// Creates a new reservation.
+  ///
+  /// @param request
+  /// @googleapis_link{google::cloud::pubsublite::v1::CreateReservationRequest,google/cloud/pubsublite/v1/admin.proto#L516}
+  /// @return
+  /// @googleapis_link{google::cloud::pubsublite::v1::Reservation,google/cloud/pubsublite/v1/common.proto#L80}
+  ///
   StatusOr<google::cloud::pubsublite::v1::Reservation> CreateReservation(
       google::cloud::pubsublite::v1::CreateReservationRequest const& request);
 
-  /**
-   * Returns the reservation configuration.
-   *
-   * @param request
-   * @googleapis_link{google::cloud::pubsublite::v1::GetReservationRequest,google/cloud/pubsublite/v1/admin.proto#L537}
-   * @return
-   * @googleapis_link{google::cloud::pubsublite::v1::Reservation,google/cloud/pubsublite/v1/common.proto#L80}
-   */
+  ///
+  /// Returns the reservation configuration.
+  ///
+  /// @param request
+  /// @googleapis_link{google::cloud::pubsublite::v1::GetReservationRequest,google/cloud/pubsublite/v1/admin.proto#L537}
+  /// @return
+  /// @googleapis_link{google::cloud::pubsublite::v1::Reservation,google/cloud/pubsublite/v1/common.proto#L80}
+  ///
   StatusOr<google::cloud::pubsublite::v1::Reservation> GetReservation(
       google::cloud::pubsublite::v1::GetReservationRequest const& request);
 
-  /**
-   * Returns the list of reservations for the given project.
-   *
-   * @param request
-   * @googleapis_link{google::cloud::pubsublite::v1::ListReservationsRequest,google/cloud/pubsublite/v1/admin.proto#L550}
-   * @return
-   * @googleapis_link{google::cloud::pubsublite::v1::Reservation,google/cloud/pubsublite/v1/common.proto#L80}
-   */
+  ///
+  /// Returns the list of reservations for the given project.
+  ///
+  /// @param request
+  /// @googleapis_link{google::cloud::pubsublite::v1::ListReservationsRequest,google/cloud/pubsublite/v1/admin.proto#L550}
+  /// @return
+  /// @googleapis_link{google::cloud::pubsublite::v1::Reservation,google/cloud/pubsublite/v1/common.proto#L80}
+  ///
   StreamRange<google::cloud::pubsublite::v1::Reservation> ListReservations(
       google::cloud::pubsublite::v1::ListReservationsRequest request);
 
-  /**
-   * Updates properties of the specified reservation.
-   *
-   * @param request
-   * @googleapis_link{google::cloud::pubsublite::v1::UpdateReservationRequest,google/cloud/pubsublite/v1/admin.proto#L585}
-   * @return
-   * @googleapis_link{google::cloud::pubsublite::v1::Reservation,google/cloud/pubsublite/v1/common.proto#L80}
-   */
+  ///
+  /// Updates properties of the specified reservation.
+  ///
+  /// @param request
+  /// @googleapis_link{google::cloud::pubsublite::v1::UpdateReservationRequest,google/cloud/pubsublite/v1/admin.proto#L585}
+  /// @return
+  /// @googleapis_link{google::cloud::pubsublite::v1::Reservation,google/cloud/pubsublite/v1/common.proto#L80}
+  ///
   StatusOr<google::cloud::pubsublite::v1::Reservation> UpdateReservation(
       google::cloud::pubsublite::v1::UpdateReservationRequest const& request);
 
-  /**
-   * Deletes the specified reservation.
-   *
-   * @param request
-   * @googleapis_link{google::cloud::pubsublite::v1::DeleteReservationRequest,google/cloud/pubsublite/v1/admin.proto#L594}
-   */
+  ///
+  /// Deletes the specified reservation.
+  ///
+  /// @param request
+  /// @googleapis_link{google::cloud::pubsublite::v1::DeleteReservationRequest,google/cloud/pubsublite/v1/admin.proto#L594}
+  ///
   Status DeleteReservation(
       google::cloud::pubsublite::v1::DeleteReservationRequest const& request);
 
-  /**
-   * Lists the topics attached to the specified reservation.
-   *
-   * @param request
-   * @googleapis_link{google::cloud::pubsublite::v1::ListReservationTopicsRequest,google/cloud/pubsublite/v1/admin.proto#L607}
-   * @return std::string
-   */
+  ///
+  /// Lists the topics attached to the specified reservation.
+  ///
+  /// @param request
+  /// @googleapis_link{google::cloud::pubsublite::v1::ListReservationTopicsRequest,google/cloud/pubsublite/v1/admin.proto#L607}
+  /// @return std::string
+  ///
   StreamRange<std::string> ListReservationTopics(
       google::cloud::pubsublite::v1::ListReservationTopicsRequest request);
 

--- a/google/cloud/spanner/admin/database_admin_client.h
+++ b/google/cloud/spanner/admin/database_admin_client.h
@@ -34,14 +34,14 @@ namespace cloud {
 namespace spanner_admin {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-/**
- * Cloud Spanner Database Admin API
- *
- * The Cloud Spanner Database Admin API can be used to create, drop, and
- * list databases. It also enables updating the schema of pre-existing
- * databases. It can be also used to create, delete and list backups for a
- * database and to restore from an existing backup.
- */
+///
+/// Cloud Spanner Database Admin API
+///
+/// The Cloud Spanner Database Admin API can be used to create, drop, and
+/// list databases. It also enables updating the schema of pre-existing
+/// databases. It can be also used to create, delete and list backups for a
+/// database and to restore from an existing backup.
+///
 class DatabaseAdminClient {
  public:
   explicit DatabaseAdminClient(
@@ -68,115 +68,118 @@ class DatabaseAdminClient {
   }
   //@}
 
-  /**
-   * Lists Cloud Spanner databases.
-   *
-   * @param parent  Required. The instance whose databases should be listed.
-   *  Values are of the form `projects/<project>/instances/<instance>`.
-   * @return
-   * @googleapis_link{google::spanner::admin::database::v1::Database,google/spanner/admin/database/v1/spanner_database_admin.proto#L326}
-   */
+  ///
+  /// Lists Cloud Spanner databases.
+  ///
+  /// @param parent  Required. The instance whose databases should be listed.
+  ///  Values are of the form `projects/<project>/instances/<instance>`.
+  /// @return
+  /// @googleapis_link{google::spanner::admin::database::v1::Database,google/spanner/admin/database/v1/spanner_database_admin.proto#L326}
+  ///
   StreamRange<google::spanner::admin::database::v1::Database> ListDatabases(
       std::string const& parent);
 
-  /**
-   * Creates a new Cloud Spanner database and starts to prepare it for serving.
-   * The returned [long-running operation][google.longrunning.Operation] will
-   * have a name of the format `<database_name>/operations/<operation_id>` and
-   * can be used to track preparation of the database. The
-   * [metadata][google.longrunning.Operation.metadata] field type is
-   * [CreateDatabaseMetadata][google.spanner.admin.database.v1.CreateDatabaseMetadata].
-   * The [response][google.longrunning.Operation.response] field type is
-   * [Database][google.spanner.admin.database.v1.Database], if successful.
-   *
-   * @param parent  Required. The name of the instance that will serve the new
-   * database. Values are of the form `projects/<project>/instances/<instance>`.
-   * @param create_statement  Required. A `CREATE DATABASE` statement, which
-   * specifies the ID of the new database.  The database ID must conform to the
-   * regular expression
-   *  `[a-z][a-z0-9_\-]*[a-z0-9]` and be between 2 and 30 characters in length.
-   *  If the database ID is a reserved word or if it contains a hyphen, the
-   *  database ID must be enclosed in backticks (`` ` ``).
-   * @return
-   * @googleapis_link{google::spanner::admin::database::v1::Database,google/spanner/admin/database/v1/spanner_database_admin.proto#L326}
-   */
+  ///
+  /// Creates a new Cloud Spanner database and starts to prepare it for serving.
+  /// The returned [long-running operation][google.longrunning.Operation] will
+  /// have a name of the format `<database_name>/operations/<operation_id>` and
+  /// can be used to track preparation of the database. The
+  /// [metadata][google.longrunning.Operation.metadata] field type is
+  /// [CreateDatabaseMetadata][google.spanner.admin.database.v1.CreateDatabaseMetadata].
+  /// The [response][google.longrunning.Operation.response] field type is
+  /// [Database][google.spanner.admin.database.v1.Database], if successful.
+  ///
+  /// @param parent  Required. The name of the instance that will serve the new
+  /// database.
+  ///  Values are of the form `projects/<project>/instances/<instance>`.
+  /// @param create_statement  Required. A `CREATE DATABASE` statement, which
+  /// specifies the ID of the
+  ///  new database.  The database ID must conform to the regular expression
+  ///  `[a-z][a-z0-9_\-]*[a-z0-9]` and be between 2 and 30 characters in length.
+  ///  If the database ID is a reserved word or if it contains a hyphen, the
+  ///  database ID must be enclosed in backticks (`` ` ``).
+  /// @return
+  /// @googleapis_link{google::spanner::admin::database::v1::Database,google/spanner/admin/database/v1/spanner_database_admin.proto#L326}
+  ///
   future<StatusOr<google::spanner::admin::database::v1::Database>>
   CreateDatabase(std::string const& parent,
                  std::string const& create_statement);
 
-  /**
-   * Gets the state of a Cloud Spanner database.
-   *
-   * @param name  Required. The name of the requested database. Values are of
-   * the form `projects/<project>/instances/<instance>/databases/<database>`.
-   * @return
-   * @googleapis_link{google::spanner::admin::database::v1::Database,google/spanner/admin/database/v1/spanner_database_admin.proto#L326}
-   */
+  ///
+  /// Gets the state of a Cloud Spanner database.
+  ///
+  /// @param name  Required. The name of the requested database. Values are of
+  /// the form
+  ///  `projects/<project>/instances/<instance>/databases/<database>`.
+  /// @return
+  /// @googleapis_link{google::spanner::admin::database::v1::Database,google/spanner/admin/database/v1/spanner_database_admin.proto#L326}
+  ///
   StatusOr<google::spanner::admin::database::v1::Database> GetDatabase(
       std::string const& name);
 
-  /**
-   * Updates the schema of a Cloud Spanner database by
-   * creating/altering/dropping tables, columns, indexes, etc. The returned
-   * [long-running operation][google.longrunning.Operation] will have a name of
-   * the format `<database_name>/operations/<operation_id>` and can be used to
-   * track execution of the schema change(s). The
-   * [metadata][google.longrunning.Operation.metadata] field type is
-   * [UpdateDatabaseDdlMetadata][google.spanner.admin.database.v1.UpdateDatabaseDdlMetadata].
-   * The operation has no response.
-   *
-   * @param database  Required. The database to update.
-   * @param statements  Required. DDL statements to be applied to the database.
-   * @return
-   * @googleapis_link{google::spanner::admin::database::v1::UpdateDatabaseDdlMetadata,google/spanner/admin/database/v1/spanner_database_admin.proto#L547}
-   */
+  ///
+  /// Updates the schema of a Cloud Spanner database by
+  /// creating/altering/dropping tables, columns, indexes, etc. The returned
+  /// [long-running operation][google.longrunning.Operation] will have a name of
+  /// the format `<database_name>/operations/<operation_id>` and can be used to
+  /// track execution of the schema change(s). The
+  /// [metadata][google.longrunning.Operation.metadata] field type is
+  /// [UpdateDatabaseDdlMetadata][google.spanner.admin.database.v1.UpdateDatabaseDdlMetadata].
+  /// The operation has no response.
+  ///
+  /// @param database  Required. The database to update.
+  /// @param statements  Required. DDL statements to be applied to the database.
+  /// @return
+  /// @googleapis_link{google::spanner::admin::database::v1::UpdateDatabaseDdlMetadata,google/spanner/admin/database/v1/spanner_database_admin.proto#L547}
+  ///
   future<
       StatusOr<google::spanner::admin::database::v1::UpdateDatabaseDdlMetadata>>
   UpdateDatabaseDdl(std::string const& database,
                     std::vector<std::string> const& statements);
 
-  /**
-   * Drops (aka deletes) a Cloud Spanner database.
-   * Completed backups for the database will be retained according to their
-   * `expire_time`.
-   *
-   * @param database  Required. The database to be dropped.
-   */
+  ///
+  /// Drops (aka deletes) a Cloud Spanner database.
+  /// Completed backups for the database will be retained according to their
+  /// `expire_time`.
+  ///
+  /// @param database  Required. The database to be dropped.
+  ///
   Status DropDatabase(std::string const& database);
 
-  /**
-   * Returns the schema of a Cloud Spanner database as a list of formatted
-   * DDL statements. This method does not show pending schema updates, those may
-   * be queried using the [Operations][google.longrunning.Operations] API.
-   *
-   * @param database  Required. The database whose schema we wish to get.
-   *  Values are of the form
-   *  `projects/<project>/instances/<instance>/databases/<database>`
-   * @return
-   * @googleapis_link{google::spanner::admin::database::v1::GetDatabaseDdlResponse,google/spanner/admin/database/v1/spanner_database_admin.proto#L603}
-   */
+  ///
+  /// Returns the schema of a Cloud Spanner database as a list of formatted
+  /// DDL statements. This method does not show pending schema updates, those
+  /// may be queried using the [Operations][google.longrunning.Operations] API.
+  ///
+  /// @param database  Required. The database whose schema we wish to get.
+  ///  Values are of the form
+  ///  `projects/<project>/instances/<instance>/databases/<database>`
+  /// @return
+  /// @googleapis_link{google::spanner::admin::database::v1::GetDatabaseDdlResponse,google/spanner/admin/database/v1/spanner_database_admin.proto#L603}
+  ///
   StatusOr<google::spanner::admin::database::v1::GetDatabaseDdlResponse>
   GetDatabaseDdl(std::string const& database);
 
-  /**
-   * Sets the access control policy on a database or backup resource.
-   * Replaces any existing policy.
-   *
-   * Authorization requires `spanner.databases.setIamPolicy`
-   * permission on [resource][google.iam.v1.SetIamPolicyRequest.resource].
-   * For backups, authorization requires `spanner.backups.setIamPolicy`
-   * permission on [resource][google.iam.v1.SetIamPolicyRequest.resource].
-   *
-   * @param resource  REQUIRED: The resource for which the policy is being
-   * specified. See the operation documentation for the appropriate value for
-   * this field.
-   * @param policy  REQUIRED: The complete policy to be applied to the
-   * `resource`. The size of the policy is limited to a few 10s of KB. An empty
-   * policy is a valid policy but certain Cloud Platform services (such as
-   * Projects) might reject them.
-   * @return
-   * @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
-   */
+  ///
+  /// Sets the access control policy on a database or backup resource.
+  /// Replaces any existing policy.
+  ///
+  /// Authorization requires `spanner.databases.setIamPolicy`
+  /// permission on [resource][google.iam.v1.SetIamPolicyRequest.resource].
+  /// For backups, authorization requires `spanner.backups.setIamPolicy`
+  /// permission on [resource][google.iam.v1.SetIamPolicyRequest.resource].
+  ///
+  /// @param resource  REQUIRED: The resource for which the policy is being
+  /// specified.
+  ///  See the operation documentation for the appropriate value for this field.
+  /// @param policy  REQUIRED: The complete policy to be applied to the
+  /// `resource`. The size of
+  ///  the policy is limited to a few 10s of KB. An empty policy is a
+  ///  valid policy but certain Cloud Platform services (such as Projects)
+  ///  might reject them.
+  /// @return
+  /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
+  ///
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
       std::string const& resource, google::iam::v1::Policy const& policy);
 
@@ -205,490 +208,499 @@ class DatabaseAdminClient {
                                                  IamUpdater const& updater,
                                                  Options options = {});
 
-  /**
-   * Gets the access control policy for a database or backup resource.
-   * Returns an empty policy if a database or backup exists but does not have a
-   * policy set.
-   *
-   * Authorization requires `spanner.databases.getIamPolicy` permission on
-   * [resource][google.iam.v1.GetIamPolicyRequest.resource].
-   * For backups, authorization requires `spanner.backups.getIamPolicy`
-   * permission on [resource][google.iam.v1.GetIamPolicyRequest.resource].
-   *
-   * @param resource  REQUIRED: The resource for which the policy is being
-   * requested. See the operation documentation for the appropriate value for
-   * this field.
-   * @return
-   * @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
-   */
+  ///
+  /// Gets the access control policy for a database or backup resource.
+  /// Returns an empty policy if a database or backup exists but does not have a
+  /// policy set.
+  ///
+  /// Authorization requires `spanner.databases.getIamPolicy` permission on
+  /// [resource][google.iam.v1.GetIamPolicyRequest.resource].
+  /// For backups, authorization requires `spanner.backups.getIamPolicy`
+  /// permission on [resource][google.iam.v1.GetIamPolicyRequest.resource].
+  ///
+  /// @param resource  REQUIRED: The resource for which the policy is being
+  /// requested.
+  ///  See the operation documentation for the appropriate value for this field.
+  /// @return
+  /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
+  ///
   StatusOr<google::iam::v1::Policy> GetIamPolicy(std::string const& resource);
 
-  /**
-   * Returns permissions that the caller has on the specified database or backup
-   * resource.
-   *
-   * Attempting this RPC on a non-existent Cloud Spanner database will
-   * result in a NOT_FOUND error if the user has
-   * `spanner.databases.list` permission on the containing Cloud
-   * Spanner instance. Otherwise returns an empty set of permissions.
-   * Calling this method on a backup that does not exist will
-   * result in a NOT_FOUND error if the user has
-   * `spanner.backups.list` permission on the containing instance.
-   *
-   * @param resource  REQUIRED: The resource for which the policy detail is
-   * being requested. See the operation documentation for the appropriate value
-   * for this field.
-   * @param permissions  The set of permissions to check for the `resource`.
-   * Permissions with wildcards (such as '*' or 'storage.*') are not allowed.
-   * For more information see [IAM
-   * Overview](https://cloud.google.com/iam/docs/overview#permissions).
-   * @return
-   * @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
-   */
+  ///
+  /// Returns permissions that the caller has on the specified database or
+  /// backup resource.
+  ///
+  /// Attempting this RPC on a non-existent Cloud Spanner database will
+  /// result in a NOT_FOUND error if the user has
+  /// `spanner.databases.list` permission on the containing Cloud
+  /// Spanner instance. Otherwise returns an empty set of permissions.
+  /// Calling this method on a backup that does not exist will
+  /// result in a NOT_FOUND error if the user has
+  /// `spanner.backups.list` permission on the containing instance.
+  ///
+  /// @param resource  REQUIRED: The resource for which the policy detail is
+  /// being requested.
+  ///  See the operation documentation for the appropriate value for this field.
+  /// @param permissions  The set of permissions to check for the `resource`.
+  /// Permissions with
+  ///  wildcards (such as '*' or 'storage.*') are not allowed. For more
+  ///  information see
+  ///  [IAM Overview](https://cloud.google.com/iam/docs/overview#permissions).
+  /// @return
+  /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
+  ///
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
       std::string const& resource, std::vector<std::string> const& permissions);
 
-  /**
-   * Starts creating a new Cloud Spanner Backup.
-   * The returned backup [long-running operation][google.longrunning.Operation]
-   * will have a name of the format
-   * `projects/<project>/instances/<instance>/backups/<backup>/operations/<operation_id>`
-   * and can be used to track creation of the backup. The
-   * [metadata][google.longrunning.Operation.metadata] field type is
-   * [CreateBackupMetadata][google.spanner.admin.database.v1.CreateBackupMetadata].
-   * The [response][google.longrunning.Operation.response] field type is
-   * [Backup][google.spanner.admin.database.v1.Backup], if successful.
-   * Cancelling the returned operation will stop the creation and delete the
-   * backup. There can be only one pending backup creation per database. Backup
-   * creation of different databases can run concurrently.
-   *
-   * @param parent  Required. The name of the instance in which the backup will
-   * be created. This must be the same instance that contains the database the
-   *  backup will be created from. The backup will be stored in the
-   *  location(s) specified in the instance configuration of this
-   *  instance. Values are of the form
-   *  `projects/<project>/instances/<instance>`.
-   * @param backup  Required. The backup to create.
-   * @param backup_id  Required. The id of the backup to be created. The
-   * `backup_id` appended to `parent` forms the full backup name of the form
-   *  `projects/<project>/instances/<instance>/backups/<backup_id>`.
-   * @return
-   * @googleapis_link{google::spanner::admin::database::v1::Backup,google/spanner/admin/database/v1/backup.proto#L36}
-   */
+  ///
+  /// Starts creating a new Cloud Spanner Backup.
+  /// The returned backup [long-running operation][google.longrunning.Operation]
+  /// will have a name of the format
+  /// `projects/<project>/instances/<instance>/backups/<backup>/operations/<operation_id>`
+  /// and can be used to track creation of the backup. The
+  /// [metadata][google.longrunning.Operation.metadata] field type is
+  /// [CreateBackupMetadata][google.spanner.admin.database.v1.CreateBackupMetadata].
+  /// The [response][google.longrunning.Operation.response] field type is
+  /// [Backup][google.spanner.admin.database.v1.Backup], if successful.
+  /// Cancelling the returned operation will stop the creation and delete the
+  /// backup. There can be only one pending backup creation per database. Backup
+  /// creation of different databases can run concurrently.
+  ///
+  /// @param parent  Required. The name of the instance in which the backup will
+  /// be
+  ///  created. This must be the same instance that contains the database the
+  ///  backup will be created from. The backup will be stored in the
+  ///  location(s) specified in the instance configuration of this
+  ///  instance. Values are of the form
+  ///  `projects/<project>/instances/<instance>`.
+  /// @param backup  Required. The backup to create.
+  /// @param backup_id  Required. The id of the backup to be created. The
+  /// `backup_id` appended to
+  ///  `parent` forms the full backup name of the form
+  ///  `projects/<project>/instances/<instance>/backups/<backup_id>`.
+  /// @return
+  /// @googleapis_link{google::spanner::admin::database::v1::Backup,google/spanner/admin/database/v1/backup.proto#L36}
+  ///
   future<StatusOr<google::spanner::admin::database::v1::Backup>> CreateBackup(
       std::string const& parent,
       google::spanner::admin::database::v1::Backup const& backup,
       std::string const& backup_id);
 
-  /**
-   * Gets metadata on a pending or completed
-   * [Backup][google.spanner.admin.database.v1.Backup].
-   *
-   * @param name  Required. Name of the backup.
-   *  Values are of the form
-   *  `projects/<project>/instances/<instance>/backups/<backup>`.
-   * @return
-   * @googleapis_link{google::spanner::admin::database::v1::Backup,google/spanner/admin/database/v1/backup.proto#L36}
-   */
+  ///
+  /// Gets metadata on a pending or completed
+  /// [Backup][google.spanner.admin.database.v1.Backup].
+  ///
+  /// @param name  Required. Name of the backup.
+  ///  Values are of the form
+  ///  `projects/<project>/instances/<instance>/backups/<backup>`.
+  /// @return
+  /// @googleapis_link{google::spanner::admin::database::v1::Backup,google/spanner/admin/database/v1/backup.proto#L36}
+  ///
   StatusOr<google::spanner::admin::database::v1::Backup> GetBackup(
       std::string const& name);
 
-  /**
-   * Updates a pending or completed
-   * [Backup][google.spanner.admin.database.v1.Backup].
-   *
-   * @param backup  Required. The backup to update. `backup.name`, and the
-   * fields to be updated as specified by `update_mask` are required. Other
-   * fields are ignored. Update is only supported for the following fields:
-   *   * `backup.expire_time`.
-   * @param update_mask  Required. A mask specifying which fields (e.g.
-   * `expire_time`) in the Backup resource should be updated. This mask is
-   * relative to the Backup resource, not to the request message. The field mask
-   * must always be specified; this prevents any future fields from being erased
-   * accidentally by clients that do not know about them.
-   * @return
-   * @googleapis_link{google::spanner::admin::database::v1::Backup,google/spanner/admin/database/v1/backup.proto#L36}
-   */
+  ///
+  /// Updates a pending or completed
+  /// [Backup][google.spanner.admin.database.v1.Backup].
+  ///
+  /// @param backup  Required. The backup to update. `backup.name`, and the
+  /// fields to be updated
+  ///  as specified by `update_mask` are required. Other fields are ignored.
+  ///  Update is only supported for the following fields:
+  ///   * `backup.expire_time`.
+  /// @param update_mask  Required. A mask specifying which fields (e.g.
+  /// `expire_time`) in the
+  ///  Backup resource should be updated. This mask is relative to the Backup
+  ///  resource, not to the request message. The field mask must always be
+  ///  specified; this prevents any future fields from being erased accidentally
+  ///  by clients that do not know about them.
+  /// @return
+  /// @googleapis_link{google::spanner::admin::database::v1::Backup,google/spanner/admin/database/v1/backup.proto#L36}
+  ///
   StatusOr<google::spanner::admin::database::v1::Backup> UpdateBackup(
       google::spanner::admin::database::v1::Backup const& backup,
       google::protobuf::FieldMask const& update_mask);
 
-  /**
-   * Deletes a pending or completed
-   * [Backup][google.spanner.admin.database.v1.Backup].
-   *
-   * @param name  Required. Name of the backup to delete.
-   *  Values are of the form
-   *  `projects/<project>/instances/<instance>/backups/<backup>`.
-   */
+  ///
+  /// Deletes a pending or completed
+  /// [Backup][google.spanner.admin.database.v1.Backup].
+  ///
+  /// @param name  Required. Name of the backup to delete.
+  ///  Values are of the form
+  ///  `projects/<project>/instances/<instance>/backups/<backup>`.
+  ///
   Status DeleteBackup(std::string const& name);
 
-  /**
-   * Lists completed and pending backups.
-   * Backups returned are ordered by `create_time` in descending order,
-   * starting from the most recent `create_time`.
-   *
-   * @param parent  Required. The instance to list backups from.  Values are of
-   * the form `projects/<project>/instances/<instance>`.
-   * @return
-   * @googleapis_link{google::spanner::admin::database::v1::Backup,google/spanner/admin/database/v1/backup.proto#L36}
-   */
+  ///
+  /// Lists completed and pending backups.
+  /// Backups returned are ordered by `create_time` in descending order,
+  /// starting from the most recent `create_time`.
+  ///
+  /// @param parent  Required. The instance to list backups from.  Values are of
+  /// the
+  ///  form `projects/<project>/instances/<instance>`.
+  /// @return
+  /// @googleapis_link{google::spanner::admin::database::v1::Backup,google/spanner/admin/database/v1/backup.proto#L36}
+  ///
   StreamRange<google::spanner::admin::database::v1::Backup> ListBackups(
       std::string const& parent);
 
-  /**
-   * Create a new database by restoring from a completed backup. The new
-   * database must be in the same project and in an instance with the same
-   * instance configuration as the instance containing
-   * the backup. The returned database [long-running
-   * operation][google.longrunning.Operation] has a name of the format
-   * `projects/<project>/instances/<instance>/databases/<database>/operations/<operation_id>`,
-   * and can be used to track the progress of the operation, and to cancel it.
-   * The [metadata][google.longrunning.Operation.metadata] field type is
-   * [RestoreDatabaseMetadata][google.spanner.admin.database.v1.RestoreDatabaseMetadata].
-   * The [response][google.longrunning.Operation.response] type
-   * is [Database][google.spanner.admin.database.v1.Database], if
-   * successful. Cancelling the returned operation will stop the restore and
-   * delete the database.
-   * There can be only one database being restored into an instance at a time.
-   * Once the restore operation completes, a new restore operation can be
-   * initiated, without waiting for the optimize operation associated with the
-   * first restore to complete.
-   *
-   * @param parent  Required. The name of the instance in which to create the
-   *  restored database. This instance must be in the same project and
-   *  have the same instance configuration as the instance containing
-   *  the source backup. Values are of the form
-   *  `projects/<project>/instances/<instance>`.
-   * @param database_id  Required. The id of the database to create and restore
-   * to. This database must not already exist. The `database_id` appended to
-   *  `parent` forms the full database name of the form
-   *  `projects/<project>/instances/<instance>/databases/<database_id>`.
-   * @param backup  Name of the backup from which to restore.  Values are of the
-   * form `projects/<project>/instances/<instance>/backups/<backup>`.
-   * @return
-   * @googleapis_link{google::spanner::admin::database::v1::Database,google/spanner/admin/database/v1/spanner_database_admin.proto#L326}
-   */
+  ///
+  /// Create a new database by restoring from a completed backup. The new
+  /// database must be in the same project and in an instance with the same
+  /// instance configuration as the instance containing
+  /// the backup. The returned database [long-running
+  /// operation][google.longrunning.Operation] has a name of the format
+  /// `projects/<project>/instances/<instance>/databases/<database>/operations/<operation_id>`,
+  /// and can be used to track the progress of the operation, and to cancel it.
+  /// The [metadata][google.longrunning.Operation.metadata] field type is
+  /// [RestoreDatabaseMetadata][google.spanner.admin.database.v1.RestoreDatabaseMetadata].
+  /// The [response][google.longrunning.Operation.response] type
+  /// is [Database][google.spanner.admin.database.v1.Database], if
+  /// successful. Cancelling the returned operation will stop the restore and
+  /// delete the database.
+  /// There can be only one database being restored into an instance at a time.
+  /// Once the restore operation completes, a new restore operation can be
+  /// initiated, without waiting for the optimize operation associated with the
+  /// first restore to complete.
+  ///
+  /// @param parent  Required. The name of the instance in which to create the
+  ///  restored database. This instance must be in the same project and
+  ///  have the same instance configuration as the instance containing
+  ///  the source backup. Values are of the form
+  ///  `projects/<project>/instances/<instance>`.
+  /// @param database_id  Required. The id of the database to create and restore
+  /// to. This
+  ///  database must not already exist. The `database_id` appended to
+  ///  `parent` forms the full database name of the form
+  ///  `projects/<project>/instances/<instance>/databases/<database_id>`.
+  /// @param backup  Name of the backup from which to restore.  Values are of
+  /// the form
+  ///  `projects/<project>/instances/<instance>/backups/<backup>`.
+  /// @return
+  /// @googleapis_link{google::spanner::admin::database::v1::Database,google/spanner/admin/database/v1/spanner_database_admin.proto#L326}
+  ///
   future<StatusOr<google::spanner::admin::database::v1::Database>>
   RestoreDatabase(std::string const& parent, std::string const& database_id,
                   std::string const& backup);
 
-  /**
-   * Lists database [longrunning-operations][google.longrunning.Operation].
-   * A database operation has a name of the form
-   * `projects/<project>/instances/<instance>/databases/<database>/operations/<operation>`.
-   * The long-running operation
-   * [metadata][google.longrunning.Operation.metadata] field type
-   * `metadata.type_url` describes the type of the metadata. Operations returned
-   * include those that have completed/failed/canceled within the last 7 days,
-   * and pending operations.
-   *
-   * @param parent  Required. The instance of the database operations.
-   *  Values are of the form `projects/<project>/instances/<instance>`.
-   * @return
-   * @googleapis_link{google::longrunning::Operation,google/longrunning/operations.proto#L128}
-   */
+  ///
+  /// Lists database [longrunning-operations][google.longrunning.Operation].
+  /// A database operation has a name of the form
+  /// `projects/<project>/instances/<instance>/databases/<database>/operations/<operation>`.
+  /// The long-running operation
+  /// [metadata][google.longrunning.Operation.metadata] field type
+  /// `metadata.type_url` describes the type of the metadata. Operations
+  /// returned include those that have completed/failed/canceled within the last
+  /// 7 days, and pending operations.
+  ///
+  /// @param parent  Required. The instance of the database operations.
+  ///  Values are of the form `projects/<project>/instances/<instance>`.
+  /// @return
+  /// @googleapis_link{google::longrunning::Operation,google/longrunning/operations.proto#L128}
+  ///
   StreamRange<google::longrunning::Operation> ListDatabaseOperations(
       std::string const& parent);
 
-  /**
-   * Lists the backup [long-running operations][google.longrunning.Operation] in
-   * the given instance. A backup operation has a name of the form
-   * `projects/<project>/instances/<instance>/backups/<backup>/operations/<operation>`.
-   * The long-running operation
-   * [metadata][google.longrunning.Operation.metadata] field type
-   * `metadata.type_url` describes the type of the metadata. Operations returned
-   * include those that have completed/failed/canceled within the last 7 days,
-   * and pending operations. Operations returned are ordered by
-   * `operation.metadata.value.progress.start_time` in descending order starting
-   * from the most recently started operation.
-   *
-   * @param parent  Required. The instance of the backup operations. Values are
-   * of the form `projects/<project>/instances/<instance>`.
-   * @return
-   * @googleapis_link{google::longrunning::Operation,google/longrunning/operations.proto#L128}
-   */
+  ///
+  /// Lists the backup [long-running operations][google.longrunning.Operation]
+  /// in the given instance. A backup operation has a name of the form
+  /// `projects/<project>/instances/<instance>/backups/<backup>/operations/<operation>`.
+  /// The long-running operation
+  /// [metadata][google.longrunning.Operation.metadata] field type
+  /// `metadata.type_url` describes the type of the metadata. Operations
+  /// returned include those that have completed/failed/canceled within the last
+  /// 7 days, and pending operations. Operations returned are ordered by
+  /// `operation.metadata.value.progress.start_time` in descending order
+  /// starting from the most recently started operation.
+  ///
+  /// @param parent  Required. The instance of the backup operations. Values are
+  /// of
+  ///  the form `projects/<project>/instances/<instance>`.
+  /// @return
+  /// @googleapis_link{google::longrunning::Operation,google/longrunning/operations.proto#L128}
+  ///
   StreamRange<google::longrunning::Operation> ListBackupOperations(
       std::string const& parent);
 
-  /**
-   * Lists Cloud Spanner databases.
-   *
-   * @param request
-   * @googleapis_link{google::spanner::admin::database::v1::ListDatabasesRequest,google/spanner/admin/database/v1/spanner_database_admin.proto#L413}
-   * @return
-   * @googleapis_link{google::spanner::admin::database::v1::Database,google/spanner/admin/database/v1/spanner_database_admin.proto#L326}
-   */
+  ///
+  /// Lists Cloud Spanner databases.
+  ///
+  /// @param request
+  /// @googleapis_link{google::spanner::admin::database::v1::ListDatabasesRequest,google/spanner/admin/database/v1/spanner_database_admin.proto#L413}
+  /// @return
+  /// @googleapis_link{google::spanner::admin::database::v1::Database,google/spanner/admin/database/v1/spanner_database_admin.proto#L326}
+  ///
   StreamRange<google::spanner::admin::database::v1::Database> ListDatabases(
       google::spanner::admin::database::v1::ListDatabasesRequest request);
 
-  /**
-   * Creates a new Cloud Spanner database and starts to prepare it for serving.
-   * The returned [long-running operation][google.longrunning.Operation] will
-   * have a name of the format `<database_name>/operations/<operation_id>` and
-   * can be used to track preparation of the database. The
-   * [metadata][google.longrunning.Operation.metadata] field type is
-   * [CreateDatabaseMetadata][google.spanner.admin.database.v1.CreateDatabaseMetadata].
-   * The [response][google.longrunning.Operation.response] field type is
-   * [Database][google.spanner.admin.database.v1.Database], if successful.
-   *
-   * @param request
-   * @googleapis_link{google::spanner::admin::database::v1::CreateDatabaseRequest,google/spanner/admin/database/v1/spanner_database_admin.proto#L445}
-   * @return
-   * @googleapis_link{google::spanner::admin::database::v1::Database,google/spanner/admin/database/v1/spanner_database_admin.proto#L326}
-   */
+  ///
+  /// Creates a new Cloud Spanner database and starts to prepare it for serving.
+  /// The returned [long-running operation][google.longrunning.Operation] will
+  /// have a name of the format `<database_name>/operations/<operation_id>` and
+  /// can be used to track preparation of the database. The
+  /// [metadata][google.longrunning.Operation.metadata] field type is
+  /// [CreateDatabaseMetadata][google.spanner.admin.database.v1.CreateDatabaseMetadata].
+  /// The [response][google.longrunning.Operation.response] field type is
+  /// [Database][google.spanner.admin.database.v1.Database], if successful.
+  ///
+  /// @param request
+  /// @googleapis_link{google::spanner::admin::database::v1::CreateDatabaseRequest,google/spanner/admin/database/v1/spanner_database_admin.proto#L445}
+  /// @return
+  /// @googleapis_link{google::spanner::admin::database::v1::Database,google/spanner/admin/database/v1/spanner_database_admin.proto#L326}
+  ///
   future<StatusOr<google::spanner::admin::database::v1::Database>>
   CreateDatabase(
       google::spanner::admin::database::v1::CreateDatabaseRequest const&
           request);
 
-  /**
-   * Gets the state of a Cloud Spanner database.
-   *
-   * @param request
-   * @googleapis_link{google::spanner::admin::database::v1::GetDatabaseRequest,google/spanner/admin/database/v1/spanner_database_admin.proto#L484}
-   * @return
-   * @googleapis_link{google::spanner::admin::database::v1::Database,google/spanner/admin/database/v1/spanner_database_admin.proto#L326}
-   */
+  ///
+  /// Gets the state of a Cloud Spanner database.
+  ///
+  /// @param request
+  /// @googleapis_link{google::spanner::admin::database::v1::GetDatabaseRequest,google/spanner/admin/database/v1/spanner_database_admin.proto#L484}
+  /// @return
+  /// @googleapis_link{google::spanner::admin::database::v1::Database,google/spanner/admin/database/v1/spanner_database_admin.proto#L326}
+  ///
   StatusOr<google::spanner::admin::database::v1::Database> GetDatabase(
       google::spanner::admin::database::v1::GetDatabaseRequest const& request);
 
-  /**
-   * Updates the schema of a Cloud Spanner database by
-   * creating/altering/dropping tables, columns, indexes, etc. The returned
-   * [long-running operation][google.longrunning.Operation] will have a name of
-   * the format `<database_name>/operations/<operation_id>` and can be used to
-   * track execution of the schema change(s). The
-   * [metadata][google.longrunning.Operation.metadata] field type is
-   * [UpdateDatabaseDdlMetadata][google.spanner.admin.database.v1.UpdateDatabaseDdlMetadata].
-   * The operation has no response.
-   *
-   * @param request
-   * @googleapis_link{google::spanner::admin::database::v1::UpdateDatabaseDdlRequest,google/spanner/admin/database/v1/spanner_database_admin.proto#L511}
-   * @return
-   * @googleapis_link{google::spanner::admin::database::v1::UpdateDatabaseDdlMetadata,google/spanner/admin/database/v1/spanner_database_admin.proto#L547}
-   */
+  ///
+  /// Updates the schema of a Cloud Spanner database by
+  /// creating/altering/dropping tables, columns, indexes, etc. The returned
+  /// [long-running operation][google.longrunning.Operation] will have a name of
+  /// the format `<database_name>/operations/<operation_id>` and can be used to
+  /// track execution of the schema change(s). The
+  /// [metadata][google.longrunning.Operation.metadata] field type is
+  /// [UpdateDatabaseDdlMetadata][google.spanner.admin.database.v1.UpdateDatabaseDdlMetadata].
+  /// The operation has no response.
+  ///
+  /// @param request
+  /// @googleapis_link{google::spanner::admin::database::v1::UpdateDatabaseDdlRequest,google/spanner/admin/database/v1/spanner_database_admin.proto#L511}
+  /// @return
+  /// @googleapis_link{google::spanner::admin::database::v1::UpdateDatabaseDdlMetadata,google/spanner/admin/database/v1/spanner_database_admin.proto#L547}
+  ///
   future<
       StatusOr<google::spanner::admin::database::v1::UpdateDatabaseDdlMetadata>>
   UpdateDatabaseDdl(
       google::spanner::admin::database::v1::UpdateDatabaseDdlRequest const&
           request);
 
-  /**
-   * Drops (aka deletes) a Cloud Spanner database.
-   * Completed backups for the database will be retained according to their
-   * `expire_time`.
-   *
-   * @param request
-   * @googleapis_link{google::spanner::admin::database::v1::DropDatabaseRequest,google/spanner/admin/database/v1/spanner_database_admin.proto#L579}
-   */
+  ///
+  /// Drops (aka deletes) a Cloud Spanner database.
+  /// Completed backups for the database will be retained according to their
+  /// `expire_time`.
+  ///
+  /// @param request
+  /// @googleapis_link{google::spanner::admin::database::v1::DropDatabaseRequest,google/spanner/admin/database/v1/spanner_database_admin.proto#L579}
+  ///
   Status DropDatabase(
       google::spanner::admin::database::v1::DropDatabaseRequest const& request);
 
-  /**
-   * Returns the schema of a Cloud Spanner database as a list of formatted
-   * DDL statements. This method does not show pending schema updates, those may
-   * be queried using the [Operations][google.longrunning.Operations] API.
-   *
-   * @param request
-   * @googleapis_link{google::spanner::admin::database::v1::GetDatabaseDdlRequest,google/spanner/admin/database/v1/spanner_database_admin.proto#L590}
-   * @return
-   * @googleapis_link{google::spanner::admin::database::v1::GetDatabaseDdlResponse,google/spanner/admin/database/v1/spanner_database_admin.proto#L603}
-   */
+  ///
+  /// Returns the schema of a Cloud Spanner database as a list of formatted
+  /// DDL statements. This method does not show pending schema updates, those
+  /// may be queried using the [Operations][google.longrunning.Operations] API.
+  ///
+  /// @param request
+  /// @googleapis_link{google::spanner::admin::database::v1::GetDatabaseDdlRequest,google/spanner/admin/database/v1/spanner_database_admin.proto#L590}
+  /// @return
+  /// @googleapis_link{google::spanner::admin::database::v1::GetDatabaseDdlResponse,google/spanner/admin/database/v1/spanner_database_admin.proto#L603}
+  ///
   StatusOr<google::spanner::admin::database::v1::GetDatabaseDdlResponse>
   GetDatabaseDdl(
       google::spanner::admin::database::v1::GetDatabaseDdlRequest const&
           request);
 
-  /**
-   * Sets the access control policy on a database or backup resource.
-   * Replaces any existing policy.
-   *
-   * Authorization requires `spanner.databases.setIamPolicy`
-   * permission on [resource][google.iam.v1.SetIamPolicyRequest.resource].
-   * For backups, authorization requires `spanner.backups.setIamPolicy`
-   * permission on [resource][google.iam.v1.SetIamPolicyRequest.resource].
-   *
-   * @param request
-   * @googleapis_link{google::iam::v1::SetIamPolicyRequest,google/iam/v1/iam_policy.proto#L98}
-   * @return
-   * @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
-   */
+  ///
+  /// Sets the access control policy on a database or backup resource.
+  /// Replaces any existing policy.
+  ///
+  /// Authorization requires `spanner.databases.setIamPolicy`
+  /// permission on [resource][google.iam.v1.SetIamPolicyRequest.resource].
+  /// For backups, authorization requires `spanner.backups.setIamPolicy`
+  /// permission on [resource][google.iam.v1.SetIamPolicyRequest.resource].
+  ///
+  /// @param request
+  /// @googleapis_link{google::iam::v1::SetIamPolicyRequest,google/iam/v1/iam_policy.proto#L98}
+  /// @return
+  /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
+  ///
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
       google::iam::v1::SetIamPolicyRequest const& request);
 
-  /**
-   * Gets the access control policy for a database or backup resource.
-   * Returns an empty policy if a database or backup exists but does not have a
-   * policy set.
-   *
-   * Authorization requires `spanner.databases.getIamPolicy` permission on
-   * [resource][google.iam.v1.GetIamPolicyRequest.resource].
-   * For backups, authorization requires `spanner.backups.getIamPolicy`
-   * permission on [resource][google.iam.v1.GetIamPolicyRequest.resource].
-   *
-   * @param request
-   * @googleapis_link{google::iam::v1::GetIamPolicyRequest,google/iam/v1/iam_policy.proto#L113}
-   * @return
-   * @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
-   */
+  ///
+  /// Gets the access control policy for a database or backup resource.
+  /// Returns an empty policy if a database or backup exists but does not have a
+  /// policy set.
+  ///
+  /// Authorization requires `spanner.databases.getIamPolicy` permission on
+  /// [resource][google.iam.v1.GetIamPolicyRequest.resource].
+  /// For backups, authorization requires `spanner.backups.getIamPolicy`
+  /// permission on [resource][google.iam.v1.GetIamPolicyRequest.resource].
+  ///
+  /// @param request
+  /// @googleapis_link{google::iam::v1::GetIamPolicyRequest,google/iam/v1/iam_policy.proto#L113}
+  /// @return
+  /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
+  ///
   StatusOr<google::iam::v1::Policy> GetIamPolicy(
       google::iam::v1::GetIamPolicyRequest const& request);
 
-  /**
-   * Returns permissions that the caller has on the specified database or backup
-   * resource.
-   *
-   * Attempting this RPC on a non-existent Cloud Spanner database will
-   * result in a NOT_FOUND error if the user has
-   * `spanner.databases.list` permission on the containing Cloud
-   * Spanner instance. Otherwise returns an empty set of permissions.
-   * Calling this method on a backup that does not exist will
-   * result in a NOT_FOUND error if the user has
-   * `spanner.backups.list` permission on the containing instance.
-   *
-   * @param request
-   * @googleapis_link{google::iam::v1::TestIamPermissionsRequest,google/iam/v1/iam_policy.proto#L126}
-   * @return
-   * @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
-   */
+  ///
+  /// Returns permissions that the caller has on the specified database or
+  /// backup resource.
+  ///
+  /// Attempting this RPC on a non-existent Cloud Spanner database will
+  /// result in a NOT_FOUND error if the user has
+  /// `spanner.databases.list` permission on the containing Cloud
+  /// Spanner instance. Otherwise returns an empty set of permissions.
+  /// Calling this method on a backup that does not exist will
+  /// result in a NOT_FOUND error if the user has
+  /// `spanner.backups.list` permission on the containing instance.
+  ///
+  /// @param request
+  /// @googleapis_link{google::iam::v1::TestIamPermissionsRequest,google/iam/v1/iam_policy.proto#L126}
+  /// @return
+  /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
+  ///
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
       google::iam::v1::TestIamPermissionsRequest const& request);
 
-  /**
-   * Starts creating a new Cloud Spanner Backup.
-   * The returned backup [long-running operation][google.longrunning.Operation]
-   * will have a name of the format
-   * `projects/<project>/instances/<instance>/backups/<backup>/operations/<operation_id>`
-   * and can be used to track creation of the backup. The
-   * [metadata][google.longrunning.Operation.metadata] field type is
-   * [CreateBackupMetadata][google.spanner.admin.database.v1.CreateBackupMetadata].
-   * The [response][google.longrunning.Operation.response] field type is
-   * [Backup][google.spanner.admin.database.v1.Backup], if successful.
-   * Cancelling the returned operation will stop the creation and delete the
-   * backup. There can be only one pending backup creation per database. Backup
-   * creation of different databases can run concurrently.
-   *
-   * @param request
-   * @googleapis_link{google::spanner::admin::database::v1::CreateBackupRequest,google/spanner/admin/database/v1/backup.proto#L123}
-   * @return
-   * @googleapis_link{google::spanner::admin::database::v1::Backup,google/spanner/admin/database/v1/backup.proto#L36}
-   */
+  ///
+  /// Starts creating a new Cloud Spanner Backup.
+  /// The returned backup [long-running operation][google.longrunning.Operation]
+  /// will have a name of the format
+  /// `projects/<project>/instances/<instance>/backups/<backup>/operations/<operation_id>`
+  /// and can be used to track creation of the backup. The
+  /// [metadata][google.longrunning.Operation.metadata] field type is
+  /// [CreateBackupMetadata][google.spanner.admin.database.v1.CreateBackupMetadata].
+  /// The [response][google.longrunning.Operation.response] field type is
+  /// [Backup][google.spanner.admin.database.v1.Backup], if successful.
+  /// Cancelling the returned operation will stop the creation and delete the
+  /// backup. There can be only one pending backup creation per database. Backup
+  /// creation of different databases can run concurrently.
+  ///
+  /// @param request
+  /// @googleapis_link{google::spanner::admin::database::v1::CreateBackupRequest,google/spanner/admin/database/v1/backup.proto#L123}
+  /// @return
+  /// @googleapis_link{google::spanner::admin::database::v1::Backup,google/spanner/admin/database/v1/backup.proto#L36}
+  ///
   future<StatusOr<google::spanner::admin::database::v1::Backup>> CreateBackup(
       google::spanner::admin::database::v1::CreateBackupRequest const& request);
 
-  /**
-   * Gets metadata on a pending or completed
-   * [Backup][google.spanner.admin.database.v1.Backup].
-   *
-   * @param request
-   * @googleapis_link{google::spanner::admin::database::v1::GetBackupRequest,google/spanner/admin/database/v1/backup.proto#L202}
-   * @return
-   * @googleapis_link{google::spanner::admin::database::v1::Backup,google/spanner/admin/database/v1/backup.proto#L36}
-   */
+  ///
+  /// Gets metadata on a pending or completed
+  /// [Backup][google.spanner.admin.database.v1.Backup].
+  ///
+  /// @param request
+  /// @googleapis_link{google::spanner::admin::database::v1::GetBackupRequest,google/spanner/admin/database/v1/backup.proto#L202}
+  /// @return
+  /// @googleapis_link{google::spanner::admin::database::v1::Backup,google/spanner/admin/database/v1/backup.proto#L36}
+  ///
   StatusOr<google::spanner::admin::database::v1::Backup> GetBackup(
       google::spanner::admin::database::v1::GetBackupRequest const& request);
 
-  /**
-   * Updates a pending or completed
-   * [Backup][google.spanner.admin.database.v1.Backup].
-   *
-   * @param request
-   * @googleapis_link{google::spanner::admin::database::v1::UpdateBackupRequest,google/spanner/admin/database/v1/backup.proto#L186}
-   * @return
-   * @googleapis_link{google::spanner::admin::database::v1::Backup,google/spanner/admin/database/v1/backup.proto#L36}
-   */
+  ///
+  /// Updates a pending or completed
+  /// [Backup][google.spanner.admin.database.v1.Backup].
+  ///
+  /// @param request
+  /// @googleapis_link{google::spanner::admin::database::v1::UpdateBackupRequest,google/spanner/admin/database/v1/backup.proto#L186}
+  /// @return
+  /// @googleapis_link{google::spanner::admin::database::v1::Backup,google/spanner/admin/database/v1/backup.proto#L36}
+  ///
   StatusOr<google::spanner::admin::database::v1::Backup> UpdateBackup(
       google::spanner::admin::database::v1::UpdateBackupRequest const& request);
 
-  /**
-   * Deletes a pending or completed
-   * [Backup][google.spanner.admin.database.v1.Backup].
-   *
-   * @param request
-   * @googleapis_link{google::spanner::admin::database::v1::DeleteBackupRequest,google/spanner/admin/database/v1/backup.proto#L215}
-   */
+  ///
+  /// Deletes a pending or completed
+  /// [Backup][google.spanner.admin.database.v1.Backup].
+  ///
+  /// @param request
+  /// @googleapis_link{google::spanner::admin::database::v1::DeleteBackupRequest,google/spanner/admin/database/v1/backup.proto#L215}
+  ///
   Status DeleteBackup(
       google::spanner::admin::database::v1::DeleteBackupRequest const& request);
 
-  /**
-   * Lists completed and pending backups.
-   * Backups returned are ordered by `create_time` in descending order,
-   * starting from the most recent `create_time`.
-   *
-   * @param request
-   * @googleapis_link{google::spanner::admin::database::v1::ListBackupsRequest,google/spanner/admin/database/v1/backup.proto#L228}
-   * @return
-   * @googleapis_link{google::spanner::admin::database::v1::Backup,google/spanner/admin/database/v1/backup.proto#L36}
-   */
+  ///
+  /// Lists completed and pending backups.
+  /// Backups returned are ordered by `create_time` in descending order,
+  /// starting from the most recent `create_time`.
+  ///
+  /// @param request
+  /// @googleapis_link{google::spanner::admin::database::v1::ListBackupsRequest,google/spanner/admin/database/v1/backup.proto#L228}
+  /// @return
+  /// @googleapis_link{google::spanner::admin::database::v1::Backup,google/spanner/admin/database/v1/backup.proto#L36}
+  ///
   StreamRange<google::spanner::admin::database::v1::Backup> ListBackups(
       google::spanner::admin::database::v1::ListBackupsRequest request);
 
-  /**
-   * Create a new database by restoring from a completed backup. The new
-   * database must be in the same project and in an instance with the same
-   * instance configuration as the instance containing
-   * the backup. The returned database [long-running
-   * operation][google.longrunning.Operation] has a name of the format
-   * `projects/<project>/instances/<instance>/databases/<database>/operations/<operation_id>`,
-   * and can be used to track the progress of the operation, and to cancel it.
-   * The [metadata][google.longrunning.Operation.metadata] field type is
-   * [RestoreDatabaseMetadata][google.spanner.admin.database.v1.RestoreDatabaseMetadata].
-   * The [response][google.longrunning.Operation.response] type
-   * is [Database][google.spanner.admin.database.v1.Database], if
-   * successful. Cancelling the returned operation will stop the restore and
-   * delete the database.
-   * There can be only one database being restored into an instance at a time.
-   * Once the restore operation completes, a new restore operation can be
-   * initiated, without waiting for the optimize operation associated with the
-   * first restore to complete.
-   *
-   * @param request
-   * @googleapis_link{google::spanner::admin::database::v1::RestoreDatabaseRequest,google/spanner/admin/database/v1/spanner_database_admin.proto#L692}
-   * @return
-   * @googleapis_link{google::spanner::admin::database::v1::Database,google/spanner/admin/database/v1/spanner_database_admin.proto#L326}
-   */
+  ///
+  /// Create a new database by restoring from a completed backup. The new
+  /// database must be in the same project and in an instance with the same
+  /// instance configuration as the instance containing
+  /// the backup. The returned database [long-running
+  /// operation][google.longrunning.Operation] has a name of the format
+  /// `projects/<project>/instances/<instance>/databases/<database>/operations/<operation_id>`,
+  /// and can be used to track the progress of the operation, and to cancel it.
+  /// The [metadata][google.longrunning.Operation.metadata] field type is
+  /// [RestoreDatabaseMetadata][google.spanner.admin.database.v1.RestoreDatabaseMetadata].
+  /// The [response][google.longrunning.Operation.response] type
+  /// is [Database][google.spanner.admin.database.v1.Database], if
+  /// successful. Cancelling the returned operation will stop the restore and
+  /// delete the database.
+  /// There can be only one database being restored into an instance at a time.
+  /// Once the restore operation completes, a new restore operation can be
+  /// initiated, without waiting for the optimize operation associated with the
+  /// first restore to complete.
+  ///
+  /// @param request
+  /// @googleapis_link{google::spanner::admin::database::v1::RestoreDatabaseRequest,google/spanner/admin/database/v1/spanner_database_admin.proto#L692}
+  /// @return
+  /// @googleapis_link{google::spanner::admin::database::v1::Database,google/spanner/admin/database/v1/spanner_database_admin.proto#L326}
+  ///
   future<StatusOr<google::spanner::admin::database::v1::Database>>
   RestoreDatabase(
       google::spanner::admin::database::v1::RestoreDatabaseRequest const&
           request);
 
-  /**
-   * Lists database [longrunning-operations][google.longrunning.Operation].
-   * A database operation has a name of the form
-   * `projects/<project>/instances/<instance>/databases/<database>/operations/<operation>`.
-   * The long-running operation
-   * [metadata][google.longrunning.Operation.metadata] field type
-   * `metadata.type_url` describes the type of the metadata. Operations returned
-   * include those that have completed/failed/canceled within the last 7 days,
-   * and pending operations.
-   *
-   * @param request
-   * @googleapis_link{google::spanner::admin::database::v1::ListDatabaseOperationsRequest,google/spanner/admin/database/v1/spanner_database_admin.proto#L611}
-   * @return
-   * @googleapis_link{google::longrunning::Operation,google/longrunning/operations.proto#L128}
-   */
+  ///
+  /// Lists database [longrunning-operations][google.longrunning.Operation].
+  /// A database operation has a name of the form
+  /// `projects/<project>/instances/<instance>/databases/<database>/operations/<operation>`.
+  /// The long-running operation
+  /// [metadata][google.longrunning.Operation.metadata] field type
+  /// `metadata.type_url` describes the type of the metadata. Operations
+  /// returned include those that have completed/failed/canceled within the last
+  /// 7 days, and pending operations.
+  ///
+  /// @param request
+  /// @googleapis_link{google::spanner::admin::database::v1::ListDatabaseOperationsRequest,google/spanner/admin/database/v1/spanner_database_admin.proto#L611}
+  /// @return
+  /// @googleapis_link{google::longrunning::Operation,google/longrunning/operations.proto#L128}
+  ///
   StreamRange<google::longrunning::Operation> ListDatabaseOperations(
       google::spanner::admin::database::v1::ListDatabaseOperationsRequest
           request);
 
-  /**
-   * Lists the backup [long-running operations][google.longrunning.Operation] in
-   * the given instance. A backup operation has a name of the form
-   * `projects/<project>/instances/<instance>/backups/<backup>/operations/<operation>`.
-   * The long-running operation
-   * [metadata][google.longrunning.Operation.metadata] field type
-   * `metadata.type_url` describes the type of the metadata. Operations returned
-   * include those that have completed/failed/canceled within the last 7 days,
-   * and pending operations. Operations returned are ordered by
-   * `operation.metadata.value.progress.start_time` in descending order starting
-   * from the most recently started operation.
-   *
-   * @param request
-   * @googleapis_link{google::spanner::admin::database::v1::ListBackupOperationsRequest,google/spanner/admin/database/v1/backup.proto#L300}
-   * @return
-   * @googleapis_link{google::longrunning::Operation,google/longrunning/operations.proto#L128}
-   */
+  ///
+  /// Lists the backup [long-running operations][google.longrunning.Operation]
+  /// in the given instance. A backup operation has a name of the form
+  /// `projects/<project>/instances/<instance>/backups/<backup>/operations/<operation>`.
+  /// The long-running operation
+  /// [metadata][google.longrunning.Operation.metadata] field type
+  /// `metadata.type_url` describes the type of the metadata. Operations
+  /// returned include those that have completed/failed/canceled within the last
+  /// 7 days, and pending operations. Operations returned are ordered by
+  /// `operation.metadata.value.progress.start_time` in descending order
+  /// starting from the most recently started operation.
+  ///
+  /// @param request
+  /// @googleapis_link{google::spanner::admin::database::v1::ListBackupOperationsRequest,google/spanner/admin/database/v1/backup.proto#L300}
+  /// @return
+  /// @googleapis_link{google::longrunning::Operation,google/longrunning/operations.proto#L128}
+  ///
   StreamRange<google::longrunning::Operation> ListBackupOperations(
       google::spanner::admin::database::v1::ListBackupOperationsRequest
           request);

--- a/google/cloud/spanner/admin/instance_admin_client.h
+++ b/google/cloud/spanner/admin/instance_admin_client.h
@@ -35,29 +35,29 @@ namespace cloud {
 namespace spanner_admin {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-/**
- * Cloud Spanner Instance Admin API
- *
- * The Cloud Spanner Instance Admin API can be used to create, delete,
- * modify and list instances. Instances are dedicated Cloud Spanner serving
- * and storage resources to be used by Cloud Spanner databases.
- *
- * Each instance has a "configuration", which dictates where the
- * serving resources for the Cloud Spanner instance are located (e.g.,
- * US-central, Europe). Configurations are created by Google based on
- * resource availability.
- *
- * Cloud Spanner billing is based on the instances that exist and their
- * sizes. After an instance exists, there are no additional
- * per-database or per-operation charges for use of the instance
- * (though there may be additional network bandwidth charges).
- * Instances offer isolation: problems with databases in one instance
- * will not affect other instances. However, within an instance
- * databases can affect each other. For example, if one database in an
- * instance receives a lot of requests and consumes most of the
- * instance resources, fewer resources are available for other
- * databases in that instance, and their performance may suffer.
- */
+///
+/// Cloud Spanner Instance Admin API
+///
+/// The Cloud Spanner Instance Admin API can be used to create, delete,
+/// modify and list instances. Instances are dedicated Cloud Spanner serving
+/// and storage resources to be used by Cloud Spanner databases.
+///
+/// Each instance has a "configuration", which dictates where the
+/// serving resources for the Cloud Spanner instance are located (e.g.,
+/// US-central, Europe). Configurations are created by Google based on
+/// resource availability.
+///
+/// Cloud Spanner billing is based on the instances that exist and their
+/// sizes. After an instance exists, there are no additional
+/// per-database or per-operation charges for use of the instance
+/// (though there may be additional network bandwidth charges).
+/// Instances offer isolation: problems with databases in one instance
+/// will not affect other instances. However, within an instance
+/// databases can affect each other. For example, if one database in an
+/// instance receives a lot of requests and consumes most of the
+/// instance resources, fewer resources are available for other
+/// databases in that instance, and their performance may suffer.
+///
 class InstanceAdminClient {
  public:
   explicit InstanceAdminClient(
@@ -84,195 +84,205 @@ class InstanceAdminClient {
   }
   //@}
 
-  /**
-   * Lists the supported instance configurations for a given project.
-   *
-   * @param parent  Required. The name of the project for which a list of
-   * supported instance configurations is requested. Values are of the form
-   *  `projects/<project>`.
-   * @return
-   * @googleapis_link{google::spanner::admin::instance::v1::InstanceConfig,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L304}
-   */
+  ///
+  /// Lists the supported instance configurations for a given project.
+  ///
+  /// @param parent  Required. The name of the project for which a list of
+  /// supported instance
+  ///  configurations is requested. Values are of the form
+  ///  `projects/<project>`.
+  /// @return
+  /// @googleapis_link{google::spanner::admin::instance::v1::InstanceConfig,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L304}
+  ///
   StreamRange<google::spanner::admin::instance::v1::InstanceConfig>
   ListInstanceConfigs(std::string const& parent);
 
-  /**
-   * Gets information about a particular instance configuration.
-   *
-   * @param name  Required. The name of the requested instance configuration.
-   * Values are of the form `projects/<project>/instanceConfigs/<config>`.
-   * @return
-   * @googleapis_link{google::spanner::admin::instance::v1::InstanceConfig,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L304}
-   */
+  ///
+  /// Gets information about a particular instance configuration.
+  ///
+  /// @param name  Required. The name of the requested instance configuration.
+  /// Values are of
+  ///  the form `projects/<project>/instanceConfigs/<config>`.
+  /// @return
+  /// @googleapis_link{google::spanner::admin::instance::v1::InstanceConfig,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L304}
+  ///
   StatusOr<google::spanner::admin::instance::v1::InstanceConfig>
   GetInstanceConfig(std::string const& name);
 
-  /**
-   * Lists all instances in the given project.
-   *
-   * @param parent  Required. The name of the project for which a list of
-   * instances is requested. Values are of the form `projects/<project>`.
-   * @return
-   * @googleapis_link{google::spanner::admin::instance::v1::Instance,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328}
-   */
+  ///
+  /// Lists all instances in the given project.
+  ///
+  /// @param parent  Required. The name of the project for which a list of
+  /// instances is
+  ///  requested. Values are of the form `projects/<project>`.
+  /// @return
+  /// @googleapis_link{google::spanner::admin::instance::v1::Instance,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328}
+  ///
   StreamRange<google::spanner::admin::instance::v1::Instance> ListInstances(
       std::string const& parent);
 
-  /**
-   * Gets information about a particular instance.
-   *
-   * @param name  Required. The name of the requested instance. Values are of
-   * the form `projects/<project>/instances/<instance>`.
-   * @return
-   * @googleapis_link{google::spanner::admin::instance::v1::Instance,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328}
-   */
+  ///
+  /// Gets information about a particular instance.
+  ///
+  /// @param name  Required. The name of the requested instance. Values are of
+  /// the form
+  ///  `projects/<project>/instances/<instance>`.
+  /// @return
+  /// @googleapis_link{google::spanner::admin::instance::v1::Instance,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328}
+  ///
   StatusOr<google::spanner::admin::instance::v1::Instance> GetInstance(
       std::string const& name);
 
-  /**
-   * Creates an instance and begins preparing it to begin serving. The
-   * returned [long-running operation][google.longrunning.Operation]
-   * can be used to track the progress of preparing the new
-   * instance. The instance name is assigned by the caller. If the
-   * named instance already exists, `CreateInstance` returns
-   * `ALREADY_EXISTS`.
-   *
-   * Immediately upon completion of this request:
-   *
-   *   * The instance is readable via the API, with all requested attributes
-   *     but no allocated resources. Its state is `CREATING`.
-   *
-   * Until completion of the returned operation:
-   *
-   *   * Cancelling the operation renders the instance immediately unreadable
-   *     via the API.
-   *   * The instance can be deleted.
-   *   * All other attempts to modify the instance are rejected.
-   *
-   * Upon completion of the returned operation:
-   *
-   *   * Billing for all successfully-allocated resources begins (some types
-   *     may have lower than the requested levels).
-   *   * Databases can be created in the instance.
-   *   * The instance's allocated resource levels are readable via the API.
-   *   * The instance's state becomes `READY`.
-   *
-   * The returned [long-running operation][google.longrunning.Operation] will
-   * have a name of the format `<instance_name>/operations/<operation_id>` and
-   * can be used to track creation of the instance.  The
-   * [metadata][google.longrunning.Operation.metadata] field type is
-   * [CreateInstanceMetadata][google.spanner.admin.instance.v1.CreateInstanceMetadata].
-   * The [response][google.longrunning.Operation.response] field type is
-   * [Instance][google.spanner.admin.instance.v1.Instance], if successful.
-   *
-   * @param parent  Required. The name of the project in which to create the
-   * instance. Values are of the form `projects/<project>`.
-   * @param instance_id  Required. The ID of the instance to create.  Valid
-   * identifiers are of the form `[a-z][-a-z0-9]*[a-z0-9]` and must be between 2
-   * and 64 characters in length.
-   * @param instance  Required. The instance to create.  The name may be
-   * omitted, but if specified must be `<parent>/instances/<instance_id>`.
-   * @return
-   * @googleapis_link{google::spanner::admin::instance::v1::Instance,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328}
-   */
+  ///
+  /// Creates an instance and begins preparing it to begin serving. The
+  /// returned [long-running operation][google.longrunning.Operation]
+  /// can be used to track the progress of preparing the new
+  /// instance. The instance name is assigned by the caller. If the
+  /// named instance already exists, `CreateInstance` returns
+  /// `ALREADY_EXISTS`.
+  ///
+  /// Immediately upon completion of this request:
+  ///
+  ///   * The instance is readable via the API, with all requested attributes
+  ///     but no allocated resources. Its state is `CREATING`.
+  ///
+  /// Until completion of the returned operation:
+  ///
+  ///   * Cancelling the operation renders the instance immediately unreadable
+  ///     via the API.
+  ///   * The instance can be deleted.
+  ///   * All other attempts to modify the instance are rejected.
+  ///
+  /// Upon completion of the returned operation:
+  ///
+  ///   * Billing for all successfully-allocated resources begins (some types
+  ///     may have lower than the requested levels).
+  ///   * Databases can be created in the instance.
+  ///   * The instance's allocated resource levels are readable via the API.
+  ///   * The instance's state becomes `READY`.
+  ///
+  /// The returned [long-running operation][google.longrunning.Operation] will
+  /// have a name of the format `<instance_name>/operations/<operation_id>` and
+  /// can be used to track creation of the instance.  The
+  /// [metadata][google.longrunning.Operation.metadata] field type is
+  /// [CreateInstanceMetadata][google.spanner.admin.instance.v1.CreateInstanceMetadata].
+  /// The [response][google.longrunning.Operation.response] field type is
+  /// [Instance][google.spanner.admin.instance.v1.Instance], if successful.
+  ///
+  /// @param parent  Required. The name of the project in which to create the
+  /// instance. Values
+  ///  are of the form `projects/<project>`.
+  /// @param instance_id  Required. The ID of the instance to create.  Valid
+  /// identifiers are of the
+  ///  form `[a-z][-a-z0-9]*[a-z0-9]` and must be between 2 and 64 characters in
+  ///  length.
+  /// @param instance  Required. The instance to create.  The name may be
+  /// omitted, but if
+  ///  specified must be `<parent>/instances/<instance_id>`.
+  /// @return
+  /// @googleapis_link{google::spanner::admin::instance::v1::Instance,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328}
+  ///
   future<StatusOr<google::spanner::admin::instance::v1::Instance>>
   CreateInstance(
       std::string const& parent, std::string const& instance_id,
       google::spanner::admin::instance::v1::Instance const& instance);
 
-  /**
-   * Updates an instance, and begins allocating or releasing resources
-   * as requested. The returned [long-running
-   * operation][google.longrunning.Operation] can be used to track the
-   * progress of updating the instance. If the named instance does not
-   * exist, returns `NOT_FOUND`.
-   *
-   * Immediately upon completion of this request:
-   *
-   *   * For resource types for which a decrease in the instance's allocation
-   *     has been requested, billing is based on the newly-requested level.
-   *
-   * Until completion of the returned operation:
-   *
-   *   * Cancelling the operation sets its metadata's
-   *     [cancel_time][google.spanner.admin.instance.v1.UpdateInstanceMetadata.cancel_time],
-   * and begins restoring resources to their pre-request values. The operation
-   *     is guaranteed to succeed at undoing all resource changes,
-   *     after which point it terminates with a `CANCELLED` status.
-   *   * All other attempts to modify the instance are rejected.
-   *   * Reading the instance via the API continues to give the pre-request
-   *     resource levels.
-   *
-   * Upon completion of the returned operation:
-   *
-   *   * Billing begins for all successfully-allocated resources (some types
-   *     may have lower than the requested levels).
-   *   * All newly-reserved resources are available for serving the instance's
-   *     tables.
-   *   * The instance's new resource levels are readable via the API.
-   *
-   * The returned [long-running operation][google.longrunning.Operation] will
-   * have a name of the format `<instance_name>/operations/<operation_id>` and
-   * can be used to track the instance modification.  The
-   * [metadata][google.longrunning.Operation.metadata] field type is
-   * [UpdateInstanceMetadata][google.spanner.admin.instance.v1.UpdateInstanceMetadata].
-   * The [response][google.longrunning.Operation.response] field type is
-   * [Instance][google.spanner.admin.instance.v1.Instance], if successful.
-   *
-   * Authorization requires `spanner.instances.update` permission on
-   * resource [name][google.spanner.admin.instance.v1.Instance.name].
-   *
-   * @param instance  Required. The instance to update, which must always
-   * include the instance name.  Otherwise, only fields mentioned in
-   * [field_mask][google.spanner.admin.instance.v1.UpdateInstanceRequest.field_mask]
-   * need be included.
-   * @param field_mask  Required. A mask specifying which fields in
-   * [Instance][google.spanner.admin.instance.v1.Instance] should be updated.
-   *  The field mask must always be specified; this prevents any future fields
-   * in [Instance][google.spanner.admin.instance.v1.Instance] from being erased
-   * accidentally by clients that do not know about them.
-   * @return
-   * @googleapis_link{google::spanner::admin::instance::v1::Instance,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328}
-   */
+  ///
+  /// Updates an instance, and begins allocating or releasing resources
+  /// as requested. The returned [long-running
+  /// operation][google.longrunning.Operation] can be used to track the
+  /// progress of updating the instance. If the named instance does not
+  /// exist, returns `NOT_FOUND`.
+  ///
+  /// Immediately upon completion of this request:
+  ///
+  ///   * For resource types for which a decrease in the instance's allocation
+  ///     has been requested, billing is based on the newly-requested level.
+  ///
+  /// Until completion of the returned operation:
+  ///
+  ///   * Cancelling the operation sets its metadata's
+  ///     [cancel_time][google.spanner.admin.instance.v1.UpdateInstanceMetadata.cancel_time],
+  ///     and begins restoring resources to their pre-request values. The
+  ///     operation is guaranteed to succeed at undoing all resource changes,
+  ///     after which point it terminates with a `CANCELLED` status.
+  ///   * All other attempts to modify the instance are rejected.
+  ///   * Reading the instance via the API continues to give the pre-request
+  ///     resource levels.
+  ///
+  /// Upon completion of the returned operation:
+  ///
+  ///   * Billing begins for all successfully-allocated resources (some types
+  ///     may have lower than the requested levels).
+  ///   * All newly-reserved resources are available for serving the instance's
+  ///     tables.
+  ///   * The instance's new resource levels are readable via the API.
+  ///
+  /// The returned [long-running operation][google.longrunning.Operation] will
+  /// have a name of the format `<instance_name>/operations/<operation_id>` and
+  /// can be used to track the instance modification.  The
+  /// [metadata][google.longrunning.Operation.metadata] field type is
+  /// [UpdateInstanceMetadata][google.spanner.admin.instance.v1.UpdateInstanceMetadata].
+  /// The [response][google.longrunning.Operation.response] field type is
+  /// [Instance][google.spanner.admin.instance.v1.Instance], if successful.
+  ///
+  /// Authorization requires `spanner.instances.update` permission on
+  /// resource [name][google.spanner.admin.instance.v1.Instance.name].
+  ///
+  /// @param instance  Required. The instance to update, which must always
+  /// include the instance
+  ///  name.  Otherwise, only fields mentioned in
+  ///  [field_mask][google.spanner.admin.instance.v1.UpdateInstanceRequest.field_mask]
+  ///  need be included.
+  /// @param field_mask  Required. A mask specifying which fields in
+  /// [Instance][google.spanner.admin.instance.v1.Instance] should be updated.
+  ///  The field mask must always be specified; this prevents any future fields
+  ///  in [Instance][google.spanner.admin.instance.v1.Instance] from being
+  ///  erased accidentally by clients that do not know about them.
+  /// @return
+  /// @googleapis_link{google::spanner::admin::instance::v1::Instance,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328}
+  ///
   future<StatusOr<google::spanner::admin::instance::v1::Instance>>
   UpdateInstance(google::spanner::admin::instance::v1::Instance const& instance,
                  google::protobuf::FieldMask const& field_mask);
 
-  /**
-   * Deletes an instance.
-   *
-   * Immediately upon completion of the request:
-   *
-   *   * Billing ceases for all of the instance's reserved resources.
-   *
-   * Soon afterward:
-   *
-   *   * The instance and *all of its databases* immediately and
-   *     irrevocably disappear from the API. All data in the databases
-   *     is permanently deleted.
-   *
-   * @param name  Required. The name of the instance to be deleted. Values are
-   * of the form `projects/<project>/instances/<instance>`
-   */
+  ///
+  /// Deletes an instance.
+  ///
+  /// Immediately upon completion of the request:
+  ///
+  ///   * Billing ceases for all of the instance's reserved resources.
+  ///
+  /// Soon afterward:
+  ///
+  ///   * The instance and *all of its databases* immediately and
+  ///     irrevocably disappear from the API. All data in the databases
+  ///     is permanently deleted.
+  ///
+  /// @param name  Required. The name of the instance to be deleted. Values are
+  /// of the form
+  ///  `projects/<project>/instances/<instance>`
+  ///
   Status DeleteInstance(std::string const& name);
 
-  /**
-   * Sets the access control policy on an instance resource. Replaces any
-   * existing policy.
-   *
-   * Authorization requires `spanner.instances.setIamPolicy` on
-   * [resource][google.iam.v1.SetIamPolicyRequest.resource].
-   *
-   * @param resource  REQUIRED: The resource for which the policy is being
-   * specified. See the operation documentation for the appropriate value for
-   * this field.
-   * @param policy  REQUIRED: The complete policy to be applied to the
-   * `resource`. The size of the policy is limited to a few 10s of KB. An empty
-   * policy is a valid policy but certain Cloud Platform services (such as
-   * Projects) might reject them.
-   * @return
-   * @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
-   */
+  ///
+  /// Sets the access control policy on an instance resource. Replaces any
+  /// existing policy.
+  ///
+  /// Authorization requires `spanner.instances.setIamPolicy` on
+  /// [resource][google.iam.v1.SetIamPolicyRequest.resource].
+  ///
+  /// @param resource  REQUIRED: The resource for which the policy is being
+  /// specified.
+  ///  See the operation documentation for the appropriate value for this field.
+  /// @param policy  REQUIRED: The complete policy to be applied to the
+  /// `resource`. The size of
+  ///  the policy is limited to a few 10s of KB. An empty policy is a
+  ///  valid policy but certain Cloud Platform services (such as Projects)
+  ///  might reject them.
+  /// @return
+  /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
+  ///
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
       std::string const& resource, google::iam::v1::Policy const& policy);
 
@@ -301,250 +311,253 @@ class InstanceAdminClient {
                                                  IamUpdater const& updater,
                                                  Options options = {});
 
-  /**
-   * Gets the access control policy for an instance resource. Returns an empty
-   * policy if an instance exists but does not have a policy set.
-   *
-   * Authorization requires `spanner.instances.getIamPolicy` on
-   * [resource][google.iam.v1.GetIamPolicyRequest.resource].
-   *
-   * @param resource  REQUIRED: The resource for which the policy is being
-   * requested. See the operation documentation for the appropriate value for
-   * this field.
-   * @return
-   * @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
-   */
+  ///
+  /// Gets the access control policy for an instance resource. Returns an empty
+  /// policy if an instance exists but does not have a policy set.
+  ///
+  /// Authorization requires `spanner.instances.getIamPolicy` on
+  /// [resource][google.iam.v1.GetIamPolicyRequest.resource].
+  ///
+  /// @param resource  REQUIRED: The resource for which the policy is being
+  /// requested.
+  ///  See the operation documentation for the appropriate value for this field.
+  /// @return
+  /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
+  ///
   StatusOr<google::iam::v1::Policy> GetIamPolicy(std::string const& resource);
 
-  /**
-   * Returns permissions that the caller has on the specified instance resource.
-   *
-   * Attempting this RPC on a non-existent Cloud Spanner instance resource will
-   * result in a NOT_FOUND error if the user has `spanner.instances.list`
-   * permission on the containing Google Cloud Project. Otherwise returns an
-   * empty set of permissions.
-   *
-   * @param resource  REQUIRED: The resource for which the policy detail is
-   * being requested. See the operation documentation for the appropriate value
-   * for this field.
-   * @param permissions  The set of permissions to check for the `resource`.
-   * Permissions with wildcards (such as '*' or 'storage.*') are not allowed.
-   * For more information see [IAM
-   * Overview](https://cloud.google.com/iam/docs/overview#permissions).
-   * @return
-   * @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
-   */
+  ///
+  /// Returns permissions that the caller has on the specified instance
+  /// resource.
+  ///
+  /// Attempting this RPC on a non-existent Cloud Spanner instance resource will
+  /// result in a NOT_FOUND error if the user has `spanner.instances.list`
+  /// permission on the containing Google Cloud Project. Otherwise returns an
+  /// empty set of permissions.
+  ///
+  /// @param resource  REQUIRED: The resource for which the policy detail is
+  /// being requested.
+  ///  See the operation documentation for the appropriate value for this field.
+  /// @param permissions  The set of permissions to check for the `resource`.
+  /// Permissions with
+  ///  wildcards (such as '*' or 'storage.*') are not allowed. For more
+  ///  information see
+  ///  [IAM Overview](https://cloud.google.com/iam/docs/overview#permissions).
+  /// @return
+  /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
+  ///
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
       std::string const& resource, std::vector<std::string> const& permissions);
 
-  /**
-   * Lists the supported instance configurations for a given project.
-   *
-   * @param request
-   * @googleapis_link{google::spanner::admin::instance::v1::ListInstanceConfigsRequest,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L415}
-   * @return
-   * @googleapis_link{google::spanner::admin::instance::v1::InstanceConfig,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L304}
-   */
+  ///
+  /// Lists the supported instance configurations for a given project.
+  ///
+  /// @param request
+  /// @googleapis_link{google::spanner::admin::instance::v1::ListInstanceConfigsRequest,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L415}
+  /// @return
+  /// @googleapis_link{google::spanner::admin::instance::v1::InstanceConfig,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L304}
+  ///
   StreamRange<google::spanner::admin::instance::v1::InstanceConfig>
   ListInstanceConfigs(
       google::spanner::admin::instance::v1::ListInstanceConfigsRequest request);
 
-  /**
-   * Gets information about a particular instance configuration.
-   *
-   * @param request
-   * @googleapis_link{google::spanner::admin::instance::v1::GetInstanceConfigRequest,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L449}
-   * @return
-   * @googleapis_link{google::spanner::admin::instance::v1::InstanceConfig,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L304}
-   */
+  ///
+  /// Gets information about a particular instance configuration.
+  ///
+  /// @param request
+  /// @googleapis_link{google::spanner::admin::instance::v1::GetInstanceConfigRequest,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L449}
+  /// @return
+  /// @googleapis_link{google::spanner::admin::instance::v1::InstanceConfig,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L304}
+  ///
   StatusOr<google::spanner::admin::instance::v1::InstanceConfig>
   GetInstanceConfig(
       google::spanner::admin::instance::v1::GetInstanceConfigRequest const&
           request);
 
-  /**
-   * Lists all instances in the given project.
-   *
-   * @param request
-   * @googleapis_link{google::spanner::admin::instance::v1::ListInstancesRequest,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L499}
-   * @return
-   * @googleapis_link{google::spanner::admin::instance::v1::Instance,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328}
-   */
+  ///
+  /// Lists all instances in the given project.
+  ///
+  /// @param request
+  /// @googleapis_link{google::spanner::admin::instance::v1::ListInstancesRequest,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L499}
+  /// @return
+  /// @googleapis_link{google::spanner::admin::instance::v1::Instance,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328}
+  ///
   StreamRange<google::spanner::admin::instance::v1::Instance> ListInstances(
       google::spanner::admin::instance::v1::ListInstancesRequest request);
 
-  /**
-   * Gets information about a particular instance.
-   *
-   * @param request
-   * @googleapis_link{google::spanner::admin::instance::v1::GetInstanceRequest,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L461}
-   * @return
-   * @googleapis_link{google::spanner::admin::instance::v1::Instance,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328}
-   */
+  ///
+  /// Gets information about a particular instance.
+  ///
+  /// @param request
+  /// @googleapis_link{google::spanner::admin::instance::v1::GetInstanceRequest,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L461}
+  /// @return
+  /// @googleapis_link{google::spanner::admin::instance::v1::Instance,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328}
+  ///
   StatusOr<google::spanner::admin::instance::v1::Instance> GetInstance(
       google::spanner::admin::instance::v1::GetInstanceRequest const& request);
 
-  /**
-   * Creates an instance and begins preparing it to begin serving. The
-   * returned [long-running operation][google.longrunning.Operation]
-   * can be used to track the progress of preparing the new
-   * instance. The instance name is assigned by the caller. If the
-   * named instance already exists, `CreateInstance` returns
-   * `ALREADY_EXISTS`.
-   *
-   * Immediately upon completion of this request:
-   *
-   *   * The instance is readable via the API, with all requested attributes
-   *     but no allocated resources. Its state is `CREATING`.
-   *
-   * Until completion of the returned operation:
-   *
-   *   * Cancelling the operation renders the instance immediately unreadable
-   *     via the API.
-   *   * The instance can be deleted.
-   *   * All other attempts to modify the instance are rejected.
-   *
-   * Upon completion of the returned operation:
-   *
-   *   * Billing for all successfully-allocated resources begins (some types
-   *     may have lower than the requested levels).
-   *   * Databases can be created in the instance.
-   *   * The instance's allocated resource levels are readable via the API.
-   *   * The instance's state becomes `READY`.
-   *
-   * The returned [long-running operation][google.longrunning.Operation] will
-   * have a name of the format `<instance_name>/operations/<operation_id>` and
-   * can be used to track creation of the instance.  The
-   * [metadata][google.longrunning.Operation.metadata] field type is
-   * [CreateInstanceMetadata][google.spanner.admin.instance.v1.CreateInstanceMetadata].
-   * The [response][google.longrunning.Operation.response] field type is
-   * [Instance][google.spanner.admin.instance.v1.Instance], if successful.
-   *
-   * @param request
-   * @googleapis_link{google::spanner::admin::instance::v1::CreateInstanceRequest,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L478}
-   * @return
-   * @googleapis_link{google::spanner::admin::instance::v1::Instance,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328}
-   */
+  ///
+  /// Creates an instance and begins preparing it to begin serving. The
+  /// returned [long-running operation][google.longrunning.Operation]
+  /// can be used to track the progress of preparing the new
+  /// instance. The instance name is assigned by the caller. If the
+  /// named instance already exists, `CreateInstance` returns
+  /// `ALREADY_EXISTS`.
+  ///
+  /// Immediately upon completion of this request:
+  ///
+  ///   * The instance is readable via the API, with all requested attributes
+  ///     but no allocated resources. Its state is `CREATING`.
+  ///
+  /// Until completion of the returned operation:
+  ///
+  ///   * Cancelling the operation renders the instance immediately unreadable
+  ///     via the API.
+  ///   * The instance can be deleted.
+  ///   * All other attempts to modify the instance are rejected.
+  ///
+  /// Upon completion of the returned operation:
+  ///
+  ///   * Billing for all successfully-allocated resources begins (some types
+  ///     may have lower than the requested levels).
+  ///   * Databases can be created in the instance.
+  ///   * The instance's allocated resource levels are readable via the API.
+  ///   * The instance's state becomes `READY`.
+  ///
+  /// The returned [long-running operation][google.longrunning.Operation] will
+  /// have a name of the format `<instance_name>/operations/<operation_id>` and
+  /// can be used to track creation of the instance.  The
+  /// [metadata][google.longrunning.Operation.metadata] field type is
+  /// [CreateInstanceMetadata][google.spanner.admin.instance.v1.CreateInstanceMetadata].
+  /// The [response][google.longrunning.Operation.response] field type is
+  /// [Instance][google.spanner.admin.instance.v1.Instance], if successful.
+  ///
+  /// @param request
+  /// @googleapis_link{google::spanner::admin::instance::v1::CreateInstanceRequest,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L478}
+  /// @return
+  /// @googleapis_link{google::spanner::admin::instance::v1::Instance,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328}
+  ///
   future<StatusOr<google::spanner::admin::instance::v1::Instance>>
   CreateInstance(
       google::spanner::admin::instance::v1::CreateInstanceRequest const&
           request);
 
-  /**
-   * Updates an instance, and begins allocating or releasing resources
-   * as requested. The returned [long-running
-   * operation][google.longrunning.Operation] can be used to track the
-   * progress of updating the instance. If the named instance does not
-   * exist, returns `NOT_FOUND`.
-   *
-   * Immediately upon completion of this request:
-   *
-   *   * For resource types for which a decrease in the instance's allocation
-   *     has been requested, billing is based on the newly-requested level.
-   *
-   * Until completion of the returned operation:
-   *
-   *   * Cancelling the operation sets its metadata's
-   *     [cancel_time][google.spanner.admin.instance.v1.UpdateInstanceMetadata.cancel_time],
-   * and begins restoring resources to their pre-request values. The operation
-   *     is guaranteed to succeed at undoing all resource changes,
-   *     after which point it terminates with a `CANCELLED` status.
-   *   * All other attempts to modify the instance are rejected.
-   *   * Reading the instance via the API continues to give the pre-request
-   *     resource levels.
-   *
-   * Upon completion of the returned operation:
-   *
-   *   * Billing begins for all successfully-allocated resources (some types
-   *     may have lower than the requested levels).
-   *   * All newly-reserved resources are available for serving the instance's
-   *     tables.
-   *   * The instance's new resource levels are readable via the API.
-   *
-   * The returned [long-running operation][google.longrunning.Operation] will
-   * have a name of the format `<instance_name>/operations/<operation_id>` and
-   * can be used to track the instance modification.  The
-   * [metadata][google.longrunning.Operation.metadata] field type is
-   * [UpdateInstanceMetadata][google.spanner.admin.instance.v1.UpdateInstanceMetadata].
-   * The [response][google.longrunning.Operation.response] field type is
-   * [Instance][google.spanner.admin.instance.v1.Instance], if successful.
-   *
-   * Authorization requires `spanner.instances.update` permission on
-   * resource [name][google.spanner.admin.instance.v1.Instance.name].
-   *
-   * @param request
-   * @googleapis_link{google::spanner::admin::instance::v1::UpdateInstanceRequest,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L552}
-   * @return
-   * @googleapis_link{google::spanner::admin::instance::v1::Instance,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328}
-   */
+  ///
+  /// Updates an instance, and begins allocating or releasing resources
+  /// as requested. The returned [long-running
+  /// operation][google.longrunning.Operation] can be used to track the
+  /// progress of updating the instance. If the named instance does not
+  /// exist, returns `NOT_FOUND`.
+  ///
+  /// Immediately upon completion of this request:
+  ///
+  ///   * For resource types for which a decrease in the instance's allocation
+  ///     has been requested, billing is based on the newly-requested level.
+  ///
+  /// Until completion of the returned operation:
+  ///
+  ///   * Cancelling the operation sets its metadata's
+  ///     [cancel_time][google.spanner.admin.instance.v1.UpdateInstanceMetadata.cancel_time],
+  ///     and begins restoring resources to their pre-request values. The
+  ///     operation is guaranteed to succeed at undoing all resource changes,
+  ///     after which point it terminates with a `CANCELLED` status.
+  ///   * All other attempts to modify the instance are rejected.
+  ///   * Reading the instance via the API continues to give the pre-request
+  ///     resource levels.
+  ///
+  /// Upon completion of the returned operation:
+  ///
+  ///   * Billing begins for all successfully-allocated resources (some types
+  ///     may have lower than the requested levels).
+  ///   * All newly-reserved resources are available for serving the instance's
+  ///     tables.
+  ///   * The instance's new resource levels are readable via the API.
+  ///
+  /// The returned [long-running operation][google.longrunning.Operation] will
+  /// have a name of the format `<instance_name>/operations/<operation_id>` and
+  /// can be used to track the instance modification.  The
+  /// [metadata][google.longrunning.Operation.metadata] field type is
+  /// [UpdateInstanceMetadata][google.spanner.admin.instance.v1.UpdateInstanceMetadata].
+  /// The [response][google.longrunning.Operation.response] field type is
+  /// [Instance][google.spanner.admin.instance.v1.Instance], if successful.
+  ///
+  /// Authorization requires `spanner.instances.update` permission on
+  /// resource [name][google.spanner.admin.instance.v1.Instance.name].
+  ///
+  /// @param request
+  /// @googleapis_link{google::spanner::admin::instance::v1::UpdateInstanceRequest,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L552}
+  /// @return
+  /// @googleapis_link{google::spanner::admin::instance::v1::Instance,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328}
+  ///
   future<StatusOr<google::spanner::admin::instance::v1::Instance>>
   UpdateInstance(
       google::spanner::admin::instance::v1::UpdateInstanceRequest const&
           request);
 
-  /**
-   * Deletes an instance.
-   *
-   * Immediately upon completion of the request:
-   *
-   *   * Billing ceases for all of the instance's reserved resources.
-   *
-   * Soon afterward:
-   *
-   *   * The instance and *all of its databases* immediately and
-   *     irrevocably disappear from the API. All data in the databases
-   *     is permanently deleted.
-   *
-   * @param request
-   * @googleapis_link{google::spanner::admin::instance::v1::DeleteInstanceRequest,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L565}
-   */
+  ///
+  /// Deletes an instance.
+  ///
+  /// Immediately upon completion of the request:
+  ///
+  ///   * Billing ceases for all of the instance's reserved resources.
+  ///
+  /// Soon afterward:
+  ///
+  ///   * The instance and *all of its databases* immediately and
+  ///     irrevocably disappear from the API. All data in the databases
+  ///     is permanently deleted.
+  ///
+  /// @param request
+  /// @googleapis_link{google::spanner::admin::instance::v1::DeleteInstanceRequest,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L565}
+  ///
   Status DeleteInstance(
       google::spanner::admin::instance::v1::DeleteInstanceRequest const&
           request);
 
-  /**
-   * Sets the access control policy on an instance resource. Replaces any
-   * existing policy.
-   *
-   * Authorization requires `spanner.instances.setIamPolicy` on
-   * [resource][google.iam.v1.SetIamPolicyRequest.resource].
-   *
-   * @param request
-   * @googleapis_link{google::iam::v1::SetIamPolicyRequest,google/iam/v1/iam_policy.proto#L98}
-   * @return
-   * @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
-   */
+  ///
+  /// Sets the access control policy on an instance resource. Replaces any
+  /// existing policy.
+  ///
+  /// Authorization requires `spanner.instances.setIamPolicy` on
+  /// [resource][google.iam.v1.SetIamPolicyRequest.resource].
+  ///
+  /// @param request
+  /// @googleapis_link{google::iam::v1::SetIamPolicyRequest,google/iam/v1/iam_policy.proto#L98}
+  /// @return
+  /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
+  ///
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
       google::iam::v1::SetIamPolicyRequest const& request);
 
-  /**
-   * Gets the access control policy for an instance resource. Returns an empty
-   * policy if an instance exists but does not have a policy set.
-   *
-   * Authorization requires `spanner.instances.getIamPolicy` on
-   * [resource][google.iam.v1.GetIamPolicyRequest.resource].
-   *
-   * @param request
-   * @googleapis_link{google::iam::v1::GetIamPolicyRequest,google/iam/v1/iam_policy.proto#L113}
-   * @return
-   * @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
-   */
+  ///
+  /// Gets the access control policy for an instance resource. Returns an empty
+  /// policy if an instance exists but does not have a policy set.
+  ///
+  /// Authorization requires `spanner.instances.getIamPolicy` on
+  /// [resource][google.iam.v1.GetIamPolicyRequest.resource].
+  ///
+  /// @param request
+  /// @googleapis_link{google::iam::v1::GetIamPolicyRequest,google/iam/v1/iam_policy.proto#L113}
+  /// @return
+  /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
+  ///
   StatusOr<google::iam::v1::Policy> GetIamPolicy(
       google::iam::v1::GetIamPolicyRequest const& request);
 
-  /**
-   * Returns permissions that the caller has on the specified instance resource.
-   *
-   * Attempting this RPC on a non-existent Cloud Spanner instance resource will
-   * result in a NOT_FOUND error if the user has `spanner.instances.list`
-   * permission on the containing Google Cloud Project. Otherwise returns an
-   * empty set of permissions.
-   *
-   * @param request
-   * @googleapis_link{google::iam::v1::TestIamPermissionsRequest,google/iam/v1/iam_policy.proto#L126}
-   * @return
-   * @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
-   */
+  ///
+  /// Returns permissions that the caller has on the specified instance
+  /// resource.
+  ///
+  /// Attempting this RPC on a non-existent Cloud Spanner instance resource will
+  /// result in a NOT_FOUND error if the user has `spanner.instances.list`
+  /// permission on the containing Google Cloud Project. Otherwise returns an
+  /// empty set of permissions.
+  ///
+  /// @param request
+  /// @googleapis_link{google::iam::v1::TestIamPermissionsRequest,google/iam/v1/iam_policy.proto#L126}
+  /// @return
+  /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
+  ///
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
       google::iam::v1::TestIamPermissionsRequest const& request);
 

--- a/google/cloud/tasks/cloud_tasks_client.h
+++ b/google/cloud/tasks/cloud_tasks_client.h
@@ -33,10 +33,10 @@ namespace cloud {
 namespace tasks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-/**
- * Cloud Tasks allows developers to manage the execution of background
- * work in their applications.
- */
+///
+/// Cloud Tasks allows developers to manage the execution of background
+/// work in their applications.
+///
 class CloudTasksClient {
  public:
   explicit CloudTasksClient(std::shared_ptr<CloudTasksConnection> connection);
@@ -60,205 +60,207 @@ class CloudTasksClient {
   }
   //@}
 
-  /**
-   * Lists queues.
-   *
-   * Queues are returned in lexicographical order.
-   *
-   * @param parent  Required. The location name.
-   *  For example: `projects/PROJECT_ID/locations/LOCATION_ID`
-   * @return
-   * @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
-   */
+  ///
+  /// Lists queues.
+  ///
+  /// Queues are returned in lexicographical order.
+  ///
+  /// @param parent  Required. The location name.
+  ///  For example: `projects/PROJECT_ID/locations/LOCATION_ID`
+  /// @return
+  /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
+  ///
   StreamRange<google::cloud::tasks::v2::Queue> ListQueues(
       std::string const& parent);
 
-  /**
-   * Gets a queue.
-   *
-   * @param name  Required. The resource name of the queue. For example:
-   *  `projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID`
-   * @return
-   * @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
-   */
+  ///
+  /// Gets a queue.
+  ///
+  /// @param name  Required. The resource name of the queue. For example:
+  ///  `projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID`
+  /// @return
+  /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
+  ///
   StatusOr<google::cloud::tasks::v2::Queue> GetQueue(std::string const& name);
 
-  /**
-   * Creates a queue.
-   *
-   * Queues created with this method allow tasks to live for a maximum of 31
-   * days. After a task is 31 days old, the task will be deleted regardless of
-   * whether it was dispatched or not.
-   *
-   * WARNING: Using this method may have unintended side effects if you are
-   * using an App Engine `queue.yaml` or `queue.xml` file to manage your queues.
-   * Read
-   * [Overview of Queue Management and
-   * queue.yaml](https://cloud.google.com/tasks/docs/queue-yaml) before using
-   * this method.
-   *
-   * @param parent  Required. The location name in which the queue will be
-   * created. For example: `projects/PROJECT_ID/locations/LOCATION_ID` The list
-   * of allowed locations can be obtained by calling Cloud Tasks' implementation
-   * of [ListLocations][google.cloud.location.Locations.ListLocations].
-   * @param queue  Required. The queue to create.
-   *  [Queue's name][google.cloud.tasks.v2.Queue.name] cannot be the same as an
-   * existing queue.
-   * @return
-   * @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
-   */
+  ///
+  /// Creates a queue.
+  ///
+  /// Queues created with this method allow tasks to live for a maximum of 31
+  /// days. After a task is 31 days old, the task will be deleted regardless of
+  /// whether it was dispatched or not.
+  ///
+  /// WARNING: Using this method may have unintended side effects if you are
+  /// using an App Engine `queue.yaml` or `queue.xml` file to manage your
+  /// queues. Read [Overview of Queue Management and
+  /// queue.yaml](https://cloud.google.com/tasks/docs/queue-yaml) before using
+  /// this method.
+  ///
+  /// @param parent  Required. The location name in which the queue will be
+  /// created.
+  ///  For example: `projects/PROJECT_ID/locations/LOCATION_ID`
+  ///  The list of allowed locations can be obtained by calling Cloud
+  ///  Tasks' implementation of
+  ///  [ListLocations][google.cloud.location.Locations.ListLocations].
+  /// @param queue  Required. The queue to create.
+  ///  [Queue's name][google.cloud.tasks.v2.Queue.name] cannot be the same as an
+  ///  existing queue.
+  /// @return
+  /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
+  ///
   StatusOr<google::cloud::tasks::v2::Queue> CreateQueue(
       std::string const& parent, google::cloud::tasks::v2::Queue const& queue);
 
-  /**
-   * Updates a queue.
-   *
-   * This method creates the queue if it does not exist and updates
-   * the queue if it does exist.
-   *
-   * Queues created with this method allow tasks to live for a maximum of 31
-   * days. After a task is 31 days old, the task will be deleted regardless of
-   * whether it was dispatched or not.
-   *
-   * WARNING: Using this method may have unintended side effects if you are
-   * using an App Engine `queue.yaml` or `queue.xml` file to manage your queues.
-   * Read
-   * [Overview of Queue Management and
-   * queue.yaml](https://cloud.google.com/tasks/docs/queue-yaml) before using
-   * this method.
-   *
-   * @param queue  Required. The queue to create or update.
-   *  The queue's [name][google.cloud.tasks.v2.Queue.name] must be specified.
-   *  Output only fields cannot be modified using UpdateQueue.
-   *  Any value specified for an output only field will be ignored.
-   *  The queue's [name][google.cloud.tasks.v2.Queue.name] cannot be changed.
-   * @param update_mask  A mask used to specify which fields of the queue are
-   * being updated. If empty, then all fields will be updated.
-   * @return
-   * @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
-   */
+  ///
+  /// Updates a queue.
+  ///
+  /// This method creates the queue if it does not exist and updates
+  /// the queue if it does exist.
+  ///
+  /// Queues created with this method allow tasks to live for a maximum of 31
+  /// days. After a task is 31 days old, the task will be deleted regardless of
+  /// whether it was dispatched or not.
+  ///
+  /// WARNING: Using this method may have unintended side effects if you are
+  /// using an App Engine `queue.yaml` or `queue.xml` file to manage your
+  /// queues. Read [Overview of Queue Management and
+  /// queue.yaml](https://cloud.google.com/tasks/docs/queue-yaml) before using
+  /// this method.
+  ///
+  /// @param queue  Required. The queue to create or update.
+  ///  The queue's [name][google.cloud.tasks.v2.Queue.name] must be specified.
+  ///  Output only fields cannot be modified using UpdateQueue.
+  ///  Any value specified for an output only field will be ignored.
+  ///  The queue's [name][google.cloud.tasks.v2.Queue.name] cannot be changed.
+  /// @param update_mask  A mask used to specify which fields of the queue are
+  /// being updated.
+  ///  If empty, then all fields will be updated.
+  /// @return
+  /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
+  ///
   StatusOr<google::cloud::tasks::v2::Queue> UpdateQueue(
       google::cloud::tasks::v2::Queue const& queue,
       google::protobuf::FieldMask const& update_mask);
 
-  /**
-   * Deletes a queue.
-   *
-   * This command will delete the queue even if it has tasks in it.
-   *
-   * Note: If you delete a queue, a queue with the same name can't be created
-   * for 7 days.
-   *
-   * WARNING: Using this method may have unintended side effects if you are
-   * using an App Engine `queue.yaml` or `queue.xml` file to manage your queues.
-   * Read
-   * [Overview of Queue Management and
-   * queue.yaml](https://cloud.google.com/tasks/docs/queue-yaml) before using
-   * this method.
-   *
-   * @param name  Required. The queue name. For example:
-   *  `projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID`
-   */
+  ///
+  /// Deletes a queue.
+  ///
+  /// This command will delete the queue even if it has tasks in it.
+  ///
+  /// Note: If you delete a queue, a queue with the same name can't be created
+  /// for 7 days.
+  ///
+  /// WARNING: Using this method may have unintended side effects if you are
+  /// using an App Engine `queue.yaml` or `queue.xml` file to manage your
+  /// queues. Read [Overview of Queue Management and
+  /// queue.yaml](https://cloud.google.com/tasks/docs/queue-yaml) before using
+  /// this method.
+  ///
+  /// @param name  Required. The queue name. For example:
+  ///  `projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID`
+  ///
   Status DeleteQueue(std::string const& name);
 
-  /**
-   * Purges a queue by deleting all of its tasks.
-   *
-   * All tasks created before this method is called are permanently deleted.
-   *
-   * Purge operations can take up to one minute to take effect. Tasks
-   * might be dispatched before the purge takes effect. A purge is irreversible.
-   *
-   * @param name  Required. The queue name. For example:
-   *  `projects/PROJECT_ID/location/LOCATION_ID/queues/QUEUE_ID`
-   * @return
-   * @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
-   */
+  ///
+  /// Purges a queue by deleting all of its tasks.
+  ///
+  /// All tasks created before this method is called are permanently deleted.
+  ///
+  /// Purge operations can take up to one minute to take effect. Tasks
+  /// might be dispatched before the purge takes effect. A purge is
+  /// irreversible.
+  ///
+  /// @param name  Required. The queue name. For example:
+  ///  `projects/PROJECT_ID/location/LOCATION_ID/queues/QUEUE_ID`
+  /// @return
+  /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
+  ///
   StatusOr<google::cloud::tasks::v2::Queue> PurgeQueue(std::string const& name);
 
-  /**
-   * Pauses the queue.
-   *
-   * If a queue is paused then the system will stop dispatching tasks
-   * until the queue is resumed via
-   * [ResumeQueue][google.cloud.tasks.v2.CloudTasks.ResumeQueue]. Tasks can
-   * still be added when the queue is paused. A queue is paused if its
-   * [state][google.cloud.tasks.v2.Queue.state] is
-   * [PAUSED][google.cloud.tasks.v2.Queue.State.PAUSED].
-   *
-   * @param name  Required. The queue name. For example:
-   *  `projects/PROJECT_ID/location/LOCATION_ID/queues/QUEUE_ID`
-   * @return
-   * @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
-   */
+  ///
+  /// Pauses the queue.
+  ///
+  /// If a queue is paused then the system will stop dispatching tasks
+  /// until the queue is resumed via
+  /// [ResumeQueue][google.cloud.tasks.v2.CloudTasks.ResumeQueue]. Tasks can
+  /// still be added when the queue is paused. A queue is paused if its
+  /// [state][google.cloud.tasks.v2.Queue.state] is
+  /// [PAUSED][google.cloud.tasks.v2.Queue.State.PAUSED].
+  ///
+  /// @param name  Required. The queue name. For example:
+  ///  `projects/PROJECT_ID/location/LOCATION_ID/queues/QUEUE_ID`
+  /// @return
+  /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
+  ///
   StatusOr<google::cloud::tasks::v2::Queue> PauseQueue(std::string const& name);
 
-  /**
-   * Resume a queue.
-   *
-   * This method resumes a queue after it has been
-   * [PAUSED][google.cloud.tasks.v2.Queue.State.PAUSED] or
-   * [DISABLED][google.cloud.tasks.v2.Queue.State.DISABLED]. The state of a
-   * queue is stored in the queue's [state][google.cloud.tasks.v2.Queue.state];
-   * after calling this method it will be set to
-   * [RUNNING][google.cloud.tasks.v2.Queue.State.RUNNING].
-   *
-   * WARNING: Resuming many high-QPS queues at the same time can
-   * lead to target overloading. If you are resuming high-QPS
-   * queues, follow the 500/50/5 pattern described in
-   * [Managing Cloud Tasks Scaling
-   * Risks](https://cloud.google.com/tasks/docs/manage-cloud-task-scaling).
-   *
-   * @param name  Required. The queue name. For example:
-   *  `projects/PROJECT_ID/location/LOCATION_ID/queues/QUEUE_ID`
-   * @return
-   * @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
-   */
+  ///
+  /// Resume a queue.
+  ///
+  /// This method resumes a queue after it has been
+  /// [PAUSED][google.cloud.tasks.v2.Queue.State.PAUSED] or
+  /// [DISABLED][google.cloud.tasks.v2.Queue.State.DISABLED]. The state of a
+  /// queue is stored in the queue's [state][google.cloud.tasks.v2.Queue.state];
+  /// after calling this method it will be set to
+  /// [RUNNING][google.cloud.tasks.v2.Queue.State.RUNNING].
+  ///
+  /// WARNING: Resuming many high-QPS queues at the same time can
+  /// lead to target overloading. If you are resuming high-QPS
+  /// queues, follow the 500/50/5 pattern described in
+  /// [Managing Cloud Tasks Scaling
+  /// Risks](https://cloud.google.com/tasks/docs/manage-cloud-task-scaling).
+  ///
+  /// @param name  Required. The queue name. For example:
+  ///  `projects/PROJECT_ID/location/LOCATION_ID/queues/QUEUE_ID`
+  /// @return
+  /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
+  ///
   StatusOr<google::cloud::tasks::v2::Queue> ResumeQueue(
       std::string const& name);
 
-  /**
-   * Gets the access control policy for a [Queue][google.cloud.tasks.v2.Queue].
-   * Returns an empty policy if the resource exists and does not have a policy
-   * set.
-   *
-   * Authorization requires the following
-   * [Google IAM](https://cloud.google.com/iam) permission on the specified
-   * resource parent:
-   *
-   * * `cloudtasks.queues.getIamPolicy`
-   *
-   * @param resource  REQUIRED: The resource for which the policy is being
-   * requested. See the operation documentation for the appropriate value for
-   * this field.
-   * @return
-   * @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
-   */
+  ///
+  /// Gets the access control policy for a [Queue][google.cloud.tasks.v2.Queue].
+  /// Returns an empty policy if the resource exists and does not have a policy
+  /// set.
+  ///
+  /// Authorization requires the following
+  /// [Google IAM](https://cloud.google.com/iam) permission on the specified
+  /// resource parent:
+  ///
+  /// * `cloudtasks.queues.getIamPolicy`
+  ///
+  /// @param resource  REQUIRED: The resource for which the policy is being
+  /// requested.
+  ///  See the operation documentation for the appropriate value for this field.
+  /// @return
+  /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
+  ///
   StatusOr<google::iam::v1::Policy> GetIamPolicy(std::string const& resource);
 
-  /**
-   * Sets the access control policy for a [Queue][google.cloud.tasks.v2.Queue].
-   * Replaces any existing policy.
-   *
-   * Note: The Cloud Console does not check queue-level IAM permissions yet.
-   * Project-level permissions are required to use the Cloud Console.
-   *
-   * Authorization requires the following
-   * [Google IAM](https://cloud.google.com/iam) permission on the specified
-   * resource parent:
-   *
-   * * `cloudtasks.queues.setIamPolicy`
-   *
-   * @param resource  REQUIRED: The resource for which the policy is being
-   * specified. See the operation documentation for the appropriate value for
-   * this field.
-   * @param policy  REQUIRED: The complete policy to be applied to the
-   * `resource`. The size of the policy is limited to a few 10s of KB. An empty
-   * policy is a valid policy but certain Cloud Platform services (such as
-   * Projects) might reject them.
-   * @return
-   * @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
-   */
+  ///
+  /// Sets the access control policy for a [Queue][google.cloud.tasks.v2.Queue].
+  /// Replaces any existing policy.
+  ///
+  /// Note: The Cloud Console does not check queue-level IAM permissions yet.
+  /// Project-level permissions are required to use the Cloud Console.
+  ///
+  /// Authorization requires the following
+  /// [Google IAM](https://cloud.google.com/iam) permission on the specified
+  /// resource parent:
+  ///
+  /// * `cloudtasks.queues.setIamPolicy`
+  ///
+  /// @param resource  REQUIRED: The resource for which the policy is being
+  /// specified.
+  ///  See the operation documentation for the appropriate value for this field.
+  /// @param policy  REQUIRED: The complete policy to be applied to the
+  /// `resource`. The size of
+  ///  the policy is limited to a few 10s of KB. An empty policy is a
+  ///  valid policy but certain Cloud Platform services (such as Projects)
+  ///  might reject them.
+  /// @return
+  /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
+  ///
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
       std::string const& resource, google::iam::v1::Policy const& policy);
 
@@ -287,445 +289,445 @@ class CloudTasksClient {
                                                  IamUpdater const& updater,
                                                  Options options = {});
 
-  /**
-   * Returns permissions that a caller has on a
-   * [Queue][google.cloud.tasks.v2.Queue]. If the resource does not exist, this
-   * will return an empty set of permissions, not a
-   * [NOT_FOUND][google.rpc.Code.NOT_FOUND] error.
-   *
-   * Note: This operation is designed to be used for building permission-aware
-   * UIs and command-line tools, not for authorization checking. This operation
-   * may "fail open" without warning.
-   *
-   * @param resource  REQUIRED: The resource for which the policy detail is
-   * being requested. See the operation documentation for the appropriate value
-   * for this field.
-   * @param permissions  The set of permissions to check for the `resource`.
-   * Permissions with wildcards (such as '*' or 'storage.*') are not allowed.
-   * For more information see [IAM
-   * Overview](https://cloud.google.com/iam/docs/overview#permissions).
-   * @return
-   * @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
-   */
+  ///
+  /// Returns permissions that a caller has on a
+  /// [Queue][google.cloud.tasks.v2.Queue]. If the resource does not exist, this
+  /// will return an empty set of permissions, not a
+  /// [NOT_FOUND][google.rpc.Code.NOT_FOUND] error.
+  ///
+  /// Note: This operation is designed to be used for building permission-aware
+  /// UIs and command-line tools, not for authorization checking. This operation
+  /// may "fail open" without warning.
+  ///
+  /// @param resource  REQUIRED: The resource for which the policy detail is
+  /// being requested.
+  ///  See the operation documentation for the appropriate value for this field.
+  /// @param permissions  The set of permissions to check for the `resource`.
+  /// Permissions with
+  ///  wildcards (such as '*' or 'storage.*') are not allowed. For more
+  ///  information see
+  ///  [IAM Overview](https://cloud.google.com/iam/docs/overview#permissions).
+  /// @return
+  /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
+  ///
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
       std::string const& resource, std::vector<std::string> const& permissions);
 
-  /**
-   * Lists the tasks in a queue.
-   *
-   * By default, only the [BASIC][google.cloud.tasks.v2.Task.View.BASIC] view is
-   * retrieved due to performance considerations;
-   * [response_view][google.cloud.tasks.v2.ListTasksRequest.response_view]
-   * controls the subset of information which is returned.
-   *
-   * The tasks may be returned in any order. The ordering may change at any
-   * time.
-   *
-   * @param parent  Required. The queue name. For example:
-   *  `projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID`
-   * @return
-   * @googleapis_link{google::cloud::tasks::v2::Task,google/cloud/tasks/v2/task.proto#L33}
-   */
+  ///
+  /// Lists the tasks in a queue.
+  ///
+  /// By default, only the [BASIC][google.cloud.tasks.v2.Task.View.BASIC] view
+  /// is retrieved due to performance considerations;
+  /// [response_view][google.cloud.tasks.v2.ListTasksRequest.response_view]
+  /// controls the subset of information which is returned.
+  ///
+  /// The tasks may be returned in any order. The ordering may change at any
+  /// time.
+  ///
+  /// @param parent  Required. The queue name. For example:
+  ///  `projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID`
+  /// @return
+  /// @googleapis_link{google::cloud::tasks::v2::Task,google/cloud/tasks/v2/task.proto#L33}
+  ///
   StreamRange<google::cloud::tasks::v2::Task> ListTasks(
       std::string const& parent);
 
-  /**
-   * Gets a task.
-   *
-   * @param name  Required. The task name. For example:
-   *  `projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID/tasks/TASK_ID`
-   * @return
-   * @googleapis_link{google::cloud::tasks::v2::Task,google/cloud/tasks/v2/task.proto#L33}
-   */
+  ///
+  /// Gets a task.
+  ///
+  /// @param name  Required. The task name. For example:
+  ///  `projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID/tasks/TASK_ID`
+  /// @return
+  /// @googleapis_link{google::cloud::tasks::v2::Task,google/cloud/tasks/v2/task.proto#L33}
+  ///
   StatusOr<google::cloud::tasks::v2::Task> GetTask(std::string const& name);
 
-  /**
-   * Creates a task and adds it to a queue.
-   *
-   * Tasks cannot be updated after creation; there is no UpdateTask command.
-   *
-   * * The maximum task size is 100KB.
-   *
-   * @param parent  Required. The queue name. For example:
-   *  `projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID`
-   *  The queue must already exist.
-   * @param task  Required. The task to add.
-   *  Task names have the following format:
-   *  `projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID/tasks/TASK_ID`.
-   *  The user can optionally specify a task
-   * [name][google.cloud.tasks.v2.Task.name]. If a name is not specified then
-   * the system will generate a random unique task id, which will be set in the
-   * task returned in the [response][google.cloud.tasks.v2.Task.name]. If
-   * [schedule_time][google.cloud.tasks.v2.Task.schedule_time] is not set or is
-   * in the past then Cloud Tasks will set it to the current time. Task
-   * De-duplication: Explicitly specifying a task ID enables task
-   * de-duplication.  If a task's ID is identical to that of an existing task or
-   * a task that was deleted or executed recently then the call will fail with
-   * [ALREADY_EXISTS][google.rpc.Code.ALREADY_EXISTS]. If the task's queue was
-   * created using Cloud Tasks, then another task with the same name can't be
-   * created for ~1hour after the original task was deleted or executed. If the
-   * task's queue was created using queue.yaml or queue.xml, then another task
-   * with the same name can't be created for ~9days after the original task was
-   * deleted or executed. Because there is an extra lookup cost to identify
-   * duplicate task names, these
-   * [CreateTask][google.cloud.tasks.v2.CloudTasks.CreateTask] calls have
-   * significantly increased latency. Using hashed strings for the task id or
-   * for the prefix of the task id is recommended. Choosing task ids that are
-   * sequential or have sequential prefixes, for example using a timestamp,
-   * causes an increase in latency and error rates in all task commands. The
-   * infrastructure relies on an approximately uniform distribution of task ids
-   * to store and serve tasks efficiently.
-   * @return
-   * @googleapis_link{google::cloud::tasks::v2::Task,google/cloud/tasks/v2/task.proto#L33}
-   */
+  ///
+  /// Creates a task and adds it to a queue.
+  ///
+  /// Tasks cannot be updated after creation; there is no UpdateTask command.
+  ///
+  /// * The maximum task size is 100KB.
+  ///
+  /// @param parent  Required. The queue name. For example:
+  ///  `projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID`
+  ///  The queue must already exist.
+  /// @param task  Required. The task to add.
+  ///  Task names have the following format:
+  ///  `projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID/tasks/TASK_ID`.
+  ///  The user can optionally specify a task
+  ///  [name][google.cloud.tasks.v2.Task.name]. If a name is not specified then
+  ///  the system will generate a random unique task id, which will be set in
+  ///  the task returned in the [response][google.cloud.tasks.v2.Task.name]. If
+  ///  [schedule_time][google.cloud.tasks.v2.Task.schedule_time] is not set or
+  ///  is in the past then Cloud Tasks will set it to the current time. Task
+  ///  De-duplication: Explicitly specifying a task ID enables task
+  ///  de-duplication.  If a task's ID is identical to that of an existing task
+  ///  or a task that was deleted or executed recently then the call will fail
+  ///  with [ALREADY_EXISTS][google.rpc.Code.ALREADY_EXISTS].
+  ///  If the task's queue was created using Cloud Tasks, then another task with
+  ///  the same name can't be created for ~1hour after the original task was
+  ///  deleted or executed. If the task's queue was created using queue.yaml or
+  ///  queue.xml, then another task with the same name can't be created
+  ///  for ~9days after the original task was deleted or executed.
+  ///  Because there is an extra lookup cost to identify duplicate task
+  ///  names, these [CreateTask][google.cloud.tasks.v2.CloudTasks.CreateTask]
+  ///  calls have significantly increased latency. Using hashed strings for the
+  ///  task id or for the prefix of the task id is recommended. Choosing task
+  ///  ids that are sequential or have sequential prefixes, for example using a
+  ///  timestamp, causes an increase in latency and error rates in all
+  ///  task commands. The infrastructure relies on an approximately
+  ///  uniform distribution of task ids to store and serve tasks
+  ///  efficiently.
+  /// @return
+  /// @googleapis_link{google::cloud::tasks::v2::Task,google/cloud/tasks/v2/task.proto#L33}
+  ///
   StatusOr<google::cloud::tasks::v2::Task> CreateTask(
       std::string const& parent, google::cloud::tasks::v2::Task const& task);
 
-  /**
-   * Deletes a task.
-   *
-   * A task can be deleted if it is scheduled or dispatched. A task
-   * cannot be deleted if it has executed successfully or permanently
-   * failed.
-   *
-   * @param name  Required. The task name. For example:
-   *  `projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID/tasks/TASK_ID`
-   */
+  ///
+  /// Deletes a task.
+  ///
+  /// A task can be deleted if it is scheduled or dispatched. A task
+  /// cannot be deleted if it has executed successfully or permanently
+  /// failed.
+  ///
+  /// @param name  Required. The task name. For example:
+  ///  `projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID/tasks/TASK_ID`
+  ///
   Status DeleteTask(std::string const& name);
 
-  /**
-   * Forces a task to run now.
-   *
-   * When this method is called, Cloud Tasks will dispatch the task, even if
-   * the task is already running, the queue has reached its
-   * [RateLimits][google.cloud.tasks.v2.RateLimits] or is
-   * [PAUSED][google.cloud.tasks.v2.Queue.State.PAUSED].
-   *
-   * This command is meant to be used for manual debugging. For
-   * example, [RunTask][google.cloud.tasks.v2.CloudTasks.RunTask] can be used to
-   * retry a failed task after a fix has been made or to manually force a task
-   * to be dispatched now.
-   *
-   * The dispatched task is returned. That is, the task that is returned
-   * contains the [status][Task.status] after the task is dispatched but
-   * before the task is received by its target.
-   *
-   * If Cloud Tasks receives a successful response from the task's
-   * target, then the task will be deleted; otherwise the task's
-   * [schedule_time][google.cloud.tasks.v2.Task.schedule_time] will be reset to
-   * the time that [RunTask][google.cloud.tasks.v2.CloudTasks.RunTask] was
-   * called plus the retry delay specified in the queue's
-   * [RetryConfig][google.cloud.tasks.v2.RetryConfig].
-   *
-   * [RunTask][google.cloud.tasks.v2.CloudTasks.RunTask] returns
-   * [NOT_FOUND][google.rpc.Code.NOT_FOUND] when it is called on a
-   * task that has already succeeded or permanently failed.
-   *
-   * @param name  Required. The task name. For example:
-   *  `projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID/tasks/TASK_ID`
-   * @return
-   * @googleapis_link{google::cloud::tasks::v2::Task,google/cloud/tasks/v2/task.proto#L33}
-   */
+  ///
+  /// Forces a task to run now.
+  ///
+  /// When this method is called, Cloud Tasks will dispatch the task, even if
+  /// the task is already running, the queue has reached its
+  /// [RateLimits][google.cloud.tasks.v2.RateLimits] or is
+  /// [PAUSED][google.cloud.tasks.v2.Queue.State.PAUSED].
+  ///
+  /// This command is meant to be used for manual debugging. For
+  /// example, [RunTask][google.cloud.tasks.v2.CloudTasks.RunTask] can be used
+  /// to retry a failed task after a fix has been made or to manually force a
+  /// task to be dispatched now.
+  ///
+  /// The dispatched task is returned. That is, the task that is returned
+  /// contains the [status][Task.status] after the task is dispatched but
+  /// before the task is received by its target.
+  ///
+  /// If Cloud Tasks receives a successful response from the task's
+  /// target, then the task will be deleted; otherwise the task's
+  /// [schedule_time][google.cloud.tasks.v2.Task.schedule_time] will be reset to
+  /// the time that [RunTask][google.cloud.tasks.v2.CloudTasks.RunTask] was
+  /// called plus the retry delay specified in the queue's
+  /// [RetryConfig][google.cloud.tasks.v2.RetryConfig].
+  ///
+  /// [RunTask][google.cloud.tasks.v2.CloudTasks.RunTask] returns
+  /// [NOT_FOUND][google.rpc.Code.NOT_FOUND] when it is called on a
+  /// task that has already succeeded or permanently failed.
+  ///
+  /// @param name  Required. The task name. For example:
+  ///  `projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID/tasks/TASK_ID`
+  /// @return
+  /// @googleapis_link{google::cloud::tasks::v2::Task,google/cloud/tasks/v2/task.proto#L33}
+  ///
   StatusOr<google::cloud::tasks::v2::Task> RunTask(std::string const& name);
 
-  /**
-   * Lists queues.
-   *
-   * Queues are returned in lexicographical order.
-   *
-   * @param request
-   * @googleapis_link{google::cloud::tasks::v2::ListQueuesRequest,google/cloud/tasks/v2/cloudtasks.proto#L308}
-   * @return
-   * @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
-   */
+  ///
+  /// Lists queues.
+  ///
+  /// Queues are returned in lexicographical order.
+  ///
+  /// @param request
+  /// @googleapis_link{google::cloud::tasks::v2::ListQueuesRequest,google/cloud/tasks/v2/cloudtasks.proto#L308}
+  /// @return
+  /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
+  ///
   StreamRange<google::cloud::tasks::v2::Queue> ListQueues(
       google::cloud::tasks::v2::ListQueuesRequest request);
 
-  /**
-   * Gets a queue.
-   *
-   * @param request
-   * @googleapis_link{google::cloud::tasks::v2::GetQueueRequest,google/cloud/tasks/v2/cloudtasks.proto#L369}
-   * @return
-   * @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
-   */
+  ///
+  /// Gets a queue.
+  ///
+  /// @param request
+  /// @googleapis_link{google::cloud::tasks::v2::GetQueueRequest,google/cloud/tasks/v2/cloudtasks.proto#L369}
+  /// @return
+  /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
+  ///
   StatusOr<google::cloud::tasks::v2::Queue> GetQueue(
       google::cloud::tasks::v2::GetQueueRequest const& request);
 
-  /**
-   * Creates a queue.
-   *
-   * Queues created with this method allow tasks to live for a maximum of 31
-   * days. After a task is 31 days old, the task will be deleted regardless of
-   * whether it was dispatched or not.
-   *
-   * WARNING: Using this method may have unintended side effects if you are
-   * using an App Engine `queue.yaml` or `queue.xml` file to manage your queues.
-   * Read
-   * [Overview of Queue Management and
-   * queue.yaml](https://cloud.google.com/tasks/docs/queue-yaml) before using
-   * this method.
-   *
-   * @param request
-   * @googleapis_link{google::cloud::tasks::v2::CreateQueueRequest,google/cloud/tasks/v2/cloudtasks.proto#L381}
-   * @return
-   * @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
-   */
+  ///
+  /// Creates a queue.
+  ///
+  /// Queues created with this method allow tasks to live for a maximum of 31
+  /// days. After a task is 31 days old, the task will be deleted regardless of
+  /// whether it was dispatched or not.
+  ///
+  /// WARNING: Using this method may have unintended side effects if you are
+  /// using an App Engine `queue.yaml` or `queue.xml` file to manage your
+  /// queues. Read [Overview of Queue Management and
+  /// queue.yaml](https://cloud.google.com/tasks/docs/queue-yaml) before using
+  /// this method.
+  ///
+  /// @param request
+  /// @googleapis_link{google::cloud::tasks::v2::CreateQueueRequest,google/cloud/tasks/v2/cloudtasks.proto#L381}
+  /// @return
+  /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
+  ///
   StatusOr<google::cloud::tasks::v2::Queue> CreateQueue(
       google::cloud::tasks::v2::CreateQueueRequest const& request);
 
-  /**
-   * Updates a queue.
-   *
-   * This method creates the queue if it does not exist and updates
-   * the queue if it does exist.
-   *
-   * Queues created with this method allow tasks to live for a maximum of 31
-   * days. After a task is 31 days old, the task will be deleted regardless of
-   * whether it was dispatched or not.
-   *
-   * WARNING: Using this method may have unintended side effects if you are
-   * using an App Engine `queue.yaml` or `queue.xml` file to manage your queues.
-   * Read
-   * [Overview of Queue Management and
-   * queue.yaml](https://cloud.google.com/tasks/docs/queue-yaml) before using
-   * this method.
-   *
-   * @param request
-   * @googleapis_link{google::cloud::tasks::v2::UpdateQueueRequest,google/cloud/tasks/v2/cloudtasks.proto#L402}
-   * @return
-   * @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
-   */
+  ///
+  /// Updates a queue.
+  ///
+  /// This method creates the queue if it does not exist and updates
+  /// the queue if it does exist.
+  ///
+  /// Queues created with this method allow tasks to live for a maximum of 31
+  /// days. After a task is 31 days old, the task will be deleted regardless of
+  /// whether it was dispatched or not.
+  ///
+  /// WARNING: Using this method may have unintended side effects if you are
+  /// using an App Engine `queue.yaml` or `queue.xml` file to manage your
+  /// queues. Read [Overview of Queue Management and
+  /// queue.yaml](https://cloud.google.com/tasks/docs/queue-yaml) before using
+  /// this method.
+  ///
+  /// @param request
+  /// @googleapis_link{google::cloud::tasks::v2::UpdateQueueRequest,google/cloud/tasks/v2/cloudtasks.proto#L402}
+  /// @return
+  /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
+  ///
   StatusOr<google::cloud::tasks::v2::Queue> UpdateQueue(
       google::cloud::tasks::v2::UpdateQueueRequest const& request);
 
-  /**
-   * Deletes a queue.
-   *
-   * This command will delete the queue even if it has tasks in it.
-   *
-   * Note: If you delete a queue, a queue with the same name can't be created
-   * for 7 days.
-   *
-   * WARNING: Using this method may have unintended side effects if you are
-   * using an App Engine `queue.yaml` or `queue.xml` file to manage your queues.
-   * Read
-   * [Overview of Queue Management and
-   * queue.yaml](https://cloud.google.com/tasks/docs/queue-yaml) before using
-   * this method.
-   *
-   * @param request
-   * @googleapis_link{google::cloud::tasks::v2::DeleteQueueRequest,google/cloud/tasks/v2/cloudtasks.proto#L419}
-   */
+  ///
+  /// Deletes a queue.
+  ///
+  /// This command will delete the queue even if it has tasks in it.
+  ///
+  /// Note: If you delete a queue, a queue with the same name can't be created
+  /// for 7 days.
+  ///
+  /// WARNING: Using this method may have unintended side effects if you are
+  /// using an App Engine `queue.yaml` or `queue.xml` file to manage your
+  /// queues. Read [Overview of Queue Management and
+  /// queue.yaml](https://cloud.google.com/tasks/docs/queue-yaml) before using
+  /// this method.
+  ///
+  /// @param request
+  /// @googleapis_link{google::cloud::tasks::v2::DeleteQueueRequest,google/cloud/tasks/v2/cloudtasks.proto#L419}
+  ///
   Status DeleteQueue(
       google::cloud::tasks::v2::DeleteQueueRequest const& request);
 
-  /**
-   * Purges a queue by deleting all of its tasks.
-   *
-   * All tasks created before this method is called are permanently deleted.
-   *
-   * Purge operations can take up to one minute to take effect. Tasks
-   * might be dispatched before the purge takes effect. A purge is irreversible.
-   *
-   * @param request
-   * @googleapis_link{google::cloud::tasks::v2::PurgeQueueRequest,google/cloud/tasks/v2/cloudtasks.proto#L431}
-   * @return
-   * @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
-   */
+  ///
+  /// Purges a queue by deleting all of its tasks.
+  ///
+  /// All tasks created before this method is called are permanently deleted.
+  ///
+  /// Purge operations can take up to one minute to take effect. Tasks
+  /// might be dispatched before the purge takes effect. A purge is
+  /// irreversible.
+  ///
+  /// @param request
+  /// @googleapis_link{google::cloud::tasks::v2::PurgeQueueRequest,google/cloud/tasks/v2/cloudtasks.proto#L431}
+  /// @return
+  /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
+  ///
   StatusOr<google::cloud::tasks::v2::Queue> PurgeQueue(
       google::cloud::tasks::v2::PurgeQueueRequest const& request);
 
-  /**
-   * Pauses the queue.
-   *
-   * If a queue is paused then the system will stop dispatching tasks
-   * until the queue is resumed via
-   * [ResumeQueue][google.cloud.tasks.v2.CloudTasks.ResumeQueue]. Tasks can
-   * still be added when the queue is paused. A queue is paused if its
-   * [state][google.cloud.tasks.v2.Queue.state] is
-   * [PAUSED][google.cloud.tasks.v2.Queue.State.PAUSED].
-   *
-   * @param request
-   * @googleapis_link{google::cloud::tasks::v2::PauseQueueRequest,google/cloud/tasks/v2/cloudtasks.proto#L443}
-   * @return
-   * @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
-   */
+  ///
+  /// Pauses the queue.
+  ///
+  /// If a queue is paused then the system will stop dispatching tasks
+  /// until the queue is resumed via
+  /// [ResumeQueue][google.cloud.tasks.v2.CloudTasks.ResumeQueue]. Tasks can
+  /// still be added when the queue is paused. A queue is paused if its
+  /// [state][google.cloud.tasks.v2.Queue.state] is
+  /// [PAUSED][google.cloud.tasks.v2.Queue.State.PAUSED].
+  ///
+  /// @param request
+  /// @googleapis_link{google::cloud::tasks::v2::PauseQueueRequest,google/cloud/tasks/v2/cloudtasks.proto#L443}
+  /// @return
+  /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
+  ///
   StatusOr<google::cloud::tasks::v2::Queue> PauseQueue(
       google::cloud::tasks::v2::PauseQueueRequest const& request);
 
-  /**
-   * Resume a queue.
-   *
-   * This method resumes a queue after it has been
-   * [PAUSED][google.cloud.tasks.v2.Queue.State.PAUSED] or
-   * [DISABLED][google.cloud.tasks.v2.Queue.State.DISABLED]. The state of a
-   * queue is stored in the queue's [state][google.cloud.tasks.v2.Queue.state];
-   * after calling this method it will be set to
-   * [RUNNING][google.cloud.tasks.v2.Queue.State.RUNNING].
-   *
-   * WARNING: Resuming many high-QPS queues at the same time can
-   * lead to target overloading. If you are resuming high-QPS
-   * queues, follow the 500/50/5 pattern described in
-   * [Managing Cloud Tasks Scaling
-   * Risks](https://cloud.google.com/tasks/docs/manage-cloud-task-scaling).
-   *
-   * @param request
-   * @googleapis_link{google::cloud::tasks::v2::ResumeQueueRequest,google/cloud/tasks/v2/cloudtasks.proto#L455}
-   * @return
-   * @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
-   */
+  ///
+  /// Resume a queue.
+  ///
+  /// This method resumes a queue after it has been
+  /// [PAUSED][google.cloud.tasks.v2.Queue.State.PAUSED] or
+  /// [DISABLED][google.cloud.tasks.v2.Queue.State.DISABLED]. The state of a
+  /// queue is stored in the queue's [state][google.cloud.tasks.v2.Queue.state];
+  /// after calling this method it will be set to
+  /// [RUNNING][google.cloud.tasks.v2.Queue.State.RUNNING].
+  ///
+  /// WARNING: Resuming many high-QPS queues at the same time can
+  /// lead to target overloading. If you are resuming high-QPS
+  /// queues, follow the 500/50/5 pattern described in
+  /// [Managing Cloud Tasks Scaling
+  /// Risks](https://cloud.google.com/tasks/docs/manage-cloud-task-scaling).
+  ///
+  /// @param request
+  /// @googleapis_link{google::cloud::tasks::v2::ResumeQueueRequest,google/cloud/tasks/v2/cloudtasks.proto#L455}
+  /// @return
+  /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
+  ///
   StatusOr<google::cloud::tasks::v2::Queue> ResumeQueue(
       google::cloud::tasks::v2::ResumeQueueRequest const& request);
 
-  /**
-   * Gets the access control policy for a [Queue][google.cloud.tasks.v2.Queue].
-   * Returns an empty policy if the resource exists and does not have a policy
-   * set.
-   *
-   * Authorization requires the following
-   * [Google IAM](https://cloud.google.com/iam) permission on the specified
-   * resource parent:
-   *
-   * * `cloudtasks.queues.getIamPolicy`
-   *
-   * @param request
-   * @googleapis_link{google::iam::v1::GetIamPolicyRequest,google/iam/v1/iam_policy.proto#L113}
-   * @return
-   * @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
-   */
+  ///
+  /// Gets the access control policy for a [Queue][google.cloud.tasks.v2.Queue].
+  /// Returns an empty policy if the resource exists and does not have a policy
+  /// set.
+  ///
+  /// Authorization requires the following
+  /// [Google IAM](https://cloud.google.com/iam) permission on the specified
+  /// resource parent:
+  ///
+  /// * `cloudtasks.queues.getIamPolicy`
+  ///
+  /// @param request
+  /// @googleapis_link{google::iam::v1::GetIamPolicyRequest,google/iam/v1/iam_policy.proto#L113}
+  /// @return
+  /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
+  ///
   StatusOr<google::iam::v1::Policy> GetIamPolicy(
       google::iam::v1::GetIamPolicyRequest const& request);
 
-  /**
-   * Sets the access control policy for a [Queue][google.cloud.tasks.v2.Queue].
-   * Replaces any existing policy.
-   *
-   * Note: The Cloud Console does not check queue-level IAM permissions yet.
-   * Project-level permissions are required to use the Cloud Console.
-   *
-   * Authorization requires the following
-   * [Google IAM](https://cloud.google.com/iam) permission on the specified
-   * resource parent:
-   *
-   * * `cloudtasks.queues.setIamPolicy`
-   *
-   * @param request
-   * @googleapis_link{google::iam::v1::SetIamPolicyRequest,google/iam/v1/iam_policy.proto#L98}
-   * @return
-   * @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
-   */
+  ///
+  /// Sets the access control policy for a [Queue][google.cloud.tasks.v2.Queue].
+  /// Replaces any existing policy.
+  ///
+  /// Note: The Cloud Console does not check queue-level IAM permissions yet.
+  /// Project-level permissions are required to use the Cloud Console.
+  ///
+  /// Authorization requires the following
+  /// [Google IAM](https://cloud.google.com/iam) permission on the specified
+  /// resource parent:
+  ///
+  /// * `cloudtasks.queues.setIamPolicy`
+  ///
+  /// @param request
+  /// @googleapis_link{google::iam::v1::SetIamPolicyRequest,google/iam/v1/iam_policy.proto#L98}
+  /// @return
+  /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
+  ///
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
       google::iam::v1::SetIamPolicyRequest const& request);
 
-  /**
-   * Returns permissions that a caller has on a
-   * [Queue][google.cloud.tasks.v2.Queue]. If the resource does not exist, this
-   * will return an empty set of permissions, not a
-   * [NOT_FOUND][google.rpc.Code.NOT_FOUND] error.
-   *
-   * Note: This operation is designed to be used for building permission-aware
-   * UIs and command-line tools, not for authorization checking. This operation
-   * may "fail open" without warning.
-   *
-   * @param request
-   * @googleapis_link{google::iam::v1::TestIamPermissionsRequest,google/iam/v1/iam_policy.proto#L126}
-   * @return
-   * @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
-   */
+  ///
+  /// Returns permissions that a caller has on a
+  /// [Queue][google.cloud.tasks.v2.Queue]. If the resource does not exist, this
+  /// will return an empty set of permissions, not a
+  /// [NOT_FOUND][google.rpc.Code.NOT_FOUND] error.
+  ///
+  /// Note: This operation is designed to be used for building permission-aware
+  /// UIs and command-line tools, not for authorization checking. This operation
+  /// may "fail open" without warning.
+  ///
+  /// @param request
+  /// @googleapis_link{google::iam::v1::TestIamPermissionsRequest,google/iam/v1/iam_policy.proto#L126}
+  /// @return
+  /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
+  ///
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
       google::iam::v1::TestIamPermissionsRequest const& request);
 
-  /**
-   * Lists the tasks in a queue.
-   *
-   * By default, only the [BASIC][google.cloud.tasks.v2.Task.View.BASIC] view is
-   * retrieved due to performance considerations;
-   * [response_view][google.cloud.tasks.v2.ListTasksRequest.response_view]
-   * controls the subset of information which is returned.
-   *
-   * The tasks may be returned in any order. The ordering may change at any
-   * time.
-   *
-   * @param request
-   * @googleapis_link{google::cloud::tasks::v2::ListTasksRequest,google/cloud/tasks/v2/cloudtasks.proto#L467}
-   * @return
-   * @googleapis_link{google::cloud::tasks::v2::Task,google/cloud/tasks/v2/task.proto#L33}
-   */
+  ///
+  /// Lists the tasks in a queue.
+  ///
+  /// By default, only the [BASIC][google.cloud.tasks.v2.Task.View.BASIC] view
+  /// is retrieved due to performance considerations;
+  /// [response_view][google.cloud.tasks.v2.ListTasksRequest.response_view]
+  /// controls the subset of information which is returned.
+  ///
+  /// The tasks may be returned in any order. The ordering may change at any
+  /// time.
+  ///
+  /// @param request
+  /// @googleapis_link{google::cloud::tasks::v2::ListTasksRequest,google/cloud/tasks/v2/cloudtasks.proto#L467}
+  /// @return
+  /// @googleapis_link{google::cloud::tasks::v2::Task,google/cloud/tasks/v2/task.proto#L33}
+  ///
   StreamRange<google::cloud::tasks::v2::Task> ListTasks(
       google::cloud::tasks::v2::ListTasksRequest request);
 
-  /**
-   * Gets a task.
-   *
-   * @param request
-   * @googleapis_link{google::cloud::tasks::v2::GetTaskRequest,google/cloud/tasks/v2/cloudtasks.proto#L529}
-   * @return
-   * @googleapis_link{google::cloud::tasks::v2::Task,google/cloud/tasks/v2/task.proto#L33}
-   */
+  ///
+  /// Gets a task.
+  ///
+  /// @param request
+  /// @googleapis_link{google::cloud::tasks::v2::GetTaskRequest,google/cloud/tasks/v2/cloudtasks.proto#L529}
+  /// @return
+  /// @googleapis_link{google::cloud::tasks::v2::Task,google/cloud/tasks/v2/task.proto#L33}
+  ///
   StatusOr<google::cloud::tasks::v2::Task> GetTask(
       google::cloud::tasks::v2::GetTaskRequest const& request);
 
-  /**
-   * Creates a task and adds it to a queue.
-   *
-   * Tasks cannot be updated after creation; there is no UpdateTask command.
-   *
-   * * The maximum task size is 100KB.
-   *
-   * @param request
-   * @googleapis_link{google::cloud::tasks::v2::CreateTaskRequest,google/cloud/tasks/v2/cloudtasks.proto#L555}
-   * @return
-   * @googleapis_link{google::cloud::tasks::v2::Task,google/cloud/tasks/v2/task.proto#L33}
-   */
+  ///
+  /// Creates a task and adds it to a queue.
+  ///
+  /// Tasks cannot be updated after creation; there is no UpdateTask command.
+  ///
+  /// * The maximum task size is 100KB.
+  ///
+  /// @param request
+  /// @googleapis_link{google::cloud::tasks::v2::CreateTaskRequest,google/cloud/tasks/v2/cloudtasks.proto#L555}
+  /// @return
+  /// @googleapis_link{google::cloud::tasks::v2::Task,google/cloud/tasks/v2/task.proto#L33}
+  ///
   StatusOr<google::cloud::tasks::v2::Task> CreateTask(
       google::cloud::tasks::v2::CreateTaskRequest const& request);
 
-  /**
-   * Deletes a task.
-   *
-   * A task can be deleted if it is scheduled or dispatched. A task
-   * cannot be deleted if it has executed successfully or permanently
-   * failed.
-   *
-   * @param request
-   * @googleapis_link{google::cloud::tasks::v2::DeleteTaskRequest,google/cloud/tasks/v2/cloudtasks.proto#L619}
-   */
+  ///
+  /// Deletes a task.
+  ///
+  /// A task can be deleted if it is scheduled or dispatched. A task
+  /// cannot be deleted if it has executed successfully or permanently
+  /// failed.
+  ///
+  /// @param request
+  /// @googleapis_link{google::cloud::tasks::v2::DeleteTaskRequest,google/cloud/tasks/v2/cloudtasks.proto#L619}
+  ///
   Status DeleteTask(google::cloud::tasks::v2::DeleteTaskRequest const& request);
 
-  /**
-   * Forces a task to run now.
-   *
-   * When this method is called, Cloud Tasks will dispatch the task, even if
-   * the task is already running, the queue has reached its
-   * [RateLimits][google.cloud.tasks.v2.RateLimits] or is
-   * [PAUSED][google.cloud.tasks.v2.Queue.State.PAUSED].
-   *
-   * This command is meant to be used for manual debugging. For
-   * example, [RunTask][google.cloud.tasks.v2.CloudTasks.RunTask] can be used to
-   * retry a failed task after a fix has been made or to manually force a task
-   * to be dispatched now.
-   *
-   * The dispatched task is returned. That is, the task that is returned
-   * contains the [status][Task.status] after the task is dispatched but
-   * before the task is received by its target.
-   *
-   * If Cloud Tasks receives a successful response from the task's
-   * target, then the task will be deleted; otherwise the task's
-   * [schedule_time][google.cloud.tasks.v2.Task.schedule_time] will be reset to
-   * the time that [RunTask][google.cloud.tasks.v2.CloudTasks.RunTask] was
-   * called plus the retry delay specified in the queue's
-   * [RetryConfig][google.cloud.tasks.v2.RetryConfig].
-   *
-   * [RunTask][google.cloud.tasks.v2.CloudTasks.RunTask] returns
-   * [NOT_FOUND][google.rpc.Code.NOT_FOUND] when it is called on a
-   * task that has already succeeded or permanently failed.
-   *
-   * @param request
-   * @googleapis_link{google::cloud::tasks::v2::RunTaskRequest,google/cloud/tasks/v2/cloudtasks.proto#L632}
-   * @return
-   * @googleapis_link{google::cloud::tasks::v2::Task,google/cloud/tasks/v2/task.proto#L33}
-   */
+  ///
+  /// Forces a task to run now.
+  ///
+  /// When this method is called, Cloud Tasks will dispatch the task, even if
+  /// the task is already running, the queue has reached its
+  /// [RateLimits][google.cloud.tasks.v2.RateLimits] or is
+  /// [PAUSED][google.cloud.tasks.v2.Queue.State.PAUSED].
+  ///
+  /// This command is meant to be used for manual debugging. For
+  /// example, [RunTask][google.cloud.tasks.v2.CloudTasks.RunTask] can be used
+  /// to retry a failed task after a fix has been made or to manually force a
+  /// task to be dispatched now.
+  ///
+  /// The dispatched task is returned. That is, the task that is returned
+  /// contains the [status][Task.status] after the task is dispatched but
+  /// before the task is received by its target.
+  ///
+  /// If Cloud Tasks receives a successful response from the task's
+  /// target, then the task will be deleted; otherwise the task's
+  /// [schedule_time][google.cloud.tasks.v2.Task.schedule_time] will be reset to
+  /// the time that [RunTask][google.cloud.tasks.v2.CloudTasks.RunTask] was
+  /// called plus the retry delay specified in the queue's
+  /// [RetryConfig][google.cloud.tasks.v2.RetryConfig].
+  ///
+  /// [RunTask][google.cloud.tasks.v2.CloudTasks.RunTask] returns
+  /// [NOT_FOUND][google.rpc.Code.NOT_FOUND] when it is called on a
+  /// task that has already succeeded or permanently failed.
+  ///
+  /// @param request
+  /// @googleapis_link{google::cloud::tasks::v2::RunTaskRequest,google/cloud/tasks/v2/cloudtasks.proto#L632}
+  /// @return
+  /// @googleapis_link{google::cloud::tasks::v2::Task,google/cloud/tasks/v2/task.proto#L33}
+  ///
   StatusOr<google::cloud::tasks::v2::Task> RunTask(
       google::cloud::tasks::v2::RunTaskRequest const& request);
 


### PR DESCRIPTION
Changed doxygen comments to use `///` in lieu of `/**` and `*/` to try and avoid misformatting from wrapped comments containing `/*` sequences.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7652)
<!-- Reviewable:end -->
