### PR TITLE
feat(common): add support for call-tree-specific options

### DIFF
--- a/google/cloud/internal/async_connection_ready.cc
+++ b/google/cloud/internal/async_connection_ready.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/internal/async_connection_ready.h"
+#include "google/cloud/options.h"
 
 namespace google {
 namespace cloud {
@@ -60,6 +61,7 @@ void AsyncConnectionReadyFuture::RunIteration(ChannelStateType state) {
     explicit OnStateChange(std::shared_ptr<AsyncConnectionReadyFuture> s)
         : self_(std::move(s)) {}
     bool Notify(bool ok) override {
+      OptionsSpan span(options_);
       self_->Notify(ok);
       return true;
     }
@@ -67,6 +69,7 @@ void AsyncConnectionReadyFuture::RunIteration(ChannelStateType state) {
 
    private:
     std::shared_ptr<AsyncConnectionReadyFuture> const self_;
+    Options options_ = CurrentOptions();
   };
 
   auto op = std::make_shared<OnStateChange>(shared_from_this());

--- a/google/cloud/internal/async_read_stream_impl.h
+++ b/google/cloud/internal/async_read_stream_impl.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/grpc_error_delegate.h"
 #include "google/cloud/internal/completion_queue_impl.h"
+#include "google/cloud/options.h"
 #include "google/cloud/version.h"
 #include <grpcpp/support/async_stream.h>
 #include <memory>
@@ -150,10 +151,12 @@ class AsyncReadStreamImpl
      private:
       void Cancel() override {}  // LCOV_EXCL_LINE
       bool Notify(bool ok) override {
+        OptionsSpan span(options_);
         control_->OnStart(ok);
         return true;
       }
       std::shared_ptr<AsyncReadStreamImpl> control_;
+      Options options_ = CurrentOptions();
     };
 
     context_ = std::move(context);
@@ -195,10 +198,12 @@ class AsyncReadStreamImpl
      private:
       void Cancel() override {}  // LCOV_EXCL_LINE
       bool Notify(bool ok) override {
+        OptionsSpan span(options_);
         control_->OnRead(ok, std::move(response));
         return true;
       }
       std::shared_ptr<AsyncReadStreamImpl> control_;
+      Options options_ = CurrentOptions();
     };
 
     auto callback = std::make_shared<NotifyRead>(this->shared_from_this());
@@ -243,10 +248,12 @@ class AsyncReadStreamImpl
      private:
       void Cancel() override {}  // LCOV_EXCL_LINE
       bool Notify(bool ok) override {
+        OptionsSpan span(options_);
         control_->OnFinish(ok, MakeStatusFromRpcError(status));
         return true;
       }
       std::shared_ptr<AsyncReadStreamImpl> control_;
+      Options options_ = CurrentOptions();
     };
 
     auto callback = std::make_shared<NotifyFinish>(this->shared_from_this());
@@ -281,10 +288,12 @@ class AsyncReadStreamImpl
      private:
       void Cancel() override {}  // LCOV_EXCL_LINE
       bool Notify(bool ok) override {
+        OptionsSpan span(options_);
         control_->OnDiscard(ok, std::move(response));
         return true;
       }
       std::shared_ptr<AsyncReadStreamImpl> control_;
+      Options options_ = CurrentOptions();
     };
 
     auto callback = std::make_shared<NotifyDiscard>(this->shared_from_this());

--- a/google/cloud/internal/async_read_write_stream_impl.h
+++ b/google/cloud/internal/async_read_write_stream_impl.h
@@ -18,6 +18,7 @@
 #include "google/cloud/completion_queue.h"
 #include "google/cloud/grpc_error_delegate.h"
 #include "google/cloud/internal/completion_queue_impl.h"
+#include "google/cloud/options.h"
 #include "google/cloud/version.h"
 #include "absl/functional/function_ref.h"
 #include "absl/types/optional.h"
