### PR TITLE
feat(storage): separate option for download timeouts

### DIFF
--- a/google/cloud/storage/client_options.cc
+++ b/google/cloud/storage/client_options.cc
@@ -183,6 +183,14 @@ Options DefaultOptions(std::shared_ptr<oauth2::Credentials> credentials,
           .set<IdempotencyPolicyOption>(AlwaysRetryIdempotencyPolicy().clone());
 
   o = google::cloud::internal::MergeOptions(std::move(opts), std::move(o));
+  // If the application did not set `DownloadStallTimeoutOption` then use the
+  // same value as `TransferStallTimeoutOption` (which could be the default
+  // value). Some applications need tighter timeouts for downloads, but longer
+  // timeouts for other transfers.
+  if (!o.has<DownloadStallTimeoutOption>()) {
+    o.set<DownloadStallTimeoutOption>(o.get<TransferStallTimeoutOption>());
+  }
+
   auto emulator = GetEmulator();
   if (emulator.has_value()) {
     o.set<RestEndpointOption>(*emulator).set<IamEndpointOption>(*emulator +

--- a/google/cloud/storage/client_options.h
+++ b/google/cloud/storage/client_options.h
@@ -413,7 +413,7 @@ class ClientOptions {
    *
    * The default value is 2 minutes. Can be disabled by setting the value to 0.
    *
-   * @deprecated Use google::cloud::Options and TransferStallTimeoutOption
+   * @deprecated Use google::cloud::Options and DownloadStallTimeoutOption
    *     instead.
    */
   std::chrono::seconds download_stall_timeout() const {
@@ -421,7 +421,7 @@ class ClientOptions {
   }
 
   /**
-   * @deprecated Use google::cloud::Options and TransferStallTimeoutOption
+   * @deprecated Use google::cloud::Options and DownloadStallTimeoutOption
    *     instead.
    */
   ClientOptions& set_download_stall_timeout(std::chrono::seconds v) {

--- a/google/cloud/storage/client_options_test.cc
+++ b/google/cloud/storage/client_options_test.cc
@@ -339,6 +339,33 @@ TEST_F(ClientOptionsTest, DefaultOptions) {
   EXPECT_EQ("https://private.googleapis.com", o.get<RestEndpointOption>());
 }
 
+TEST_F(ClientOptionsTest, Timeouts) {
+  EXPECT_EQ(std::chrono::seconds(42),
+            internal::DefaultOptions(oauth2::CreateAnonymousCredentials(),
+                                     Options{}.set<TransferStallTimeoutOption>(
+                                         std::chrono::seconds(42)))
+                .get<DownloadStallTimeoutOption>());
+
+  EXPECT_EQ(std::chrono::seconds(7),
+            internal::DefaultOptions(
+                oauth2::CreateAnonymousCredentials(),
+                Options{}
+                    .set<TransferStallTimeoutOption>(std::chrono::seconds(42))
+                    .set<DownloadStallTimeoutOption>(std::chrono::seconds(7)))
+                .get<DownloadStallTimeoutOption>());
+
+  EXPECT_EQ(std::chrono::seconds(7),
+            internal::DefaultOptions(oauth2::CreateAnonymousCredentials(),
+                                     Options{}.set<DownloadStallTimeoutOption>(
+                                         std::chrono::seconds(7)))
+                .get<DownloadStallTimeoutOption>());
+
+  EXPECT_NE(
+      std::chrono::seconds(0),
+      internal::DefaultOptions(oauth2::CreateAnonymousCredentials(), Options{})
+          .get<DownloadStallTimeoutOption>());
+}
+
 }  // namespace
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace storage

--- a/google/cloud/storage/internal/curl_download_request.cc
+++ b/google/cloud/storage/internal/curl_download_request.cc
@@ -85,7 +85,7 @@ extern "C" std::size_t CurlDownloadRequestHeader(char* contents,
 CurlDownloadRequest::CurlDownloadRequest(CurlHeaders headers, CurlHandle handle,
                                          CurlMulti multi)
     : headers_(std::move(headers)),
-      transfer_stall_timeout_(0),
+      download_stall_timeout_(0),
       handle_(std::move(handle)),
       multi_(std::move(multi)),
       spill_(CURL_MAX_WRITE_SIZE) {}
@@ -227,9 +227,9 @@ void CurlDownloadRequest::SetOptions() {
   handle_.SetSocketCallback(socket_options_);
   handle_.SetOptionUnchecked(CURLOPT_HTTP_VERSION,
                              VersionToCurlCode(http_version_));
-  if (transfer_stall_timeout_.count() != 0) {
+  if (download_stall_timeout_.count() != 0) {
     // NOLINTNEXTLINE(google-runtime-int) - libcurl *requires* `long`
-    auto const timeout = static_cast<long>(transfer_stall_timeout_.count());
+    auto const timeout = static_cast<long>(download_stall_timeout_.count());
     handle_.SetOption(CURLOPT_CONNECTTIMEOUT, timeout);
     // Timeout if the download receives less than 1 byte/second (i.e.
     // effectively no bytes) for `transfer_stall_timeout_` seconds.

--- a/google/cloud/storage/internal/curl_download_request.h
+++ b/google/cloud/storage/internal/curl_download_request.h
@@ -133,7 +133,7 @@ class CurlDownloadRequest : public ObjectReadSource {
   std::int32_t http_code_ = 0;
   bool logging_enabled_ = false;
   CurlHandle::SocketOptions socket_options_;
-  std::chrono::seconds transfer_stall_timeout_;
+  std::chrono::seconds download_stall_timeout_;
   CurlHandle handle_;
   CurlMulti multi_;
   std::shared_ptr<CurlHandleFactory> factory_;

--- a/google/cloud/storage/internal/curl_request_builder.cc
+++ b/google/cloud/storage/internal/curl_request_builder.cc
@@ -43,7 +43,8 @@ CurlRequestBuilder::CurlRequestBuilder(
       url_(std::move(base_url)),
       query_parameter_separator_(InitialQueryParameterSeparator(url_)),
       logging_enabled_(false),
-      transfer_stall_timeout_(0) {}
+      transfer_stall_timeout_(0),
+      download_stall_timeout_(0) {}
 
 CurlRequest CurlRequestBuilder::BuildRequest() && {
   ValidateBuilderState(__func__);
@@ -72,7 +73,7 @@ CurlRequestBuilder::BuildDownloadRequest() && {
   request->factory_ = factory_;
   request->logging_enabled_ = logging_enabled_;
   request->socket_options_ = socket_options_;
-  request->transfer_stall_timeout_ = transfer_stall_timeout_;
+  request->download_stall_timeout_ = download_stall_timeout_;
   request->SetOptions();
   return request;
 }
@@ -92,6 +93,7 @@ CurlRequestBuilder& CurlRequestBuilder::ApplyClientOptions(
   http_version_ =
       std::move(options.get<storage_experimental::HttpVersionOption>());
   transfer_stall_timeout_ = options.get<TransferStallTimeoutOption>();
+  download_stall_timeout_ = options.get<DownloadStallTimeoutOption>();
   return *this;
 }
 

--- a/google/cloud/storage/internal/curl_request_builder.h
+++ b/google/cloud/storage/internal/curl_request_builder.h
@@ -196,6 +196,7 @@ class CurlRequestBuilder {
   bool logging_enabled_;
   CurlHandle::SocketOptions socket_options_;
   std::chrono::seconds transfer_stall_timeout_;
+  std::chrono::seconds download_stall_timeout_;
   std::string http_version_;
 };
 

--- a/google/cloud/storage/internal/grpc_client.cc
+++ b/google/cloud/storage/internal/grpc_client.cc
@@ -347,7 +347,7 @@ StatusOr<std::unique_ptr<ObjectReadSource>> GrpcClient::ReadObject(
   }
   auto context = absl::make_unique<grpc::ClientContext>();
   ApplyQueryParameters(*context, request);
-  auto const timeout = options_.get<TransferStallTimeoutOption>();
+  auto const timeout = options_.get<DownloadStallTimeoutOption>();
   if (timeout.count() != 0) {
     context->set_deadline(std::chrono::system_clock::now() + timeout);
   }

--- a/google/cloud/storage/options.h
+++ b/google/cloud/storage/options.h
@@ -206,7 +206,8 @@ struct MaximumCurlSocketSendSizeOption {
  *
  * If a transfer (upload, download, or request) *stalls*, i.e., no bytes are
  * sent or received for a significant period, it may be better to restart the
- * transfer as this may indicate a network glitch.
+ * transfer as this may indicate a network glitch.  For downloads the
+ * #DownloadStallTimeoutOption takes precedence.
  *
  * For large requests (e.g. downloads in the GiB to TiB range) this is a better
  * configuration parameter than a simple timeout, as the transfers will take
@@ -220,9 +221,22 @@ struct TransferStallTimeoutOption {
 };
 
 /**
- * @deprecated Please use TransferStallTimeoutOption instead
+ * Sets the download stall timeout.
+ *
+ * If a download *stalls*, i.e., no bytes are received for a significant period,
+ * it may be better to restart the download as this may indicate a network
+ * glitch.
+ *
+ * For large requests (e.g. downloads in the GiB to TiB range) this is a better
+ * configuration parameter than a simple timeout, as the transfers will take
+ * minutes or hours to complete. Relying on a timeout value for them would not
+ * work, as the timeout would be too large to be useful. For small requests,
+ * this is as effective as a timeout parameter, but maybe unfamiliar and thus
+ * harder to reason about.
  */
-using DownloadStallTimeoutOption = TransferStallTimeoutOption;
+struct DownloadStallTimeoutOption {
+  using Type = std::chrono::seconds;
+};
 
 /// Set the retry policy for a GCS client.
 struct RetryPolicyOption {

--- a/google/cloud/storage/options.h
+++ b/google/cloud/storage/options.h
@@ -207,7 +207,7 @@ struct MaximumCurlSocketSendSizeOption {
  * If a transfer (upload, download, or request) *stalls*, i.e., no bytes are
  * sent or received for a significant period, it may be better to restart the
  * transfer as this may indicate a network glitch.  For downloads the
- * #DownloadStallTimeoutOption takes precedence.
+ * google::cloud::storage::DownloadStallTimeoutOption takes precedence.
  *
  * For large requests (e.g. downloads in the GiB to TiB range) this is a better
  * configuration parameter than a simple timeout, as the transfers will take


### PR DESCRIPTION
Use a separate option for download timeouts.  Some customers need to
tune the downloads differently than other operations.

Fixes #7613

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7655)
<!-- Reviewable:end -->
