### PR TITLE
feat(generator): link each method input and output types

### DIFF
--- a/cmake/GoogleapisConfig.cmake
+++ b/cmake/GoogleapisConfig.cmake
@@ -27,4 +27,5 @@ mark_as_advanced(GOOGLE_CLOUD_CPP_GOOGLEAPIS_SHA256)
 
 set(DOXYGEN_ALIASES
     "googleapis_link{2}=\"[\\1](https://github.com/googleapis/googleapis/blob/${GOOGLE_CLOUD_CPP_GOOGLEAPIS_COMMIT_SHA}/\\2)\""
+    "googleapis_reference_link{1}=\"https://github.com/googleapis/googleapis/blob/${GOOGLE_CLOUD_CPP_GOOGLEAPIS_COMMIT_SHA}/\\1\""
 )

--- a/generator/integration_tests/golden/golden_kitchen_sink_client.h
+++ b/generator/integration_tests/golden/golden_kitchen_sink_client.h
@@ -93,8 +93,8 @@ class GoldenKitchenSinkClient {
   ///  hour.
   /// @return @googleapis_link{google::test::admin::database::v1::GenerateAccessTokenResponse,generator/integration_tests/test.proto#L872}
   ///
-  /// [google.test.admin.database.v1.GenerateAccessTokenRequest]: @googleapis_link{google::test::admin::database::v1::GenerateAccessTokenRequest,generator/integration_tests/test.proto#L835}
-  /// [google.test.admin.database.v1.GenerateAccessTokenResponse]: @googleapis_link{google::test::admin::database::v1::GenerateAccessTokenResponse,generator/integration_tests/test.proto#L872}
+  /// [google.test.admin.database.v1.GenerateAccessTokenRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L835}
+  /// [google.test.admin.database.v1.GenerateAccessTokenResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L872}
   ///
   StatusOr<google::test::admin::database::v1::GenerateAccessTokenResponse>
   GenerateAccessToken(std::string const& name, std::vector<std::string> const& delegates, std::vector<std::string> const& scope, google::protobuf::Duration const& lifetime);
@@ -121,8 +121,8 @@ class GoldenKitchenSinkClient {
   ///  token will contain `email` and `email_verified` claims.
   /// @return @googleapis_link{google::test::admin::database::v1::GenerateIdTokenResponse,generator/integration_tests/test.proto#L914}
   ///
-  /// [google.test.admin.database.v1.GenerateIdTokenRequest]: @googleapis_link{google::test::admin::database::v1::GenerateIdTokenRequest,generator/integration_tests/test.proto#L881}
-  /// [google.test.admin.database.v1.GenerateIdTokenResponse]: @googleapis_link{google::test::admin::database::v1::GenerateIdTokenResponse,generator/integration_tests/test.proto#L914}
+  /// [google.test.admin.database.v1.GenerateIdTokenRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L881}
+  /// [google.test.admin.database.v1.GenerateIdTokenResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L914}
   ///
   StatusOr<google::test::admin::database::v1::GenerateIdTokenResponse>
   GenerateIdToken(std::string const& name, std::vector<std::string> const& delegates, std::string const& audience, bool include_email);
@@ -155,8 +155,8 @@ class GoldenKitchenSinkClient {
   ///  See [LogEntry][google.logging.v2.LogEntry]. Test delimiter$
   /// @return @googleapis_link{google::test::admin::database::v1::WriteLogEntriesResponse,generator/integration_tests/test.proto#L953}
   ///
-  /// [google.test.admin.database.v1.WriteLogEntriesRequest]: @googleapis_link{google::test::admin::database::v1::WriteLogEntriesRequest,generator/integration_tests/test.proto#L920}
-  /// [google.test.admin.database.v1.WriteLogEntriesResponse]: @googleapis_link{google::test::admin::database::v1::WriteLogEntriesResponse,generator/integration_tests/test.proto#L953}
+  /// [google.test.admin.database.v1.WriteLogEntriesRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L920}
+  /// [google.test.admin.database.v1.WriteLogEntriesResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L953}
   ///
   StatusOr<google::test::admin::database::v1::WriteLogEntriesResponse>
   WriteLogEntries(std::string const& log_name, std::map<std::string, std::string> const& labels);
@@ -172,7 +172,7 @@ class GoldenKitchenSinkClient {
   ///      "folders/[FOLDER_ID]"
   /// @return std::string
   ///
-  /// [google.test.admin.database.v1.ListLogsRequest]: @googleapis_link{google::test::admin::database::v1::ListLogsRequest,generator/integration_tests/test.proto#L956}
+  /// [google.test.admin.database.v1.ListLogsRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L956}
   ///
   StreamRange<std::string>
   ListLogs(std::string const& parent);
@@ -193,8 +193,8 @@ class GoldenKitchenSinkClient {
   ///      "folders/[FOLDER_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]"
   /// @return @googleapis_link{google::test::admin::database::v1::TailLogEntriesResponse,generator/integration_tests/test.proto#L1214}
   ///
-  /// [google.test.admin.database.v1.TailLogEntriesRequest]: @googleapis_link{google::test::admin::database::v1::TailLogEntriesRequest,generator/integration_tests/test.proto#L1182}
-  /// [google.test.admin.database.v1.TailLogEntriesResponse]: @googleapis_link{google::test::admin::database::v1::TailLogEntriesResponse,generator/integration_tests/test.proto#L1214}
+  /// [google.test.admin.database.v1.TailLogEntriesRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1182}
+  /// [google.test.admin.database.v1.TailLogEntriesResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1214}
   ///
   StreamRange<google::test::admin::database::v1::TailLogEntriesResponse>
   TailLogEntries(std::vector<std::string> const& resource_names);
@@ -212,8 +212,8 @@ class GoldenKitchenSinkClient {
   ///  is provided, all keys are returned.
   /// @return @googleapis_link{google::test::admin::database::v1::ListServiceAccountKeysResponse,generator/integration_tests/test.proto#L1286}
   ///
-  /// [google.test.admin.database.v1.ListServiceAccountKeysRequest]: @googleapis_link{google::test::admin::database::v1::ListServiceAccountKeysRequest,generator/integration_tests/test.proto#L1254}
-  /// [google.test.admin.database.v1.ListServiceAccountKeysResponse]: @googleapis_link{google::test::admin::database::v1::ListServiceAccountKeysResponse,generator/integration_tests/test.proto#L1286}
+  /// [google.test.admin.database.v1.ListServiceAccountKeysRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1254}
+  /// [google.test.admin.database.v1.ListServiceAccountKeysResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1286}
   ///
   StatusOr<google::test::admin::database::v1::ListServiceAccountKeysResponse>
   ListServiceAccountKeys(std::string const& name, std::vector<google::test::admin::database::v1::ListServiceAccountKeysRequest::KeyType> const& key_types);
@@ -224,8 +224,8 @@ class GoldenKitchenSinkClient {
   /// @param request @googleapis_link{google::test::admin::database::v1::GenerateAccessTokenRequest,generator/integration_tests/test.proto#L835}
   /// @return @googleapis_link{google::test::admin::database::v1::GenerateAccessTokenResponse,generator/integration_tests/test.proto#L872}
   ///
-  /// [google.test.admin.database.v1.GenerateAccessTokenRequest]: @googleapis_link{google::test::admin::database::v1::GenerateAccessTokenRequest,generator/integration_tests/test.proto#L835}
-  /// [google.test.admin.database.v1.GenerateAccessTokenResponse]: @googleapis_link{google::test::admin::database::v1::GenerateAccessTokenResponse,generator/integration_tests/test.proto#L872}
+  /// [google.test.admin.database.v1.GenerateAccessTokenRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L835}
+  /// [google.test.admin.database.v1.GenerateAccessTokenResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L872}
   ///
   StatusOr<google::test::admin::database::v1::GenerateAccessTokenResponse>
   GenerateAccessToken(google::test::admin::database::v1::GenerateAccessTokenRequest const& request);
@@ -236,8 +236,8 @@ class GoldenKitchenSinkClient {
   /// @param request @googleapis_link{google::test::admin::database::v1::GenerateIdTokenRequest,generator/integration_tests/test.proto#L881}
   /// @return @googleapis_link{google::test::admin::database::v1::GenerateIdTokenResponse,generator/integration_tests/test.proto#L914}
   ///
-  /// [google.test.admin.database.v1.GenerateIdTokenRequest]: @googleapis_link{google::test::admin::database::v1::GenerateIdTokenRequest,generator/integration_tests/test.proto#L881}
-  /// [google.test.admin.database.v1.GenerateIdTokenResponse]: @googleapis_link{google::test::admin::database::v1::GenerateIdTokenResponse,generator/integration_tests/test.proto#L914}
+  /// [google.test.admin.database.v1.GenerateIdTokenRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L881}
+  /// [google.test.admin.database.v1.GenerateIdTokenResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L914}
   ///
   StatusOr<google::test::admin::database::v1::GenerateIdTokenResponse>
   GenerateIdToken(google::test::admin::database::v1::GenerateIdTokenRequest const& request);
@@ -254,8 +254,8 @@ class GoldenKitchenSinkClient {
   /// @param request @googleapis_link{google::test::admin::database::v1::WriteLogEntriesRequest,generator/integration_tests/test.proto#L920}
   /// @return @googleapis_link{google::test::admin::database::v1::WriteLogEntriesResponse,generator/integration_tests/test.proto#L953}
   ///
-  /// [google.test.admin.database.v1.WriteLogEntriesRequest]: @googleapis_link{google::test::admin::database::v1::WriteLogEntriesRequest,generator/integration_tests/test.proto#L920}
-  /// [google.test.admin.database.v1.WriteLogEntriesResponse]: @googleapis_link{google::test::admin::database::v1::WriteLogEntriesResponse,generator/integration_tests/test.proto#L953}
+  /// [google.test.admin.database.v1.WriteLogEntriesRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L920}
+  /// [google.test.admin.database.v1.WriteLogEntriesResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L953}
   ///
   StatusOr<google::test::admin::database::v1::WriteLogEntriesResponse>
   WriteLogEntries(google::test::admin::database::v1::WriteLogEntriesRequest const& request);
@@ -267,7 +267,7 @@ class GoldenKitchenSinkClient {
   /// @param request @googleapis_link{google::test::admin::database::v1::ListLogsRequest,generator/integration_tests/test.proto#L956}
   /// @return std::string
   ///
-  /// [google.test.admin.database.v1.ListLogsRequest]: @googleapis_link{google::test::admin::database::v1::ListLogsRequest,generator/integration_tests/test.proto#L956}
+  /// [google.test.admin.database.v1.ListLogsRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L956}
   ///
   StreamRange<std::string>
   ListLogs(google::test::admin::database::v1::ListLogsRequest request);
@@ -279,8 +279,8 @@ class GoldenKitchenSinkClient {
   /// @param request @googleapis_link{google::test::admin::database::v1::TailLogEntriesRequest,generator/integration_tests/test.proto#L1182}
   /// @return @googleapis_link{google::test::admin::database::v1::TailLogEntriesResponse,generator/integration_tests/test.proto#L1214}
   ///
-  /// [google.test.admin.database.v1.TailLogEntriesRequest]: @googleapis_link{google::test::admin::database::v1::TailLogEntriesRequest,generator/integration_tests/test.proto#L1182}
-  /// [google.test.admin.database.v1.TailLogEntriesResponse]: @googleapis_link{google::test::admin::database::v1::TailLogEntriesResponse,generator/integration_tests/test.proto#L1214}
+  /// [google.test.admin.database.v1.TailLogEntriesRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1182}
+  /// [google.test.admin.database.v1.TailLogEntriesResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1214}
   ///
   StreamRange<google::test::admin::database::v1::TailLogEntriesResponse>
   TailLogEntries(google::test::admin::database::v1::TailLogEntriesRequest const& request);
@@ -291,8 +291,8 @@ class GoldenKitchenSinkClient {
   /// @param request @googleapis_link{google::test::admin::database::v1::ListServiceAccountKeysRequest,generator/integration_tests/test.proto#L1254}
   /// @return @googleapis_link{google::test::admin::database::v1::ListServiceAccountKeysResponse,generator/integration_tests/test.proto#L1286}
   ///
-  /// [google.test.admin.database.v1.ListServiceAccountKeysRequest]: @googleapis_link{google::test::admin::database::v1::ListServiceAccountKeysRequest,generator/integration_tests/test.proto#L1254}
-  /// [google.test.admin.database.v1.ListServiceAccountKeysResponse]: @googleapis_link{google::test::admin::database::v1::ListServiceAccountKeysResponse,generator/integration_tests/test.proto#L1286}
+  /// [google.test.admin.database.v1.ListServiceAccountKeysRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1254}
+  /// [google.test.admin.database.v1.ListServiceAccountKeysResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1286}
   ///
   StatusOr<google::test::admin::database::v1::ListServiceAccountKeysResponse>
   ListServiceAccountKeys(google::test::admin::database::v1::ListServiceAccountKeysRequest const& request);

--- a/generator/integration_tests/golden/golden_kitchen_sink_client.h
+++ b/generator/integration_tests/golden/golden_kitchen_sink_client.h
@@ -93,6 +93,9 @@ class GoldenKitchenSinkClient {
   ///  hour.
   /// @return @googleapis_link{google::test::admin::database::v1::GenerateAccessTokenResponse,generator/integration_tests/test.proto#L872}
   ///
+  /// [google.test.admin.database.v1.GenerateAccessTokenRequest]: @googleapis_link{google::test::admin::database::v1::GenerateAccessTokenRequest,generator/integration_tests/test.proto#L835}
+  /// [google.test.admin.database.v1.GenerateAccessTokenResponse]: @googleapis_link{google::test::admin::database::v1::GenerateAccessTokenResponse,generator/integration_tests/test.proto#L872}
+  ///
   StatusOr<google::test::admin::database::v1::GenerateAccessTokenResponse>
   GenerateAccessToken(std::string const& name, std::vector<std::string> const& delegates, std::vector<std::string> const& scope, google::protobuf::Duration const& lifetime);
 
@@ -117,6 +120,9 @@ class GoldenKitchenSinkClient {
   /// @param include_email  Include the service account email in the token. If set to `true`, the
   ///  token will contain `email` and `email_verified` claims.
   /// @return @googleapis_link{google::test::admin::database::v1::GenerateIdTokenResponse,generator/integration_tests/test.proto#L914}
+  ///
+  /// [google.test.admin.database.v1.GenerateIdTokenRequest]: @googleapis_link{google::test::admin::database::v1::GenerateIdTokenRequest,generator/integration_tests/test.proto#L881}
+  /// [google.test.admin.database.v1.GenerateIdTokenResponse]: @googleapis_link{google::test::admin::database::v1::GenerateIdTokenResponse,generator/integration_tests/test.proto#L914}
   ///
   StatusOr<google::test::admin::database::v1::GenerateIdTokenResponse>
   GenerateIdToken(std::string const& name, std::vector<std::string> const& delegates, std::string const& audience, bool include_email);
@@ -149,6 +155,9 @@ class GoldenKitchenSinkClient {
   ///  See [LogEntry][google.logging.v2.LogEntry]. Test delimiter$
   /// @return @googleapis_link{google::test::admin::database::v1::WriteLogEntriesResponse,generator/integration_tests/test.proto#L953}
   ///
+  /// [google.test.admin.database.v1.WriteLogEntriesRequest]: @googleapis_link{google::test::admin::database::v1::WriteLogEntriesRequest,generator/integration_tests/test.proto#L920}
+  /// [google.test.admin.database.v1.WriteLogEntriesResponse]: @googleapis_link{google::test::admin::database::v1::WriteLogEntriesResponse,generator/integration_tests/test.proto#L953}
+  ///
   StatusOr<google::test::admin::database::v1::WriteLogEntriesResponse>
   WriteLogEntries(std::string const& log_name, std::map<std::string, std::string> const& labels);
 
@@ -162,6 +171,8 @@ class GoldenKitchenSinkClient {
   ///      "billingAccounts/[BILLING_ACCOUNT_ID]"
   ///      "folders/[FOLDER_ID]"
   /// @return std::string
+  ///
+  /// [google.test.admin.database.v1.ListLogsRequest]: @googleapis_link{google::test::admin::database::v1::ListLogsRequest,generator/integration_tests/test.proto#L956}
   ///
   StreamRange<std::string>
   ListLogs(std::string const& parent);
@@ -182,6 +193,9 @@ class GoldenKitchenSinkClient {
   ///      "folders/[FOLDER_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]"
   /// @return @googleapis_link{google::test::admin::database::v1::TailLogEntriesResponse,generator/integration_tests/test.proto#L1214}
   ///
+  /// [google.test.admin.database.v1.TailLogEntriesRequest]: @googleapis_link{google::test::admin::database::v1::TailLogEntriesRequest,generator/integration_tests/test.proto#L1182}
+  /// [google.test.admin.database.v1.TailLogEntriesResponse]: @googleapis_link{google::test::admin::database::v1::TailLogEntriesResponse,generator/integration_tests/test.proto#L1214}
+  ///
   StreamRange<google::test::admin::database::v1::TailLogEntriesResponse>
   TailLogEntries(std::vector<std::string> const& resource_names);
 
@@ -198,6 +212,9 @@ class GoldenKitchenSinkClient {
   ///  is provided, all keys are returned.
   /// @return @googleapis_link{google::test::admin::database::v1::ListServiceAccountKeysResponse,generator/integration_tests/test.proto#L1286}
   ///
+  /// [google.test.admin.database.v1.ListServiceAccountKeysRequest]: @googleapis_link{google::test::admin::database::v1::ListServiceAccountKeysRequest,generator/integration_tests/test.proto#L1254}
+  /// [google.test.admin.database.v1.ListServiceAccountKeysResponse]: @googleapis_link{google::test::admin::database::v1::ListServiceAccountKeysResponse,generator/integration_tests/test.proto#L1286}
+  ///
   StatusOr<google::test::admin::database::v1::ListServiceAccountKeysResponse>
   ListServiceAccountKeys(std::string const& name, std::vector<google::test::admin::database::v1::ListServiceAccountKeysRequest::KeyType> const& key_types);
 
@@ -207,6 +224,9 @@ class GoldenKitchenSinkClient {
   /// @param request @googleapis_link{google::test::admin::database::v1::GenerateAccessTokenRequest,generator/integration_tests/test.proto#L835}
   /// @return @googleapis_link{google::test::admin::database::v1::GenerateAccessTokenResponse,generator/integration_tests/test.proto#L872}
   ///
+  /// [google.test.admin.database.v1.GenerateAccessTokenRequest]: @googleapis_link{google::test::admin::database::v1::GenerateAccessTokenRequest,generator/integration_tests/test.proto#L835}
+  /// [google.test.admin.database.v1.GenerateAccessTokenResponse]: @googleapis_link{google::test::admin::database::v1::GenerateAccessTokenResponse,generator/integration_tests/test.proto#L872}
+  ///
   StatusOr<google::test::admin::database::v1::GenerateAccessTokenResponse>
   GenerateAccessToken(google::test::admin::database::v1::GenerateAccessTokenRequest const& request);
 
@@ -215,6 +235,9 @@ class GoldenKitchenSinkClient {
   ///
   /// @param request @googleapis_link{google::test::admin::database::v1::GenerateIdTokenRequest,generator/integration_tests/test.proto#L881}
   /// @return @googleapis_link{google::test::admin::database::v1::GenerateIdTokenResponse,generator/integration_tests/test.proto#L914}
+  ///
+  /// [google.test.admin.database.v1.GenerateIdTokenRequest]: @googleapis_link{google::test::admin::database::v1::GenerateIdTokenRequest,generator/integration_tests/test.proto#L881}
+  /// [google.test.admin.database.v1.GenerateIdTokenResponse]: @googleapis_link{google::test::admin::database::v1::GenerateIdTokenResponse,generator/integration_tests/test.proto#L914}
   ///
   StatusOr<google::test::admin::database::v1::GenerateIdTokenResponse>
   GenerateIdToken(google::test::admin::database::v1::GenerateIdTokenRequest const& request);
@@ -231,6 +254,9 @@ class GoldenKitchenSinkClient {
   /// @param request @googleapis_link{google::test::admin::database::v1::WriteLogEntriesRequest,generator/integration_tests/test.proto#L920}
   /// @return @googleapis_link{google::test::admin::database::v1::WriteLogEntriesResponse,generator/integration_tests/test.proto#L953}
   ///
+  /// [google.test.admin.database.v1.WriteLogEntriesRequest]: @googleapis_link{google::test::admin::database::v1::WriteLogEntriesRequest,generator/integration_tests/test.proto#L920}
+  /// [google.test.admin.database.v1.WriteLogEntriesResponse]: @googleapis_link{google::test::admin::database::v1::WriteLogEntriesResponse,generator/integration_tests/test.proto#L953}
+  ///
   StatusOr<google::test::admin::database::v1::WriteLogEntriesResponse>
   WriteLogEntries(google::test::admin::database::v1::WriteLogEntriesRequest const& request);
 
@@ -240,6 +266,8 @@ class GoldenKitchenSinkClient {
   ///
   /// @param request @googleapis_link{google::test::admin::database::v1::ListLogsRequest,generator/integration_tests/test.proto#L956}
   /// @return std::string
+  ///
+  /// [google.test.admin.database.v1.ListLogsRequest]: @googleapis_link{google::test::admin::database::v1::ListLogsRequest,generator/integration_tests/test.proto#L956}
   ///
   StreamRange<std::string>
   ListLogs(google::test::admin::database::v1::ListLogsRequest request);
@@ -251,6 +279,9 @@ class GoldenKitchenSinkClient {
   /// @param request @googleapis_link{google::test::admin::database::v1::TailLogEntriesRequest,generator/integration_tests/test.proto#L1182}
   /// @return @googleapis_link{google::test::admin::database::v1::TailLogEntriesResponse,generator/integration_tests/test.proto#L1214}
   ///
+  /// [google.test.admin.database.v1.TailLogEntriesRequest]: @googleapis_link{google::test::admin::database::v1::TailLogEntriesRequest,generator/integration_tests/test.proto#L1182}
+  /// [google.test.admin.database.v1.TailLogEntriesResponse]: @googleapis_link{google::test::admin::database::v1::TailLogEntriesResponse,generator/integration_tests/test.proto#L1214}
+  ///
   StreamRange<google::test::admin::database::v1::TailLogEntriesResponse>
   TailLogEntries(google::test::admin::database::v1::TailLogEntriesRequest const& request);
 
@@ -259,6 +290,9 @@ class GoldenKitchenSinkClient {
   ///
   /// @param request @googleapis_link{google::test::admin::database::v1::ListServiceAccountKeysRequest,generator/integration_tests/test.proto#L1254}
   /// @return @googleapis_link{google::test::admin::database::v1::ListServiceAccountKeysResponse,generator/integration_tests/test.proto#L1286}
+  ///
+  /// [google.test.admin.database.v1.ListServiceAccountKeysRequest]: @googleapis_link{google::test::admin::database::v1::ListServiceAccountKeysRequest,generator/integration_tests/test.proto#L1254}
+  /// [google.test.admin.database.v1.ListServiceAccountKeysResponse]: @googleapis_link{google::test::admin::database::v1::ListServiceAccountKeysResponse,generator/integration_tests/test.proto#L1286}
   ///
   StatusOr<google::test::admin::database::v1::ListServiceAccountKeysResponse>
   ListServiceAccountKeys(google::test::admin::database::v1::ListServiceAccountKeysRequest const& request);

--- a/generator/integration_tests/golden/golden_thing_admin_client.h
+++ b/generator/integration_tests/golden/golden_thing_admin_client.h
@@ -72,6 +72,9 @@ class GoldenThingAdminClient {
   ///  Values are of the form `projects/<project>/instances/<instance>`.
   /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
   ///
+  /// [google.test.admin.database.v1.ListDatabasesRequest]: @googleapis_link{google::test::admin::database::v1::ListDatabasesRequest,generator/integration_tests/test.proto#L377}
+  /// [google.test.admin.database.v1.Database]: @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
+  ///
   StreamRange<google::test::admin::database::v1::Database>
   ListDatabases(std::string const& parent);
 
@@ -94,6 +97,9 @@ class GoldenThingAdminClient {
   ///  database ID must be enclosed in backticks (`` ` ``).
   /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
   ///
+  /// [google.test.admin.database.v1.CreateDatabaseRequest]: @googleapis_link{google::test::admin::database::v1::CreateDatabaseRequest,generator/integration_tests/test.proto#L409}
+  /// [google.test.admin.database.v1.Database]: @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
+  ///
   future<StatusOr<google::test::admin::database::v1::Database>>
   CreateDatabase(std::string const& parent, std::string const& create_statement);
 
@@ -103,6 +109,9 @@ class GoldenThingAdminClient {
   /// @param name  Required. The name of the requested database. Values are of the form
   ///  `projects/<project>/instances/<instance>/databases/<database>`.
   /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
+  ///
+  /// [google.test.admin.database.v1.GetDatabaseRequest]: @googleapis_link{google::test::admin::database::v1::GetDatabaseRequest,generator/integration_tests/test.proto#L443}
+  /// [google.test.admin.database.v1.Database]: @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
   ///
   StatusOr<google::test::admin::database::v1::Database>
   GetDatabase(std::string const& name);
@@ -120,6 +129,9 @@ class GoldenThingAdminClient {
   /// @param statements  Required. DDL statements to be applied to the database.
   /// @return @googleapis_link{google::test::admin::database::v1::UpdateDatabaseDdlMetadata,generator/integration_tests/test.proto#L506}
   ///
+  /// [google.test.admin.database.v1.UpdateDatabaseDdlRequest]: @googleapis_link{google::test::admin::database::v1::UpdateDatabaseDdlRequest,generator/integration_tests/test.proto#L470}
+  /// [google.test.admin.database.v1.UpdateDatabaseDdlMetadata]: @googleapis_link{google::test::admin::database::v1::UpdateDatabaseDdlMetadata,generator/integration_tests/test.proto#L506}
+  ///
   future<StatusOr<google::test::admin::database::v1::UpdateDatabaseDdlMetadata>>
   UpdateDatabaseDdl(std::string const& database, std::vector<std::string> const& statements);
 
@@ -129,6 +141,8 @@ class GoldenThingAdminClient {
   /// `expire_time`.
   ///
   /// @param database  Required. The database to be dropped.
+  ///
+  /// [google.test.admin.database.v1.DropDatabaseRequest]: @googleapis_link{google::test::admin::database::v1::DropDatabaseRequest,generator/integration_tests/test.proto#L523}
   ///
   Status
   DropDatabase(std::string const& database);
@@ -140,6 +154,9 @@ class GoldenThingAdminClient {
   ///
   /// @param database  Required. The database whose schema we wish to get.
   /// @return @googleapis_link{google::test::admin::database::v1::GetDatabaseDdlResponse,generator/integration_tests/test.proto#L545}
+  ///
+  /// [google.test.admin.database.v1.GetDatabaseDdlRequest]: @googleapis_link{google::test::admin::database::v1::GetDatabaseDdlRequest,generator/integration_tests/test.proto#L534}
+  /// [google.test.admin.database.v1.GetDatabaseDdlResponse]: @googleapis_link{google::test::admin::database::v1::GetDatabaseDdlResponse,generator/integration_tests/test.proto#L545}
   ///
   StatusOr<google::test::admin::database::v1::GetDatabaseDdlResponse>
   GetDatabaseDdl(std::string const& database);
@@ -160,6 +177,9 @@ class GoldenThingAdminClient {
   ///  valid policy but certain Cloud Platform services (such as Projects)
   ///  might reject them.
   /// @return @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
+  ///
+  /// [google.iam.v1.SetIamPolicyRequest]: @googleapis_link{google::iam::v1::SetIamPolicyRequest,google/iam/v1/iam_policy.proto#L98}
+  /// [google.iam.v1.Policy]: @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy>
   SetIamPolicy(std::string const& resource, google::iam::v1::Policy const& policy);
@@ -202,6 +222,9 @@ class GoldenThingAdminClient {
   ///  See the operation documentation for the appropriate value for this field.
   /// @return @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
+  /// [google.iam.v1.GetIamPolicyRequest]: @googleapis_link{google::iam::v1::GetIamPolicyRequest,google/iam/v1/iam_policy.proto#L113}
+  /// [google.iam.v1.Policy]: @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
+  ///
   StatusOr<google::iam::v1::Policy>
   GetIamPolicy(std::string const& resource);
 
@@ -224,6 +247,9 @@ class GoldenThingAdminClient {
   ///  information see
   ///  [IAM Overview](https://cloud.google.com/iam/docs/overview#permissions).
   /// @return @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
+  ///
+  /// [google.iam.v1.TestIamPermissionsRequest]: @googleapis_link{google::iam::v1::TestIamPermissionsRequest,google/iam/v1/iam_policy.proto#L126}
+  /// [google.iam.v1.TestIamPermissionsResponse]: @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
   ///
   StatusOr<google::iam::v1::TestIamPermissionsResponse>
   TestIamPermissions(std::string const& resource, std::vector<std::string> const& permissions);
@@ -254,6 +280,9 @@ class GoldenThingAdminClient {
   ///  `projects/<project>/instances/<instance>/backups/<backup_id>`.
   /// @return @googleapis_link{google::test::admin::database::v1::Backup,generator/integration_tests/backup.proto#L36}
   ///
+  /// [google.test.admin.database.v1.CreateBackupRequest]: @googleapis_link{google::test::admin::database::v1::CreateBackupRequest,generator/integration_tests/backup.proto#L110}
+  /// [google.test.admin.database.v1.Backup]: @googleapis_link{google::test::admin::database::v1::Backup,generator/integration_tests/backup.proto#L36}
+  ///
   future<StatusOr<google::test::admin::database::v1::Backup>>
   CreateBackup(std::string const& parent, google::test::admin::database::v1::Backup const& backup, std::string const& backup_id);
 
@@ -264,6 +293,9 @@ class GoldenThingAdminClient {
   ///  Values are of the form
   ///  `projects/<project>/instances/<instance>/backups/<backup>`.
   /// @return @googleapis_link{google::test::admin::database::v1::Backup,generator/integration_tests/backup.proto#L36}
+  ///
+  /// [google.test.admin.database.v1.GetBackupRequest]: @googleapis_link{google::test::admin::database::v1::GetBackupRequest,generator/integration_tests/backup.proto#L177}
+  /// [google.test.admin.database.v1.Backup]: @googleapis_link{google::test::admin::database::v1::Backup,generator/integration_tests/backup.proto#L36}
   ///
   StatusOr<google::test::admin::database::v1::Backup>
   GetBackup(std::string const& name);
@@ -282,6 +314,9 @@ class GoldenThingAdminClient {
   ///  by clients that do not know about them.
   /// @return @googleapis_link{google::test::admin::database::v1::Backup,generator/integration_tests/backup.proto#L36}
   ///
+  /// [google.test.admin.database.v1.UpdateBackupRequest]: @googleapis_link{google::test::admin::database::v1::UpdateBackupRequest,generator/integration_tests/backup.proto#L161}
+  /// [google.test.admin.database.v1.Backup]: @googleapis_link{google::test::admin::database::v1::Backup,generator/integration_tests/backup.proto#L36}
+  ///
   StatusOr<google::test::admin::database::v1::Backup>
   UpdateBackup(google::test::admin::database::v1::Backup const& backup, google::protobuf::FieldMask const& update_mask);
 
@@ -291,6 +326,8 @@ class GoldenThingAdminClient {
   /// @param name  Required. Name of the backup to delete.
   ///  Values are of the form
   ///  `projects/<project>/instances/<instance>/backups/<backup>`.
+  ///
+  /// [google.test.admin.database.v1.DeleteBackupRequest]: @googleapis_link{google::test::admin::database::v1::DeleteBackupRequest,generator/integration_tests/backup.proto#L190}
   ///
   Status
   DeleteBackup(std::string const& name);
@@ -303,6 +340,9 @@ class GoldenThingAdminClient {
   /// @param parent  Required. The instance to list backups from.  Values are of the
   ///  form `projects/<project>/instances/<instance>`.
   /// @return @googleapis_link{google::test::admin::database::v1::Backup,generator/integration_tests/backup.proto#L36}
+  ///
+  /// [google.test.admin.database.v1.ListBackupsRequest]: @googleapis_link{google::test::admin::database::v1::ListBackupsRequest,generator/integration_tests/backup.proto#L203}
+  /// [google.test.admin.database.v1.Backup]: @googleapis_link{google::test::admin::database::v1::Backup,generator/integration_tests/backup.proto#L36}
   ///
   StreamRange<google::test::admin::database::v1::Backup>
   ListBackups(std::string const& parent);
@@ -339,6 +379,9 @@ class GoldenThingAdminClient {
   ///  `projects/<project>/instances/<instance>/backups/<backup>`.
   /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
   ///
+  /// [google.test.admin.database.v1.RestoreDatabaseRequest]: @googleapis_link{google::test::admin::database::v1::RestoreDatabaseRequest,generator/integration_tests/test.proto#L634}
+  /// [google.test.admin.database.v1.Database]: @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
+  ///
   future<StatusOr<google::test::admin::database::v1::Database>>
   RestoreDatabase(std::string const& parent, std::string const& database_id, std::string const& backup);
 
@@ -355,6 +398,9 @@ class GoldenThingAdminClient {
   /// @param parent  Required. The instance of the database operations.
   ///  Values are of the form `projects/<project>/instances/<instance>`.
   /// @return @googleapis_link{google::longrunning::Operation,google/longrunning/operations.proto#L128}
+  ///
+  /// [google.test.admin.database.v1.ListDatabaseOperationsRequest]: @googleapis_link{google::test::admin::database::v1::ListDatabaseOperationsRequest,generator/integration_tests/test.proto#L553}
+  /// [google.longrunning.Operation]: @googleapis_link{google::longrunning::Operation,google/longrunning/operations.proto#L128}
   ///
   StreamRange<google::longrunning::Operation>
   ListDatabaseOperations(std::string const& parent);
@@ -375,6 +421,9 @@ class GoldenThingAdminClient {
   ///  the form `projects/<project>/instances/<instance>`.
   /// @return @googleapis_link{google::longrunning::Operation,google/longrunning/operations.proto#L128}
   ///
+  /// [google.test.admin.database.v1.ListBackupOperationsRequest]: @googleapis_link{google::test::admin::database::v1::ListBackupOperationsRequest,generator/integration_tests/backup.proto#L274}
+  /// [google.longrunning.Operation]: @googleapis_link{google::longrunning::Operation,google/longrunning/operations.proto#L128}
+  ///
   StreamRange<google::longrunning::Operation>
   ListBackupOperations(std::string const& parent);
 
@@ -384,6 +433,9 @@ class GoldenThingAdminClient {
   /// @param name  Required. The name of the requested database. Values are of the form
   ///  `projects/<project>/instances/<instance>/databases/<database>`.
   /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
+  ///
+  /// [google.test.admin.database.v1.GetDatabaseRequest]: @googleapis_link{google::test::admin::database::v1::GetDatabaseRequest,generator/integration_tests/test.proto#L443}
+  /// [google.test.admin.database.v1.Database]: @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
   ///
   future<StatusOr<google::test::admin::database::v1::Database>>
   AsyncGetDatabase(std::string const& name);
@@ -395,6 +447,8 @@ class GoldenThingAdminClient {
   ///
   /// @param database  Required. The database to be dropped.
   ///
+  /// [google.test.admin.database.v1.DropDatabaseRequest]: @googleapis_link{google::test::admin::database::v1::DropDatabaseRequest,generator/integration_tests/test.proto#L523}
+  ///
   future<Status>
   AsyncDropDatabase(std::string const& database);
 
@@ -403,6 +457,9 @@ class GoldenThingAdminClient {
   ///
   /// @param request @googleapis_link{google::test::admin::database::v1::ListDatabasesRequest,generator/integration_tests/test.proto#L377}
   /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
+  ///
+  /// [google.test.admin.database.v1.ListDatabasesRequest]: @googleapis_link{google::test::admin::database::v1::ListDatabasesRequest,generator/integration_tests/test.proto#L377}
+  /// [google.test.admin.database.v1.Database]: @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
   ///
   StreamRange<google::test::admin::database::v1::Database>
   ListDatabases(google::test::admin::database::v1::ListDatabasesRequest request);
@@ -420,6 +477,9 @@ class GoldenThingAdminClient {
   /// @param request @googleapis_link{google::test::admin::database::v1::CreateDatabaseRequest,generator/integration_tests/test.proto#L409}
   /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
   ///
+  /// [google.test.admin.database.v1.CreateDatabaseRequest]: @googleapis_link{google::test::admin::database::v1::CreateDatabaseRequest,generator/integration_tests/test.proto#L409}
+  /// [google.test.admin.database.v1.Database]: @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
+  ///
   future<StatusOr<google::test::admin::database::v1::Database>>
   CreateDatabase(google::test::admin::database::v1::CreateDatabaseRequest const& request);
 
@@ -428,6 +488,9 @@ class GoldenThingAdminClient {
   ///
   /// @param request @googleapis_link{google::test::admin::database::v1::GetDatabaseRequest,generator/integration_tests/test.proto#L443}
   /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
+  ///
+  /// [google.test.admin.database.v1.GetDatabaseRequest]: @googleapis_link{google::test::admin::database::v1::GetDatabaseRequest,generator/integration_tests/test.proto#L443}
+  /// [google.test.admin.database.v1.Database]: @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
   ///
   StatusOr<google::test::admin::database::v1::Database>
   GetDatabase(google::test::admin::database::v1::GetDatabaseRequest const& request);
@@ -444,6 +507,9 @@ class GoldenThingAdminClient {
   /// @param request @googleapis_link{google::test::admin::database::v1::UpdateDatabaseDdlRequest,generator/integration_tests/test.proto#L470}
   /// @return @googleapis_link{google::test::admin::database::v1::UpdateDatabaseDdlMetadata,generator/integration_tests/test.proto#L506}
   ///
+  /// [google.test.admin.database.v1.UpdateDatabaseDdlRequest]: @googleapis_link{google::test::admin::database::v1::UpdateDatabaseDdlRequest,generator/integration_tests/test.proto#L470}
+  /// [google.test.admin.database.v1.UpdateDatabaseDdlMetadata]: @googleapis_link{google::test::admin::database::v1::UpdateDatabaseDdlMetadata,generator/integration_tests/test.proto#L506}
+  ///
   future<StatusOr<google::test::admin::database::v1::UpdateDatabaseDdlMetadata>>
   UpdateDatabaseDdl(google::test::admin::database::v1::UpdateDatabaseDdlRequest const& request);
 
@@ -453,6 +519,8 @@ class GoldenThingAdminClient {
   /// `expire_time`.
   ///
   /// @param request @googleapis_link{google::test::admin::database::v1::DropDatabaseRequest,generator/integration_tests/test.proto#L523}
+  ///
+  /// [google.test.admin.database.v1.DropDatabaseRequest]: @googleapis_link{google::test::admin::database::v1::DropDatabaseRequest,generator/integration_tests/test.proto#L523}
   ///
   Status
   DropDatabase(google::test::admin::database::v1::DropDatabaseRequest const& request);
@@ -464,6 +532,9 @@ class GoldenThingAdminClient {
   ///
   /// @param request @googleapis_link{google::test::admin::database::v1::GetDatabaseDdlRequest,generator/integration_tests/test.proto#L534}
   /// @return @googleapis_link{google::test::admin::database::v1::GetDatabaseDdlResponse,generator/integration_tests/test.proto#L545}
+  ///
+  /// [google.test.admin.database.v1.GetDatabaseDdlRequest]: @googleapis_link{google::test::admin::database::v1::GetDatabaseDdlRequest,generator/integration_tests/test.proto#L534}
+  /// [google.test.admin.database.v1.GetDatabaseDdlResponse]: @googleapis_link{google::test::admin::database::v1::GetDatabaseDdlResponse,generator/integration_tests/test.proto#L545}
   ///
   StatusOr<google::test::admin::database::v1::GetDatabaseDdlResponse>
   GetDatabaseDdl(google::test::admin::database::v1::GetDatabaseDdlRequest const& request);
@@ -480,6 +551,9 @@ class GoldenThingAdminClient {
   /// @param request @googleapis_link{google::iam::v1::SetIamPolicyRequest,google/iam/v1/iam_policy.proto#L98}
   /// @return @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
+  /// [google.iam.v1.SetIamPolicyRequest]: @googleapis_link{google::iam::v1::SetIamPolicyRequest,google/iam/v1/iam_policy.proto#L98}
+  /// [google.iam.v1.Policy]: @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
+  ///
   StatusOr<google::iam::v1::Policy>
   SetIamPolicy(google::iam::v1::SetIamPolicyRequest const& request);
 
@@ -495,6 +569,9 @@ class GoldenThingAdminClient {
   ///
   /// @param request @googleapis_link{google::iam::v1::GetIamPolicyRequest,google/iam/v1/iam_policy.proto#L113}
   /// @return @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
+  ///
+  /// [google.iam.v1.GetIamPolicyRequest]: @googleapis_link{google::iam::v1::GetIamPolicyRequest,google/iam/v1/iam_policy.proto#L113}
+  /// [google.iam.v1.Policy]: @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy>
   GetIamPolicy(google::iam::v1::GetIamPolicyRequest const& request);
@@ -513,6 +590,9 @@ class GoldenThingAdminClient {
   ///
   /// @param request @googleapis_link{google::iam::v1::TestIamPermissionsRequest,google/iam/v1/iam_policy.proto#L126}
   /// @return @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
+  ///
+  /// [google.iam.v1.TestIamPermissionsRequest]: @googleapis_link{google::iam::v1::TestIamPermissionsRequest,google/iam/v1/iam_policy.proto#L126}
+  /// [google.iam.v1.TestIamPermissionsResponse]: @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
   ///
   StatusOr<google::iam::v1::TestIamPermissionsResponse>
   TestIamPermissions(google::iam::v1::TestIamPermissionsRequest const& request);
@@ -534,6 +614,9 @@ class GoldenThingAdminClient {
   /// @param request @googleapis_link{google::test::admin::database::v1::CreateBackupRequest,generator/integration_tests/backup.proto#L110}
   /// @return @googleapis_link{google::test::admin::database::v1::Backup,generator/integration_tests/backup.proto#L36}
   ///
+  /// [google.test.admin.database.v1.CreateBackupRequest]: @googleapis_link{google::test::admin::database::v1::CreateBackupRequest,generator/integration_tests/backup.proto#L110}
+  /// [google.test.admin.database.v1.Backup]: @googleapis_link{google::test::admin::database::v1::Backup,generator/integration_tests/backup.proto#L36}
+  ///
   future<StatusOr<google::test::admin::database::v1::Backup>>
   CreateBackup(google::test::admin::database::v1::CreateBackupRequest const& request);
 
@@ -542,6 +625,9 @@ class GoldenThingAdminClient {
   ///
   /// @param request @googleapis_link{google::test::admin::database::v1::GetBackupRequest,generator/integration_tests/backup.proto#L177}
   /// @return @googleapis_link{google::test::admin::database::v1::Backup,generator/integration_tests/backup.proto#L36}
+  ///
+  /// [google.test.admin.database.v1.GetBackupRequest]: @googleapis_link{google::test::admin::database::v1::GetBackupRequest,generator/integration_tests/backup.proto#L177}
+  /// [google.test.admin.database.v1.Backup]: @googleapis_link{google::test::admin::database::v1::Backup,generator/integration_tests/backup.proto#L36}
   ///
   StatusOr<google::test::admin::database::v1::Backup>
   GetBackup(google::test::admin::database::v1::GetBackupRequest const& request);
@@ -552,6 +638,9 @@ class GoldenThingAdminClient {
   /// @param request @googleapis_link{google::test::admin::database::v1::UpdateBackupRequest,generator/integration_tests/backup.proto#L161}
   /// @return @googleapis_link{google::test::admin::database::v1::Backup,generator/integration_tests/backup.proto#L36}
   ///
+  /// [google.test.admin.database.v1.UpdateBackupRequest]: @googleapis_link{google::test::admin::database::v1::UpdateBackupRequest,generator/integration_tests/backup.proto#L161}
+  /// [google.test.admin.database.v1.Backup]: @googleapis_link{google::test::admin::database::v1::Backup,generator/integration_tests/backup.proto#L36}
+  ///
   StatusOr<google::test::admin::database::v1::Backup>
   UpdateBackup(google::test::admin::database::v1::UpdateBackupRequest const& request);
 
@@ -559,6 +648,8 @@ class GoldenThingAdminClient {
   /// Deletes a pending or completed [Backup][google.test.admin.database.v1.Backup].
   ///
   /// @param request @googleapis_link{google::test::admin::database::v1::DeleteBackupRequest,generator/integration_tests/backup.proto#L190}
+  ///
+  /// [google.test.admin.database.v1.DeleteBackupRequest]: @googleapis_link{google::test::admin::database::v1::DeleteBackupRequest,generator/integration_tests/backup.proto#L190}
   ///
   Status
   DeleteBackup(google::test::admin::database::v1::DeleteBackupRequest const& request);
@@ -570,6 +661,9 @@ class GoldenThingAdminClient {
   ///
   /// @param request @googleapis_link{google::test::admin::database::v1::ListBackupsRequest,generator/integration_tests/backup.proto#L203}
   /// @return @googleapis_link{google::test::admin::database::v1::Backup,generator/integration_tests/backup.proto#L36}
+  ///
+  /// [google.test.admin.database.v1.ListBackupsRequest]: @googleapis_link{google::test::admin::database::v1::ListBackupsRequest,generator/integration_tests/backup.proto#L203}
+  /// [google.test.admin.database.v1.Backup]: @googleapis_link{google::test::admin::database::v1::Backup,generator/integration_tests/backup.proto#L36}
   ///
   StreamRange<google::test::admin::database::v1::Backup>
   ListBackups(google::test::admin::database::v1::ListBackupsRequest request);
@@ -596,6 +690,9 @@ class GoldenThingAdminClient {
   /// @param request @googleapis_link{google::test::admin::database::v1::RestoreDatabaseRequest,generator/integration_tests/test.proto#L634}
   /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
   ///
+  /// [google.test.admin.database.v1.RestoreDatabaseRequest]: @googleapis_link{google::test::admin::database::v1::RestoreDatabaseRequest,generator/integration_tests/test.proto#L634}
+  /// [google.test.admin.database.v1.Database]: @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
+  ///
   future<StatusOr<google::test::admin::database::v1::Database>>
   RestoreDatabase(google::test::admin::database::v1::RestoreDatabaseRequest const& request);
 
@@ -611,6 +708,9 @@ class GoldenThingAdminClient {
   ///
   /// @param request @googleapis_link{google::test::admin::database::v1::ListDatabaseOperationsRequest,generator/integration_tests/test.proto#L553}
   /// @return @googleapis_link{google::longrunning::Operation,google/longrunning/operations.proto#L128}
+  ///
+  /// [google.test.admin.database.v1.ListDatabaseOperationsRequest]: @googleapis_link{google::test::admin::database::v1::ListDatabaseOperationsRequest,generator/integration_tests/test.proto#L553}
+  /// [google.longrunning.Operation]: @googleapis_link{google::longrunning::Operation,google/longrunning/operations.proto#L128}
   ///
   StreamRange<google::longrunning::Operation>
   ListDatabaseOperations(google::test::admin::database::v1::ListDatabaseOperationsRequest request);
@@ -630,6 +730,9 @@ class GoldenThingAdminClient {
   /// @param request @googleapis_link{google::test::admin::database::v1::ListBackupOperationsRequest,generator/integration_tests/backup.proto#L274}
   /// @return @googleapis_link{google::longrunning::Operation,google/longrunning/operations.proto#L128}
   ///
+  /// [google.test.admin.database.v1.ListBackupOperationsRequest]: @googleapis_link{google::test::admin::database::v1::ListBackupOperationsRequest,generator/integration_tests/backup.proto#L274}
+  /// [google.longrunning.Operation]: @googleapis_link{google::longrunning::Operation,google/longrunning/operations.proto#L128}
+  ///
   StreamRange<google::longrunning::Operation>
   ListBackupOperations(google::test::admin::database::v1::ListBackupOperationsRequest request);
 
@@ -638,6 +741,9 @@ class GoldenThingAdminClient {
   ///
   /// @param request @googleapis_link{google::test::admin::database::v1::GetDatabaseRequest,generator/integration_tests/test.proto#L443}
   /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
+  ///
+  /// [google.test.admin.database.v1.GetDatabaseRequest]: @googleapis_link{google::test::admin::database::v1::GetDatabaseRequest,generator/integration_tests/test.proto#L443}
+  /// [google.test.admin.database.v1.Database]: @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
   ///
   future<StatusOr<google::test::admin::database::v1::Database>>
   AsyncGetDatabase(google::test::admin::database::v1::GetDatabaseRequest const& request);
@@ -648,6 +754,8 @@ class GoldenThingAdminClient {
   /// `expire_time`.
   ///
   /// @param request @googleapis_link{google::test::admin::database::v1::DropDatabaseRequest,generator/integration_tests/test.proto#L523}
+  ///
+  /// [google.test.admin.database.v1.DropDatabaseRequest]: @googleapis_link{google::test::admin::database::v1::DropDatabaseRequest,generator/integration_tests/test.proto#L523}
   ///
   future<Status>
   AsyncDropDatabase(google::test::admin::database::v1::DropDatabaseRequest const& request);

--- a/generator/integration_tests/golden/golden_thing_admin_client.h
+++ b/generator/integration_tests/golden/golden_thing_admin_client.h
@@ -72,8 +72,8 @@ class GoldenThingAdminClient {
   ///  Values are of the form `projects/<project>/instances/<instance>`.
   /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
   ///
-  /// [google.test.admin.database.v1.ListDatabasesRequest]: @googleapis_link{google::test::admin::database::v1::ListDatabasesRequest,generator/integration_tests/test.proto#L377}
-  /// [google.test.admin.database.v1.Database]: @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
+  /// [google.test.admin.database.v1.ListDatabasesRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L377}
+  /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L329}
   ///
   StreamRange<google::test::admin::database::v1::Database>
   ListDatabases(std::string const& parent);
@@ -97,8 +97,8 @@ class GoldenThingAdminClient {
   ///  database ID must be enclosed in backticks (`` ` ``).
   /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
   ///
-  /// [google.test.admin.database.v1.CreateDatabaseRequest]: @googleapis_link{google::test::admin::database::v1::CreateDatabaseRequest,generator/integration_tests/test.proto#L409}
-  /// [google.test.admin.database.v1.Database]: @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
+  /// [google.test.admin.database.v1.CreateDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L409}
+  /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L329}
   ///
   future<StatusOr<google::test::admin::database::v1::Database>>
   CreateDatabase(std::string const& parent, std::string const& create_statement);
@@ -110,8 +110,8 @@ class GoldenThingAdminClient {
   ///  `projects/<project>/instances/<instance>/databases/<database>`.
   /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
   ///
-  /// [google.test.admin.database.v1.GetDatabaseRequest]: @googleapis_link{google::test::admin::database::v1::GetDatabaseRequest,generator/integration_tests/test.proto#L443}
-  /// [google.test.admin.database.v1.Database]: @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
+  /// [google.test.admin.database.v1.GetDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L443}
+  /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L329}
   ///
   StatusOr<google::test::admin::database::v1::Database>
   GetDatabase(std::string const& name);
@@ -129,8 +129,8 @@ class GoldenThingAdminClient {
   /// @param statements  Required. DDL statements to be applied to the database.
   /// @return @googleapis_link{google::test::admin::database::v1::UpdateDatabaseDdlMetadata,generator/integration_tests/test.proto#L506}
   ///
-  /// [google.test.admin.database.v1.UpdateDatabaseDdlRequest]: @googleapis_link{google::test::admin::database::v1::UpdateDatabaseDdlRequest,generator/integration_tests/test.proto#L470}
-  /// [google.test.admin.database.v1.UpdateDatabaseDdlMetadata]: @googleapis_link{google::test::admin::database::v1::UpdateDatabaseDdlMetadata,generator/integration_tests/test.proto#L506}
+  /// [google.test.admin.database.v1.UpdateDatabaseDdlRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L470}
+  /// [google.test.admin.database.v1.UpdateDatabaseDdlMetadata]: @googleapis_reference_link{generator/integration_tests/test.proto#L506}
   ///
   future<StatusOr<google::test::admin::database::v1::UpdateDatabaseDdlMetadata>>
   UpdateDatabaseDdl(std::string const& database, std::vector<std::string> const& statements);
@@ -142,7 +142,7 @@ class GoldenThingAdminClient {
   ///
   /// @param database  Required. The database to be dropped.
   ///
-  /// [google.test.admin.database.v1.DropDatabaseRequest]: @googleapis_link{google::test::admin::database::v1::DropDatabaseRequest,generator/integration_tests/test.proto#L523}
+  /// [google.test.admin.database.v1.DropDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L523}
   ///
   Status
   DropDatabase(std::string const& database);
@@ -155,8 +155,8 @@ class GoldenThingAdminClient {
   /// @param database  Required. The database whose schema we wish to get.
   /// @return @googleapis_link{google::test::admin::database::v1::GetDatabaseDdlResponse,generator/integration_tests/test.proto#L545}
   ///
-  /// [google.test.admin.database.v1.GetDatabaseDdlRequest]: @googleapis_link{google::test::admin::database::v1::GetDatabaseDdlRequest,generator/integration_tests/test.proto#L534}
-  /// [google.test.admin.database.v1.GetDatabaseDdlResponse]: @googleapis_link{google::test::admin::database::v1::GetDatabaseDdlResponse,generator/integration_tests/test.proto#L545}
+  /// [google.test.admin.database.v1.GetDatabaseDdlRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L534}
+  /// [google.test.admin.database.v1.GetDatabaseDdlResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L545}
   ///
   StatusOr<google::test::admin::database::v1::GetDatabaseDdlResponse>
   GetDatabaseDdl(std::string const& database);
@@ -178,8 +178,8 @@ class GoldenThingAdminClient {
   ///  might reject them.
   /// @return @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
-  /// [google.iam.v1.SetIamPolicyRequest]: @googleapis_link{google::iam::v1::SetIamPolicyRequest,google/iam/v1/iam_policy.proto#L98}
-  /// [google.iam.v1.Policy]: @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
+  /// [google.iam.v1.SetIamPolicyRequest]: @googleapis_reference_link{google/iam/v1/iam_policy.proto#L98}
+  /// [google.iam.v1.Policy]: @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy>
   SetIamPolicy(std::string const& resource, google::iam::v1::Policy const& policy);
@@ -222,8 +222,8 @@ class GoldenThingAdminClient {
   ///  See the operation documentation for the appropriate value for this field.
   /// @return @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
-  /// [google.iam.v1.GetIamPolicyRequest]: @googleapis_link{google::iam::v1::GetIamPolicyRequest,google/iam/v1/iam_policy.proto#L113}
-  /// [google.iam.v1.Policy]: @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
+  /// [google.iam.v1.GetIamPolicyRequest]: @googleapis_reference_link{google/iam/v1/iam_policy.proto#L113}
+  /// [google.iam.v1.Policy]: @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy>
   GetIamPolicy(std::string const& resource);
@@ -248,8 +248,8 @@ class GoldenThingAdminClient {
   ///  [IAM Overview](https://cloud.google.com/iam/docs/overview#permissions).
   /// @return @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
   ///
-  /// [google.iam.v1.TestIamPermissionsRequest]: @googleapis_link{google::iam::v1::TestIamPermissionsRequest,google/iam/v1/iam_policy.proto#L126}
-  /// [google.iam.v1.TestIamPermissionsResponse]: @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
+  /// [google.iam.v1.TestIamPermissionsRequest]: @googleapis_reference_link{google/iam/v1/iam_policy.proto#L126}
+  /// [google.iam.v1.TestIamPermissionsResponse]: @googleapis_reference_link{google/iam/v1/iam_policy.proto#L141}
   ///
   StatusOr<google::iam::v1::TestIamPermissionsResponse>
   TestIamPermissions(std::string const& resource, std::vector<std::string> const& permissions);
@@ -280,8 +280,8 @@ class GoldenThingAdminClient {
   ///  `projects/<project>/instances/<instance>/backups/<backup_id>`.
   /// @return @googleapis_link{google::test::admin::database::v1::Backup,generator/integration_tests/backup.proto#L36}
   ///
-  /// [google.test.admin.database.v1.CreateBackupRequest]: @googleapis_link{google::test::admin::database::v1::CreateBackupRequest,generator/integration_tests/backup.proto#L110}
-  /// [google.test.admin.database.v1.Backup]: @googleapis_link{google::test::admin::database::v1::Backup,generator/integration_tests/backup.proto#L36}
+  /// [google.test.admin.database.v1.CreateBackupRequest]: @googleapis_reference_link{generator/integration_tests/backup.proto#L110}
+  /// [google.test.admin.database.v1.Backup]: @googleapis_reference_link{generator/integration_tests/backup.proto#L36}
   ///
   future<StatusOr<google::test::admin::database::v1::Backup>>
   CreateBackup(std::string const& parent, google::test::admin::database::v1::Backup const& backup, std::string const& backup_id);
@@ -294,8 +294,8 @@ class GoldenThingAdminClient {
   ///  `projects/<project>/instances/<instance>/backups/<backup>`.
   /// @return @googleapis_link{google::test::admin::database::v1::Backup,generator/integration_tests/backup.proto#L36}
   ///
-  /// [google.test.admin.database.v1.GetBackupRequest]: @googleapis_link{google::test::admin::database::v1::GetBackupRequest,generator/integration_tests/backup.proto#L177}
-  /// [google.test.admin.database.v1.Backup]: @googleapis_link{google::test::admin::database::v1::Backup,generator/integration_tests/backup.proto#L36}
+  /// [google.test.admin.database.v1.GetBackupRequest]: @googleapis_reference_link{generator/integration_tests/backup.proto#L177}
+  /// [google.test.admin.database.v1.Backup]: @googleapis_reference_link{generator/integration_tests/backup.proto#L36}
   ///
   StatusOr<google::test::admin::database::v1::Backup>
   GetBackup(std::string const& name);
@@ -314,8 +314,8 @@ class GoldenThingAdminClient {
   ///  by clients that do not know about them.
   /// @return @googleapis_link{google::test::admin::database::v1::Backup,generator/integration_tests/backup.proto#L36}
   ///
-  /// [google.test.admin.database.v1.UpdateBackupRequest]: @googleapis_link{google::test::admin::database::v1::UpdateBackupRequest,generator/integration_tests/backup.proto#L161}
-  /// [google.test.admin.database.v1.Backup]: @googleapis_link{google::test::admin::database::v1::Backup,generator/integration_tests/backup.proto#L36}
+  /// [google.test.admin.database.v1.UpdateBackupRequest]: @googleapis_reference_link{generator/integration_tests/backup.proto#L161}
+  /// [google.test.admin.database.v1.Backup]: @googleapis_reference_link{generator/integration_tests/backup.proto#L36}
   ///
   StatusOr<google::test::admin::database::v1::Backup>
   UpdateBackup(google::test::admin::database::v1::Backup const& backup, google::protobuf::FieldMask const& update_mask);
@@ -327,7 +327,7 @@ class GoldenThingAdminClient {
   ///  Values are of the form
   ///  `projects/<project>/instances/<instance>/backups/<backup>`.
   ///
-  /// [google.test.admin.database.v1.DeleteBackupRequest]: @googleapis_link{google::test::admin::database::v1::DeleteBackupRequest,generator/integration_tests/backup.proto#L190}
+  /// [google.test.admin.database.v1.DeleteBackupRequest]: @googleapis_reference_link{generator/integration_tests/backup.proto#L190}
   ///
   Status
   DeleteBackup(std::string const& name);
@@ -341,8 +341,8 @@ class GoldenThingAdminClient {
   ///  form `projects/<project>/instances/<instance>`.
   /// @return @googleapis_link{google::test::admin::database::v1::Backup,generator/integration_tests/backup.proto#L36}
   ///
-  /// [google.test.admin.database.v1.ListBackupsRequest]: @googleapis_link{google::test::admin::database::v1::ListBackupsRequest,generator/integration_tests/backup.proto#L203}
-  /// [google.test.admin.database.v1.Backup]: @googleapis_link{google::test::admin::database::v1::Backup,generator/integration_tests/backup.proto#L36}
+  /// [google.test.admin.database.v1.ListBackupsRequest]: @googleapis_reference_link{generator/integration_tests/backup.proto#L203}
+  /// [google.test.admin.database.v1.Backup]: @googleapis_reference_link{generator/integration_tests/backup.proto#L36}
   ///
   StreamRange<google::test::admin::database::v1::Backup>
   ListBackups(std::string const& parent);
@@ -379,8 +379,8 @@ class GoldenThingAdminClient {
   ///  `projects/<project>/instances/<instance>/backups/<backup>`.
   /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
   ///
-  /// [google.test.admin.database.v1.RestoreDatabaseRequest]: @googleapis_link{google::test::admin::database::v1::RestoreDatabaseRequest,generator/integration_tests/test.proto#L634}
-  /// [google.test.admin.database.v1.Database]: @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
+  /// [google.test.admin.database.v1.RestoreDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L634}
+  /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L329}
   ///
   future<StatusOr<google::test::admin::database::v1::Database>>
   RestoreDatabase(std::string const& parent, std::string const& database_id, std::string const& backup);
@@ -399,8 +399,8 @@ class GoldenThingAdminClient {
   ///  Values are of the form `projects/<project>/instances/<instance>`.
   /// @return @googleapis_link{google::longrunning::Operation,google/longrunning/operations.proto#L128}
   ///
-  /// [google.test.admin.database.v1.ListDatabaseOperationsRequest]: @googleapis_link{google::test::admin::database::v1::ListDatabaseOperationsRequest,generator/integration_tests/test.proto#L553}
-  /// [google.longrunning.Operation]: @googleapis_link{google::longrunning::Operation,google/longrunning/operations.proto#L128}
+  /// [google.test.admin.database.v1.ListDatabaseOperationsRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L553}
+  /// [google.longrunning.Operation]: @googleapis_reference_link{google/longrunning/operations.proto#L128}
   ///
   StreamRange<google::longrunning::Operation>
   ListDatabaseOperations(std::string const& parent);
@@ -421,8 +421,8 @@ class GoldenThingAdminClient {
   ///  the form `projects/<project>/instances/<instance>`.
   /// @return @googleapis_link{google::longrunning::Operation,google/longrunning/operations.proto#L128}
   ///
-  /// [google.test.admin.database.v1.ListBackupOperationsRequest]: @googleapis_link{google::test::admin::database::v1::ListBackupOperationsRequest,generator/integration_tests/backup.proto#L274}
-  /// [google.longrunning.Operation]: @googleapis_link{google::longrunning::Operation,google/longrunning/operations.proto#L128}
+  /// [google.test.admin.database.v1.ListBackupOperationsRequest]: @googleapis_reference_link{generator/integration_tests/backup.proto#L274}
+  /// [google.longrunning.Operation]: @googleapis_reference_link{google/longrunning/operations.proto#L128}
   ///
   StreamRange<google::longrunning::Operation>
   ListBackupOperations(std::string const& parent);
@@ -434,8 +434,8 @@ class GoldenThingAdminClient {
   ///  `projects/<project>/instances/<instance>/databases/<database>`.
   /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
   ///
-  /// [google.test.admin.database.v1.GetDatabaseRequest]: @googleapis_link{google::test::admin::database::v1::GetDatabaseRequest,generator/integration_tests/test.proto#L443}
-  /// [google.test.admin.database.v1.Database]: @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
+  /// [google.test.admin.database.v1.GetDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L443}
+  /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L329}
   ///
   future<StatusOr<google::test::admin::database::v1::Database>>
   AsyncGetDatabase(std::string const& name);
@@ -447,7 +447,7 @@ class GoldenThingAdminClient {
   ///
   /// @param database  Required. The database to be dropped.
   ///
-  /// [google.test.admin.database.v1.DropDatabaseRequest]: @googleapis_link{google::test::admin::database::v1::DropDatabaseRequest,generator/integration_tests/test.proto#L523}
+  /// [google.test.admin.database.v1.DropDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L523}
   ///
   future<Status>
   AsyncDropDatabase(std::string const& database);
@@ -458,8 +458,8 @@ class GoldenThingAdminClient {
   /// @param request @googleapis_link{google::test::admin::database::v1::ListDatabasesRequest,generator/integration_tests/test.proto#L377}
   /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
   ///
-  /// [google.test.admin.database.v1.ListDatabasesRequest]: @googleapis_link{google::test::admin::database::v1::ListDatabasesRequest,generator/integration_tests/test.proto#L377}
-  /// [google.test.admin.database.v1.Database]: @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
+  /// [google.test.admin.database.v1.ListDatabasesRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L377}
+  /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L329}
   ///
   StreamRange<google::test::admin::database::v1::Database>
   ListDatabases(google::test::admin::database::v1::ListDatabasesRequest request);
@@ -477,8 +477,8 @@ class GoldenThingAdminClient {
   /// @param request @googleapis_link{google::test::admin::database::v1::CreateDatabaseRequest,generator/integration_tests/test.proto#L409}
   /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
   ///
-  /// [google.test.admin.database.v1.CreateDatabaseRequest]: @googleapis_link{google::test::admin::database::v1::CreateDatabaseRequest,generator/integration_tests/test.proto#L409}
-  /// [google.test.admin.database.v1.Database]: @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
+  /// [google.test.admin.database.v1.CreateDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L409}
+  /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L329}
   ///
   future<StatusOr<google::test::admin::database::v1::Database>>
   CreateDatabase(google::test::admin::database::v1::CreateDatabaseRequest const& request);
@@ -489,8 +489,8 @@ class GoldenThingAdminClient {
   /// @param request @googleapis_link{google::test::admin::database::v1::GetDatabaseRequest,generator/integration_tests/test.proto#L443}
   /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
   ///
-  /// [google.test.admin.database.v1.GetDatabaseRequest]: @googleapis_link{google::test::admin::database::v1::GetDatabaseRequest,generator/integration_tests/test.proto#L443}
-  /// [google.test.admin.database.v1.Database]: @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
+  /// [google.test.admin.database.v1.GetDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L443}
+  /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L329}
   ///
   StatusOr<google::test::admin::database::v1::Database>
   GetDatabase(google::test::admin::database::v1::GetDatabaseRequest const& request);
@@ -507,8 +507,8 @@ class GoldenThingAdminClient {
   /// @param request @googleapis_link{google::test::admin::database::v1::UpdateDatabaseDdlRequest,generator/integration_tests/test.proto#L470}
   /// @return @googleapis_link{google::test::admin::database::v1::UpdateDatabaseDdlMetadata,generator/integration_tests/test.proto#L506}
   ///
-  /// [google.test.admin.database.v1.UpdateDatabaseDdlRequest]: @googleapis_link{google::test::admin::database::v1::UpdateDatabaseDdlRequest,generator/integration_tests/test.proto#L470}
-  /// [google.test.admin.database.v1.UpdateDatabaseDdlMetadata]: @googleapis_link{google::test::admin::database::v1::UpdateDatabaseDdlMetadata,generator/integration_tests/test.proto#L506}
+  /// [google.test.admin.database.v1.UpdateDatabaseDdlRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L470}
+  /// [google.test.admin.database.v1.UpdateDatabaseDdlMetadata]: @googleapis_reference_link{generator/integration_tests/test.proto#L506}
   ///
   future<StatusOr<google::test::admin::database::v1::UpdateDatabaseDdlMetadata>>
   UpdateDatabaseDdl(google::test::admin::database::v1::UpdateDatabaseDdlRequest const& request);
@@ -520,7 +520,7 @@ class GoldenThingAdminClient {
   ///
   /// @param request @googleapis_link{google::test::admin::database::v1::DropDatabaseRequest,generator/integration_tests/test.proto#L523}
   ///
-  /// [google.test.admin.database.v1.DropDatabaseRequest]: @googleapis_link{google::test::admin::database::v1::DropDatabaseRequest,generator/integration_tests/test.proto#L523}
+  /// [google.test.admin.database.v1.DropDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L523}
   ///
   Status
   DropDatabase(google::test::admin::database::v1::DropDatabaseRequest const& request);
@@ -533,8 +533,8 @@ class GoldenThingAdminClient {
   /// @param request @googleapis_link{google::test::admin::database::v1::GetDatabaseDdlRequest,generator/integration_tests/test.proto#L534}
   /// @return @googleapis_link{google::test::admin::database::v1::GetDatabaseDdlResponse,generator/integration_tests/test.proto#L545}
   ///
-  /// [google.test.admin.database.v1.GetDatabaseDdlRequest]: @googleapis_link{google::test::admin::database::v1::GetDatabaseDdlRequest,generator/integration_tests/test.proto#L534}
-  /// [google.test.admin.database.v1.GetDatabaseDdlResponse]: @googleapis_link{google::test::admin::database::v1::GetDatabaseDdlResponse,generator/integration_tests/test.proto#L545}
+  /// [google.test.admin.database.v1.GetDatabaseDdlRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L534}
+  /// [google.test.admin.database.v1.GetDatabaseDdlResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L545}
   ///
   StatusOr<google::test::admin::database::v1::GetDatabaseDdlResponse>
   GetDatabaseDdl(google::test::admin::database::v1::GetDatabaseDdlRequest const& request);
@@ -551,8 +551,8 @@ class GoldenThingAdminClient {
   /// @param request @googleapis_link{google::iam::v1::SetIamPolicyRequest,google/iam/v1/iam_policy.proto#L98}
   /// @return @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
-  /// [google.iam.v1.SetIamPolicyRequest]: @googleapis_link{google::iam::v1::SetIamPolicyRequest,google/iam/v1/iam_policy.proto#L98}
-  /// [google.iam.v1.Policy]: @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
+  /// [google.iam.v1.SetIamPolicyRequest]: @googleapis_reference_link{google/iam/v1/iam_policy.proto#L98}
+  /// [google.iam.v1.Policy]: @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy>
   SetIamPolicy(google::iam::v1::SetIamPolicyRequest const& request);
@@ -570,8 +570,8 @@ class GoldenThingAdminClient {
   /// @param request @googleapis_link{google::iam::v1::GetIamPolicyRequest,google/iam/v1/iam_policy.proto#L113}
   /// @return @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
-  /// [google.iam.v1.GetIamPolicyRequest]: @googleapis_link{google::iam::v1::GetIamPolicyRequest,google/iam/v1/iam_policy.proto#L113}
-  /// [google.iam.v1.Policy]: @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
+  /// [google.iam.v1.GetIamPolicyRequest]: @googleapis_reference_link{google/iam/v1/iam_policy.proto#L113}
+  /// [google.iam.v1.Policy]: @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy>
   GetIamPolicy(google::iam::v1::GetIamPolicyRequest const& request);
@@ -591,8 +591,8 @@ class GoldenThingAdminClient {
   /// @param request @googleapis_link{google::iam::v1::TestIamPermissionsRequest,google/iam/v1/iam_policy.proto#L126}
   /// @return @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
   ///
-  /// [google.iam.v1.TestIamPermissionsRequest]: @googleapis_link{google::iam::v1::TestIamPermissionsRequest,google/iam/v1/iam_policy.proto#L126}
-  /// [google.iam.v1.TestIamPermissionsResponse]: @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
+  /// [google.iam.v1.TestIamPermissionsRequest]: @googleapis_reference_link{google/iam/v1/iam_policy.proto#L126}
+  /// [google.iam.v1.TestIamPermissionsResponse]: @googleapis_reference_link{google/iam/v1/iam_policy.proto#L141}
   ///
   StatusOr<google::iam::v1::TestIamPermissionsResponse>
   TestIamPermissions(google::iam::v1::TestIamPermissionsRequest const& request);
@@ -614,8 +614,8 @@ class GoldenThingAdminClient {
   /// @param request @googleapis_link{google::test::admin::database::v1::CreateBackupRequest,generator/integration_tests/backup.proto#L110}
   /// @return @googleapis_link{google::test::admin::database::v1::Backup,generator/integration_tests/backup.proto#L36}
   ///
-  /// [google.test.admin.database.v1.CreateBackupRequest]: @googleapis_link{google::test::admin::database::v1::CreateBackupRequest,generator/integration_tests/backup.proto#L110}
-  /// [google.test.admin.database.v1.Backup]: @googleapis_link{google::test::admin::database::v1::Backup,generator/integration_tests/backup.proto#L36}
+  /// [google.test.admin.database.v1.CreateBackupRequest]: @googleapis_reference_link{generator/integration_tests/backup.proto#L110}
+  /// [google.test.admin.database.v1.Backup]: @googleapis_reference_link{generator/integration_tests/backup.proto#L36}
   ///
   future<StatusOr<google::test::admin::database::v1::Backup>>
   CreateBackup(google::test::admin::database::v1::CreateBackupRequest const& request);
@@ -626,8 +626,8 @@ class GoldenThingAdminClient {
   /// @param request @googleapis_link{google::test::admin::database::v1::GetBackupRequest,generator/integration_tests/backup.proto#L177}
   /// @return @googleapis_link{google::test::admin::database::v1::Backup,generator/integration_tests/backup.proto#L36}
   ///
-  /// [google.test.admin.database.v1.GetBackupRequest]: @googleapis_link{google::test::admin::database::v1::GetBackupRequest,generator/integration_tests/backup.proto#L177}
-  /// [google.test.admin.database.v1.Backup]: @googleapis_link{google::test::admin::database::v1::Backup,generator/integration_tests/backup.proto#L36}
+  /// [google.test.admin.database.v1.GetBackupRequest]: @googleapis_reference_link{generator/integration_tests/backup.proto#L177}
+  /// [google.test.admin.database.v1.Backup]: @googleapis_reference_link{generator/integration_tests/backup.proto#L36}
   ///
   StatusOr<google::test::admin::database::v1::Backup>
   GetBackup(google::test::admin::database::v1::GetBackupRequest const& request);
@@ -638,8 +638,8 @@ class GoldenThingAdminClient {
   /// @param request @googleapis_link{google::test::admin::database::v1::UpdateBackupRequest,generator/integration_tests/backup.proto#L161}
   /// @return @googleapis_link{google::test::admin::database::v1::Backup,generator/integration_tests/backup.proto#L36}
   ///
-  /// [google.test.admin.database.v1.UpdateBackupRequest]: @googleapis_link{google::test::admin::database::v1::UpdateBackupRequest,generator/integration_tests/backup.proto#L161}
-  /// [google.test.admin.database.v1.Backup]: @googleapis_link{google::test::admin::database::v1::Backup,generator/integration_tests/backup.proto#L36}
+  /// [google.test.admin.database.v1.UpdateBackupRequest]: @googleapis_reference_link{generator/integration_tests/backup.proto#L161}
+  /// [google.test.admin.database.v1.Backup]: @googleapis_reference_link{generator/integration_tests/backup.proto#L36}
   ///
   StatusOr<google::test::admin::database::v1::Backup>
   UpdateBackup(google::test::admin::database::v1::UpdateBackupRequest const& request);
@@ -649,7 +649,7 @@ class GoldenThingAdminClient {
   ///
   /// @param request @googleapis_link{google::test::admin::database::v1::DeleteBackupRequest,generator/integration_tests/backup.proto#L190}
   ///
-  /// [google.test.admin.database.v1.DeleteBackupRequest]: @googleapis_link{google::test::admin::database::v1::DeleteBackupRequest,generator/integration_tests/backup.proto#L190}
+  /// [google.test.admin.database.v1.DeleteBackupRequest]: @googleapis_reference_link{generator/integration_tests/backup.proto#L190}
   ///
   Status
   DeleteBackup(google::test::admin::database::v1::DeleteBackupRequest const& request);
@@ -662,8 +662,8 @@ class GoldenThingAdminClient {
   /// @param request @googleapis_link{google::test::admin::database::v1::ListBackupsRequest,generator/integration_tests/backup.proto#L203}
   /// @return @googleapis_link{google::test::admin::database::v1::Backup,generator/integration_tests/backup.proto#L36}
   ///
-  /// [google.test.admin.database.v1.ListBackupsRequest]: @googleapis_link{google::test::admin::database::v1::ListBackupsRequest,generator/integration_tests/backup.proto#L203}
-  /// [google.test.admin.database.v1.Backup]: @googleapis_link{google::test::admin::database::v1::Backup,generator/integration_tests/backup.proto#L36}
+  /// [google.test.admin.database.v1.ListBackupsRequest]: @googleapis_reference_link{generator/integration_tests/backup.proto#L203}
+  /// [google.test.admin.database.v1.Backup]: @googleapis_reference_link{generator/integration_tests/backup.proto#L36}
   ///
   StreamRange<google::test::admin::database::v1::Backup>
   ListBackups(google::test::admin::database::v1::ListBackupsRequest request);
@@ -690,8 +690,8 @@ class GoldenThingAdminClient {
   /// @param request @googleapis_link{google::test::admin::database::v1::RestoreDatabaseRequest,generator/integration_tests/test.proto#L634}
   /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
   ///
-  /// [google.test.admin.database.v1.RestoreDatabaseRequest]: @googleapis_link{google::test::admin::database::v1::RestoreDatabaseRequest,generator/integration_tests/test.proto#L634}
-  /// [google.test.admin.database.v1.Database]: @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
+  /// [google.test.admin.database.v1.RestoreDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L634}
+  /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L329}
   ///
   future<StatusOr<google::test::admin::database::v1::Database>>
   RestoreDatabase(google::test::admin::database::v1::RestoreDatabaseRequest const& request);
@@ -709,8 +709,8 @@ class GoldenThingAdminClient {
   /// @param request @googleapis_link{google::test::admin::database::v1::ListDatabaseOperationsRequest,generator/integration_tests/test.proto#L553}
   /// @return @googleapis_link{google::longrunning::Operation,google/longrunning/operations.proto#L128}
   ///
-  /// [google.test.admin.database.v1.ListDatabaseOperationsRequest]: @googleapis_link{google::test::admin::database::v1::ListDatabaseOperationsRequest,generator/integration_tests/test.proto#L553}
-  /// [google.longrunning.Operation]: @googleapis_link{google::longrunning::Operation,google/longrunning/operations.proto#L128}
+  /// [google.test.admin.database.v1.ListDatabaseOperationsRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L553}
+  /// [google.longrunning.Operation]: @googleapis_reference_link{google/longrunning/operations.proto#L128}
   ///
   StreamRange<google::longrunning::Operation>
   ListDatabaseOperations(google::test::admin::database::v1::ListDatabaseOperationsRequest request);
@@ -730,8 +730,8 @@ class GoldenThingAdminClient {
   /// @param request @googleapis_link{google::test::admin::database::v1::ListBackupOperationsRequest,generator/integration_tests/backup.proto#L274}
   /// @return @googleapis_link{google::longrunning::Operation,google/longrunning/operations.proto#L128}
   ///
-  /// [google.test.admin.database.v1.ListBackupOperationsRequest]: @googleapis_link{google::test::admin::database::v1::ListBackupOperationsRequest,generator/integration_tests/backup.proto#L274}
-  /// [google.longrunning.Operation]: @googleapis_link{google::longrunning::Operation,google/longrunning/operations.proto#L128}
+  /// [google.test.admin.database.v1.ListBackupOperationsRequest]: @googleapis_reference_link{generator/integration_tests/backup.proto#L274}
+  /// [google.longrunning.Operation]: @googleapis_reference_link{google/longrunning/operations.proto#L128}
   ///
   StreamRange<google::longrunning::Operation>
   ListBackupOperations(google::test::admin::database::v1::ListBackupOperationsRequest request);
@@ -742,8 +742,8 @@ class GoldenThingAdminClient {
   /// @param request @googleapis_link{google::test::admin::database::v1::GetDatabaseRequest,generator/integration_tests/test.proto#L443}
   /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
   ///
-  /// [google.test.admin.database.v1.GetDatabaseRequest]: @googleapis_link{google::test::admin::database::v1::GetDatabaseRequest,generator/integration_tests/test.proto#L443}
-  /// [google.test.admin.database.v1.Database]: @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
+  /// [google.test.admin.database.v1.GetDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L443}
+  /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L329}
   ///
   future<StatusOr<google::test::admin::database::v1::Database>>
   AsyncGetDatabase(google::test::admin::database::v1::GetDatabaseRequest const& request);
@@ -755,7 +755,7 @@ class GoldenThingAdminClient {
   ///
   /// @param request @googleapis_link{google::test::admin::database::v1::DropDatabaseRequest,generator/integration_tests/test.proto#L523}
   ///
-  /// [google.test.admin.database.v1.DropDatabaseRequest]: @googleapis_link{google::test::admin::database::v1::DropDatabaseRequest,generator/integration_tests/test.proto#L523}
+  /// [google.test.admin.database.v1.DropDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L523}
   ///
   future<Status>
   AsyncDropDatabase(google::test::admin::database::v1::DropDatabaseRequest const& request);

--- a/generator/internal/descriptor_utils_test.cc
+++ b/generator/internal/descriptor_utils_test.cc
@@ -496,25 +496,30 @@ TEST_F(CreateMethodVarsTest,
        FormatMethodCommentsFromRpcCommentsProtobufRequest) {
   FileDescriptor const* service_file_descriptor =
       pool_.FindFileByName("google/foo/v1/service.proto");
-  EXPECT_EQ(
-      FormatMethodCommentsFromRpcComments(
-          *service_file_descriptor->service(0)->method(0),
-          MethodParameterStyle::kProtobufRequest),
-      "  ///\n  /// Leading comments about rpc Method0$$.\n  ///\n  /// @param "
-      "request "
-      "@googleapis_link{google::protobuf::Bar,google/foo/v1/"
-      "service.proto#L14}\n  ///\n");
+  EXPECT_THAT(FormatMethodCommentsFromRpcComments(
+                  *service_file_descriptor->service(0)->method(0),
+                  MethodParameterStyle::kProtobufRequest),
+              HasSubstr(R"""(  ///
+  /// Leading comments about rpc Method0$$.
+  ///
+  /// @param request @googleapis_link{google::protobuf::Bar,google/foo/v1/service.proto#L14}
+  ///
+)"""));
 }
 
 TEST_F(CreateMethodVarsTest,
        FormatMethodCommentsFromRpcCommentsApiMethodSignature) {
   FileDescriptor const* service_file_descriptor =
       pool_.FindFileByName("google/foo/v1/service.proto");
-  EXPECT_EQ(FormatMethodCommentsFromRpcComments(
-                *service_file_descriptor->service(0)->method(6),
-                MethodParameterStyle::kApiMethodSignature),
-            "  ///\n  /// Leading comments about rpc $$Method6.\n  ///\n  /// "
-            "@param labels  labels $$field comment.\n  ///\n");
+  EXPECT_THAT(FormatMethodCommentsFromRpcComments(
+                  *service_file_descriptor->service(0)->method(6),
+                  MethodParameterStyle::kApiMethodSignature),
+              HasSubstr(R"""(  ///
+  /// Leading comments about rpc $$Method6.
+  ///
+  /// @param labels  labels $$field comment.
+  ///
+)"""));
 }
 
 TEST_P(CreateMethodVarsTest, KeySetCorrectly) {

--- a/google/cloud/bigquery/bigquery_read_client.h
+++ b/google/cloud/bigquery/bigquery_read_client.h
@@ -99,9 +99,9 @@ class BigQueryReadClient {
   /// @googleapis_link{google::cloud::bigquery::storage::v1::ReadSession,google/cloud/bigquery/storage/v1/stream.proto#L47}
   ///
   /// [google.cloud.bigquery.storage.v1.CreateReadSessionRequest]:
-  /// @googleapis_link{google::cloud::bigquery::storage::v1::CreateReadSessionRequest,google/cloud/bigquery/storage/v1/storage.proto#L229}
+  /// @googleapis_reference_link{google/cloud/bigquery/storage/v1/storage.proto#L229}
   /// [google.cloud.bigquery.storage.v1.ReadSession]:
-  /// @googleapis_link{google::cloud::bigquery::storage::v1::ReadSession,google/cloud/bigquery/storage/v1/stream.proto#L47}
+  /// @googleapis_reference_link{google/cloud/bigquery/storage/v1/stream.proto#L47}
   ///
   StatusOr<google::cloud::bigquery::storage::v1::ReadSession> CreateReadSession(
       std::string const& parent,
@@ -126,9 +126,9 @@ class BigQueryReadClient {
   /// @googleapis_link{google::cloud::bigquery::storage::v1::ReadRowsResponse,google/cloud/bigquery/storage/v1/storage.proto#L304}
   ///
   /// [google.cloud.bigquery.storage.v1.ReadRowsRequest]:
-  /// @googleapis_link{google::cloud::bigquery::storage::v1::ReadRowsRequest,google/cloud/bigquery/storage/v1/storage.proto#L254}
+  /// @googleapis_reference_link{google/cloud/bigquery/storage/v1/storage.proto#L254}
   /// [google.cloud.bigquery.storage.v1.ReadRowsResponse]:
-  /// @googleapis_link{google::cloud::bigquery::storage::v1::ReadRowsResponse,google/cloud/bigquery/storage/v1/storage.proto#L304}
+  /// @googleapis_reference_link{google/cloud/bigquery/storage/v1/storage.proto#L304}
   ///
   StreamRange<google::cloud::bigquery::storage::v1::ReadRowsResponse> ReadRows(
       std::string const& read_stream, std::int64_t offset);
@@ -160,9 +160,9 @@ class BigQueryReadClient {
   /// @googleapis_link{google::cloud::bigquery::storage::v1::ReadSession,google/cloud/bigquery/storage/v1/stream.proto#L47}
   ///
   /// [google.cloud.bigquery.storage.v1.CreateReadSessionRequest]:
-  /// @googleapis_link{google::cloud::bigquery::storage::v1::CreateReadSessionRequest,google/cloud/bigquery/storage/v1/storage.proto#L229}
+  /// @googleapis_reference_link{google/cloud/bigquery/storage/v1/storage.proto#L229}
   /// [google.cloud.bigquery.storage.v1.ReadSession]:
-  /// @googleapis_link{google::cloud::bigquery::storage::v1::ReadSession,google/cloud/bigquery/storage/v1/stream.proto#L47}
+  /// @googleapis_reference_link{google/cloud/bigquery/storage/v1/stream.proto#L47}
   ///
   StatusOr<google::cloud::bigquery::storage::v1::ReadSession> CreateReadSession(
       google::cloud::bigquery::storage::v1::CreateReadSessionRequest const&
@@ -183,9 +183,9 @@ class BigQueryReadClient {
   /// @googleapis_link{google::cloud::bigquery::storage::v1::ReadRowsResponse,google/cloud/bigquery/storage/v1/storage.proto#L304}
   ///
   /// [google.cloud.bigquery.storage.v1.ReadRowsRequest]:
-  /// @googleapis_link{google::cloud::bigquery::storage::v1::ReadRowsRequest,google/cloud/bigquery/storage/v1/storage.proto#L254}
+  /// @googleapis_reference_link{google/cloud/bigquery/storage/v1/storage.proto#L254}
   /// [google.cloud.bigquery.storage.v1.ReadRowsResponse]:
-  /// @googleapis_link{google::cloud::bigquery::storage::v1::ReadRowsResponse,google/cloud/bigquery/storage/v1/storage.proto#L304}
+  /// @googleapis_reference_link{google/cloud/bigquery/storage/v1/storage.proto#L304}
   ///
   StreamRange<google::cloud::bigquery::storage::v1::ReadRowsResponse> ReadRows(
       google::cloud::bigquery::storage::v1::ReadRowsRequest const& request);
@@ -210,9 +210,9 @@ class BigQueryReadClient {
   /// @googleapis_link{google::cloud::bigquery::storage::v1::SplitReadStreamResponse,google/cloud/bigquery/storage/v1/storage.proto#L359}
   ///
   /// [google.cloud.bigquery.storage.v1.SplitReadStreamRequest]:
-  /// @googleapis_link{google::cloud::bigquery::storage::v1::SplitReadStreamRequest,google/cloud/bigquery/storage/v1/storage.proto#L339}
+  /// @googleapis_reference_link{google/cloud/bigquery/storage/v1/storage.proto#L339}
   /// [google.cloud.bigquery.storage.v1.SplitReadStreamResponse]:
-  /// @googleapis_link{google::cloud::bigquery::storage::v1::SplitReadStreamResponse,google/cloud/bigquery/storage/v1/storage.proto#L359}
+  /// @googleapis_reference_link{google/cloud/bigquery/storage/v1/storage.proto#L359}
   ///
   StatusOr<google::cloud::bigquery::storage::v1::SplitReadStreamResponse>
   SplitReadStream(

--- a/google/cloud/bigquery/bigquery_read_client.h
+++ b/google/cloud/bigquery/bigquery_read_client.h
@@ -98,6 +98,11 @@ class BigQueryReadClient {
   /// @return
   /// @googleapis_link{google::cloud::bigquery::storage::v1::ReadSession,google/cloud/bigquery/storage/v1/stream.proto#L47}
   ///
+  /// [google.cloud.bigquery.storage.v1.CreateReadSessionRequest]:
+  /// @googleapis_link{google::cloud::bigquery::storage::v1::CreateReadSessionRequest,google/cloud/bigquery/storage/v1/storage.proto#L229}
+  /// [google.cloud.bigquery.storage.v1.ReadSession]:
+  /// @googleapis_link{google::cloud::bigquery::storage::v1::ReadSession,google/cloud/bigquery/storage/v1/stream.proto#L47}
+  ///
   StatusOr<google::cloud::bigquery::storage::v1::ReadSession> CreateReadSession(
       std::string const& parent,
       google::cloud::bigquery::storage::v1::ReadSession const& read_session,
@@ -118,6 +123,11 @@ class BigQueryReadClient {
   ///  Requesting a larger offset is undefined. If not specified, start reading
   ///  from offset zero.
   /// @return
+  /// @googleapis_link{google::cloud::bigquery::storage::v1::ReadRowsResponse,google/cloud/bigquery/storage/v1/storage.proto#L304}
+  ///
+  /// [google.cloud.bigquery.storage.v1.ReadRowsRequest]:
+  /// @googleapis_link{google::cloud::bigquery::storage::v1::ReadRowsRequest,google/cloud/bigquery/storage/v1/storage.proto#L254}
+  /// [google.cloud.bigquery.storage.v1.ReadRowsResponse]:
   /// @googleapis_link{google::cloud::bigquery::storage::v1::ReadRowsResponse,google/cloud/bigquery/storage/v1/storage.proto#L304}
   ///
   StreamRange<google::cloud::bigquery::storage::v1::ReadRowsResponse> ReadRows(
@@ -149,6 +159,11 @@ class BigQueryReadClient {
   /// @return
   /// @googleapis_link{google::cloud::bigquery::storage::v1::ReadSession,google/cloud/bigquery/storage/v1/stream.proto#L47}
   ///
+  /// [google.cloud.bigquery.storage.v1.CreateReadSessionRequest]:
+  /// @googleapis_link{google::cloud::bigquery::storage::v1::CreateReadSessionRequest,google/cloud/bigquery/storage/v1/storage.proto#L229}
+  /// [google.cloud.bigquery.storage.v1.ReadSession]:
+  /// @googleapis_link{google::cloud::bigquery::storage::v1::ReadSession,google/cloud/bigquery/storage/v1/stream.proto#L47}
+  ///
   StatusOr<google::cloud::bigquery::storage::v1::ReadSession> CreateReadSession(
       google::cloud::bigquery::storage::v1::CreateReadSessionRequest const&
           request);
@@ -165,6 +180,11 @@ class BigQueryReadClient {
   /// @param request
   /// @googleapis_link{google::cloud::bigquery::storage::v1::ReadRowsRequest,google/cloud/bigquery/storage/v1/storage.proto#L254}
   /// @return
+  /// @googleapis_link{google::cloud::bigquery::storage::v1::ReadRowsResponse,google/cloud/bigquery/storage/v1/storage.proto#L304}
+  ///
+  /// [google.cloud.bigquery.storage.v1.ReadRowsRequest]:
+  /// @googleapis_link{google::cloud::bigquery::storage::v1::ReadRowsRequest,google/cloud/bigquery/storage/v1/storage.proto#L254}
+  /// [google.cloud.bigquery.storage.v1.ReadRowsResponse]:
   /// @googleapis_link{google::cloud::bigquery::storage::v1::ReadRowsResponse,google/cloud/bigquery/storage/v1/storage.proto#L304}
   ///
   StreamRange<google::cloud::bigquery::storage::v1::ReadRowsResponse> ReadRows(
@@ -187,6 +207,11 @@ class BigQueryReadClient {
   /// @param request
   /// @googleapis_link{google::cloud::bigquery::storage::v1::SplitReadStreamRequest,google/cloud/bigquery/storage/v1/storage.proto#L339}
   /// @return
+  /// @googleapis_link{google::cloud::bigquery::storage::v1::SplitReadStreamResponse,google/cloud/bigquery/storage/v1/storage.proto#L359}
+  ///
+  /// [google.cloud.bigquery.storage.v1.SplitReadStreamRequest]:
+  /// @googleapis_link{google::cloud::bigquery::storage::v1::SplitReadStreamRequest,google/cloud/bigquery/storage/v1/storage.proto#L339}
+  /// [google.cloud.bigquery.storage.v1.SplitReadStreamResponse]:
   /// @googleapis_link{google::cloud::bigquery::storage::v1::SplitReadStreamResponse,google/cloud/bigquery/storage/v1/storage.proto#L359}
   ///
   StatusOr<google::cloud::bigquery::storage::v1::SplitReadStreamResponse>

--- a/google/cloud/bigtable/admin/bigtable_instance_admin_client.h
+++ b/google/cloud/bigtable/admin/bigtable_instance_admin_client.h
@@ -95,6 +95,11 @@ class BigtableInstanceAdminClient {
   /// @return
   /// @googleapis_link{google::bigtable::admin::v2::Instance,google/bigtable/admin/v2/instance.proto#L41}
   ///
+  /// [google.bigtable.admin.v2.CreateInstanceRequest]:
+  /// @googleapis_link{google::bigtable::admin::v2::CreateInstanceRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L280}
+  /// [google.bigtable.admin.v2.Instance]:
+  /// @googleapis_link{google::bigtable::admin::v2::Instance,google/bigtable/admin/v2/instance.proto#L41}
+  ///
   future<StatusOr<google::bigtable::admin::v2::Instance>> CreateInstance(
       std::string const& parent, std::string const& instance_id,
       google::bigtable::admin::v2::Instance const& instance,
@@ -110,6 +115,11 @@ class BigtableInstanceAdminClient {
   /// @return
   /// @googleapis_link{google::bigtable::admin::v2::Instance,google/bigtable/admin/v2/instance.proto#L41}
   ///
+  /// [google.bigtable.admin.v2.GetInstanceRequest]:
+  /// @googleapis_link{google::bigtable::admin::v2::GetInstanceRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L308}
+  /// [google.bigtable.admin.v2.Instance]:
+  /// @googleapis_link{google::bigtable::admin::v2::Instance,google/bigtable/admin/v2/instance.proto#L41}
+  ///
   StatusOr<google::bigtable::admin::v2::Instance> GetInstance(
       std::string const& name);
 
@@ -120,6 +130,11 @@ class BigtableInstanceAdminClient {
   /// of instances is requested.
   ///  Values are of the form `projects/{project}`.
   /// @return
+  /// @googleapis_link{google::bigtable::admin::v2::ListInstancesResponse,google/bigtable/admin/v2/bigtable_instance_admin.proto#L335}
+  ///
+  /// [google.bigtable.admin.v2.ListInstancesRequest]:
+  /// @googleapis_link{google::bigtable::admin::v2::ListInstancesRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L320}
+  /// [google.bigtable.admin.v2.ListInstancesResponse]:
   /// @googleapis_link{google::bigtable::admin::v2::ListInstancesResponse,google/bigtable/admin/v2/bigtable_instance_admin.proto#L335}
   ///
   StatusOr<google::bigtable::admin::v2::ListInstancesResponse> ListInstances(
@@ -137,6 +152,11 @@ class BigtableInstanceAdminClient {
   /// @return
   /// @googleapis_link{google::bigtable::admin::v2::Instance,google/bigtable/admin/v2/instance.proto#L41}
   ///
+  /// [google.bigtable.admin.v2.PartialUpdateInstanceRequest]:
+  /// @googleapis_link{google::bigtable::admin::v2::PartialUpdateInstanceRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L352}
+  /// [google.bigtable.admin.v2.Instance]:
+  /// @googleapis_link{google::bigtable::admin::v2::Instance,google/bigtable/admin/v2/instance.proto#L41}
+  ///
   future<StatusOr<google::bigtable::admin::v2::Instance>> PartialUpdateInstance(
       google::bigtable::admin::v2::Instance const& instance,
       google::protobuf::FieldMask const& update_mask);
@@ -146,6 +166,9 @@ class BigtableInstanceAdminClient {
   ///
   /// @param name  Required. The unique name of the instance to be deleted.
   ///  Values are of the form `projects/{project}/instances/{instance}`.
+  ///
+  /// [google.bigtable.admin.v2.DeleteInstanceRequest]:
+  /// @googleapis_link{google::bigtable::admin::v2::DeleteInstanceRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L362}
   ///
   Status DeleteInstance(std::string const& name);
 
@@ -171,6 +194,11 @@ class BigtableInstanceAdminClient {
   /// @return
   /// @googleapis_link{google::bigtable::admin::v2::Cluster,google/bigtable/admin/v2/instance.proto#L137}
   ///
+  /// [google.bigtable.admin.v2.CreateClusterRequest]:
+  /// @googleapis_link{google::bigtable::admin::v2::CreateClusterRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L374}
+  /// [google.bigtable.admin.v2.Cluster]:
+  /// @googleapis_link{google::bigtable::admin::v2::Cluster,google/bigtable/admin/v2/instance.proto#L137}
+  ///
   future<StatusOr<google::bigtable::admin::v2::Cluster>> CreateCluster(
       std::string const& parent, std::string const& cluster_id,
       google::bigtable::admin::v2::Cluster const& cluster);
@@ -182,6 +210,11 @@ class BigtableInstanceAdminClient {
   /// are of the form
   ///  `projects/{project}/instances/{instance}/clusters/{cluster}`.
   /// @return
+  /// @googleapis_link{google::bigtable::admin::v2::Cluster,google/bigtable/admin/v2/instance.proto#L137}
+  ///
+  /// [google.bigtable.admin.v2.GetClusterRequest]:
+  /// @googleapis_link{google::bigtable::admin::v2::GetClusterRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L396}
+  /// [google.bigtable.admin.v2.Cluster]:
   /// @googleapis_link{google::bigtable::admin::v2::Cluster,google/bigtable/admin/v2/instance.proto#L137}
   ///
   StatusOr<google::bigtable::admin::v2::Cluster> GetCluster(
@@ -196,6 +229,11 @@ class BigtableInstanceAdminClient {
   ///  Use `{instance} = '-'` to list Clusters for all Instances in a project,
   ///  e.g., `projects/myproject/instances/-`.
   /// @return
+  /// @googleapis_link{google::bigtable::admin::v2::ListClustersResponse,google/bigtable/admin/v2/bigtable_instance_admin.proto#L425}
+  ///
+  /// [google.bigtable.admin.v2.ListClustersRequest]:
+  /// @googleapis_link{google::bigtable::admin::v2::ListClustersRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L408}
+  /// [google.bigtable.admin.v2.ListClustersResponse]:
   /// @googleapis_link{google::bigtable::admin::v2::ListClustersResponse,google/bigtable/admin/v2/bigtable_instance_admin.proto#L425}
   ///
   StatusOr<google::bigtable::admin::v2::ListClustersResponse> ListClusters(
@@ -223,6 +261,11 @@ class BigtableInstanceAdminClient {
   /// @return
   /// @googleapis_link{google::bigtable::admin::v2::Cluster,google/bigtable/admin/v2/instance.proto#L137}
   ///
+  /// [google.bigtable.admin.v2.PartialUpdateClusterRequest]:
+  /// @googleapis_link{google::bigtable::admin::v2::PartialUpdateClusterRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L513}
+  /// [google.bigtable.admin.v2.Cluster]:
+  /// @googleapis_link{google::bigtable::admin::v2::Cluster,google/bigtable/admin/v2/instance.proto#L137}
+  ///
   future<StatusOr<google::bigtable::admin::v2::Cluster>> PartialUpdateCluster(
       google::bigtable::admin::v2::Cluster const& cluster,
       google::protobuf::FieldMask const& update_mask);
@@ -233,6 +276,9 @@ class BigtableInstanceAdminClient {
   /// @param name  Required. The unique name of the cluster to be deleted.
   /// Values are of the form
   ///  `projects/{project}/instances/{instance}/clusters/{cluster}`.
+  ///
+  /// [google.bigtable.admin.v2.DeleteClusterRequest]:
+  /// @googleapis_link{google::bigtable::admin::v2::DeleteClusterRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L441}
   ///
   Status DeleteCluster(std::string const& name);
 
@@ -252,6 +298,11 @@ class BigtableInstanceAdminClient {
   /// @return
   /// @googleapis_link{google::bigtable::admin::v2::AppProfile,google/bigtable/admin/v2/instance.proto#L236}
   ///
+  /// [google.bigtable.admin.v2.CreateAppProfileRequest]:
+  /// @googleapis_link{google::bigtable::admin::v2::CreateAppProfileRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L523}
+  /// [google.bigtable.admin.v2.AppProfile]:
+  /// @googleapis_link{google::bigtable::admin::v2::AppProfile,google/bigtable/admin/v2/instance.proto#L236}
+  ///
   StatusOr<google::bigtable::admin::v2::AppProfile> CreateAppProfile(
       std::string const& parent, std::string const& app_profile_id,
       google::bigtable::admin::v2::AppProfile const& app_profile);
@@ -263,6 +314,11 @@ class BigtableInstanceAdminClient {
   /// Values are of the form
   ///  `projects/{project}/instances/{instance}/appProfiles/{app_profile}`.
   /// @return
+  /// @googleapis_link{google::bigtable::admin::v2::AppProfile,google/bigtable/admin/v2/instance.proto#L236}
+  ///
+  /// [google.bigtable.admin.v2.GetAppProfileRequest]:
+  /// @googleapis_link{google::bigtable::admin::v2::GetAppProfileRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L548}
+  /// [google.bigtable.admin.v2.AppProfile]:
   /// @googleapis_link{google::bigtable::admin::v2::AppProfile,google/bigtable/admin/v2/instance.proto#L236}
   ///
   StatusOr<google::bigtable::admin::v2::AppProfile> GetAppProfile(
@@ -280,6 +336,11 @@ class BigtableInstanceAdminClient {
   /// @return
   /// @googleapis_link{google::bigtable::admin::v2::AppProfile,google/bigtable/admin/v2/instance.proto#L236}
   ///
+  /// [google.bigtable.admin.v2.ListAppProfilesRequest]:
+  /// @googleapis_link{google::bigtable::admin::v2::ListAppProfilesRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L560}
+  /// [google::bigtable::admin::v2::AppProfile]:
+  /// @googleapis_link{google::bigtable::admin::v2::AppProfile,google/bigtable/admin/v2/instance.proto#L236}
+  ///
   StreamRange<google::bigtable::admin::v2::AppProfile> ListAppProfiles(
       std::string const& parent);
 
@@ -294,6 +355,11 @@ class BigtableInstanceAdminClient {
   /// @return
   /// @googleapis_link{google::bigtable::admin::v2::AppProfile,google/bigtable/admin/v2/instance.proto#L236}
   ///
+  /// [google.bigtable.admin.v2.UpdateAppProfileRequest]:
+  /// @googleapis_link{google::bigtable::admin::v2::UpdateAppProfileRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L606}
+  /// [google.bigtable.admin.v2.AppProfile]:
+  /// @googleapis_link{google::bigtable::admin::v2::AppProfile,google/bigtable/admin/v2/instance.proto#L236}
+  ///
   future<StatusOr<google::bigtable::admin::v2::AppProfile>> UpdateAppProfile(
       google::bigtable::admin::v2::AppProfile const& app_profile,
       google::protobuf::FieldMask const& update_mask);
@@ -305,6 +371,9 @@ class BigtableInstanceAdminClient {
   /// Values are of the form
   ///  `projects/{project}/instances/{instance}/appProfiles/{app_profile}`.
   ///
+  /// [google.bigtable.admin.v2.DeleteAppProfileRequest]:
+  /// @googleapis_link{google::bigtable::admin::v2::DeleteAppProfileRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L619}
+  ///
   Status DeleteAppProfile(std::string const& name);
 
   ///
@@ -315,6 +384,11 @@ class BigtableInstanceAdminClient {
   /// requested.
   ///  See the operation documentation for the appropriate value for this field.
   /// @return
+  /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
+  ///
+  /// [google.iam.v1.GetIamPolicyRequest]:
+  /// @googleapis_link{google::iam::v1::GetIamPolicyRequest,google/iam/v1/iam_policy.proto#L113}
+  /// [google.iam.v1.Policy]:
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> GetIamPolicy(std::string const& resource);
@@ -332,6 +406,11 @@ class BigtableInstanceAdminClient {
   ///  valid policy but certain Cloud Platform services (such as Projects)
   ///  might reject them.
   /// @return
+  /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
+  ///
+  /// [google.iam.v1.SetIamPolicyRequest]:
+  /// @googleapis_link{google::iam::v1::SetIamPolicyRequest,google/iam/v1/iam_policy.proto#L98}
+  /// [google.iam.v1.Policy]:
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
@@ -377,6 +456,11 @@ class BigtableInstanceAdminClient {
   /// @return
   /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
   ///
+  /// [google.iam.v1.TestIamPermissionsRequest]:
+  /// @googleapis_link{google::iam::v1::TestIamPermissionsRequest,google/iam/v1/iam_policy.proto#L126}
+  /// [google.iam.v1.TestIamPermissionsResponse]:
+  /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
+  ///
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
       std::string const& resource, std::vector<std::string> const& permissions);
 
@@ -394,6 +478,11 @@ class BigtableInstanceAdminClient {
   /// @return
   /// @googleapis_link{google::bigtable::admin::v2::Instance,google/bigtable/admin/v2/instance.proto#L41}
   ///
+  /// [google.bigtable.admin.v2.CreateInstanceRequest]:
+  /// @googleapis_link{google::bigtable::admin::v2::CreateInstanceRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L280}
+  /// [google.bigtable.admin.v2.Instance]:
+  /// @googleapis_link{google::bigtable::admin::v2::Instance,google/bigtable/admin/v2/instance.proto#L41}
+  ///
   future<StatusOr<google::bigtable::admin::v2::Instance>> CreateInstance(
       google::bigtable::admin::v2::CreateInstanceRequest const& request);
 
@@ -405,6 +494,11 @@ class BigtableInstanceAdminClient {
   /// @return
   /// @googleapis_link{google::bigtable::admin::v2::Instance,google/bigtable/admin/v2/instance.proto#L41}
   ///
+  /// [google.bigtable.admin.v2.GetInstanceRequest]:
+  /// @googleapis_link{google::bigtable::admin::v2::GetInstanceRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L308}
+  /// [google.bigtable.admin.v2.Instance]:
+  /// @googleapis_link{google::bigtable::admin::v2::Instance,google/bigtable/admin/v2/instance.proto#L41}
+  ///
   StatusOr<google::bigtable::admin::v2::Instance> GetInstance(
       google::bigtable::admin::v2::GetInstanceRequest const& request);
 
@@ -414,6 +508,11 @@ class BigtableInstanceAdminClient {
   /// @param request
   /// @googleapis_link{google::bigtable::admin::v2::ListInstancesRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L320}
   /// @return
+  /// @googleapis_link{google::bigtable::admin::v2::ListInstancesResponse,google/bigtable/admin/v2/bigtable_instance_admin.proto#L335}
+  ///
+  /// [google.bigtable.admin.v2.ListInstancesRequest]:
+  /// @googleapis_link{google::bigtable::admin::v2::ListInstancesRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L320}
+  /// [google.bigtable.admin.v2.ListInstancesResponse]:
   /// @googleapis_link{google::bigtable::admin::v2::ListInstancesResponse,google/bigtable/admin/v2/bigtable_instance_admin.proto#L335}
   ///
   StatusOr<google::bigtable::admin::v2::ListInstancesResponse> ListInstances(
@@ -429,6 +528,11 @@ class BigtableInstanceAdminClient {
   /// @return
   /// @googleapis_link{google::bigtable::admin::v2::Instance,google/bigtable/admin/v2/instance.proto#L41}
   ///
+  /// [google.bigtable.admin.v2.Instance]:
+  /// @googleapis_link{google::bigtable::admin::v2::Instance,google/bigtable/admin/v2/instance.proto#L41}
+  /// [google.bigtable.admin.v2.Instance]:
+  /// @googleapis_link{google::bigtable::admin::v2::Instance,google/bigtable/admin/v2/instance.proto#L41}
+  ///
   StatusOr<google::bigtable::admin::v2::Instance> UpdateInstance(
       google::bigtable::admin::v2::Instance const& request);
 
@@ -441,6 +545,11 @@ class BigtableInstanceAdminClient {
   /// @return
   /// @googleapis_link{google::bigtable::admin::v2::Instance,google/bigtable/admin/v2/instance.proto#L41}
   ///
+  /// [google.bigtable.admin.v2.PartialUpdateInstanceRequest]:
+  /// @googleapis_link{google::bigtable::admin::v2::PartialUpdateInstanceRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L352}
+  /// [google.bigtable.admin.v2.Instance]:
+  /// @googleapis_link{google::bigtable::admin::v2::Instance,google/bigtable/admin/v2/instance.proto#L41}
+  ///
   future<StatusOr<google::bigtable::admin::v2::Instance>> PartialUpdateInstance(
       google::bigtable::admin::v2::PartialUpdateInstanceRequest const& request);
 
@@ -448,6 +557,9 @@ class BigtableInstanceAdminClient {
   /// Delete an instance from a project.
   ///
   /// @param request
+  /// @googleapis_link{google::bigtable::admin::v2::DeleteInstanceRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L362}
+  ///
+  /// [google.bigtable.admin.v2.DeleteInstanceRequest]:
   /// @googleapis_link{google::bigtable::admin::v2::DeleteInstanceRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L362}
   ///
   Status DeleteInstance(
@@ -467,6 +579,11 @@ class BigtableInstanceAdminClient {
   /// @return
   /// @googleapis_link{google::bigtable::admin::v2::Cluster,google/bigtable/admin/v2/instance.proto#L137}
   ///
+  /// [google.bigtable.admin.v2.CreateClusterRequest]:
+  /// @googleapis_link{google::bigtable::admin::v2::CreateClusterRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L374}
+  /// [google.bigtable.admin.v2.Cluster]:
+  /// @googleapis_link{google::bigtable::admin::v2::Cluster,google/bigtable/admin/v2/instance.proto#L137}
+  ///
   future<StatusOr<google::bigtable::admin::v2::Cluster>> CreateCluster(
       google::bigtable::admin::v2::CreateClusterRequest const& request);
 
@@ -478,6 +595,11 @@ class BigtableInstanceAdminClient {
   /// @return
   /// @googleapis_link{google::bigtable::admin::v2::Cluster,google/bigtable/admin/v2/instance.proto#L137}
   ///
+  /// [google.bigtable.admin.v2.GetClusterRequest]:
+  /// @googleapis_link{google::bigtable::admin::v2::GetClusterRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L396}
+  /// [google.bigtable.admin.v2.Cluster]:
+  /// @googleapis_link{google::bigtable::admin::v2::Cluster,google/bigtable/admin/v2/instance.proto#L137}
+  ///
   StatusOr<google::bigtable::admin::v2::Cluster> GetCluster(
       google::bigtable::admin::v2::GetClusterRequest const& request);
 
@@ -487,6 +609,11 @@ class BigtableInstanceAdminClient {
   /// @param request
   /// @googleapis_link{google::bigtable::admin::v2::ListClustersRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L408}
   /// @return
+  /// @googleapis_link{google::bigtable::admin::v2::ListClustersResponse,google/bigtable/admin/v2/bigtable_instance_admin.proto#L425}
+  ///
+  /// [google.bigtable.admin.v2.ListClustersRequest]:
+  /// @googleapis_link{google::bigtable::admin::v2::ListClustersRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L408}
+  /// [google.bigtable.admin.v2.ListClustersResponse]:
   /// @googleapis_link{google::bigtable::admin::v2::ListClustersResponse,google/bigtable/admin/v2/bigtable_instance_admin.proto#L425}
   ///
   StatusOr<google::bigtable::admin::v2::ListClustersResponse> ListClusters(
@@ -502,6 +629,11 @@ class BigtableInstanceAdminClient {
   /// @param request
   /// @googleapis_link{google::bigtable::admin::v2::Cluster,google/bigtable/admin/v2/instance.proto#L137}
   /// @return
+  /// @googleapis_link{google::bigtable::admin::v2::Cluster,google/bigtable/admin/v2/instance.proto#L137}
+  ///
+  /// [google.bigtable.admin.v2.Cluster]:
+  /// @googleapis_link{google::bigtable::admin::v2::Cluster,google/bigtable/admin/v2/instance.proto#L137}
+  /// [google.bigtable.admin.v2.Cluster]:
   /// @googleapis_link{google::bigtable::admin::v2::Cluster,google/bigtable/admin/v2/instance.proto#L137}
   ///
   future<StatusOr<google::bigtable::admin::v2::Cluster>> UpdateCluster(
@@ -526,6 +658,11 @@ class BigtableInstanceAdminClient {
   /// @return
   /// @googleapis_link{google::bigtable::admin::v2::Cluster,google/bigtable/admin/v2/instance.proto#L137}
   ///
+  /// [google.bigtable.admin.v2.PartialUpdateClusterRequest]:
+  /// @googleapis_link{google::bigtable::admin::v2::PartialUpdateClusterRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L513}
+  /// [google.bigtable.admin.v2.Cluster]:
+  /// @googleapis_link{google::bigtable::admin::v2::Cluster,google/bigtable/admin/v2/instance.proto#L137}
+  ///
   future<StatusOr<google::bigtable::admin::v2::Cluster>> PartialUpdateCluster(
       google::bigtable::admin::v2::PartialUpdateClusterRequest const& request);
 
@@ -533,6 +670,9 @@ class BigtableInstanceAdminClient {
   /// Deletes a cluster from an instance.
   ///
   /// @param request
+  /// @googleapis_link{google::bigtable::admin::v2::DeleteClusterRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L441}
+  ///
+  /// [google.bigtable.admin.v2.DeleteClusterRequest]:
   /// @googleapis_link{google::bigtable::admin::v2::DeleteClusterRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L441}
   ///
   Status DeleteCluster(
@@ -546,6 +686,11 @@ class BigtableInstanceAdminClient {
   /// @return
   /// @googleapis_link{google::bigtable::admin::v2::AppProfile,google/bigtable/admin/v2/instance.proto#L236}
   ///
+  /// [google.bigtable.admin.v2.CreateAppProfileRequest]:
+  /// @googleapis_link{google::bigtable::admin::v2::CreateAppProfileRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L523}
+  /// [google.bigtable.admin.v2.AppProfile]:
+  /// @googleapis_link{google::bigtable::admin::v2::AppProfile,google/bigtable/admin/v2/instance.proto#L236}
+  ///
   StatusOr<google::bigtable::admin::v2::AppProfile> CreateAppProfile(
       google::bigtable::admin::v2::CreateAppProfileRequest const& request);
 
@@ -555,6 +700,11 @@ class BigtableInstanceAdminClient {
   /// @param request
   /// @googleapis_link{google::bigtable::admin::v2::GetAppProfileRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L548}
   /// @return
+  /// @googleapis_link{google::bigtable::admin::v2::AppProfile,google/bigtable/admin/v2/instance.proto#L236}
+  ///
+  /// [google.bigtable.admin.v2.GetAppProfileRequest]:
+  /// @googleapis_link{google::bigtable::admin::v2::GetAppProfileRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L548}
+  /// [google.bigtable.admin.v2.AppProfile]:
   /// @googleapis_link{google::bigtable::admin::v2::AppProfile,google/bigtable/admin/v2/instance.proto#L236}
   ///
   StatusOr<google::bigtable::admin::v2::AppProfile> GetAppProfile(
@@ -568,6 +718,11 @@ class BigtableInstanceAdminClient {
   /// @return
   /// @googleapis_link{google::bigtable::admin::v2::AppProfile,google/bigtable/admin/v2/instance.proto#L236}
   ///
+  /// [google.bigtable.admin.v2.ListAppProfilesRequest]:
+  /// @googleapis_link{google::bigtable::admin::v2::ListAppProfilesRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L560}
+  /// [google::bigtable::admin::v2::AppProfile]:
+  /// @googleapis_link{google::bigtable::admin::v2::AppProfile,google/bigtable/admin/v2/instance.proto#L236}
+  ///
   StreamRange<google::bigtable::admin::v2::AppProfile> ListAppProfiles(
       google::bigtable::admin::v2::ListAppProfilesRequest request);
 
@@ -579,6 +734,11 @@ class BigtableInstanceAdminClient {
   /// @return
   /// @googleapis_link{google::bigtable::admin::v2::AppProfile,google/bigtable/admin/v2/instance.proto#L236}
   ///
+  /// [google.bigtable.admin.v2.UpdateAppProfileRequest]:
+  /// @googleapis_link{google::bigtable::admin::v2::UpdateAppProfileRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L606}
+  /// [google.bigtable.admin.v2.AppProfile]:
+  /// @googleapis_link{google::bigtable::admin::v2::AppProfile,google/bigtable/admin/v2/instance.proto#L236}
+  ///
   future<StatusOr<google::bigtable::admin::v2::AppProfile>> UpdateAppProfile(
       google::bigtable::admin::v2::UpdateAppProfileRequest const& request);
 
@@ -586,6 +746,9 @@ class BigtableInstanceAdminClient {
   /// Deletes an app profile from an instance.
   ///
   /// @param request
+  /// @googleapis_link{google::bigtable::admin::v2::DeleteAppProfileRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L619}
+  ///
+  /// [google.bigtable.admin.v2.DeleteAppProfileRequest]:
   /// @googleapis_link{google::bigtable::admin::v2::DeleteAppProfileRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L619}
   ///
   Status DeleteAppProfile(
@@ -600,6 +763,11 @@ class BigtableInstanceAdminClient {
   /// @return
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
+  /// [google.iam.v1.GetIamPolicyRequest]:
+  /// @googleapis_link{google::iam::v1::GetIamPolicyRequest,google/iam/v1/iam_policy.proto#L113}
+  /// [google.iam.v1.Policy]:
+  /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
+  ///
   StatusOr<google::iam::v1::Policy> GetIamPolicy(
       google::iam::v1::GetIamPolicyRequest const& request);
 
@@ -612,6 +780,11 @@ class BigtableInstanceAdminClient {
   /// @return
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
+  /// [google.iam.v1.SetIamPolicyRequest]:
+  /// @googleapis_link{google::iam::v1::SetIamPolicyRequest,google/iam/v1/iam_policy.proto#L98}
+  /// [google.iam.v1.Policy]:
+  /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
+  ///
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
       google::iam::v1::SetIamPolicyRequest const& request);
 
@@ -622,6 +795,11 @@ class BigtableInstanceAdminClient {
   /// @param request
   /// @googleapis_link{google::iam::v1::TestIamPermissionsRequest,google/iam/v1/iam_policy.proto#L126}
   /// @return
+  /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
+  ///
+  /// [google.iam.v1.TestIamPermissionsRequest]:
+  /// @googleapis_link{google::iam::v1::TestIamPermissionsRequest,google/iam/v1/iam_policy.proto#L126}
+  /// [google.iam.v1.TestIamPermissionsResponse]:
   /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
   ///
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(

--- a/google/cloud/bigtable/admin/bigtable_instance_admin_client.h
+++ b/google/cloud/bigtable/admin/bigtable_instance_admin_client.h
@@ -96,9 +96,9 @@ class BigtableInstanceAdminClient {
   /// @googleapis_link{google::bigtable::admin::v2::Instance,google/bigtable/admin/v2/instance.proto#L41}
   ///
   /// [google.bigtable.admin.v2.CreateInstanceRequest]:
-  /// @googleapis_link{google::bigtable::admin::v2::CreateInstanceRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L280}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_instance_admin.proto#L280}
   /// [google.bigtable.admin.v2.Instance]:
-  /// @googleapis_link{google::bigtable::admin::v2::Instance,google/bigtable/admin/v2/instance.proto#L41}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/instance.proto#L41}
   ///
   future<StatusOr<google::bigtable::admin::v2::Instance>> CreateInstance(
       std::string const& parent, std::string const& instance_id,
@@ -116,9 +116,9 @@ class BigtableInstanceAdminClient {
   /// @googleapis_link{google::bigtable::admin::v2::Instance,google/bigtable/admin/v2/instance.proto#L41}
   ///
   /// [google.bigtable.admin.v2.GetInstanceRequest]:
-  /// @googleapis_link{google::bigtable::admin::v2::GetInstanceRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L308}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_instance_admin.proto#L308}
   /// [google.bigtable.admin.v2.Instance]:
-  /// @googleapis_link{google::bigtable::admin::v2::Instance,google/bigtable/admin/v2/instance.proto#L41}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/instance.proto#L41}
   ///
   StatusOr<google::bigtable::admin::v2::Instance> GetInstance(
       std::string const& name);
@@ -133,9 +133,9 @@ class BigtableInstanceAdminClient {
   /// @googleapis_link{google::bigtable::admin::v2::ListInstancesResponse,google/bigtable/admin/v2/bigtable_instance_admin.proto#L335}
   ///
   /// [google.bigtable.admin.v2.ListInstancesRequest]:
-  /// @googleapis_link{google::bigtable::admin::v2::ListInstancesRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L320}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_instance_admin.proto#L320}
   /// [google.bigtable.admin.v2.ListInstancesResponse]:
-  /// @googleapis_link{google::bigtable::admin::v2::ListInstancesResponse,google/bigtable/admin/v2/bigtable_instance_admin.proto#L335}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_instance_admin.proto#L335}
   ///
   StatusOr<google::bigtable::admin::v2::ListInstancesResponse> ListInstances(
       std::string const& parent);
@@ -153,9 +153,9 @@ class BigtableInstanceAdminClient {
   /// @googleapis_link{google::bigtable::admin::v2::Instance,google/bigtable/admin/v2/instance.proto#L41}
   ///
   /// [google.bigtable.admin.v2.PartialUpdateInstanceRequest]:
-  /// @googleapis_link{google::bigtable::admin::v2::PartialUpdateInstanceRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L352}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_instance_admin.proto#L352}
   /// [google.bigtable.admin.v2.Instance]:
-  /// @googleapis_link{google::bigtable::admin::v2::Instance,google/bigtable/admin/v2/instance.proto#L41}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/instance.proto#L41}
   ///
   future<StatusOr<google::bigtable::admin::v2::Instance>> PartialUpdateInstance(
       google::bigtable::admin::v2::Instance const& instance,
@@ -168,7 +168,7 @@ class BigtableInstanceAdminClient {
   ///  Values are of the form `projects/{project}/instances/{instance}`.
   ///
   /// [google.bigtable.admin.v2.DeleteInstanceRequest]:
-  /// @googleapis_link{google::bigtable::admin::v2::DeleteInstanceRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L362}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_instance_admin.proto#L362}
   ///
   Status DeleteInstance(std::string const& name);
 
@@ -195,9 +195,9 @@ class BigtableInstanceAdminClient {
   /// @googleapis_link{google::bigtable::admin::v2::Cluster,google/bigtable/admin/v2/instance.proto#L137}
   ///
   /// [google.bigtable.admin.v2.CreateClusterRequest]:
-  /// @googleapis_link{google::bigtable::admin::v2::CreateClusterRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L374}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_instance_admin.proto#L374}
   /// [google.bigtable.admin.v2.Cluster]:
-  /// @googleapis_link{google::bigtable::admin::v2::Cluster,google/bigtable/admin/v2/instance.proto#L137}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/instance.proto#L137}
   ///
   future<StatusOr<google::bigtable::admin::v2::Cluster>> CreateCluster(
       std::string const& parent, std::string const& cluster_id,
@@ -213,9 +213,9 @@ class BigtableInstanceAdminClient {
   /// @googleapis_link{google::bigtable::admin::v2::Cluster,google/bigtable/admin/v2/instance.proto#L137}
   ///
   /// [google.bigtable.admin.v2.GetClusterRequest]:
-  /// @googleapis_link{google::bigtable::admin::v2::GetClusterRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L396}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_instance_admin.proto#L396}
   /// [google.bigtable.admin.v2.Cluster]:
-  /// @googleapis_link{google::bigtable::admin::v2::Cluster,google/bigtable/admin/v2/instance.proto#L137}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/instance.proto#L137}
   ///
   StatusOr<google::bigtable::admin::v2::Cluster> GetCluster(
       std::string const& name);
@@ -232,9 +232,9 @@ class BigtableInstanceAdminClient {
   /// @googleapis_link{google::bigtable::admin::v2::ListClustersResponse,google/bigtable/admin/v2/bigtable_instance_admin.proto#L425}
   ///
   /// [google.bigtable.admin.v2.ListClustersRequest]:
-  /// @googleapis_link{google::bigtable::admin::v2::ListClustersRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L408}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_instance_admin.proto#L408}
   /// [google.bigtable.admin.v2.ListClustersResponse]:
-  /// @googleapis_link{google::bigtable::admin::v2::ListClustersResponse,google/bigtable/admin/v2/bigtable_instance_admin.proto#L425}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_instance_admin.proto#L425}
   ///
   StatusOr<google::bigtable::admin::v2::ListClustersResponse> ListClusters(
       std::string const& parent);
@@ -262,9 +262,9 @@ class BigtableInstanceAdminClient {
   /// @googleapis_link{google::bigtable::admin::v2::Cluster,google/bigtable/admin/v2/instance.proto#L137}
   ///
   /// [google.bigtable.admin.v2.PartialUpdateClusterRequest]:
-  /// @googleapis_link{google::bigtable::admin::v2::PartialUpdateClusterRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L513}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_instance_admin.proto#L513}
   /// [google.bigtable.admin.v2.Cluster]:
-  /// @googleapis_link{google::bigtable::admin::v2::Cluster,google/bigtable/admin/v2/instance.proto#L137}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/instance.proto#L137}
   ///
   future<StatusOr<google::bigtable::admin::v2::Cluster>> PartialUpdateCluster(
       google::bigtable::admin::v2::Cluster const& cluster,
@@ -278,7 +278,7 @@ class BigtableInstanceAdminClient {
   ///  `projects/{project}/instances/{instance}/clusters/{cluster}`.
   ///
   /// [google.bigtable.admin.v2.DeleteClusterRequest]:
-  /// @googleapis_link{google::bigtable::admin::v2::DeleteClusterRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L441}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_instance_admin.proto#L441}
   ///
   Status DeleteCluster(std::string const& name);
 
@@ -299,9 +299,9 @@ class BigtableInstanceAdminClient {
   /// @googleapis_link{google::bigtable::admin::v2::AppProfile,google/bigtable/admin/v2/instance.proto#L236}
   ///
   /// [google.bigtable.admin.v2.CreateAppProfileRequest]:
-  /// @googleapis_link{google::bigtable::admin::v2::CreateAppProfileRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L523}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_instance_admin.proto#L523}
   /// [google.bigtable.admin.v2.AppProfile]:
-  /// @googleapis_link{google::bigtable::admin::v2::AppProfile,google/bigtable/admin/v2/instance.proto#L236}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/instance.proto#L236}
   ///
   StatusOr<google::bigtable::admin::v2::AppProfile> CreateAppProfile(
       std::string const& parent, std::string const& app_profile_id,
@@ -317,9 +317,9 @@ class BigtableInstanceAdminClient {
   /// @googleapis_link{google::bigtable::admin::v2::AppProfile,google/bigtable/admin/v2/instance.proto#L236}
   ///
   /// [google.bigtable.admin.v2.GetAppProfileRequest]:
-  /// @googleapis_link{google::bigtable::admin::v2::GetAppProfileRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L548}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_instance_admin.proto#L548}
   /// [google.bigtable.admin.v2.AppProfile]:
-  /// @googleapis_link{google::bigtable::admin::v2::AppProfile,google/bigtable/admin/v2/instance.proto#L236}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/instance.proto#L236}
   ///
   StatusOr<google::bigtable::admin::v2::AppProfile> GetAppProfile(
       std::string const& name);
@@ -337,9 +337,9 @@ class BigtableInstanceAdminClient {
   /// @googleapis_link{google::bigtable::admin::v2::AppProfile,google/bigtable/admin/v2/instance.proto#L236}
   ///
   /// [google.bigtable.admin.v2.ListAppProfilesRequest]:
-  /// @googleapis_link{google::bigtable::admin::v2::ListAppProfilesRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L560}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_instance_admin.proto#L560}
   /// [google.bigtable.admin.v2.AppProfile]:
-  /// @googleapis_link{google::bigtable::admin::v2::AppProfile,google/bigtable/admin/v2/instance.proto#L236}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/instance.proto#L236}
   ///
   StreamRange<google::bigtable::admin::v2::AppProfile> ListAppProfiles(
       std::string const& parent);
@@ -356,9 +356,9 @@ class BigtableInstanceAdminClient {
   /// @googleapis_link{google::bigtable::admin::v2::AppProfile,google/bigtable/admin/v2/instance.proto#L236}
   ///
   /// [google.bigtable.admin.v2.UpdateAppProfileRequest]:
-  /// @googleapis_link{google::bigtable::admin::v2::UpdateAppProfileRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L606}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_instance_admin.proto#L606}
   /// [google.bigtable.admin.v2.AppProfile]:
-  /// @googleapis_link{google::bigtable::admin::v2::AppProfile,google/bigtable/admin/v2/instance.proto#L236}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/instance.proto#L236}
   ///
   future<StatusOr<google::bigtable::admin::v2::AppProfile>> UpdateAppProfile(
       google::bigtable::admin::v2::AppProfile const& app_profile,
@@ -372,7 +372,7 @@ class BigtableInstanceAdminClient {
   ///  `projects/{project}/instances/{instance}/appProfiles/{app_profile}`.
   ///
   /// [google.bigtable.admin.v2.DeleteAppProfileRequest]:
-  /// @googleapis_link{google::bigtable::admin::v2::DeleteAppProfileRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L619}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_instance_admin.proto#L619}
   ///
   Status DeleteAppProfile(std::string const& name);
 
@@ -387,9 +387,9 @@ class BigtableInstanceAdminClient {
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
   /// [google.iam.v1.GetIamPolicyRequest]:
-  /// @googleapis_link{google::iam::v1::GetIamPolicyRequest,google/iam/v1/iam_policy.proto#L113}
+  /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L113}
   /// [google.iam.v1.Policy]:
-  /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
+  /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> GetIamPolicy(std::string const& resource);
 
@@ -409,9 +409,9 @@ class BigtableInstanceAdminClient {
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
   /// [google.iam.v1.SetIamPolicyRequest]:
-  /// @googleapis_link{google::iam::v1::SetIamPolicyRequest,google/iam/v1/iam_policy.proto#L98}
+  /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L98}
   /// [google.iam.v1.Policy]:
-  /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
+  /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
       std::string const& resource, google::iam::v1::Policy const& policy);
@@ -457,9 +457,9 @@ class BigtableInstanceAdminClient {
   /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
   ///
   /// [google.iam.v1.TestIamPermissionsRequest]:
-  /// @googleapis_link{google::iam::v1::TestIamPermissionsRequest,google/iam/v1/iam_policy.proto#L126}
+  /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L126}
   /// [google.iam.v1.TestIamPermissionsResponse]:
-  /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
+  /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L141}
   ///
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
       std::string const& resource, std::vector<std::string> const& permissions);
@@ -479,9 +479,9 @@ class BigtableInstanceAdminClient {
   /// @googleapis_link{google::bigtable::admin::v2::Instance,google/bigtable/admin/v2/instance.proto#L41}
   ///
   /// [google.bigtable.admin.v2.CreateInstanceRequest]:
-  /// @googleapis_link{google::bigtable::admin::v2::CreateInstanceRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L280}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_instance_admin.proto#L280}
   /// [google.bigtable.admin.v2.Instance]:
-  /// @googleapis_link{google::bigtable::admin::v2::Instance,google/bigtable/admin/v2/instance.proto#L41}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/instance.proto#L41}
   ///
   future<StatusOr<google::bigtable::admin::v2::Instance>> CreateInstance(
       google::bigtable::admin::v2::CreateInstanceRequest const& request);
@@ -495,9 +495,9 @@ class BigtableInstanceAdminClient {
   /// @googleapis_link{google::bigtable::admin::v2::Instance,google/bigtable/admin/v2/instance.proto#L41}
   ///
   /// [google.bigtable.admin.v2.GetInstanceRequest]:
-  /// @googleapis_link{google::bigtable::admin::v2::GetInstanceRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L308}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_instance_admin.proto#L308}
   /// [google.bigtable.admin.v2.Instance]:
-  /// @googleapis_link{google::bigtable::admin::v2::Instance,google/bigtable/admin/v2/instance.proto#L41}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/instance.proto#L41}
   ///
   StatusOr<google::bigtable::admin::v2::Instance> GetInstance(
       google::bigtable::admin::v2::GetInstanceRequest const& request);
@@ -511,9 +511,9 @@ class BigtableInstanceAdminClient {
   /// @googleapis_link{google::bigtable::admin::v2::ListInstancesResponse,google/bigtable/admin/v2/bigtable_instance_admin.proto#L335}
   ///
   /// [google.bigtable.admin.v2.ListInstancesRequest]:
-  /// @googleapis_link{google::bigtable::admin::v2::ListInstancesRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L320}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_instance_admin.proto#L320}
   /// [google.bigtable.admin.v2.ListInstancesResponse]:
-  /// @googleapis_link{google::bigtable::admin::v2::ListInstancesResponse,google/bigtable/admin/v2/bigtable_instance_admin.proto#L335}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_instance_admin.proto#L335}
   ///
   StatusOr<google::bigtable::admin::v2::ListInstancesResponse> ListInstances(
       google::bigtable::admin::v2::ListInstancesRequest const& request);
@@ -529,9 +529,9 @@ class BigtableInstanceAdminClient {
   /// @googleapis_link{google::bigtable::admin::v2::Instance,google/bigtable/admin/v2/instance.proto#L41}
   ///
   /// [google.bigtable.admin.v2.Instance]:
-  /// @googleapis_link{google::bigtable::admin::v2::Instance,google/bigtable/admin/v2/instance.proto#L41}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/instance.proto#L41}
   /// [google.bigtable.admin.v2.Instance]:
-  /// @googleapis_link{google::bigtable::admin::v2::Instance,google/bigtable/admin/v2/instance.proto#L41}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/instance.proto#L41}
   ///
   StatusOr<google::bigtable::admin::v2::Instance> UpdateInstance(
       google::bigtable::admin::v2::Instance const& request);
@@ -546,9 +546,9 @@ class BigtableInstanceAdminClient {
   /// @googleapis_link{google::bigtable::admin::v2::Instance,google/bigtable/admin/v2/instance.proto#L41}
   ///
   /// [google.bigtable.admin.v2.PartialUpdateInstanceRequest]:
-  /// @googleapis_link{google::bigtable::admin::v2::PartialUpdateInstanceRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L352}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_instance_admin.proto#L352}
   /// [google.bigtable.admin.v2.Instance]:
-  /// @googleapis_link{google::bigtable::admin::v2::Instance,google/bigtable/admin/v2/instance.proto#L41}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/instance.proto#L41}
   ///
   future<StatusOr<google::bigtable::admin::v2::Instance>> PartialUpdateInstance(
       google::bigtable::admin::v2::PartialUpdateInstanceRequest const& request);
@@ -560,7 +560,7 @@ class BigtableInstanceAdminClient {
   /// @googleapis_link{google::bigtable::admin::v2::DeleteInstanceRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L362}
   ///
   /// [google.bigtable.admin.v2.DeleteInstanceRequest]:
-  /// @googleapis_link{google::bigtable::admin::v2::DeleteInstanceRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L362}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_instance_admin.proto#L362}
   ///
   Status DeleteInstance(
       google::bigtable::admin::v2::DeleteInstanceRequest const& request);
@@ -580,9 +580,9 @@ class BigtableInstanceAdminClient {
   /// @googleapis_link{google::bigtable::admin::v2::Cluster,google/bigtable/admin/v2/instance.proto#L137}
   ///
   /// [google.bigtable.admin.v2.CreateClusterRequest]:
-  /// @googleapis_link{google::bigtable::admin::v2::CreateClusterRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L374}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_instance_admin.proto#L374}
   /// [google.bigtable.admin.v2.Cluster]:
-  /// @googleapis_link{google::bigtable::admin::v2::Cluster,google/bigtable/admin/v2/instance.proto#L137}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/instance.proto#L137}
   ///
   future<StatusOr<google::bigtable::admin::v2::Cluster>> CreateCluster(
       google::bigtable::admin::v2::CreateClusterRequest const& request);
@@ -596,9 +596,9 @@ class BigtableInstanceAdminClient {
   /// @googleapis_link{google::bigtable::admin::v2::Cluster,google/bigtable/admin/v2/instance.proto#L137}
   ///
   /// [google.bigtable.admin.v2.GetClusterRequest]:
-  /// @googleapis_link{google::bigtable::admin::v2::GetClusterRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L396}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_instance_admin.proto#L396}
   /// [google.bigtable.admin.v2.Cluster]:
-  /// @googleapis_link{google::bigtable::admin::v2::Cluster,google/bigtable/admin/v2/instance.proto#L137}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/instance.proto#L137}
   ///
   StatusOr<google::bigtable::admin::v2::Cluster> GetCluster(
       google::bigtable::admin::v2::GetClusterRequest const& request);
@@ -612,9 +612,9 @@ class BigtableInstanceAdminClient {
   /// @googleapis_link{google::bigtable::admin::v2::ListClustersResponse,google/bigtable/admin/v2/bigtable_instance_admin.proto#L425}
   ///
   /// [google.bigtable.admin.v2.ListClustersRequest]:
-  /// @googleapis_link{google::bigtable::admin::v2::ListClustersRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L408}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_instance_admin.proto#L408}
   /// [google.bigtable.admin.v2.ListClustersResponse]:
-  /// @googleapis_link{google::bigtable::admin::v2::ListClustersResponse,google/bigtable/admin/v2/bigtable_instance_admin.proto#L425}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_instance_admin.proto#L425}
   ///
   StatusOr<google::bigtable::admin::v2::ListClustersResponse> ListClusters(
       google::bigtable::admin::v2::ListClustersRequest const& request);
@@ -632,9 +632,9 @@ class BigtableInstanceAdminClient {
   /// @googleapis_link{google::bigtable::admin::v2::Cluster,google/bigtable/admin/v2/instance.proto#L137}
   ///
   /// [google.bigtable.admin.v2.Cluster]:
-  /// @googleapis_link{google::bigtable::admin::v2::Cluster,google/bigtable/admin/v2/instance.proto#L137}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/instance.proto#L137}
   /// [google.bigtable.admin.v2.Cluster]:
-  /// @googleapis_link{google::bigtable::admin::v2::Cluster,google/bigtable/admin/v2/instance.proto#L137}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/instance.proto#L137}
   ///
   future<StatusOr<google::bigtable::admin::v2::Cluster>> UpdateCluster(
       google::bigtable::admin::v2::Cluster const& request);
@@ -659,9 +659,9 @@ class BigtableInstanceAdminClient {
   /// @googleapis_link{google::bigtable::admin::v2::Cluster,google/bigtable/admin/v2/instance.proto#L137}
   ///
   /// [google.bigtable.admin.v2.PartialUpdateClusterRequest]:
-  /// @googleapis_link{google::bigtable::admin::v2::PartialUpdateClusterRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L513}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_instance_admin.proto#L513}
   /// [google.bigtable.admin.v2.Cluster]:
-  /// @googleapis_link{google::bigtable::admin::v2::Cluster,google/bigtable/admin/v2/instance.proto#L137}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/instance.proto#L137}
   ///
   future<StatusOr<google::bigtable::admin::v2::Cluster>> PartialUpdateCluster(
       google::bigtable::admin::v2::PartialUpdateClusterRequest const& request);
@@ -673,7 +673,7 @@ class BigtableInstanceAdminClient {
   /// @googleapis_link{google::bigtable::admin::v2::DeleteClusterRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L441}
   ///
   /// [google.bigtable.admin.v2.DeleteClusterRequest]:
-  /// @googleapis_link{google::bigtable::admin::v2::DeleteClusterRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L441}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_instance_admin.proto#L441}
   ///
   Status DeleteCluster(
       google::bigtable::admin::v2::DeleteClusterRequest const& request);
@@ -687,9 +687,9 @@ class BigtableInstanceAdminClient {
   /// @googleapis_link{google::bigtable::admin::v2::AppProfile,google/bigtable/admin/v2/instance.proto#L236}
   ///
   /// [google.bigtable.admin.v2.CreateAppProfileRequest]:
-  /// @googleapis_link{google::bigtable::admin::v2::CreateAppProfileRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L523}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_instance_admin.proto#L523}
   /// [google.bigtable.admin.v2.AppProfile]:
-  /// @googleapis_link{google::bigtable::admin::v2::AppProfile,google/bigtable/admin/v2/instance.proto#L236}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/instance.proto#L236}
   ///
   StatusOr<google::bigtable::admin::v2::AppProfile> CreateAppProfile(
       google::bigtable::admin::v2::CreateAppProfileRequest const& request);
@@ -703,9 +703,9 @@ class BigtableInstanceAdminClient {
   /// @googleapis_link{google::bigtable::admin::v2::AppProfile,google/bigtable/admin/v2/instance.proto#L236}
   ///
   /// [google.bigtable.admin.v2.GetAppProfileRequest]:
-  /// @googleapis_link{google::bigtable::admin::v2::GetAppProfileRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L548}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_instance_admin.proto#L548}
   /// [google.bigtable.admin.v2.AppProfile]:
-  /// @googleapis_link{google::bigtable::admin::v2::AppProfile,google/bigtable/admin/v2/instance.proto#L236}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/instance.proto#L236}
   ///
   StatusOr<google::bigtable::admin::v2::AppProfile> GetAppProfile(
       google::bigtable::admin::v2::GetAppProfileRequest const& request);
@@ -719,9 +719,9 @@ class BigtableInstanceAdminClient {
   /// @googleapis_link{google::bigtable::admin::v2::AppProfile,google/bigtable/admin/v2/instance.proto#L236}
   ///
   /// [google.bigtable.admin.v2.ListAppProfilesRequest]:
-  /// @googleapis_link{google::bigtable::admin::v2::ListAppProfilesRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L560}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_instance_admin.proto#L560}
   /// [google.bigtable.admin.v2.AppProfile]:
-  /// @googleapis_link{google::bigtable::admin::v2::AppProfile,google/bigtable/admin/v2/instance.proto#L236}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/instance.proto#L236}
   ///
   StreamRange<google::bigtable::admin::v2::AppProfile> ListAppProfiles(
       google::bigtable::admin::v2::ListAppProfilesRequest request);
@@ -735,9 +735,9 @@ class BigtableInstanceAdminClient {
   /// @googleapis_link{google::bigtable::admin::v2::AppProfile,google/bigtable/admin/v2/instance.proto#L236}
   ///
   /// [google.bigtable.admin.v2.UpdateAppProfileRequest]:
-  /// @googleapis_link{google::bigtable::admin::v2::UpdateAppProfileRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L606}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_instance_admin.proto#L606}
   /// [google.bigtable.admin.v2.AppProfile]:
-  /// @googleapis_link{google::bigtable::admin::v2::AppProfile,google/bigtable/admin/v2/instance.proto#L236}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/instance.proto#L236}
   ///
   future<StatusOr<google::bigtable::admin::v2::AppProfile>> UpdateAppProfile(
       google::bigtable::admin::v2::UpdateAppProfileRequest const& request);
@@ -749,7 +749,7 @@ class BigtableInstanceAdminClient {
   /// @googleapis_link{google::bigtable::admin::v2::DeleteAppProfileRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L619}
   ///
   /// [google.bigtable.admin.v2.DeleteAppProfileRequest]:
-  /// @googleapis_link{google::bigtable::admin::v2::DeleteAppProfileRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L619}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_instance_admin.proto#L619}
   ///
   Status DeleteAppProfile(
       google::bigtable::admin::v2::DeleteAppProfileRequest const& request);
@@ -764,9 +764,9 @@ class BigtableInstanceAdminClient {
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
   /// [google.iam.v1.GetIamPolicyRequest]:
-  /// @googleapis_link{google::iam::v1::GetIamPolicyRequest,google/iam/v1/iam_policy.proto#L113}
+  /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L113}
   /// [google.iam.v1.Policy]:
-  /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
+  /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> GetIamPolicy(
       google::iam::v1::GetIamPolicyRequest const& request);
@@ -781,9 +781,9 @@ class BigtableInstanceAdminClient {
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
   /// [google.iam.v1.SetIamPolicyRequest]:
-  /// @googleapis_link{google::iam::v1::SetIamPolicyRequest,google/iam/v1/iam_policy.proto#L98}
+  /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L98}
   /// [google.iam.v1.Policy]:
-  /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
+  /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
       google::iam::v1::SetIamPolicyRequest const& request);
@@ -798,9 +798,9 @@ class BigtableInstanceAdminClient {
   /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
   ///
   /// [google.iam.v1.TestIamPermissionsRequest]:
-  /// @googleapis_link{google::iam::v1::TestIamPermissionsRequest,google/iam/v1/iam_policy.proto#L126}
+  /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L126}
   /// [google.iam.v1.TestIamPermissionsResponse]:
-  /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
+  /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L141}
   ///
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
       google::iam::v1::TestIamPermissionsRequest const& request);

--- a/google/cloud/bigtable/admin/bigtable_instance_admin_client.h
+++ b/google/cloud/bigtable/admin/bigtable_instance_admin_client.h
@@ -338,7 +338,7 @@ class BigtableInstanceAdminClient {
   ///
   /// [google.bigtable.admin.v2.ListAppProfilesRequest]:
   /// @googleapis_link{google::bigtable::admin::v2::ListAppProfilesRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L560}
-  /// [google::bigtable::admin::v2::AppProfile]:
+  /// [google.bigtable.admin.v2.AppProfile]:
   /// @googleapis_link{google::bigtable::admin::v2::AppProfile,google/bigtable/admin/v2/instance.proto#L236}
   ///
   StreamRange<google::bigtable::admin::v2::AppProfile> ListAppProfiles(
@@ -720,7 +720,7 @@ class BigtableInstanceAdminClient {
   ///
   /// [google.bigtable.admin.v2.ListAppProfilesRequest]:
   /// @googleapis_link{google::bigtable::admin::v2::ListAppProfilesRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L560}
-  /// [google::bigtable::admin::v2::AppProfile]:
+  /// [google.bigtable.admin.v2.AppProfile]:
   /// @googleapis_link{google::bigtable::admin::v2::AppProfile,google/bigtable/admin/v2/instance.proto#L236}
   ///
   StreamRange<google::bigtable::admin::v2::AppProfile> ListAppProfiles(

--- a/google/cloud/bigtable/admin/bigtable_table_admin_client.h
+++ b/google/cloud/bigtable/admin/bigtable_table_admin_client.h
@@ -105,7 +105,7 @@ class BigtableTableAdminClient {
   ///
   /// [google.bigtable.admin.v2.ListTablesRequest]:
   /// @googleapis_link{google::bigtable::admin::v2::ListTablesRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L510}
-  /// [google::bigtable::admin::v2::Table]:
+  /// [google.bigtable.admin.v2.Table]:
   /// @googleapis_link{google::bigtable::admin::v2::Table,google/bigtable/admin/v2/table.proto#L61}
   ///
   StreamRange<google::bigtable::admin::v2::Table> ListTables(
@@ -315,7 +315,7 @@ class BigtableTableAdminClient {
   ///
   /// [google.bigtable.admin.v2.ListBackupsRequest]:
   /// @googleapis_link{google::bigtable::admin::v2::ListBackupsRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L915}
-  /// [google::bigtable::admin::v2::Backup]:
+  /// [google.bigtable.admin.v2.Backup]:
   /// @googleapis_link{google::bigtable::admin::v2::Backup,google/bigtable/admin/v2/table.proto#L317}
   ///
   StreamRange<google::bigtable::admin::v2::Backup> ListBackups(
@@ -461,7 +461,7 @@ class BigtableTableAdminClient {
   ///
   /// [google.bigtable.admin.v2.ListTablesRequest]:
   /// @googleapis_link{google::bigtable::admin::v2::ListTablesRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L510}
-  /// [google::bigtable::admin::v2::Table]:
+  /// [google.bigtable.admin.v2.Table]:
   /// @googleapis_link{google::bigtable::admin::v2::Table,google/bigtable/admin/v2/table.proto#L61}
   ///
   StreamRange<google::bigtable::admin::v2::Table> ListTables(
@@ -646,7 +646,7 @@ class BigtableTableAdminClient {
   ///
   /// [google.bigtable.admin.v2.ListBackupsRequest]:
   /// @googleapis_link{google::bigtable::admin::v2::ListBackupsRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L915}
-  /// [google::bigtable::admin::v2::Backup]:
+  /// [google.bigtable.admin.v2.Backup]:
   /// @googleapis_link{google::bigtable::admin::v2::Backup,google/bigtable/admin/v2/table.proto#L317}
   ///
   StreamRange<google::bigtable::admin::v2::Backup> ListBackups(

--- a/google/cloud/bigtable/admin/bigtable_table_admin_client.h
+++ b/google/cloud/bigtable/admin/bigtable_table_admin_client.h
@@ -86,9 +86,9 @@ class BigtableTableAdminClient {
   /// @googleapis_link{google::bigtable::admin::v2::Table,google/bigtable/admin/v2/table.proto#L61}
   ///
   /// [google.bigtable.admin.v2.CreateTableRequest]:
-  /// @googleapis_link{google::bigtable::admin::v2::CreateTableRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L408}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_table_admin.proto#L408}
   /// [google.bigtable.admin.v2.Table]:
-  /// @googleapis_link{google::bigtable::admin::v2::Table,google/bigtable/admin/v2/table.proto#L61}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/table.proto#L61}
   ///
   StatusOr<google::bigtable::admin::v2::Table> CreateTable(
       std::string const& parent, std::string const& table_id,
@@ -104,9 +104,9 @@ class BigtableTableAdminClient {
   /// @googleapis_link{google::bigtable::admin::v2::Table,google/bigtable/admin/v2/table.proto#L61}
   ///
   /// [google.bigtable.admin.v2.ListTablesRequest]:
-  /// @googleapis_link{google::bigtable::admin::v2::ListTablesRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L510}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_table_admin.proto#L510}
   /// [google.bigtable.admin.v2.Table]:
-  /// @googleapis_link{google::bigtable::admin::v2::Table,google/bigtable/admin/v2/table.proto#L61}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/table.proto#L61}
   ///
   StreamRange<google::bigtable::admin::v2::Table> ListTables(
       std::string const& parent);
@@ -121,9 +121,9 @@ class BigtableTableAdminClient {
   /// @googleapis_link{google::bigtable::admin::v2::Table,google/bigtable/admin/v2/table.proto#L61}
   ///
   /// [google.bigtable.admin.v2.GetTableRequest]:
-  /// @googleapis_link{google::bigtable::admin::v2::GetTableRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L553}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_table_admin.proto#L553}
   /// [google.bigtable.admin.v2.Table]:
-  /// @googleapis_link{google::bigtable::admin::v2::Table,google/bigtable/admin/v2/table.proto#L61}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/table.proto#L61}
   ///
   StatusOr<google::bigtable::admin::v2::Table> GetTable(
       std::string const& name);
@@ -136,7 +136,7 @@ class BigtableTableAdminClient {
   ///  `projects/{project}/instances/{instance}/tables/{table}`.
   ///
   /// [google.bigtable.admin.v2.DeleteTableRequest]:
-  /// @googleapis_link{google::bigtable::admin::v2::DeleteTableRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L571}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_table_admin.proto#L571}
   ///
   Status DeleteTable(std::string const& name);
 
@@ -159,9 +159,9 @@ class BigtableTableAdminClient {
   /// @googleapis_link{google::bigtable::admin::v2::Table,google/bigtable/admin/v2/table.proto#L61}
   ///
   /// [google.bigtable.admin.v2.ModifyColumnFamiliesRequest]:
-  /// @googleapis_link{google::bigtable::admin::v2::ModifyColumnFamiliesRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L585}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_table_admin.proto#L585}
   /// [google.bigtable.admin.v2.Table]:
-  /// @googleapis_link{google::bigtable::admin::v2::Table,google/bigtable/admin/v2/table.proto#L61}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/table.proto#L61}
   ///
   StatusOr<google::bigtable::admin::v2::Table> ModifyColumnFamilies(
       std::string const& name,
@@ -182,9 +182,9 @@ class BigtableTableAdminClient {
   /// @googleapis_link{google::bigtable::admin::v2::GenerateConsistencyTokenResponse,google/bigtable/admin/v2/bigtable_table_admin.proto#L640}
   ///
   /// [google.bigtable.admin.v2.GenerateConsistencyTokenRequest]:
-  /// @googleapis_link{google::bigtable::admin::v2::GenerateConsistencyTokenRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L626}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_table_admin.proto#L626}
   /// [google.bigtable.admin.v2.GenerateConsistencyTokenResponse]:
-  /// @googleapis_link{google::bigtable::admin::v2::GenerateConsistencyTokenResponse,google/bigtable/admin/v2/bigtable_table_admin.proto#L640}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_table_admin.proto#L640}
   ///
   StatusOr<google::bigtable::admin::v2::GenerateConsistencyTokenResponse>
   GenerateConsistencyToken(std::string const& name);
@@ -204,9 +204,9 @@ class BigtableTableAdminClient {
   /// @googleapis_link{google::bigtable::admin::v2::CheckConsistencyResponse,google/bigtable/admin/v2/bigtable_table_admin.proto#L664}
   ///
   /// [google.bigtable.admin.v2.CheckConsistencyRequest]:
-  /// @googleapis_link{google::bigtable::admin::v2::CheckConsistencyRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L647}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_table_admin.proto#L647}
   /// [google.bigtable.admin.v2.CheckConsistencyResponse]:
-  /// @googleapis_link{google::bigtable::admin::v2::CheckConsistencyResponse,google/bigtable/admin/v2/bigtable_table_admin.proto#L664}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_table_admin.proto#L664}
   ///
   StatusOr<google::bigtable::admin::v2::CheckConsistencyResponse>
   CheckConsistency(std::string const& name,
@@ -238,9 +238,9 @@ class BigtableTableAdminClient {
   /// @googleapis_link{google::bigtable::admin::v2::Backup,google/bigtable/admin/v2/table.proto#L317}
   ///
   /// [google.bigtable.admin.v2.CreateBackupRequest]:
-  /// @googleapis_link{google::bigtable::admin::v2::CreateBackupRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L833}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_table_admin.proto#L833}
   /// [google.bigtable.admin.v2.Backup]:
-  /// @googleapis_link{google::bigtable::admin::v2::Backup,google/bigtable/admin/v2/table.proto#L317}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/table.proto#L317}
   ///
   future<StatusOr<google::bigtable::admin::v2::Backup>> CreateBackup(
       std::string const& parent, std::string const& backup_id,
@@ -256,9 +256,9 @@ class BigtableTableAdminClient {
   /// @googleapis_link{google::bigtable::admin::v2::Backup,google/bigtable/admin/v2/table.proto#L317}
   ///
   /// [google.bigtable.admin.v2.GetBackupRequest]:
-  /// @googleapis_link{google::bigtable::admin::v2::GetBackupRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L889}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_table_admin.proto#L889}
   /// [google.bigtable.admin.v2.Backup]:
-  /// @googleapis_link{google::bigtable::admin::v2::Backup,google/bigtable/admin/v2/table.proto#L317}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/table.proto#L317}
   ///
   StatusOr<google::bigtable::admin::v2::Backup> GetBackup(
       std::string const& name);
@@ -281,9 +281,9 @@ class BigtableTableAdminClient {
   /// @googleapis_link{google::bigtable::admin::v2::Backup,google/bigtable/admin/v2/table.proto#L317}
   ///
   /// [google.bigtable.admin.v2.UpdateBackupRequest]:
-  /// @googleapis_link{google::bigtable::admin::v2::UpdateBackupRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L873}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_table_admin.proto#L873}
   /// [google.bigtable.admin.v2.Backup]:
-  /// @googleapis_link{google::bigtable::admin::v2::Backup,google/bigtable/admin/v2/table.proto#L317}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/table.proto#L317}
   ///
   StatusOr<google::bigtable::admin::v2::Backup> UpdateBackup(
       google::bigtable::admin::v2::Backup const& backup,
@@ -297,7 +297,7 @@ class BigtableTableAdminClient {
   ///  `projects/{project}/instances/{instance}/clusters/{cluster}/backups/{backup}`.
   ///
   /// [google.bigtable.admin.v2.DeleteBackupRequest]:
-  /// @googleapis_link{google::bigtable::admin::v2::DeleteBackupRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L902}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_table_admin.proto#L902}
   ///
   Status DeleteBackup(std::string const& name);
 
@@ -314,9 +314,9 @@ class BigtableTableAdminClient {
   /// @googleapis_link{google::bigtable::admin::v2::Backup,google/bigtable/admin/v2/table.proto#L317}
   ///
   /// [google.bigtable.admin.v2.ListBackupsRequest]:
-  /// @googleapis_link{google::bigtable::admin::v2::ListBackupsRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L915}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_table_admin.proto#L915}
   /// [google.bigtable.admin.v2.Backup]:
-  /// @googleapis_link{google::bigtable::admin::v2::Backup,google/bigtable/admin/v2/table.proto#L317}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/table.proto#L317}
   ///
   StreamRange<google::bigtable::admin::v2::Backup> ListBackups(
       std::string const& parent);
@@ -333,9 +333,9 @@ class BigtableTableAdminClient {
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
   /// [google.iam.v1.GetIamPolicyRequest]:
-  /// @googleapis_link{google::iam::v1::GetIamPolicyRequest,google/iam/v1/iam_policy.proto#L113}
+  /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L113}
   /// [google.iam.v1.Policy]:
-  /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
+  /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> GetIamPolicy(std::string const& resource);
 
@@ -355,9 +355,9 @@ class BigtableTableAdminClient {
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
   /// [google.iam.v1.SetIamPolicyRequest]:
-  /// @googleapis_link{google::iam::v1::SetIamPolicyRequest,google/iam/v1/iam_policy.proto#L98}
+  /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L98}
   /// [google.iam.v1.Policy]:
-  /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
+  /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
       std::string const& resource, google::iam::v1::Policy const& policy);
@@ -403,9 +403,9 @@ class BigtableTableAdminClient {
   /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
   ///
   /// [google.iam.v1.TestIamPermissionsRequest]:
-  /// @googleapis_link{google::iam::v1::TestIamPermissionsRequest,google/iam/v1/iam_policy.proto#L126}
+  /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L126}
   /// [google.iam.v1.TestIamPermissionsResponse]:
-  /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
+  /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L141}
   ///
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
       std::string const& resource, std::vector<std::string> const& permissions);
@@ -425,9 +425,9 @@ class BigtableTableAdminClient {
   /// @googleapis_link{google::bigtable::admin::v2::CheckConsistencyResponse,google/bigtable/admin/v2/bigtable_table_admin.proto#L664}
   ///
   /// [google.bigtable.admin.v2.CheckConsistencyRequest]:
-  /// @googleapis_link{google::bigtable::admin::v2::CheckConsistencyRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L647}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_table_admin.proto#L647}
   /// [google.bigtable.admin.v2.CheckConsistencyResponse]:
-  /// @googleapis_link{google::bigtable::admin::v2::CheckConsistencyResponse,google/bigtable/admin/v2/bigtable_table_admin.proto#L664}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_table_admin.proto#L664}
   ///
   future<StatusOr<google::bigtable::admin::v2::CheckConsistencyResponse>>
   AsyncCheckConsistency(std::string const& name,
@@ -444,9 +444,9 @@ class BigtableTableAdminClient {
   /// @googleapis_link{google::bigtable::admin::v2::Table,google/bigtable/admin/v2/table.proto#L61}
   ///
   /// [google.bigtable.admin.v2.CreateTableRequest]:
-  /// @googleapis_link{google::bigtable::admin::v2::CreateTableRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L408}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_table_admin.proto#L408}
   /// [google.bigtable.admin.v2.Table]:
-  /// @googleapis_link{google::bigtable::admin::v2::Table,google/bigtable/admin/v2/table.proto#L61}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/table.proto#L61}
   ///
   StatusOr<google::bigtable::admin::v2::Table> CreateTable(
       google::bigtable::admin::v2::CreateTableRequest const& request);
@@ -460,9 +460,9 @@ class BigtableTableAdminClient {
   /// @googleapis_link{google::bigtable::admin::v2::Table,google/bigtable/admin/v2/table.proto#L61}
   ///
   /// [google.bigtable.admin.v2.ListTablesRequest]:
-  /// @googleapis_link{google::bigtable::admin::v2::ListTablesRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L510}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_table_admin.proto#L510}
   /// [google.bigtable.admin.v2.Table]:
-  /// @googleapis_link{google::bigtable::admin::v2::Table,google/bigtable/admin/v2/table.proto#L61}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/table.proto#L61}
   ///
   StreamRange<google::bigtable::admin::v2::Table> ListTables(
       google::bigtable::admin::v2::ListTablesRequest request);
@@ -476,9 +476,9 @@ class BigtableTableAdminClient {
   /// @googleapis_link{google::bigtable::admin::v2::Table,google/bigtable/admin/v2/table.proto#L61}
   ///
   /// [google.bigtable.admin.v2.GetTableRequest]:
-  /// @googleapis_link{google::bigtable::admin::v2::GetTableRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L553}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_table_admin.proto#L553}
   /// [google.bigtable.admin.v2.Table]:
-  /// @googleapis_link{google::bigtable::admin::v2::Table,google/bigtable/admin/v2/table.proto#L61}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/table.proto#L61}
   ///
   StatusOr<google::bigtable::admin::v2::Table> GetTable(
       google::bigtable::admin::v2::GetTableRequest const& request);
@@ -490,7 +490,7 @@ class BigtableTableAdminClient {
   /// @googleapis_link{google::bigtable::admin::v2::DeleteTableRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L571}
   ///
   /// [google.bigtable.admin.v2.DeleteTableRequest]:
-  /// @googleapis_link{google::bigtable::admin::v2::DeleteTableRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L571}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_table_admin.proto#L571}
   ///
   Status DeleteTable(
       google::bigtable::admin::v2::DeleteTableRequest const& request);
@@ -507,9 +507,9 @@ class BigtableTableAdminClient {
   /// @googleapis_link{google::bigtable::admin::v2::Table,google/bigtable/admin/v2/table.proto#L61}
   ///
   /// [google.bigtable.admin.v2.ModifyColumnFamiliesRequest]:
-  /// @googleapis_link{google::bigtable::admin::v2::ModifyColumnFamiliesRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L585}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_table_admin.proto#L585}
   /// [google.bigtable.admin.v2.Table]:
-  /// @googleapis_link{google::bigtable::admin::v2::Table,google/bigtable/admin/v2/table.proto#L61}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/table.proto#L61}
   ///
   StatusOr<google::bigtable::admin::v2::Table> ModifyColumnFamilies(
       google::bigtable::admin::v2::ModifyColumnFamiliesRequest const& request);
@@ -523,7 +523,7 @@ class BigtableTableAdminClient {
   /// @googleapis_link{google::bigtable::admin::v2::DropRowRangeRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L486}
   ///
   /// [google.bigtable.admin.v2.DropRowRangeRequest]:
-  /// @googleapis_link{google::bigtable::admin::v2::DropRowRangeRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L486}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_table_admin.proto#L486}
   ///
   Status DropRowRange(
       google::bigtable::admin::v2::DropRowRangeRequest const& request);
@@ -540,9 +540,9 @@ class BigtableTableAdminClient {
   /// @googleapis_link{google::bigtable::admin::v2::GenerateConsistencyTokenResponse,google/bigtable/admin/v2/bigtable_table_admin.proto#L640}
   ///
   /// [google.bigtable.admin.v2.GenerateConsistencyTokenRequest]:
-  /// @googleapis_link{google::bigtable::admin::v2::GenerateConsistencyTokenRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L626}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_table_admin.proto#L626}
   /// [google.bigtable.admin.v2.GenerateConsistencyTokenResponse]:
-  /// @googleapis_link{google::bigtable::admin::v2::GenerateConsistencyTokenResponse,google/bigtable/admin/v2/bigtable_table_admin.proto#L640}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_table_admin.proto#L640}
   ///
   StatusOr<google::bigtable::admin::v2::GenerateConsistencyTokenResponse>
   GenerateConsistencyToken(
@@ -560,9 +560,9 @@ class BigtableTableAdminClient {
   /// @googleapis_link{google::bigtable::admin::v2::CheckConsistencyResponse,google/bigtable/admin/v2/bigtable_table_admin.proto#L664}
   ///
   /// [google.bigtable.admin.v2.CheckConsistencyRequest]:
-  /// @googleapis_link{google::bigtable::admin::v2::CheckConsistencyRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L647}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_table_admin.proto#L647}
   /// [google.bigtable.admin.v2.CheckConsistencyResponse]:
-  /// @googleapis_link{google::bigtable::admin::v2::CheckConsistencyResponse,google/bigtable/admin/v2/bigtable_table_admin.proto#L664}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_table_admin.proto#L664}
   ///
   StatusOr<google::bigtable::admin::v2::CheckConsistencyResponse>
   CheckConsistency(
@@ -584,9 +584,9 @@ class BigtableTableAdminClient {
   /// @googleapis_link{google::bigtable::admin::v2::Backup,google/bigtable/admin/v2/table.proto#L317}
   ///
   /// [google.bigtable.admin.v2.CreateBackupRequest]:
-  /// @googleapis_link{google::bigtable::admin::v2::CreateBackupRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L833}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_table_admin.proto#L833}
   /// [google.bigtable.admin.v2.Backup]:
-  /// @googleapis_link{google::bigtable::admin::v2::Backup,google/bigtable/admin/v2/table.proto#L317}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/table.proto#L317}
   ///
   future<StatusOr<google::bigtable::admin::v2::Backup>> CreateBackup(
       google::bigtable::admin::v2::CreateBackupRequest const& request);
@@ -600,9 +600,9 @@ class BigtableTableAdminClient {
   /// @googleapis_link{google::bigtable::admin::v2::Backup,google/bigtable/admin/v2/table.proto#L317}
   ///
   /// [google.bigtable.admin.v2.GetBackupRequest]:
-  /// @googleapis_link{google::bigtable::admin::v2::GetBackupRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L889}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_table_admin.proto#L889}
   /// [google.bigtable.admin.v2.Backup]:
-  /// @googleapis_link{google::bigtable::admin::v2::Backup,google/bigtable/admin/v2/table.proto#L317}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/table.proto#L317}
   ///
   StatusOr<google::bigtable::admin::v2::Backup> GetBackup(
       google::bigtable::admin::v2::GetBackupRequest const& request);
@@ -616,9 +616,9 @@ class BigtableTableAdminClient {
   /// @googleapis_link{google::bigtable::admin::v2::Backup,google/bigtable/admin/v2/table.proto#L317}
   ///
   /// [google.bigtable.admin.v2.UpdateBackupRequest]:
-  /// @googleapis_link{google::bigtable::admin::v2::UpdateBackupRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L873}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_table_admin.proto#L873}
   /// [google.bigtable.admin.v2.Backup]:
-  /// @googleapis_link{google::bigtable::admin::v2::Backup,google/bigtable/admin/v2/table.proto#L317}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/table.proto#L317}
   ///
   StatusOr<google::bigtable::admin::v2::Backup> UpdateBackup(
       google::bigtable::admin::v2::UpdateBackupRequest const& request);
@@ -630,7 +630,7 @@ class BigtableTableAdminClient {
   /// @googleapis_link{google::bigtable::admin::v2::DeleteBackupRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L902}
   ///
   /// [google.bigtable.admin.v2.DeleteBackupRequest]:
-  /// @googleapis_link{google::bigtable::admin::v2::DeleteBackupRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L902}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_table_admin.proto#L902}
   ///
   Status DeleteBackup(
       google::bigtable::admin::v2::DeleteBackupRequest const& request);
@@ -645,9 +645,9 @@ class BigtableTableAdminClient {
   /// @googleapis_link{google::bigtable::admin::v2::Backup,google/bigtable/admin/v2/table.proto#L317}
   ///
   /// [google.bigtable.admin.v2.ListBackupsRequest]:
-  /// @googleapis_link{google::bigtable::admin::v2::ListBackupsRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L915}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_table_admin.proto#L915}
   /// [google.bigtable.admin.v2.Backup]:
-  /// @googleapis_link{google::bigtable::admin::v2::Backup,google/bigtable/admin/v2/table.proto#L317}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/table.proto#L317}
   ///
   StreamRange<google::bigtable::admin::v2::Backup> ListBackups(
       google::bigtable::admin::v2::ListBackupsRequest request);
@@ -668,9 +668,9 @@ class BigtableTableAdminClient {
   /// @googleapis_link{google::bigtable::admin::v2::Table,google/bigtable/admin/v2/table.proto#L61}
   ///
   /// [google.bigtable.admin.v2.RestoreTableRequest]:
-  /// @googleapis_link{google::bigtable::admin::v2::RestoreTableRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L336}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_table_admin.proto#L336}
   /// [google.bigtable.admin.v2.Table]:
-  /// @googleapis_link{google::bigtable::admin::v2::Table,google/bigtable/admin/v2/table.proto#L61}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/table.proto#L61}
   ///
   future<StatusOr<google::bigtable::admin::v2::Table>> RestoreTable(
       google::bigtable::admin::v2::RestoreTableRequest const& request);
@@ -686,9 +686,9 @@ class BigtableTableAdminClient {
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
   /// [google.iam.v1.GetIamPolicyRequest]:
-  /// @googleapis_link{google::iam::v1::GetIamPolicyRequest,google/iam/v1/iam_policy.proto#L113}
+  /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L113}
   /// [google.iam.v1.Policy]:
-  /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
+  /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> GetIamPolicy(
       google::iam::v1::GetIamPolicyRequest const& request);
@@ -703,9 +703,9 @@ class BigtableTableAdminClient {
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
   /// [google.iam.v1.SetIamPolicyRequest]:
-  /// @googleapis_link{google::iam::v1::SetIamPolicyRequest,google/iam/v1/iam_policy.proto#L98}
+  /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L98}
   /// [google.iam.v1.Policy]:
-  /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
+  /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
       google::iam::v1::SetIamPolicyRequest const& request);
@@ -720,9 +720,9 @@ class BigtableTableAdminClient {
   /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
   ///
   /// [google.iam.v1.TestIamPermissionsRequest]:
-  /// @googleapis_link{google::iam::v1::TestIamPermissionsRequest,google/iam/v1/iam_policy.proto#L126}
+  /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L126}
   /// [google.iam.v1.TestIamPermissionsResponse]:
-  /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
+  /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L141}
   ///
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
       google::iam::v1::TestIamPermissionsRequest const& request);
@@ -738,9 +738,9 @@ class BigtableTableAdminClient {
   /// @googleapis_link{google::bigtable::admin::v2::CheckConsistencyResponse,google/bigtable/admin/v2/bigtable_table_admin.proto#L664}
   ///
   /// [google.bigtable.admin.v2.CheckConsistencyRequest]:
-  /// @googleapis_link{google::bigtable::admin::v2::CheckConsistencyRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L647}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_table_admin.proto#L647}
   /// [google.bigtable.admin.v2.CheckConsistencyResponse]:
-  /// @googleapis_link{google::bigtable::admin::v2::CheckConsistencyResponse,google/bigtable/admin/v2/bigtable_table_admin.proto#L664}
+  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_table_admin.proto#L664}
   ///
   future<StatusOr<google::bigtable::admin::v2::CheckConsistencyResponse>>
   AsyncCheckConsistency(

--- a/google/cloud/bigtable/admin/bigtable_table_admin_client.h
+++ b/google/cloud/bigtable/admin/bigtable_table_admin_client.h
@@ -85,6 +85,11 @@ class BigtableTableAdminClient {
   /// @return
   /// @googleapis_link{google::bigtable::admin::v2::Table,google/bigtable/admin/v2/table.proto#L61}
   ///
+  /// [google.bigtable.admin.v2.CreateTableRequest]:
+  /// @googleapis_link{google::bigtable::admin::v2::CreateTableRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L408}
+  /// [google.bigtable.admin.v2.Table]:
+  /// @googleapis_link{google::bigtable::admin::v2::Table,google/bigtable/admin/v2/table.proto#L61}
+  ///
   StatusOr<google::bigtable::admin::v2::Table> CreateTable(
       std::string const& parent, std::string const& table_id,
       google::bigtable::admin::v2::Table const& table);
@@ -96,6 +101,11 @@ class BigtableTableAdminClient {
   /// should be listed.
   ///  Values are of the form `projects/{project}/instances/{instance}`.
   /// @return
+  /// @googleapis_link{google::bigtable::admin::v2::Table,google/bigtable/admin/v2/table.proto#L61}
+  ///
+  /// [google.bigtable.admin.v2.ListTablesRequest]:
+  /// @googleapis_link{google::bigtable::admin::v2::ListTablesRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L510}
+  /// [google::bigtable::admin::v2::Table]:
   /// @googleapis_link{google::bigtable::admin::v2::Table,google/bigtable/admin/v2/table.proto#L61}
   ///
   StreamRange<google::bigtable::admin::v2::Table> ListTables(
@@ -110,6 +120,11 @@ class BigtableTableAdminClient {
   /// @return
   /// @googleapis_link{google::bigtable::admin::v2::Table,google/bigtable/admin/v2/table.proto#L61}
   ///
+  /// [google.bigtable.admin.v2.GetTableRequest]:
+  /// @googleapis_link{google::bigtable::admin::v2::GetTableRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L553}
+  /// [google.bigtable.admin.v2.Table]:
+  /// @googleapis_link{google::bigtable::admin::v2::Table,google/bigtable/admin/v2/table.proto#L61}
+  ///
   StatusOr<google::bigtable::admin::v2::Table> GetTable(
       std::string const& name);
 
@@ -119,6 +134,9 @@ class BigtableTableAdminClient {
   /// @param name  Required. The unique name of the table to be deleted.
   ///  Values are of the form
   ///  `projects/{project}/instances/{instance}/tables/{table}`.
+  ///
+  /// [google.bigtable.admin.v2.DeleteTableRequest]:
+  /// @googleapis_link{google::bigtable::admin::v2::DeleteTableRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L571}
   ///
   Status DeleteTable(std::string const& name);
 
@@ -140,6 +158,11 @@ class BigtableTableAdminClient {
   /// @return
   /// @googleapis_link{google::bigtable::admin::v2::Table,google/bigtable/admin/v2/table.proto#L61}
   ///
+  /// [google.bigtable.admin.v2.ModifyColumnFamiliesRequest]:
+  /// @googleapis_link{google::bigtable::admin::v2::ModifyColumnFamiliesRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L585}
+  /// [google.bigtable.admin.v2.Table]:
+  /// @googleapis_link{google::bigtable::admin::v2::Table,google/bigtable/admin/v2/table.proto#L61}
+  ///
   StatusOr<google::bigtable::admin::v2::Table> ModifyColumnFamilies(
       std::string const& name,
       std::vector<google::bigtable::admin::v2::ModifyColumnFamiliesRequest::
@@ -158,6 +181,11 @@ class BigtableTableAdminClient {
   /// @return
   /// @googleapis_link{google::bigtable::admin::v2::GenerateConsistencyTokenResponse,google/bigtable/admin/v2/bigtable_table_admin.proto#L640}
   ///
+  /// [google.bigtable.admin.v2.GenerateConsistencyTokenRequest]:
+  /// @googleapis_link{google::bigtable::admin::v2::GenerateConsistencyTokenRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L626}
+  /// [google.bigtable.admin.v2.GenerateConsistencyTokenResponse]:
+  /// @googleapis_link{google::bigtable::admin::v2::GenerateConsistencyTokenResponse,google/bigtable/admin/v2/bigtable_table_admin.proto#L640}
+  ///
   StatusOr<google::bigtable::admin::v2::GenerateConsistencyTokenResponse>
   GenerateConsistencyToken(std::string const& name);
 
@@ -173,6 +201,11 @@ class BigtableTableAdminClient {
   /// @param consistency_token  Required. The token created using
   /// GenerateConsistencyToken for the Table.
   /// @return
+  /// @googleapis_link{google::bigtable::admin::v2::CheckConsistencyResponse,google/bigtable/admin/v2/bigtable_table_admin.proto#L664}
+  ///
+  /// [google.bigtable.admin.v2.CheckConsistencyRequest]:
+  /// @googleapis_link{google::bigtable::admin::v2::CheckConsistencyRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L647}
+  /// [google.bigtable.admin.v2.CheckConsistencyResponse]:
   /// @googleapis_link{google::bigtable::admin::v2::CheckConsistencyResponse,google/bigtable/admin/v2/bigtable_table_admin.proto#L664}
   ///
   StatusOr<google::bigtable::admin::v2::CheckConsistencyResponse>
@@ -204,6 +237,11 @@ class BigtableTableAdminClient {
   /// @return
   /// @googleapis_link{google::bigtable::admin::v2::Backup,google/bigtable/admin/v2/table.proto#L317}
   ///
+  /// [google.bigtable.admin.v2.CreateBackupRequest]:
+  /// @googleapis_link{google::bigtable::admin::v2::CreateBackupRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L833}
+  /// [google.bigtable.admin.v2.Backup]:
+  /// @googleapis_link{google::bigtable::admin::v2::Backup,google/bigtable/admin/v2/table.proto#L317}
+  ///
   future<StatusOr<google::bigtable::admin::v2::Backup>> CreateBackup(
       std::string const& parent, std::string const& backup_id,
       google::bigtable::admin::v2::Backup const& backup);
@@ -215,6 +253,11 @@ class BigtableTableAdminClient {
   ///  Values are of the form
   ///  `projects/{project}/instances/{instance}/clusters/{cluster}/backups/{backup}`.
   /// @return
+  /// @googleapis_link{google::bigtable::admin::v2::Backup,google/bigtable/admin/v2/table.proto#L317}
+  ///
+  /// [google.bigtable.admin.v2.GetBackupRequest]:
+  /// @googleapis_link{google::bigtable::admin::v2::GetBackupRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L889}
+  /// [google.bigtable.admin.v2.Backup]:
   /// @googleapis_link{google::bigtable::admin::v2::Backup,google/bigtable/admin/v2/table.proto#L317}
   ///
   StatusOr<google::bigtable::admin::v2::Backup> GetBackup(
@@ -237,6 +280,11 @@ class BigtableTableAdminClient {
   /// @return
   /// @googleapis_link{google::bigtable::admin::v2::Backup,google/bigtable/admin/v2/table.proto#L317}
   ///
+  /// [google.bigtable.admin.v2.UpdateBackupRequest]:
+  /// @googleapis_link{google::bigtable::admin::v2::UpdateBackupRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L873}
+  /// [google.bigtable.admin.v2.Backup]:
+  /// @googleapis_link{google::bigtable::admin::v2::Backup,google/bigtable/admin/v2/table.proto#L317}
+  ///
   StatusOr<google::bigtable::admin::v2::Backup> UpdateBackup(
       google::bigtable::admin::v2::Backup const& backup,
       google::protobuf::FieldMask const& update_mask);
@@ -247,6 +295,9 @@ class BigtableTableAdminClient {
   /// @param name  Required. Name of the backup to delete.
   ///  Values are of the form
   ///  `projects/{project}/instances/{instance}/clusters/{cluster}/backups/{backup}`.
+  ///
+  /// [google.bigtable.admin.v2.DeleteBackupRequest]:
+  /// @googleapis_link{google::bigtable::admin::v2::DeleteBackupRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L902}
   ///
   Status DeleteBackup(std::string const& name);
 
@@ -262,6 +313,11 @@ class BigtableTableAdminClient {
   /// @return
   /// @googleapis_link{google::bigtable::admin::v2::Backup,google/bigtable/admin/v2/table.proto#L317}
   ///
+  /// [google.bigtable.admin.v2.ListBackupsRequest]:
+  /// @googleapis_link{google::bigtable::admin::v2::ListBackupsRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L915}
+  /// [google::bigtable::admin::v2::Backup]:
+  /// @googleapis_link{google::bigtable::admin::v2::Backup,google/bigtable/admin/v2/table.proto#L317}
+  ///
   StreamRange<google::bigtable::admin::v2::Backup> ListBackups(
       std::string const& parent);
 
@@ -274,6 +330,11 @@ class BigtableTableAdminClient {
   /// requested.
   ///  See the operation documentation for the appropriate value for this field.
   /// @return
+  /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
+  ///
+  /// [google.iam.v1.GetIamPolicyRequest]:
+  /// @googleapis_link{google::iam::v1::GetIamPolicyRequest,google/iam/v1/iam_policy.proto#L113}
+  /// [google.iam.v1.Policy]:
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> GetIamPolicy(std::string const& resource);
@@ -291,6 +352,11 @@ class BigtableTableAdminClient {
   ///  valid policy but certain Cloud Platform services (such as Projects)
   ///  might reject them.
   /// @return
+  /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
+  ///
+  /// [google.iam.v1.SetIamPolicyRequest]:
+  /// @googleapis_link{google::iam::v1::SetIamPolicyRequest,google/iam/v1/iam_policy.proto#L98}
+  /// [google.iam.v1.Policy]:
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
@@ -336,6 +402,11 @@ class BigtableTableAdminClient {
   /// @return
   /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
   ///
+  /// [google.iam.v1.TestIamPermissionsRequest]:
+  /// @googleapis_link{google::iam::v1::TestIamPermissionsRequest,google/iam/v1/iam_policy.proto#L126}
+  /// [google.iam.v1.TestIamPermissionsResponse]:
+  /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
+  ///
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
       std::string const& resource, std::vector<std::string> const& permissions);
 
@@ -353,6 +424,11 @@ class BigtableTableAdminClient {
   /// @return
   /// @googleapis_link{google::bigtable::admin::v2::CheckConsistencyResponse,google/bigtable/admin/v2/bigtable_table_admin.proto#L664}
   ///
+  /// [google.bigtable.admin.v2.CheckConsistencyRequest]:
+  /// @googleapis_link{google::bigtable::admin::v2::CheckConsistencyRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L647}
+  /// [google.bigtable.admin.v2.CheckConsistencyResponse]:
+  /// @googleapis_link{google::bigtable::admin::v2::CheckConsistencyResponse,google/bigtable/admin/v2/bigtable_table_admin.proto#L664}
+  ///
   future<StatusOr<google::bigtable::admin::v2::CheckConsistencyResponse>>
   AsyncCheckConsistency(std::string const& name,
                         std::string const& consistency_token);
@@ -367,6 +443,11 @@ class BigtableTableAdminClient {
   /// @return
   /// @googleapis_link{google::bigtable::admin::v2::Table,google/bigtable/admin/v2/table.proto#L61}
   ///
+  /// [google.bigtable.admin.v2.CreateTableRequest]:
+  /// @googleapis_link{google::bigtable::admin::v2::CreateTableRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L408}
+  /// [google.bigtable.admin.v2.Table]:
+  /// @googleapis_link{google::bigtable::admin::v2::Table,google/bigtable/admin/v2/table.proto#L61}
+  ///
   StatusOr<google::bigtable::admin::v2::Table> CreateTable(
       google::bigtable::admin::v2::CreateTableRequest const& request);
 
@@ -376,6 +457,11 @@ class BigtableTableAdminClient {
   /// @param request
   /// @googleapis_link{google::bigtable::admin::v2::ListTablesRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L510}
   /// @return
+  /// @googleapis_link{google::bigtable::admin::v2::Table,google/bigtable/admin/v2/table.proto#L61}
+  ///
+  /// [google.bigtable.admin.v2.ListTablesRequest]:
+  /// @googleapis_link{google::bigtable::admin::v2::ListTablesRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L510}
+  /// [google::bigtable::admin::v2::Table]:
   /// @googleapis_link{google::bigtable::admin::v2::Table,google/bigtable/admin/v2/table.proto#L61}
   ///
   StreamRange<google::bigtable::admin::v2::Table> ListTables(
@@ -389,6 +475,11 @@ class BigtableTableAdminClient {
   /// @return
   /// @googleapis_link{google::bigtable::admin::v2::Table,google/bigtable/admin/v2/table.proto#L61}
   ///
+  /// [google.bigtable.admin.v2.GetTableRequest]:
+  /// @googleapis_link{google::bigtable::admin::v2::GetTableRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L553}
+  /// [google.bigtable.admin.v2.Table]:
+  /// @googleapis_link{google::bigtable::admin::v2::Table,google/bigtable/admin/v2/table.proto#L61}
+  ///
   StatusOr<google::bigtable::admin::v2::Table> GetTable(
       google::bigtable::admin::v2::GetTableRequest const& request);
 
@@ -396,6 +487,9 @@ class BigtableTableAdminClient {
   /// Permanently deletes a specified table and all of its data.
   ///
   /// @param request
+  /// @googleapis_link{google::bigtable::admin::v2::DeleteTableRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L571}
+  ///
+  /// [google.bigtable.admin.v2.DeleteTableRequest]:
   /// @googleapis_link{google::bigtable::admin::v2::DeleteTableRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L571}
   ///
   Status DeleteTable(
@@ -412,6 +506,11 @@ class BigtableTableAdminClient {
   /// @return
   /// @googleapis_link{google::bigtable::admin::v2::Table,google/bigtable/admin/v2/table.proto#L61}
   ///
+  /// [google.bigtable.admin.v2.ModifyColumnFamiliesRequest]:
+  /// @googleapis_link{google::bigtable::admin::v2::ModifyColumnFamiliesRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L585}
+  /// [google.bigtable.admin.v2.Table]:
+  /// @googleapis_link{google::bigtable::admin::v2::Table,google/bigtable/admin/v2/table.proto#L61}
+  ///
   StatusOr<google::bigtable::admin::v2::Table> ModifyColumnFamilies(
       google::bigtable::admin::v2::ModifyColumnFamiliesRequest const& request);
 
@@ -421,6 +520,9 @@ class BigtableTableAdminClient {
   /// match a particular prefix.
   ///
   /// @param request
+  /// @googleapis_link{google::bigtable::admin::v2::DropRowRangeRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L486}
+  ///
+  /// [google.bigtable.admin.v2.DropRowRangeRequest]:
   /// @googleapis_link{google::bigtable::admin::v2::DropRowRangeRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L486}
   ///
   Status DropRowRange(
@@ -437,6 +539,11 @@ class BigtableTableAdminClient {
   /// @return
   /// @googleapis_link{google::bigtable::admin::v2::GenerateConsistencyTokenResponse,google/bigtable/admin/v2/bigtable_table_admin.proto#L640}
   ///
+  /// [google.bigtable.admin.v2.GenerateConsistencyTokenRequest]:
+  /// @googleapis_link{google::bigtable::admin::v2::GenerateConsistencyTokenRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L626}
+  /// [google.bigtable.admin.v2.GenerateConsistencyTokenResponse]:
+  /// @googleapis_link{google::bigtable::admin::v2::GenerateConsistencyTokenResponse,google/bigtable/admin/v2/bigtable_table_admin.proto#L640}
+  ///
   StatusOr<google::bigtable::admin::v2::GenerateConsistencyTokenResponse>
   GenerateConsistencyToken(
       google::bigtable::admin::v2::GenerateConsistencyTokenRequest const&
@@ -450,6 +557,11 @@ class BigtableTableAdminClient {
   /// @param request
   /// @googleapis_link{google::bigtable::admin::v2::CheckConsistencyRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L647}
   /// @return
+  /// @googleapis_link{google::bigtable::admin::v2::CheckConsistencyResponse,google/bigtable/admin/v2/bigtable_table_admin.proto#L664}
+  ///
+  /// [google.bigtable.admin.v2.CheckConsistencyRequest]:
+  /// @googleapis_link{google::bigtable::admin::v2::CheckConsistencyRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L647}
+  /// [google.bigtable.admin.v2.CheckConsistencyResponse]:
   /// @googleapis_link{google::bigtable::admin::v2::CheckConsistencyResponse,google/bigtable/admin/v2/bigtable_table_admin.proto#L664}
   ///
   StatusOr<google::bigtable::admin::v2::CheckConsistencyResponse>
@@ -471,6 +583,11 @@ class BigtableTableAdminClient {
   /// @return
   /// @googleapis_link{google::bigtable::admin::v2::Backup,google/bigtable/admin/v2/table.proto#L317}
   ///
+  /// [google.bigtable.admin.v2.CreateBackupRequest]:
+  /// @googleapis_link{google::bigtable::admin::v2::CreateBackupRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L833}
+  /// [google.bigtable.admin.v2.Backup]:
+  /// @googleapis_link{google::bigtable::admin::v2::Backup,google/bigtable/admin/v2/table.proto#L317}
+  ///
   future<StatusOr<google::bigtable::admin::v2::Backup>> CreateBackup(
       google::bigtable::admin::v2::CreateBackupRequest const& request);
 
@@ -480,6 +597,11 @@ class BigtableTableAdminClient {
   /// @param request
   /// @googleapis_link{google::bigtable::admin::v2::GetBackupRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L889}
   /// @return
+  /// @googleapis_link{google::bigtable::admin::v2::Backup,google/bigtable/admin/v2/table.proto#L317}
+  ///
+  /// [google.bigtable.admin.v2.GetBackupRequest]:
+  /// @googleapis_link{google::bigtable::admin::v2::GetBackupRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L889}
+  /// [google.bigtable.admin.v2.Backup]:
   /// @googleapis_link{google::bigtable::admin::v2::Backup,google/bigtable/admin/v2/table.proto#L317}
   ///
   StatusOr<google::bigtable::admin::v2::Backup> GetBackup(
@@ -493,6 +615,11 @@ class BigtableTableAdminClient {
   /// @return
   /// @googleapis_link{google::bigtable::admin::v2::Backup,google/bigtable/admin/v2/table.proto#L317}
   ///
+  /// [google.bigtable.admin.v2.UpdateBackupRequest]:
+  /// @googleapis_link{google::bigtable::admin::v2::UpdateBackupRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L873}
+  /// [google.bigtable.admin.v2.Backup]:
+  /// @googleapis_link{google::bigtable::admin::v2::Backup,google/bigtable/admin/v2/table.proto#L317}
+  ///
   StatusOr<google::bigtable::admin::v2::Backup> UpdateBackup(
       google::bigtable::admin::v2::UpdateBackupRequest const& request);
 
@@ -500,6 +627,9 @@ class BigtableTableAdminClient {
   /// Deletes a pending or completed Cloud Bigtable backup.
   ///
   /// @param request
+  /// @googleapis_link{google::bigtable::admin::v2::DeleteBackupRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L902}
+  ///
+  /// [google.bigtable.admin.v2.DeleteBackupRequest]:
   /// @googleapis_link{google::bigtable::admin::v2::DeleteBackupRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L902}
   ///
   Status DeleteBackup(
@@ -512,6 +642,11 @@ class BigtableTableAdminClient {
   /// @param request
   /// @googleapis_link{google::bigtable::admin::v2::ListBackupsRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L915}
   /// @return
+  /// @googleapis_link{google::bigtable::admin::v2::Backup,google/bigtable/admin/v2/table.proto#L317}
+  ///
+  /// [google.bigtable.admin.v2.ListBackupsRequest]:
+  /// @googleapis_link{google::bigtable::admin::v2::ListBackupsRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L915}
+  /// [google::bigtable::admin::v2::Backup]:
   /// @googleapis_link{google::bigtable::admin::v2::Backup,google/bigtable/admin/v2/table.proto#L317}
   ///
   StreamRange<google::bigtable::admin::v2::Backup> ListBackups(
@@ -532,6 +667,11 @@ class BigtableTableAdminClient {
   /// @return
   /// @googleapis_link{google::bigtable::admin::v2::Table,google/bigtable/admin/v2/table.proto#L61}
   ///
+  /// [google.bigtable.admin.v2.RestoreTableRequest]:
+  /// @googleapis_link{google::bigtable::admin::v2::RestoreTableRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L336}
+  /// [google.bigtable.admin.v2.Table]:
+  /// @googleapis_link{google::bigtable::admin::v2::Table,google/bigtable/admin/v2/table.proto#L61}
+  ///
   future<StatusOr<google::bigtable::admin::v2::Table>> RestoreTable(
       google::bigtable::admin::v2::RestoreTableRequest const& request);
 
@@ -543,6 +683,11 @@ class BigtableTableAdminClient {
   /// @param request
   /// @googleapis_link{google::iam::v1::GetIamPolicyRequest,google/iam/v1/iam_policy.proto#L113}
   /// @return
+  /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
+  ///
+  /// [google.iam.v1.GetIamPolicyRequest]:
+  /// @googleapis_link{google::iam::v1::GetIamPolicyRequest,google/iam/v1/iam_policy.proto#L113}
+  /// [google.iam.v1.Policy]:
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> GetIamPolicy(
@@ -557,6 +702,11 @@ class BigtableTableAdminClient {
   /// @return
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
+  /// [google.iam.v1.SetIamPolicyRequest]:
+  /// @googleapis_link{google::iam::v1::SetIamPolicyRequest,google/iam/v1/iam_policy.proto#L98}
+  /// [google.iam.v1.Policy]:
+  /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
+  ///
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
       google::iam::v1::SetIamPolicyRequest const& request);
 
@@ -567,6 +717,11 @@ class BigtableTableAdminClient {
   /// @param request
   /// @googleapis_link{google::iam::v1::TestIamPermissionsRequest,google/iam/v1/iam_policy.proto#L126}
   /// @return
+  /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
+  ///
+  /// [google.iam.v1.TestIamPermissionsRequest]:
+  /// @googleapis_link{google::iam::v1::TestIamPermissionsRequest,google/iam/v1/iam_policy.proto#L126}
+  /// [google.iam.v1.TestIamPermissionsResponse]:
   /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
   ///
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
@@ -580,6 +735,11 @@ class BigtableTableAdminClient {
   /// @param request
   /// @googleapis_link{google::bigtable::admin::v2::CheckConsistencyRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L647}
   /// @return
+  /// @googleapis_link{google::bigtable::admin::v2::CheckConsistencyResponse,google/bigtable/admin/v2/bigtable_table_admin.proto#L664}
+  ///
+  /// [google.bigtable.admin.v2.CheckConsistencyRequest]:
+  /// @googleapis_link{google::bigtable::admin::v2::CheckConsistencyRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L647}
+  /// [google.bigtable.admin.v2.CheckConsistencyResponse]:
   /// @googleapis_link{google::bigtable::admin::v2::CheckConsistencyResponse,google/bigtable/admin/v2/bigtable_table_admin.proto#L664}
   ///
   future<StatusOr<google::bigtable::admin::v2::CheckConsistencyResponse>>

--- a/google/cloud/iam/iam_client.h
+++ b/google/cloud/iam/iam_client.h
@@ -89,7 +89,7 @@ class IAMClient {
   ///
   /// [google.iam.admin.v1.ListServiceAccountsRequest]:
   /// @googleapis_link{google::iam::admin::v1::ListServiceAccountsRequest,google/iam/admin/v1/iam.proto#L544}
-  /// [google::iam::admin::v1::ServiceAccount]:
+  /// [google.iam.admin.v1.ServiceAccount]:
   /// @googleapis_link{google::iam::admin::v1::ServiceAccount,google/iam/admin/v1/iam.proto#L461}
   ///
   StreamRange<google::iam::admin::v1::ServiceAccount> ListServiceAccounts(
@@ -401,7 +401,7 @@ class IAMClient {
   ///
   /// [google.iam.admin.v1.QueryGrantableRolesRequest]:
   /// @googleapis_link{google::iam::admin::v1::QueryGrantableRolesRequest,google/iam/admin/v1/iam.proto#L1062}
-  /// [google::iam::admin::v1::Role]:
+  /// [google.iam.admin.v1.Role]:
   /// @googleapis_link{google::iam::admin::v1::Role,google/iam/admin/v1/iam.proto#L1004}
   ///
   StreamRange<google::iam::admin::v1::Role> QueryGrantableRoles(
@@ -418,7 +418,7 @@ class IAMClient {
   ///
   /// [google.iam.admin.v1.ListServiceAccountsRequest]:
   /// @googleapis_link{google::iam::admin::v1::ListServiceAccountsRequest,google/iam/admin/v1/iam.proto#L544}
-  /// [google::iam::admin::v1::ServiceAccount]:
+  /// [google.iam.admin.v1.ServiceAccount]:
   /// @googleapis_link{google::iam::admin::v1::ServiceAccount,google/iam/admin/v1/iam.proto#L461}
   ///
   StreamRange<google::iam::admin::v1::ServiceAccount> ListServiceAccounts(
@@ -745,7 +745,7 @@ class IAMClient {
   ///
   /// [google.iam.admin.v1.QueryGrantableRolesRequest]:
   /// @googleapis_link{google::iam::admin::v1::QueryGrantableRolesRequest,google/iam/admin/v1/iam.proto#L1062}
-  /// [google::iam::admin::v1::Role]:
+  /// [google.iam.admin.v1.Role]:
   /// @googleapis_link{google::iam::admin::v1::Role,google/iam/admin/v1/iam.proto#L1004}
   ///
   StreamRange<google::iam::admin::v1::Role> QueryGrantableRoles(
@@ -762,7 +762,7 @@ class IAMClient {
   ///
   /// [google.iam.admin.v1.ListRolesRequest]:
   /// @googleapis_link{google::iam::admin::v1::ListRolesRequest,google/iam/admin/v1/iam.proto#L1093}
-  /// [google::iam::admin::v1::Role]:
+  /// [google.iam.admin.v1.Role]:
   /// @googleapis_link{google::iam::admin::v1::Role,google/iam/admin/v1/iam.proto#L1004}
   ///
   StreamRange<google::iam::admin::v1::Role> ListRoles(
@@ -877,7 +877,7 @@ class IAMClient {
   ///
   /// [google.iam.admin.v1.QueryTestablePermissionsRequest]:
   /// @googleapis_link{google::iam::admin::v1::QueryTestablePermissionsRequest,google/iam/admin/v1/iam.proto#L1361}
-  /// [google::iam::admin::v1::Permission]:
+  /// [google.iam.admin.v1.Permission]:
   /// @googleapis_link{google::iam::admin::v1::Permission,google/iam/admin/v1/iam.proto#L1306}
   ///
   StreamRange<google::iam::admin::v1::Permission> QueryTestablePermissions(

--- a/google/cloud/iam/iam_client.h
+++ b/google/cloud/iam/iam_client.h
@@ -88,9 +88,9 @@ class IAMClient {
   /// @googleapis_link{google::iam::admin::v1::ServiceAccount,google/iam/admin/v1/iam.proto#L461}
   ///
   /// [google.iam.admin.v1.ListServiceAccountsRequest]:
-  /// @googleapis_link{google::iam::admin::v1::ListServiceAccountsRequest,google/iam/admin/v1/iam.proto#L544}
+  /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L544}
   /// [google.iam.admin.v1.ServiceAccount]:
-  /// @googleapis_link{google::iam::admin::v1::ServiceAccount,google/iam/admin/v1/iam.proto#L461}
+  /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L461}
   ///
   StreamRange<google::iam::admin::v1::ServiceAccount> ListServiceAccounts(
       std::string const& name);
@@ -108,9 +108,9 @@ class IAMClient {
   /// @googleapis_link{google::iam::admin::v1::ServiceAccount,google/iam/admin/v1/iam.proto#L461}
   ///
   /// [google.iam.admin.v1.GetServiceAccountRequest]:
-  /// @googleapis_link{google::iam::admin::v1::GetServiceAccountRequest,google/iam/admin/v1/iam.proto#L579}
+  /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L579}
   /// [google.iam.admin.v1.ServiceAccount]:
-  /// @googleapis_link{google::iam::admin::v1::ServiceAccount,google/iam/admin/v1/iam.proto#L461}
+  /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L461}
   ///
   StatusOr<google::iam::admin::v1::ServiceAccount> GetServiceAccount(
       std::string const& name);
@@ -134,9 +134,9 @@ class IAMClient {
   /// @googleapis_link{google::iam::admin::v1::ServiceAccount,google/iam/admin/v1/iam.proto#L461}
   ///
   /// [google.iam.admin.v1.CreateServiceAccountRequest]:
-  /// @googleapis_link{google::iam::admin::v1::CreateServiceAccountRequest,google/iam/admin/v1/iam.proto#L521}
+  /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L521}
   /// [google.iam.admin.v1.ServiceAccount]:
-  /// @googleapis_link{google::iam::admin::v1::ServiceAccount,google/iam/admin/v1/iam.proto#L461}
+  /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L461}
   ///
   StatusOr<google::iam::admin::v1::ServiceAccount> CreateServiceAccount(
       std::string const& name, std::string const& account_id,
@@ -170,7 +170,7 @@ class IAMClient {
   ///  `unique_id` of the service account.
   ///
   /// [google.iam.admin.v1.DeleteServiceAccountRequest]:
-  /// @googleapis_link{google::iam::admin::v1::DeleteServiceAccountRequest,google/iam/admin/v1/iam.proto#L594}
+  /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L594}
   ///
   Status DeleteServiceAccount(std::string const& name);
 
@@ -192,9 +192,9 @@ class IAMClient {
   /// @googleapis_link{google::iam::admin::v1::ListServiceAccountKeysResponse,google/iam/admin/v1/iam.proto#L692}
   ///
   /// [google.iam.admin.v1.ListServiceAccountKeysRequest]:
-  /// @googleapis_link{google::iam::admin::v1::ListServiceAccountKeysRequest,google/iam/admin/v1/iam.proto#L657}
+  /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L657}
   /// [google.iam.admin.v1.ListServiceAccountKeysResponse]:
-  /// @googleapis_link{google::iam::admin::v1::ListServiceAccountKeysResponse,google/iam/admin/v1/iam.proto#L692}
+  /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L692}
   ///
   StatusOr<google::iam::admin::v1::ListServiceAccountKeysResponse>
   ListServiceAccountKeys(
@@ -218,9 +218,9 @@ class IAMClient {
   /// @googleapis_link{google::iam::admin::v1::ServiceAccountKey,google/iam/admin/v1/iam.proto#L741}
   ///
   /// [google.iam.admin.v1.GetServiceAccountKeyRequest]:
-  /// @googleapis_link{google::iam::admin::v1::GetServiceAccountKeyRequest,google/iam/admin/v1/iam.proto#L698}
+  /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L698}
   /// [google.iam.admin.v1.ServiceAccountKey]:
-  /// @googleapis_link{google::iam::admin::v1::ServiceAccountKey,google/iam/admin/v1/iam.proto#L741}
+  /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L741}
   ///
   StatusOr<google::iam::admin::v1::ServiceAccountKey> GetServiceAccountKey(
       std::string const& name,
@@ -246,9 +246,9 @@ class IAMClient {
   /// @googleapis_link{google::iam::admin::v1::ServiceAccountKey,google/iam/admin/v1/iam.proto#L741}
   ///
   /// [google.iam.admin.v1.CreateServiceAccountKeyRequest]:
-  /// @googleapis_link{google::iam::admin::v1::CreateServiceAccountKeyRequest,google/iam/admin/v1/iam.proto#L791}
+  /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L791}
   /// [google.iam.admin.v1.ServiceAccountKey]:
-  /// @googleapis_link{google::iam::admin::v1::ServiceAccountKey,google/iam/admin/v1/iam.proto#L741}
+  /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L741}
   ///
   StatusOr<google::iam::admin::v1::ServiceAccountKey> CreateServiceAccountKey(
       std::string const& name,
@@ -268,7 +268,7 @@ class IAMClient {
   ///  `unique_id` of the service account.
   ///
   /// [google.iam.admin.v1.DeleteServiceAccountKeyRequest]:
-  /// @googleapis_link{google::iam::admin::v1::DeleteServiceAccountKeyRequest,google/iam/admin/v1/iam.proto#L832}
+  /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L832}
   ///
   Status DeleteServiceAccountKey(std::string const& name);
 
@@ -292,9 +292,9 @@ class IAMClient {
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
   /// [google.iam.v1.GetIamPolicyRequest]:
-  /// @googleapis_link{google::iam::v1::GetIamPolicyRequest,google/iam/v1/iam_policy.proto#L113}
+  /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L113}
   /// [google.iam.v1.Policy]:
-  /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
+  /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> GetIamPolicy(std::string const& resource);
 
@@ -331,9 +331,9 @@ class IAMClient {
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
   /// [google.iam.v1.SetIamPolicyRequest]:
-  /// @googleapis_link{google::iam::v1::SetIamPolicyRequest,google/iam/v1/iam_policy.proto#L98}
+  /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L98}
   /// [google.iam.v1.Policy]:
-  /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
+  /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
       std::string const& resource, google::iam::v1::Policy const& policy);
@@ -379,9 +379,9 @@ class IAMClient {
   /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
   ///
   /// [google.iam.v1.TestIamPermissionsRequest]:
-  /// @googleapis_link{google::iam::v1::TestIamPermissionsRequest,google/iam/v1/iam_policy.proto#L126}
+  /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L126}
   /// [google.iam.v1.TestIamPermissionsResponse]:
-  /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
+  /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L141}
   ///
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
       std::string const& resource, std::vector<std::string> const& permissions);
@@ -400,9 +400,9 @@ class IAMClient {
   /// @googleapis_link{google::iam::admin::v1::Role,google/iam/admin/v1/iam.proto#L1004}
   ///
   /// [google.iam.admin.v1.QueryGrantableRolesRequest]:
-  /// @googleapis_link{google::iam::admin::v1::QueryGrantableRolesRequest,google/iam/admin/v1/iam.proto#L1062}
+  /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L1062}
   /// [google.iam.admin.v1.Role]:
-  /// @googleapis_link{google::iam::admin::v1::Role,google/iam/admin/v1/iam.proto#L1004}
+  /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L1004}
   ///
   StreamRange<google::iam::admin::v1::Role> QueryGrantableRoles(
       std::string const& full_resource_name);
@@ -417,9 +417,9 @@ class IAMClient {
   /// @googleapis_link{google::iam::admin::v1::ServiceAccount,google/iam/admin/v1/iam.proto#L461}
   ///
   /// [google.iam.admin.v1.ListServiceAccountsRequest]:
-  /// @googleapis_link{google::iam::admin::v1::ListServiceAccountsRequest,google/iam/admin/v1/iam.proto#L544}
+  /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L544}
   /// [google.iam.admin.v1.ServiceAccount]:
-  /// @googleapis_link{google::iam::admin::v1::ServiceAccount,google/iam/admin/v1/iam.proto#L461}
+  /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L461}
   ///
   StreamRange<google::iam::admin::v1::ServiceAccount> ListServiceAccounts(
       google::iam::admin::v1::ListServiceAccountsRequest request);
@@ -433,9 +433,9 @@ class IAMClient {
   /// @googleapis_link{google::iam::admin::v1::ServiceAccount,google/iam/admin/v1/iam.proto#L461}
   ///
   /// [google.iam.admin.v1.GetServiceAccountRequest]:
-  /// @googleapis_link{google::iam::admin::v1::GetServiceAccountRequest,google/iam/admin/v1/iam.proto#L579}
+  /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L579}
   /// [google.iam.admin.v1.ServiceAccount]:
-  /// @googleapis_link{google::iam::admin::v1::ServiceAccount,google/iam/admin/v1/iam.proto#L461}
+  /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L461}
   ///
   StatusOr<google::iam::admin::v1::ServiceAccount> GetServiceAccount(
       google::iam::admin::v1::GetServiceAccountRequest const& request);
@@ -449,9 +449,9 @@ class IAMClient {
   /// @googleapis_link{google::iam::admin::v1::ServiceAccount,google/iam/admin/v1/iam.proto#L461}
   ///
   /// [google.iam.admin.v1.CreateServiceAccountRequest]:
-  /// @googleapis_link{google::iam::admin::v1::CreateServiceAccountRequest,google/iam/admin/v1/iam.proto#L521}
+  /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L521}
   /// [google.iam.admin.v1.ServiceAccount]:
-  /// @googleapis_link{google::iam::admin::v1::ServiceAccount,google/iam/admin/v1/iam.proto#L461}
+  /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L461}
   ///
   StatusOr<google::iam::admin::v1::ServiceAccount> CreateServiceAccount(
       google::iam::admin::v1::CreateServiceAccountRequest const& request);
@@ -465,9 +465,9 @@ class IAMClient {
   /// @googleapis_link{google::iam::admin::v1::ServiceAccount,google/iam/admin/v1/iam.proto#L461}
   ///
   /// [google.iam.admin.v1.PatchServiceAccountRequest]:
-  /// @googleapis_link{google::iam::admin::v1::PatchServiceAccountRequest,google/iam/admin/v1/iam.proto#L616}
+  /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L616}
   /// [google.iam.admin.v1.ServiceAccount]:
-  /// @googleapis_link{google::iam::admin::v1::ServiceAccount,google/iam/admin/v1/iam.proto#L461}
+  /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L461}
   ///
   StatusOr<google::iam::admin::v1::ServiceAccount> PatchServiceAccount(
       google::iam::admin::v1::PatchServiceAccountRequest const& request);
@@ -496,7 +496,7 @@ class IAMClient {
   /// @googleapis_link{google::iam::admin::v1::DeleteServiceAccountRequest,google/iam/admin/v1/iam.proto#L594}
   ///
   /// [google.iam.admin.v1.DeleteServiceAccountRequest]:
-  /// @googleapis_link{google::iam::admin::v1::DeleteServiceAccountRequest,google/iam/admin/v1/iam.proto#L594}
+  /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L594}
   ///
   Status DeleteServiceAccount(
       google::iam::admin::v1::DeleteServiceAccountRequest const& request);
@@ -517,9 +517,9 @@ class IAMClient {
   /// @googleapis_link{google::iam::admin::v1::UndeleteServiceAccountResponse,google/iam/admin/v1/iam.proto#L631}
   ///
   /// [google.iam.admin.v1.UndeleteServiceAccountRequest]:
-  /// @googleapis_link{google::iam::admin::v1::UndeleteServiceAccountRequest,google/iam/admin/v1/iam.proto#L623}
+  /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L623}
   /// [google.iam.admin.v1.UndeleteServiceAccountResponse]:
-  /// @googleapis_link{google::iam::admin::v1::UndeleteServiceAccountResponse,google/iam/admin/v1/iam.proto#L631}
+  /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L631}
   ///
   StatusOr<google::iam::admin::v1::UndeleteServiceAccountResponse>
   UndeleteServiceAccount(
@@ -540,7 +540,7 @@ class IAMClient {
   /// @googleapis_link{google::iam::admin::v1::EnableServiceAccountRequest,google/iam/admin/v1/iam.proto#L637}
   ///
   /// [google.iam.admin.v1.EnableServiceAccountRequest]:
-  /// @googleapis_link{google::iam::admin::v1::EnableServiceAccountRequest,google/iam/admin/v1/iam.proto#L637}
+  /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L637}
   ///
   Status EnableServiceAccount(
       google::iam::admin::v1::EnableServiceAccountRequest const& request);
@@ -570,7 +570,7 @@ class IAMClient {
   /// @googleapis_link{google::iam::admin::v1::DisableServiceAccountRequest,google/iam/admin/v1/iam.proto#L647}
   ///
   /// [google.iam.admin.v1.DisableServiceAccountRequest]:
-  /// @googleapis_link{google::iam::admin::v1::DisableServiceAccountRequest,google/iam/admin/v1/iam.proto#L647}
+  /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L647}
   ///
   Status DisableServiceAccount(
       google::iam::admin::v1::DisableServiceAccountRequest const& request);
@@ -585,9 +585,9 @@ class IAMClient {
   /// @googleapis_link{google::iam::admin::v1::ListServiceAccountKeysResponse,google/iam/admin/v1/iam.proto#L692}
   ///
   /// [google.iam.admin.v1.ListServiceAccountKeysRequest]:
-  /// @googleapis_link{google::iam::admin::v1::ListServiceAccountKeysRequest,google/iam/admin/v1/iam.proto#L657}
+  /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L657}
   /// [google.iam.admin.v1.ListServiceAccountKeysResponse]:
-  /// @googleapis_link{google::iam::admin::v1::ListServiceAccountKeysResponse,google/iam/admin/v1/iam.proto#L692}
+  /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L692}
   ///
   StatusOr<google::iam::admin::v1::ListServiceAccountKeysResponse>
   ListServiceAccountKeys(
@@ -602,9 +602,9 @@ class IAMClient {
   /// @googleapis_link{google::iam::admin::v1::ServiceAccountKey,google/iam/admin/v1/iam.proto#L741}
   ///
   /// [google.iam.admin.v1.GetServiceAccountKeyRequest]:
-  /// @googleapis_link{google::iam::admin::v1::GetServiceAccountKeyRequest,google/iam/admin/v1/iam.proto#L698}
+  /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L698}
   /// [google.iam.admin.v1.ServiceAccountKey]:
-  /// @googleapis_link{google::iam::admin::v1::ServiceAccountKey,google/iam/admin/v1/iam.proto#L741}
+  /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L741}
   ///
   StatusOr<google::iam::admin::v1::ServiceAccountKey> GetServiceAccountKey(
       google::iam::admin::v1::GetServiceAccountKeyRequest const& request);
@@ -618,9 +618,9 @@ class IAMClient {
   /// @googleapis_link{google::iam::admin::v1::ServiceAccountKey,google/iam/admin/v1/iam.proto#L741}
   ///
   /// [google.iam.admin.v1.CreateServiceAccountKeyRequest]:
-  /// @googleapis_link{google::iam::admin::v1::CreateServiceAccountKeyRequest,google/iam/admin/v1/iam.proto#L791}
+  /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L791}
   /// [google.iam.admin.v1.ServiceAccountKey]:
-  /// @googleapis_link{google::iam::admin::v1::ServiceAccountKey,google/iam/admin/v1/iam.proto#L741}
+  /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L741}
   ///
   StatusOr<google::iam::admin::v1::ServiceAccountKey> CreateServiceAccountKey(
       google::iam::admin::v1::CreateServiceAccountKeyRequest const& request);
@@ -635,9 +635,9 @@ class IAMClient {
   /// @googleapis_link{google::iam::admin::v1::ServiceAccountKey,google/iam/admin/v1/iam.proto#L741}
   ///
   /// [google.iam.admin.v1.UploadServiceAccountKeyRequest]:
-  /// @googleapis_link{google::iam::admin::v1::UploadServiceAccountKeyRequest,google/iam/admin/v1/iam.proto#L816}
+  /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L816}
   /// [google.iam.admin.v1.ServiceAccountKey]:
-  /// @googleapis_link{google::iam::admin::v1::ServiceAccountKey,google/iam/admin/v1/iam.proto#L741}
+  /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L741}
   ///
   StatusOr<google::iam::admin::v1::ServiceAccountKey> UploadServiceAccountKey(
       google::iam::admin::v1::UploadServiceAccountKeyRequest const& request);
@@ -651,7 +651,7 @@ class IAMClient {
   /// @googleapis_link{google::iam::admin::v1::DeleteServiceAccountKeyRequest,google/iam/admin/v1/iam.proto#L832}
   ///
   /// [google.iam.admin.v1.DeleteServiceAccountKeyRequest]:
-  /// @googleapis_link{google::iam::admin::v1::DeleteServiceAccountKeyRequest,google/iam/admin/v1/iam.proto#L832}
+  /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L832}
   ///
   Status DeleteServiceAccountKey(
       google::iam::admin::v1::DeleteServiceAccountKeyRequest const& request);
@@ -675,9 +675,9 @@ class IAMClient {
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
   /// [google.iam.v1.GetIamPolicyRequest]:
-  /// @googleapis_link{google::iam::v1::GetIamPolicyRequest,google/iam/v1/iam_policy.proto#L113}
+  /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L113}
   /// [google.iam.v1.Policy]:
-  /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
+  /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> GetIamPolicy(
       google::iam::v1::GetIamPolicyRequest const& request);
@@ -709,9 +709,9 @@ class IAMClient {
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
   /// [google.iam.v1.SetIamPolicyRequest]:
-  /// @googleapis_link{google::iam::v1::SetIamPolicyRequest,google/iam/v1/iam_policy.proto#L98}
+  /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L98}
   /// [google.iam.v1.Policy]:
-  /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
+  /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
       google::iam::v1::SetIamPolicyRequest const& request);
@@ -726,9 +726,9 @@ class IAMClient {
   /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
   ///
   /// [google.iam.v1.TestIamPermissionsRequest]:
-  /// @googleapis_link{google::iam::v1::TestIamPermissionsRequest,google/iam/v1/iam_policy.proto#L126}
+  /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L126}
   /// [google.iam.v1.TestIamPermissionsResponse]:
-  /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
+  /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L141}
   ///
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
       google::iam::v1::TestIamPermissionsRequest const& request);
@@ -744,9 +744,9 @@ class IAMClient {
   /// @googleapis_link{google::iam::admin::v1::Role,google/iam/admin/v1/iam.proto#L1004}
   ///
   /// [google.iam.admin.v1.QueryGrantableRolesRequest]:
-  /// @googleapis_link{google::iam::admin::v1::QueryGrantableRolesRequest,google/iam/admin/v1/iam.proto#L1062}
+  /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L1062}
   /// [google.iam.admin.v1.Role]:
-  /// @googleapis_link{google::iam::admin::v1::Role,google/iam/admin/v1/iam.proto#L1004}
+  /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L1004}
   ///
   StreamRange<google::iam::admin::v1::Role> QueryGrantableRoles(
       google::iam::admin::v1::QueryGrantableRolesRequest request);
@@ -761,9 +761,9 @@ class IAMClient {
   /// @googleapis_link{google::iam::admin::v1::Role,google/iam/admin/v1/iam.proto#L1004}
   ///
   /// [google.iam.admin.v1.ListRolesRequest]:
-  /// @googleapis_link{google::iam::admin::v1::ListRolesRequest,google/iam/admin/v1/iam.proto#L1093}
+  /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L1093}
   /// [google.iam.admin.v1.Role]:
-  /// @googleapis_link{google::iam::admin::v1::Role,google/iam/admin/v1/iam.proto#L1004}
+  /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L1004}
   ///
   StreamRange<google::iam::admin::v1::Role> ListRoles(
       google::iam::admin::v1::ListRolesRequest request);
@@ -777,9 +777,9 @@ class IAMClient {
   /// @googleapis_link{google::iam::admin::v1::Role,google/iam/admin/v1/iam.proto#L1004}
   ///
   /// [google.iam.admin.v1.GetRoleRequest]:
-  /// @googleapis_link{google::iam::admin::v1::GetRoleRequest,google/iam/admin/v1/iam.proto#L1152}
+  /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L1152}
   /// [google.iam.admin.v1.Role]:
-  /// @googleapis_link{google::iam::admin::v1::Role,google/iam/admin/v1/iam.proto#L1004}
+  /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L1004}
   ///
   StatusOr<google::iam::admin::v1::Role> GetRole(
       google::iam::admin::v1::GetRoleRequest const& request);
@@ -793,9 +793,9 @@ class IAMClient {
   /// @googleapis_link{google::iam::admin::v1::Role,google/iam/admin/v1/iam.proto#L1004}
   ///
   /// [google.iam.admin.v1.CreateRoleRequest]:
-  /// @googleapis_link{google::iam::admin::v1::CreateRoleRequest,google/iam/admin/v1/iam.proto#L1184}
+  /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L1184}
   /// [google.iam.admin.v1.Role]:
-  /// @googleapis_link{google::iam::admin::v1::Role,google/iam/admin/v1/iam.proto#L1004}
+  /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L1004}
   ///
   StatusOr<google::iam::admin::v1::Role> CreateRole(
       google::iam::admin::v1::CreateRoleRequest const& request);
@@ -809,9 +809,9 @@ class IAMClient {
   /// @googleapis_link{google::iam::admin::v1::Role,google/iam/admin/v1/iam.proto#L1004}
   ///
   /// [google.iam.admin.v1.UpdateRoleRequest]:
-  /// @googleapis_link{google::iam::admin::v1::UpdateRoleRequest,google/iam/admin/v1/iam.proto#L1219}
+  /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L1219}
   /// [google.iam.admin.v1.Role]:
-  /// @googleapis_link{google::iam::admin::v1::Role,google/iam/admin/v1/iam.proto#L1004}
+  /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L1004}
   ///
   StatusOr<google::iam::admin::v1::Role> UpdateRole(
       google::iam::admin::v1::UpdateRoleRequest const& request);
@@ -842,9 +842,9 @@ class IAMClient {
   /// @googleapis_link{google::iam::admin::v1::Role,google/iam/admin/v1/iam.proto#L1004}
   ///
   /// [google.iam.admin.v1.DeleteRoleRequest]:
-  /// @googleapis_link{google::iam::admin::v1::DeleteRoleRequest,google/iam/admin/v1/iam.proto#L1250}
+  /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L1250}
   /// [google.iam.admin.v1.Role]:
-  /// @googleapis_link{google::iam::admin::v1::Role,google/iam/admin/v1/iam.proto#L1004}
+  /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L1004}
   ///
   StatusOr<google::iam::admin::v1::Role> DeleteRole(
       google::iam::admin::v1::DeleteRoleRequest const& request);
@@ -858,9 +858,9 @@ class IAMClient {
   /// @googleapis_link{google::iam::admin::v1::Role,google/iam/admin/v1/iam.proto#L1004}
   ///
   /// [google.iam.admin.v1.UndeleteRoleRequest]:
-  /// @googleapis_link{google::iam::admin::v1::UndeleteRoleRequest,google/iam/admin/v1/iam.proto#L1278}
+  /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L1278}
   /// [google.iam.admin.v1.Role]:
-  /// @googleapis_link{google::iam::admin::v1::Role,google/iam/admin/v1/iam.proto#L1004}
+  /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L1004}
   ///
   StatusOr<google::iam::admin::v1::Role> UndeleteRole(
       google::iam::admin::v1::UndeleteRoleRequest const& request);
@@ -876,9 +876,9 @@ class IAMClient {
   /// @googleapis_link{google::iam::admin::v1::Permission,google/iam/admin/v1/iam.proto#L1306}
   ///
   /// [google.iam.admin.v1.QueryTestablePermissionsRequest]:
-  /// @googleapis_link{google::iam::admin::v1::QueryTestablePermissionsRequest,google/iam/admin/v1/iam.proto#L1361}
+  /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L1361}
   /// [google.iam.admin.v1.Permission]:
-  /// @googleapis_link{google::iam::admin::v1::Permission,google/iam/admin/v1/iam.proto#L1306}
+  /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L1306}
   ///
   StreamRange<google::iam::admin::v1::Permission> QueryTestablePermissions(
       google::iam::admin::v1::QueryTestablePermissionsRequest request);
@@ -896,9 +896,9 @@ class IAMClient {
   /// @googleapis_link{google::iam::admin::v1::QueryAuditableServicesResponse,google/iam/admin/v1/iam.proto#L1402}
   ///
   /// [google.iam.admin.v1.QueryAuditableServicesRequest]:
-  /// @googleapis_link{google::iam::admin::v1::QueryAuditableServicesRequest,google/iam/admin/v1/iam.proto#L1391}
+  /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L1391}
   /// [google.iam.admin.v1.QueryAuditableServicesResponse]:
-  /// @googleapis_link{google::iam::admin::v1::QueryAuditableServicesResponse,google/iam/admin/v1/iam.proto#L1402}
+  /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L1402}
   ///
   StatusOr<google::iam::admin::v1::QueryAuditableServicesResponse>
   QueryAuditableServices(
@@ -918,9 +918,9 @@ class IAMClient {
   /// @googleapis_link{google::iam::admin::v1::LintPolicyResponse,google/iam/admin/v1/iam.proto#L1513}
   ///
   /// [google.iam.admin.v1.LintPolicyRequest]:
-  /// @googleapis_link{google::iam::admin::v1::LintPolicyRequest,google/iam/admin/v1/iam.proto#L1415}
+  /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L1415}
   /// [google.iam.admin.v1.LintPolicyResponse]:
-  /// @googleapis_link{google::iam::admin::v1::LintPolicyResponse,google/iam/admin/v1/iam.proto#L1513}
+  /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L1513}
   ///
   StatusOr<google::iam::admin::v1::LintPolicyResponse> LintPolicy(
       google::iam::admin::v1::LintPolicyRequest const& request);

--- a/google/cloud/iam/iam_client.h
+++ b/google/cloud/iam/iam_client.h
@@ -87,6 +87,11 @@ class IAMClient {
   /// @return
   /// @googleapis_link{google::iam::admin::v1::ServiceAccount,google/iam/admin/v1/iam.proto#L461}
   ///
+  /// [google.iam.admin.v1.ListServiceAccountsRequest]:
+  /// @googleapis_link{google::iam::admin::v1::ListServiceAccountsRequest,google/iam/admin/v1/iam.proto#L544}
+  /// [google::iam::admin::v1::ServiceAccount]:
+  /// @googleapis_link{google::iam::admin::v1::ServiceAccount,google/iam/admin/v1/iam.proto#L461}
+  ///
   StreamRange<google::iam::admin::v1::ServiceAccount> ListServiceAccounts(
       std::string const& name);
 
@@ -100,6 +105,11 @@ class IAMClient {
   ///  the account. The `ACCOUNT` value can be the `email` address or the
   ///  `unique_id` of the service account.
   /// @return
+  /// @googleapis_link{google::iam::admin::v1::ServiceAccount,google/iam/admin/v1/iam.proto#L461}
+  ///
+  /// [google.iam.admin.v1.GetServiceAccountRequest]:
+  /// @googleapis_link{google::iam::admin::v1::GetServiceAccountRequest,google/iam/admin/v1/iam.proto#L579}
+  /// [google.iam.admin.v1.ServiceAccount]:
   /// @googleapis_link{google::iam::admin::v1::ServiceAccount,google/iam/admin/v1/iam.proto#L461}
   ///
   StatusOr<google::iam::admin::v1::ServiceAccount> GetServiceAccount(
@@ -121,6 +131,11 @@ class IAMClient {
   ///  create. Currently, only the following values are user assignable:
   ///  `display_name` and `description`.
   /// @return
+  /// @googleapis_link{google::iam::admin::v1::ServiceAccount,google/iam/admin/v1/iam.proto#L461}
+  ///
+  /// [google.iam.admin.v1.CreateServiceAccountRequest]:
+  /// @googleapis_link{google::iam::admin::v1::CreateServiceAccountRequest,google/iam/admin/v1/iam.proto#L521}
+  /// [google.iam.admin.v1.ServiceAccount]:
   /// @googleapis_link{google::iam::admin::v1::ServiceAccount,google/iam/admin/v1/iam.proto#L461}
   ///
   StatusOr<google::iam::admin::v1::ServiceAccount> CreateServiceAccount(
@@ -154,6 +169,9 @@ class IAMClient {
   ///  the account. The `ACCOUNT` value can be the `email` address or the
   ///  `unique_id` of the service account.
   ///
+  /// [google.iam.admin.v1.DeleteServiceAccountRequest]:
+  /// @googleapis_link{google::iam::admin::v1::DeleteServiceAccountRequest,google/iam/admin/v1/iam.proto#L594}
+  ///
   Status DeleteServiceAccount(std::string const& name);
 
   ///
@@ -171,6 +189,11 @@ class IAMClient {
   ///  response. Duplicate key types are not allowed. If no key type
   ///  is provided, all keys are returned.
   /// @return
+  /// @googleapis_link{google::iam::admin::v1::ListServiceAccountKeysResponse,google/iam/admin/v1/iam.proto#L692}
+  ///
+  /// [google.iam.admin.v1.ListServiceAccountKeysRequest]:
+  /// @googleapis_link{google::iam::admin::v1::ListServiceAccountKeysRequest,google/iam/admin/v1/iam.proto#L657}
+  /// [google.iam.admin.v1.ListServiceAccountKeysResponse]:
   /// @googleapis_link{google::iam::admin::v1::ListServiceAccountKeysResponse,google/iam/admin/v1/iam.proto#L692}
   ///
   StatusOr<google::iam::admin::v1::ListServiceAccountKeysResponse>
@@ -192,6 +215,11 @@ class IAMClient {
   /// @param public_key_type  The output format of the public key requested.
   ///  X509_PEM is the default output format.
   /// @return
+  /// @googleapis_link{google::iam::admin::v1::ServiceAccountKey,google/iam/admin/v1/iam.proto#L741}
+  ///
+  /// [google.iam.admin.v1.GetServiceAccountKeyRequest]:
+  /// @googleapis_link{google::iam::admin::v1::GetServiceAccountKeyRequest,google/iam/admin/v1/iam.proto#L698}
+  /// [google.iam.admin.v1.ServiceAccountKey]:
   /// @googleapis_link{google::iam::admin::v1::ServiceAccountKey,google/iam/admin/v1/iam.proto#L741}
   ///
   StatusOr<google::iam::admin::v1::ServiceAccountKey> GetServiceAccountKey(
@@ -217,6 +245,11 @@ class IAMClient {
   /// @return
   /// @googleapis_link{google::iam::admin::v1::ServiceAccountKey,google/iam/admin/v1/iam.proto#L741}
   ///
+  /// [google.iam.admin.v1.CreateServiceAccountKeyRequest]:
+  /// @googleapis_link{google::iam::admin::v1::CreateServiceAccountKeyRequest,google/iam/admin/v1/iam.proto#L791}
+  /// [google.iam.admin.v1.ServiceAccountKey]:
+  /// @googleapis_link{google::iam::admin::v1::ServiceAccountKey,google/iam/admin/v1/iam.proto#L741}
+  ///
   StatusOr<google::iam::admin::v1::ServiceAccountKey> CreateServiceAccountKey(
       std::string const& name,
       google::iam::admin::v1::ServiceAccountPrivateKeyType private_key_type,
@@ -233,6 +266,9 @@ class IAMClient {
   ///  Using `-` as a wildcard for the `PROJECT_ID` will infer the project from
   ///  the account. The `ACCOUNT` value can be the `email` address or the
   ///  `unique_id` of the service account.
+  ///
+  /// [google.iam.admin.v1.DeleteServiceAccountKeyRequest]:
+  /// @googleapis_link{google::iam::admin::v1::DeleteServiceAccountKeyRequest,google/iam/admin/v1/iam.proto#L832}
   ///
   Status DeleteServiceAccountKey(std::string const& name);
 
@@ -253,6 +289,11 @@ class IAMClient {
   /// requested.
   ///  See the operation documentation for the appropriate value for this field.
   /// @return
+  /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
+  ///
+  /// [google.iam.v1.GetIamPolicyRequest]:
+  /// @googleapis_link{google::iam::v1::GetIamPolicyRequest,google/iam/v1/iam_policy.proto#L113}
+  /// [google.iam.v1.Policy]:
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> GetIamPolicy(std::string const& resource);
@@ -287,6 +328,11 @@ class IAMClient {
   ///  valid policy but certain Cloud Platform services (such as Projects)
   ///  might reject them.
   /// @return
+  /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
+  ///
+  /// [google.iam.v1.SetIamPolicyRequest]:
+  /// @googleapis_link{google::iam::v1::SetIamPolicyRequest,google/iam/v1/iam_policy.proto#L98}
+  /// [google.iam.v1.Policy]:
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
@@ -332,6 +378,11 @@ class IAMClient {
   /// @return
   /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
   ///
+  /// [google.iam.v1.TestIamPermissionsRequest]:
+  /// @googleapis_link{google::iam::v1::TestIamPermissionsRequest,google/iam/v1/iam_policy.proto#L126}
+  /// [google.iam.v1.TestIamPermissionsResponse]:
+  /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
+  ///
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
       std::string const& resource, std::vector<std::string> const& permissions);
 
@@ -348,6 +399,11 @@ class IAMClient {
   /// @return
   /// @googleapis_link{google::iam::admin::v1::Role,google/iam/admin/v1/iam.proto#L1004}
   ///
+  /// [google.iam.admin.v1.QueryGrantableRolesRequest]:
+  /// @googleapis_link{google::iam::admin::v1::QueryGrantableRolesRequest,google/iam/admin/v1/iam.proto#L1062}
+  /// [google::iam::admin::v1::Role]:
+  /// @googleapis_link{google::iam::admin::v1::Role,google/iam/admin/v1/iam.proto#L1004}
+  ///
   StreamRange<google::iam::admin::v1::Role> QueryGrantableRoles(
       std::string const& full_resource_name);
 
@@ -358,6 +414,11 @@ class IAMClient {
   /// @param request
   /// @googleapis_link{google::iam::admin::v1::ListServiceAccountsRequest,google/iam/admin/v1/iam.proto#L544}
   /// @return
+  /// @googleapis_link{google::iam::admin::v1::ServiceAccount,google/iam/admin/v1/iam.proto#L461}
+  ///
+  /// [google.iam.admin.v1.ListServiceAccountsRequest]:
+  /// @googleapis_link{google::iam::admin::v1::ListServiceAccountsRequest,google/iam/admin/v1/iam.proto#L544}
+  /// [google::iam::admin::v1::ServiceAccount]:
   /// @googleapis_link{google::iam::admin::v1::ServiceAccount,google/iam/admin/v1/iam.proto#L461}
   ///
   StreamRange<google::iam::admin::v1::ServiceAccount> ListServiceAccounts(
@@ -371,6 +432,11 @@ class IAMClient {
   /// @return
   /// @googleapis_link{google::iam::admin::v1::ServiceAccount,google/iam/admin/v1/iam.proto#L461}
   ///
+  /// [google.iam.admin.v1.GetServiceAccountRequest]:
+  /// @googleapis_link{google::iam::admin::v1::GetServiceAccountRequest,google/iam/admin/v1/iam.proto#L579}
+  /// [google.iam.admin.v1.ServiceAccount]:
+  /// @googleapis_link{google::iam::admin::v1::ServiceAccount,google/iam/admin/v1/iam.proto#L461}
+  ///
   StatusOr<google::iam::admin::v1::ServiceAccount> GetServiceAccount(
       google::iam::admin::v1::GetServiceAccountRequest const& request);
 
@@ -382,6 +448,11 @@ class IAMClient {
   /// @return
   /// @googleapis_link{google::iam::admin::v1::ServiceAccount,google/iam/admin/v1/iam.proto#L461}
   ///
+  /// [google.iam.admin.v1.CreateServiceAccountRequest]:
+  /// @googleapis_link{google::iam::admin::v1::CreateServiceAccountRequest,google/iam/admin/v1/iam.proto#L521}
+  /// [google.iam.admin.v1.ServiceAccount]:
+  /// @googleapis_link{google::iam::admin::v1::ServiceAccount,google/iam/admin/v1/iam.proto#L461}
+  ///
   StatusOr<google::iam::admin::v1::ServiceAccount> CreateServiceAccount(
       google::iam::admin::v1::CreateServiceAccountRequest const& request);
 
@@ -391,6 +462,11 @@ class IAMClient {
   /// @param request
   /// @googleapis_link{google::iam::admin::v1::PatchServiceAccountRequest,google/iam/admin/v1/iam.proto#L616}
   /// @return
+  /// @googleapis_link{google::iam::admin::v1::ServiceAccount,google/iam/admin/v1/iam.proto#L461}
+  ///
+  /// [google.iam.admin.v1.PatchServiceAccountRequest]:
+  /// @googleapis_link{google::iam::admin::v1::PatchServiceAccountRequest,google/iam/admin/v1/iam.proto#L616}
+  /// [google.iam.admin.v1.ServiceAccount]:
   /// @googleapis_link{google::iam::admin::v1::ServiceAccount,google/iam/admin/v1/iam.proto#L461}
   ///
   StatusOr<google::iam::admin::v1::ServiceAccount> PatchServiceAccount(
@@ -419,6 +495,9 @@ class IAMClient {
   /// @param request
   /// @googleapis_link{google::iam::admin::v1::DeleteServiceAccountRequest,google/iam/admin/v1/iam.proto#L594}
   ///
+  /// [google.iam.admin.v1.DeleteServiceAccountRequest]:
+  /// @googleapis_link{google::iam::admin::v1::DeleteServiceAccountRequest,google/iam/admin/v1/iam.proto#L594}
+  ///
   Status DeleteServiceAccount(
       google::iam::admin::v1::DeleteServiceAccountRequest const& request);
 
@@ -437,6 +516,11 @@ class IAMClient {
   /// @return
   /// @googleapis_link{google::iam::admin::v1::UndeleteServiceAccountResponse,google/iam/admin/v1/iam.proto#L631}
   ///
+  /// [google.iam.admin.v1.UndeleteServiceAccountRequest]:
+  /// @googleapis_link{google::iam::admin::v1::UndeleteServiceAccountRequest,google/iam/admin/v1/iam.proto#L623}
+  /// [google.iam.admin.v1.UndeleteServiceAccountResponse]:
+  /// @googleapis_link{google::iam::admin::v1::UndeleteServiceAccountResponse,google/iam/admin/v1/iam.proto#L631}
+  ///
   StatusOr<google::iam::admin::v1::UndeleteServiceAccountResponse>
   UndeleteServiceAccount(
       google::iam::admin::v1::UndeleteServiceAccountRequest const& request);
@@ -453,6 +537,9 @@ class IAMClient {
   /// this method to enable the service account.
   ///
   /// @param request
+  /// @googleapis_link{google::iam::admin::v1::EnableServiceAccountRequest,google/iam/admin/v1/iam.proto#L637}
+  ///
+  /// [google.iam.admin.v1.EnableServiceAccountRequest]:
   /// @googleapis_link{google::iam::admin::v1::EnableServiceAccountRequest,google/iam/admin/v1/iam.proto#L637}
   ///
   Status EnableServiceAccount(
@@ -482,6 +569,9 @@ class IAMClient {
   /// @param request
   /// @googleapis_link{google::iam::admin::v1::DisableServiceAccountRequest,google/iam/admin/v1/iam.proto#L647}
   ///
+  /// [google.iam.admin.v1.DisableServiceAccountRequest]:
+  /// @googleapis_link{google::iam::admin::v1::DisableServiceAccountRequest,google/iam/admin/v1/iam.proto#L647}
+  ///
   Status DisableServiceAccount(
       google::iam::admin::v1::DisableServiceAccountRequest const& request);
 
@@ -492,6 +582,11 @@ class IAMClient {
   /// @param request
   /// @googleapis_link{google::iam::admin::v1::ListServiceAccountKeysRequest,google/iam/admin/v1/iam.proto#L657}
   /// @return
+  /// @googleapis_link{google::iam::admin::v1::ListServiceAccountKeysResponse,google/iam/admin/v1/iam.proto#L692}
+  ///
+  /// [google.iam.admin.v1.ListServiceAccountKeysRequest]:
+  /// @googleapis_link{google::iam::admin::v1::ListServiceAccountKeysRequest,google/iam/admin/v1/iam.proto#L657}
+  /// [google.iam.admin.v1.ListServiceAccountKeysResponse]:
   /// @googleapis_link{google::iam::admin::v1::ListServiceAccountKeysResponse,google/iam/admin/v1/iam.proto#L692}
   ///
   StatusOr<google::iam::admin::v1::ListServiceAccountKeysResponse>
@@ -506,6 +601,11 @@ class IAMClient {
   /// @return
   /// @googleapis_link{google::iam::admin::v1::ServiceAccountKey,google/iam/admin/v1/iam.proto#L741}
   ///
+  /// [google.iam.admin.v1.GetServiceAccountKeyRequest]:
+  /// @googleapis_link{google::iam::admin::v1::GetServiceAccountKeyRequest,google/iam/admin/v1/iam.proto#L698}
+  /// [google.iam.admin.v1.ServiceAccountKey]:
+  /// @googleapis_link{google::iam::admin::v1::ServiceAccountKey,google/iam/admin/v1/iam.proto#L741}
+  ///
   StatusOr<google::iam::admin::v1::ServiceAccountKey> GetServiceAccountKey(
       google::iam::admin::v1::GetServiceAccountKeyRequest const& request);
 
@@ -515,6 +615,11 @@ class IAMClient {
   /// @param request
   /// @googleapis_link{google::iam::admin::v1::CreateServiceAccountKeyRequest,google/iam/admin/v1/iam.proto#L791}
   /// @return
+  /// @googleapis_link{google::iam::admin::v1::ServiceAccountKey,google/iam/admin/v1/iam.proto#L741}
+  ///
+  /// [google.iam.admin.v1.CreateServiceAccountKeyRequest]:
+  /// @googleapis_link{google::iam::admin::v1::CreateServiceAccountKeyRequest,google/iam/admin/v1/iam.proto#L791}
+  /// [google.iam.admin.v1.ServiceAccountKey]:
   /// @googleapis_link{google::iam::admin::v1::ServiceAccountKey,google/iam/admin/v1/iam.proto#L741}
   ///
   StatusOr<google::iam::admin::v1::ServiceAccountKey> CreateServiceAccountKey(
@@ -529,6 +634,11 @@ class IAMClient {
   /// @return
   /// @googleapis_link{google::iam::admin::v1::ServiceAccountKey,google/iam/admin/v1/iam.proto#L741}
   ///
+  /// [google.iam.admin.v1.UploadServiceAccountKeyRequest]:
+  /// @googleapis_link{google::iam::admin::v1::UploadServiceAccountKeyRequest,google/iam/admin/v1/iam.proto#L816}
+  /// [google.iam.admin.v1.ServiceAccountKey]:
+  /// @googleapis_link{google::iam::admin::v1::ServiceAccountKey,google/iam/admin/v1/iam.proto#L741}
+  ///
   StatusOr<google::iam::admin::v1::ServiceAccountKey> UploadServiceAccountKey(
       google::iam::admin::v1::UploadServiceAccountKeyRequest const& request);
 
@@ -538,6 +648,9 @@ class IAMClient {
   /// that have been issued based on the service account key.
   ///
   /// @param request
+  /// @googleapis_link{google::iam::admin::v1::DeleteServiceAccountKeyRequest,google/iam/admin/v1/iam.proto#L832}
+  ///
+  /// [google.iam.admin.v1.DeleteServiceAccountKeyRequest]:
   /// @googleapis_link{google::iam::admin::v1::DeleteServiceAccountKeyRequest,google/iam/admin/v1/iam.proto#L832}
   ///
   Status DeleteServiceAccountKey(
@@ -559,6 +672,11 @@ class IAMClient {
   /// @param request
   /// @googleapis_link{google::iam::v1::GetIamPolicyRequest,google/iam/v1/iam_policy.proto#L113}
   /// @return
+  /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
+  ///
+  /// [google.iam.v1.GetIamPolicyRequest]:
+  /// @googleapis_link{google::iam::v1::GetIamPolicyRequest,google/iam/v1/iam_policy.proto#L113}
+  /// [google.iam.v1.Policy]:
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> GetIamPolicy(
@@ -590,6 +708,11 @@ class IAMClient {
   /// @return
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
+  /// [google.iam.v1.SetIamPolicyRequest]:
+  /// @googleapis_link{google::iam::v1::SetIamPolicyRequest,google/iam/v1/iam_policy.proto#L98}
+  /// [google.iam.v1.Policy]:
+  /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
+  ///
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
       google::iam::v1::SetIamPolicyRequest const& request);
 
@@ -600,6 +723,11 @@ class IAMClient {
   /// @param request
   /// @googleapis_link{google::iam::v1::TestIamPermissionsRequest,google/iam/v1/iam_policy.proto#L126}
   /// @return
+  /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
+  ///
+  /// [google.iam.v1.TestIamPermissionsRequest]:
+  /// @googleapis_link{google::iam::v1::TestIamPermissionsRequest,google/iam/v1/iam_policy.proto#L126}
+  /// [google.iam.v1.TestIamPermissionsResponse]:
   /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
   ///
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
@@ -615,6 +743,11 @@ class IAMClient {
   /// @return
   /// @googleapis_link{google::iam::admin::v1::Role,google/iam/admin/v1/iam.proto#L1004}
   ///
+  /// [google.iam.admin.v1.QueryGrantableRolesRequest]:
+  /// @googleapis_link{google::iam::admin::v1::QueryGrantableRolesRequest,google/iam/admin/v1/iam.proto#L1062}
+  /// [google::iam::admin::v1::Role]:
+  /// @googleapis_link{google::iam::admin::v1::Role,google/iam/admin/v1/iam.proto#L1004}
+  ///
   StreamRange<google::iam::admin::v1::Role> QueryGrantableRoles(
       google::iam::admin::v1::QueryGrantableRolesRequest request);
 
@@ -625,6 +758,11 @@ class IAMClient {
   /// @param request
   /// @googleapis_link{google::iam::admin::v1::ListRolesRequest,google/iam/admin/v1/iam.proto#L1093}
   /// @return
+  /// @googleapis_link{google::iam::admin::v1::Role,google/iam/admin/v1/iam.proto#L1004}
+  ///
+  /// [google.iam.admin.v1.ListRolesRequest]:
+  /// @googleapis_link{google::iam::admin::v1::ListRolesRequest,google/iam/admin/v1/iam.proto#L1093}
+  /// [google::iam::admin::v1::Role]:
   /// @googleapis_link{google::iam::admin::v1::Role,google/iam/admin/v1/iam.proto#L1004}
   ///
   StreamRange<google::iam::admin::v1::Role> ListRoles(
@@ -638,6 +776,11 @@ class IAMClient {
   /// @return
   /// @googleapis_link{google::iam::admin::v1::Role,google/iam/admin/v1/iam.proto#L1004}
   ///
+  /// [google.iam.admin.v1.GetRoleRequest]:
+  /// @googleapis_link{google::iam::admin::v1::GetRoleRequest,google/iam/admin/v1/iam.proto#L1152}
+  /// [google.iam.admin.v1.Role]:
+  /// @googleapis_link{google::iam::admin::v1::Role,google/iam/admin/v1/iam.proto#L1004}
+  ///
   StatusOr<google::iam::admin::v1::Role> GetRole(
       google::iam::admin::v1::GetRoleRequest const& request);
 
@@ -649,6 +792,11 @@ class IAMClient {
   /// @return
   /// @googleapis_link{google::iam::admin::v1::Role,google/iam/admin/v1/iam.proto#L1004}
   ///
+  /// [google.iam.admin.v1.CreateRoleRequest]:
+  /// @googleapis_link{google::iam::admin::v1::CreateRoleRequest,google/iam/admin/v1/iam.proto#L1184}
+  /// [google.iam.admin.v1.Role]:
+  /// @googleapis_link{google::iam::admin::v1::Role,google/iam/admin/v1/iam.proto#L1004}
+  ///
   StatusOr<google::iam::admin::v1::Role> CreateRole(
       google::iam::admin::v1::CreateRoleRequest const& request);
 
@@ -658,6 +806,11 @@ class IAMClient {
   /// @param request
   /// @googleapis_link{google::iam::admin::v1::UpdateRoleRequest,google/iam/admin/v1/iam.proto#L1219}
   /// @return
+  /// @googleapis_link{google::iam::admin::v1::Role,google/iam/admin/v1/iam.proto#L1004}
+  ///
+  /// [google.iam.admin.v1.UpdateRoleRequest]:
+  /// @googleapis_link{google::iam::admin::v1::UpdateRoleRequest,google/iam/admin/v1/iam.proto#L1219}
+  /// [google.iam.admin.v1.Role]:
   /// @googleapis_link{google::iam::admin::v1::Role,google/iam/admin/v1/iam.proto#L1004}
   ///
   StatusOr<google::iam::admin::v1::Role> UpdateRole(
@@ -688,6 +841,11 @@ class IAMClient {
   /// @return
   /// @googleapis_link{google::iam::admin::v1::Role,google/iam/admin/v1/iam.proto#L1004}
   ///
+  /// [google.iam.admin.v1.DeleteRoleRequest]:
+  /// @googleapis_link{google::iam::admin::v1::DeleteRoleRequest,google/iam/admin/v1/iam.proto#L1250}
+  /// [google.iam.admin.v1.Role]:
+  /// @googleapis_link{google::iam::admin::v1::Role,google/iam/admin/v1/iam.proto#L1004}
+  ///
   StatusOr<google::iam::admin::v1::Role> DeleteRole(
       google::iam::admin::v1::DeleteRoleRequest const& request);
 
@@ -697,6 +855,11 @@ class IAMClient {
   /// @param request
   /// @googleapis_link{google::iam::admin::v1::UndeleteRoleRequest,google/iam/admin/v1/iam.proto#L1278}
   /// @return
+  /// @googleapis_link{google::iam::admin::v1::Role,google/iam/admin/v1/iam.proto#L1004}
+  ///
+  /// [google.iam.admin.v1.UndeleteRoleRequest]:
+  /// @googleapis_link{google::iam::admin::v1::UndeleteRoleRequest,google/iam/admin/v1/iam.proto#L1278}
+  /// [google.iam.admin.v1.Role]:
   /// @googleapis_link{google::iam::admin::v1::Role,google/iam/admin/v1/iam.proto#L1004}
   ///
   StatusOr<google::iam::admin::v1::Role> UndeleteRole(
@@ -710,6 +873,11 @@ class IAMClient {
   /// @param request
   /// @googleapis_link{google::iam::admin::v1::QueryTestablePermissionsRequest,google/iam/admin/v1/iam.proto#L1361}
   /// @return
+  /// @googleapis_link{google::iam::admin::v1::Permission,google/iam/admin/v1/iam.proto#L1306}
+  ///
+  /// [google.iam.admin.v1.QueryTestablePermissionsRequest]:
+  /// @googleapis_link{google::iam::admin::v1::QueryTestablePermissionsRequest,google/iam/admin/v1/iam.proto#L1361}
+  /// [google::iam::admin::v1::Permission]:
   /// @googleapis_link{google::iam::admin::v1::Permission,google/iam/admin/v1/iam.proto#L1306}
   ///
   StreamRange<google::iam::admin::v1::Permission> QueryTestablePermissions(
@@ -727,6 +895,11 @@ class IAMClient {
   /// @return
   /// @googleapis_link{google::iam::admin::v1::QueryAuditableServicesResponse,google/iam/admin/v1/iam.proto#L1402}
   ///
+  /// [google.iam.admin.v1.QueryAuditableServicesRequest]:
+  /// @googleapis_link{google::iam::admin::v1::QueryAuditableServicesRequest,google/iam/admin/v1/iam.proto#L1391}
+  /// [google.iam.admin.v1.QueryAuditableServicesResponse]:
+  /// @googleapis_link{google::iam::admin::v1::QueryAuditableServicesResponse,google/iam/admin/v1/iam.proto#L1402}
+  ///
   StatusOr<google::iam::admin::v1::QueryAuditableServicesResponse>
   QueryAuditableServices(
       google::iam::admin::v1::QueryAuditableServicesRequest const& request);
@@ -742,6 +915,11 @@ class IAMClient {
   /// @param request
   /// @googleapis_link{google::iam::admin::v1::LintPolicyRequest,google/iam/admin/v1/iam.proto#L1415}
   /// @return
+  /// @googleapis_link{google::iam::admin::v1::LintPolicyResponse,google/iam/admin/v1/iam.proto#L1513}
+  ///
+  /// [google.iam.admin.v1.LintPolicyRequest]:
+  /// @googleapis_link{google::iam::admin::v1::LintPolicyRequest,google/iam/admin/v1/iam.proto#L1415}
+  /// [google.iam.admin.v1.LintPolicyResponse]:
   /// @googleapis_link{google::iam::admin::v1::LintPolicyResponse,google/iam/admin/v1/iam.proto#L1513}
   ///
   StatusOr<google::iam::admin::v1::LintPolicyResponse> LintPolicy(

--- a/google/cloud/iam/iam_credentials_client.h
+++ b/google/cloud/iam/iam_credentials_client.h
@@ -101,6 +101,11 @@ class IAMCredentialsClient {
   /// @return
   /// @googleapis_link{google::iam::credentials::v1::GenerateAccessTokenResponse,google/iam/credentials/v1/common.proto#L72}
   ///
+  /// [google.iam.credentials.v1.GenerateAccessTokenRequest]:
+  /// @googleapis_link{google::iam::credentials::v1::GenerateAccessTokenRequest,google/iam/credentials/v1/common.proto#L35}
+  /// [google.iam.credentials.v1.GenerateAccessTokenResponse]:
+  /// @googleapis_link{google::iam::credentials::v1::GenerateAccessTokenResponse,google/iam/credentials/v1/common.proto#L72}
+  ///
   StatusOr<google::iam::credentials::v1::GenerateAccessTokenResponse>
   GenerateAccessToken(std::string const& name,
                       std::vector<std::string> const& delegates,
@@ -136,6 +141,11 @@ class IAMCredentialsClient {
   /// @return
   /// @googleapis_link{google::iam::credentials::v1::GenerateIdTokenResponse,google/iam/credentials/v1/common.proto#L186}
   ///
+  /// [google.iam.credentials.v1.GenerateIdTokenRequest]:
+  /// @googleapis_link{google::iam::credentials::v1::GenerateIdTokenRequest,google/iam/credentials/v1/common.proto#L153}
+  /// [google.iam.credentials.v1.GenerateIdTokenResponse]:
+  /// @googleapis_link{google::iam::credentials::v1::GenerateIdTokenResponse,google/iam/credentials/v1/common.proto#L186}
+  ///
   StatusOr<google::iam::credentials::v1::GenerateIdTokenResponse>
   GenerateIdToken(std::string const& name,
                   std::vector<std::string> const& delegates,
@@ -163,6 +173,11 @@ class IAMCredentialsClient {
   ///  invalid.
   /// @param payload  Required. The bytes to sign.
   /// @return
+  /// @googleapis_link{google::iam::credentials::v1::SignBlobResponse,google/iam/credentials/v1/common.proto#L109}
+  ///
+  /// [google.iam.credentials.v1.SignBlobRequest]:
+  /// @googleapis_link{google::iam::credentials::v1::SignBlobRequest,google/iam/credentials/v1/common.proto#L81}
+  /// [google.iam.credentials.v1.SignBlobResponse]:
   /// @googleapis_link{google::iam::credentials::v1::SignBlobResponse,google/iam/credentials/v1/common.proto#L109}
   ///
   StatusOr<google::iam::credentials::v1::SignBlobResponse> SignBlob(
@@ -194,6 +209,11 @@ class IAMCredentialsClient {
   /// @return
   /// @googleapis_link{google::iam::credentials::v1::SignJwtResponse,google/iam/credentials/v1/common.proto#L145}
   ///
+  /// [google.iam.credentials.v1.SignJwtRequest]:
+  /// @googleapis_link{google::iam::credentials::v1::SignJwtRequest,google/iam/credentials/v1/common.proto#L117}
+  /// [google.iam.credentials.v1.SignJwtResponse]:
+  /// @googleapis_link{google::iam::credentials::v1::SignJwtResponse,google/iam/credentials/v1/common.proto#L145}
+  ///
   StatusOr<google::iam::credentials::v1::SignJwtResponse> SignJwt(
       std::string const& name, std::vector<std::string> const& delegates,
       std::string const& payload);
@@ -204,6 +224,11 @@ class IAMCredentialsClient {
   /// @param request
   /// @googleapis_link{google::iam::credentials::v1::GenerateAccessTokenRequest,google/iam/credentials/v1/common.proto#L35}
   /// @return
+  /// @googleapis_link{google::iam::credentials::v1::GenerateAccessTokenResponse,google/iam/credentials/v1/common.proto#L72}
+  ///
+  /// [google.iam.credentials.v1.GenerateAccessTokenRequest]:
+  /// @googleapis_link{google::iam::credentials::v1::GenerateAccessTokenRequest,google/iam/credentials/v1/common.proto#L35}
+  /// [google.iam.credentials.v1.GenerateAccessTokenResponse]:
   /// @googleapis_link{google::iam::credentials::v1::GenerateAccessTokenResponse,google/iam/credentials/v1/common.proto#L72}
   ///
   StatusOr<google::iam::credentials::v1::GenerateAccessTokenResponse>
@@ -218,6 +243,11 @@ class IAMCredentialsClient {
   /// @return
   /// @googleapis_link{google::iam::credentials::v1::GenerateIdTokenResponse,google/iam/credentials/v1/common.proto#L186}
   ///
+  /// [google.iam.credentials.v1.GenerateIdTokenRequest]:
+  /// @googleapis_link{google::iam::credentials::v1::GenerateIdTokenRequest,google/iam/credentials/v1/common.proto#L153}
+  /// [google.iam.credentials.v1.GenerateIdTokenResponse]:
+  /// @googleapis_link{google::iam::credentials::v1::GenerateIdTokenResponse,google/iam/credentials/v1/common.proto#L186}
+  ///
   StatusOr<google::iam::credentials::v1::GenerateIdTokenResponse>
   GenerateIdToken(
       google::iam::credentials::v1::GenerateIdTokenRequest const& request);
@@ -230,6 +260,11 @@ class IAMCredentialsClient {
   /// @return
   /// @googleapis_link{google::iam::credentials::v1::SignBlobResponse,google/iam/credentials/v1/common.proto#L109}
   ///
+  /// [google.iam.credentials.v1.SignBlobRequest]:
+  /// @googleapis_link{google::iam::credentials::v1::SignBlobRequest,google/iam/credentials/v1/common.proto#L81}
+  /// [google.iam.credentials.v1.SignBlobResponse]:
+  /// @googleapis_link{google::iam::credentials::v1::SignBlobResponse,google/iam/credentials/v1/common.proto#L109}
+  ///
   StatusOr<google::iam::credentials::v1::SignBlobResponse> SignBlob(
       google::iam::credentials::v1::SignBlobRequest const& request);
 
@@ -239,6 +274,11 @@ class IAMCredentialsClient {
   /// @param request
   /// @googleapis_link{google::iam::credentials::v1::SignJwtRequest,google/iam/credentials/v1/common.proto#L117}
   /// @return
+  /// @googleapis_link{google::iam::credentials::v1::SignJwtResponse,google/iam/credentials/v1/common.proto#L145}
+  ///
+  /// [google.iam.credentials.v1.SignJwtRequest]:
+  /// @googleapis_link{google::iam::credentials::v1::SignJwtRequest,google/iam/credentials/v1/common.proto#L117}
+  /// [google.iam.credentials.v1.SignJwtResponse]:
   /// @googleapis_link{google::iam::credentials::v1::SignJwtResponse,google/iam/credentials/v1/common.proto#L145}
   ///
   StatusOr<google::iam::credentials::v1::SignJwtResponse> SignJwt(

--- a/google/cloud/iam/iam_credentials_client.h
+++ b/google/cloud/iam/iam_credentials_client.h
@@ -102,9 +102,9 @@ class IAMCredentialsClient {
   /// @googleapis_link{google::iam::credentials::v1::GenerateAccessTokenResponse,google/iam/credentials/v1/common.proto#L72}
   ///
   /// [google.iam.credentials.v1.GenerateAccessTokenRequest]:
-  /// @googleapis_link{google::iam::credentials::v1::GenerateAccessTokenRequest,google/iam/credentials/v1/common.proto#L35}
+  /// @googleapis_reference_link{google/iam/credentials/v1/common.proto#L35}
   /// [google.iam.credentials.v1.GenerateAccessTokenResponse]:
-  /// @googleapis_link{google::iam::credentials::v1::GenerateAccessTokenResponse,google/iam/credentials/v1/common.proto#L72}
+  /// @googleapis_reference_link{google/iam/credentials/v1/common.proto#L72}
   ///
   StatusOr<google::iam::credentials::v1::GenerateAccessTokenResponse>
   GenerateAccessToken(std::string const& name,
@@ -142,9 +142,9 @@ class IAMCredentialsClient {
   /// @googleapis_link{google::iam::credentials::v1::GenerateIdTokenResponse,google/iam/credentials/v1/common.proto#L186}
   ///
   /// [google.iam.credentials.v1.GenerateIdTokenRequest]:
-  /// @googleapis_link{google::iam::credentials::v1::GenerateIdTokenRequest,google/iam/credentials/v1/common.proto#L153}
+  /// @googleapis_reference_link{google/iam/credentials/v1/common.proto#L153}
   /// [google.iam.credentials.v1.GenerateIdTokenResponse]:
-  /// @googleapis_link{google::iam::credentials::v1::GenerateIdTokenResponse,google/iam/credentials/v1/common.proto#L186}
+  /// @googleapis_reference_link{google/iam/credentials/v1/common.proto#L186}
   ///
   StatusOr<google::iam::credentials::v1::GenerateIdTokenResponse>
   GenerateIdToken(std::string const& name,
@@ -176,9 +176,9 @@ class IAMCredentialsClient {
   /// @googleapis_link{google::iam::credentials::v1::SignBlobResponse,google/iam/credentials/v1/common.proto#L109}
   ///
   /// [google.iam.credentials.v1.SignBlobRequest]:
-  /// @googleapis_link{google::iam::credentials::v1::SignBlobRequest,google/iam/credentials/v1/common.proto#L81}
+  /// @googleapis_reference_link{google/iam/credentials/v1/common.proto#L81}
   /// [google.iam.credentials.v1.SignBlobResponse]:
-  /// @googleapis_link{google::iam::credentials::v1::SignBlobResponse,google/iam/credentials/v1/common.proto#L109}
+  /// @googleapis_reference_link{google/iam/credentials/v1/common.proto#L109}
   ///
   StatusOr<google::iam::credentials::v1::SignBlobResponse> SignBlob(
       std::string const& name, std::vector<std::string> const& delegates,
@@ -210,9 +210,9 @@ class IAMCredentialsClient {
   /// @googleapis_link{google::iam::credentials::v1::SignJwtResponse,google/iam/credentials/v1/common.proto#L145}
   ///
   /// [google.iam.credentials.v1.SignJwtRequest]:
-  /// @googleapis_link{google::iam::credentials::v1::SignJwtRequest,google/iam/credentials/v1/common.proto#L117}
+  /// @googleapis_reference_link{google/iam/credentials/v1/common.proto#L117}
   /// [google.iam.credentials.v1.SignJwtResponse]:
-  /// @googleapis_link{google::iam::credentials::v1::SignJwtResponse,google/iam/credentials/v1/common.proto#L145}
+  /// @googleapis_reference_link{google/iam/credentials/v1/common.proto#L145}
   ///
   StatusOr<google::iam::credentials::v1::SignJwtResponse> SignJwt(
       std::string const& name, std::vector<std::string> const& delegates,
@@ -227,9 +227,9 @@ class IAMCredentialsClient {
   /// @googleapis_link{google::iam::credentials::v1::GenerateAccessTokenResponse,google/iam/credentials/v1/common.proto#L72}
   ///
   /// [google.iam.credentials.v1.GenerateAccessTokenRequest]:
-  /// @googleapis_link{google::iam::credentials::v1::GenerateAccessTokenRequest,google/iam/credentials/v1/common.proto#L35}
+  /// @googleapis_reference_link{google/iam/credentials/v1/common.proto#L35}
   /// [google.iam.credentials.v1.GenerateAccessTokenResponse]:
-  /// @googleapis_link{google::iam::credentials::v1::GenerateAccessTokenResponse,google/iam/credentials/v1/common.proto#L72}
+  /// @googleapis_reference_link{google/iam/credentials/v1/common.proto#L72}
   ///
   StatusOr<google::iam::credentials::v1::GenerateAccessTokenResponse>
   GenerateAccessToken(
@@ -244,9 +244,9 @@ class IAMCredentialsClient {
   /// @googleapis_link{google::iam::credentials::v1::GenerateIdTokenResponse,google/iam/credentials/v1/common.proto#L186}
   ///
   /// [google.iam.credentials.v1.GenerateIdTokenRequest]:
-  /// @googleapis_link{google::iam::credentials::v1::GenerateIdTokenRequest,google/iam/credentials/v1/common.proto#L153}
+  /// @googleapis_reference_link{google/iam/credentials/v1/common.proto#L153}
   /// [google.iam.credentials.v1.GenerateIdTokenResponse]:
-  /// @googleapis_link{google::iam::credentials::v1::GenerateIdTokenResponse,google/iam/credentials/v1/common.proto#L186}
+  /// @googleapis_reference_link{google/iam/credentials/v1/common.proto#L186}
   ///
   StatusOr<google::iam::credentials::v1::GenerateIdTokenResponse>
   GenerateIdToken(
@@ -261,9 +261,9 @@ class IAMCredentialsClient {
   /// @googleapis_link{google::iam::credentials::v1::SignBlobResponse,google/iam/credentials/v1/common.proto#L109}
   ///
   /// [google.iam.credentials.v1.SignBlobRequest]:
-  /// @googleapis_link{google::iam::credentials::v1::SignBlobRequest,google/iam/credentials/v1/common.proto#L81}
+  /// @googleapis_reference_link{google/iam/credentials/v1/common.proto#L81}
   /// [google.iam.credentials.v1.SignBlobResponse]:
-  /// @googleapis_link{google::iam::credentials::v1::SignBlobResponse,google/iam/credentials/v1/common.proto#L109}
+  /// @googleapis_reference_link{google/iam/credentials/v1/common.proto#L109}
   ///
   StatusOr<google::iam::credentials::v1::SignBlobResponse> SignBlob(
       google::iam::credentials::v1::SignBlobRequest const& request);
@@ -277,9 +277,9 @@ class IAMCredentialsClient {
   /// @googleapis_link{google::iam::credentials::v1::SignJwtResponse,google/iam/credentials/v1/common.proto#L145}
   ///
   /// [google.iam.credentials.v1.SignJwtRequest]:
-  /// @googleapis_link{google::iam::credentials::v1::SignJwtRequest,google/iam/credentials/v1/common.proto#L117}
+  /// @googleapis_reference_link{google/iam/credentials/v1/common.proto#L117}
   /// [google.iam.credentials.v1.SignJwtResponse]:
-  /// @googleapis_link{google::iam::credentials::v1::SignJwtResponse,google/iam/credentials/v1/common.proto#L145}
+  /// @googleapis_reference_link{google/iam/credentials/v1/common.proto#L145}
   ///
   StatusOr<google::iam::credentials::v1::SignJwtResponse> SignJwt(
       google::iam::credentials::v1::SignJwtRequest const& request);

--- a/google/cloud/logging/logging_service_v2_client.h
+++ b/google/cloud/logging/logging_service_v2_client.h
@@ -79,7 +79,7 @@ class LoggingServiceV2Client {
   ///  [LogEntry][google.logging.v2.LogEntry].
   ///
   /// [google.logging.v2.DeleteLogRequest]:
-  /// @googleapis_link{google::logging::v2::DeleteLogRequest,google/logging/v2/logging.proto#L140}
+  /// @googleapis_reference_link{google/logging/v2/logging.proto#L140}
   ///
   Status DeleteLog(std::string const& log_name);
 
@@ -144,9 +144,9 @@ class LoggingServiceV2Client {
   /// @googleapis_link{google::logging::v2::WriteLogEntriesResponse,google/logging/v2/logging.proto#L243}
   ///
   /// [google.logging.v2.WriteLogEntriesRequest]:
-  /// @googleapis_link{google::logging::v2::WriteLogEntriesRequest,google/logging/v2/logging.proto#L162}
+  /// @googleapis_reference_link{google/logging/v2/logging.proto#L162}
   /// [google.logging.v2.WriteLogEntriesResponse]:
-  /// @googleapis_link{google::logging::v2::WriteLogEntriesResponse,google/logging/v2/logging.proto#L243}
+  /// @googleapis_reference_link{google/logging/v2/logging.proto#L243}
   ///
   StatusOr<google::logging::v2::WriteLogEntriesResponse> WriteLogEntries(
       std::string const& log_name,
@@ -193,9 +193,9 @@ class LoggingServiceV2Client {
   /// @googleapis_link{google::logging::v2::LogEntry,google/logging/v2/log_entry.proto#L42}
   ///
   /// [google.logging.v2.ListLogEntriesRequest]:
-  /// @googleapis_link{google::logging::v2::ListLogEntriesRequest,google/logging/v2/logging.proto#L257}
+  /// @googleapis_reference_link{google/logging/v2/logging.proto#L257}
   /// [google.logging.v2.LogEntry]:
-  /// @googleapis_link{google::logging::v2::LogEntry,google/logging/v2/log_entry.proto#L42}
+  /// @googleapis_reference_link{google/logging/v2/log_entry.proto#L42}
   ///
   StreamRange<google::logging::v2::LogEntry> ListLogEntries(
       std::vector<std::string> const& resource_names, std::string const& filter,
@@ -213,7 +213,7 @@ class LoggingServiceV2Client {
   /// @return std::string
   ///
   /// [google.logging.v2.ListLogsRequest]:
-  /// @googleapis_link{google::logging::v2::ListLogsRequest,google/logging/v2/logging.proto#L356}
+  /// @googleapis_reference_link{google/logging/v2/logging.proto#L356}
   ///
   StreamRange<std::string> ListLogs(std::string const& parent);
 
@@ -227,7 +227,7 @@ class LoggingServiceV2Client {
   /// @googleapis_link{google::logging::v2::DeleteLogRequest,google/logging/v2/logging.proto#L140}
   ///
   /// [google.logging.v2.DeleteLogRequest]:
-  /// @googleapis_link{google::logging::v2::DeleteLogRequest,google/logging/v2/logging.proto#L140}
+  /// @googleapis_reference_link{google/logging/v2/logging.proto#L140}
   ///
   Status DeleteLog(google::logging::v2::DeleteLogRequest const& request);
 
@@ -246,9 +246,9 @@ class LoggingServiceV2Client {
   /// @googleapis_link{google::logging::v2::WriteLogEntriesResponse,google/logging/v2/logging.proto#L243}
   ///
   /// [google.logging.v2.WriteLogEntriesRequest]:
-  /// @googleapis_link{google::logging::v2::WriteLogEntriesRequest,google/logging/v2/logging.proto#L162}
+  /// @googleapis_reference_link{google/logging/v2/logging.proto#L162}
   /// [google.logging.v2.WriteLogEntriesResponse]:
-  /// @googleapis_link{google::logging::v2::WriteLogEntriesResponse,google/logging/v2/logging.proto#L243}
+  /// @googleapis_reference_link{google/logging/v2/logging.proto#L243}
   ///
   StatusOr<google::logging::v2::WriteLogEntriesResponse> WriteLogEntries(
       google::logging::v2::WriteLogEntriesRequest const& request);
@@ -265,9 +265,9 @@ class LoggingServiceV2Client {
   /// @googleapis_link{google::logging::v2::LogEntry,google/logging/v2/log_entry.proto#L42}
   ///
   /// [google.logging.v2.ListLogEntriesRequest]:
-  /// @googleapis_link{google::logging::v2::ListLogEntriesRequest,google/logging/v2/logging.proto#L257}
+  /// @googleapis_reference_link{google/logging/v2/logging.proto#L257}
   /// [google.logging.v2.LogEntry]:
-  /// @googleapis_link{google::logging::v2::LogEntry,google/logging/v2/log_entry.proto#L42}
+  /// @googleapis_reference_link{google/logging/v2/log_entry.proto#L42}
   ///
   StreamRange<google::logging::v2::LogEntry> ListLogEntries(
       google::logging::v2::ListLogEntriesRequest request);
@@ -281,9 +281,9 @@ class LoggingServiceV2Client {
   /// @googleapis_link{google::api::MonitoredResourceDescriptor,google/api/monitored_resource.proto#L40}
   ///
   /// [google.logging.v2.ListMonitoredResourceDescriptorsRequest]:
-  /// @googleapis_link{google::logging::v2::ListMonitoredResourceDescriptorsRequest,google/logging/v2/logging.proto#L331}
+  /// @googleapis_reference_link{google/logging/v2/logging.proto#L331}
   /// [google.api.MonitoredResourceDescriptor]:
-  /// @googleapis_link{google::api::MonitoredResourceDescriptor,google/api/monitored_resource.proto#L40}
+  /// @googleapis_reference_link{google/api/monitored_resource.proto#L40}
   ///
   StreamRange<google::api::MonitoredResourceDescriptor>
   ListMonitoredResourceDescriptors(
@@ -298,7 +298,7 @@ class LoggingServiceV2Client {
   /// @return std::string
   ///
   /// [google.logging.v2.ListLogsRequest]:
-  /// @googleapis_link{google::logging::v2::ListLogsRequest,google/logging/v2/logging.proto#L356}
+  /// @googleapis_reference_link{google/logging/v2/logging.proto#L356}
   ///
   StreamRange<std::string> ListLogs(
       google::logging::v2::ListLogsRequest request);

--- a/google/cloud/logging/logging_service_v2_client.h
+++ b/google/cloud/logging/logging_service_v2_client.h
@@ -194,7 +194,7 @@ class LoggingServiceV2Client {
   ///
   /// [google.logging.v2.ListLogEntriesRequest]:
   /// @googleapis_link{google::logging::v2::ListLogEntriesRequest,google/logging/v2/logging.proto#L257}
-  /// [google::logging::v2::LogEntry]:
+  /// [google.logging.v2.LogEntry]:
   /// @googleapis_link{google::logging::v2::LogEntry,google/logging/v2/log_entry.proto#L42}
   ///
   StreamRange<google::logging::v2::LogEntry> ListLogEntries(
@@ -214,7 +214,6 @@ class LoggingServiceV2Client {
   ///
   /// [google.logging.v2.ListLogsRequest]:
   /// @googleapis_link{google::logging::v2::ListLogsRequest,google/logging/v2/logging.proto#L356}
-  /// [std::string]: std::string
   ///
   StreamRange<std::string> ListLogs(std::string const& parent);
 
@@ -267,7 +266,7 @@ class LoggingServiceV2Client {
   ///
   /// [google.logging.v2.ListLogEntriesRequest]:
   /// @googleapis_link{google::logging::v2::ListLogEntriesRequest,google/logging/v2/logging.proto#L257}
-  /// [google::logging::v2::LogEntry]:
+  /// [google.logging.v2.LogEntry]:
   /// @googleapis_link{google::logging::v2::LogEntry,google/logging/v2/log_entry.proto#L42}
   ///
   StreamRange<google::logging::v2::LogEntry> ListLogEntries(
@@ -283,7 +282,7 @@ class LoggingServiceV2Client {
   ///
   /// [google.logging.v2.ListMonitoredResourceDescriptorsRequest]:
   /// @googleapis_link{google::logging::v2::ListMonitoredResourceDescriptorsRequest,google/logging/v2/logging.proto#L331}
-  /// [google::api::MonitoredResourceDescriptor]:
+  /// [google.api.MonitoredResourceDescriptor]:
   /// @googleapis_link{google::api::MonitoredResourceDescriptor,google/api/monitored_resource.proto#L40}
   ///
   StreamRange<google::api::MonitoredResourceDescriptor>
@@ -300,7 +299,6 @@ class LoggingServiceV2Client {
   ///
   /// [google.logging.v2.ListLogsRequest]:
   /// @googleapis_link{google::logging::v2::ListLogsRequest,google/logging/v2/logging.proto#L356}
-  /// [std::string]: std::string
   ///
   StreamRange<std::string> ListLogs(
       google::logging::v2::ListLogsRequest request);

--- a/google/cloud/logging/logging_service_v2_client.h
+++ b/google/cloud/logging/logging_service_v2_client.h
@@ -78,6 +78,9 @@ class LoggingServiceV2Client {
   ///  For more information about log names, see
   ///  [LogEntry][google.logging.v2.LogEntry].
   ///
+  /// [google.logging.v2.DeleteLogRequest]:
+  /// @googleapis_link{google::logging::v2::DeleteLogRequest,google/logging/v2/logging.proto#L140}
+  ///
   Status DeleteLog(std::string const& log_name);
 
   ///
@@ -140,6 +143,11 @@ class LoggingServiceV2Client {
   /// @return
   /// @googleapis_link{google::logging::v2::WriteLogEntriesResponse,google/logging/v2/logging.proto#L243}
   ///
+  /// [google.logging.v2.WriteLogEntriesRequest]:
+  /// @googleapis_link{google::logging::v2::WriteLogEntriesRequest,google/logging/v2/logging.proto#L162}
+  /// [google.logging.v2.WriteLogEntriesResponse]:
+  /// @googleapis_link{google::logging::v2::WriteLogEntriesResponse,google/logging/v2/logging.proto#L243}
+  ///
   StatusOr<google::logging::v2::WriteLogEntriesResponse> WriteLogEntries(
       std::string const& log_name,
       google::api::MonitoredResource const& resource,
@@ -184,6 +192,11 @@ class LoggingServiceV2Client {
   /// @return
   /// @googleapis_link{google::logging::v2::LogEntry,google/logging/v2/log_entry.proto#L42}
   ///
+  /// [google.logging.v2.ListLogEntriesRequest]:
+  /// @googleapis_link{google::logging::v2::ListLogEntriesRequest,google/logging/v2/logging.proto#L257}
+  /// [google::logging::v2::LogEntry]:
+  /// @googleapis_link{google::logging::v2::LogEntry,google/logging/v2/log_entry.proto#L42}
+  ///
   StreamRange<google::logging::v2::LogEntry> ListLogEntries(
       std::vector<std::string> const& resource_names, std::string const& filter,
       std::string const& order_by);
@@ -199,6 +212,10 @@ class LoggingServiceV2Client {
   ///      "folders/[FOLDER_ID]"
   /// @return std::string
   ///
+  /// [google.logging.v2.ListLogsRequest]:
+  /// @googleapis_link{google::logging::v2::ListLogsRequest,google/logging/v2/logging.proto#L356}
+  /// [std::string]: std::string
+  ///
   StreamRange<std::string> ListLogs(std::string const& parent);
 
   ///
@@ -208,6 +225,9 @@ class LoggingServiceV2Client {
   /// before the operation will be deleted.
   ///
   /// @param request
+  /// @googleapis_link{google::logging::v2::DeleteLogRequest,google/logging/v2/logging.proto#L140}
+  ///
+  /// [google.logging.v2.DeleteLogRequest]:
   /// @googleapis_link{google::logging::v2::DeleteLogRequest,google/logging/v2/logging.proto#L140}
   ///
   Status DeleteLog(google::logging::v2::DeleteLogRequest const& request);
@@ -226,6 +246,11 @@ class LoggingServiceV2Client {
   /// @return
   /// @googleapis_link{google::logging::v2::WriteLogEntriesResponse,google/logging/v2/logging.proto#L243}
   ///
+  /// [google.logging.v2.WriteLogEntriesRequest]:
+  /// @googleapis_link{google::logging::v2::WriteLogEntriesRequest,google/logging/v2/logging.proto#L162}
+  /// [google.logging.v2.WriteLogEntriesResponse]:
+  /// @googleapis_link{google::logging::v2::WriteLogEntriesResponse,google/logging/v2/logging.proto#L243}
+  ///
   StatusOr<google::logging::v2::WriteLogEntriesResponse> WriteLogEntries(
       google::logging::v2::WriteLogEntriesRequest const& request);
 
@@ -240,6 +265,11 @@ class LoggingServiceV2Client {
   /// @return
   /// @googleapis_link{google::logging::v2::LogEntry,google/logging/v2/log_entry.proto#L42}
   ///
+  /// [google.logging.v2.ListLogEntriesRequest]:
+  /// @googleapis_link{google::logging::v2::ListLogEntriesRequest,google/logging/v2/logging.proto#L257}
+  /// [google::logging::v2::LogEntry]:
+  /// @googleapis_link{google::logging::v2::LogEntry,google/logging/v2/log_entry.proto#L42}
+  ///
   StreamRange<google::logging::v2::LogEntry> ListLogEntries(
       google::logging::v2::ListLogEntriesRequest request);
 
@@ -249,6 +279,11 @@ class LoggingServiceV2Client {
   /// @param request
   /// @googleapis_link{google::logging::v2::ListMonitoredResourceDescriptorsRequest,google/logging/v2/logging.proto#L331}
   /// @return
+  /// @googleapis_link{google::api::MonitoredResourceDescriptor,google/api/monitored_resource.proto#L40}
+  ///
+  /// [google.logging.v2.ListMonitoredResourceDescriptorsRequest]:
+  /// @googleapis_link{google::logging::v2::ListMonitoredResourceDescriptorsRequest,google/logging/v2/logging.proto#L331}
+  /// [google::api::MonitoredResourceDescriptor]:
   /// @googleapis_link{google::api::MonitoredResourceDescriptor,google/api/monitored_resource.proto#L40}
   ///
   StreamRange<google::api::MonitoredResourceDescriptor>
@@ -262,6 +297,10 @@ class LoggingServiceV2Client {
   /// @param request
   /// @googleapis_link{google::logging::v2::ListLogsRequest,google/logging/v2/logging.proto#L356}
   /// @return std::string
+  ///
+  /// [google.logging.v2.ListLogsRequest]:
+  /// @googleapis_link{google::logging::v2::ListLogsRequest,google/logging/v2/logging.proto#L356}
+  /// [std::string]: std::string
   ///
   StreamRange<std::string> ListLogs(
       google::logging::v2::ListLogsRequest request);

--- a/google/cloud/pubsublite/admin_client.h
+++ b/google/cloud/pubsublite/admin_client.h
@@ -78,9 +78,9 @@ class AdminServiceClient {
   /// @googleapis_link{google::cloud::pubsublite::v1::Topic,google/cloud/pubsublite/v1/common.proto#L102}
   ///
   /// [google.cloud.pubsublite.v1.CreateTopicRequest]:
-  /// @googleapis_link{google::cloud::pubsublite::v1::CreateTopicRequest,google/cloud/pubsublite/v1/admin.proto#L227}
+  /// @googleapis_reference_link{google/cloud/pubsublite/v1/admin.proto#L227}
   /// [google.cloud.pubsublite.v1.Topic]:
-  /// @googleapis_link{google::cloud::pubsublite::v1::Topic,google/cloud/pubsublite/v1/common.proto#L102}
+  /// @googleapis_reference_link{google/cloud/pubsublite/v1/common.proto#L102}
   ///
   StatusOr<google::cloud::pubsublite::v1::Topic> CreateTopic(
       std::string const& parent,
@@ -96,9 +96,9 @@ class AdminServiceClient {
   /// @googleapis_link{google::cloud::pubsublite::v1::Topic,google/cloud/pubsublite/v1/common.proto#L102}
   ///
   /// [google.cloud.pubsublite.v1.GetTopicRequest]:
-  /// @googleapis_link{google::cloud::pubsublite::v1::GetTopicRequest,google/cloud/pubsublite/v1/admin.proto#L248}
+  /// @googleapis_reference_link{google/cloud/pubsublite/v1/admin.proto#L248}
   /// [google.cloud.pubsublite.v1.Topic]:
-  /// @googleapis_link{google::cloud::pubsublite::v1::Topic,google/cloud/pubsublite/v1/common.proto#L102}
+  /// @googleapis_reference_link{google/cloud/pubsublite/v1/common.proto#L102}
   ///
   StatusOr<google::cloud::pubsublite::v1::Topic> GetTopic(
       std::string const& name);
@@ -111,9 +111,9 @@ class AdminServiceClient {
   /// @googleapis_link{google::cloud::pubsublite::v1::TopicPartitions,google/cloud/pubsublite/v1/admin.proto#L270}
   ///
   /// [google.cloud.pubsublite.v1.GetTopicPartitionsRequest]:
-  /// @googleapis_link{google::cloud::pubsublite::v1::GetTopicPartitionsRequest,google/cloud/pubsublite/v1/admin.proto#L259}
+  /// @googleapis_reference_link{google/cloud/pubsublite/v1/admin.proto#L259}
   /// [google.cloud.pubsublite.v1.TopicPartitions]:
-  /// @googleapis_link{google::cloud::pubsublite::v1::TopicPartitions,google/cloud/pubsublite/v1/admin.proto#L270}
+  /// @googleapis_reference_link{google/cloud/pubsublite/v1/admin.proto#L270}
   ///
   StatusOr<google::cloud::pubsublite::v1::TopicPartitions> GetTopicPartitions(
       std::string const& name);
@@ -127,9 +127,9 @@ class AdminServiceClient {
   /// @googleapis_link{google::cloud::pubsublite::v1::Topic,google/cloud/pubsublite/v1/common.proto#L102}
   ///
   /// [google.cloud.pubsublite.v1.ListTopicsRequest]:
-  /// @googleapis_link{google::cloud::pubsublite::v1::ListTopicsRequest,google/cloud/pubsublite/v1/admin.proto#L276}
+  /// @googleapis_reference_link{google/cloud/pubsublite/v1/admin.proto#L276}
   /// [google.cloud.pubsublite.v1.Topic]:
-  /// @googleapis_link{google::cloud::pubsublite::v1::Topic,google/cloud/pubsublite/v1/common.proto#L102}
+  /// @googleapis_reference_link{google/cloud/pubsublite/v1/common.proto#L102}
   ///
   StreamRange<google::cloud::pubsublite::v1::Topic> ListTopics(
       std::string const& parent);
@@ -145,9 +145,9 @@ class AdminServiceClient {
   /// @googleapis_link{google::cloud::pubsublite::v1::Topic,google/cloud/pubsublite/v1/common.proto#L102}
   ///
   /// [google.cloud.pubsublite.v1.UpdateTopicRequest]:
-  /// @googleapis_link{google::cloud::pubsublite::v1::UpdateTopicRequest,google/cloud/pubsublite/v1/admin.proto#L311}
+  /// @googleapis_reference_link{google/cloud/pubsublite/v1/admin.proto#L311}
   /// [google.cloud.pubsublite.v1.Topic]:
-  /// @googleapis_link{google::cloud::pubsublite::v1::Topic,google/cloud/pubsublite/v1/common.proto#L102}
+  /// @googleapis_reference_link{google/cloud/pubsublite/v1/common.proto#L102}
   ///
   StatusOr<google::cloud::pubsublite::v1::Topic> UpdateTopic(
       google::cloud::pubsublite::v1::Topic const& topic,
@@ -159,7 +159,7 @@ class AdminServiceClient {
   /// @param name  Required. The name of the topic to delete.
   ///
   /// [google.cloud.pubsublite.v1.DeleteTopicRequest]:
-  /// @googleapis_link{google::cloud::pubsublite::v1::DeleteTopicRequest,google/cloud/pubsublite/v1/admin.proto#L320}
+  /// @googleapis_reference_link{google/cloud/pubsublite/v1/admin.proto#L320}
   ///
   Status DeleteTopic(std::string const& name);
 
@@ -170,7 +170,7 @@ class AdminServiceClient {
   /// @return std::string
   ///
   /// [google.cloud.pubsublite.v1.ListTopicSubscriptionsRequest]:
-  /// @googleapis_link{google::cloud::pubsublite::v1::ListTopicSubscriptionsRequest,google/cloud/pubsublite/v1/admin.proto#L331}
+  /// @googleapis_reference_link{google/cloud/pubsublite/v1/admin.proto#L331}
   ///
   StreamRange<std::string> ListTopicSubscriptions(std::string const& name);
 
@@ -190,9 +190,9 @@ class AdminServiceClient {
   /// @googleapis_link{google::cloud::pubsublite::v1::Subscription,google/cloud/pubsublite/v1/common.proto#L186}
   ///
   /// [google.cloud.pubsublite.v1.CreateSubscriptionRequest]:
-  /// @googleapis_link{google::cloud::pubsublite::v1::CreateSubscriptionRequest,google/cloud/pubsublite/v1/admin.proto#L365}
+  /// @googleapis_reference_link{google/cloud/pubsublite/v1/admin.proto#L365}
   /// [google.cloud.pubsublite.v1.Subscription]:
-  /// @googleapis_link{google::cloud::pubsublite::v1::Subscription,google/cloud/pubsublite/v1/common.proto#L186}
+  /// @googleapis_reference_link{google/cloud/pubsublite/v1/common.proto#L186}
   ///
   StatusOr<google::cloud::pubsublite::v1::Subscription> CreateSubscription(
       std::string const& parent,
@@ -208,9 +208,9 @@ class AdminServiceClient {
   /// @googleapis_link{google::cloud::pubsublite::v1::Subscription,google/cloud/pubsublite/v1/common.proto#L186}
   ///
   /// [google.cloud.pubsublite.v1.GetSubscriptionRequest]:
-  /// @googleapis_link{google::cloud::pubsublite::v1::GetSubscriptionRequest,google/cloud/pubsublite/v1/admin.proto#L391}
+  /// @googleapis_reference_link{google/cloud/pubsublite/v1/admin.proto#L391}
   /// [google.cloud.pubsublite.v1.Subscription]:
-  /// @googleapis_link{google::cloud::pubsublite::v1::Subscription,google/cloud/pubsublite/v1/common.proto#L186}
+  /// @googleapis_reference_link{google/cloud/pubsublite/v1/common.proto#L186}
   ///
   StatusOr<google::cloud::pubsublite::v1::Subscription> GetSubscription(
       std::string const& name);
@@ -224,9 +224,9 @@ class AdminServiceClient {
   /// @googleapis_link{google::cloud::pubsublite::v1::Subscription,google/cloud/pubsublite/v1/common.proto#L186}
   ///
   /// [google.cloud.pubsublite.v1.ListSubscriptionsRequest]:
-  /// @googleapis_link{google::cloud::pubsublite::v1::ListSubscriptionsRequest,google/cloud/pubsublite/v1/admin.proto#L402}
+  /// @googleapis_reference_link{google/cloud/pubsublite/v1/admin.proto#L402}
   /// [google.cloud.pubsublite.v1.Subscription]:
-  /// @googleapis_link{google::cloud::pubsublite::v1::Subscription,google/cloud/pubsublite/v1/common.proto#L186}
+  /// @googleapis_reference_link{google/cloud/pubsublite/v1/common.proto#L186}
   ///
   StreamRange<google::cloud::pubsublite::v1::Subscription> ListSubscriptions(
       std::string const& parent);
@@ -243,9 +243,9 @@ class AdminServiceClient {
   /// @googleapis_link{google::cloud::pubsublite::v1::Subscription,google/cloud/pubsublite/v1/common.proto#L186}
   ///
   /// [google.cloud.pubsublite.v1.UpdateSubscriptionRequest]:
-  /// @googleapis_link{google::cloud::pubsublite::v1::UpdateSubscriptionRequest,google/cloud/pubsublite/v1/admin.proto#L437}
+  /// @googleapis_reference_link{google/cloud/pubsublite/v1/admin.proto#L437}
   /// [google.cloud.pubsublite.v1.Subscription]:
-  /// @googleapis_link{google::cloud::pubsublite::v1::Subscription,google/cloud/pubsublite/v1/common.proto#L186}
+  /// @googleapis_reference_link{google/cloud/pubsublite/v1/common.proto#L186}
   ///
   StatusOr<google::cloud::pubsublite::v1::Subscription> UpdateSubscription(
       google::cloud::pubsublite::v1::Subscription const& subscription,
@@ -257,7 +257,7 @@ class AdminServiceClient {
   /// @param name  Required. The name of the subscription to delete.
   ///
   /// [google.cloud.pubsublite.v1.DeleteSubscriptionRequest]:
-  /// @googleapis_link{google::cloud::pubsublite::v1::DeleteSubscriptionRequest,google/cloud/pubsublite/v1/admin.proto#L447}
+  /// @googleapis_reference_link{google/cloud/pubsublite/v1/admin.proto#L447}
   ///
   Status DeleteSubscription(std::string const& name);
 
@@ -277,9 +277,9 @@ class AdminServiceClient {
   /// @googleapis_link{google::cloud::pubsublite::v1::Reservation,google/cloud/pubsublite/v1/common.proto#L80}
   ///
   /// [google.cloud.pubsublite.v1.CreateReservationRequest]:
-  /// @googleapis_link{google::cloud::pubsublite::v1::CreateReservationRequest,google/cloud/pubsublite/v1/admin.proto#L516}
+  /// @googleapis_reference_link{google/cloud/pubsublite/v1/admin.proto#L516}
   /// [google.cloud.pubsublite.v1.Reservation]:
-  /// @googleapis_link{google::cloud::pubsublite::v1::Reservation,google/cloud/pubsublite/v1/common.proto#L80}
+  /// @googleapis_reference_link{google/cloud/pubsublite/v1/common.proto#L80}
   ///
   StatusOr<google::cloud::pubsublite::v1::Reservation> CreateReservation(
       std::string const& parent,
@@ -297,9 +297,9 @@ class AdminServiceClient {
   /// @googleapis_link{google::cloud::pubsublite::v1::Reservation,google/cloud/pubsublite/v1/common.proto#L80}
   ///
   /// [google.cloud.pubsublite.v1.GetReservationRequest]:
-  /// @googleapis_link{google::cloud::pubsublite::v1::GetReservationRequest,google/cloud/pubsublite/v1/admin.proto#L537}
+  /// @googleapis_reference_link{google/cloud/pubsublite/v1/admin.proto#L537}
   /// [google.cloud.pubsublite.v1.Reservation]:
-  /// @googleapis_link{google::cloud::pubsublite::v1::Reservation,google/cloud/pubsublite/v1/common.proto#L80}
+  /// @googleapis_reference_link{google/cloud/pubsublite/v1/common.proto#L80}
   ///
   StatusOr<google::cloud::pubsublite::v1::Reservation> GetReservation(
       std::string const& name);
@@ -313,9 +313,9 @@ class AdminServiceClient {
   /// @googleapis_link{google::cloud::pubsublite::v1::Reservation,google/cloud/pubsublite/v1/common.proto#L80}
   ///
   /// [google.cloud.pubsublite.v1.ListReservationsRequest]:
-  /// @googleapis_link{google::cloud::pubsublite::v1::ListReservationsRequest,google/cloud/pubsublite/v1/admin.proto#L550}
+  /// @googleapis_reference_link{google/cloud/pubsublite/v1/admin.proto#L550}
   /// [google.cloud.pubsublite.v1.Reservation]:
-  /// @googleapis_link{google::cloud::pubsublite::v1::Reservation,google/cloud/pubsublite/v1/common.proto#L80}
+  /// @googleapis_reference_link{google/cloud/pubsublite/v1/common.proto#L80}
   ///
   StreamRange<google::cloud::pubsublite::v1::Reservation> ListReservations(
       std::string const& parent);
@@ -331,9 +331,9 @@ class AdminServiceClient {
   /// @googleapis_link{google::cloud::pubsublite::v1::Reservation,google/cloud/pubsublite/v1/common.proto#L80}
   ///
   /// [google.cloud.pubsublite.v1.UpdateReservationRequest]:
-  /// @googleapis_link{google::cloud::pubsublite::v1::UpdateReservationRequest,google/cloud/pubsublite/v1/admin.proto#L585}
+  /// @googleapis_reference_link{google/cloud/pubsublite/v1/admin.proto#L585}
   /// [google.cloud.pubsublite.v1.Reservation]:
-  /// @googleapis_link{google::cloud::pubsublite::v1::Reservation,google/cloud/pubsublite/v1/common.proto#L80}
+  /// @googleapis_reference_link{google/cloud/pubsublite/v1/common.proto#L80}
   ///
   StatusOr<google::cloud::pubsublite::v1::Reservation> UpdateReservation(
       google::cloud::pubsublite::v1::Reservation const& reservation,
@@ -347,7 +347,7 @@ class AdminServiceClient {
   ///  projects/{project_number}/locations/{location}/reservations/{reservation_id}
   ///
   /// [google.cloud.pubsublite.v1.DeleteReservationRequest]:
-  /// @googleapis_link{google::cloud::pubsublite::v1::DeleteReservationRequest,google/cloud/pubsublite/v1/admin.proto#L594}
+  /// @googleapis_reference_link{google/cloud/pubsublite/v1/admin.proto#L594}
   ///
   Status DeleteReservation(std::string const& name);
 
@@ -360,7 +360,7 @@ class AdminServiceClient {
   /// @return std::string
   ///
   /// [google.cloud.pubsublite.v1.ListReservationTopicsRequest]:
-  /// @googleapis_link{google::cloud::pubsublite::v1::ListReservationTopicsRequest,google/cloud/pubsublite/v1/admin.proto#L607}
+  /// @googleapis_reference_link{google/cloud/pubsublite/v1/admin.proto#L607}
   ///
   StreamRange<std::string> ListReservationTopics(std::string const& name);
 
@@ -373,9 +373,9 @@ class AdminServiceClient {
   /// @googleapis_link{google::cloud::pubsublite::v1::Topic,google/cloud/pubsublite/v1/common.proto#L102}
   ///
   /// [google.cloud.pubsublite.v1.CreateTopicRequest]:
-  /// @googleapis_link{google::cloud::pubsublite::v1::CreateTopicRequest,google/cloud/pubsublite/v1/admin.proto#L227}
+  /// @googleapis_reference_link{google/cloud/pubsublite/v1/admin.proto#L227}
   /// [google.cloud.pubsublite.v1.Topic]:
-  /// @googleapis_link{google::cloud::pubsublite::v1::Topic,google/cloud/pubsublite/v1/common.proto#L102}
+  /// @googleapis_reference_link{google/cloud/pubsublite/v1/common.proto#L102}
   ///
   StatusOr<google::cloud::pubsublite::v1::Topic> CreateTopic(
       google::cloud::pubsublite::v1::CreateTopicRequest const& request);
@@ -389,9 +389,9 @@ class AdminServiceClient {
   /// @googleapis_link{google::cloud::pubsublite::v1::Topic,google/cloud/pubsublite/v1/common.proto#L102}
   ///
   /// [google.cloud.pubsublite.v1.GetTopicRequest]:
-  /// @googleapis_link{google::cloud::pubsublite::v1::GetTopicRequest,google/cloud/pubsublite/v1/admin.proto#L248}
+  /// @googleapis_reference_link{google/cloud/pubsublite/v1/admin.proto#L248}
   /// [google.cloud.pubsublite.v1.Topic]:
-  /// @googleapis_link{google::cloud::pubsublite::v1::Topic,google/cloud/pubsublite/v1/common.proto#L102}
+  /// @googleapis_reference_link{google/cloud/pubsublite/v1/common.proto#L102}
   ///
   StatusOr<google::cloud::pubsublite::v1::Topic> GetTopic(
       google::cloud::pubsublite::v1::GetTopicRequest const& request);
@@ -405,9 +405,9 @@ class AdminServiceClient {
   /// @googleapis_link{google::cloud::pubsublite::v1::TopicPartitions,google/cloud/pubsublite/v1/admin.proto#L270}
   ///
   /// [google.cloud.pubsublite.v1.GetTopicPartitionsRequest]:
-  /// @googleapis_link{google::cloud::pubsublite::v1::GetTopicPartitionsRequest,google/cloud/pubsublite/v1/admin.proto#L259}
+  /// @googleapis_reference_link{google/cloud/pubsublite/v1/admin.proto#L259}
   /// [google.cloud.pubsublite.v1.TopicPartitions]:
-  /// @googleapis_link{google::cloud::pubsublite::v1::TopicPartitions,google/cloud/pubsublite/v1/admin.proto#L270}
+  /// @googleapis_reference_link{google/cloud/pubsublite/v1/admin.proto#L270}
   ///
   StatusOr<google::cloud::pubsublite::v1::TopicPartitions> GetTopicPartitions(
       google::cloud::pubsublite::v1::GetTopicPartitionsRequest const& request);
@@ -421,9 +421,9 @@ class AdminServiceClient {
   /// @googleapis_link{google::cloud::pubsublite::v1::Topic,google/cloud/pubsublite/v1/common.proto#L102}
   ///
   /// [google.cloud.pubsublite.v1.ListTopicsRequest]:
-  /// @googleapis_link{google::cloud::pubsublite::v1::ListTopicsRequest,google/cloud/pubsublite/v1/admin.proto#L276}
+  /// @googleapis_reference_link{google/cloud/pubsublite/v1/admin.proto#L276}
   /// [google.cloud.pubsublite.v1.Topic]:
-  /// @googleapis_link{google::cloud::pubsublite::v1::Topic,google/cloud/pubsublite/v1/common.proto#L102}
+  /// @googleapis_reference_link{google/cloud/pubsublite/v1/common.proto#L102}
   ///
   StreamRange<google::cloud::pubsublite::v1::Topic> ListTopics(
       google::cloud::pubsublite::v1::ListTopicsRequest request);
@@ -437,9 +437,9 @@ class AdminServiceClient {
   /// @googleapis_link{google::cloud::pubsublite::v1::Topic,google/cloud/pubsublite/v1/common.proto#L102}
   ///
   /// [google.cloud.pubsublite.v1.UpdateTopicRequest]:
-  /// @googleapis_link{google::cloud::pubsublite::v1::UpdateTopicRequest,google/cloud/pubsublite/v1/admin.proto#L311}
+  /// @googleapis_reference_link{google/cloud/pubsublite/v1/admin.proto#L311}
   /// [google.cloud.pubsublite.v1.Topic]:
-  /// @googleapis_link{google::cloud::pubsublite::v1::Topic,google/cloud/pubsublite/v1/common.proto#L102}
+  /// @googleapis_reference_link{google/cloud/pubsublite/v1/common.proto#L102}
   ///
   StatusOr<google::cloud::pubsublite::v1::Topic> UpdateTopic(
       google::cloud::pubsublite::v1::UpdateTopicRequest const& request);
@@ -451,7 +451,7 @@ class AdminServiceClient {
   /// @googleapis_link{google::cloud::pubsublite::v1::DeleteTopicRequest,google/cloud/pubsublite/v1/admin.proto#L320}
   ///
   /// [google.cloud.pubsublite.v1.DeleteTopicRequest]:
-  /// @googleapis_link{google::cloud::pubsublite::v1::DeleteTopicRequest,google/cloud/pubsublite/v1/admin.proto#L320}
+  /// @googleapis_reference_link{google/cloud/pubsublite/v1/admin.proto#L320}
   ///
   Status DeleteTopic(
       google::cloud::pubsublite::v1::DeleteTopicRequest const& request);
@@ -464,7 +464,7 @@ class AdminServiceClient {
   /// @return std::string
   ///
   /// [google.cloud.pubsublite.v1.ListTopicSubscriptionsRequest]:
-  /// @googleapis_link{google::cloud::pubsublite::v1::ListTopicSubscriptionsRequest,google/cloud/pubsublite/v1/admin.proto#L331}
+  /// @googleapis_reference_link{google/cloud/pubsublite/v1/admin.proto#L331}
   ///
   StreamRange<std::string> ListTopicSubscriptions(
       google::cloud::pubsublite::v1::ListTopicSubscriptionsRequest request);
@@ -478,9 +478,9 @@ class AdminServiceClient {
   /// @googleapis_link{google::cloud::pubsublite::v1::Subscription,google/cloud/pubsublite/v1/common.proto#L186}
   ///
   /// [google.cloud.pubsublite.v1.CreateSubscriptionRequest]:
-  /// @googleapis_link{google::cloud::pubsublite::v1::CreateSubscriptionRequest,google/cloud/pubsublite/v1/admin.proto#L365}
+  /// @googleapis_reference_link{google/cloud/pubsublite/v1/admin.proto#L365}
   /// [google.cloud.pubsublite.v1.Subscription]:
-  /// @googleapis_link{google::cloud::pubsublite::v1::Subscription,google/cloud/pubsublite/v1/common.proto#L186}
+  /// @googleapis_reference_link{google/cloud/pubsublite/v1/common.proto#L186}
   ///
   StatusOr<google::cloud::pubsublite::v1::Subscription> CreateSubscription(
       google::cloud::pubsublite::v1::CreateSubscriptionRequest const& request);
@@ -494,9 +494,9 @@ class AdminServiceClient {
   /// @googleapis_link{google::cloud::pubsublite::v1::Subscription,google/cloud/pubsublite/v1/common.proto#L186}
   ///
   /// [google.cloud.pubsublite.v1.GetSubscriptionRequest]:
-  /// @googleapis_link{google::cloud::pubsublite::v1::GetSubscriptionRequest,google/cloud/pubsublite/v1/admin.proto#L391}
+  /// @googleapis_reference_link{google/cloud/pubsublite/v1/admin.proto#L391}
   /// [google.cloud.pubsublite.v1.Subscription]:
-  /// @googleapis_link{google::cloud::pubsublite::v1::Subscription,google/cloud/pubsublite/v1/common.proto#L186}
+  /// @googleapis_reference_link{google/cloud/pubsublite/v1/common.proto#L186}
   ///
   StatusOr<google::cloud::pubsublite::v1::Subscription> GetSubscription(
       google::cloud::pubsublite::v1::GetSubscriptionRequest const& request);
@@ -510,9 +510,9 @@ class AdminServiceClient {
   /// @googleapis_link{google::cloud::pubsublite::v1::Subscription,google/cloud/pubsublite/v1/common.proto#L186}
   ///
   /// [google.cloud.pubsublite.v1.ListSubscriptionsRequest]:
-  /// @googleapis_link{google::cloud::pubsublite::v1::ListSubscriptionsRequest,google/cloud/pubsublite/v1/admin.proto#L402}
+  /// @googleapis_reference_link{google/cloud/pubsublite/v1/admin.proto#L402}
   /// [google.cloud.pubsublite.v1.Subscription]:
-  /// @googleapis_link{google::cloud::pubsublite::v1::Subscription,google/cloud/pubsublite/v1/common.proto#L186}
+  /// @googleapis_reference_link{google/cloud/pubsublite/v1/common.proto#L186}
   ///
   StreamRange<google::cloud::pubsublite::v1::Subscription> ListSubscriptions(
       google::cloud::pubsublite::v1::ListSubscriptionsRequest request);
@@ -526,9 +526,9 @@ class AdminServiceClient {
   /// @googleapis_link{google::cloud::pubsublite::v1::Subscription,google/cloud/pubsublite/v1/common.proto#L186}
   ///
   /// [google.cloud.pubsublite.v1.UpdateSubscriptionRequest]:
-  /// @googleapis_link{google::cloud::pubsublite::v1::UpdateSubscriptionRequest,google/cloud/pubsublite/v1/admin.proto#L437}
+  /// @googleapis_reference_link{google/cloud/pubsublite/v1/admin.proto#L437}
   /// [google.cloud.pubsublite.v1.Subscription]:
-  /// @googleapis_link{google::cloud::pubsublite::v1::Subscription,google/cloud/pubsublite/v1/common.proto#L186}
+  /// @googleapis_reference_link{google/cloud/pubsublite/v1/common.proto#L186}
   ///
   StatusOr<google::cloud::pubsublite::v1::Subscription> UpdateSubscription(
       google::cloud::pubsublite::v1::UpdateSubscriptionRequest const& request);
@@ -540,7 +540,7 @@ class AdminServiceClient {
   /// @googleapis_link{google::cloud::pubsublite::v1::DeleteSubscriptionRequest,google/cloud/pubsublite/v1/admin.proto#L447}
   ///
   /// [google.cloud.pubsublite.v1.DeleteSubscriptionRequest]:
-  /// @googleapis_link{google::cloud::pubsublite::v1::DeleteSubscriptionRequest,google/cloud/pubsublite/v1/admin.proto#L447}
+  /// @googleapis_reference_link{google/cloud/pubsublite/v1/admin.proto#L447}
   ///
   Status DeleteSubscription(
       google::cloud::pubsublite::v1::DeleteSubscriptionRequest const& request);
@@ -574,9 +574,9 @@ class AdminServiceClient {
   /// @googleapis_link{google::cloud::pubsublite::v1::SeekSubscriptionResponse,google/cloud/pubsublite/v1/admin.proto#L493}
   ///
   /// [google.cloud.pubsublite.v1.SeekSubscriptionRequest]:
-  /// @googleapis_link{google::cloud::pubsublite::v1::SeekSubscriptionRequest,google/cloud/pubsublite/v1/admin.proto#L458}
+  /// @googleapis_reference_link{google/cloud/pubsublite/v1/admin.proto#L458}
   /// [google.cloud.pubsublite.v1.SeekSubscriptionResponse]:
-  /// @googleapis_link{google::cloud::pubsublite::v1::SeekSubscriptionResponse,google/cloud/pubsublite/v1/admin.proto#L493}
+  /// @googleapis_reference_link{google/cloud/pubsublite/v1/admin.proto#L493}
   ///
   future<StatusOr<google::cloud::pubsublite::v1::SeekSubscriptionResponse>>
   SeekSubscription(
@@ -591,9 +591,9 @@ class AdminServiceClient {
   /// @googleapis_link{google::cloud::pubsublite::v1::Reservation,google/cloud/pubsublite/v1/common.proto#L80}
   ///
   /// [google.cloud.pubsublite.v1.CreateReservationRequest]:
-  /// @googleapis_link{google::cloud::pubsublite::v1::CreateReservationRequest,google/cloud/pubsublite/v1/admin.proto#L516}
+  /// @googleapis_reference_link{google/cloud/pubsublite/v1/admin.proto#L516}
   /// [google.cloud.pubsublite.v1.Reservation]:
-  /// @googleapis_link{google::cloud::pubsublite::v1::Reservation,google/cloud/pubsublite/v1/common.proto#L80}
+  /// @googleapis_reference_link{google/cloud/pubsublite/v1/common.proto#L80}
   ///
   StatusOr<google::cloud::pubsublite::v1::Reservation> CreateReservation(
       google::cloud::pubsublite::v1::CreateReservationRequest const& request);
@@ -607,9 +607,9 @@ class AdminServiceClient {
   /// @googleapis_link{google::cloud::pubsublite::v1::Reservation,google/cloud/pubsublite/v1/common.proto#L80}
   ///
   /// [google.cloud.pubsublite.v1.GetReservationRequest]:
-  /// @googleapis_link{google::cloud::pubsublite::v1::GetReservationRequest,google/cloud/pubsublite/v1/admin.proto#L537}
+  /// @googleapis_reference_link{google/cloud/pubsublite/v1/admin.proto#L537}
   /// [google.cloud.pubsublite.v1.Reservation]:
-  /// @googleapis_link{google::cloud::pubsublite::v1::Reservation,google/cloud/pubsublite/v1/common.proto#L80}
+  /// @googleapis_reference_link{google/cloud/pubsublite/v1/common.proto#L80}
   ///
   StatusOr<google::cloud::pubsublite::v1::Reservation> GetReservation(
       google::cloud::pubsublite::v1::GetReservationRequest const& request);
@@ -623,9 +623,9 @@ class AdminServiceClient {
   /// @googleapis_link{google::cloud::pubsublite::v1::Reservation,google/cloud/pubsublite/v1/common.proto#L80}
   ///
   /// [google.cloud.pubsublite.v1.ListReservationsRequest]:
-  /// @googleapis_link{google::cloud::pubsublite::v1::ListReservationsRequest,google/cloud/pubsublite/v1/admin.proto#L550}
+  /// @googleapis_reference_link{google/cloud/pubsublite/v1/admin.proto#L550}
   /// [google.cloud.pubsublite.v1.Reservation]:
-  /// @googleapis_link{google::cloud::pubsublite::v1::Reservation,google/cloud/pubsublite/v1/common.proto#L80}
+  /// @googleapis_reference_link{google/cloud/pubsublite/v1/common.proto#L80}
   ///
   StreamRange<google::cloud::pubsublite::v1::Reservation> ListReservations(
       google::cloud::pubsublite::v1::ListReservationsRequest request);
@@ -639,9 +639,9 @@ class AdminServiceClient {
   /// @googleapis_link{google::cloud::pubsublite::v1::Reservation,google/cloud/pubsublite/v1/common.proto#L80}
   ///
   /// [google.cloud.pubsublite.v1.UpdateReservationRequest]:
-  /// @googleapis_link{google::cloud::pubsublite::v1::UpdateReservationRequest,google/cloud/pubsublite/v1/admin.proto#L585}
+  /// @googleapis_reference_link{google/cloud/pubsublite/v1/admin.proto#L585}
   /// [google.cloud.pubsublite.v1.Reservation]:
-  /// @googleapis_link{google::cloud::pubsublite::v1::Reservation,google/cloud/pubsublite/v1/common.proto#L80}
+  /// @googleapis_reference_link{google/cloud/pubsublite/v1/common.proto#L80}
   ///
   StatusOr<google::cloud::pubsublite::v1::Reservation> UpdateReservation(
       google::cloud::pubsublite::v1::UpdateReservationRequest const& request);
@@ -653,7 +653,7 @@ class AdminServiceClient {
   /// @googleapis_link{google::cloud::pubsublite::v1::DeleteReservationRequest,google/cloud/pubsublite/v1/admin.proto#L594}
   ///
   /// [google.cloud.pubsublite.v1.DeleteReservationRequest]:
-  /// @googleapis_link{google::cloud::pubsublite::v1::DeleteReservationRequest,google/cloud/pubsublite/v1/admin.proto#L594}
+  /// @googleapis_reference_link{google/cloud/pubsublite/v1/admin.proto#L594}
   ///
   Status DeleteReservation(
       google::cloud::pubsublite::v1::DeleteReservationRequest const& request);
@@ -666,7 +666,7 @@ class AdminServiceClient {
   /// @return std::string
   ///
   /// [google.cloud.pubsublite.v1.ListReservationTopicsRequest]:
-  /// @googleapis_link{google::cloud::pubsublite::v1::ListReservationTopicsRequest,google/cloud/pubsublite/v1/admin.proto#L607}
+  /// @googleapis_reference_link{google/cloud/pubsublite/v1/admin.proto#L607}
   ///
   StreamRange<std::string> ListReservationTopics(
       google::cloud::pubsublite::v1::ListReservationTopicsRequest request);

--- a/google/cloud/pubsublite/admin_client.h
+++ b/google/cloud/pubsublite/admin_client.h
@@ -77,6 +77,11 @@ class AdminServiceClient {
   /// @return
   /// @googleapis_link{google::cloud::pubsublite::v1::Topic,google/cloud/pubsublite/v1/common.proto#L102}
   ///
+  /// [google.cloud.pubsublite.v1.CreateTopicRequest]:
+  /// @googleapis_link{google::cloud::pubsublite::v1::CreateTopicRequest,google/cloud/pubsublite/v1/admin.proto#L227}
+  /// [google.cloud.pubsublite.v1.Topic]:
+  /// @googleapis_link{google::cloud::pubsublite::v1::Topic,google/cloud/pubsublite/v1/common.proto#L102}
+  ///
   StatusOr<google::cloud::pubsublite::v1::Topic> CreateTopic(
       std::string const& parent,
       google::cloud::pubsublite::v1::Topic const& topic,
@@ -90,6 +95,11 @@ class AdminServiceClient {
   /// @return
   /// @googleapis_link{google::cloud::pubsublite::v1::Topic,google/cloud/pubsublite/v1/common.proto#L102}
   ///
+  /// [google.cloud.pubsublite.v1.GetTopicRequest]:
+  /// @googleapis_link{google::cloud::pubsublite::v1::GetTopicRequest,google/cloud/pubsublite/v1/admin.proto#L248}
+  /// [google.cloud.pubsublite.v1.Topic]:
+  /// @googleapis_link{google::cloud::pubsublite::v1::Topic,google/cloud/pubsublite/v1/common.proto#L102}
+  ///
   StatusOr<google::cloud::pubsublite::v1::Topic> GetTopic(
       std::string const& name);
 
@@ -98,6 +108,11 @@ class AdminServiceClient {
   ///
   /// @param name  Required. The topic whose partition information to return.
   /// @return
+  /// @googleapis_link{google::cloud::pubsublite::v1::TopicPartitions,google/cloud/pubsublite/v1/admin.proto#L270}
+  ///
+  /// [google.cloud.pubsublite.v1.GetTopicPartitionsRequest]:
+  /// @googleapis_link{google::cloud::pubsublite::v1::GetTopicPartitionsRequest,google/cloud/pubsublite/v1/admin.proto#L259}
+  /// [google.cloud.pubsublite.v1.TopicPartitions]:
   /// @googleapis_link{google::cloud::pubsublite::v1::TopicPartitions,google/cloud/pubsublite/v1/admin.proto#L270}
   ///
   StatusOr<google::cloud::pubsublite::v1::TopicPartitions> GetTopicPartitions(
@@ -109,6 +124,11 @@ class AdminServiceClient {
   /// @param parent  Required. The parent whose topics are to be listed.
   ///  Structured like `projects/{project_number}/locations/{location}`.
   /// @return
+  /// @googleapis_link{google::cloud::pubsublite::v1::Topic,google/cloud/pubsublite/v1/common.proto#L102}
+  ///
+  /// [google.cloud.pubsublite.v1.ListTopicsRequest]:
+  /// @googleapis_link{google::cloud::pubsublite::v1::ListTopicsRequest,google/cloud/pubsublite/v1/admin.proto#L276}
+  /// [google::cloud::pubsublite::v1::Topic]:
   /// @googleapis_link{google::cloud::pubsublite::v1::Topic,google/cloud/pubsublite/v1/common.proto#L102}
   ///
   StreamRange<google::cloud::pubsublite::v1::Topic> ListTopics(
@@ -124,6 +144,11 @@ class AdminServiceClient {
   /// @return
   /// @googleapis_link{google::cloud::pubsublite::v1::Topic,google/cloud/pubsublite/v1/common.proto#L102}
   ///
+  /// [google.cloud.pubsublite.v1.UpdateTopicRequest]:
+  /// @googleapis_link{google::cloud::pubsublite::v1::UpdateTopicRequest,google/cloud/pubsublite/v1/admin.proto#L311}
+  /// [google.cloud.pubsublite.v1.Topic]:
+  /// @googleapis_link{google::cloud::pubsublite::v1::Topic,google/cloud/pubsublite/v1/common.proto#L102}
+  ///
   StatusOr<google::cloud::pubsublite::v1::Topic> UpdateTopic(
       google::cloud::pubsublite::v1::Topic const& topic,
       google::protobuf::FieldMask const& update_mask);
@@ -133,6 +158,9 @@ class AdminServiceClient {
   ///
   /// @param name  Required. The name of the topic to delete.
   ///
+  /// [google.cloud.pubsublite.v1.DeleteTopicRequest]:
+  /// @googleapis_link{google::cloud::pubsublite::v1::DeleteTopicRequest,google/cloud/pubsublite/v1/admin.proto#L320}
+  ///
   Status DeleteTopic(std::string const& name);
 
   ///
@@ -140,6 +168,10 @@ class AdminServiceClient {
   ///
   /// @param name  Required. The name of the topic whose subscriptions to list.
   /// @return std::string
+  ///
+  /// [google.cloud.pubsublite.v1.ListTopicSubscriptionsRequest]:
+  /// @googleapis_link{google::cloud::pubsublite::v1::ListTopicSubscriptionsRequest,google/cloud/pubsublite/v1/admin.proto#L331}
+  /// [std::string]: std::string
   ///
   StreamRange<std::string> ListTopicSubscriptions(std::string const& name);
 
@@ -158,6 +190,11 @@ class AdminServiceClient {
   /// @return
   /// @googleapis_link{google::cloud::pubsublite::v1::Subscription,google/cloud/pubsublite/v1/common.proto#L186}
   ///
+  /// [google.cloud.pubsublite.v1.CreateSubscriptionRequest]:
+  /// @googleapis_link{google::cloud::pubsublite::v1::CreateSubscriptionRequest,google/cloud/pubsublite/v1/admin.proto#L365}
+  /// [google.cloud.pubsublite.v1.Subscription]:
+  /// @googleapis_link{google::cloud::pubsublite::v1::Subscription,google/cloud/pubsublite/v1/common.proto#L186}
+  ///
   StatusOr<google::cloud::pubsublite::v1::Subscription> CreateSubscription(
       std::string const& parent,
       google::cloud::pubsublite::v1::Subscription const& subscription,
@@ -171,6 +208,11 @@ class AdminServiceClient {
   /// @return
   /// @googleapis_link{google::cloud::pubsublite::v1::Subscription,google/cloud/pubsublite/v1/common.proto#L186}
   ///
+  /// [google.cloud.pubsublite.v1.GetSubscriptionRequest]:
+  /// @googleapis_link{google::cloud::pubsublite::v1::GetSubscriptionRequest,google/cloud/pubsublite/v1/admin.proto#L391}
+  /// [google.cloud.pubsublite.v1.Subscription]:
+  /// @googleapis_link{google::cloud::pubsublite::v1::Subscription,google/cloud/pubsublite/v1/common.proto#L186}
+  ///
   StatusOr<google::cloud::pubsublite::v1::Subscription> GetSubscription(
       std::string const& name);
 
@@ -180,6 +222,11 @@ class AdminServiceClient {
   /// @param parent  Required. The parent whose subscriptions are to be listed.
   ///  Structured like `projects/{project_number}/locations/{location}`.
   /// @return
+  /// @googleapis_link{google::cloud::pubsublite::v1::Subscription,google/cloud/pubsublite/v1/common.proto#L186}
+  ///
+  /// [google.cloud.pubsublite.v1.ListSubscriptionsRequest]:
+  /// @googleapis_link{google::cloud::pubsublite::v1::ListSubscriptionsRequest,google/cloud/pubsublite/v1/admin.proto#L402}
+  /// [google::cloud::pubsublite::v1::Subscription]:
   /// @googleapis_link{google::cloud::pubsublite::v1::Subscription,google/cloud/pubsublite/v1/common.proto#L186}
   ///
   StreamRange<google::cloud::pubsublite::v1::Subscription> ListSubscriptions(
@@ -196,6 +243,11 @@ class AdminServiceClient {
   /// @return
   /// @googleapis_link{google::cloud::pubsublite::v1::Subscription,google/cloud/pubsublite/v1/common.proto#L186}
   ///
+  /// [google.cloud.pubsublite.v1.UpdateSubscriptionRequest]:
+  /// @googleapis_link{google::cloud::pubsublite::v1::UpdateSubscriptionRequest,google/cloud/pubsublite/v1/admin.proto#L437}
+  /// [google.cloud.pubsublite.v1.Subscription]:
+  /// @googleapis_link{google::cloud::pubsublite::v1::Subscription,google/cloud/pubsublite/v1/common.proto#L186}
+  ///
   StatusOr<google::cloud::pubsublite::v1::Subscription> UpdateSubscription(
       google::cloud::pubsublite::v1::Subscription const& subscription,
       google::protobuf::FieldMask const& update_mask);
@@ -204,6 +256,9 @@ class AdminServiceClient {
   /// Deletes the specified subscription.
   ///
   /// @param name  Required. The name of the subscription to delete.
+  ///
+  /// [google.cloud.pubsublite.v1.DeleteSubscriptionRequest]:
+  /// @googleapis_link{google::cloud::pubsublite::v1::DeleteSubscriptionRequest,google/cloud/pubsublite/v1/admin.proto#L447}
   ///
   Status DeleteSubscription(std::string const& name);
 
@@ -222,6 +277,11 @@ class AdminServiceClient {
   /// @return
   /// @googleapis_link{google::cloud::pubsublite::v1::Reservation,google/cloud/pubsublite/v1/common.proto#L80}
   ///
+  /// [google.cloud.pubsublite.v1.CreateReservationRequest]:
+  /// @googleapis_link{google::cloud::pubsublite::v1::CreateReservationRequest,google/cloud/pubsublite/v1/admin.proto#L516}
+  /// [google.cloud.pubsublite.v1.Reservation]:
+  /// @googleapis_link{google::cloud::pubsublite::v1::Reservation,google/cloud/pubsublite/v1/common.proto#L80}
+  ///
   StatusOr<google::cloud::pubsublite::v1::Reservation> CreateReservation(
       std::string const& parent,
       google::cloud::pubsublite::v1::Reservation const& reservation,
@@ -237,6 +297,11 @@ class AdminServiceClient {
   /// @return
   /// @googleapis_link{google::cloud::pubsublite::v1::Reservation,google/cloud/pubsublite/v1/common.proto#L80}
   ///
+  /// [google.cloud.pubsublite.v1.GetReservationRequest]:
+  /// @googleapis_link{google::cloud::pubsublite::v1::GetReservationRequest,google/cloud/pubsublite/v1/admin.proto#L537}
+  /// [google.cloud.pubsublite.v1.Reservation]:
+  /// @googleapis_link{google::cloud::pubsublite::v1::Reservation,google/cloud/pubsublite/v1/common.proto#L80}
+  ///
   StatusOr<google::cloud::pubsublite::v1::Reservation> GetReservation(
       std::string const& name);
 
@@ -246,6 +311,11 @@ class AdminServiceClient {
   /// @param parent  Required. The parent whose reservations are to be listed.
   ///  Structured like `projects/{project_number}/locations/{location}`.
   /// @return
+  /// @googleapis_link{google::cloud::pubsublite::v1::Reservation,google/cloud/pubsublite/v1/common.proto#L80}
+  ///
+  /// [google.cloud.pubsublite.v1.ListReservationsRequest]:
+  /// @googleapis_link{google::cloud::pubsublite::v1::ListReservationsRequest,google/cloud/pubsublite/v1/admin.proto#L550}
+  /// [google::cloud::pubsublite::v1::Reservation]:
   /// @googleapis_link{google::cloud::pubsublite::v1::Reservation,google/cloud/pubsublite/v1/common.proto#L80}
   ///
   StreamRange<google::cloud::pubsublite::v1::Reservation> ListReservations(
@@ -261,6 +331,11 @@ class AdminServiceClient {
   /// @return
   /// @googleapis_link{google::cloud::pubsublite::v1::Reservation,google/cloud/pubsublite/v1/common.proto#L80}
   ///
+  /// [google.cloud.pubsublite.v1.UpdateReservationRequest]:
+  /// @googleapis_link{google::cloud::pubsublite::v1::UpdateReservationRequest,google/cloud/pubsublite/v1/admin.proto#L585}
+  /// [google.cloud.pubsublite.v1.Reservation]:
+  /// @googleapis_link{google::cloud::pubsublite::v1::Reservation,google/cloud/pubsublite/v1/common.proto#L80}
+  ///
   StatusOr<google::cloud::pubsublite::v1::Reservation> UpdateReservation(
       google::cloud::pubsublite::v1::Reservation const& reservation,
       google::protobuf::FieldMask const& update_mask);
@@ -272,6 +347,9 @@ class AdminServiceClient {
   ///  Structured like:
   ///  projects/{project_number}/locations/{location}/reservations/{reservation_id}
   ///
+  /// [google.cloud.pubsublite.v1.DeleteReservationRequest]:
+  /// @googleapis_link{google::cloud::pubsublite::v1::DeleteReservationRequest,google/cloud/pubsublite/v1/admin.proto#L594}
+  ///
   Status DeleteReservation(std::string const& name);
 
   ///
@@ -282,6 +360,10 @@ class AdminServiceClient {
   ///  projects/{project_number}/locations/{location}/reservations/{reservation_id}
   /// @return std::string
   ///
+  /// [google.cloud.pubsublite.v1.ListReservationTopicsRequest]:
+  /// @googleapis_link{google::cloud::pubsublite::v1::ListReservationTopicsRequest,google/cloud/pubsublite/v1/admin.proto#L607}
+  /// [std::string]: std::string
+  ///
   StreamRange<std::string> ListReservationTopics(std::string const& name);
 
   ///
@@ -290,6 +372,11 @@ class AdminServiceClient {
   /// @param request
   /// @googleapis_link{google::cloud::pubsublite::v1::CreateTopicRequest,google/cloud/pubsublite/v1/admin.proto#L227}
   /// @return
+  /// @googleapis_link{google::cloud::pubsublite::v1::Topic,google/cloud/pubsublite/v1/common.proto#L102}
+  ///
+  /// [google.cloud.pubsublite.v1.CreateTopicRequest]:
+  /// @googleapis_link{google::cloud::pubsublite::v1::CreateTopicRequest,google/cloud/pubsublite/v1/admin.proto#L227}
+  /// [google.cloud.pubsublite.v1.Topic]:
   /// @googleapis_link{google::cloud::pubsublite::v1::Topic,google/cloud/pubsublite/v1/common.proto#L102}
   ///
   StatusOr<google::cloud::pubsublite::v1::Topic> CreateTopic(
@@ -303,6 +390,11 @@ class AdminServiceClient {
   /// @return
   /// @googleapis_link{google::cloud::pubsublite::v1::Topic,google/cloud/pubsublite/v1/common.proto#L102}
   ///
+  /// [google.cloud.pubsublite.v1.GetTopicRequest]:
+  /// @googleapis_link{google::cloud::pubsublite::v1::GetTopicRequest,google/cloud/pubsublite/v1/admin.proto#L248}
+  /// [google.cloud.pubsublite.v1.Topic]:
+  /// @googleapis_link{google::cloud::pubsublite::v1::Topic,google/cloud/pubsublite/v1/common.proto#L102}
+  ///
   StatusOr<google::cloud::pubsublite::v1::Topic> GetTopic(
       google::cloud::pubsublite::v1::GetTopicRequest const& request);
 
@@ -312,6 +404,11 @@ class AdminServiceClient {
   /// @param request
   /// @googleapis_link{google::cloud::pubsublite::v1::GetTopicPartitionsRequest,google/cloud/pubsublite/v1/admin.proto#L259}
   /// @return
+  /// @googleapis_link{google::cloud::pubsublite::v1::TopicPartitions,google/cloud/pubsublite/v1/admin.proto#L270}
+  ///
+  /// [google.cloud.pubsublite.v1.GetTopicPartitionsRequest]:
+  /// @googleapis_link{google::cloud::pubsublite::v1::GetTopicPartitionsRequest,google/cloud/pubsublite/v1/admin.proto#L259}
+  /// [google.cloud.pubsublite.v1.TopicPartitions]:
   /// @googleapis_link{google::cloud::pubsublite::v1::TopicPartitions,google/cloud/pubsublite/v1/admin.proto#L270}
   ///
   StatusOr<google::cloud::pubsublite::v1::TopicPartitions> GetTopicPartitions(
@@ -325,6 +422,11 @@ class AdminServiceClient {
   /// @return
   /// @googleapis_link{google::cloud::pubsublite::v1::Topic,google/cloud/pubsublite/v1/common.proto#L102}
   ///
+  /// [google.cloud.pubsublite.v1.ListTopicsRequest]:
+  /// @googleapis_link{google::cloud::pubsublite::v1::ListTopicsRequest,google/cloud/pubsublite/v1/admin.proto#L276}
+  /// [google::cloud::pubsublite::v1::Topic]:
+  /// @googleapis_link{google::cloud::pubsublite::v1::Topic,google/cloud/pubsublite/v1/common.proto#L102}
+  ///
   StreamRange<google::cloud::pubsublite::v1::Topic> ListTopics(
       google::cloud::pubsublite::v1::ListTopicsRequest request);
 
@@ -336,6 +438,11 @@ class AdminServiceClient {
   /// @return
   /// @googleapis_link{google::cloud::pubsublite::v1::Topic,google/cloud/pubsublite/v1/common.proto#L102}
   ///
+  /// [google.cloud.pubsublite.v1.UpdateTopicRequest]:
+  /// @googleapis_link{google::cloud::pubsublite::v1::UpdateTopicRequest,google/cloud/pubsublite/v1/admin.proto#L311}
+  /// [google.cloud.pubsublite.v1.Topic]:
+  /// @googleapis_link{google::cloud::pubsublite::v1::Topic,google/cloud/pubsublite/v1/common.proto#L102}
+  ///
   StatusOr<google::cloud::pubsublite::v1::Topic> UpdateTopic(
       google::cloud::pubsublite::v1::UpdateTopicRequest const& request);
 
@@ -343,6 +450,9 @@ class AdminServiceClient {
   /// Deletes the specified topic.
   ///
   /// @param request
+  /// @googleapis_link{google::cloud::pubsublite::v1::DeleteTopicRequest,google/cloud/pubsublite/v1/admin.proto#L320}
+  ///
+  /// [google.cloud.pubsublite.v1.DeleteTopicRequest]:
   /// @googleapis_link{google::cloud::pubsublite::v1::DeleteTopicRequest,google/cloud/pubsublite/v1/admin.proto#L320}
   ///
   Status DeleteTopic(
@@ -355,6 +465,10 @@ class AdminServiceClient {
   /// @googleapis_link{google::cloud::pubsublite::v1::ListTopicSubscriptionsRequest,google/cloud/pubsublite/v1/admin.proto#L331}
   /// @return std::string
   ///
+  /// [google.cloud.pubsublite.v1.ListTopicSubscriptionsRequest]:
+  /// @googleapis_link{google::cloud::pubsublite::v1::ListTopicSubscriptionsRequest,google/cloud/pubsublite/v1/admin.proto#L331}
+  /// [std::string]: std::string
+  ///
   StreamRange<std::string> ListTopicSubscriptions(
       google::cloud::pubsublite::v1::ListTopicSubscriptionsRequest request);
 
@@ -364,6 +478,11 @@ class AdminServiceClient {
   /// @param request
   /// @googleapis_link{google::cloud::pubsublite::v1::CreateSubscriptionRequest,google/cloud/pubsublite/v1/admin.proto#L365}
   /// @return
+  /// @googleapis_link{google::cloud::pubsublite::v1::Subscription,google/cloud/pubsublite/v1/common.proto#L186}
+  ///
+  /// [google.cloud.pubsublite.v1.CreateSubscriptionRequest]:
+  /// @googleapis_link{google::cloud::pubsublite::v1::CreateSubscriptionRequest,google/cloud/pubsublite/v1/admin.proto#L365}
+  /// [google.cloud.pubsublite.v1.Subscription]:
   /// @googleapis_link{google::cloud::pubsublite::v1::Subscription,google/cloud/pubsublite/v1/common.proto#L186}
   ///
   StatusOr<google::cloud::pubsublite::v1::Subscription> CreateSubscription(
@@ -377,6 +496,11 @@ class AdminServiceClient {
   /// @return
   /// @googleapis_link{google::cloud::pubsublite::v1::Subscription,google/cloud/pubsublite/v1/common.proto#L186}
   ///
+  /// [google.cloud.pubsublite.v1.GetSubscriptionRequest]:
+  /// @googleapis_link{google::cloud::pubsublite::v1::GetSubscriptionRequest,google/cloud/pubsublite/v1/admin.proto#L391}
+  /// [google.cloud.pubsublite.v1.Subscription]:
+  /// @googleapis_link{google::cloud::pubsublite::v1::Subscription,google/cloud/pubsublite/v1/common.proto#L186}
+  ///
   StatusOr<google::cloud::pubsublite::v1::Subscription> GetSubscription(
       google::cloud::pubsublite::v1::GetSubscriptionRequest const& request);
 
@@ -386,6 +510,11 @@ class AdminServiceClient {
   /// @param request
   /// @googleapis_link{google::cloud::pubsublite::v1::ListSubscriptionsRequest,google/cloud/pubsublite/v1/admin.proto#L402}
   /// @return
+  /// @googleapis_link{google::cloud::pubsublite::v1::Subscription,google/cloud/pubsublite/v1/common.proto#L186}
+  ///
+  /// [google.cloud.pubsublite.v1.ListSubscriptionsRequest]:
+  /// @googleapis_link{google::cloud::pubsublite::v1::ListSubscriptionsRequest,google/cloud/pubsublite/v1/admin.proto#L402}
+  /// [google::cloud::pubsublite::v1::Subscription]:
   /// @googleapis_link{google::cloud::pubsublite::v1::Subscription,google/cloud/pubsublite/v1/common.proto#L186}
   ///
   StreamRange<google::cloud::pubsublite::v1::Subscription> ListSubscriptions(
@@ -399,6 +528,11 @@ class AdminServiceClient {
   /// @return
   /// @googleapis_link{google::cloud::pubsublite::v1::Subscription,google/cloud/pubsublite/v1/common.proto#L186}
   ///
+  /// [google.cloud.pubsublite.v1.UpdateSubscriptionRequest]:
+  /// @googleapis_link{google::cloud::pubsublite::v1::UpdateSubscriptionRequest,google/cloud/pubsublite/v1/admin.proto#L437}
+  /// [google.cloud.pubsublite.v1.Subscription]:
+  /// @googleapis_link{google::cloud::pubsublite::v1::Subscription,google/cloud/pubsublite/v1/common.proto#L186}
+  ///
   StatusOr<google::cloud::pubsublite::v1::Subscription> UpdateSubscription(
       google::cloud::pubsublite::v1::UpdateSubscriptionRequest const& request);
 
@@ -406,6 +540,9 @@ class AdminServiceClient {
   /// Deletes the specified subscription.
   ///
   /// @param request
+  /// @googleapis_link{google::cloud::pubsublite::v1::DeleteSubscriptionRequest,google/cloud/pubsublite/v1/admin.proto#L447}
+  ///
+  /// [google.cloud.pubsublite.v1.DeleteSubscriptionRequest]:
   /// @googleapis_link{google::cloud::pubsublite::v1::DeleteSubscriptionRequest,google/cloud/pubsublite/v1/admin.proto#L447}
   ///
   Status DeleteSubscription(
@@ -439,6 +576,11 @@ class AdminServiceClient {
   /// @return
   /// @googleapis_link{google::cloud::pubsublite::v1::SeekSubscriptionResponse,google/cloud/pubsublite/v1/admin.proto#L493}
   ///
+  /// [google.cloud.pubsublite.v1.SeekSubscriptionRequest]:
+  /// @googleapis_link{google::cloud::pubsublite::v1::SeekSubscriptionRequest,google/cloud/pubsublite/v1/admin.proto#L458}
+  /// [google.cloud.pubsublite.v1.SeekSubscriptionResponse]:
+  /// @googleapis_link{google::cloud::pubsublite::v1::SeekSubscriptionResponse,google/cloud/pubsublite/v1/admin.proto#L493}
+  ///
   future<StatusOr<google::cloud::pubsublite::v1::SeekSubscriptionResponse>>
   SeekSubscription(
       google::cloud::pubsublite::v1::SeekSubscriptionRequest const& request);
@@ -449,6 +591,11 @@ class AdminServiceClient {
   /// @param request
   /// @googleapis_link{google::cloud::pubsublite::v1::CreateReservationRequest,google/cloud/pubsublite/v1/admin.proto#L516}
   /// @return
+  /// @googleapis_link{google::cloud::pubsublite::v1::Reservation,google/cloud/pubsublite/v1/common.proto#L80}
+  ///
+  /// [google.cloud.pubsublite.v1.CreateReservationRequest]:
+  /// @googleapis_link{google::cloud::pubsublite::v1::CreateReservationRequest,google/cloud/pubsublite/v1/admin.proto#L516}
+  /// [google.cloud.pubsublite.v1.Reservation]:
   /// @googleapis_link{google::cloud::pubsublite::v1::Reservation,google/cloud/pubsublite/v1/common.proto#L80}
   ///
   StatusOr<google::cloud::pubsublite::v1::Reservation> CreateReservation(
@@ -462,6 +609,11 @@ class AdminServiceClient {
   /// @return
   /// @googleapis_link{google::cloud::pubsublite::v1::Reservation,google/cloud/pubsublite/v1/common.proto#L80}
   ///
+  /// [google.cloud.pubsublite.v1.GetReservationRequest]:
+  /// @googleapis_link{google::cloud::pubsublite::v1::GetReservationRequest,google/cloud/pubsublite/v1/admin.proto#L537}
+  /// [google.cloud.pubsublite.v1.Reservation]:
+  /// @googleapis_link{google::cloud::pubsublite::v1::Reservation,google/cloud/pubsublite/v1/common.proto#L80}
+  ///
   StatusOr<google::cloud::pubsublite::v1::Reservation> GetReservation(
       google::cloud::pubsublite::v1::GetReservationRequest const& request);
 
@@ -471,6 +623,11 @@ class AdminServiceClient {
   /// @param request
   /// @googleapis_link{google::cloud::pubsublite::v1::ListReservationsRequest,google/cloud/pubsublite/v1/admin.proto#L550}
   /// @return
+  /// @googleapis_link{google::cloud::pubsublite::v1::Reservation,google/cloud/pubsublite/v1/common.proto#L80}
+  ///
+  /// [google.cloud.pubsublite.v1.ListReservationsRequest]:
+  /// @googleapis_link{google::cloud::pubsublite::v1::ListReservationsRequest,google/cloud/pubsublite/v1/admin.proto#L550}
+  /// [google::cloud::pubsublite::v1::Reservation]:
   /// @googleapis_link{google::cloud::pubsublite::v1::Reservation,google/cloud/pubsublite/v1/common.proto#L80}
   ///
   StreamRange<google::cloud::pubsublite::v1::Reservation> ListReservations(
@@ -484,6 +641,11 @@ class AdminServiceClient {
   /// @return
   /// @googleapis_link{google::cloud::pubsublite::v1::Reservation,google/cloud/pubsublite/v1/common.proto#L80}
   ///
+  /// [google.cloud.pubsublite.v1.UpdateReservationRequest]:
+  /// @googleapis_link{google::cloud::pubsublite::v1::UpdateReservationRequest,google/cloud/pubsublite/v1/admin.proto#L585}
+  /// [google.cloud.pubsublite.v1.Reservation]:
+  /// @googleapis_link{google::cloud::pubsublite::v1::Reservation,google/cloud/pubsublite/v1/common.proto#L80}
+  ///
   StatusOr<google::cloud::pubsublite::v1::Reservation> UpdateReservation(
       google::cloud::pubsublite::v1::UpdateReservationRequest const& request);
 
@@ -491,6 +653,9 @@ class AdminServiceClient {
   /// Deletes the specified reservation.
   ///
   /// @param request
+  /// @googleapis_link{google::cloud::pubsublite::v1::DeleteReservationRequest,google/cloud/pubsublite/v1/admin.proto#L594}
+  ///
+  /// [google.cloud.pubsublite.v1.DeleteReservationRequest]:
   /// @googleapis_link{google::cloud::pubsublite::v1::DeleteReservationRequest,google/cloud/pubsublite/v1/admin.proto#L594}
   ///
   Status DeleteReservation(
@@ -502,6 +667,10 @@ class AdminServiceClient {
   /// @param request
   /// @googleapis_link{google::cloud::pubsublite::v1::ListReservationTopicsRequest,google/cloud/pubsublite/v1/admin.proto#L607}
   /// @return std::string
+  ///
+  /// [google.cloud.pubsublite.v1.ListReservationTopicsRequest]:
+  /// @googleapis_link{google::cloud::pubsublite::v1::ListReservationTopicsRequest,google/cloud/pubsublite/v1/admin.proto#L607}
+  /// [std::string]: std::string
   ///
   StreamRange<std::string> ListReservationTopics(
       google::cloud::pubsublite::v1::ListReservationTopicsRequest request);

--- a/google/cloud/pubsublite/admin_client.h
+++ b/google/cloud/pubsublite/admin_client.h
@@ -128,7 +128,7 @@ class AdminServiceClient {
   ///
   /// [google.cloud.pubsublite.v1.ListTopicsRequest]:
   /// @googleapis_link{google::cloud::pubsublite::v1::ListTopicsRequest,google/cloud/pubsublite/v1/admin.proto#L276}
-  /// [google::cloud::pubsublite::v1::Topic]:
+  /// [google.cloud.pubsublite.v1.Topic]:
   /// @googleapis_link{google::cloud::pubsublite::v1::Topic,google/cloud/pubsublite/v1/common.proto#L102}
   ///
   StreamRange<google::cloud::pubsublite::v1::Topic> ListTopics(
@@ -171,7 +171,6 @@ class AdminServiceClient {
   ///
   /// [google.cloud.pubsublite.v1.ListTopicSubscriptionsRequest]:
   /// @googleapis_link{google::cloud::pubsublite::v1::ListTopicSubscriptionsRequest,google/cloud/pubsublite/v1/admin.proto#L331}
-  /// [std::string]: std::string
   ///
   StreamRange<std::string> ListTopicSubscriptions(std::string const& name);
 
@@ -226,7 +225,7 @@ class AdminServiceClient {
   ///
   /// [google.cloud.pubsublite.v1.ListSubscriptionsRequest]:
   /// @googleapis_link{google::cloud::pubsublite::v1::ListSubscriptionsRequest,google/cloud/pubsublite/v1/admin.proto#L402}
-  /// [google::cloud::pubsublite::v1::Subscription]:
+  /// [google.cloud.pubsublite.v1.Subscription]:
   /// @googleapis_link{google::cloud::pubsublite::v1::Subscription,google/cloud/pubsublite/v1/common.proto#L186}
   ///
   StreamRange<google::cloud::pubsublite::v1::Subscription> ListSubscriptions(
@@ -315,7 +314,7 @@ class AdminServiceClient {
   ///
   /// [google.cloud.pubsublite.v1.ListReservationsRequest]:
   /// @googleapis_link{google::cloud::pubsublite::v1::ListReservationsRequest,google/cloud/pubsublite/v1/admin.proto#L550}
-  /// [google::cloud::pubsublite::v1::Reservation]:
+  /// [google.cloud.pubsublite.v1.Reservation]:
   /// @googleapis_link{google::cloud::pubsublite::v1::Reservation,google/cloud/pubsublite/v1/common.proto#L80}
   ///
   StreamRange<google::cloud::pubsublite::v1::Reservation> ListReservations(
@@ -362,7 +361,6 @@ class AdminServiceClient {
   ///
   /// [google.cloud.pubsublite.v1.ListReservationTopicsRequest]:
   /// @googleapis_link{google::cloud::pubsublite::v1::ListReservationTopicsRequest,google/cloud/pubsublite/v1/admin.proto#L607}
-  /// [std::string]: std::string
   ///
   StreamRange<std::string> ListReservationTopics(std::string const& name);
 
@@ -424,7 +422,7 @@ class AdminServiceClient {
   ///
   /// [google.cloud.pubsublite.v1.ListTopicsRequest]:
   /// @googleapis_link{google::cloud::pubsublite::v1::ListTopicsRequest,google/cloud/pubsublite/v1/admin.proto#L276}
-  /// [google::cloud::pubsublite::v1::Topic]:
+  /// [google.cloud.pubsublite.v1.Topic]:
   /// @googleapis_link{google::cloud::pubsublite::v1::Topic,google/cloud/pubsublite/v1/common.proto#L102}
   ///
   StreamRange<google::cloud::pubsublite::v1::Topic> ListTopics(
@@ -467,7 +465,6 @@ class AdminServiceClient {
   ///
   /// [google.cloud.pubsublite.v1.ListTopicSubscriptionsRequest]:
   /// @googleapis_link{google::cloud::pubsublite::v1::ListTopicSubscriptionsRequest,google/cloud/pubsublite/v1/admin.proto#L331}
-  /// [std::string]: std::string
   ///
   StreamRange<std::string> ListTopicSubscriptions(
       google::cloud::pubsublite::v1::ListTopicSubscriptionsRequest request);
@@ -514,7 +511,7 @@ class AdminServiceClient {
   ///
   /// [google.cloud.pubsublite.v1.ListSubscriptionsRequest]:
   /// @googleapis_link{google::cloud::pubsublite::v1::ListSubscriptionsRequest,google/cloud/pubsublite/v1/admin.proto#L402}
-  /// [google::cloud::pubsublite::v1::Subscription]:
+  /// [google.cloud.pubsublite.v1.Subscription]:
   /// @googleapis_link{google::cloud::pubsublite::v1::Subscription,google/cloud/pubsublite/v1/common.proto#L186}
   ///
   StreamRange<google::cloud::pubsublite::v1::Subscription> ListSubscriptions(
@@ -627,7 +624,7 @@ class AdminServiceClient {
   ///
   /// [google.cloud.pubsublite.v1.ListReservationsRequest]:
   /// @googleapis_link{google::cloud::pubsublite::v1::ListReservationsRequest,google/cloud/pubsublite/v1/admin.proto#L550}
-  /// [google::cloud::pubsublite::v1::Reservation]:
+  /// [google.cloud.pubsublite.v1.Reservation]:
   /// @googleapis_link{google::cloud::pubsublite::v1::Reservation,google/cloud/pubsublite/v1/common.proto#L80}
   ///
   StreamRange<google::cloud::pubsublite::v1::Reservation> ListReservations(
@@ -670,7 +667,6 @@ class AdminServiceClient {
   ///
   /// [google.cloud.pubsublite.v1.ListReservationTopicsRequest]:
   /// @googleapis_link{google::cloud::pubsublite::v1::ListReservationTopicsRequest,google/cloud/pubsublite/v1/admin.proto#L607}
-  /// [std::string]: std::string
   ///
   StreamRange<std::string> ListReservationTopics(
       google::cloud::pubsublite::v1::ListReservationTopicsRequest request);

--- a/google/cloud/secretmanager/secret_manager_client.h
+++ b/google/cloud/secretmanager/secret_manager_client.h
@@ -80,7 +80,7 @@ class SecretManagerServiceClient {
   ///
   /// [google.cloud.secretmanager.v1.ListSecretsRequest]:
   /// @googleapis_link{google::cloud::secretmanager::v1::ListSecretsRequest,google/cloud/secretmanager/v1/service.proto#L206}
-  /// [google::cloud::secretmanager::v1::Secret]:
+  /// [google.cloud.secretmanager.v1.Secret]:
   /// @googleapis_link{google::cloud::secretmanager::v1::Secret,google/cloud/secretmanager/v1/resources.proto#L40}
   ///
   StreamRange<google::cloud::secretmanager::v1::Secret> ListSecrets(
@@ -196,7 +196,7 @@ class SecretManagerServiceClient {
   ///
   /// [google.cloud.secretmanager.v1.ListSecretVersionsRequest]:
   /// @googleapis_link{google::cloud::secretmanager::v1::ListSecretVersionsRequest,google/cloud/secretmanager/v1/service.proto#L296}
-  /// [google::cloud::secretmanager::v1::SecretVersion]:
+  /// [google.cloud.secretmanager.v1.SecretVersion]:
   /// @googleapis_link{google::cloud::secretmanager::v1::SecretVersion,google/cloud/secretmanager/v1/resources.proto#L103}
   ///
   StreamRange<google::cloud::secretmanager::v1::SecretVersion>
@@ -325,7 +325,7 @@ class SecretManagerServiceClient {
   ///
   /// [google.cloud.secretmanager.v1.ListSecretsRequest]:
   /// @googleapis_link{google::cloud::secretmanager::v1::ListSecretsRequest,google/cloud/secretmanager/v1/service.proto#L206}
-  /// [google::cloud::secretmanager::v1::Secret]:
+  /// [google.cloud.secretmanager.v1.Secret]:
   /// @googleapis_link{google::cloud::secretmanager::v1::Secret,google/cloud/secretmanager/v1/resources.proto#L40}
   ///
   StreamRange<google::cloud::secretmanager::v1::Secret> ListSecrets(
@@ -422,7 +422,7 @@ class SecretManagerServiceClient {
   ///
   /// [google.cloud.secretmanager.v1.ListSecretVersionsRequest]:
   /// @googleapis_link{google::cloud::secretmanager::v1::ListSecretVersionsRequest,google/cloud/secretmanager/v1/service.proto#L296}
-  /// [google::cloud::secretmanager::v1::SecretVersion]:
+  /// [google.cloud.secretmanager.v1.SecretVersion]:
   /// @googleapis_link{google::cloud::secretmanager::v1::SecretVersion,google/cloud/secretmanager/v1/resources.proto#L103}
   ///
   StreamRange<google::cloud::secretmanager::v1::SecretVersion>

--- a/google/cloud/secretmanager/secret_manager_client.h
+++ b/google/cloud/secretmanager/secret_manager_client.h
@@ -78,6 +78,11 @@ class SecretManagerServiceClient {
   /// @return
   /// @googleapis_link{google::cloud::secretmanager::v1::Secret,google/cloud/secretmanager/v1/resources.proto#L40}
   ///
+  /// [google.cloud.secretmanager.v1.ListSecretsRequest]:
+  /// @googleapis_link{google::cloud::secretmanager::v1::ListSecretsRequest,google/cloud/secretmanager/v1/service.proto#L206}
+  /// [google::cloud::secretmanager::v1::Secret]:
+  /// @googleapis_link{google::cloud::secretmanager::v1::Secret,google/cloud/secretmanager/v1/resources.proto#L40}
+  ///
   StreamRange<google::cloud::secretmanager::v1::Secret> ListSecrets(
       std::string const& parent);
 
@@ -98,6 +103,11 @@ class SecretManagerServiceClient {
   /// @return
   /// @googleapis_link{google::cloud::secretmanager::v1::Secret,google/cloud/secretmanager/v1/resources.proto#L40}
   ///
+  /// [google.cloud.secretmanager.v1.CreateSecretRequest]:
+  /// @googleapis_link{google::cloud::secretmanager::v1::CreateSecretRequest,google/cloud/secretmanager/v1/service.proto#L248}
+  /// [google.cloud.secretmanager.v1.Secret]:
+  /// @googleapis_link{google::cloud::secretmanager::v1::Secret,google/cloud/secretmanager/v1/resources.proto#L40}
+  ///
   StatusOr<google::cloud::secretmanager::v1::Secret> CreateSecret(
       std::string const& parent, std::string const& secret_id,
       google::cloud::secretmanager::v1::Secret const& secret);
@@ -116,6 +126,11 @@ class SecretManagerServiceClient {
   /// @return
   /// @googleapis_link{google::cloud::secretmanager::v1::SecretVersion,google/cloud/secretmanager/v1/resources.proto#L103}
   ///
+  /// [google.cloud.secretmanager.v1.AddSecretVersionRequest]:
+  /// @googleapis_link{google::cloud::secretmanager::v1::AddSecretVersionRequest,google/cloud/secretmanager/v1/service.proto#L270}
+  /// [google.cloud.secretmanager.v1.SecretVersion]:
+  /// @googleapis_link{google::cloud::secretmanager::v1::SecretVersion,google/cloud/secretmanager/v1/resources.proto#L103}
+  ///
   StatusOr<google::cloud::secretmanager::v1::SecretVersion> AddSecretVersion(
       std::string const& parent,
       google::cloud::secretmanager::v1::SecretPayload const& payload);
@@ -127,6 +142,11 @@ class SecretManagerServiceClient {
   /// [Secret][google.cloud.secretmanager.v1.Secret], in the format
   /// `projects/*/secrets/*`.
   /// @return
+  /// @googleapis_link{google::cloud::secretmanager::v1::Secret,google/cloud/secretmanager/v1/resources.proto#L40}
+  ///
+  /// [google.cloud.secretmanager.v1.GetSecretRequest]:
+  /// @googleapis_link{google::cloud::secretmanager::v1::GetSecretRequest,google/cloud/secretmanager/v1/service.proto#L285}
+  /// [google.cloud.secretmanager.v1.Secret]:
   /// @googleapis_link{google::cloud::secretmanager::v1::Secret,google/cloud/secretmanager/v1/resources.proto#L40}
   ///
   StatusOr<google::cloud::secretmanager::v1::Secret> GetSecret(
@@ -142,6 +162,11 @@ class SecretManagerServiceClient {
   /// @return
   /// @googleapis_link{google::cloud::secretmanager::v1::Secret,google/cloud/secretmanager/v1/resources.proto#L40}
   ///
+  /// [google.cloud.secretmanager.v1.UpdateSecretRequest]:
+  /// @googleapis_link{google::cloud::secretmanager::v1::UpdateSecretRequest,google/cloud/secretmanager/v1/service.proto#L354}
+  /// [google.cloud.secretmanager.v1.Secret]:
+  /// @googleapis_link{google::cloud::secretmanager::v1::Secret,google/cloud/secretmanager/v1/resources.proto#L40}
+  ///
   StatusOr<google::cloud::secretmanager::v1::Secret> UpdateSecret(
       google::cloud::secretmanager::v1::Secret const& secret,
       google::protobuf::FieldMask const& update_mask);
@@ -152,6 +177,9 @@ class SecretManagerServiceClient {
   /// @param name  Required. The resource name of the
   /// [Secret][google.cloud.secretmanager.v1.Secret] to delete in the format
   ///  `projects/*/secrets/*`.
+  ///
+  /// [google.cloud.secretmanager.v1.DeleteSecretRequest]:
+  /// @googleapis_link{google::cloud::secretmanager::v1::DeleteSecretRequest,google/cloud/secretmanager/v1/service.proto#L390}
   ///
   Status DeleteSecret(std::string const& name);
 
@@ -164,6 +192,11 @@ class SecretManagerServiceClient {
   ///  [SecretVersions][google.cloud.secretmanager.v1.SecretVersion] to list, in
   ///  the format `projects/*/secrets/*`.
   /// @return
+  /// @googleapis_link{google::cloud::secretmanager::v1::SecretVersion,google/cloud/secretmanager/v1/resources.proto#L103}
+  ///
+  /// [google.cloud.secretmanager.v1.ListSecretVersionsRequest]:
+  /// @googleapis_link{google::cloud::secretmanager::v1::ListSecretVersionsRequest,google/cloud/secretmanager/v1/service.proto#L296}
+  /// [google::cloud::secretmanager::v1::SecretVersion]:
   /// @googleapis_link{google::cloud::secretmanager::v1::SecretVersion,google/cloud/secretmanager/v1/resources.proto#L103}
   ///
   StreamRange<google::cloud::secretmanager::v1::SecretVersion>
@@ -184,6 +217,11 @@ class SecretManagerServiceClient {
   /// @return
   /// @googleapis_link{google::cloud::secretmanager::v1::SecretVersion,google/cloud/secretmanager/v1/resources.proto#L103}
   ///
+  /// [google.cloud.secretmanager.v1.GetSecretVersionRequest]:
+  /// @googleapis_link{google::cloud::secretmanager::v1::GetSecretVersionRequest,google/cloud/secretmanager/v1/service.proto#L339}
+  /// [google.cloud.secretmanager.v1.SecretVersion]:
+  /// @googleapis_link{google::cloud::secretmanager::v1::SecretVersion,google/cloud/secretmanager/v1/resources.proto#L103}
+  ///
   StatusOr<google::cloud::secretmanager::v1::SecretVersion> GetSecretVersion(
       std::string const& name);
 
@@ -200,6 +238,11 @@ class SecretManagerServiceClient {
   ///  `projects/*/secrets/*/versions/latest` is an alias to the most recently
   ///  created [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
   /// @return
+  /// @googleapis_link{google::cloud::secretmanager::v1::AccessSecretVersionResponse,google/cloud/secretmanager/v1/service.proto#L378}
+  ///
+  /// [google.cloud.secretmanager.v1.AccessSecretVersionRequest]:
+  /// @googleapis_link{google::cloud::secretmanager::v1::AccessSecretVersionRequest,google/cloud/secretmanager/v1/service.proto#L363}
+  /// [google.cloud.secretmanager.v1.AccessSecretVersionResponse]:
   /// @googleapis_link{google::cloud::secretmanager::v1::AccessSecretVersionResponse,google/cloud/secretmanager/v1/service.proto#L378}
   ///
   StatusOr<google::cloud::secretmanager::v1::AccessSecretVersionResponse>
@@ -219,6 +262,11 @@ class SecretManagerServiceClient {
   /// @return
   /// @googleapis_link{google::cloud::secretmanager::v1::SecretVersion,google/cloud/secretmanager/v1/resources.proto#L103}
   ///
+  /// [google.cloud.secretmanager.v1.DisableSecretVersionRequest]:
+  /// @googleapis_link{google::cloud::secretmanager::v1::DisableSecretVersionRequest,google/cloud/secretmanager/v1/service.proto#L407}
+  /// [google.cloud.secretmanager.v1.SecretVersion]:
+  /// @googleapis_link{google::cloud::secretmanager::v1::SecretVersion,google/cloud/secretmanager/v1/resources.proto#L103}
+  ///
   StatusOr<google::cloud::secretmanager::v1::SecretVersion>
   DisableSecretVersion(std::string const& name);
 
@@ -234,6 +282,11 @@ class SecretManagerServiceClient {
   /// the format
   ///  `projects/*/secrets/*/versions/*`.
   /// @return
+  /// @googleapis_link{google::cloud::secretmanager::v1::SecretVersion,google/cloud/secretmanager/v1/resources.proto#L103}
+  ///
+  /// [google.cloud.secretmanager.v1.EnableSecretVersionRequest]:
+  /// @googleapis_link{google::cloud::secretmanager::v1::EnableSecretVersionRequest,google/cloud/secretmanager/v1/service.proto#L424}
+  /// [google.cloud.secretmanager.v1.SecretVersion]:
   /// @googleapis_link{google::cloud::secretmanager::v1::SecretVersion,google/cloud/secretmanager/v1/resources.proto#L103}
   ///
   StatusOr<google::cloud::secretmanager::v1::SecretVersion> EnableSecretVersion(
@@ -254,6 +307,11 @@ class SecretManagerServiceClient {
   /// @return
   /// @googleapis_link{google::cloud::secretmanager::v1::SecretVersion,google/cloud/secretmanager/v1/resources.proto#L103}
   ///
+  /// [google.cloud.secretmanager.v1.DestroySecretVersionRequest]:
+  /// @googleapis_link{google::cloud::secretmanager::v1::DestroySecretVersionRequest,google/cloud/secretmanager/v1/service.proto#L441}
+  /// [google.cloud.secretmanager.v1.SecretVersion]:
+  /// @googleapis_link{google::cloud::secretmanager::v1::SecretVersion,google/cloud/secretmanager/v1/resources.proto#L103}
+  ///
   StatusOr<google::cloud::secretmanager::v1::SecretVersion>
   DestroySecretVersion(std::string const& name);
 
@@ -263,6 +321,11 @@ class SecretManagerServiceClient {
   /// @param request
   /// @googleapis_link{google::cloud::secretmanager::v1::ListSecretsRequest,google/cloud/secretmanager/v1/service.proto#L206}
   /// @return
+  /// @googleapis_link{google::cloud::secretmanager::v1::Secret,google/cloud/secretmanager/v1/resources.proto#L40}
+  ///
+  /// [google.cloud.secretmanager.v1.ListSecretsRequest]:
+  /// @googleapis_link{google::cloud::secretmanager::v1::ListSecretsRequest,google/cloud/secretmanager/v1/service.proto#L206}
+  /// [google::cloud::secretmanager::v1::Secret]:
   /// @googleapis_link{google::cloud::secretmanager::v1::Secret,google/cloud/secretmanager/v1/resources.proto#L40}
   ///
   StreamRange<google::cloud::secretmanager::v1::Secret> ListSecrets(
@@ -275,6 +338,11 @@ class SecretManagerServiceClient {
   /// @param request
   /// @googleapis_link{google::cloud::secretmanager::v1::CreateSecretRequest,google/cloud/secretmanager/v1/service.proto#L248}
   /// @return
+  /// @googleapis_link{google::cloud::secretmanager::v1::Secret,google/cloud/secretmanager/v1/resources.proto#L40}
+  ///
+  /// [google.cloud.secretmanager.v1.CreateSecretRequest]:
+  /// @googleapis_link{google::cloud::secretmanager::v1::CreateSecretRequest,google/cloud/secretmanager/v1/service.proto#L248}
+  /// [google.cloud.secretmanager.v1.Secret]:
   /// @googleapis_link{google::cloud::secretmanager::v1::Secret,google/cloud/secretmanager/v1/resources.proto#L40}
   ///
   StatusOr<google::cloud::secretmanager::v1::Secret> CreateSecret(
@@ -290,6 +358,11 @@ class SecretManagerServiceClient {
   /// @return
   /// @googleapis_link{google::cloud::secretmanager::v1::SecretVersion,google/cloud/secretmanager/v1/resources.proto#L103}
   ///
+  /// [google.cloud.secretmanager.v1.AddSecretVersionRequest]:
+  /// @googleapis_link{google::cloud::secretmanager::v1::AddSecretVersionRequest,google/cloud/secretmanager/v1/service.proto#L270}
+  /// [google.cloud.secretmanager.v1.SecretVersion]:
+  /// @googleapis_link{google::cloud::secretmanager::v1::SecretVersion,google/cloud/secretmanager/v1/resources.proto#L103}
+  ///
   StatusOr<google::cloud::secretmanager::v1::SecretVersion> AddSecretVersion(
       google::cloud::secretmanager::v1::AddSecretVersionRequest const& request);
 
@@ -299,6 +372,11 @@ class SecretManagerServiceClient {
   /// @param request
   /// @googleapis_link{google::cloud::secretmanager::v1::GetSecretRequest,google/cloud/secretmanager/v1/service.proto#L285}
   /// @return
+  /// @googleapis_link{google::cloud::secretmanager::v1::Secret,google/cloud/secretmanager/v1/resources.proto#L40}
+  ///
+  /// [google.cloud.secretmanager.v1.GetSecretRequest]:
+  /// @googleapis_link{google::cloud::secretmanager::v1::GetSecretRequest,google/cloud/secretmanager/v1/service.proto#L285}
+  /// [google.cloud.secretmanager.v1.Secret]:
   /// @googleapis_link{google::cloud::secretmanager::v1::Secret,google/cloud/secretmanager/v1/resources.proto#L40}
   ///
   StatusOr<google::cloud::secretmanager::v1::Secret> GetSecret(
@@ -313,6 +391,11 @@ class SecretManagerServiceClient {
   /// @return
   /// @googleapis_link{google::cloud::secretmanager::v1::Secret,google/cloud/secretmanager/v1/resources.proto#L40}
   ///
+  /// [google.cloud.secretmanager.v1.UpdateSecretRequest]:
+  /// @googleapis_link{google::cloud::secretmanager::v1::UpdateSecretRequest,google/cloud/secretmanager/v1/service.proto#L354}
+  /// [google.cloud.secretmanager.v1.Secret]:
+  /// @googleapis_link{google::cloud::secretmanager::v1::Secret,google/cloud/secretmanager/v1/resources.proto#L40}
+  ///
   StatusOr<google::cloud::secretmanager::v1::Secret> UpdateSecret(
       google::cloud::secretmanager::v1::UpdateSecretRequest const& request);
 
@@ -320,6 +403,9 @@ class SecretManagerServiceClient {
   /// Deletes a [Secret][google.cloud.secretmanager.v1.Secret].
   ///
   /// @param request
+  /// @googleapis_link{google::cloud::secretmanager::v1::DeleteSecretRequest,google/cloud/secretmanager/v1/service.proto#L390}
+  ///
+  /// [google.cloud.secretmanager.v1.DeleteSecretRequest]:
   /// @googleapis_link{google::cloud::secretmanager::v1::DeleteSecretRequest,google/cloud/secretmanager/v1/service.proto#L390}
   ///
   Status DeleteSecret(
@@ -332,6 +418,11 @@ class SecretManagerServiceClient {
   /// @param request
   /// @googleapis_link{google::cloud::secretmanager::v1::ListSecretVersionsRequest,google/cloud/secretmanager/v1/service.proto#L296}
   /// @return
+  /// @googleapis_link{google::cloud::secretmanager::v1::SecretVersion,google/cloud/secretmanager/v1/resources.proto#L103}
+  ///
+  /// [google.cloud.secretmanager.v1.ListSecretVersionsRequest]:
+  /// @googleapis_link{google::cloud::secretmanager::v1::ListSecretVersionsRequest,google/cloud/secretmanager/v1/service.proto#L296}
+  /// [google::cloud::secretmanager::v1::SecretVersion]:
   /// @googleapis_link{google::cloud::secretmanager::v1::SecretVersion,google/cloud/secretmanager/v1/resources.proto#L103}
   ///
   StreamRange<google::cloud::secretmanager::v1::SecretVersion>
@@ -350,6 +441,11 @@ class SecretManagerServiceClient {
   /// @return
   /// @googleapis_link{google::cloud::secretmanager::v1::SecretVersion,google/cloud/secretmanager/v1/resources.proto#L103}
   ///
+  /// [google.cloud.secretmanager.v1.GetSecretVersionRequest]:
+  /// @googleapis_link{google::cloud::secretmanager::v1::GetSecretVersionRequest,google/cloud/secretmanager/v1/service.proto#L339}
+  /// [google.cloud.secretmanager.v1.SecretVersion]:
+  /// @googleapis_link{google::cloud::secretmanager::v1::SecretVersion,google/cloud/secretmanager/v1/resources.proto#L103}
+  ///
   StatusOr<google::cloud::secretmanager::v1::SecretVersion> GetSecretVersion(
       google::cloud::secretmanager::v1::GetSecretVersionRequest const& request);
 
@@ -363,6 +459,11 @@ class SecretManagerServiceClient {
   /// @param request
   /// @googleapis_link{google::cloud::secretmanager::v1::AccessSecretVersionRequest,google/cloud/secretmanager/v1/service.proto#L363}
   /// @return
+  /// @googleapis_link{google::cloud::secretmanager::v1::AccessSecretVersionResponse,google/cloud/secretmanager/v1/service.proto#L378}
+  ///
+  /// [google.cloud.secretmanager.v1.AccessSecretVersionRequest]:
+  /// @googleapis_link{google::cloud::secretmanager::v1::AccessSecretVersionRequest,google/cloud/secretmanager/v1/service.proto#L363}
+  /// [google.cloud.secretmanager.v1.AccessSecretVersionResponse]:
   /// @googleapis_link{google::cloud::secretmanager::v1::AccessSecretVersionResponse,google/cloud/secretmanager/v1/service.proto#L378}
   ///
   StatusOr<google::cloud::secretmanager::v1::AccessSecretVersionResponse>
@@ -382,6 +483,11 @@ class SecretManagerServiceClient {
   /// @return
   /// @googleapis_link{google::cloud::secretmanager::v1::SecretVersion,google/cloud/secretmanager/v1/resources.proto#L103}
   ///
+  /// [google.cloud.secretmanager.v1.DisableSecretVersionRequest]:
+  /// @googleapis_link{google::cloud::secretmanager::v1::DisableSecretVersionRequest,google/cloud/secretmanager/v1/service.proto#L407}
+  /// [google.cloud.secretmanager.v1.SecretVersion]:
+  /// @googleapis_link{google::cloud::secretmanager::v1::SecretVersion,google/cloud/secretmanager/v1/resources.proto#L103}
+  ///
   StatusOr<google::cloud::secretmanager::v1::SecretVersion>
   DisableSecretVersion(
       google::cloud::secretmanager::v1::DisableSecretVersionRequest const&
@@ -399,6 +505,11 @@ class SecretManagerServiceClient {
   /// @return
   /// @googleapis_link{google::cloud::secretmanager::v1::SecretVersion,google/cloud/secretmanager/v1/resources.proto#L103}
   ///
+  /// [google.cloud.secretmanager.v1.EnableSecretVersionRequest]:
+  /// @googleapis_link{google::cloud::secretmanager::v1::EnableSecretVersionRequest,google/cloud/secretmanager/v1/service.proto#L424}
+  /// [google.cloud.secretmanager.v1.SecretVersion]:
+  /// @googleapis_link{google::cloud::secretmanager::v1::SecretVersion,google/cloud/secretmanager/v1/resources.proto#L103}
+  ///
   StatusOr<google::cloud::secretmanager::v1::SecretVersion> EnableSecretVersion(
       google::cloud::secretmanager::v1::EnableSecretVersionRequest const&
           request);
@@ -414,6 +525,11 @@ class SecretManagerServiceClient {
   /// @param request
   /// @googleapis_link{google::cloud::secretmanager::v1::DestroySecretVersionRequest,google/cloud/secretmanager/v1/service.proto#L441}
   /// @return
+  /// @googleapis_link{google::cloud::secretmanager::v1::SecretVersion,google/cloud/secretmanager/v1/resources.proto#L103}
+  ///
+  /// [google.cloud.secretmanager.v1.DestroySecretVersionRequest]:
+  /// @googleapis_link{google::cloud::secretmanager::v1::DestroySecretVersionRequest,google/cloud/secretmanager/v1/service.proto#L441}
+  /// [google.cloud.secretmanager.v1.SecretVersion]:
   /// @googleapis_link{google::cloud::secretmanager::v1::SecretVersion,google/cloud/secretmanager/v1/resources.proto#L103}
   ///
   StatusOr<google::cloud::secretmanager::v1::SecretVersion>
@@ -435,6 +551,11 @@ class SecretManagerServiceClient {
   /// @return
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
+  /// [google.iam.v1.SetIamPolicyRequest]:
+  /// @googleapis_link{google::iam::v1::SetIamPolicyRequest,google/iam/v1/iam_policy.proto#L98}
+  /// [google.iam.v1.Policy]:
+  /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
+  ///
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
       google::iam::v1::SetIamPolicyRequest const& request);
 
@@ -445,6 +566,11 @@ class SecretManagerServiceClient {
   /// @param request
   /// @googleapis_link{google::iam::v1::GetIamPolicyRequest,google/iam/v1/iam_policy.proto#L113}
   /// @return
+  /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
+  ///
+  /// [google.iam.v1.GetIamPolicyRequest]:
+  /// @googleapis_link{google::iam::v1::GetIamPolicyRequest,google/iam/v1/iam_policy.proto#L113}
+  /// [google.iam.v1.Policy]:
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> GetIamPolicy(
@@ -462,6 +588,11 @@ class SecretManagerServiceClient {
   /// @param request
   /// @googleapis_link{google::iam::v1::TestIamPermissionsRequest,google/iam/v1/iam_policy.proto#L126}
   /// @return
+  /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
+  ///
+  /// [google.iam.v1.TestIamPermissionsRequest]:
+  /// @googleapis_link{google::iam::v1::TestIamPermissionsRequest,google/iam/v1/iam_policy.proto#L126}
+  /// [google.iam.v1.TestIamPermissionsResponse]:
   /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
   ///
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(

--- a/google/cloud/secretmanager/secret_manager_client.h
+++ b/google/cloud/secretmanager/secret_manager_client.h
@@ -79,9 +79,9 @@ class SecretManagerServiceClient {
   /// @googleapis_link{google::cloud::secretmanager::v1::Secret,google/cloud/secretmanager/v1/resources.proto#L40}
   ///
   /// [google.cloud.secretmanager.v1.ListSecretsRequest]:
-  /// @googleapis_link{google::cloud::secretmanager::v1::ListSecretsRequest,google/cloud/secretmanager/v1/service.proto#L206}
+  /// @googleapis_reference_link{google/cloud/secretmanager/v1/service.proto#L206}
   /// [google.cloud.secretmanager.v1.Secret]:
-  /// @googleapis_link{google::cloud::secretmanager::v1::Secret,google/cloud/secretmanager/v1/resources.proto#L40}
+  /// @googleapis_reference_link{google/cloud/secretmanager/v1/resources.proto#L40}
   ///
   StreamRange<google::cloud::secretmanager::v1::Secret> ListSecrets(
       std::string const& parent);
@@ -104,9 +104,9 @@ class SecretManagerServiceClient {
   /// @googleapis_link{google::cloud::secretmanager::v1::Secret,google/cloud/secretmanager/v1/resources.proto#L40}
   ///
   /// [google.cloud.secretmanager.v1.CreateSecretRequest]:
-  /// @googleapis_link{google::cloud::secretmanager::v1::CreateSecretRequest,google/cloud/secretmanager/v1/service.proto#L248}
+  /// @googleapis_reference_link{google/cloud/secretmanager/v1/service.proto#L248}
   /// [google.cloud.secretmanager.v1.Secret]:
-  /// @googleapis_link{google::cloud::secretmanager::v1::Secret,google/cloud/secretmanager/v1/resources.proto#L40}
+  /// @googleapis_reference_link{google/cloud/secretmanager/v1/resources.proto#L40}
   ///
   StatusOr<google::cloud::secretmanager::v1::Secret> CreateSecret(
       std::string const& parent, std::string const& secret_id,
@@ -127,9 +127,9 @@ class SecretManagerServiceClient {
   /// @googleapis_link{google::cloud::secretmanager::v1::SecretVersion,google/cloud/secretmanager/v1/resources.proto#L103}
   ///
   /// [google.cloud.secretmanager.v1.AddSecretVersionRequest]:
-  /// @googleapis_link{google::cloud::secretmanager::v1::AddSecretVersionRequest,google/cloud/secretmanager/v1/service.proto#L270}
+  /// @googleapis_reference_link{google/cloud/secretmanager/v1/service.proto#L270}
   /// [google.cloud.secretmanager.v1.SecretVersion]:
-  /// @googleapis_link{google::cloud::secretmanager::v1::SecretVersion,google/cloud/secretmanager/v1/resources.proto#L103}
+  /// @googleapis_reference_link{google/cloud/secretmanager/v1/resources.proto#L103}
   ///
   StatusOr<google::cloud::secretmanager::v1::SecretVersion> AddSecretVersion(
       std::string const& parent,
@@ -145,9 +145,9 @@ class SecretManagerServiceClient {
   /// @googleapis_link{google::cloud::secretmanager::v1::Secret,google/cloud/secretmanager/v1/resources.proto#L40}
   ///
   /// [google.cloud.secretmanager.v1.GetSecretRequest]:
-  /// @googleapis_link{google::cloud::secretmanager::v1::GetSecretRequest,google/cloud/secretmanager/v1/service.proto#L285}
+  /// @googleapis_reference_link{google/cloud/secretmanager/v1/service.proto#L285}
   /// [google.cloud.secretmanager.v1.Secret]:
-  /// @googleapis_link{google::cloud::secretmanager::v1::Secret,google/cloud/secretmanager/v1/resources.proto#L40}
+  /// @googleapis_reference_link{google/cloud/secretmanager/v1/resources.proto#L40}
   ///
   StatusOr<google::cloud::secretmanager::v1::Secret> GetSecret(
       std::string const& name);
@@ -163,9 +163,9 @@ class SecretManagerServiceClient {
   /// @googleapis_link{google::cloud::secretmanager::v1::Secret,google/cloud/secretmanager/v1/resources.proto#L40}
   ///
   /// [google.cloud.secretmanager.v1.UpdateSecretRequest]:
-  /// @googleapis_link{google::cloud::secretmanager::v1::UpdateSecretRequest,google/cloud/secretmanager/v1/service.proto#L354}
+  /// @googleapis_reference_link{google/cloud/secretmanager/v1/service.proto#L354}
   /// [google.cloud.secretmanager.v1.Secret]:
-  /// @googleapis_link{google::cloud::secretmanager::v1::Secret,google/cloud/secretmanager/v1/resources.proto#L40}
+  /// @googleapis_reference_link{google/cloud/secretmanager/v1/resources.proto#L40}
   ///
   StatusOr<google::cloud::secretmanager::v1::Secret> UpdateSecret(
       google::cloud::secretmanager::v1::Secret const& secret,
@@ -179,7 +179,7 @@ class SecretManagerServiceClient {
   ///  `projects/*/secrets/*`.
   ///
   /// [google.cloud.secretmanager.v1.DeleteSecretRequest]:
-  /// @googleapis_link{google::cloud::secretmanager::v1::DeleteSecretRequest,google/cloud/secretmanager/v1/service.proto#L390}
+  /// @googleapis_reference_link{google/cloud/secretmanager/v1/service.proto#L390}
   ///
   Status DeleteSecret(std::string const& name);
 
@@ -195,9 +195,9 @@ class SecretManagerServiceClient {
   /// @googleapis_link{google::cloud::secretmanager::v1::SecretVersion,google/cloud/secretmanager/v1/resources.proto#L103}
   ///
   /// [google.cloud.secretmanager.v1.ListSecretVersionsRequest]:
-  /// @googleapis_link{google::cloud::secretmanager::v1::ListSecretVersionsRequest,google/cloud/secretmanager/v1/service.proto#L296}
+  /// @googleapis_reference_link{google/cloud/secretmanager/v1/service.proto#L296}
   /// [google.cloud.secretmanager.v1.SecretVersion]:
-  /// @googleapis_link{google::cloud::secretmanager::v1::SecretVersion,google/cloud/secretmanager/v1/resources.proto#L103}
+  /// @googleapis_reference_link{google/cloud/secretmanager/v1/resources.proto#L103}
   ///
   StreamRange<google::cloud::secretmanager::v1::SecretVersion>
   ListSecretVersions(std::string const& parent);
@@ -218,9 +218,9 @@ class SecretManagerServiceClient {
   /// @googleapis_link{google::cloud::secretmanager::v1::SecretVersion,google/cloud/secretmanager/v1/resources.proto#L103}
   ///
   /// [google.cloud.secretmanager.v1.GetSecretVersionRequest]:
-  /// @googleapis_link{google::cloud::secretmanager::v1::GetSecretVersionRequest,google/cloud/secretmanager/v1/service.proto#L339}
+  /// @googleapis_reference_link{google/cloud/secretmanager/v1/service.proto#L339}
   /// [google.cloud.secretmanager.v1.SecretVersion]:
-  /// @googleapis_link{google::cloud::secretmanager::v1::SecretVersion,google/cloud/secretmanager/v1/resources.proto#L103}
+  /// @googleapis_reference_link{google/cloud/secretmanager/v1/resources.proto#L103}
   ///
   StatusOr<google::cloud::secretmanager::v1::SecretVersion> GetSecretVersion(
       std::string const& name);
@@ -241,9 +241,9 @@ class SecretManagerServiceClient {
   /// @googleapis_link{google::cloud::secretmanager::v1::AccessSecretVersionResponse,google/cloud/secretmanager/v1/service.proto#L378}
   ///
   /// [google.cloud.secretmanager.v1.AccessSecretVersionRequest]:
-  /// @googleapis_link{google::cloud::secretmanager::v1::AccessSecretVersionRequest,google/cloud/secretmanager/v1/service.proto#L363}
+  /// @googleapis_reference_link{google/cloud/secretmanager/v1/service.proto#L363}
   /// [google.cloud.secretmanager.v1.AccessSecretVersionResponse]:
-  /// @googleapis_link{google::cloud::secretmanager::v1::AccessSecretVersionResponse,google/cloud/secretmanager/v1/service.proto#L378}
+  /// @googleapis_reference_link{google/cloud/secretmanager/v1/service.proto#L378}
   ///
   StatusOr<google::cloud::secretmanager::v1::AccessSecretVersionResponse>
   AccessSecretVersion(std::string const& name);
@@ -263,9 +263,9 @@ class SecretManagerServiceClient {
   /// @googleapis_link{google::cloud::secretmanager::v1::SecretVersion,google/cloud/secretmanager/v1/resources.proto#L103}
   ///
   /// [google.cloud.secretmanager.v1.DisableSecretVersionRequest]:
-  /// @googleapis_link{google::cloud::secretmanager::v1::DisableSecretVersionRequest,google/cloud/secretmanager/v1/service.proto#L407}
+  /// @googleapis_reference_link{google/cloud/secretmanager/v1/service.proto#L407}
   /// [google.cloud.secretmanager.v1.SecretVersion]:
-  /// @googleapis_link{google::cloud::secretmanager::v1::SecretVersion,google/cloud/secretmanager/v1/resources.proto#L103}
+  /// @googleapis_reference_link{google/cloud/secretmanager/v1/resources.proto#L103}
   ///
   StatusOr<google::cloud::secretmanager::v1::SecretVersion>
   DisableSecretVersion(std::string const& name);
@@ -285,9 +285,9 @@ class SecretManagerServiceClient {
   /// @googleapis_link{google::cloud::secretmanager::v1::SecretVersion,google/cloud/secretmanager/v1/resources.proto#L103}
   ///
   /// [google.cloud.secretmanager.v1.EnableSecretVersionRequest]:
-  /// @googleapis_link{google::cloud::secretmanager::v1::EnableSecretVersionRequest,google/cloud/secretmanager/v1/service.proto#L424}
+  /// @googleapis_reference_link{google/cloud/secretmanager/v1/service.proto#L424}
   /// [google.cloud.secretmanager.v1.SecretVersion]:
-  /// @googleapis_link{google::cloud::secretmanager::v1::SecretVersion,google/cloud/secretmanager/v1/resources.proto#L103}
+  /// @googleapis_reference_link{google/cloud/secretmanager/v1/resources.proto#L103}
   ///
   StatusOr<google::cloud::secretmanager::v1::SecretVersion> EnableSecretVersion(
       std::string const& name);
@@ -308,9 +308,9 @@ class SecretManagerServiceClient {
   /// @googleapis_link{google::cloud::secretmanager::v1::SecretVersion,google/cloud/secretmanager/v1/resources.proto#L103}
   ///
   /// [google.cloud.secretmanager.v1.DestroySecretVersionRequest]:
-  /// @googleapis_link{google::cloud::secretmanager::v1::DestroySecretVersionRequest,google/cloud/secretmanager/v1/service.proto#L441}
+  /// @googleapis_reference_link{google/cloud/secretmanager/v1/service.proto#L441}
   /// [google.cloud.secretmanager.v1.SecretVersion]:
-  /// @googleapis_link{google::cloud::secretmanager::v1::SecretVersion,google/cloud/secretmanager/v1/resources.proto#L103}
+  /// @googleapis_reference_link{google/cloud/secretmanager/v1/resources.proto#L103}
   ///
   StatusOr<google::cloud::secretmanager::v1::SecretVersion>
   DestroySecretVersion(std::string const& name);
@@ -324,9 +324,9 @@ class SecretManagerServiceClient {
   /// @googleapis_link{google::cloud::secretmanager::v1::Secret,google/cloud/secretmanager/v1/resources.proto#L40}
   ///
   /// [google.cloud.secretmanager.v1.ListSecretsRequest]:
-  /// @googleapis_link{google::cloud::secretmanager::v1::ListSecretsRequest,google/cloud/secretmanager/v1/service.proto#L206}
+  /// @googleapis_reference_link{google/cloud/secretmanager/v1/service.proto#L206}
   /// [google.cloud.secretmanager.v1.Secret]:
-  /// @googleapis_link{google::cloud::secretmanager::v1::Secret,google/cloud/secretmanager/v1/resources.proto#L40}
+  /// @googleapis_reference_link{google/cloud/secretmanager/v1/resources.proto#L40}
   ///
   StreamRange<google::cloud::secretmanager::v1::Secret> ListSecrets(
       google::cloud::secretmanager::v1::ListSecretsRequest request);
@@ -341,9 +341,9 @@ class SecretManagerServiceClient {
   /// @googleapis_link{google::cloud::secretmanager::v1::Secret,google/cloud/secretmanager/v1/resources.proto#L40}
   ///
   /// [google.cloud.secretmanager.v1.CreateSecretRequest]:
-  /// @googleapis_link{google::cloud::secretmanager::v1::CreateSecretRequest,google/cloud/secretmanager/v1/service.proto#L248}
+  /// @googleapis_reference_link{google/cloud/secretmanager/v1/service.proto#L248}
   /// [google.cloud.secretmanager.v1.Secret]:
-  /// @googleapis_link{google::cloud::secretmanager::v1::Secret,google/cloud/secretmanager/v1/resources.proto#L40}
+  /// @googleapis_reference_link{google/cloud/secretmanager/v1/resources.proto#L40}
   ///
   StatusOr<google::cloud::secretmanager::v1::Secret> CreateSecret(
       google::cloud::secretmanager::v1::CreateSecretRequest const& request);
@@ -359,9 +359,9 @@ class SecretManagerServiceClient {
   /// @googleapis_link{google::cloud::secretmanager::v1::SecretVersion,google/cloud/secretmanager/v1/resources.proto#L103}
   ///
   /// [google.cloud.secretmanager.v1.AddSecretVersionRequest]:
-  /// @googleapis_link{google::cloud::secretmanager::v1::AddSecretVersionRequest,google/cloud/secretmanager/v1/service.proto#L270}
+  /// @googleapis_reference_link{google/cloud/secretmanager/v1/service.proto#L270}
   /// [google.cloud.secretmanager.v1.SecretVersion]:
-  /// @googleapis_link{google::cloud::secretmanager::v1::SecretVersion,google/cloud/secretmanager/v1/resources.proto#L103}
+  /// @googleapis_reference_link{google/cloud/secretmanager/v1/resources.proto#L103}
   ///
   StatusOr<google::cloud::secretmanager::v1::SecretVersion> AddSecretVersion(
       google::cloud::secretmanager::v1::AddSecretVersionRequest const& request);
@@ -375,9 +375,9 @@ class SecretManagerServiceClient {
   /// @googleapis_link{google::cloud::secretmanager::v1::Secret,google/cloud/secretmanager/v1/resources.proto#L40}
   ///
   /// [google.cloud.secretmanager.v1.GetSecretRequest]:
-  /// @googleapis_link{google::cloud::secretmanager::v1::GetSecretRequest,google/cloud/secretmanager/v1/service.proto#L285}
+  /// @googleapis_reference_link{google/cloud/secretmanager/v1/service.proto#L285}
   /// [google.cloud.secretmanager.v1.Secret]:
-  /// @googleapis_link{google::cloud::secretmanager::v1::Secret,google/cloud/secretmanager/v1/resources.proto#L40}
+  /// @googleapis_reference_link{google/cloud/secretmanager/v1/resources.proto#L40}
   ///
   StatusOr<google::cloud::secretmanager::v1::Secret> GetSecret(
       google::cloud::secretmanager::v1::GetSecretRequest const& request);
@@ -392,9 +392,9 @@ class SecretManagerServiceClient {
   /// @googleapis_link{google::cloud::secretmanager::v1::Secret,google/cloud/secretmanager/v1/resources.proto#L40}
   ///
   /// [google.cloud.secretmanager.v1.UpdateSecretRequest]:
-  /// @googleapis_link{google::cloud::secretmanager::v1::UpdateSecretRequest,google/cloud/secretmanager/v1/service.proto#L354}
+  /// @googleapis_reference_link{google/cloud/secretmanager/v1/service.proto#L354}
   /// [google.cloud.secretmanager.v1.Secret]:
-  /// @googleapis_link{google::cloud::secretmanager::v1::Secret,google/cloud/secretmanager/v1/resources.proto#L40}
+  /// @googleapis_reference_link{google/cloud/secretmanager/v1/resources.proto#L40}
   ///
   StatusOr<google::cloud::secretmanager::v1::Secret> UpdateSecret(
       google::cloud::secretmanager::v1::UpdateSecretRequest const& request);
@@ -406,7 +406,7 @@ class SecretManagerServiceClient {
   /// @googleapis_link{google::cloud::secretmanager::v1::DeleteSecretRequest,google/cloud/secretmanager/v1/service.proto#L390}
   ///
   /// [google.cloud.secretmanager.v1.DeleteSecretRequest]:
-  /// @googleapis_link{google::cloud::secretmanager::v1::DeleteSecretRequest,google/cloud/secretmanager/v1/service.proto#L390}
+  /// @googleapis_reference_link{google/cloud/secretmanager/v1/service.proto#L390}
   ///
   Status DeleteSecret(
       google::cloud::secretmanager::v1::DeleteSecretRequest const& request);
@@ -421,9 +421,9 @@ class SecretManagerServiceClient {
   /// @googleapis_link{google::cloud::secretmanager::v1::SecretVersion,google/cloud/secretmanager/v1/resources.proto#L103}
   ///
   /// [google.cloud.secretmanager.v1.ListSecretVersionsRequest]:
-  /// @googleapis_link{google::cloud::secretmanager::v1::ListSecretVersionsRequest,google/cloud/secretmanager/v1/service.proto#L296}
+  /// @googleapis_reference_link{google/cloud/secretmanager/v1/service.proto#L296}
   /// [google.cloud.secretmanager.v1.SecretVersion]:
-  /// @googleapis_link{google::cloud::secretmanager::v1::SecretVersion,google/cloud/secretmanager/v1/resources.proto#L103}
+  /// @googleapis_reference_link{google/cloud/secretmanager/v1/resources.proto#L103}
   ///
   StreamRange<google::cloud::secretmanager::v1::SecretVersion>
   ListSecretVersions(
@@ -442,9 +442,9 @@ class SecretManagerServiceClient {
   /// @googleapis_link{google::cloud::secretmanager::v1::SecretVersion,google/cloud/secretmanager/v1/resources.proto#L103}
   ///
   /// [google.cloud.secretmanager.v1.GetSecretVersionRequest]:
-  /// @googleapis_link{google::cloud::secretmanager::v1::GetSecretVersionRequest,google/cloud/secretmanager/v1/service.proto#L339}
+  /// @googleapis_reference_link{google/cloud/secretmanager/v1/service.proto#L339}
   /// [google.cloud.secretmanager.v1.SecretVersion]:
-  /// @googleapis_link{google::cloud::secretmanager::v1::SecretVersion,google/cloud/secretmanager/v1/resources.proto#L103}
+  /// @googleapis_reference_link{google/cloud/secretmanager/v1/resources.proto#L103}
   ///
   StatusOr<google::cloud::secretmanager::v1::SecretVersion> GetSecretVersion(
       google::cloud::secretmanager::v1::GetSecretVersionRequest const& request);
@@ -462,9 +462,9 @@ class SecretManagerServiceClient {
   /// @googleapis_link{google::cloud::secretmanager::v1::AccessSecretVersionResponse,google/cloud/secretmanager/v1/service.proto#L378}
   ///
   /// [google.cloud.secretmanager.v1.AccessSecretVersionRequest]:
-  /// @googleapis_link{google::cloud::secretmanager::v1::AccessSecretVersionRequest,google/cloud/secretmanager/v1/service.proto#L363}
+  /// @googleapis_reference_link{google/cloud/secretmanager/v1/service.proto#L363}
   /// [google.cloud.secretmanager.v1.AccessSecretVersionResponse]:
-  /// @googleapis_link{google::cloud::secretmanager::v1::AccessSecretVersionResponse,google/cloud/secretmanager/v1/service.proto#L378}
+  /// @googleapis_reference_link{google/cloud/secretmanager/v1/service.proto#L378}
   ///
   StatusOr<google::cloud::secretmanager::v1::AccessSecretVersionResponse>
   AccessSecretVersion(
@@ -484,9 +484,9 @@ class SecretManagerServiceClient {
   /// @googleapis_link{google::cloud::secretmanager::v1::SecretVersion,google/cloud/secretmanager/v1/resources.proto#L103}
   ///
   /// [google.cloud.secretmanager.v1.DisableSecretVersionRequest]:
-  /// @googleapis_link{google::cloud::secretmanager::v1::DisableSecretVersionRequest,google/cloud/secretmanager/v1/service.proto#L407}
+  /// @googleapis_reference_link{google/cloud/secretmanager/v1/service.proto#L407}
   /// [google.cloud.secretmanager.v1.SecretVersion]:
-  /// @googleapis_link{google::cloud::secretmanager::v1::SecretVersion,google/cloud/secretmanager/v1/resources.proto#L103}
+  /// @googleapis_reference_link{google/cloud/secretmanager/v1/resources.proto#L103}
   ///
   StatusOr<google::cloud::secretmanager::v1::SecretVersion>
   DisableSecretVersion(
@@ -506,9 +506,9 @@ class SecretManagerServiceClient {
   /// @googleapis_link{google::cloud::secretmanager::v1::SecretVersion,google/cloud/secretmanager/v1/resources.proto#L103}
   ///
   /// [google.cloud.secretmanager.v1.EnableSecretVersionRequest]:
-  /// @googleapis_link{google::cloud::secretmanager::v1::EnableSecretVersionRequest,google/cloud/secretmanager/v1/service.proto#L424}
+  /// @googleapis_reference_link{google/cloud/secretmanager/v1/service.proto#L424}
   /// [google.cloud.secretmanager.v1.SecretVersion]:
-  /// @googleapis_link{google::cloud::secretmanager::v1::SecretVersion,google/cloud/secretmanager/v1/resources.proto#L103}
+  /// @googleapis_reference_link{google/cloud/secretmanager/v1/resources.proto#L103}
   ///
   StatusOr<google::cloud::secretmanager::v1::SecretVersion> EnableSecretVersion(
       google::cloud::secretmanager::v1::EnableSecretVersionRequest const&
@@ -528,9 +528,9 @@ class SecretManagerServiceClient {
   /// @googleapis_link{google::cloud::secretmanager::v1::SecretVersion,google/cloud/secretmanager/v1/resources.proto#L103}
   ///
   /// [google.cloud.secretmanager.v1.DestroySecretVersionRequest]:
-  /// @googleapis_link{google::cloud::secretmanager::v1::DestroySecretVersionRequest,google/cloud/secretmanager/v1/service.proto#L441}
+  /// @googleapis_reference_link{google/cloud/secretmanager/v1/service.proto#L441}
   /// [google.cloud.secretmanager.v1.SecretVersion]:
-  /// @googleapis_link{google::cloud::secretmanager::v1::SecretVersion,google/cloud/secretmanager/v1/resources.proto#L103}
+  /// @googleapis_reference_link{google/cloud/secretmanager/v1/resources.proto#L103}
   ///
   StatusOr<google::cloud::secretmanager::v1::SecretVersion>
   DestroySecretVersion(
@@ -552,9 +552,9 @@ class SecretManagerServiceClient {
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
   /// [google.iam.v1.SetIamPolicyRequest]:
-  /// @googleapis_link{google::iam::v1::SetIamPolicyRequest,google/iam/v1/iam_policy.proto#L98}
+  /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L98}
   /// [google.iam.v1.Policy]:
-  /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
+  /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
       google::iam::v1::SetIamPolicyRequest const& request);
@@ -569,9 +569,9 @@ class SecretManagerServiceClient {
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
   /// [google.iam.v1.GetIamPolicyRequest]:
-  /// @googleapis_link{google::iam::v1::GetIamPolicyRequest,google/iam/v1/iam_policy.proto#L113}
+  /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L113}
   /// [google.iam.v1.Policy]:
-  /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
+  /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> GetIamPolicy(
       google::iam::v1::GetIamPolicyRequest const& request);
@@ -591,9 +591,9 @@ class SecretManagerServiceClient {
   /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
   ///
   /// [google.iam.v1.TestIamPermissionsRequest]:
-  /// @googleapis_link{google::iam::v1::TestIamPermissionsRequest,google/iam/v1/iam_policy.proto#L126}
+  /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L126}
   /// [google.iam.v1.TestIamPermissionsResponse]:
-  /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
+  /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L141}
   ///
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
       google::iam::v1::TestIamPermissionsRequest const& request);

--- a/google/cloud/spanner/admin/database_admin_client.h
+++ b/google/cloud/spanner/admin/database_admin_client.h
@@ -78,7 +78,7 @@ class DatabaseAdminClient {
   ///
   /// [google.spanner.admin.database.v1.ListDatabasesRequest]:
   /// @googleapis_link{google::spanner::admin::database::v1::ListDatabasesRequest,google/spanner/admin/database/v1/spanner_database_admin.proto#L413}
-  /// [google::spanner::admin::database::v1::Database]:
+  /// [google.spanner.admin.database.v1.Database]:
   /// @googleapis_link{google::spanner::admin::database::v1::Database,google/spanner/admin/database/v1/spanner_database_admin.proto#L326}
   ///
   StreamRange<google::spanner::admin::database::v1::Database> ListDatabases(
@@ -405,7 +405,7 @@ class DatabaseAdminClient {
   ///
   /// [google.spanner.admin.database.v1.ListBackupsRequest]:
   /// @googleapis_link{google::spanner::admin::database::v1::ListBackupsRequest,google/spanner/admin/database/v1/backup.proto#L228}
-  /// [google::spanner::admin::database::v1::Backup]:
+  /// [google.spanner.admin.database.v1.Backup]:
   /// @googleapis_link{google::spanner::admin::database::v1::Backup,google/spanner/admin/database/v1/backup.proto#L36}
   ///
   StreamRange<google::spanner::admin::database::v1::Backup> ListBackups(
@@ -472,7 +472,7 @@ class DatabaseAdminClient {
   ///
   /// [google.spanner.admin.database.v1.ListDatabaseOperationsRequest]:
   /// @googleapis_link{google::spanner::admin::database::v1::ListDatabaseOperationsRequest,google/spanner/admin/database/v1/spanner_database_admin.proto#L611}
-  /// [google::longrunning::Operation]:
+  /// [google.longrunning.Operation]:
   /// @googleapis_link{google::longrunning::Operation,google/longrunning/operations.proto#L128}
   ///
   StreamRange<google::longrunning::Operation> ListDatabaseOperations(
@@ -498,7 +498,7 @@ class DatabaseAdminClient {
   ///
   /// [google.spanner.admin.database.v1.ListBackupOperationsRequest]:
   /// @googleapis_link{google::spanner::admin::database::v1::ListBackupOperationsRequest,google/spanner/admin/database/v1/backup.proto#L300}
-  /// [google::longrunning::Operation]:
+  /// [google.longrunning.Operation]:
   /// @googleapis_link{google::longrunning::Operation,google/longrunning/operations.proto#L128}
   ///
   StreamRange<google::longrunning::Operation> ListBackupOperations(
@@ -514,7 +514,7 @@ class DatabaseAdminClient {
   ///
   /// [google.spanner.admin.database.v1.ListDatabasesRequest]:
   /// @googleapis_link{google::spanner::admin::database::v1::ListDatabasesRequest,google/spanner/admin/database/v1/spanner_database_admin.proto#L413}
-  /// [google::spanner::admin::database::v1::Database]:
+  /// [google.spanner.admin.database.v1.Database]:
   /// @googleapis_link{google::spanner::admin::database::v1::Database,google/spanner/admin/database/v1/spanner_database_admin.proto#L326}
   ///
   StreamRange<google::spanner::admin::database::v1::Database> ListDatabases(
@@ -777,7 +777,7 @@ class DatabaseAdminClient {
   ///
   /// [google.spanner.admin.database.v1.ListBackupsRequest]:
   /// @googleapis_link{google::spanner::admin::database::v1::ListBackupsRequest,google/spanner/admin/database/v1/backup.proto#L228}
-  /// [google::spanner::admin::database::v1::Backup]:
+  /// [google.spanner.admin.database.v1.Backup]:
   /// @googleapis_link{google::spanner::admin::database::v1::Backup,google/spanner/admin/database/v1/backup.proto#L36}
   ///
   StreamRange<google::spanner::admin::database::v1::Backup> ListBackups(
@@ -834,7 +834,7 @@ class DatabaseAdminClient {
   ///
   /// [google.spanner.admin.database.v1.ListDatabaseOperationsRequest]:
   /// @googleapis_link{google::spanner::admin::database::v1::ListDatabaseOperationsRequest,google/spanner/admin/database/v1/spanner_database_admin.proto#L611}
-  /// [google::longrunning::Operation]:
+  /// [google.longrunning.Operation]:
   /// @googleapis_link{google::longrunning::Operation,google/longrunning/operations.proto#L128}
   ///
   StreamRange<google::longrunning::Operation> ListDatabaseOperations(
@@ -860,7 +860,7 @@ class DatabaseAdminClient {
   ///
   /// [google.spanner.admin.database.v1.ListBackupOperationsRequest]:
   /// @googleapis_link{google::spanner::admin::database::v1::ListBackupOperationsRequest,google/spanner/admin/database/v1/backup.proto#L300}
-  /// [google::longrunning::Operation]:
+  /// [google.longrunning.Operation]:
   /// @googleapis_link{google::longrunning::Operation,google/longrunning/operations.proto#L128}
   ///
   StreamRange<google::longrunning::Operation> ListBackupOperations(

--- a/google/cloud/spanner/admin/database_admin_client.h
+++ b/google/cloud/spanner/admin/database_admin_client.h
@@ -76,6 +76,11 @@ class DatabaseAdminClient {
   /// @return
   /// @googleapis_link{google::spanner::admin::database::v1::Database,google/spanner/admin/database/v1/spanner_database_admin.proto#L326}
   ///
+  /// [google.spanner.admin.database.v1.ListDatabasesRequest]:
+  /// @googleapis_link{google::spanner::admin::database::v1::ListDatabasesRequest,google/spanner/admin/database/v1/spanner_database_admin.proto#L413}
+  /// [google::spanner::admin::database::v1::Database]:
+  /// @googleapis_link{google::spanner::admin::database::v1::Database,google/spanner/admin/database/v1/spanner_database_admin.proto#L326}
+  ///
   StreamRange<google::spanner::admin::database::v1::Database> ListDatabases(
       std::string const& parent);
 
@@ -101,6 +106,11 @@ class DatabaseAdminClient {
   /// @return
   /// @googleapis_link{google::spanner::admin::database::v1::Database,google/spanner/admin/database/v1/spanner_database_admin.proto#L326}
   ///
+  /// [google.spanner.admin.database.v1.CreateDatabaseRequest]:
+  /// @googleapis_link{google::spanner::admin::database::v1::CreateDatabaseRequest,google/spanner/admin/database/v1/spanner_database_admin.proto#L445}
+  /// [google.spanner.admin.database.v1.Database]:
+  /// @googleapis_link{google::spanner::admin::database::v1::Database,google/spanner/admin/database/v1/spanner_database_admin.proto#L326}
+  ///
   future<StatusOr<google::spanner::admin::database::v1::Database>>
   CreateDatabase(std::string const& parent,
                  std::string const& create_statement);
@@ -112,6 +122,11 @@ class DatabaseAdminClient {
   /// the form
   ///  `projects/<project>/instances/<instance>/databases/<database>`.
   /// @return
+  /// @googleapis_link{google::spanner::admin::database::v1::Database,google/spanner/admin/database/v1/spanner_database_admin.proto#L326}
+  ///
+  /// [google.spanner.admin.database.v1.GetDatabaseRequest]:
+  /// @googleapis_link{google::spanner::admin::database::v1::GetDatabaseRequest,google/spanner/admin/database/v1/spanner_database_admin.proto#L484}
+  /// [google.spanner.admin.database.v1.Database]:
   /// @googleapis_link{google::spanner::admin::database::v1::Database,google/spanner/admin/database/v1/spanner_database_admin.proto#L326}
   ///
   StatusOr<google::spanner::admin::database::v1::Database> GetDatabase(
@@ -132,6 +147,11 @@ class DatabaseAdminClient {
   /// @return
   /// @googleapis_link{google::spanner::admin::database::v1::UpdateDatabaseDdlMetadata,google/spanner/admin/database/v1/spanner_database_admin.proto#L547}
   ///
+  /// [google.spanner.admin.database.v1.UpdateDatabaseDdlRequest]:
+  /// @googleapis_link{google::spanner::admin::database::v1::UpdateDatabaseDdlRequest,google/spanner/admin/database/v1/spanner_database_admin.proto#L511}
+  /// [google.spanner.admin.database.v1.UpdateDatabaseDdlMetadata]:
+  /// @googleapis_link{google::spanner::admin::database::v1::UpdateDatabaseDdlMetadata,google/spanner/admin/database/v1/spanner_database_admin.proto#L547}
+  ///
   future<
       StatusOr<google::spanner::admin::database::v1::UpdateDatabaseDdlMetadata>>
   UpdateDatabaseDdl(std::string const& database,
@@ -144,6 +164,9 @@ class DatabaseAdminClient {
   ///
   /// @param database  Required. The database to be dropped.
   ///
+  /// [google.spanner.admin.database.v1.DropDatabaseRequest]:
+  /// @googleapis_link{google::spanner::admin::database::v1::DropDatabaseRequest,google/spanner/admin/database/v1/spanner_database_admin.proto#L579}
+  ///
   Status DropDatabase(std::string const& database);
 
   ///
@@ -155,6 +178,11 @@ class DatabaseAdminClient {
   ///  Values are of the form
   ///  `projects/<project>/instances/<instance>/databases/<database>`
   /// @return
+  /// @googleapis_link{google::spanner::admin::database::v1::GetDatabaseDdlResponse,google/spanner/admin/database/v1/spanner_database_admin.proto#L603}
+  ///
+  /// [google.spanner.admin.database.v1.GetDatabaseDdlRequest]:
+  /// @googleapis_link{google::spanner::admin::database::v1::GetDatabaseDdlRequest,google/spanner/admin/database/v1/spanner_database_admin.proto#L590}
+  /// [google.spanner.admin.database.v1.GetDatabaseDdlResponse]:
   /// @googleapis_link{google::spanner::admin::database::v1::GetDatabaseDdlResponse,google/spanner/admin/database/v1/spanner_database_admin.proto#L603}
   ///
   StatusOr<google::spanner::admin::database::v1::GetDatabaseDdlResponse>
@@ -178,6 +206,11 @@ class DatabaseAdminClient {
   ///  valid policy but certain Cloud Platform services (such as Projects)
   ///  might reject them.
   /// @return
+  /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
+  ///
+  /// [google.iam.v1.SetIamPolicyRequest]:
+  /// @googleapis_link{google::iam::v1::SetIamPolicyRequest,google/iam/v1/iam_policy.proto#L98}
+  /// [google.iam.v1.Policy]:
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
@@ -224,6 +257,11 @@ class DatabaseAdminClient {
   /// @return
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
+  /// [google.iam.v1.GetIamPolicyRequest]:
+  /// @googleapis_link{google::iam::v1::GetIamPolicyRequest,google/iam/v1/iam_policy.proto#L113}
+  /// [google.iam.v1.Policy]:
+  /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
+  ///
   StatusOr<google::iam::v1::Policy> GetIamPolicy(std::string const& resource);
 
   ///
@@ -247,6 +285,11 @@ class DatabaseAdminClient {
   ///  information see
   ///  [IAM Overview](https://cloud.google.com/iam/docs/overview#permissions).
   /// @return
+  /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
+  ///
+  /// [google.iam.v1.TestIamPermissionsRequest]:
+  /// @googleapis_link{google::iam::v1::TestIamPermissionsRequest,google/iam/v1/iam_policy.proto#L126}
+  /// [google.iam.v1.TestIamPermissionsResponse]:
   /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
   ///
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
@@ -281,6 +324,11 @@ class DatabaseAdminClient {
   /// @return
   /// @googleapis_link{google::spanner::admin::database::v1::Backup,google/spanner/admin/database/v1/backup.proto#L36}
   ///
+  /// [google.spanner.admin.database.v1.CreateBackupRequest]:
+  /// @googleapis_link{google::spanner::admin::database::v1::CreateBackupRequest,google/spanner/admin/database/v1/backup.proto#L123}
+  /// [google.spanner.admin.database.v1.Backup]:
+  /// @googleapis_link{google::spanner::admin::database::v1::Backup,google/spanner/admin/database/v1/backup.proto#L36}
+  ///
   future<StatusOr<google::spanner::admin::database::v1::Backup>> CreateBackup(
       std::string const& parent,
       google::spanner::admin::database::v1::Backup const& backup,
@@ -294,6 +342,11 @@ class DatabaseAdminClient {
   ///  Values are of the form
   ///  `projects/<project>/instances/<instance>/backups/<backup>`.
   /// @return
+  /// @googleapis_link{google::spanner::admin::database::v1::Backup,google/spanner/admin/database/v1/backup.proto#L36}
+  ///
+  /// [google.spanner.admin.database.v1.GetBackupRequest]:
+  /// @googleapis_link{google::spanner::admin::database::v1::GetBackupRequest,google/spanner/admin/database/v1/backup.proto#L202}
+  /// [google.spanner.admin.database.v1.Backup]:
   /// @googleapis_link{google::spanner::admin::database::v1::Backup,google/spanner/admin/database/v1/backup.proto#L36}
   ///
   StatusOr<google::spanner::admin::database::v1::Backup> GetBackup(
@@ -317,6 +370,11 @@ class DatabaseAdminClient {
   /// @return
   /// @googleapis_link{google::spanner::admin::database::v1::Backup,google/spanner/admin/database/v1/backup.proto#L36}
   ///
+  /// [google.spanner.admin.database.v1.UpdateBackupRequest]:
+  /// @googleapis_link{google::spanner::admin::database::v1::UpdateBackupRequest,google/spanner/admin/database/v1/backup.proto#L186}
+  /// [google.spanner.admin.database.v1.Backup]:
+  /// @googleapis_link{google::spanner::admin::database::v1::Backup,google/spanner/admin/database/v1/backup.proto#L36}
+  ///
   StatusOr<google::spanner::admin::database::v1::Backup> UpdateBackup(
       google::spanner::admin::database::v1::Backup const& backup,
       google::protobuf::FieldMask const& update_mask);
@@ -329,6 +387,9 @@ class DatabaseAdminClient {
   ///  Values are of the form
   ///  `projects/<project>/instances/<instance>/backups/<backup>`.
   ///
+  /// [google.spanner.admin.database.v1.DeleteBackupRequest]:
+  /// @googleapis_link{google::spanner::admin::database::v1::DeleteBackupRequest,google/spanner/admin/database/v1/backup.proto#L215}
+  ///
   Status DeleteBackup(std::string const& name);
 
   ///
@@ -340,6 +401,11 @@ class DatabaseAdminClient {
   /// the
   ///  form `projects/<project>/instances/<instance>`.
   /// @return
+  /// @googleapis_link{google::spanner::admin::database::v1::Backup,google/spanner/admin/database/v1/backup.proto#L36}
+  ///
+  /// [google.spanner.admin.database.v1.ListBackupsRequest]:
+  /// @googleapis_link{google::spanner::admin::database::v1::ListBackupsRequest,google/spanner/admin/database/v1/backup.proto#L228}
+  /// [google::spanner::admin::database::v1::Backup]:
   /// @googleapis_link{google::spanner::admin::database::v1::Backup,google/spanner/admin/database/v1/backup.proto#L36}
   ///
   StreamRange<google::spanner::admin::database::v1::Backup> ListBackups(
@@ -380,6 +446,11 @@ class DatabaseAdminClient {
   /// @return
   /// @googleapis_link{google::spanner::admin::database::v1::Database,google/spanner/admin/database/v1/spanner_database_admin.proto#L326}
   ///
+  /// [google.spanner.admin.database.v1.RestoreDatabaseRequest]:
+  /// @googleapis_link{google::spanner::admin::database::v1::RestoreDatabaseRequest,google/spanner/admin/database/v1/spanner_database_admin.proto#L692}
+  /// [google.spanner.admin.database.v1.Database]:
+  /// @googleapis_link{google::spanner::admin::database::v1::Database,google/spanner/admin/database/v1/spanner_database_admin.proto#L326}
+  ///
   future<StatusOr<google::spanner::admin::database::v1::Database>>
   RestoreDatabase(std::string const& parent, std::string const& database_id,
                   std::string const& backup);
@@ -397,6 +468,11 @@ class DatabaseAdminClient {
   /// @param parent  Required. The instance of the database operations.
   ///  Values are of the form `projects/<project>/instances/<instance>`.
   /// @return
+  /// @googleapis_link{google::longrunning::Operation,google/longrunning/operations.proto#L128}
+  ///
+  /// [google.spanner.admin.database.v1.ListDatabaseOperationsRequest]:
+  /// @googleapis_link{google::spanner::admin::database::v1::ListDatabaseOperationsRequest,google/spanner/admin/database/v1/spanner_database_admin.proto#L611}
+  /// [google::longrunning::Operation]:
   /// @googleapis_link{google::longrunning::Operation,google/longrunning/operations.proto#L128}
   ///
   StreamRange<google::longrunning::Operation> ListDatabaseOperations(
@@ -420,6 +496,11 @@ class DatabaseAdminClient {
   /// @return
   /// @googleapis_link{google::longrunning::Operation,google/longrunning/operations.proto#L128}
   ///
+  /// [google.spanner.admin.database.v1.ListBackupOperationsRequest]:
+  /// @googleapis_link{google::spanner::admin::database::v1::ListBackupOperationsRequest,google/spanner/admin/database/v1/backup.proto#L300}
+  /// [google::longrunning::Operation]:
+  /// @googleapis_link{google::longrunning::Operation,google/longrunning/operations.proto#L128}
+  ///
   StreamRange<google::longrunning::Operation> ListBackupOperations(
       std::string const& parent);
 
@@ -429,6 +510,11 @@ class DatabaseAdminClient {
   /// @param request
   /// @googleapis_link{google::spanner::admin::database::v1::ListDatabasesRequest,google/spanner/admin/database/v1/spanner_database_admin.proto#L413}
   /// @return
+  /// @googleapis_link{google::spanner::admin::database::v1::Database,google/spanner/admin/database/v1/spanner_database_admin.proto#L326}
+  ///
+  /// [google.spanner.admin.database.v1.ListDatabasesRequest]:
+  /// @googleapis_link{google::spanner::admin::database::v1::ListDatabasesRequest,google/spanner/admin/database/v1/spanner_database_admin.proto#L413}
+  /// [google::spanner::admin::database::v1::Database]:
   /// @googleapis_link{google::spanner::admin::database::v1::Database,google/spanner/admin/database/v1/spanner_database_admin.proto#L326}
   ///
   StreamRange<google::spanner::admin::database::v1::Database> ListDatabases(
@@ -449,6 +535,11 @@ class DatabaseAdminClient {
   /// @return
   /// @googleapis_link{google::spanner::admin::database::v1::Database,google/spanner/admin/database/v1/spanner_database_admin.proto#L326}
   ///
+  /// [google.spanner.admin.database.v1.CreateDatabaseRequest]:
+  /// @googleapis_link{google::spanner::admin::database::v1::CreateDatabaseRequest,google/spanner/admin/database/v1/spanner_database_admin.proto#L445}
+  /// [google.spanner.admin.database.v1.Database]:
+  /// @googleapis_link{google::spanner::admin::database::v1::Database,google/spanner/admin/database/v1/spanner_database_admin.proto#L326}
+  ///
   future<StatusOr<google::spanner::admin::database::v1::Database>>
   CreateDatabase(
       google::spanner::admin::database::v1::CreateDatabaseRequest const&
@@ -460,6 +551,11 @@ class DatabaseAdminClient {
   /// @param request
   /// @googleapis_link{google::spanner::admin::database::v1::GetDatabaseRequest,google/spanner/admin/database/v1/spanner_database_admin.proto#L484}
   /// @return
+  /// @googleapis_link{google::spanner::admin::database::v1::Database,google/spanner/admin/database/v1/spanner_database_admin.proto#L326}
+  ///
+  /// [google.spanner.admin.database.v1.GetDatabaseRequest]:
+  /// @googleapis_link{google::spanner::admin::database::v1::GetDatabaseRequest,google/spanner/admin/database/v1/spanner_database_admin.proto#L484}
+  /// [google.spanner.admin.database.v1.Database]:
   /// @googleapis_link{google::spanner::admin::database::v1::Database,google/spanner/admin/database/v1/spanner_database_admin.proto#L326}
   ///
   StatusOr<google::spanner::admin::database::v1::Database> GetDatabase(
@@ -480,6 +576,11 @@ class DatabaseAdminClient {
   /// @return
   /// @googleapis_link{google::spanner::admin::database::v1::UpdateDatabaseDdlMetadata,google/spanner/admin/database/v1/spanner_database_admin.proto#L547}
   ///
+  /// [google.spanner.admin.database.v1.UpdateDatabaseDdlRequest]:
+  /// @googleapis_link{google::spanner::admin::database::v1::UpdateDatabaseDdlRequest,google/spanner/admin/database/v1/spanner_database_admin.proto#L511}
+  /// [google.spanner.admin.database.v1.UpdateDatabaseDdlMetadata]:
+  /// @googleapis_link{google::spanner::admin::database::v1::UpdateDatabaseDdlMetadata,google/spanner/admin/database/v1/spanner_database_admin.proto#L547}
+  ///
   future<
       StatusOr<google::spanner::admin::database::v1::UpdateDatabaseDdlMetadata>>
   UpdateDatabaseDdl(
@@ -494,6 +595,9 @@ class DatabaseAdminClient {
   /// @param request
   /// @googleapis_link{google::spanner::admin::database::v1::DropDatabaseRequest,google/spanner/admin/database/v1/spanner_database_admin.proto#L579}
   ///
+  /// [google.spanner.admin.database.v1.DropDatabaseRequest]:
+  /// @googleapis_link{google::spanner::admin::database::v1::DropDatabaseRequest,google/spanner/admin/database/v1/spanner_database_admin.proto#L579}
+  ///
   Status DropDatabase(
       google::spanner::admin::database::v1::DropDatabaseRequest const& request);
 
@@ -505,6 +609,11 @@ class DatabaseAdminClient {
   /// @param request
   /// @googleapis_link{google::spanner::admin::database::v1::GetDatabaseDdlRequest,google/spanner/admin/database/v1/spanner_database_admin.proto#L590}
   /// @return
+  /// @googleapis_link{google::spanner::admin::database::v1::GetDatabaseDdlResponse,google/spanner/admin/database/v1/spanner_database_admin.proto#L603}
+  ///
+  /// [google.spanner.admin.database.v1.GetDatabaseDdlRequest]:
+  /// @googleapis_link{google::spanner::admin::database::v1::GetDatabaseDdlRequest,google/spanner/admin/database/v1/spanner_database_admin.proto#L590}
+  /// [google.spanner.admin.database.v1.GetDatabaseDdlResponse]:
   /// @googleapis_link{google::spanner::admin::database::v1::GetDatabaseDdlResponse,google/spanner/admin/database/v1/spanner_database_admin.proto#L603}
   ///
   StatusOr<google::spanner::admin::database::v1::GetDatabaseDdlResponse>
@@ -526,6 +635,11 @@ class DatabaseAdminClient {
   /// @return
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
+  /// [google.iam.v1.SetIamPolicyRequest]:
+  /// @googleapis_link{google::iam::v1::SetIamPolicyRequest,google/iam/v1/iam_policy.proto#L98}
+  /// [google.iam.v1.Policy]:
+  /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
+  ///
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
       google::iam::v1::SetIamPolicyRequest const& request);
 
@@ -542,6 +656,11 @@ class DatabaseAdminClient {
   /// @param request
   /// @googleapis_link{google::iam::v1::GetIamPolicyRequest,google/iam/v1/iam_policy.proto#L113}
   /// @return
+  /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
+  ///
+  /// [google.iam.v1.GetIamPolicyRequest]:
+  /// @googleapis_link{google::iam::v1::GetIamPolicyRequest,google/iam/v1/iam_policy.proto#L113}
+  /// [google.iam.v1.Policy]:
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> GetIamPolicy(
@@ -562,6 +681,11 @@ class DatabaseAdminClient {
   /// @param request
   /// @googleapis_link{google::iam::v1::TestIamPermissionsRequest,google/iam/v1/iam_policy.proto#L126}
   /// @return
+  /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
+  ///
+  /// [google.iam.v1.TestIamPermissionsRequest]:
+  /// @googleapis_link{google::iam::v1::TestIamPermissionsRequest,google/iam/v1/iam_policy.proto#L126}
+  /// [google.iam.v1.TestIamPermissionsResponse]:
   /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
   ///
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
@@ -586,6 +710,11 @@ class DatabaseAdminClient {
   /// @return
   /// @googleapis_link{google::spanner::admin::database::v1::Backup,google/spanner/admin/database/v1/backup.proto#L36}
   ///
+  /// [google.spanner.admin.database.v1.CreateBackupRequest]:
+  /// @googleapis_link{google::spanner::admin::database::v1::CreateBackupRequest,google/spanner/admin/database/v1/backup.proto#L123}
+  /// [google.spanner.admin.database.v1.Backup]:
+  /// @googleapis_link{google::spanner::admin::database::v1::Backup,google/spanner/admin/database/v1/backup.proto#L36}
+  ///
   future<StatusOr<google::spanner::admin::database::v1::Backup>> CreateBackup(
       google::spanner::admin::database::v1::CreateBackupRequest const& request);
 
@@ -596,6 +725,11 @@ class DatabaseAdminClient {
   /// @param request
   /// @googleapis_link{google::spanner::admin::database::v1::GetBackupRequest,google/spanner/admin/database/v1/backup.proto#L202}
   /// @return
+  /// @googleapis_link{google::spanner::admin::database::v1::Backup,google/spanner/admin/database/v1/backup.proto#L36}
+  ///
+  /// [google.spanner.admin.database.v1.GetBackupRequest]:
+  /// @googleapis_link{google::spanner::admin::database::v1::GetBackupRequest,google/spanner/admin/database/v1/backup.proto#L202}
+  /// [google.spanner.admin.database.v1.Backup]:
   /// @googleapis_link{google::spanner::admin::database::v1::Backup,google/spanner/admin/database/v1/backup.proto#L36}
   ///
   StatusOr<google::spanner::admin::database::v1::Backup> GetBackup(
@@ -610,6 +744,11 @@ class DatabaseAdminClient {
   /// @return
   /// @googleapis_link{google::spanner::admin::database::v1::Backup,google/spanner/admin/database/v1/backup.proto#L36}
   ///
+  /// [google.spanner.admin.database.v1.UpdateBackupRequest]:
+  /// @googleapis_link{google::spanner::admin::database::v1::UpdateBackupRequest,google/spanner/admin/database/v1/backup.proto#L186}
+  /// [google.spanner.admin.database.v1.Backup]:
+  /// @googleapis_link{google::spanner::admin::database::v1::Backup,google/spanner/admin/database/v1/backup.proto#L36}
+  ///
   StatusOr<google::spanner::admin::database::v1::Backup> UpdateBackup(
       google::spanner::admin::database::v1::UpdateBackupRequest const& request);
 
@@ -618,6 +757,9 @@ class DatabaseAdminClient {
   /// [Backup][google.spanner.admin.database.v1.Backup].
   ///
   /// @param request
+  /// @googleapis_link{google::spanner::admin::database::v1::DeleteBackupRequest,google/spanner/admin/database/v1/backup.proto#L215}
+  ///
+  /// [google.spanner.admin.database.v1.DeleteBackupRequest]:
   /// @googleapis_link{google::spanner::admin::database::v1::DeleteBackupRequest,google/spanner/admin/database/v1/backup.proto#L215}
   ///
   Status DeleteBackup(
@@ -631,6 +773,11 @@ class DatabaseAdminClient {
   /// @param request
   /// @googleapis_link{google::spanner::admin::database::v1::ListBackupsRequest,google/spanner/admin/database/v1/backup.proto#L228}
   /// @return
+  /// @googleapis_link{google::spanner::admin::database::v1::Backup,google/spanner/admin/database/v1/backup.proto#L36}
+  ///
+  /// [google.spanner.admin.database.v1.ListBackupsRequest]:
+  /// @googleapis_link{google::spanner::admin::database::v1::ListBackupsRequest,google/spanner/admin/database/v1/backup.proto#L228}
+  /// [google::spanner::admin::database::v1::Backup]:
   /// @googleapis_link{google::spanner::admin::database::v1::Backup,google/spanner/admin/database/v1/backup.proto#L36}
   ///
   StreamRange<google::spanner::admin::database::v1::Backup> ListBackups(
@@ -660,6 +807,11 @@ class DatabaseAdminClient {
   /// @return
   /// @googleapis_link{google::spanner::admin::database::v1::Database,google/spanner/admin/database/v1/spanner_database_admin.proto#L326}
   ///
+  /// [google.spanner.admin.database.v1.RestoreDatabaseRequest]:
+  /// @googleapis_link{google::spanner::admin::database::v1::RestoreDatabaseRequest,google/spanner/admin/database/v1/spanner_database_admin.proto#L692}
+  /// [google.spanner.admin.database.v1.Database]:
+  /// @googleapis_link{google::spanner::admin::database::v1::Database,google/spanner/admin/database/v1/spanner_database_admin.proto#L326}
+  ///
   future<StatusOr<google::spanner::admin::database::v1::Database>>
   RestoreDatabase(
       google::spanner::admin::database::v1::RestoreDatabaseRequest const&
@@ -678,6 +830,11 @@ class DatabaseAdminClient {
   /// @param request
   /// @googleapis_link{google::spanner::admin::database::v1::ListDatabaseOperationsRequest,google/spanner/admin/database/v1/spanner_database_admin.proto#L611}
   /// @return
+  /// @googleapis_link{google::longrunning::Operation,google/longrunning/operations.proto#L128}
+  ///
+  /// [google.spanner.admin.database.v1.ListDatabaseOperationsRequest]:
+  /// @googleapis_link{google::spanner::admin::database::v1::ListDatabaseOperationsRequest,google/spanner/admin/database/v1/spanner_database_admin.proto#L611}
+  /// [google::longrunning::Operation]:
   /// @googleapis_link{google::longrunning::Operation,google/longrunning/operations.proto#L128}
   ///
   StreamRange<google::longrunning::Operation> ListDatabaseOperations(
@@ -699,6 +856,11 @@ class DatabaseAdminClient {
   /// @param request
   /// @googleapis_link{google::spanner::admin::database::v1::ListBackupOperationsRequest,google/spanner/admin/database/v1/backup.proto#L300}
   /// @return
+  /// @googleapis_link{google::longrunning::Operation,google/longrunning/operations.proto#L128}
+  ///
+  /// [google.spanner.admin.database.v1.ListBackupOperationsRequest]:
+  /// @googleapis_link{google::spanner::admin::database::v1::ListBackupOperationsRequest,google/spanner/admin/database/v1/backup.proto#L300}
+  /// [google::longrunning::Operation]:
   /// @googleapis_link{google::longrunning::Operation,google/longrunning/operations.proto#L128}
   ///
   StreamRange<google::longrunning::Operation> ListBackupOperations(

--- a/google/cloud/spanner/admin/database_admin_client.h
+++ b/google/cloud/spanner/admin/database_admin_client.h
@@ -77,9 +77,9 @@ class DatabaseAdminClient {
   /// @googleapis_link{google::spanner::admin::database::v1::Database,google/spanner/admin/database/v1/spanner_database_admin.proto#L326}
   ///
   /// [google.spanner.admin.database.v1.ListDatabasesRequest]:
-  /// @googleapis_link{google::spanner::admin::database::v1::ListDatabasesRequest,google/spanner/admin/database/v1/spanner_database_admin.proto#L413}
+  /// @googleapis_reference_link{google/spanner/admin/database/v1/spanner_database_admin.proto#L413}
   /// [google.spanner.admin.database.v1.Database]:
-  /// @googleapis_link{google::spanner::admin::database::v1::Database,google/spanner/admin/database/v1/spanner_database_admin.proto#L326}
+  /// @googleapis_reference_link{google/spanner/admin/database/v1/spanner_database_admin.proto#L326}
   ///
   StreamRange<google::spanner::admin::database::v1::Database> ListDatabases(
       std::string const& parent);
@@ -107,9 +107,9 @@ class DatabaseAdminClient {
   /// @googleapis_link{google::spanner::admin::database::v1::Database,google/spanner/admin/database/v1/spanner_database_admin.proto#L326}
   ///
   /// [google.spanner.admin.database.v1.CreateDatabaseRequest]:
-  /// @googleapis_link{google::spanner::admin::database::v1::CreateDatabaseRequest,google/spanner/admin/database/v1/spanner_database_admin.proto#L445}
+  /// @googleapis_reference_link{google/spanner/admin/database/v1/spanner_database_admin.proto#L445}
   /// [google.spanner.admin.database.v1.Database]:
-  /// @googleapis_link{google::spanner::admin::database::v1::Database,google/spanner/admin/database/v1/spanner_database_admin.proto#L326}
+  /// @googleapis_reference_link{google/spanner/admin/database/v1/spanner_database_admin.proto#L326}
   ///
   future<StatusOr<google::spanner::admin::database::v1::Database>>
   CreateDatabase(std::string const& parent,
@@ -125,9 +125,9 @@ class DatabaseAdminClient {
   /// @googleapis_link{google::spanner::admin::database::v1::Database,google/spanner/admin/database/v1/spanner_database_admin.proto#L326}
   ///
   /// [google.spanner.admin.database.v1.GetDatabaseRequest]:
-  /// @googleapis_link{google::spanner::admin::database::v1::GetDatabaseRequest,google/spanner/admin/database/v1/spanner_database_admin.proto#L484}
+  /// @googleapis_reference_link{google/spanner/admin/database/v1/spanner_database_admin.proto#L484}
   /// [google.spanner.admin.database.v1.Database]:
-  /// @googleapis_link{google::spanner::admin::database::v1::Database,google/spanner/admin/database/v1/spanner_database_admin.proto#L326}
+  /// @googleapis_reference_link{google/spanner/admin/database/v1/spanner_database_admin.proto#L326}
   ///
   StatusOr<google::spanner::admin::database::v1::Database> GetDatabase(
       std::string const& name);
@@ -148,9 +148,9 @@ class DatabaseAdminClient {
   /// @googleapis_link{google::spanner::admin::database::v1::UpdateDatabaseDdlMetadata,google/spanner/admin/database/v1/spanner_database_admin.proto#L547}
   ///
   /// [google.spanner.admin.database.v1.UpdateDatabaseDdlRequest]:
-  /// @googleapis_link{google::spanner::admin::database::v1::UpdateDatabaseDdlRequest,google/spanner/admin/database/v1/spanner_database_admin.proto#L511}
+  /// @googleapis_reference_link{google/spanner/admin/database/v1/spanner_database_admin.proto#L511}
   /// [google.spanner.admin.database.v1.UpdateDatabaseDdlMetadata]:
-  /// @googleapis_link{google::spanner::admin::database::v1::UpdateDatabaseDdlMetadata,google/spanner/admin/database/v1/spanner_database_admin.proto#L547}
+  /// @googleapis_reference_link{google/spanner/admin/database/v1/spanner_database_admin.proto#L547}
   ///
   future<
       StatusOr<google::spanner::admin::database::v1::UpdateDatabaseDdlMetadata>>
@@ -165,7 +165,7 @@ class DatabaseAdminClient {
   /// @param database  Required. The database to be dropped.
   ///
   /// [google.spanner.admin.database.v1.DropDatabaseRequest]:
-  /// @googleapis_link{google::spanner::admin::database::v1::DropDatabaseRequest,google/spanner/admin/database/v1/spanner_database_admin.proto#L579}
+  /// @googleapis_reference_link{google/spanner/admin/database/v1/spanner_database_admin.proto#L579}
   ///
   Status DropDatabase(std::string const& database);
 
@@ -181,9 +181,9 @@ class DatabaseAdminClient {
   /// @googleapis_link{google::spanner::admin::database::v1::GetDatabaseDdlResponse,google/spanner/admin/database/v1/spanner_database_admin.proto#L603}
   ///
   /// [google.spanner.admin.database.v1.GetDatabaseDdlRequest]:
-  /// @googleapis_link{google::spanner::admin::database::v1::GetDatabaseDdlRequest,google/spanner/admin/database/v1/spanner_database_admin.proto#L590}
+  /// @googleapis_reference_link{google/spanner/admin/database/v1/spanner_database_admin.proto#L590}
   /// [google.spanner.admin.database.v1.GetDatabaseDdlResponse]:
-  /// @googleapis_link{google::spanner::admin::database::v1::GetDatabaseDdlResponse,google/spanner/admin/database/v1/spanner_database_admin.proto#L603}
+  /// @googleapis_reference_link{google/spanner/admin/database/v1/spanner_database_admin.proto#L603}
   ///
   StatusOr<google::spanner::admin::database::v1::GetDatabaseDdlResponse>
   GetDatabaseDdl(std::string const& database);
@@ -209,9 +209,9 @@ class DatabaseAdminClient {
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
   /// [google.iam.v1.SetIamPolicyRequest]:
-  /// @googleapis_link{google::iam::v1::SetIamPolicyRequest,google/iam/v1/iam_policy.proto#L98}
+  /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L98}
   /// [google.iam.v1.Policy]:
-  /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
+  /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
       std::string const& resource, google::iam::v1::Policy const& policy);
@@ -258,9 +258,9 @@ class DatabaseAdminClient {
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
   /// [google.iam.v1.GetIamPolicyRequest]:
-  /// @googleapis_link{google::iam::v1::GetIamPolicyRequest,google/iam/v1/iam_policy.proto#L113}
+  /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L113}
   /// [google.iam.v1.Policy]:
-  /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
+  /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> GetIamPolicy(std::string const& resource);
 
@@ -288,9 +288,9 @@ class DatabaseAdminClient {
   /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
   ///
   /// [google.iam.v1.TestIamPermissionsRequest]:
-  /// @googleapis_link{google::iam::v1::TestIamPermissionsRequest,google/iam/v1/iam_policy.proto#L126}
+  /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L126}
   /// [google.iam.v1.TestIamPermissionsResponse]:
-  /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
+  /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L141}
   ///
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
       std::string const& resource, std::vector<std::string> const& permissions);
@@ -325,9 +325,9 @@ class DatabaseAdminClient {
   /// @googleapis_link{google::spanner::admin::database::v1::Backup,google/spanner/admin/database/v1/backup.proto#L36}
   ///
   /// [google.spanner.admin.database.v1.CreateBackupRequest]:
-  /// @googleapis_link{google::spanner::admin::database::v1::CreateBackupRequest,google/spanner/admin/database/v1/backup.proto#L123}
+  /// @googleapis_reference_link{google/spanner/admin/database/v1/backup.proto#L123}
   /// [google.spanner.admin.database.v1.Backup]:
-  /// @googleapis_link{google::spanner::admin::database::v1::Backup,google/spanner/admin/database/v1/backup.proto#L36}
+  /// @googleapis_reference_link{google/spanner/admin/database/v1/backup.proto#L36}
   ///
   future<StatusOr<google::spanner::admin::database::v1::Backup>> CreateBackup(
       std::string const& parent,
@@ -345,9 +345,9 @@ class DatabaseAdminClient {
   /// @googleapis_link{google::spanner::admin::database::v1::Backup,google/spanner/admin/database/v1/backup.proto#L36}
   ///
   /// [google.spanner.admin.database.v1.GetBackupRequest]:
-  /// @googleapis_link{google::spanner::admin::database::v1::GetBackupRequest,google/spanner/admin/database/v1/backup.proto#L202}
+  /// @googleapis_reference_link{google/spanner/admin/database/v1/backup.proto#L202}
   /// [google.spanner.admin.database.v1.Backup]:
-  /// @googleapis_link{google::spanner::admin::database::v1::Backup,google/spanner/admin/database/v1/backup.proto#L36}
+  /// @googleapis_reference_link{google/spanner/admin/database/v1/backup.proto#L36}
   ///
   StatusOr<google::spanner::admin::database::v1::Backup> GetBackup(
       std::string const& name);
@@ -371,9 +371,9 @@ class DatabaseAdminClient {
   /// @googleapis_link{google::spanner::admin::database::v1::Backup,google/spanner/admin/database/v1/backup.proto#L36}
   ///
   /// [google.spanner.admin.database.v1.UpdateBackupRequest]:
-  /// @googleapis_link{google::spanner::admin::database::v1::UpdateBackupRequest,google/spanner/admin/database/v1/backup.proto#L186}
+  /// @googleapis_reference_link{google/spanner/admin/database/v1/backup.proto#L186}
   /// [google.spanner.admin.database.v1.Backup]:
-  /// @googleapis_link{google::spanner::admin::database::v1::Backup,google/spanner/admin/database/v1/backup.proto#L36}
+  /// @googleapis_reference_link{google/spanner/admin/database/v1/backup.proto#L36}
   ///
   StatusOr<google::spanner::admin::database::v1::Backup> UpdateBackup(
       google::spanner::admin::database::v1::Backup const& backup,
@@ -388,7 +388,7 @@ class DatabaseAdminClient {
   ///  `projects/<project>/instances/<instance>/backups/<backup>`.
   ///
   /// [google.spanner.admin.database.v1.DeleteBackupRequest]:
-  /// @googleapis_link{google::spanner::admin::database::v1::DeleteBackupRequest,google/spanner/admin/database/v1/backup.proto#L215}
+  /// @googleapis_reference_link{google/spanner/admin/database/v1/backup.proto#L215}
   ///
   Status DeleteBackup(std::string const& name);
 
@@ -404,9 +404,9 @@ class DatabaseAdminClient {
   /// @googleapis_link{google::spanner::admin::database::v1::Backup,google/spanner/admin/database/v1/backup.proto#L36}
   ///
   /// [google.spanner.admin.database.v1.ListBackupsRequest]:
-  /// @googleapis_link{google::spanner::admin::database::v1::ListBackupsRequest,google/spanner/admin/database/v1/backup.proto#L228}
+  /// @googleapis_reference_link{google/spanner/admin/database/v1/backup.proto#L228}
   /// [google.spanner.admin.database.v1.Backup]:
-  /// @googleapis_link{google::spanner::admin::database::v1::Backup,google/spanner/admin/database/v1/backup.proto#L36}
+  /// @googleapis_reference_link{google/spanner/admin/database/v1/backup.proto#L36}
   ///
   StreamRange<google::spanner::admin::database::v1::Backup> ListBackups(
       std::string const& parent);
@@ -447,9 +447,9 @@ class DatabaseAdminClient {
   /// @googleapis_link{google::spanner::admin::database::v1::Database,google/spanner/admin/database/v1/spanner_database_admin.proto#L326}
   ///
   /// [google.spanner.admin.database.v1.RestoreDatabaseRequest]:
-  /// @googleapis_link{google::spanner::admin::database::v1::RestoreDatabaseRequest,google/spanner/admin/database/v1/spanner_database_admin.proto#L692}
+  /// @googleapis_reference_link{google/spanner/admin/database/v1/spanner_database_admin.proto#L692}
   /// [google.spanner.admin.database.v1.Database]:
-  /// @googleapis_link{google::spanner::admin::database::v1::Database,google/spanner/admin/database/v1/spanner_database_admin.proto#L326}
+  /// @googleapis_reference_link{google/spanner/admin/database/v1/spanner_database_admin.proto#L326}
   ///
   future<StatusOr<google::spanner::admin::database::v1::Database>>
   RestoreDatabase(std::string const& parent, std::string const& database_id,
@@ -471,9 +471,9 @@ class DatabaseAdminClient {
   /// @googleapis_link{google::longrunning::Operation,google/longrunning/operations.proto#L128}
   ///
   /// [google.spanner.admin.database.v1.ListDatabaseOperationsRequest]:
-  /// @googleapis_link{google::spanner::admin::database::v1::ListDatabaseOperationsRequest,google/spanner/admin/database/v1/spanner_database_admin.proto#L611}
+  /// @googleapis_reference_link{google/spanner/admin/database/v1/spanner_database_admin.proto#L611}
   /// [google.longrunning.Operation]:
-  /// @googleapis_link{google::longrunning::Operation,google/longrunning/operations.proto#L128}
+  /// @googleapis_reference_link{google/longrunning/operations.proto#L128}
   ///
   StreamRange<google::longrunning::Operation> ListDatabaseOperations(
       std::string const& parent);
@@ -497,9 +497,9 @@ class DatabaseAdminClient {
   /// @googleapis_link{google::longrunning::Operation,google/longrunning/operations.proto#L128}
   ///
   /// [google.spanner.admin.database.v1.ListBackupOperationsRequest]:
-  /// @googleapis_link{google::spanner::admin::database::v1::ListBackupOperationsRequest,google/spanner/admin/database/v1/backup.proto#L300}
+  /// @googleapis_reference_link{google/spanner/admin/database/v1/backup.proto#L300}
   /// [google.longrunning.Operation]:
-  /// @googleapis_link{google::longrunning::Operation,google/longrunning/operations.proto#L128}
+  /// @googleapis_reference_link{google/longrunning/operations.proto#L128}
   ///
   StreamRange<google::longrunning::Operation> ListBackupOperations(
       std::string const& parent);
@@ -513,9 +513,9 @@ class DatabaseAdminClient {
   /// @googleapis_link{google::spanner::admin::database::v1::Database,google/spanner/admin/database/v1/spanner_database_admin.proto#L326}
   ///
   /// [google.spanner.admin.database.v1.ListDatabasesRequest]:
-  /// @googleapis_link{google::spanner::admin::database::v1::ListDatabasesRequest,google/spanner/admin/database/v1/spanner_database_admin.proto#L413}
+  /// @googleapis_reference_link{google/spanner/admin/database/v1/spanner_database_admin.proto#L413}
   /// [google.spanner.admin.database.v1.Database]:
-  /// @googleapis_link{google::spanner::admin::database::v1::Database,google/spanner/admin/database/v1/spanner_database_admin.proto#L326}
+  /// @googleapis_reference_link{google/spanner/admin/database/v1/spanner_database_admin.proto#L326}
   ///
   StreamRange<google::spanner::admin::database::v1::Database> ListDatabases(
       google::spanner::admin::database::v1::ListDatabasesRequest request);
@@ -536,9 +536,9 @@ class DatabaseAdminClient {
   /// @googleapis_link{google::spanner::admin::database::v1::Database,google/spanner/admin/database/v1/spanner_database_admin.proto#L326}
   ///
   /// [google.spanner.admin.database.v1.CreateDatabaseRequest]:
-  /// @googleapis_link{google::spanner::admin::database::v1::CreateDatabaseRequest,google/spanner/admin/database/v1/spanner_database_admin.proto#L445}
+  /// @googleapis_reference_link{google/spanner/admin/database/v1/spanner_database_admin.proto#L445}
   /// [google.spanner.admin.database.v1.Database]:
-  /// @googleapis_link{google::spanner::admin::database::v1::Database,google/spanner/admin/database/v1/spanner_database_admin.proto#L326}
+  /// @googleapis_reference_link{google/spanner/admin/database/v1/spanner_database_admin.proto#L326}
   ///
   future<StatusOr<google::spanner::admin::database::v1::Database>>
   CreateDatabase(
@@ -554,9 +554,9 @@ class DatabaseAdminClient {
   /// @googleapis_link{google::spanner::admin::database::v1::Database,google/spanner/admin/database/v1/spanner_database_admin.proto#L326}
   ///
   /// [google.spanner.admin.database.v1.GetDatabaseRequest]:
-  /// @googleapis_link{google::spanner::admin::database::v1::GetDatabaseRequest,google/spanner/admin/database/v1/spanner_database_admin.proto#L484}
+  /// @googleapis_reference_link{google/spanner/admin/database/v1/spanner_database_admin.proto#L484}
   /// [google.spanner.admin.database.v1.Database]:
-  /// @googleapis_link{google::spanner::admin::database::v1::Database,google/spanner/admin/database/v1/spanner_database_admin.proto#L326}
+  /// @googleapis_reference_link{google/spanner/admin/database/v1/spanner_database_admin.proto#L326}
   ///
   StatusOr<google::spanner::admin::database::v1::Database> GetDatabase(
       google::spanner::admin::database::v1::GetDatabaseRequest const& request);
@@ -577,9 +577,9 @@ class DatabaseAdminClient {
   /// @googleapis_link{google::spanner::admin::database::v1::UpdateDatabaseDdlMetadata,google/spanner/admin/database/v1/spanner_database_admin.proto#L547}
   ///
   /// [google.spanner.admin.database.v1.UpdateDatabaseDdlRequest]:
-  /// @googleapis_link{google::spanner::admin::database::v1::UpdateDatabaseDdlRequest,google/spanner/admin/database/v1/spanner_database_admin.proto#L511}
+  /// @googleapis_reference_link{google/spanner/admin/database/v1/spanner_database_admin.proto#L511}
   /// [google.spanner.admin.database.v1.UpdateDatabaseDdlMetadata]:
-  /// @googleapis_link{google::spanner::admin::database::v1::UpdateDatabaseDdlMetadata,google/spanner/admin/database/v1/spanner_database_admin.proto#L547}
+  /// @googleapis_reference_link{google/spanner/admin/database/v1/spanner_database_admin.proto#L547}
   ///
   future<
       StatusOr<google::spanner::admin::database::v1::UpdateDatabaseDdlMetadata>>
@@ -596,7 +596,7 @@ class DatabaseAdminClient {
   /// @googleapis_link{google::spanner::admin::database::v1::DropDatabaseRequest,google/spanner/admin/database/v1/spanner_database_admin.proto#L579}
   ///
   /// [google.spanner.admin.database.v1.DropDatabaseRequest]:
-  /// @googleapis_link{google::spanner::admin::database::v1::DropDatabaseRequest,google/spanner/admin/database/v1/spanner_database_admin.proto#L579}
+  /// @googleapis_reference_link{google/spanner/admin/database/v1/spanner_database_admin.proto#L579}
   ///
   Status DropDatabase(
       google::spanner::admin::database::v1::DropDatabaseRequest const& request);
@@ -612,9 +612,9 @@ class DatabaseAdminClient {
   /// @googleapis_link{google::spanner::admin::database::v1::GetDatabaseDdlResponse,google/spanner/admin/database/v1/spanner_database_admin.proto#L603}
   ///
   /// [google.spanner.admin.database.v1.GetDatabaseDdlRequest]:
-  /// @googleapis_link{google::spanner::admin::database::v1::GetDatabaseDdlRequest,google/spanner/admin/database/v1/spanner_database_admin.proto#L590}
+  /// @googleapis_reference_link{google/spanner/admin/database/v1/spanner_database_admin.proto#L590}
   /// [google.spanner.admin.database.v1.GetDatabaseDdlResponse]:
-  /// @googleapis_link{google::spanner::admin::database::v1::GetDatabaseDdlResponse,google/spanner/admin/database/v1/spanner_database_admin.proto#L603}
+  /// @googleapis_reference_link{google/spanner/admin/database/v1/spanner_database_admin.proto#L603}
   ///
   StatusOr<google::spanner::admin::database::v1::GetDatabaseDdlResponse>
   GetDatabaseDdl(
@@ -636,9 +636,9 @@ class DatabaseAdminClient {
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
   /// [google.iam.v1.SetIamPolicyRequest]:
-  /// @googleapis_link{google::iam::v1::SetIamPolicyRequest,google/iam/v1/iam_policy.proto#L98}
+  /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L98}
   /// [google.iam.v1.Policy]:
-  /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
+  /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
       google::iam::v1::SetIamPolicyRequest const& request);
@@ -659,9 +659,9 @@ class DatabaseAdminClient {
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
   /// [google.iam.v1.GetIamPolicyRequest]:
-  /// @googleapis_link{google::iam::v1::GetIamPolicyRequest,google/iam/v1/iam_policy.proto#L113}
+  /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L113}
   /// [google.iam.v1.Policy]:
-  /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
+  /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> GetIamPolicy(
       google::iam::v1::GetIamPolicyRequest const& request);
@@ -684,9 +684,9 @@ class DatabaseAdminClient {
   /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
   ///
   /// [google.iam.v1.TestIamPermissionsRequest]:
-  /// @googleapis_link{google::iam::v1::TestIamPermissionsRequest,google/iam/v1/iam_policy.proto#L126}
+  /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L126}
   /// [google.iam.v1.TestIamPermissionsResponse]:
-  /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
+  /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L141}
   ///
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
       google::iam::v1::TestIamPermissionsRequest const& request);
@@ -711,9 +711,9 @@ class DatabaseAdminClient {
   /// @googleapis_link{google::spanner::admin::database::v1::Backup,google/spanner/admin/database/v1/backup.proto#L36}
   ///
   /// [google.spanner.admin.database.v1.CreateBackupRequest]:
-  /// @googleapis_link{google::spanner::admin::database::v1::CreateBackupRequest,google/spanner/admin/database/v1/backup.proto#L123}
+  /// @googleapis_reference_link{google/spanner/admin/database/v1/backup.proto#L123}
   /// [google.spanner.admin.database.v1.Backup]:
-  /// @googleapis_link{google::spanner::admin::database::v1::Backup,google/spanner/admin/database/v1/backup.proto#L36}
+  /// @googleapis_reference_link{google/spanner/admin/database/v1/backup.proto#L36}
   ///
   future<StatusOr<google::spanner::admin::database::v1::Backup>> CreateBackup(
       google::spanner::admin::database::v1::CreateBackupRequest const& request);
@@ -728,9 +728,9 @@ class DatabaseAdminClient {
   /// @googleapis_link{google::spanner::admin::database::v1::Backup,google/spanner/admin/database/v1/backup.proto#L36}
   ///
   /// [google.spanner.admin.database.v1.GetBackupRequest]:
-  /// @googleapis_link{google::spanner::admin::database::v1::GetBackupRequest,google/spanner/admin/database/v1/backup.proto#L202}
+  /// @googleapis_reference_link{google/spanner/admin/database/v1/backup.proto#L202}
   /// [google.spanner.admin.database.v1.Backup]:
-  /// @googleapis_link{google::spanner::admin::database::v1::Backup,google/spanner/admin/database/v1/backup.proto#L36}
+  /// @googleapis_reference_link{google/spanner/admin/database/v1/backup.proto#L36}
   ///
   StatusOr<google::spanner::admin::database::v1::Backup> GetBackup(
       google::spanner::admin::database::v1::GetBackupRequest const& request);
@@ -745,9 +745,9 @@ class DatabaseAdminClient {
   /// @googleapis_link{google::spanner::admin::database::v1::Backup,google/spanner/admin/database/v1/backup.proto#L36}
   ///
   /// [google.spanner.admin.database.v1.UpdateBackupRequest]:
-  /// @googleapis_link{google::spanner::admin::database::v1::UpdateBackupRequest,google/spanner/admin/database/v1/backup.proto#L186}
+  /// @googleapis_reference_link{google/spanner/admin/database/v1/backup.proto#L186}
   /// [google.spanner.admin.database.v1.Backup]:
-  /// @googleapis_link{google::spanner::admin::database::v1::Backup,google/spanner/admin/database/v1/backup.proto#L36}
+  /// @googleapis_reference_link{google/spanner/admin/database/v1/backup.proto#L36}
   ///
   StatusOr<google::spanner::admin::database::v1::Backup> UpdateBackup(
       google::spanner::admin::database::v1::UpdateBackupRequest const& request);
@@ -760,7 +760,7 @@ class DatabaseAdminClient {
   /// @googleapis_link{google::spanner::admin::database::v1::DeleteBackupRequest,google/spanner/admin/database/v1/backup.proto#L215}
   ///
   /// [google.spanner.admin.database.v1.DeleteBackupRequest]:
-  /// @googleapis_link{google::spanner::admin::database::v1::DeleteBackupRequest,google/spanner/admin/database/v1/backup.proto#L215}
+  /// @googleapis_reference_link{google/spanner/admin/database/v1/backup.proto#L215}
   ///
   Status DeleteBackup(
       google::spanner::admin::database::v1::DeleteBackupRequest const& request);
@@ -776,9 +776,9 @@ class DatabaseAdminClient {
   /// @googleapis_link{google::spanner::admin::database::v1::Backup,google/spanner/admin/database/v1/backup.proto#L36}
   ///
   /// [google.spanner.admin.database.v1.ListBackupsRequest]:
-  /// @googleapis_link{google::spanner::admin::database::v1::ListBackupsRequest,google/spanner/admin/database/v1/backup.proto#L228}
+  /// @googleapis_reference_link{google/spanner/admin/database/v1/backup.proto#L228}
   /// [google.spanner.admin.database.v1.Backup]:
-  /// @googleapis_link{google::spanner::admin::database::v1::Backup,google/spanner/admin/database/v1/backup.proto#L36}
+  /// @googleapis_reference_link{google/spanner/admin/database/v1/backup.proto#L36}
   ///
   StreamRange<google::spanner::admin::database::v1::Backup> ListBackups(
       google::spanner::admin::database::v1::ListBackupsRequest request);
@@ -808,9 +808,9 @@ class DatabaseAdminClient {
   /// @googleapis_link{google::spanner::admin::database::v1::Database,google/spanner/admin/database/v1/spanner_database_admin.proto#L326}
   ///
   /// [google.spanner.admin.database.v1.RestoreDatabaseRequest]:
-  /// @googleapis_link{google::spanner::admin::database::v1::RestoreDatabaseRequest,google/spanner/admin/database/v1/spanner_database_admin.proto#L692}
+  /// @googleapis_reference_link{google/spanner/admin/database/v1/spanner_database_admin.proto#L692}
   /// [google.spanner.admin.database.v1.Database]:
-  /// @googleapis_link{google::spanner::admin::database::v1::Database,google/spanner/admin/database/v1/spanner_database_admin.proto#L326}
+  /// @googleapis_reference_link{google/spanner/admin/database/v1/spanner_database_admin.proto#L326}
   ///
   future<StatusOr<google::spanner::admin::database::v1::Database>>
   RestoreDatabase(
@@ -833,9 +833,9 @@ class DatabaseAdminClient {
   /// @googleapis_link{google::longrunning::Operation,google/longrunning/operations.proto#L128}
   ///
   /// [google.spanner.admin.database.v1.ListDatabaseOperationsRequest]:
-  /// @googleapis_link{google::spanner::admin::database::v1::ListDatabaseOperationsRequest,google/spanner/admin/database/v1/spanner_database_admin.proto#L611}
+  /// @googleapis_reference_link{google/spanner/admin/database/v1/spanner_database_admin.proto#L611}
   /// [google.longrunning.Operation]:
-  /// @googleapis_link{google::longrunning::Operation,google/longrunning/operations.proto#L128}
+  /// @googleapis_reference_link{google/longrunning/operations.proto#L128}
   ///
   StreamRange<google::longrunning::Operation> ListDatabaseOperations(
       google::spanner::admin::database::v1::ListDatabaseOperationsRequest
@@ -859,9 +859,9 @@ class DatabaseAdminClient {
   /// @googleapis_link{google::longrunning::Operation,google/longrunning/operations.proto#L128}
   ///
   /// [google.spanner.admin.database.v1.ListBackupOperationsRequest]:
-  /// @googleapis_link{google::spanner::admin::database::v1::ListBackupOperationsRequest,google/spanner/admin/database/v1/backup.proto#L300}
+  /// @googleapis_reference_link{google/spanner/admin/database/v1/backup.proto#L300}
   /// [google.longrunning.Operation]:
-  /// @googleapis_link{google::longrunning::Operation,google/longrunning/operations.proto#L128}
+  /// @googleapis_reference_link{google/longrunning/operations.proto#L128}
   ///
   StreamRange<google::longrunning::Operation> ListBackupOperations(
       google::spanner::admin::database::v1::ListBackupOperationsRequest

--- a/google/cloud/spanner/admin/instance_admin_client.h
+++ b/google/cloud/spanner/admin/instance_admin_client.h
@@ -96,7 +96,7 @@ class InstanceAdminClient {
   ///
   /// [google.spanner.admin.instance.v1.ListInstanceConfigsRequest]:
   /// @googleapis_link{google::spanner::admin::instance::v1::ListInstanceConfigsRequest,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L415}
-  /// [google::spanner::admin::instance::v1::InstanceConfig]:
+  /// [google.spanner.admin.instance.v1.InstanceConfig]:
   /// @googleapis_link{google::spanner::admin::instance::v1::InstanceConfig,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L304}
   ///
   StreamRange<google::spanner::admin::instance::v1::InstanceConfig>
@@ -130,7 +130,7 @@ class InstanceAdminClient {
   ///
   /// [google.spanner.admin.instance.v1.ListInstancesRequest]:
   /// @googleapis_link{google::spanner::admin::instance::v1::ListInstancesRequest,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L499}
-  /// [google::spanner::admin::instance::v1::Instance]:
+  /// [google.spanner.admin.instance.v1.Instance]:
   /// @googleapis_link{google::spanner::admin::instance::v1::Instance,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328}
   ///
   StreamRange<google::spanner::admin::instance::v1::Instance> ListInstances(
@@ -407,7 +407,7 @@ class InstanceAdminClient {
   ///
   /// [google.spanner.admin.instance.v1.ListInstanceConfigsRequest]:
   /// @googleapis_link{google::spanner::admin::instance::v1::ListInstanceConfigsRequest,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L415}
-  /// [google::spanner::admin::instance::v1::InstanceConfig]:
+  /// [google.spanner.admin.instance.v1.InstanceConfig]:
   /// @googleapis_link{google::spanner::admin::instance::v1::InstanceConfig,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L304}
   ///
   StreamRange<google::spanner::admin::instance::v1::InstanceConfig>
@@ -442,7 +442,7 @@ class InstanceAdminClient {
   ///
   /// [google.spanner.admin.instance.v1.ListInstancesRequest]:
   /// @googleapis_link{google::spanner::admin::instance::v1::ListInstancesRequest,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L499}
-  /// [google::spanner::admin::instance::v1::Instance]:
+  /// [google.spanner.admin.instance.v1.Instance]:
   /// @googleapis_link{google::spanner::admin::instance::v1::Instance,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328}
   ///
   StreamRange<google::spanner::admin::instance::v1::Instance> ListInstances(

--- a/google/cloud/spanner/admin/instance_admin_client.h
+++ b/google/cloud/spanner/admin/instance_admin_client.h
@@ -94,6 +94,11 @@ class InstanceAdminClient {
   /// @return
   /// @googleapis_link{google::spanner::admin::instance::v1::InstanceConfig,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L304}
   ///
+  /// [google.spanner.admin.instance.v1.ListInstanceConfigsRequest]:
+  /// @googleapis_link{google::spanner::admin::instance::v1::ListInstanceConfigsRequest,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L415}
+  /// [google::spanner::admin::instance::v1::InstanceConfig]:
+  /// @googleapis_link{google::spanner::admin::instance::v1::InstanceConfig,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L304}
+  ///
   StreamRange<google::spanner::admin::instance::v1::InstanceConfig>
   ListInstanceConfigs(std::string const& parent);
 
@@ -104,6 +109,11 @@ class InstanceAdminClient {
   /// Values are of
   ///  the form `projects/<project>/instanceConfigs/<config>`.
   /// @return
+  /// @googleapis_link{google::spanner::admin::instance::v1::InstanceConfig,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L304}
+  ///
+  /// [google.spanner.admin.instance.v1.GetInstanceConfigRequest]:
+  /// @googleapis_link{google::spanner::admin::instance::v1::GetInstanceConfigRequest,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L449}
+  /// [google.spanner.admin.instance.v1.InstanceConfig]:
   /// @googleapis_link{google::spanner::admin::instance::v1::InstanceConfig,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L304}
   ///
   StatusOr<google::spanner::admin::instance::v1::InstanceConfig>
@@ -118,6 +128,11 @@ class InstanceAdminClient {
   /// @return
   /// @googleapis_link{google::spanner::admin::instance::v1::Instance,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328}
   ///
+  /// [google.spanner.admin.instance.v1.ListInstancesRequest]:
+  /// @googleapis_link{google::spanner::admin::instance::v1::ListInstancesRequest,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L499}
+  /// [google::spanner::admin::instance::v1::Instance]:
+  /// @googleapis_link{google::spanner::admin::instance::v1::Instance,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328}
+  ///
   StreamRange<google::spanner::admin::instance::v1::Instance> ListInstances(
       std::string const& parent);
 
@@ -128,6 +143,11 @@ class InstanceAdminClient {
   /// the form
   ///  `projects/<project>/instances/<instance>`.
   /// @return
+  /// @googleapis_link{google::spanner::admin::instance::v1::Instance,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328}
+  ///
+  /// [google.spanner.admin.instance.v1.GetInstanceRequest]:
+  /// @googleapis_link{google::spanner::admin::instance::v1::GetInstanceRequest,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L461}
+  /// [google.spanner.admin.instance.v1.Instance]:
   /// @googleapis_link{google::spanner::admin::instance::v1::Instance,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328}
   ///
   StatusOr<google::spanner::admin::instance::v1::Instance> GetInstance(
@@ -180,6 +200,11 @@ class InstanceAdminClient {
   /// omitted, but if
   ///  specified must be `<parent>/instances/<instance_id>`.
   /// @return
+  /// @googleapis_link{google::spanner::admin::instance::v1::Instance,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328}
+  ///
+  /// [google.spanner.admin.instance.v1.CreateInstanceRequest]:
+  /// @googleapis_link{google::spanner::admin::instance::v1::CreateInstanceRequest,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L478}
+  /// [google.spanner.admin.instance.v1.Instance]:
   /// @googleapis_link{google::spanner::admin::instance::v1::Instance,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328}
   ///
   future<StatusOr<google::spanner::admin::instance::v1::Instance>>
@@ -242,6 +267,11 @@ class InstanceAdminClient {
   /// @return
   /// @googleapis_link{google::spanner::admin::instance::v1::Instance,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328}
   ///
+  /// [google.spanner.admin.instance.v1.UpdateInstanceRequest]:
+  /// @googleapis_link{google::spanner::admin::instance::v1::UpdateInstanceRequest,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L552}
+  /// [google.spanner.admin.instance.v1.Instance]:
+  /// @googleapis_link{google::spanner::admin::instance::v1::Instance,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328}
+  ///
   future<StatusOr<google::spanner::admin::instance::v1::Instance>>
   UpdateInstance(google::spanner::admin::instance::v1::Instance const& instance,
                  google::protobuf::FieldMask const& field_mask);
@@ -263,6 +293,9 @@ class InstanceAdminClient {
   /// of the form
   ///  `projects/<project>/instances/<instance>`
   ///
+  /// [google.spanner.admin.instance.v1.DeleteInstanceRequest]:
+  /// @googleapis_link{google::spanner::admin::instance::v1::DeleteInstanceRequest,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L565}
+  ///
   Status DeleteInstance(std::string const& name);
 
   ///
@@ -281,6 +314,11 @@ class InstanceAdminClient {
   ///  valid policy but certain Cloud Platform services (such as Projects)
   ///  might reject them.
   /// @return
+  /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
+  ///
+  /// [google.iam.v1.SetIamPolicyRequest]:
+  /// @googleapis_link{google::iam::v1::SetIamPolicyRequest,google/iam/v1/iam_policy.proto#L98}
+  /// [google.iam.v1.Policy]:
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
@@ -324,6 +362,11 @@ class InstanceAdminClient {
   /// @return
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
+  /// [google.iam.v1.GetIamPolicyRequest]:
+  /// @googleapis_link{google::iam::v1::GetIamPolicyRequest,google/iam/v1/iam_policy.proto#L113}
+  /// [google.iam.v1.Policy]:
+  /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
+  ///
   StatusOr<google::iam::v1::Policy> GetIamPolicy(std::string const& resource);
 
   ///
@@ -346,6 +389,11 @@ class InstanceAdminClient {
   /// @return
   /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
   ///
+  /// [google.iam.v1.TestIamPermissionsRequest]:
+  /// @googleapis_link{google::iam::v1::TestIamPermissionsRequest,google/iam/v1/iam_policy.proto#L126}
+  /// [google.iam.v1.TestIamPermissionsResponse]:
+  /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
+  ///
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
       std::string const& resource, std::vector<std::string> const& permissions);
 
@@ -355,6 +403,11 @@ class InstanceAdminClient {
   /// @param request
   /// @googleapis_link{google::spanner::admin::instance::v1::ListInstanceConfigsRequest,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L415}
   /// @return
+  /// @googleapis_link{google::spanner::admin::instance::v1::InstanceConfig,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L304}
+  ///
+  /// [google.spanner.admin.instance.v1.ListInstanceConfigsRequest]:
+  /// @googleapis_link{google::spanner::admin::instance::v1::ListInstanceConfigsRequest,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L415}
+  /// [google::spanner::admin::instance::v1::InstanceConfig]:
   /// @googleapis_link{google::spanner::admin::instance::v1::InstanceConfig,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L304}
   ///
   StreamRange<google::spanner::admin::instance::v1::InstanceConfig>
@@ -367,6 +420,11 @@ class InstanceAdminClient {
   /// @param request
   /// @googleapis_link{google::spanner::admin::instance::v1::GetInstanceConfigRequest,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L449}
   /// @return
+  /// @googleapis_link{google::spanner::admin::instance::v1::InstanceConfig,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L304}
+  ///
+  /// [google.spanner.admin.instance.v1.GetInstanceConfigRequest]:
+  /// @googleapis_link{google::spanner::admin::instance::v1::GetInstanceConfigRequest,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L449}
+  /// [google.spanner.admin.instance.v1.InstanceConfig]:
   /// @googleapis_link{google::spanner::admin::instance::v1::InstanceConfig,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L304}
   ///
   StatusOr<google::spanner::admin::instance::v1::InstanceConfig>
@@ -382,6 +440,11 @@ class InstanceAdminClient {
   /// @return
   /// @googleapis_link{google::spanner::admin::instance::v1::Instance,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328}
   ///
+  /// [google.spanner.admin.instance.v1.ListInstancesRequest]:
+  /// @googleapis_link{google::spanner::admin::instance::v1::ListInstancesRequest,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L499}
+  /// [google::spanner::admin::instance::v1::Instance]:
+  /// @googleapis_link{google::spanner::admin::instance::v1::Instance,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328}
+  ///
   StreamRange<google::spanner::admin::instance::v1::Instance> ListInstances(
       google::spanner::admin::instance::v1::ListInstancesRequest request);
 
@@ -391,6 +454,11 @@ class InstanceAdminClient {
   /// @param request
   /// @googleapis_link{google::spanner::admin::instance::v1::GetInstanceRequest,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L461}
   /// @return
+  /// @googleapis_link{google::spanner::admin::instance::v1::Instance,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328}
+  ///
+  /// [google.spanner.admin.instance.v1.GetInstanceRequest]:
+  /// @googleapis_link{google::spanner::admin::instance::v1::GetInstanceRequest,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L461}
+  /// [google.spanner.admin.instance.v1.Instance]:
   /// @googleapis_link{google::spanner::admin::instance::v1::Instance,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328}
   ///
   StatusOr<google::spanner::admin::instance::v1::Instance> GetInstance(
@@ -435,6 +503,11 @@ class InstanceAdminClient {
   /// @param request
   /// @googleapis_link{google::spanner::admin::instance::v1::CreateInstanceRequest,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L478}
   /// @return
+  /// @googleapis_link{google::spanner::admin::instance::v1::Instance,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328}
+  ///
+  /// [google.spanner.admin.instance.v1.CreateInstanceRequest]:
+  /// @googleapis_link{google::spanner::admin::instance::v1::CreateInstanceRequest,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L478}
+  /// [google.spanner.admin.instance.v1.Instance]:
   /// @googleapis_link{google::spanner::admin::instance::v1::Instance,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328}
   ///
   future<StatusOr<google::spanner::admin::instance::v1::Instance>>
@@ -489,6 +562,11 @@ class InstanceAdminClient {
   /// @return
   /// @googleapis_link{google::spanner::admin::instance::v1::Instance,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328}
   ///
+  /// [google.spanner.admin.instance.v1.UpdateInstanceRequest]:
+  /// @googleapis_link{google::spanner::admin::instance::v1::UpdateInstanceRequest,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L552}
+  /// [google.spanner.admin.instance.v1.Instance]:
+  /// @googleapis_link{google::spanner::admin::instance::v1::Instance,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328}
+  ///
   future<StatusOr<google::spanner::admin::instance::v1::Instance>>
   UpdateInstance(
       google::spanner::admin::instance::v1::UpdateInstanceRequest const&
@@ -510,6 +588,9 @@ class InstanceAdminClient {
   /// @param request
   /// @googleapis_link{google::spanner::admin::instance::v1::DeleteInstanceRequest,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L565}
   ///
+  /// [google.spanner.admin.instance.v1.DeleteInstanceRequest]:
+  /// @googleapis_link{google::spanner::admin::instance::v1::DeleteInstanceRequest,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L565}
+  ///
   Status DeleteInstance(
       google::spanner::admin::instance::v1::DeleteInstanceRequest const&
           request);
@@ -524,6 +605,11 @@ class InstanceAdminClient {
   /// @param request
   /// @googleapis_link{google::iam::v1::SetIamPolicyRequest,google/iam/v1/iam_policy.proto#L98}
   /// @return
+  /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
+  ///
+  /// [google.iam.v1.SetIamPolicyRequest]:
+  /// @googleapis_link{google::iam::v1::SetIamPolicyRequest,google/iam/v1/iam_policy.proto#L98}
+  /// [google.iam.v1.Policy]:
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
@@ -541,6 +627,11 @@ class InstanceAdminClient {
   /// @return
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
+  /// [google.iam.v1.GetIamPolicyRequest]:
+  /// @googleapis_link{google::iam::v1::GetIamPolicyRequest,google/iam/v1/iam_policy.proto#L113}
+  /// [google.iam.v1.Policy]:
+  /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
+  ///
   StatusOr<google::iam::v1::Policy> GetIamPolicy(
       google::iam::v1::GetIamPolicyRequest const& request);
 
@@ -556,6 +647,11 @@ class InstanceAdminClient {
   /// @param request
   /// @googleapis_link{google::iam::v1::TestIamPermissionsRequest,google/iam/v1/iam_policy.proto#L126}
   /// @return
+  /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
+  ///
+  /// [google.iam.v1.TestIamPermissionsRequest]:
+  /// @googleapis_link{google::iam::v1::TestIamPermissionsRequest,google/iam/v1/iam_policy.proto#L126}
+  /// [google.iam.v1.TestIamPermissionsResponse]:
   /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
   ///
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(

--- a/google/cloud/spanner/admin/instance_admin_client.h
+++ b/google/cloud/spanner/admin/instance_admin_client.h
@@ -95,9 +95,9 @@ class InstanceAdminClient {
   /// @googleapis_link{google::spanner::admin::instance::v1::InstanceConfig,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L304}
   ///
   /// [google.spanner.admin.instance.v1.ListInstanceConfigsRequest]:
-  /// @googleapis_link{google::spanner::admin::instance::v1::ListInstanceConfigsRequest,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L415}
+  /// @googleapis_reference_link{google/spanner/admin/instance/v1/spanner_instance_admin.proto#L415}
   /// [google.spanner.admin.instance.v1.InstanceConfig]:
-  /// @googleapis_link{google::spanner::admin::instance::v1::InstanceConfig,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L304}
+  /// @googleapis_reference_link{google/spanner/admin/instance/v1/spanner_instance_admin.proto#L304}
   ///
   StreamRange<google::spanner::admin::instance::v1::InstanceConfig>
   ListInstanceConfigs(std::string const& parent);
@@ -112,9 +112,9 @@ class InstanceAdminClient {
   /// @googleapis_link{google::spanner::admin::instance::v1::InstanceConfig,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L304}
   ///
   /// [google.spanner.admin.instance.v1.GetInstanceConfigRequest]:
-  /// @googleapis_link{google::spanner::admin::instance::v1::GetInstanceConfigRequest,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L449}
+  /// @googleapis_reference_link{google/spanner/admin/instance/v1/spanner_instance_admin.proto#L449}
   /// [google.spanner.admin.instance.v1.InstanceConfig]:
-  /// @googleapis_link{google::spanner::admin::instance::v1::InstanceConfig,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L304}
+  /// @googleapis_reference_link{google/spanner/admin/instance/v1/spanner_instance_admin.proto#L304}
   ///
   StatusOr<google::spanner::admin::instance::v1::InstanceConfig>
   GetInstanceConfig(std::string const& name);
@@ -129,9 +129,9 @@ class InstanceAdminClient {
   /// @googleapis_link{google::spanner::admin::instance::v1::Instance,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328}
   ///
   /// [google.spanner.admin.instance.v1.ListInstancesRequest]:
-  /// @googleapis_link{google::spanner::admin::instance::v1::ListInstancesRequest,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L499}
+  /// @googleapis_reference_link{google/spanner/admin/instance/v1/spanner_instance_admin.proto#L499}
   /// [google.spanner.admin.instance.v1.Instance]:
-  /// @googleapis_link{google::spanner::admin::instance::v1::Instance,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328}
+  /// @googleapis_reference_link{google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328}
   ///
   StreamRange<google::spanner::admin::instance::v1::Instance> ListInstances(
       std::string const& parent);
@@ -146,9 +146,9 @@ class InstanceAdminClient {
   /// @googleapis_link{google::spanner::admin::instance::v1::Instance,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328}
   ///
   /// [google.spanner.admin.instance.v1.GetInstanceRequest]:
-  /// @googleapis_link{google::spanner::admin::instance::v1::GetInstanceRequest,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L461}
+  /// @googleapis_reference_link{google/spanner/admin/instance/v1/spanner_instance_admin.proto#L461}
   /// [google.spanner.admin.instance.v1.Instance]:
-  /// @googleapis_link{google::spanner::admin::instance::v1::Instance,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328}
+  /// @googleapis_reference_link{google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328}
   ///
   StatusOr<google::spanner::admin::instance::v1::Instance> GetInstance(
       std::string const& name);
@@ -203,9 +203,9 @@ class InstanceAdminClient {
   /// @googleapis_link{google::spanner::admin::instance::v1::Instance,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328}
   ///
   /// [google.spanner.admin.instance.v1.CreateInstanceRequest]:
-  /// @googleapis_link{google::spanner::admin::instance::v1::CreateInstanceRequest,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L478}
+  /// @googleapis_reference_link{google/spanner/admin/instance/v1/spanner_instance_admin.proto#L478}
   /// [google.spanner.admin.instance.v1.Instance]:
-  /// @googleapis_link{google::spanner::admin::instance::v1::Instance,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328}
+  /// @googleapis_reference_link{google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328}
   ///
   future<StatusOr<google::spanner::admin::instance::v1::Instance>>
   CreateInstance(
@@ -268,9 +268,9 @@ class InstanceAdminClient {
   /// @googleapis_link{google::spanner::admin::instance::v1::Instance,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328}
   ///
   /// [google.spanner.admin.instance.v1.UpdateInstanceRequest]:
-  /// @googleapis_link{google::spanner::admin::instance::v1::UpdateInstanceRequest,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L552}
+  /// @googleapis_reference_link{google/spanner/admin/instance/v1/spanner_instance_admin.proto#L552}
   /// [google.spanner.admin.instance.v1.Instance]:
-  /// @googleapis_link{google::spanner::admin::instance::v1::Instance,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328}
+  /// @googleapis_reference_link{google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328}
   ///
   future<StatusOr<google::spanner::admin::instance::v1::Instance>>
   UpdateInstance(google::spanner::admin::instance::v1::Instance const& instance,
@@ -294,7 +294,7 @@ class InstanceAdminClient {
   ///  `projects/<project>/instances/<instance>`
   ///
   /// [google.spanner.admin.instance.v1.DeleteInstanceRequest]:
-  /// @googleapis_link{google::spanner::admin::instance::v1::DeleteInstanceRequest,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L565}
+  /// @googleapis_reference_link{google/spanner/admin/instance/v1/spanner_instance_admin.proto#L565}
   ///
   Status DeleteInstance(std::string const& name);
 
@@ -317,9 +317,9 @@ class InstanceAdminClient {
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
   /// [google.iam.v1.SetIamPolicyRequest]:
-  /// @googleapis_link{google::iam::v1::SetIamPolicyRequest,google/iam/v1/iam_policy.proto#L98}
+  /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L98}
   /// [google.iam.v1.Policy]:
-  /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
+  /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
       std::string const& resource, google::iam::v1::Policy const& policy);
@@ -363,9 +363,9 @@ class InstanceAdminClient {
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
   /// [google.iam.v1.GetIamPolicyRequest]:
-  /// @googleapis_link{google::iam::v1::GetIamPolicyRequest,google/iam/v1/iam_policy.proto#L113}
+  /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L113}
   /// [google.iam.v1.Policy]:
-  /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
+  /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> GetIamPolicy(std::string const& resource);
 
@@ -390,9 +390,9 @@ class InstanceAdminClient {
   /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
   ///
   /// [google.iam.v1.TestIamPermissionsRequest]:
-  /// @googleapis_link{google::iam::v1::TestIamPermissionsRequest,google/iam/v1/iam_policy.proto#L126}
+  /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L126}
   /// [google.iam.v1.TestIamPermissionsResponse]:
-  /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
+  /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L141}
   ///
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
       std::string const& resource, std::vector<std::string> const& permissions);
@@ -406,9 +406,9 @@ class InstanceAdminClient {
   /// @googleapis_link{google::spanner::admin::instance::v1::InstanceConfig,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L304}
   ///
   /// [google.spanner.admin.instance.v1.ListInstanceConfigsRequest]:
-  /// @googleapis_link{google::spanner::admin::instance::v1::ListInstanceConfigsRequest,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L415}
+  /// @googleapis_reference_link{google/spanner/admin/instance/v1/spanner_instance_admin.proto#L415}
   /// [google.spanner.admin.instance.v1.InstanceConfig]:
-  /// @googleapis_link{google::spanner::admin::instance::v1::InstanceConfig,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L304}
+  /// @googleapis_reference_link{google/spanner/admin/instance/v1/spanner_instance_admin.proto#L304}
   ///
   StreamRange<google::spanner::admin::instance::v1::InstanceConfig>
   ListInstanceConfigs(
@@ -423,9 +423,9 @@ class InstanceAdminClient {
   /// @googleapis_link{google::spanner::admin::instance::v1::InstanceConfig,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L304}
   ///
   /// [google.spanner.admin.instance.v1.GetInstanceConfigRequest]:
-  /// @googleapis_link{google::spanner::admin::instance::v1::GetInstanceConfigRequest,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L449}
+  /// @googleapis_reference_link{google/spanner/admin/instance/v1/spanner_instance_admin.proto#L449}
   /// [google.spanner.admin.instance.v1.InstanceConfig]:
-  /// @googleapis_link{google::spanner::admin::instance::v1::InstanceConfig,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L304}
+  /// @googleapis_reference_link{google/spanner/admin/instance/v1/spanner_instance_admin.proto#L304}
   ///
   StatusOr<google::spanner::admin::instance::v1::InstanceConfig>
   GetInstanceConfig(
@@ -441,9 +441,9 @@ class InstanceAdminClient {
   /// @googleapis_link{google::spanner::admin::instance::v1::Instance,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328}
   ///
   /// [google.spanner.admin.instance.v1.ListInstancesRequest]:
-  /// @googleapis_link{google::spanner::admin::instance::v1::ListInstancesRequest,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L499}
+  /// @googleapis_reference_link{google/spanner/admin/instance/v1/spanner_instance_admin.proto#L499}
   /// [google.spanner.admin.instance.v1.Instance]:
-  /// @googleapis_link{google::spanner::admin::instance::v1::Instance,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328}
+  /// @googleapis_reference_link{google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328}
   ///
   StreamRange<google::spanner::admin::instance::v1::Instance> ListInstances(
       google::spanner::admin::instance::v1::ListInstancesRequest request);
@@ -457,9 +457,9 @@ class InstanceAdminClient {
   /// @googleapis_link{google::spanner::admin::instance::v1::Instance,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328}
   ///
   /// [google.spanner.admin.instance.v1.GetInstanceRequest]:
-  /// @googleapis_link{google::spanner::admin::instance::v1::GetInstanceRequest,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L461}
+  /// @googleapis_reference_link{google/spanner/admin/instance/v1/spanner_instance_admin.proto#L461}
   /// [google.spanner.admin.instance.v1.Instance]:
-  /// @googleapis_link{google::spanner::admin::instance::v1::Instance,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328}
+  /// @googleapis_reference_link{google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328}
   ///
   StatusOr<google::spanner::admin::instance::v1::Instance> GetInstance(
       google::spanner::admin::instance::v1::GetInstanceRequest const& request);
@@ -506,9 +506,9 @@ class InstanceAdminClient {
   /// @googleapis_link{google::spanner::admin::instance::v1::Instance,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328}
   ///
   /// [google.spanner.admin.instance.v1.CreateInstanceRequest]:
-  /// @googleapis_link{google::spanner::admin::instance::v1::CreateInstanceRequest,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L478}
+  /// @googleapis_reference_link{google/spanner/admin/instance/v1/spanner_instance_admin.proto#L478}
   /// [google.spanner.admin.instance.v1.Instance]:
-  /// @googleapis_link{google::spanner::admin::instance::v1::Instance,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328}
+  /// @googleapis_reference_link{google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328}
   ///
   future<StatusOr<google::spanner::admin::instance::v1::Instance>>
   CreateInstance(
@@ -563,9 +563,9 @@ class InstanceAdminClient {
   /// @googleapis_link{google::spanner::admin::instance::v1::Instance,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328}
   ///
   /// [google.spanner.admin.instance.v1.UpdateInstanceRequest]:
-  /// @googleapis_link{google::spanner::admin::instance::v1::UpdateInstanceRequest,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L552}
+  /// @googleapis_reference_link{google/spanner/admin/instance/v1/spanner_instance_admin.proto#L552}
   /// [google.spanner.admin.instance.v1.Instance]:
-  /// @googleapis_link{google::spanner::admin::instance::v1::Instance,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328}
+  /// @googleapis_reference_link{google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328}
   ///
   future<StatusOr<google::spanner::admin::instance::v1::Instance>>
   UpdateInstance(
@@ -589,7 +589,7 @@ class InstanceAdminClient {
   /// @googleapis_link{google::spanner::admin::instance::v1::DeleteInstanceRequest,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L565}
   ///
   /// [google.spanner.admin.instance.v1.DeleteInstanceRequest]:
-  /// @googleapis_link{google::spanner::admin::instance::v1::DeleteInstanceRequest,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L565}
+  /// @googleapis_reference_link{google/spanner/admin/instance/v1/spanner_instance_admin.proto#L565}
   ///
   Status DeleteInstance(
       google::spanner::admin::instance::v1::DeleteInstanceRequest const&
@@ -608,9 +608,9 @@ class InstanceAdminClient {
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
   /// [google.iam.v1.SetIamPolicyRequest]:
-  /// @googleapis_link{google::iam::v1::SetIamPolicyRequest,google/iam/v1/iam_policy.proto#L98}
+  /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L98}
   /// [google.iam.v1.Policy]:
-  /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
+  /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
       google::iam::v1::SetIamPolicyRequest const& request);
@@ -628,9 +628,9 @@ class InstanceAdminClient {
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
   /// [google.iam.v1.GetIamPolicyRequest]:
-  /// @googleapis_link{google::iam::v1::GetIamPolicyRequest,google/iam/v1/iam_policy.proto#L113}
+  /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L113}
   /// [google.iam.v1.Policy]:
-  /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
+  /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> GetIamPolicy(
       google::iam::v1::GetIamPolicyRequest const& request);
@@ -650,9 +650,9 @@ class InstanceAdminClient {
   /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
   ///
   /// [google.iam.v1.TestIamPermissionsRequest]:
-  /// @googleapis_link{google::iam::v1::TestIamPermissionsRequest,google/iam/v1/iam_policy.proto#L126}
+  /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L126}
   /// [google.iam.v1.TestIamPermissionsResponse]:
-  /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
+  /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L141}
   ///
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
       google::iam::v1::TestIamPermissionsRequest const& request);

--- a/google/cloud/tasks/cloud_tasks_client.h
+++ b/google/cloud/tasks/cloud_tasks_client.h
@@ -70,6 +70,11 @@ class CloudTasksClient {
   /// @return
   /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
   ///
+  /// [google.cloud.tasks.v2.ListQueuesRequest]:
+  /// @googleapis_link{google::cloud::tasks::v2::ListQueuesRequest,google/cloud/tasks/v2/cloudtasks.proto#L308}
+  /// [google::cloud::tasks::v2::Queue]:
+  /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
+  ///
   StreamRange<google::cloud::tasks::v2::Queue> ListQueues(
       std::string const& parent);
 
@@ -79,6 +84,11 @@ class CloudTasksClient {
   /// @param name  Required. The resource name of the queue. For example:
   ///  `projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID`
   /// @return
+  /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
+  ///
+  /// [google.cloud.tasks.v2.GetQueueRequest]:
+  /// @googleapis_link{google::cloud::tasks::v2::GetQueueRequest,google/cloud/tasks/v2/cloudtasks.proto#L369}
+  /// [google.cloud.tasks.v2.Queue]:
   /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
   ///
   StatusOr<google::cloud::tasks::v2::Queue> GetQueue(std::string const& name);
@@ -106,6 +116,11 @@ class CloudTasksClient {
   ///  [Queue's name][google.cloud.tasks.v2.Queue.name] cannot be the same as an
   ///  existing queue.
   /// @return
+  /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
+  ///
+  /// [google.cloud.tasks.v2.CreateQueueRequest]:
+  /// @googleapis_link{google::cloud::tasks::v2::CreateQueueRequest,google/cloud/tasks/v2/cloudtasks.proto#L381}
+  /// [google.cloud.tasks.v2.Queue]:
   /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
   ///
   StatusOr<google::cloud::tasks::v2::Queue> CreateQueue(
@@ -138,6 +153,11 @@ class CloudTasksClient {
   /// @return
   /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
   ///
+  /// [google.cloud.tasks.v2.UpdateQueueRequest]:
+  /// @googleapis_link{google::cloud::tasks::v2::UpdateQueueRequest,google/cloud/tasks/v2/cloudtasks.proto#L402}
+  /// [google.cloud.tasks.v2.Queue]:
+  /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
+  ///
   StatusOr<google::cloud::tasks::v2::Queue> UpdateQueue(
       google::cloud::tasks::v2::Queue const& queue,
       google::protobuf::FieldMask const& update_mask);
@@ -159,6 +179,9 @@ class CloudTasksClient {
   /// @param name  Required. The queue name. For example:
   ///  `projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID`
   ///
+  /// [google.cloud.tasks.v2.DeleteQueueRequest]:
+  /// @googleapis_link{google::cloud::tasks::v2::DeleteQueueRequest,google/cloud/tasks/v2/cloudtasks.proto#L419}
+  ///
   Status DeleteQueue(std::string const& name);
 
   ///
@@ -173,6 +196,11 @@ class CloudTasksClient {
   /// @param name  Required. The queue name. For example:
   ///  `projects/PROJECT_ID/location/LOCATION_ID/queues/QUEUE_ID`
   /// @return
+  /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
+  ///
+  /// [google.cloud.tasks.v2.PurgeQueueRequest]:
+  /// @googleapis_link{google::cloud::tasks::v2::PurgeQueueRequest,google/cloud/tasks/v2/cloudtasks.proto#L431}
+  /// [google.cloud.tasks.v2.Queue]:
   /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
   ///
   StatusOr<google::cloud::tasks::v2::Queue> PurgeQueue(std::string const& name);
@@ -190,6 +218,11 @@ class CloudTasksClient {
   /// @param name  Required. The queue name. For example:
   ///  `projects/PROJECT_ID/location/LOCATION_ID/queues/QUEUE_ID`
   /// @return
+  /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
+  ///
+  /// [google.cloud.tasks.v2.PauseQueueRequest]:
+  /// @googleapis_link{google::cloud::tasks::v2::PauseQueueRequest,google/cloud/tasks/v2/cloudtasks.proto#L443}
+  /// [google.cloud.tasks.v2.Queue]:
   /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
   ///
   StatusOr<google::cloud::tasks::v2::Queue> PauseQueue(std::string const& name);
@@ -215,6 +248,11 @@ class CloudTasksClient {
   /// @return
   /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
   ///
+  /// [google.cloud.tasks.v2.ResumeQueueRequest]:
+  /// @googleapis_link{google::cloud::tasks::v2::ResumeQueueRequest,google/cloud/tasks/v2/cloudtasks.proto#L455}
+  /// [google.cloud.tasks.v2.Queue]:
+  /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
+  ///
   StatusOr<google::cloud::tasks::v2::Queue> ResumeQueue(
       std::string const& name);
 
@@ -233,6 +271,11 @@ class CloudTasksClient {
   /// requested.
   ///  See the operation documentation for the appropriate value for this field.
   /// @return
+  /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
+  ///
+  /// [google.iam.v1.GetIamPolicyRequest]:
+  /// @googleapis_link{google::iam::v1::GetIamPolicyRequest,google/iam/v1/iam_policy.proto#L113}
+  /// [google.iam.v1.Policy]:
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> GetIamPolicy(std::string const& resource);
@@ -259,6 +302,11 @@ class CloudTasksClient {
   ///  valid policy but certain Cloud Platform services (such as Projects)
   ///  might reject them.
   /// @return
+  /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
+  ///
+  /// [google.iam.v1.SetIamPolicyRequest]:
+  /// @googleapis_link{google::iam::v1::SetIamPolicyRequest,google/iam/v1/iam_policy.proto#L98}
+  /// [google.iam.v1.Policy]:
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
@@ -310,6 +358,11 @@ class CloudTasksClient {
   /// @return
   /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
   ///
+  /// [google.iam.v1.TestIamPermissionsRequest]:
+  /// @googleapis_link{google::iam::v1::TestIamPermissionsRequest,google/iam/v1/iam_policy.proto#L126}
+  /// [google.iam.v1.TestIamPermissionsResponse]:
+  /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
+  ///
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
       std::string const& resource, std::vector<std::string> const& permissions);
 
@@ -329,6 +382,11 @@ class CloudTasksClient {
   /// @return
   /// @googleapis_link{google::cloud::tasks::v2::Task,google/cloud/tasks/v2/task.proto#L33}
   ///
+  /// [google.cloud.tasks.v2.ListTasksRequest]:
+  /// @googleapis_link{google::cloud::tasks::v2::ListTasksRequest,google/cloud/tasks/v2/cloudtasks.proto#L467}
+  /// [google::cloud::tasks::v2::Task]:
+  /// @googleapis_link{google::cloud::tasks::v2::Task,google/cloud/tasks/v2/task.proto#L33}
+  ///
   StreamRange<google::cloud::tasks::v2::Task> ListTasks(
       std::string const& parent);
 
@@ -338,6 +396,11 @@ class CloudTasksClient {
   /// @param name  Required. The task name. For example:
   ///  `projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID/tasks/TASK_ID`
   /// @return
+  /// @googleapis_link{google::cloud::tasks::v2::Task,google/cloud/tasks/v2/task.proto#L33}
+  ///
+  /// [google.cloud.tasks.v2.GetTaskRequest]:
+  /// @googleapis_link{google::cloud::tasks::v2::GetTaskRequest,google/cloud/tasks/v2/cloudtasks.proto#L529}
+  /// [google.cloud.tasks.v2.Task]:
   /// @googleapis_link{google::cloud::tasks::v2::Task,google/cloud/tasks/v2/task.proto#L33}
   ///
   StatusOr<google::cloud::tasks::v2::Task> GetTask(std::string const& name);
@@ -382,6 +445,11 @@ class CloudTasksClient {
   /// @return
   /// @googleapis_link{google::cloud::tasks::v2::Task,google/cloud/tasks/v2/task.proto#L33}
   ///
+  /// [google.cloud.tasks.v2.CreateTaskRequest]:
+  /// @googleapis_link{google::cloud::tasks::v2::CreateTaskRequest,google/cloud/tasks/v2/cloudtasks.proto#L555}
+  /// [google.cloud.tasks.v2.Task]:
+  /// @googleapis_link{google::cloud::tasks::v2::Task,google/cloud/tasks/v2/task.proto#L33}
+  ///
   StatusOr<google::cloud::tasks::v2::Task> CreateTask(
       std::string const& parent, google::cloud::tasks::v2::Task const& task);
 
@@ -394,6 +462,9 @@ class CloudTasksClient {
   ///
   /// @param name  Required. The task name. For example:
   ///  `projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID/tasks/TASK_ID`
+  ///
+  /// [google.cloud.tasks.v2.DeleteTaskRequest]:
+  /// @googleapis_link{google::cloud::tasks::v2::DeleteTaskRequest,google/cloud/tasks/v2/cloudtasks.proto#L619}
   ///
   Status DeleteTask(std::string const& name);
 
@@ -430,6 +501,11 @@ class CloudTasksClient {
   /// @return
   /// @googleapis_link{google::cloud::tasks::v2::Task,google/cloud/tasks/v2/task.proto#L33}
   ///
+  /// [google.cloud.tasks.v2.RunTaskRequest]:
+  /// @googleapis_link{google::cloud::tasks::v2::RunTaskRequest,google/cloud/tasks/v2/cloudtasks.proto#L632}
+  /// [google.cloud.tasks.v2.Task]:
+  /// @googleapis_link{google::cloud::tasks::v2::Task,google/cloud/tasks/v2/task.proto#L33}
+  ///
   StatusOr<google::cloud::tasks::v2::Task> RunTask(std::string const& name);
 
   ///
@@ -442,6 +518,11 @@ class CloudTasksClient {
   /// @return
   /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
   ///
+  /// [google.cloud.tasks.v2.ListQueuesRequest]:
+  /// @googleapis_link{google::cloud::tasks::v2::ListQueuesRequest,google/cloud/tasks/v2/cloudtasks.proto#L308}
+  /// [google::cloud::tasks::v2::Queue]:
+  /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
+  ///
   StreamRange<google::cloud::tasks::v2::Queue> ListQueues(
       google::cloud::tasks::v2::ListQueuesRequest request);
 
@@ -451,6 +532,11 @@ class CloudTasksClient {
   /// @param request
   /// @googleapis_link{google::cloud::tasks::v2::GetQueueRequest,google/cloud/tasks/v2/cloudtasks.proto#L369}
   /// @return
+  /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
+  ///
+  /// [google.cloud.tasks.v2.GetQueueRequest]:
+  /// @googleapis_link{google::cloud::tasks::v2::GetQueueRequest,google/cloud/tasks/v2/cloudtasks.proto#L369}
+  /// [google.cloud.tasks.v2.Queue]:
   /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
   ///
   StatusOr<google::cloud::tasks::v2::Queue> GetQueue(
@@ -472,6 +558,11 @@ class CloudTasksClient {
   /// @param request
   /// @googleapis_link{google::cloud::tasks::v2::CreateQueueRequest,google/cloud/tasks/v2/cloudtasks.proto#L381}
   /// @return
+  /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
+  ///
+  /// [google.cloud.tasks.v2.CreateQueueRequest]:
+  /// @googleapis_link{google::cloud::tasks::v2::CreateQueueRequest,google/cloud/tasks/v2/cloudtasks.proto#L381}
+  /// [google.cloud.tasks.v2.Queue]:
   /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
   ///
   StatusOr<google::cloud::tasks::v2::Queue> CreateQueue(
@@ -498,6 +589,11 @@ class CloudTasksClient {
   /// @return
   /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
   ///
+  /// [google.cloud.tasks.v2.UpdateQueueRequest]:
+  /// @googleapis_link{google::cloud::tasks::v2::UpdateQueueRequest,google/cloud/tasks/v2/cloudtasks.proto#L402}
+  /// [google.cloud.tasks.v2.Queue]:
+  /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
+  ///
   StatusOr<google::cloud::tasks::v2::Queue> UpdateQueue(
       google::cloud::tasks::v2::UpdateQueueRequest const& request);
 
@@ -518,6 +614,9 @@ class CloudTasksClient {
   /// @param request
   /// @googleapis_link{google::cloud::tasks::v2::DeleteQueueRequest,google/cloud/tasks/v2/cloudtasks.proto#L419}
   ///
+  /// [google.cloud.tasks.v2.DeleteQueueRequest]:
+  /// @googleapis_link{google::cloud::tasks::v2::DeleteQueueRequest,google/cloud/tasks/v2/cloudtasks.proto#L419}
+  ///
   Status DeleteQueue(
       google::cloud::tasks::v2::DeleteQueueRequest const& request);
 
@@ -533,6 +632,11 @@ class CloudTasksClient {
   /// @param request
   /// @googleapis_link{google::cloud::tasks::v2::PurgeQueueRequest,google/cloud/tasks/v2/cloudtasks.proto#L431}
   /// @return
+  /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
+  ///
+  /// [google.cloud.tasks.v2.PurgeQueueRequest]:
+  /// @googleapis_link{google::cloud::tasks::v2::PurgeQueueRequest,google/cloud/tasks/v2/cloudtasks.proto#L431}
+  /// [google.cloud.tasks.v2.Queue]:
   /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
   ///
   StatusOr<google::cloud::tasks::v2::Queue> PurgeQueue(
@@ -551,6 +655,11 @@ class CloudTasksClient {
   /// @param request
   /// @googleapis_link{google::cloud::tasks::v2::PauseQueueRequest,google/cloud/tasks/v2/cloudtasks.proto#L443}
   /// @return
+  /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
+  ///
+  /// [google.cloud.tasks.v2.PauseQueueRequest]:
+  /// @googleapis_link{google::cloud::tasks::v2::PauseQueueRequest,google/cloud/tasks/v2/cloudtasks.proto#L443}
+  /// [google.cloud.tasks.v2.Queue]:
   /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
   ///
   StatusOr<google::cloud::tasks::v2::Queue> PauseQueue(
@@ -577,6 +686,11 @@ class CloudTasksClient {
   /// @return
   /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
   ///
+  /// [google.cloud.tasks.v2.ResumeQueueRequest]:
+  /// @googleapis_link{google::cloud::tasks::v2::ResumeQueueRequest,google/cloud/tasks/v2/cloudtasks.proto#L455}
+  /// [google.cloud.tasks.v2.Queue]:
+  /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
+  ///
   StatusOr<google::cloud::tasks::v2::Queue> ResumeQueue(
       google::cloud::tasks::v2::ResumeQueueRequest const& request);
 
@@ -594,6 +708,11 @@ class CloudTasksClient {
   /// @param request
   /// @googleapis_link{google::iam::v1::GetIamPolicyRequest,google/iam/v1/iam_policy.proto#L113}
   /// @return
+  /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
+  ///
+  /// [google.iam.v1.GetIamPolicyRequest]:
+  /// @googleapis_link{google::iam::v1::GetIamPolicyRequest,google/iam/v1/iam_policy.proto#L113}
+  /// [google.iam.v1.Policy]:
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> GetIamPolicy(
@@ -617,6 +736,11 @@ class CloudTasksClient {
   /// @return
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
+  /// [google.iam.v1.SetIamPolicyRequest]:
+  /// @googleapis_link{google::iam::v1::SetIamPolicyRequest,google/iam/v1/iam_policy.proto#L98}
+  /// [google.iam.v1.Policy]:
+  /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
+  ///
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
       google::iam::v1::SetIamPolicyRequest const& request);
 
@@ -633,6 +757,11 @@ class CloudTasksClient {
   /// @param request
   /// @googleapis_link{google::iam::v1::TestIamPermissionsRequest,google/iam/v1/iam_policy.proto#L126}
   /// @return
+  /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
+  ///
+  /// [google.iam.v1.TestIamPermissionsRequest]:
+  /// @googleapis_link{google::iam::v1::TestIamPermissionsRequest,google/iam/v1/iam_policy.proto#L126}
+  /// [google.iam.v1.TestIamPermissionsResponse]:
   /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
   ///
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
@@ -654,6 +783,11 @@ class CloudTasksClient {
   /// @return
   /// @googleapis_link{google::cloud::tasks::v2::Task,google/cloud/tasks/v2/task.proto#L33}
   ///
+  /// [google.cloud.tasks.v2.ListTasksRequest]:
+  /// @googleapis_link{google::cloud::tasks::v2::ListTasksRequest,google/cloud/tasks/v2/cloudtasks.proto#L467}
+  /// [google::cloud::tasks::v2::Task]:
+  /// @googleapis_link{google::cloud::tasks::v2::Task,google/cloud/tasks/v2/task.proto#L33}
+  ///
   StreamRange<google::cloud::tasks::v2::Task> ListTasks(
       google::cloud::tasks::v2::ListTasksRequest request);
 
@@ -663,6 +797,11 @@ class CloudTasksClient {
   /// @param request
   /// @googleapis_link{google::cloud::tasks::v2::GetTaskRequest,google/cloud/tasks/v2/cloudtasks.proto#L529}
   /// @return
+  /// @googleapis_link{google::cloud::tasks::v2::Task,google/cloud/tasks/v2/task.proto#L33}
+  ///
+  /// [google.cloud.tasks.v2.GetTaskRequest]:
+  /// @googleapis_link{google::cloud::tasks::v2::GetTaskRequest,google/cloud/tasks/v2/cloudtasks.proto#L529}
+  /// [google.cloud.tasks.v2.Task]:
   /// @googleapis_link{google::cloud::tasks::v2::Task,google/cloud/tasks/v2/task.proto#L33}
   ///
   StatusOr<google::cloud::tasks::v2::Task> GetTask(
@@ -680,6 +819,11 @@ class CloudTasksClient {
   /// @return
   /// @googleapis_link{google::cloud::tasks::v2::Task,google/cloud/tasks/v2/task.proto#L33}
   ///
+  /// [google.cloud.tasks.v2.CreateTaskRequest]:
+  /// @googleapis_link{google::cloud::tasks::v2::CreateTaskRequest,google/cloud/tasks/v2/cloudtasks.proto#L555}
+  /// [google.cloud.tasks.v2.Task]:
+  /// @googleapis_link{google::cloud::tasks::v2::Task,google/cloud/tasks/v2/task.proto#L33}
+  ///
   StatusOr<google::cloud::tasks::v2::Task> CreateTask(
       google::cloud::tasks::v2::CreateTaskRequest const& request);
 
@@ -691,6 +835,9 @@ class CloudTasksClient {
   /// failed.
   ///
   /// @param request
+  /// @googleapis_link{google::cloud::tasks::v2::DeleteTaskRequest,google/cloud/tasks/v2/cloudtasks.proto#L619}
+  ///
+  /// [google.cloud.tasks.v2.DeleteTaskRequest]:
   /// @googleapis_link{google::cloud::tasks::v2::DeleteTaskRequest,google/cloud/tasks/v2/cloudtasks.proto#L619}
   ///
   Status DeleteTask(google::cloud::tasks::v2::DeleteTaskRequest const& request);
@@ -726,6 +873,11 @@ class CloudTasksClient {
   /// @param request
   /// @googleapis_link{google::cloud::tasks::v2::RunTaskRequest,google/cloud/tasks/v2/cloudtasks.proto#L632}
   /// @return
+  /// @googleapis_link{google::cloud::tasks::v2::Task,google/cloud/tasks/v2/task.proto#L33}
+  ///
+  /// [google.cloud.tasks.v2.RunTaskRequest]:
+  /// @googleapis_link{google::cloud::tasks::v2::RunTaskRequest,google/cloud/tasks/v2/cloudtasks.proto#L632}
+  /// [google.cloud.tasks.v2.Task]:
   /// @googleapis_link{google::cloud::tasks::v2::Task,google/cloud/tasks/v2/task.proto#L33}
   ///
   StatusOr<google::cloud::tasks::v2::Task> RunTask(

--- a/google/cloud/tasks/cloud_tasks_client.h
+++ b/google/cloud/tasks/cloud_tasks_client.h
@@ -71,9 +71,9 @@ class CloudTasksClient {
   /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
   ///
   /// [google.cloud.tasks.v2.ListQueuesRequest]:
-  /// @googleapis_link{google::cloud::tasks::v2::ListQueuesRequest,google/cloud/tasks/v2/cloudtasks.proto#L308}
+  /// @googleapis_reference_link{google/cloud/tasks/v2/cloudtasks.proto#L308}
   /// [google.cloud.tasks.v2.Queue]:
-  /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
+  /// @googleapis_reference_link{google/cloud/tasks/v2/queue.proto#L34}
   ///
   StreamRange<google::cloud::tasks::v2::Queue> ListQueues(
       std::string const& parent);
@@ -87,9 +87,9 @@ class CloudTasksClient {
   /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
   ///
   /// [google.cloud.tasks.v2.GetQueueRequest]:
-  /// @googleapis_link{google::cloud::tasks::v2::GetQueueRequest,google/cloud/tasks/v2/cloudtasks.proto#L369}
+  /// @googleapis_reference_link{google/cloud/tasks/v2/cloudtasks.proto#L369}
   /// [google.cloud.tasks.v2.Queue]:
-  /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
+  /// @googleapis_reference_link{google/cloud/tasks/v2/queue.proto#L34}
   ///
   StatusOr<google::cloud::tasks::v2::Queue> GetQueue(std::string const& name);
 
@@ -119,9 +119,9 @@ class CloudTasksClient {
   /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
   ///
   /// [google.cloud.tasks.v2.CreateQueueRequest]:
-  /// @googleapis_link{google::cloud::tasks::v2::CreateQueueRequest,google/cloud/tasks/v2/cloudtasks.proto#L381}
+  /// @googleapis_reference_link{google/cloud/tasks/v2/cloudtasks.proto#L381}
   /// [google.cloud.tasks.v2.Queue]:
-  /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
+  /// @googleapis_reference_link{google/cloud/tasks/v2/queue.proto#L34}
   ///
   StatusOr<google::cloud::tasks::v2::Queue> CreateQueue(
       std::string const& parent, google::cloud::tasks::v2::Queue const& queue);
@@ -154,9 +154,9 @@ class CloudTasksClient {
   /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
   ///
   /// [google.cloud.tasks.v2.UpdateQueueRequest]:
-  /// @googleapis_link{google::cloud::tasks::v2::UpdateQueueRequest,google/cloud/tasks/v2/cloudtasks.proto#L402}
+  /// @googleapis_reference_link{google/cloud/tasks/v2/cloudtasks.proto#L402}
   /// [google.cloud.tasks.v2.Queue]:
-  /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
+  /// @googleapis_reference_link{google/cloud/tasks/v2/queue.proto#L34}
   ///
   StatusOr<google::cloud::tasks::v2::Queue> UpdateQueue(
       google::cloud::tasks::v2::Queue const& queue,
@@ -180,7 +180,7 @@ class CloudTasksClient {
   ///  `projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID`
   ///
   /// [google.cloud.tasks.v2.DeleteQueueRequest]:
-  /// @googleapis_link{google::cloud::tasks::v2::DeleteQueueRequest,google/cloud/tasks/v2/cloudtasks.proto#L419}
+  /// @googleapis_reference_link{google/cloud/tasks/v2/cloudtasks.proto#L419}
   ///
   Status DeleteQueue(std::string const& name);
 
@@ -199,9 +199,9 @@ class CloudTasksClient {
   /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
   ///
   /// [google.cloud.tasks.v2.PurgeQueueRequest]:
-  /// @googleapis_link{google::cloud::tasks::v2::PurgeQueueRequest,google/cloud/tasks/v2/cloudtasks.proto#L431}
+  /// @googleapis_reference_link{google/cloud/tasks/v2/cloudtasks.proto#L431}
   /// [google.cloud.tasks.v2.Queue]:
-  /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
+  /// @googleapis_reference_link{google/cloud/tasks/v2/queue.proto#L34}
   ///
   StatusOr<google::cloud::tasks::v2::Queue> PurgeQueue(std::string const& name);
 
@@ -221,9 +221,9 @@ class CloudTasksClient {
   /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
   ///
   /// [google.cloud.tasks.v2.PauseQueueRequest]:
-  /// @googleapis_link{google::cloud::tasks::v2::PauseQueueRequest,google/cloud/tasks/v2/cloudtasks.proto#L443}
+  /// @googleapis_reference_link{google/cloud/tasks/v2/cloudtasks.proto#L443}
   /// [google.cloud.tasks.v2.Queue]:
-  /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
+  /// @googleapis_reference_link{google/cloud/tasks/v2/queue.proto#L34}
   ///
   StatusOr<google::cloud::tasks::v2::Queue> PauseQueue(std::string const& name);
 
@@ -249,9 +249,9 @@ class CloudTasksClient {
   /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
   ///
   /// [google.cloud.tasks.v2.ResumeQueueRequest]:
-  /// @googleapis_link{google::cloud::tasks::v2::ResumeQueueRequest,google/cloud/tasks/v2/cloudtasks.proto#L455}
+  /// @googleapis_reference_link{google/cloud/tasks/v2/cloudtasks.proto#L455}
   /// [google.cloud.tasks.v2.Queue]:
-  /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
+  /// @googleapis_reference_link{google/cloud/tasks/v2/queue.proto#L34}
   ///
   StatusOr<google::cloud::tasks::v2::Queue> ResumeQueue(
       std::string const& name);
@@ -274,9 +274,9 @@ class CloudTasksClient {
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
   /// [google.iam.v1.GetIamPolicyRequest]:
-  /// @googleapis_link{google::iam::v1::GetIamPolicyRequest,google/iam/v1/iam_policy.proto#L113}
+  /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L113}
   /// [google.iam.v1.Policy]:
-  /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
+  /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> GetIamPolicy(std::string const& resource);
 
@@ -305,9 +305,9 @@ class CloudTasksClient {
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
   /// [google.iam.v1.SetIamPolicyRequest]:
-  /// @googleapis_link{google::iam::v1::SetIamPolicyRequest,google/iam/v1/iam_policy.proto#L98}
+  /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L98}
   /// [google.iam.v1.Policy]:
-  /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
+  /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
       std::string const& resource, google::iam::v1::Policy const& policy);
@@ -359,9 +359,9 @@ class CloudTasksClient {
   /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
   ///
   /// [google.iam.v1.TestIamPermissionsRequest]:
-  /// @googleapis_link{google::iam::v1::TestIamPermissionsRequest,google/iam/v1/iam_policy.proto#L126}
+  /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L126}
   /// [google.iam.v1.TestIamPermissionsResponse]:
-  /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
+  /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L141}
   ///
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
       std::string const& resource, std::vector<std::string> const& permissions);
@@ -383,9 +383,9 @@ class CloudTasksClient {
   /// @googleapis_link{google::cloud::tasks::v2::Task,google/cloud/tasks/v2/task.proto#L33}
   ///
   /// [google.cloud.tasks.v2.ListTasksRequest]:
-  /// @googleapis_link{google::cloud::tasks::v2::ListTasksRequest,google/cloud/tasks/v2/cloudtasks.proto#L467}
+  /// @googleapis_reference_link{google/cloud/tasks/v2/cloudtasks.proto#L467}
   /// [google.cloud.tasks.v2.Task]:
-  /// @googleapis_link{google::cloud::tasks::v2::Task,google/cloud/tasks/v2/task.proto#L33}
+  /// @googleapis_reference_link{google/cloud/tasks/v2/task.proto#L33}
   ///
   StreamRange<google::cloud::tasks::v2::Task> ListTasks(
       std::string const& parent);
@@ -399,9 +399,9 @@ class CloudTasksClient {
   /// @googleapis_link{google::cloud::tasks::v2::Task,google/cloud/tasks/v2/task.proto#L33}
   ///
   /// [google.cloud.tasks.v2.GetTaskRequest]:
-  /// @googleapis_link{google::cloud::tasks::v2::GetTaskRequest,google/cloud/tasks/v2/cloudtasks.proto#L529}
+  /// @googleapis_reference_link{google/cloud/tasks/v2/cloudtasks.proto#L529}
   /// [google.cloud.tasks.v2.Task]:
-  /// @googleapis_link{google::cloud::tasks::v2::Task,google/cloud/tasks/v2/task.proto#L33}
+  /// @googleapis_reference_link{google/cloud/tasks/v2/task.proto#L33}
   ///
   StatusOr<google::cloud::tasks::v2::Task> GetTask(std::string const& name);
 
@@ -446,9 +446,9 @@ class CloudTasksClient {
   /// @googleapis_link{google::cloud::tasks::v2::Task,google/cloud/tasks/v2/task.proto#L33}
   ///
   /// [google.cloud.tasks.v2.CreateTaskRequest]:
-  /// @googleapis_link{google::cloud::tasks::v2::CreateTaskRequest,google/cloud/tasks/v2/cloudtasks.proto#L555}
+  /// @googleapis_reference_link{google/cloud/tasks/v2/cloudtasks.proto#L555}
   /// [google.cloud.tasks.v2.Task]:
-  /// @googleapis_link{google::cloud::tasks::v2::Task,google/cloud/tasks/v2/task.proto#L33}
+  /// @googleapis_reference_link{google/cloud/tasks/v2/task.proto#L33}
   ///
   StatusOr<google::cloud::tasks::v2::Task> CreateTask(
       std::string const& parent, google::cloud::tasks::v2::Task const& task);
@@ -464,7 +464,7 @@ class CloudTasksClient {
   ///  `projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID/tasks/TASK_ID`
   ///
   /// [google.cloud.tasks.v2.DeleteTaskRequest]:
-  /// @googleapis_link{google::cloud::tasks::v2::DeleteTaskRequest,google/cloud/tasks/v2/cloudtasks.proto#L619}
+  /// @googleapis_reference_link{google/cloud/tasks/v2/cloudtasks.proto#L619}
   ///
   Status DeleteTask(std::string const& name);
 
@@ -502,9 +502,9 @@ class CloudTasksClient {
   /// @googleapis_link{google::cloud::tasks::v2::Task,google/cloud/tasks/v2/task.proto#L33}
   ///
   /// [google.cloud.tasks.v2.RunTaskRequest]:
-  /// @googleapis_link{google::cloud::tasks::v2::RunTaskRequest,google/cloud/tasks/v2/cloudtasks.proto#L632}
+  /// @googleapis_reference_link{google/cloud/tasks/v2/cloudtasks.proto#L632}
   /// [google.cloud.tasks.v2.Task]:
-  /// @googleapis_link{google::cloud::tasks::v2::Task,google/cloud/tasks/v2/task.proto#L33}
+  /// @googleapis_reference_link{google/cloud/tasks/v2/task.proto#L33}
   ///
   StatusOr<google::cloud::tasks::v2::Task> RunTask(std::string const& name);
 
@@ -519,9 +519,9 @@ class CloudTasksClient {
   /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
   ///
   /// [google.cloud.tasks.v2.ListQueuesRequest]:
-  /// @googleapis_link{google::cloud::tasks::v2::ListQueuesRequest,google/cloud/tasks/v2/cloudtasks.proto#L308}
+  /// @googleapis_reference_link{google/cloud/tasks/v2/cloudtasks.proto#L308}
   /// [google.cloud.tasks.v2.Queue]:
-  /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
+  /// @googleapis_reference_link{google/cloud/tasks/v2/queue.proto#L34}
   ///
   StreamRange<google::cloud::tasks::v2::Queue> ListQueues(
       google::cloud::tasks::v2::ListQueuesRequest request);
@@ -535,9 +535,9 @@ class CloudTasksClient {
   /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
   ///
   /// [google.cloud.tasks.v2.GetQueueRequest]:
-  /// @googleapis_link{google::cloud::tasks::v2::GetQueueRequest,google/cloud/tasks/v2/cloudtasks.proto#L369}
+  /// @googleapis_reference_link{google/cloud/tasks/v2/cloudtasks.proto#L369}
   /// [google.cloud.tasks.v2.Queue]:
-  /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
+  /// @googleapis_reference_link{google/cloud/tasks/v2/queue.proto#L34}
   ///
   StatusOr<google::cloud::tasks::v2::Queue> GetQueue(
       google::cloud::tasks::v2::GetQueueRequest const& request);
@@ -561,9 +561,9 @@ class CloudTasksClient {
   /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
   ///
   /// [google.cloud.tasks.v2.CreateQueueRequest]:
-  /// @googleapis_link{google::cloud::tasks::v2::CreateQueueRequest,google/cloud/tasks/v2/cloudtasks.proto#L381}
+  /// @googleapis_reference_link{google/cloud/tasks/v2/cloudtasks.proto#L381}
   /// [google.cloud.tasks.v2.Queue]:
-  /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
+  /// @googleapis_reference_link{google/cloud/tasks/v2/queue.proto#L34}
   ///
   StatusOr<google::cloud::tasks::v2::Queue> CreateQueue(
       google::cloud::tasks::v2::CreateQueueRequest const& request);
@@ -590,9 +590,9 @@ class CloudTasksClient {
   /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
   ///
   /// [google.cloud.tasks.v2.UpdateQueueRequest]:
-  /// @googleapis_link{google::cloud::tasks::v2::UpdateQueueRequest,google/cloud/tasks/v2/cloudtasks.proto#L402}
+  /// @googleapis_reference_link{google/cloud/tasks/v2/cloudtasks.proto#L402}
   /// [google.cloud.tasks.v2.Queue]:
-  /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
+  /// @googleapis_reference_link{google/cloud/tasks/v2/queue.proto#L34}
   ///
   StatusOr<google::cloud::tasks::v2::Queue> UpdateQueue(
       google::cloud::tasks::v2::UpdateQueueRequest const& request);
@@ -615,7 +615,7 @@ class CloudTasksClient {
   /// @googleapis_link{google::cloud::tasks::v2::DeleteQueueRequest,google/cloud/tasks/v2/cloudtasks.proto#L419}
   ///
   /// [google.cloud.tasks.v2.DeleteQueueRequest]:
-  /// @googleapis_link{google::cloud::tasks::v2::DeleteQueueRequest,google/cloud/tasks/v2/cloudtasks.proto#L419}
+  /// @googleapis_reference_link{google/cloud/tasks/v2/cloudtasks.proto#L419}
   ///
   Status DeleteQueue(
       google::cloud::tasks::v2::DeleteQueueRequest const& request);
@@ -635,9 +635,9 @@ class CloudTasksClient {
   /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
   ///
   /// [google.cloud.tasks.v2.PurgeQueueRequest]:
-  /// @googleapis_link{google::cloud::tasks::v2::PurgeQueueRequest,google/cloud/tasks/v2/cloudtasks.proto#L431}
+  /// @googleapis_reference_link{google/cloud/tasks/v2/cloudtasks.proto#L431}
   /// [google.cloud.tasks.v2.Queue]:
-  /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
+  /// @googleapis_reference_link{google/cloud/tasks/v2/queue.proto#L34}
   ///
   StatusOr<google::cloud::tasks::v2::Queue> PurgeQueue(
       google::cloud::tasks::v2::PurgeQueueRequest const& request);
@@ -658,9 +658,9 @@ class CloudTasksClient {
   /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
   ///
   /// [google.cloud.tasks.v2.PauseQueueRequest]:
-  /// @googleapis_link{google::cloud::tasks::v2::PauseQueueRequest,google/cloud/tasks/v2/cloudtasks.proto#L443}
+  /// @googleapis_reference_link{google/cloud/tasks/v2/cloudtasks.proto#L443}
   /// [google.cloud.tasks.v2.Queue]:
-  /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
+  /// @googleapis_reference_link{google/cloud/tasks/v2/queue.proto#L34}
   ///
   StatusOr<google::cloud::tasks::v2::Queue> PauseQueue(
       google::cloud::tasks::v2::PauseQueueRequest const& request);
@@ -687,9 +687,9 @@ class CloudTasksClient {
   /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
   ///
   /// [google.cloud.tasks.v2.ResumeQueueRequest]:
-  /// @googleapis_link{google::cloud::tasks::v2::ResumeQueueRequest,google/cloud/tasks/v2/cloudtasks.proto#L455}
+  /// @googleapis_reference_link{google/cloud/tasks/v2/cloudtasks.proto#L455}
   /// [google.cloud.tasks.v2.Queue]:
-  /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
+  /// @googleapis_reference_link{google/cloud/tasks/v2/queue.proto#L34}
   ///
   StatusOr<google::cloud::tasks::v2::Queue> ResumeQueue(
       google::cloud::tasks::v2::ResumeQueueRequest const& request);
@@ -711,9 +711,9 @@ class CloudTasksClient {
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
   /// [google.iam.v1.GetIamPolicyRequest]:
-  /// @googleapis_link{google::iam::v1::GetIamPolicyRequest,google/iam/v1/iam_policy.proto#L113}
+  /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L113}
   /// [google.iam.v1.Policy]:
-  /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
+  /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> GetIamPolicy(
       google::iam::v1::GetIamPolicyRequest const& request);
@@ -737,9 +737,9 @@ class CloudTasksClient {
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
   /// [google.iam.v1.SetIamPolicyRequest]:
-  /// @googleapis_link{google::iam::v1::SetIamPolicyRequest,google/iam/v1/iam_policy.proto#L98}
+  /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L98}
   /// [google.iam.v1.Policy]:
-  /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
+  /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
       google::iam::v1::SetIamPolicyRequest const& request);
@@ -760,9 +760,9 @@ class CloudTasksClient {
   /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
   ///
   /// [google.iam.v1.TestIamPermissionsRequest]:
-  /// @googleapis_link{google::iam::v1::TestIamPermissionsRequest,google/iam/v1/iam_policy.proto#L126}
+  /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L126}
   /// [google.iam.v1.TestIamPermissionsResponse]:
-  /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
+  /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L141}
   ///
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
       google::iam::v1::TestIamPermissionsRequest const& request);
@@ -784,9 +784,9 @@ class CloudTasksClient {
   /// @googleapis_link{google::cloud::tasks::v2::Task,google/cloud/tasks/v2/task.proto#L33}
   ///
   /// [google.cloud.tasks.v2.ListTasksRequest]:
-  /// @googleapis_link{google::cloud::tasks::v2::ListTasksRequest,google/cloud/tasks/v2/cloudtasks.proto#L467}
+  /// @googleapis_reference_link{google/cloud/tasks/v2/cloudtasks.proto#L467}
   /// [google.cloud.tasks.v2.Task]:
-  /// @googleapis_link{google::cloud::tasks::v2::Task,google/cloud/tasks/v2/task.proto#L33}
+  /// @googleapis_reference_link{google/cloud/tasks/v2/task.proto#L33}
   ///
   StreamRange<google::cloud::tasks::v2::Task> ListTasks(
       google::cloud::tasks::v2::ListTasksRequest request);
@@ -800,9 +800,9 @@ class CloudTasksClient {
   /// @googleapis_link{google::cloud::tasks::v2::Task,google/cloud/tasks/v2/task.proto#L33}
   ///
   /// [google.cloud.tasks.v2.GetTaskRequest]:
-  /// @googleapis_link{google::cloud::tasks::v2::GetTaskRequest,google/cloud/tasks/v2/cloudtasks.proto#L529}
+  /// @googleapis_reference_link{google/cloud/tasks/v2/cloudtasks.proto#L529}
   /// [google.cloud.tasks.v2.Task]:
-  /// @googleapis_link{google::cloud::tasks::v2::Task,google/cloud/tasks/v2/task.proto#L33}
+  /// @googleapis_reference_link{google/cloud/tasks/v2/task.proto#L33}
   ///
   StatusOr<google::cloud::tasks::v2::Task> GetTask(
       google::cloud::tasks::v2::GetTaskRequest const& request);
@@ -820,9 +820,9 @@ class CloudTasksClient {
   /// @googleapis_link{google::cloud::tasks::v2::Task,google/cloud/tasks/v2/task.proto#L33}
   ///
   /// [google.cloud.tasks.v2.CreateTaskRequest]:
-  /// @googleapis_link{google::cloud::tasks::v2::CreateTaskRequest,google/cloud/tasks/v2/cloudtasks.proto#L555}
+  /// @googleapis_reference_link{google/cloud/tasks/v2/cloudtasks.proto#L555}
   /// [google.cloud.tasks.v2.Task]:
-  /// @googleapis_link{google::cloud::tasks::v2::Task,google/cloud/tasks/v2/task.proto#L33}
+  /// @googleapis_reference_link{google/cloud/tasks/v2/task.proto#L33}
   ///
   StatusOr<google::cloud::tasks::v2::Task> CreateTask(
       google::cloud::tasks::v2::CreateTaskRequest const& request);
@@ -838,7 +838,7 @@ class CloudTasksClient {
   /// @googleapis_link{google::cloud::tasks::v2::DeleteTaskRequest,google/cloud/tasks/v2/cloudtasks.proto#L619}
   ///
   /// [google.cloud.tasks.v2.DeleteTaskRequest]:
-  /// @googleapis_link{google::cloud::tasks::v2::DeleteTaskRequest,google/cloud/tasks/v2/cloudtasks.proto#L619}
+  /// @googleapis_reference_link{google/cloud/tasks/v2/cloudtasks.proto#L619}
   ///
   Status DeleteTask(google::cloud::tasks::v2::DeleteTaskRequest const& request);
 
@@ -876,9 +876,9 @@ class CloudTasksClient {
   /// @googleapis_link{google::cloud::tasks::v2::Task,google/cloud/tasks/v2/task.proto#L33}
   ///
   /// [google.cloud.tasks.v2.RunTaskRequest]:
-  /// @googleapis_link{google::cloud::tasks::v2::RunTaskRequest,google/cloud/tasks/v2/cloudtasks.proto#L632}
+  /// @googleapis_reference_link{google/cloud/tasks/v2/cloudtasks.proto#L632}
   /// [google.cloud.tasks.v2.Task]:
-  /// @googleapis_link{google::cloud::tasks::v2::Task,google/cloud/tasks/v2/task.proto#L33}
+  /// @googleapis_reference_link{google/cloud/tasks/v2/task.proto#L33}
   ///
   StatusOr<google::cloud::tasks::v2::Task> RunTask(
       google::cloud::tasks::v2::RunTaskRequest const& request);

--- a/google/cloud/tasks/cloud_tasks_client.h
+++ b/google/cloud/tasks/cloud_tasks_client.h
@@ -72,7 +72,7 @@ class CloudTasksClient {
   ///
   /// [google.cloud.tasks.v2.ListQueuesRequest]:
   /// @googleapis_link{google::cloud::tasks::v2::ListQueuesRequest,google/cloud/tasks/v2/cloudtasks.proto#L308}
-  /// [google::cloud::tasks::v2::Queue]:
+  /// [google.cloud.tasks.v2.Queue]:
   /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
   ///
   StreamRange<google::cloud::tasks::v2::Queue> ListQueues(
@@ -384,7 +384,7 @@ class CloudTasksClient {
   ///
   /// [google.cloud.tasks.v2.ListTasksRequest]:
   /// @googleapis_link{google::cloud::tasks::v2::ListTasksRequest,google/cloud/tasks/v2/cloudtasks.proto#L467}
-  /// [google::cloud::tasks::v2::Task]:
+  /// [google.cloud.tasks.v2.Task]:
   /// @googleapis_link{google::cloud::tasks::v2::Task,google/cloud/tasks/v2/task.proto#L33}
   ///
   StreamRange<google::cloud::tasks::v2::Task> ListTasks(
@@ -520,7 +520,7 @@ class CloudTasksClient {
   ///
   /// [google.cloud.tasks.v2.ListQueuesRequest]:
   /// @googleapis_link{google::cloud::tasks::v2::ListQueuesRequest,google/cloud/tasks/v2/cloudtasks.proto#L308}
-  /// [google::cloud::tasks::v2::Queue]:
+  /// [google.cloud.tasks.v2.Queue]:
   /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
   ///
   StreamRange<google::cloud::tasks::v2::Queue> ListQueues(
@@ -785,7 +785,7 @@ class CloudTasksClient {
   ///
   /// [google.cloud.tasks.v2.ListTasksRequest]:
   /// @googleapis_link{google::cloud::tasks::v2::ListTasksRequest,google/cloud/tasks/v2/cloudtasks.proto#L467}
-  /// [google::cloud::tasks::v2::Task]:
+  /// [google.cloud.tasks.v2.Task]:
   /// @googleapis_link{google::cloud::tasks::v2::Task,google/cloud/tasks/v2/task.proto#L33}
   ///
   StreamRange<google::cloud::tasks::v2::Task> ListTasks(


### PR DESCRIPTION
The protobuf documentation seems to use reference-style markdown links
for protos in the comments, i.e., each reference to `Foo` is formatted
as `[Foo][google.blah.blah.v1.Foo]`.  This formatting is very
distracting if left verbatim, but it can be turned into a link if we
define `google.blah.blah.v1.Foo` as a link reference in Doxygen's
markdown.

With this change the input and output types of each method get such
reference link definitions. The definitions themselves are not visible,
but they make the generated Doxygen output easier to read.

This does not solve the problem when the referenced entity is not an
input or output type of the method, or when it references another
method. But it works in enough cases to make the change worthwhile.

Part of the work for #7664

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7665)
<!-- Reviewable:end -->