@@ -67,7 +68,9 @@ class AsyncStreamingReadWriteRpcImpl
   future<bool> Start() override {
     struct OnStart : public AsyncGrpcOperation {
       promise<bool> p;
+      Options options_ = CurrentOptions();
       bool Notify(bool ok) override {
+        OptionsSpan span(options_);
         p.set_value(ok);
         return true;
       }
@@ -82,7 +85,9 @@ class AsyncStreamingReadWriteRpcImpl
     struct OnRead : public AsyncGrpcOperation {
       promise<absl::optional<Response>> p;
       Response response;
+      Options options_ = CurrentOptions();
       bool Notify(bool ok) override {
+        OptionsSpan span(options_);
         if (!ok) {
           p.set_value({});
           return true;
@@ -102,7 +107,9 @@ class AsyncStreamingReadWriteRpcImpl
                      grpc::WriteOptions options) override {
     struct OnWrite : public AsyncGrpcOperation {
       promise<bool> p;
+      Options options_ = CurrentOptions();
       bool Notify(bool ok) override {
+        OptionsSpan span(options_);
         p.set_value(ok);
         return true;
       }
@@ -118,7 +125,9 @@ class AsyncStreamingReadWriteRpcImpl
   future<bool> WritesDone() override {
     struct OnWritesDone : public AsyncGrpcOperation {
       promise<bool> p;
+      Options options_ = CurrentOptions();
       bool Notify(bool ok) override {
+        OptionsSpan span(options_);
         p.set_value(ok);
         return true;
       }
@@ -132,8 +141,10 @@ class AsyncStreamingReadWriteRpcImpl
   future<Status> Finish() override {
     struct OnFinish : public AsyncGrpcOperation {
       promise<Status> p;
+      Options options_ = CurrentOptions();
       grpc::Status status;
       bool Notify(bool /*ok*/) override {
+        OptionsSpan span(options_);
         p.set_value(MakeStatusFromRpcError(std::move(status)));
         return true;
       }

--- a/google/cloud/internal/async_rpc_details.h
+++ b/google/cloud/internal/async_rpc_details.h
@@ -18,6 +18,7 @@
 #include "google/cloud/async_operation.h"
 #include "google/cloud/future.h"
 #include "google/cloud/grpc_error_delegate.h"
+#include "google/cloud/options.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include <grpcpp/support/async_unary_call.h>
@@ -68,6 +69,7 @@ class AsyncUnaryRpcFuture : public AsyncGrpcOperation {
   void Cancel() override {}
 
   bool Notify(bool ok) override {
+    OptionsSpan span(options_);
     if (!ok) {
       // `Finish()` always returns `true` for unary RPCs, so the only time we
       // get `!ok` is after `Shutdown()` was called; treat that as "cancelled".
@@ -95,6 +97,7 @@ class AsyncUnaryRpcFuture : public AsyncGrpcOperation {
   Response response_;
 
   promise<StatusOr<Response>> promise_;
+  Options options_ = CurrentOptions();
 };
 
 /// Verify that @p Functor meets the requirements for an AsyncUnaryRpc callback.

--- a/google/cloud/options.cc
+++ b/google/cloud/options.cc
@@ -46,18 +46,21 @@ namespace {
 // The prevailing options for the current operation.  Thread local, so
 // additional propagation must be done whenever work for the operation
 // is done in another thread.
-thread_local Options current_options;
+Options& ThreadLocalOptions() {
+  thread_local Options current_options;
+  return current_options;
+}
 
 }  // namespace
 
-Options const& CurrentOptions() { return current_options; }
+Options const& CurrentOptions() { return ThreadLocalOptions(); }
 
 OptionsSpan::OptionsSpan(Options opts) : opts_(std::move(opts)) {
   using std::swap;
-  swap(opts_, current_options);
+  swap(opts_, ThreadLocalOptions());
 }
 
-OptionsSpan::~OptionsSpan() { current_options = std::move(opts_); }
+OptionsSpan::~OptionsSpan() { ThreadLocalOptions() = std::move(opts_); }
 
 }  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/options_test.cc
+++ b/google/cloud/options_test.cc
@@ -260,6 +260,20 @@ TEST(MergeOptions, Basics) {
   EXPECT_EQ(a.get<IntOption>(), 42);           // From a
 }
 
+TEST(OptionsSpan, Basics) {
+  EXPECT_FALSE(internal::CurrentOptions().has<IntOption>());
+  {
+    internal::OptionsSpan span(Options{}.set<IntOption>(1));
+    EXPECT_EQ(internal::CurrentOptions().get<IntOption>(), 1);
+    {
+      internal::OptionsSpan span(Options{}.set<IntOption>(2));
+      EXPECT_EQ(internal::CurrentOptions().get<IntOption>(), 2);
+    }
+    EXPECT_EQ(internal::CurrentOptions().get<IntOption>(), 1);
+  }
+  EXPECT_FALSE(internal::CurrentOptions().has<IntOption>());
+}
+
 }  // namespace
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace cloud

--- a/google/cloud/testing_util/fake_completion_queue_impl.cc
+++ b/google/cloud/testing_util/fake_completion_queue_impl.cc
@@ -13,12 +13,14 @@
 // limitations under the License.
 
 #include "google/cloud/testing_util/fake_completion_queue_impl.h"
+#include "google/cloud/options.h"
 
 namespace google {
 namespace cloud {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace testing_util {
 namespace {
+
 class FakeAsyncTimer : public internal::AsyncGrpcOperation {
  public:
   explicit FakeAsyncTimer(std::chrono::system_clock::time_point deadline)
@@ -31,6 +33,7 @@ class FakeAsyncTimer : public internal::AsyncGrpcOperation {
   void Cancel() override {}
 
   bool Notify(bool ok) override {
+    internal::OptionsSpan span(options_);
     if (!ok) {
       promise_.set_value(Status(StatusCode::kCancelled, "timer canceled"));
     } else {
@@ -42,6 +45,7 @@ class FakeAsyncTimer : public internal::AsyncGrpcOperation {
  private:
   std::chrono::system_clock::time_point const deadline_;
   promise<StatusOr<std::chrono::system_clock::time_point>> promise_;
+  Options options_ = internal::CurrentOptions();
 };
 
 class FakeAsyncFunction : public internal::AsyncGrpcOperation {
@@ -53,6 +57,7 @@ class FakeAsyncFunction : public internal::AsyncGrpcOperation {
 
  private:
   bool Notify(bool ok) override {
+    internal::OptionsSpan span(options_);
     auto f = std::move(function_);
     if (!ok) return true;
     f->exec();
@@ -60,6 +65,7 @@ class FakeAsyncFunction : public internal::AsyncGrpcOperation {
   }
 
   std::unique_ptr<internal::RunAsyncBase> function_;
+  Options options_ = internal::CurrentOptions();
 };
 
 }  // namespace


### PR DESCRIPTION
Provide access to the prevailing `Options` for an operation without having
to plumb function parameters through the various and sundry layers, like
connection.

This also means that helper libraries can determine things like whether a
tracing component is enabled, without having to distort their APIs.

For example, if all `ServiceClient::Operation()` calls are implemented like
```
class ServiceClient {
 public
  ServiceClient(std::shared_ptr<ServiceConnection> connection,
                Options options = {})
      : connection_(std::move(connection)),
        options_(ServiceDefaultOptions(std::move(options))) {}

  T Operation(..., Options options = {}) {
    internal::OptionsSpan span(internal::MergeOptions(options, options_));
    ...
  }

 private:
  std::shared_ptr<ServiceConnection> connection_;
  Options options_;
};
```
then the connection layer, or any other internal library, can retrieve the
prevailing options using `internal::CurrentOptions()`.  If the operation is
asynchronous, the invocation-time `Options` are also installed during its
callbacks.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7669)
<!-- Reviewable:end -->
