### PR TITLE
feat(storage): better debugging for session rewinds

### DIFF
--- a/google/cloud/storage/client_write_object_test.cc
+++ b/google/cloud/storage/client_write_object_test.cc
@@ -169,6 +169,7 @@ TEST_F(WriteObjectTest, WriteObjectPermanentSessionFailurePropagates) {
   EXPECT_CALL(*mock_, CreateResumableSession).WillOnce(returner);
   EXPECT_CALL(*mock_session, UploadChunk)
       .WillRepeatedly(Return(PermanentError()));
+  EXPECT_CALL(*mock_session, next_expected_byte()).WillRepeatedly(Return(0));
   EXPECT_CALL(*mock_session, done()).WillRepeatedly(Return(false));
   EXPECT_CALL(*mock_session, session_id()).WillRepeatedly(ReturnRef(empty));
   auto client = ClientForMock();
@@ -260,6 +261,7 @@ TEST_F(WriteObjectTest, UploadStreamResumableSimulateBug) {
   std::uint64_t bytes_written = 0;
   auto last_response_value = StatusOr<internal::ResumableUploadResponse>(
       Status(StatusCode::kUnknown, ""));
+  auto session_id_value = std::string{"test-only-session-id"};
 
   // This test needs a specially tuned MockClient and ClientOptions.
   auto mock = std::make_shared<testing::MockClient>();
@@ -299,6 +301,8 @@ TEST_F(WriteObjectTest, UploadStreamResumableSimulateBug) {
                 });
         EXPECT_CALL(*mock, last_response())
             .WillRepeatedly(ReturnRef(last_response_value));
+        EXPECT_CALL(*mock, session_id)
+            .WillRepeatedly(ReturnRef(session_id_value));
 
         return make_status_or(
             std::unique_ptr<internal::ResumableUploadSession>(std::move(mock)));

--- a/google/cloud/storage/internal/resumable_upload_session_test.cc
+++ b/google/cloud/storage/internal/resumable_upload_session_test.cc
@@ -53,7 +53,6 @@ TEST(ResumableUploadResponseTest, NoLocation) {
   EXPECT_FALSE(actual.payload.has_value());
   EXPECT_EQ("", actual.upload_session_url);
   EXPECT_EQ(2000, actual.last_committed_byte);
-  EXPECT_EQ("", actual.annotations);
   EXPECT_EQ(ResumableUploadResponse::kInProgress, actual.upload_state);
 }
 
@@ -67,7 +66,6 @@ TEST(ResumableUploadResponseTest, NoRange) {
   EXPECT_EQ("test-object-name", actual.payload->name());
   EXPECT_EQ("location-value", actual.upload_session_url);
   EXPECT_EQ(0, actual.last_committed_byte);
-  EXPECT_NE("", actual.annotations);
   EXPECT_EQ(ResumableUploadResponse::kDone, actual.upload_state);
 }
 
@@ -81,7 +79,6 @@ TEST(ResumableUploadResponseTest, MissingBytesInRange) {
   EXPECT_FALSE(actual.payload.has_value());
   EXPECT_EQ("location-value", actual.upload_session_url);
   EXPECT_EQ(0, actual.last_committed_byte);
-  EXPECT_NE("", actual.annotations);
   EXPECT_EQ(ResumableUploadResponse::kInProgress, actual.upload_state);
 }
 
@@ -92,7 +89,6 @@ TEST(ResumableUploadResponseTest, MissingRangeEnd) {
   EXPECT_FALSE(actual.payload.has_value());
   EXPECT_EQ("", actual.upload_session_url);
   EXPECT_EQ(0, actual.last_committed_byte);
-  EXPECT_NE("", actual.annotations);
   EXPECT_EQ(ResumableUploadResponse::kInProgress, actual.upload_state);
 }
 
@@ -103,7 +99,6 @@ TEST(ResumableUploadResponseTest, InvalidRangeEnd) {
   EXPECT_FALSE(actual.payload.has_value());
   EXPECT_EQ("", actual.upload_session_url);
   EXPECT_EQ(0, actual.last_committed_byte);
-  EXPECT_NE("", actual.annotations);
   EXPECT_EQ(ResumableUploadResponse::kInProgress, actual.upload_state);
 }
 
@@ -114,7 +109,6 @@ TEST(ResumableUploadResponseTest, InvalidRangeBegin) {
   EXPECT_FALSE(actual.payload.has_value());
   EXPECT_EQ("", actual.upload_session_url);
   EXPECT_EQ(0, actual.last_committed_byte);
-  EXPECT_NE("", actual.annotations);
   EXPECT_EQ(ResumableUploadResponse::kInProgress, actual.upload_state);
 }
 
@@ -125,7 +119,6 @@ TEST(ResumableUploadResponseTest, UnexpectedRangeBegin) {
   EXPECT_FALSE(actual.payload.has_value());
   EXPECT_EQ("", actual.upload_session_url);
   EXPECT_EQ(0, actual.last_committed_byte);
-  EXPECT_NE("", actual.annotations);
   EXPECT_EQ(ResumableUploadResponse::kInProgress, actual.upload_state);
 }
 
@@ -136,7 +129,6 @@ TEST(ResumableUploadResponseTest, NegativeEnd) {
   EXPECT_FALSE(actual.payload.has_value());
   EXPECT_EQ("", actual.upload_session_url);
   EXPECT_EQ(0, actual.last_committed_byte);
-  EXPECT_NE("", actual.annotations);
   EXPECT_EQ(ResumableUploadResponse::kInProgress, actual.upload_state);
 }
 

--- a/google/cloud/storage/internal/retry_resumable_upload_session.h
+++ b/google/cloud/storage/internal/retry_resumable_upload_session.h
@@ -20,8 +20,11 @@
 #include "google/cloud/storage/version.h"
 #include "absl/functional/function_ref.h"
 #include "absl/types/optional.h"
+#include <deque>
 #include <memory>
+#include <mutex>
 #include <string>
+#include <thread>
 
 namespace google {
 namespace cloud {
@@ -70,9 +73,19 @@ class RetryResumableUploadSession : public ResumableUploadSession {
                                                  BackoffPolicy& backoff_policy,
                                                  Status last_status);
 
+  void AppendDebug(char const* action, std::uint64_t value);
+
+  struct DebugEntry {
+    std::string action;
+    std::uint64_t value;
+    std::thread::id tid_;
+  };
+
   std::unique_ptr<ResumableUploadSession> session_;
   std::unique_ptr<RetryPolicy const> retry_policy_prototype_;
   std::unique_ptr<BackoffPolicy const> backoff_policy_prototype_;
+  std::mutex mu_;
+  std::deque<DebugEntry> debug_;
 };
 
 }  // namespace internal

--- a/google/cloud/storage/internal/retry_resumable_upload_session_test.cc
+++ b/google/cloud/storage/internal/retry_resumable_upload_session_test.cc
@@ -929,6 +929,9 @@ TEST_F(RetryResumableUploadSessionTest, UploadFinalChunkUncommitted) {
         "", 0, {}, ResumableUploadResponse::kInProgress, {}});
   });
 
+  auto const session_id_value = std::string{"test-only-session-id"};
+  EXPECT_CALL(*mock, session_id).WillRepeatedly(ReturnRef(session_id_value));
+
   EXPECT_CALL(*mock, next_expected_byte())
       .WillOnce([&]() {
         EXPECT_EQ(1, ++count);


### PR DESCRIPTION
Our debug message on session rewinds (i.e., when the "last committed
byte" goes backwards) was not sufficient. Adding some additional
debugging to make it easier to troubleshoot, should this ever happen
again.

Fixes #7610

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7662)
<!-- Reviewable:end -->
