### PR TITLE
feat(generator): generate quickstart scaffold

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -7,6 +7,10 @@ cmake-build-release/
 google/cloud/bigquery/quickstart/
 google/cloud/bigtable/quickstart/
 google/cloud/iam/quickstart/
+google/cloud/logging/quickstart/
+google/cloud/pubsublite/quickstart/
 google/cloud/pubsub/quickstart/
+google/cloud/secretmanager/quickstart/
 google/cloud/spanner/quickstart/
 google/cloud/storage/quickstart/
+google/cloud/tasks/quickstart/

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -17,3 +17,6 @@ ignore:
   - "google/cloud/iam"
   - "google/cloud/logging"
   - "google/cloud/spanner/admin"
+  - "google/cloud/pubsublite"
+  - "google/cloud/secretmanager"
+  - "google/cloud/tasks"

--- a/ci/cloudbuild/builds/cmake-install.sh
+++ b/ci/cloudbuild/builds/cmake-install.sh
@@ -170,7 +170,7 @@ done
 
 # Tests the installed artifacts by building and running the quickstarts.
 # shellcheck disable=SC2046
-libraries="$(printf ";%s" $(quickstart::libraries))"
+libraries="$(printf ";%s" $(features::list | grep -v experimental-))"
 libraries="${libraries:1}"
 cmake -G Ninja \
   -S "${PROJECT_ROOT}/ci/verify_quickstart" \

--- a/generator/internal/scaffold_generator.cc
+++ b/generator/internal/scaffold_generator.cc
@@ -534,12 +534,13 @@ the client library.
 ### Setting up your repo
 
 In order to use the $title$ C++ client library from your own code,
-you'll need to configure your build system how to fetch and compile the Cloud
-C++ client libraries. The Cloud C++ client libraries natively supports the
-[Bazel](https://bazel.build/) and [CMake](https://cmake.org/) build systems.
-We've created a minimal, "Hello World", [quickstart repo][quickstart-link] that
-includes detailed instructions on how to compile the library for use in your
-application. You can fetch the source from [GitHub][github-link] as normal:
+you'll need to configure your build system to discover and compile the Cloud
+C++ client libraries. In some cases your build system or package manager may
+need to download the libraries too. The Cloud C++ client libraries natively
+support [Bazel](https://bazel.build/) and [CMake](https://cmake.org/) as build
+systems. We've created a minimal, "Hello World", [quickstart][quickstart-link]
+that includes detailed instructions on how to compile the library for use in
+your application. You can fetch the source from [GitHub][github-link] as normal:
 
 @code{.sh}
 git clone https://github.com/googleapis/google-cloud-cpp.git
@@ -558,7 +559,7 @@ which should give you a taste of the $title$ C++ client library API.
 
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC
-  request and response.  Unless you have configured you own logging backend,
+  request and response.  Unless you have configured your own logging backend,
   you should also set `GOOGLE_CLOUD_CPP_ENABLE_CLOG` to produce any output on
   the program's console.
 
@@ -571,9 +572,9 @@ which should give you a taste of the $title$ C++ client library API.
   including whether messages will be output on multiple lines, or whether
   string/bytes fields will be truncated.
 
-- `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` turns on logging in the library, basically
+- `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` turns on logging in the library. Basically
   the library always "logs" but the logging infrastructure has no backend to
-  actually print anything until the application sets a backend or they set this
+  actually print anything until the application sets a backend or it sets this
   environment variable.
 
 ### Error Handling
@@ -585,9 +586,9 @@ to detect errors in the returned objects. In general, the library returns a
 [`StatusOr<T>`][status-or-header] if an error is possible. This is an "outcome"
 type, when the operation is successful a `StatusOr<T>` converts to `true` in
 boolean context (and its `.ok()` member function returns `true`), the
-application can then use `operator->` or `operator*` to access then `T` value.
+application can then use `operator->` or `operator*` to access the `T` value.
 When the operation fails a `StatusOr<T>` converts to `false` (and `.ok()`
-returns false). It is undefined behavior to use the value in this case.
+returns `false`). It is undefined behavior to use the value in this case.
 
 If you prefer to use exceptions on error, you can use the `.value()` accessor.
 It will return the `T` value or throw on error.
@@ -610,7 +611,7 @@ can override the default policies.
 [github-link]: https://github.com/googleapis/google-cloud-cpp 'GitHub Repository'
 <!-- The ugly %2E disables auto-linking in Doxygen -->
 [github-readme]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/$library$/README%2Emd
-[github-install]: https://github.com/googleapis/google-cloud-cpp/blob/main/doc/packagin%2Emd
+[github-install]: https://github.com/googleapis/google-cloud-cpp/blob/main/doc/packaging%2Emd
 
 */
 )""";

--- a/generator/internal/scaffold_generator.h
+++ b/generator/internal/scaffold_generator.h
@@ -42,6 +42,8 @@ std::map<std::string, std::string> ScaffoldVars(
     std::string const& googleapis_path, std::string const& project_root,
     google::cloud::cpp::generator::ServiceConfiguration const& service);
 
+void MakeDirectory(std::string const& path);
+
 void GenerateScaffold(
     std::string const& googleapis_path, std::string const& output_path,
     google::cloud::cpp::generator::ServiceConfiguration const& service);
@@ -56,6 +58,20 @@ void GenerateBuild(std::ostream& os,
                    std::map<std::string, std::string> const& variables);
 void GenerateCMakeLists(std::ostream& os,
                         std::map<std::string, std::string> const& variables);
+void GenerateDoxygenMainPage(
+    std::ostream& os, std::map<std::string, std::string> const& variables);
+void GenerateQuickstartReadme(
+    std::ostream& os, std::map<std::string, std::string> const& variables);
+void GenerateQuickstartSkeleton(
+    std::ostream& os, std::map<std::string, std::string> const& variables);
+void GenerateQuickstartCMake(
+    std::ostream& os, std::map<std::string, std::string> const& variables);
+void GenerateQuickstartMakefile(
+    std::ostream& os, std::map<std::string, std::string> const& variables);
+void GenerateQuickstartWorkspace(
+    std::ostream& os, std::map<std::string, std::string> const& variables);
+void GenerateQuickstartBuild(
+    std::ostream& os, std::map<std::string, std::string> const& variables);
 
 }  // namespace generator_internal
 }  // namespace cloud

--- a/generator/internal/scaffold_generator_test.cc
+++ b/generator/internal/scaffold_generator_test.cc
@@ -18,11 +18,6 @@
 #include <cstdlib>
 #include <fstream>
 #include <sstream>
-#ifdef _WIN32
-#include <direct.h>
-#else
-#include <sys/stat.h>
-#endif  // _WIN32
 
 namespace google {
 namespace cloud {
@@ -34,14 +29,6 @@ using ::testing::Contains;
 using ::testing::HasSubstr;
 using ::testing::Not;
 using ::testing::Pair;
-
-void MakeDirectory(std::string const& path) {
-#if _WIN32
-  _mkdir(path.c_str());
-#else
-  mkdir(path.c_str(), 0755);
-#endif  // _WIN32
-}
 
 void RemoveDirectory(std::string const& path) {
 #if _WIN32
@@ -213,6 +200,73 @@ target_link_libraries(google_cloud_cpp_test_protos PUBLIC #
     google-cloud-cpp::api_annotations_protos
     google-cloud-cpp::api_http_protos)
 )"""));
+}
+
+TEST_F(ScaffoldGenerator, DoxygenMainPage) {
+  auto const vars = ScaffoldVars(path(), path(), service());
+  std::ostringstream os;
+  GenerateDoxygenMainPage(os, vars);
+  auto const actual = std::move(os).str();
+  EXPECT_THAT(actual, HasSubstr(R"""(
+[Test Only API](https://cloud.google.com/test/), a service that
+Provides a placeholder to write this test.
+)"""));
+}
+
+TEST_F(ScaffoldGenerator, QuickstartReadme) {
+  auto const vars = ScaffoldVars(path(), path(), service());
+  std::ostringstream os;
+  GenerateQuickstartReadme(os, vars);
+  auto const actual = std::move(os).str();
+  EXPECT_THAT(
+      actual,
+      HasSubstr(R"""(# HOWTO: using the Test Only API C++ client in your project
+)"""));
+}
+
+TEST_F(ScaffoldGenerator, QuickstartSkeleton) {
+  auto const vars = ScaffoldVars(path(), path(), service());
+  std::ostringstream os;
+  GenerateQuickstartSkeleton(os, vars);
+  auto const actual = std::move(os).str();
+  EXPECT_THAT(actual, HasSubstr("2034"));
+  EXPECT_THAT(actual, Not(HasSubstr("$copyright_year$")));
+}
+
+TEST_F(ScaffoldGenerator, QuickstartCMake) {
+  auto const vars = ScaffoldVars(path(), path(), service());
+  std::ostringstream os;
+  GenerateQuickstartCMake(os, vars);
+  auto const actual = std::move(os).str();
+  EXPECT_THAT(actual, HasSubstr("2034"));
+  EXPECT_THAT(actual, Not(HasSubstr("$copyright_year$")));
+}
+
+TEST_F(ScaffoldGenerator, QuickstartMakefile) {
+  auto const vars = ScaffoldVars(path(), path(), service());
+  std::ostringstream os;
+  GenerateQuickstartMakefile(os, vars);
+  auto const actual = std::move(os).str();
+  EXPECT_THAT(actual, HasSubstr("2034"));
+  EXPECT_THAT(actual, Not(HasSubstr("$copyright_year$")));
+}
+
+TEST_F(ScaffoldGenerator, QuickstartWorkspace) {
+  auto const vars = ScaffoldVars(path(), path(), service());
+  std::ostringstream os;
+  GenerateQuickstartWorkspace(os, vars);
+  auto const actual = std::move(os).str();
+  EXPECT_THAT(actual, HasSubstr("2034"));
+  EXPECT_THAT(actual, Not(HasSubstr("$copyright_year$")));
+}
+
+TEST_F(ScaffoldGenerator, QuickstartBuild) {
+  auto const vars = ScaffoldVars(path(), path(), service());
+  std::ostringstream os;
+  GenerateQuickstartBuild(os, vars);
+  auto const actual = std::move(os).str();
+  EXPECT_THAT(actual, HasSubstr("2034"));
+  EXPECT_THAT(actual, Not(HasSubstr("$copyright_year$")));
 }
 
 }  // namespace

--- a/google/cloud/logging/BUILD
+++ b/google/cloud/logging/BUILD
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google/cloud/logging/CMakeLists.txt
+++ b/google/cloud/logging/CMakeLists.txt
@@ -20,6 +20,7 @@ set(DOXYGEN_PROJECT_BRIEF "A C++ Client Library for Google Cloud Logging")
 set(DOXYGEN_PROJECT_NUMBER "${PROJECT_VERSION} (Beta)")
 set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "logging_internal" "logging_testing"
                             "examples")
+set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
 
 # Creates the proto headers needed by doxygen.
 set(GOOGLE_CLOUD_CPP_DOXYGEN_DEPS google-cloud-cpp::logging_protos)
@@ -146,7 +147,7 @@ set(GOOGLE_CLOUD_PC_DESCRIPTION
     "Provides C++ APIs to access Google Cloud Logging.")
 set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_logging")
 string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
-              " google_cloud_cpp_common" " googleapis_cpp_logging_protos")
+              " google_cloud_cpp_common" " google_cloud_cpp_logging_protos")
 
 # Create and install the pkg-config files.
 configure_file("${PROJECT_SOURCE_DIR}/google/cloud/logging/config.pc.in"

--- a/google/cloud/logging/config.cmake.in
+++ b/google/cloud/logging/config.cmake.in
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google/cloud/logging/config.pc.in
+++ b/google/cloud/logging/config.pc.in
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google/cloud/logging/doc/main.dox
+++ b/google/cloud/logging/doc/main.dox
@@ -1,0 +1,98 @@
+/*!
+
+@mainpage Cloud Logging API C++ Client Library
+
+An idiomatic C++ client library for
+[Cloud Logging API](https://cloud.google.com/logging/), a service that writes
+log entries and manages your Cloud Logging configuration.
+
+This library is **experimental**. Its APIS are subject to change without notice.
+
+This library requires a C++11 compiler, it is supported (and tested) on multiple
+Linux distributions, as well as Windows and macOS. The
+[README][github-readme] on [GitHub][github-link] provides detailed
+instructions to install the necessary dependencies, as well as how to compile
+the client library.
+
+### Setting up your repo
+
+In order to use the Cloud Logging API C++ client library from your own code,
+you'll need to configure your build system how to fetch and compile the Cloud
+C++ client libraries. The Cloud C++ client libraries natively supports the
+[Bazel](https://bazel.build/) and [CMake](https://cmake.org/) build systems.
+We've created a minimal, "Hello World", [quickstart repo][quickstart-link] that
+includes detailed instructions on how to compile the library for use in your
+application. You can fetch the source from [GitHub][github-link] as normal:
+
+@code{.sh}
+git clone https://github.com/googleapis/google-cloud-cpp.git
+cd google-cloud-cpp/google/cloud/logging/quickstart
+@endcode
+
+@par Example: Quickstart
+
+The following shows the code that you'll run in the
+`google/cloud/logging/quickstart/` directory,
+which should give you a taste of the Cloud Logging API C++ client library API.
+
+@include quickstart.cc
+
+## Environment Variables
+
+- `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
+  calls. The library injects an additional Stub decorator that prints each gRPC
+  request and response.  Unless you have configured you own logging backend,
+  you should also set `GOOGLE_CLOUD_CPP_ENABLE_CLOG` to produce any output on
+  the program's console.
+
+- `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc-streams` turns on tracing for streaming
+  gRPC calls, such as `Client::Read()`, `Client::ExecuteQuery()`, and
+  `Client::ProfileQuery()`. This can produce a lot of output, so use with
+  caution!
+
+- `GOOGLE_CLOUD_CPP_TRACING_OPTIONS=...` modifies the behavior of gRPC tracing,
+  including whether messages will be output on multiple lines, or whether
+  string/bytes fields will be truncated.
+
+- `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` turns on logging in the library, basically
+  the library always "logs" but the logging infrastructure has no backend to
+  actually print anything until the application sets a backend or they set this
+  environment variable.
+
+### Error Handling
+
+[status-or-header]: https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/status_or.h
+
+This library never throws exceptions to signal error, but you can use exceptions
+to detect errors in the returned objects. In general, the library returns a
+[`StatusOr<T>`][status-or-header] if an error is possible. This is an "outcome"
+type, when the operation is successful a `StatusOr<T>` converts to `true` in
+boolean context (and its `.ok()` member function returns `true`), the
+application can then use `operator->` or `operator*` to access then `T` value.
+When the operation fails a `StatusOr<T>` converts to `false` (and `.ok()`
+returns false). It is undefined behavior to use the value in this case.
+
+If you prefer to use exceptions on error, you can use the `.value()` accessor.
+It will return the `T` value or throw on error.
+
+For operations that do not return a value the library simply returns
+`google::cloud::Status`.
+
+### Retry, Backoff, and Idempotency Policies.
+
+The library automatically retries requests that fail with transient errors, and
+uses [exponential backoff] to backoff between retries. Application developers
+can override the default policies.
+
+[exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff
+[gcs-quickstart]: https://cloud.google.com/logging/docs/quickstarts 'Quickstarts'
+[resource-link]: https://console.cloud.google.com/cloud-resource-manager 'Console Resource Manager'
+[billing-link]: https://cloud.google.com/billing/docs/how-to/modify-project 'How to: Modify Project'
+[authentication-quickstart]: https://cloud.google.com/docs/authentication/getting-started 'Authentication Getting Started'
+[gcloud-quickstart]: https://cloud.google.com/sdk/docs/quickstarts
+[github-link]: https://github.com/googleapis/google-cloud-cpp 'GitHub Repository'
+<!-- The ugly %2E disables auto-linking in Doxygen -->
+[github-readme]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/logging/README%2Emd
+[github-install]: https://github.com/googleapis/google-cloud-cpp/blob/main/doc/packagin%2Emd
+
+*/

--- a/google/cloud/logging/doc/main.dox
+++ b/google/cloud/logging/doc/main.dox
@@ -17,12 +17,13 @@ the client library.
 ### Setting up your repo
 
 In order to use the Cloud Logging API C++ client library from your own code,
-you'll need to configure your build system how to fetch and compile the Cloud
-C++ client libraries. The Cloud C++ client libraries natively supports the
-[Bazel](https://bazel.build/) and [CMake](https://cmake.org/) build systems.
-We've created a minimal, "Hello World", [quickstart repo][quickstart-link] that
-includes detailed instructions on how to compile the library for use in your
-application. You can fetch the source from [GitHub][github-link] as normal:
+you'll need to configure your build system to discover and compile the Cloud
+C++ client libraries. In some cases your build system or package manager may
+need to download the libraries too. The Cloud C++ client libraries natively
+support [Bazel](https://bazel.build/) and [CMake](https://cmake.org/) as build
+systems. We've created a minimal, "Hello World", [quickstart][quickstart-link]
+that includes detailed instructions on how to compile the library for use in
+your application. You can fetch the source from [GitHub][github-link] as normal:
 
 @code{.sh}
 git clone https://github.com/googleapis/google-cloud-cpp.git
@@ -41,7 +42,7 @@ which should give you a taste of the Cloud Logging API C++ client library API.
 
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC
-  request and response.  Unless you have configured you own logging backend,
+  request and response.  Unless you have configured your own logging backend,
   you should also set `GOOGLE_CLOUD_CPP_ENABLE_CLOG` to produce any output on
   the program's console.
 
@@ -54,9 +55,9 @@ which should give you a taste of the Cloud Logging API C++ client library API.
   including whether messages will be output on multiple lines, or whether
   string/bytes fields will be truncated.
 
-- `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` turns on logging in the library, basically
+- `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` turns on logging in the library. Basically
   the library always "logs" but the logging infrastructure has no backend to
-  actually print anything until the application sets a backend or they set this
+  actually print anything until the application sets a backend or it sets this
   environment variable.
 
 ### Error Handling
@@ -68,9 +69,9 @@ to detect errors in the returned objects. In general, the library returns a
 [`StatusOr<T>`][status-or-header] if an error is possible. This is an "outcome"
 type, when the operation is successful a `StatusOr<T>` converts to `true` in
 boolean context (and its `.ok()` member function returns `true`), the
-application can then use `operator->` or `operator*` to access then `T` value.
+application can then use `operator->` or `operator*` to access the `T` value.
 When the operation fails a `StatusOr<T>` converts to `false` (and `.ok()`
-returns false). It is undefined behavior to use the value in this case.
+returns `false`). It is undefined behavior to use the value in this case.
 
 If you prefer to use exceptions on error, you can use the `.value()` accessor.
 It will return the `T` value or throw on error.
@@ -93,6 +94,6 @@ can override the default policies.
 [github-link]: https://github.com/googleapis/google-cloud-cpp 'GitHub Repository'
 <!-- The ugly %2E disables auto-linking in Doxygen -->
 [github-readme]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/logging/README%2Emd
-[github-install]: https://github.com/googleapis/google-cloud-cpp/blob/main/doc/packagin%2Emd
+[github-install]: https://github.com/googleapis/google-cloud-cpp/blob/main/doc/packaging%2Emd
 
 */

--- a/google/cloud/logging/quickstart/BUILD
+++ b/google/cloud/logging/quickstart/BUILD
@@ -1,0 +1,25 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+licenses(["notice"])  # Apache 2.0
+
+cc_binary(
+    name = "quickstart",
+    srcs = [
+        "quickstart.cc",
+    ],
+    deps = [
+        "@com_github_googleapis_google_cloud_cpp//:experimental-logging",
+    ],
+)

--- a/google/cloud/logging/quickstart/CMakeLists.txt
+++ b/google/cloud/logging/quickstart/CMakeLists.txt
@@ -1,0 +1,32 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+# This file shows how to use the Cloud Logging API C++ client library from a
+# larger CMake project.
+
+cmake_minimum_required(VERSION 3.5)
+project(google-cloud-cpp-logging-quickstart CXX)
+
+find_package(google_cloud_cpp_logging REQUIRED)
+
+# MSVC requires some additional code to select the correct runtime library
+if (VCPKG_TARGET_TRIPLET MATCHES "-static$")
+    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+else ()
+    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
+endif ()
+
+# Define your targets.
+add_executable(quickstart quickstart.cc)
+target_link_libraries(quickstart google-cloud-cpp::experimental-logging)

--- a/google/cloud/logging/quickstart/Makefile
+++ b/google/cloud/logging/quickstart/Makefile
@@ -1,0 +1,35 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This is a minimal Makefile to show how to use the Cloud Logging API C++ client
+# for developers that use make(1) as their build system.
+
+# The CXX, CXXFLAGS and CXXLD variables are hard-coded. These values work for
+# our tests, but applications would typically make them configurable parameters.
+CXX=g++
+CXXFLAGS=
+CXXLD=$(CXX)
+BIN=.
+
+all: $(BIN)/quickstart
+
+# Configuration variables to compile and link against the Cloud Logging API C++
+# client library.
+CLIENT_MODULE     := google_cloud_cpp_logging
+CLIENT_CXXFLAGS   := $(shell pkg-config $(CLIENT_MODULE) --cflags)
+CLIENT_CXXLDFLAGS := $(shell pkg-config $(CLIENT_MODULE) --libs-only-L)
+CLIENT_LIBS       := $(shell pkg-config $(CLIENT_MODULE) --libs-only-l)
+
+$(BIN)/quickstart: quickstart.cc
+	$(CXXLD) $(CXXFLAGS) $(CLIENT_CXXFLAGS) $(CLIENT_CXXLDFLAGS) -o $@ $^ $(CLIENT_LIBS)

--- a/google/cloud/logging/quickstart/README.md
+++ b/google/cloud/logging/quickstart/README.md
@@ -1,0 +1,168 @@
+# HOWTO: using the Cloud Logging API C++ client in your project
+
+This directory contains small examples showing how to use the Cloud Logging API C++
+client library in your own project. These instructions assume that you have
+some experience as a C++ developer and that you have a working C++ toolchain
+(compiler, linker, etc.) installed on your platform.
+
+* Packaging maintainers or developers that prefer to install the library in a
+  fixed directory (such as `/usr/local` or `/opt`) should consult the
+  [packaging guide](/doc/packaging.md).
+* Developers wanting to use the libraries as part of a larger CMake or Bazel
+  project should consult the current document. Note that there are similar
+  documents for each library in their corresponding directories.
+* Developers wanting to compile the library just to run some of the examples or
+  tests should consult the
+  [building and installing](/README.md#building-and-installing) section of the
+  top-level README file.
+* Contributors and developers to `google-cloud-cpp` should consult the guide to
+  [setup a development workstation][howto-setup-dev-workstation].
+
+[howto-setup-dev-workstation]: /doc/contributor/howto-guide-setup-development-workstation.md
+
+## Before you begin
+
+To run the quickstart examples you will need a working Google Cloud Platform
+(GCP) project, as well as a Cloud Spanner instance and database.
+The [quickstart][quickstart-link] covers the necessary
+steps in detail. Make a note of the GCP project id, the instance id, and the
+database id as you will need them below.
+
+## Configuring authentication for the C++ Client Library
+
+Like most Google Cloud Platform (GCP) services, Cloud Spanner requires that
+your application authenticates with the service before accessing any data. If
+you are not familiar with GCP authentication please take this opportunity to
+review the [Authentication Overview][authentication-quickstart]. This library
+uses the `GOOGLE_APPLICATION_CREDENTIALS` environment variable to find the
+credentials file. For example:
+
+| Shell              | Command                                        |
+| :----------------- | ---------------------------------------------- |
+| Bash/zsh/ksh/etc.  | `export GOOGLE_APPLICATION_CREDENTIALS=[PATH]` |
+| sh                 | `GOOGLE_APPLICATION_CREDENTIALS=[PATH];`<br> `export GOOGLE_APPLICATION_CREDENTIALS` |
+| csh/tsch           | `setenv GOOGLE_APPLICATION_CREDENTIALS [PATH]` |
+| Windows Powershell | `$env:GOOGLE_APPLICATION_CREDENTIALS=[PATH]`   |
+| Windows cmd.exe    | `set GOOGLE_APPLICATION_CREDENTIALS=[PATH]`    |
+
+Setting this environment variable is the recommended way to configure the
+authentication preferences, though if the environment variable is not set, the
+library searches for a credentials file in the same location as the [Cloud
+SDK](https://cloud.google.com/sdk/). For more information about *Application
+Default Credentials*, see
+https://cloud.google.com/docs/authentication/production
+
+## Using with Bazel
+
+> :warning: If you are using Windows or macOS there are additional instructions
+> at the end of this document.
+
+1. Install Bazel using [the instructions][bazel-install] from the `bazel.build`
+   website.
+
+2. Compile this example using Bazel:
+
+   ```bash
+   cd $HOME/google-cloud-cpp/google/cloud/logging/quickstart
+   bazel build ...
+   ```
+
+   Note that Bazel automatically downloads and compiles all dependencies of the
+   project. As it is often the case with C++ libraries, compiling these
+   dependencies may take several minutes.
+
+3. Run the example, change the place holder(s) to appropriate values:
+
+   ```bash
+   bazel run :quickstart -- [...]
+   ```
+
+## Using with CMake
+
+> :warning: If you are using Windows or macOS there are additional instructions
+> at the end of this document.
+
+1. Install CMake. The package managers for most Linux distributions include a
+   package for CMake. Likewise, you can install CMake on Windows using a package
+   manager such as [chocolatey][choco-cmake-link], and on macOS using
+   [homebrew][homebrew-cmake-link]. You can also obtain the software directly
+   from the [cmake.org](https://cmake.org/download/).
+
+2. Install the dependencies with your favorite tools. As an example, if you use
+   [vcpkg](https://github.com/Microsoft/vcpkg.git):
+
+   ```bash
+   cd $HOME/vcpkg
+   ./vcpkg install google-cloud-cpp[core,logging]
+   ```
+
+   Note that, as it is often the case with C++ libraries, compiling these
+   dependencies may take several minutes.
+
+3. Configure CMake, if necessary, configure the directory where you installed
+   the dependencies:
+
+   ```bash
+   cd $HOME/gooogle-cloud-cpp/google/cloud/logging/quickstart
+   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake --build .build
+   ```
+
+4. Run the example, change the place holder to appropriate values:
+
+   ```bash
+   .build/quickstart [...]
+   ```
+
+## Platform Specific Notes
+
+### macOS
+
+gRPC [requires][grpc-roots-pem-bug] an environment variable to configure the
+trust store for SSL certificates, you can download and configure this using:
+
+```bash
+curl -Lo roots.pem https://pki.google.com/roots.pem
+export GRPC_DEFAULT_SSL_ROOTS_FILE_PATH="$PWD/roots.pem"
+```
+
+To workaround a [bug in Bazel][bazel-grpc-macos-bug], gRPC requires this flag on
+macOS builds, you can add the option manually or include it in your `.bazelrc`
+file:
+
+```bash
+bazel build --copt=-DGRPC_BAZEL_BUILD ...
+```
+
+### Windows
+
+To correctly configure the MSVC runtime you should change the CMake minimum
+required version to 3.15 or add `-DCMAKE_POLICY_DEFAULT_CMP0091=NEW` to the
+CMake configuration step.
+
+Bazel tends to create very long file names and paths. You may need to use a
+short directory to store the build output, such as `c:\b`, and instruct Bazel
+to use it via:
+
+```shell
+bazel --output_user_root=c:\b build ...
+```
+
+gRPC [requires][grpc-roots-pem-bug] an environment variable to configure the
+trust store for SSL certificates, you can download and configure this using:
+
+```console
+@powershell -NoProfile -ExecutionPolicy unrestricted -Command ^
+    (new-object System.Net.WebClient).Downloadfile( ^
+        'https://pki.google.com/roots.pem', 'roots.pem')
+set GRPC_DEFAULT_SSL_ROOTS_FILE_PATH=%cd%\roots.pem
+```
+
+[bazel-install]: https://docs.bazel.build/versions/main/install.html
+[quickstart-link]: https://cloud.google.com/logging/docs
+[grpc-roots-pem-bug]: https://github.com/grpc/grpc/issues/16571
+[choco-cmake-link]: https://chocolatey.org/packages/cmake
+[homebrew-cmake-link]: https://formulae.brew.sh/formula/cmake
+[cmake-download-link]: https://cmake.org/download/
+[bazel-grpc-macos-bug]: https://github.com/bazelbuild/bazel/issues/4341
+[authentication-quickstart]: https://cloud.google.com/docs/authentication/getting-started 'Authentication Getting Started'

--- a/google/cloud/logging/quickstart/WORKSPACE
+++ b/google/cloud/logging/quickstart/WORKSPACE
@@ -1,0 +1,51 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A minimal WORKSPACE file showing how to use the Cloud Logging API C++
+# client library in Bazel-based projects.
+workspace(name = "logging_quickstart")
+
+# Add the necessary Starlark functions to fetch google-cloud-cpp.
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+# Fetch the Google Cloud C++ libraries.
+# NOTE: Update this version and SHA256 as needed.
+http_archive(
+    name = "com_github_googleapis_google_cloud_cpp",
+    sha256 = "b024dfde34efd328001d6446e1416fa008caa40d9020c424a8f8a3711061af35",
+    strip_prefix = "google-cloud-cpp-1.33.0",
+    url = "https://github.com/googleapis/google-cloud-cpp/archive/v1.33.0.tar.gz",
+)
+
+# Load indirect dependencies due to
+#     https://github.com/bazelbuild/bazel/issues/1943
+load("@com_github_googleapis_google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+
+google_cloud_cpp_deps()
+
+load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+
+switched_rules_by_language(
+    name = "com_google_googleapis_imports",
+    cc = True,
+    grpc = True,
+)
+
+load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+
+grpc_deps()
+
+load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+
+grpc_extra_deps()

--- a/google/cloud/logging/quickstart/quickstart.cc
+++ b/google/cloud/logging/quickstart/quickstart.cc
@@ -1,0 +1,37 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/logging/logging_service_v2_client.h"
+#include <iostream>
+#include <stdexcept>
+
+int main(int argc, char* argv[]) try {
+  if (argc != 4) {
+    std::cerr << "Usage: " << argv[0] << " project-id \n";
+    return 1;
+  }
+
+  namespace logging = ::google::cloud::logging;
+  auto client = logging::LoggingServiceV2Client(
+      logging::MakeLoggingServiceV2Connection());
+  auto const parent = std::string("projects/") + argv[1];
+  for (auto const& logs : client.ListLogs(parent)) {
+    std::cout << logs.value() << "\n";
+  }
+
+  return 0;
+} catch (std::exception const& ex) {
+  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+  return 1;
+}

--- a/google/cloud/pubsublite/BUILD
+++ b/google/cloud/pubsublite/BUILD
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google/cloud/pubsublite/CMakeLists.txt
+++ b/google/cloud/pubsublite/CMakeLists.txt
@@ -5,7 +5,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -42,12 +42,12 @@ include(CompileProtos)
 google_cloud_cpp_grpcpp_library(
     google_cloud_cpp_pubsublite_protos
     # cmake-format: sort
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/pubsublite/v1/topic_stats.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/pubsublite/v1/subscriber.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/pubsublite/v1/publisher.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/pubsublite/v1/cursor.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/pubsublite/v1/common.proto
     ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/pubsublite/v1/admin.proto
+    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/pubsublite/v1/common.proto
+    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/pubsublite/v1/cursor.proto
+    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/pubsublite/v1/publisher.proto
+    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/pubsublite/v1/subscriber.proto
+    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/pubsublite/v1/topic_stats.proto
     PROTO_PATH_DIRECTORIES
     "${EXTERNAL_GOOGLEAPIS_SOURCE}"
     "${PROTO_INCLUDE_DIR}")
@@ -55,13 +55,13 @@ external_googleapis_set_version_and_alias(pubsublite_protos)
 target_link_libraries(
     google_cloud_cpp_pubsublite_protos
     PUBLIC #
-           google-cloud-cpp::longrunning_operations_protos
-           google-cloud-cpp::rpc_status_protos
-           google-cloud-cpp::api_resource_protos
-           google-cloud-cpp::api_field_behavior_protos
-           google-cloud-cpp::api_client_protos
            google-cloud-cpp::api_annotations_protos
-           google-cloud-cpp::api_http_protos)
+           google-cloud-cpp::api_client_protos
+           google-cloud-cpp::api_field_behavior_protos
+           google-cloud-cpp::api_http_protos
+           google-cloud-cpp::api_resource_protos
+           google-cloud-cpp::longrunning_operations_protos
+           google-cloud-cpp::rpc_status_protos)
 
 file(
     GLOB source_files

--- a/google/cloud/pubsublite/CMakeLists.txt
+++ b/google/cloud/pubsublite/CMakeLists.txt
@@ -20,6 +20,7 @@ set(DOXYGEN_PROJECT_BRIEF "A C++ Client Library for the Pub/Sub Lite API")
 set(DOXYGEN_PROJECT_NUMBER "${PROJECT_VERSION} (Experimental)")
 set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "pubsublite_internal"
                             "pubsublite_testing" "examples")
+set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
 
 # Creates the proto headers needed by doxygen.
 set(GOOGLE_CLOUD_CPP_DOXYGEN_DEPS google-cloud-cpp::pubsublite_protos)
@@ -197,4 +198,4 @@ install(
     COMPONENT google_cloud_cpp_development)
 
 external_googleapis_install_pc("google_cloud_cpp_pubsublite_protos"
-                               "${CMAKE_CURRENT_LIST_DIR}")
+                               "${PROJECT_SOURCE_DIR}/external/googleapis")

--- a/google/cloud/pubsublite/config.cmake.in
+++ b/google/cloud/pubsublite/config.cmake.in
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google/cloud/pubsublite/config.pc.in
+++ b/google/cloud/pubsublite/config.pc.in
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google/cloud/pubsublite/doc/main.dox
+++ b/google/cloud/pubsublite/doc/main.dox
@@ -18,12 +18,13 @@ the client library.
 ### Setting up your repo
 
 In order to use the Pub/Sub Lite API C++ client library from your own code,
-you'll need to configure your build system how to fetch and compile the Cloud
-C++ client libraries. The Cloud C++ client libraries natively supports the
-[Bazel](https://bazel.build/) and [CMake](https://cmake.org/) build systems.
-We've created a minimal, "Hello World", [quickstart repo][quickstart-link] that
-includes detailed instructions on how to compile the library for use in your
-application. You can fetch the source from [GitHub][github-link] as normal:
+you'll need to configure your build system to discover and compile the Cloud
+C++ client libraries. In some cases your build system or package manager may
+need to download the libraries too. The Cloud C++ client libraries natively
+support [Bazel](https://bazel.build/) and [CMake](https://cmake.org/) as build
+systems. We've created a minimal, "Hello World", [quickstart][quickstart-link]
+that includes detailed instructions on how to compile the library for use in
+your application. You can fetch the source from [GitHub][github-link] as normal:
 
 @code{.sh}
 git clone https://github.com/googleapis/google-cloud-cpp.git
@@ -42,7 +43,7 @@ which should give you a taste of the Pub/Sub Lite API C++ client library API.
 
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC
-  request and response.  Unless you have configured you own logging backend,
+  request and response.  Unless you have configured your own logging backend,
   you should also set `GOOGLE_CLOUD_CPP_ENABLE_CLOG` to produce any output on
   the program's console.
 
@@ -55,9 +56,9 @@ which should give you a taste of the Pub/Sub Lite API C++ client library API.
   including whether messages will be output on multiple lines, or whether
   string/bytes fields will be truncated.
 
-- `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` turns on logging in the library, basically
+- `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` turns on logging in the library. Basically
   the library always "logs" but the logging infrastructure has no backend to
-  actually print anything until the application sets a backend or they set this
+  actually print anything until the application sets a backend or it sets this
   environment variable.
 
 ### Error Handling
@@ -69,9 +70,9 @@ to detect errors in the returned objects. In general, the library returns a
 [`StatusOr<T>`][status-or-header] if an error is possible. This is an "outcome"
 type, when the operation is successful a `StatusOr<T>` converts to `true` in
 boolean context (and its `.ok()` member function returns `true`), the
-application can then use `operator->` or `operator*` to access then `T` value.
+application can then use `operator->` or `operator*` to access the `T` value.
 When the operation fails a `StatusOr<T>` converts to `false` (and `.ok()`
-returns false). It is undefined behavior to use the value in this case.
+returns `false`). It is undefined behavior to use the value in this case.
 
 If you prefer to use exceptions on error, you can use the `.value()` accessor.
 It will return the `T` value or throw on error.
@@ -94,6 +95,6 @@ can override the default policies.
 [github-link]: https://github.com/googleapis/google-cloud-cpp 'GitHub Repository'
 <!-- The ugly %2E disables auto-linking in Doxygen -->
 [github-readme]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/pubsublite/README%2Emd
-[github-install]: https://github.com/googleapis/google-cloud-cpp/blob/main/doc/packagin%2Emd
+[github-install]: https://github.com/googleapis/google-cloud-cpp/blob/main/doc/packaging%2Emd
 
 */

--- a/google/cloud/pubsublite/doc/main.dox
+++ b/google/cloud/pubsublite/doc/main.dox
@@ -1,0 +1,99 @@
+/*!
+
+@mainpage Pub/Sub Lite API C++ Client Library
+
+An idiomatic C++ client library for
+[Pub/Sub Lite API](https://cloud.google.com/pubsublite/),  a high-volume
+messaging service built for very low cost of operation by offering zonal storage
+and pre-provisioned capacity.
+
+This library is **experimental**. Its APIS are subject to change without notice.
+
+This library requires a C++11 compiler, it is supported (and tested) on multiple
+Linux distributions, as well as Windows and macOS. The
+[README][github-readme] on [GitHub][github-link] provides detailed
+instructions to install the necessary dependencies, as well as how to compile
+the client library.
+
+### Setting up your repo
+
+In order to use the Pub/Sub Lite API C++ client library from your own code,
+you'll need to configure your build system how to fetch and compile the Cloud
+C++ client libraries. The Cloud C++ client libraries natively supports the
+[Bazel](https://bazel.build/) and [CMake](https://cmake.org/) build systems.
+We've created a minimal, "Hello World", [quickstart repo][quickstart-link] that
+includes detailed instructions on how to compile the library for use in your
+application. You can fetch the source from [GitHub][github-link] as normal:
+
+@code{.sh}
+git clone https://github.com/googleapis/google-cloud-cpp.git
+cd google-cloud-cpp/google/cloud/pubsublite/quickstart
+@endcode
+
+@par Example: Quickstart
+
+The following shows the code that you'll run in the
+`google/cloud/pubsublite/quickstart/` directory,
+which should give you a taste of the Pub/Sub Lite API C++ client library API.
+
+@include quickstart.cc
+
+## Environment Variables
+
+- `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
+  calls. The library injects an additional Stub decorator that prints each gRPC
+  request and response.  Unless you have configured you own logging backend,
+  you should also set `GOOGLE_CLOUD_CPP_ENABLE_CLOG` to produce any output on
+  the program's console.
+
+- `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc-streams` turns on tracing for streaming
+  gRPC calls, such as `Client::Read()`, `Client::ExecuteQuery()`, and
+  `Client::ProfileQuery()`. This can produce a lot of output, so use with
+  caution!
+
+- `GOOGLE_CLOUD_CPP_TRACING_OPTIONS=...` modifies the behavior of gRPC tracing,
+  including whether messages will be output on multiple lines, or whether
+  string/bytes fields will be truncated.
+
+- `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` turns on logging in the library, basically
+  the library always "logs" but the logging infrastructure has no backend to
+  actually print anything until the application sets a backend or they set this
+  environment variable.
+
+### Error Handling
+
+[status-or-header]: https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/status_or.h
+
+This library never throws exceptions to signal error, but you can use exceptions
+to detect errors in the returned objects. In general, the library returns a
+[`StatusOr<T>`][status-or-header] if an error is possible. This is an "outcome"
+type, when the operation is successful a `StatusOr<T>` converts to `true` in
+boolean context (and its `.ok()` member function returns `true`), the
+application can then use `operator->` or `operator*` to access then `T` value.
+When the operation fails a `StatusOr<T>` converts to `false` (and `.ok()`
+returns false). It is undefined behavior to use the value in this case.
+
+If you prefer to use exceptions on error, you can use the `.value()` accessor.
+It will return the `T` value or throw on error.
+
+For operations that do not return a value the library simply returns
+`google::cloud::Status`.
+
+### Retry, Backoff, and Idempotency Policies.
+
+The library automatically retries requests that fail with transient errors, and
+uses [exponential backoff] to backoff between retries. Application developers
+can override the default policies.
+
+[exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff
+[gcs-quickstart]: https://cloud.google.com/pubsublite/docs/quickstarts 'Quickstarts'
+[resource-link]: https://console.cloud.google.com/cloud-resource-manager 'Console Resource Manager'
+[billing-link]: https://cloud.google.com/billing/docs/how-to/modify-project 'How to: Modify Project'
+[authentication-quickstart]: https://cloud.google.com/docs/authentication/getting-started 'Authentication Getting Started'
+[gcloud-quickstart]: https://cloud.google.com/sdk/docs/quickstarts
+[github-link]: https://github.com/googleapis/google-cloud-cpp 'GitHub Repository'
+<!-- The ugly %2E disables auto-linking in Doxygen -->
+[github-readme]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/pubsublite/README%2Emd
+[github-install]: https://github.com/googleapis/google-cloud-cpp/blob/main/doc/packagin%2Emd
+
+*/

--- a/google/cloud/pubsublite/quickstart/BUILD
+++ b/google/cloud/pubsublite/quickstart/BUILD
@@ -1,0 +1,25 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+licenses(["notice"])  # Apache 2.0
+
+cc_binary(
+    name = "quickstart",
+    srcs = [
+        "quickstart.cc",
+    ],
+    deps = [
+        "@com_github_googleapis_google_cloud_cpp//:experimental-pubsublite",
+    ],
+)

--- a/google/cloud/pubsublite/quickstart/CMakeLists.txt
+++ b/google/cloud/pubsublite/quickstart/CMakeLists.txt
@@ -1,0 +1,32 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+# This file shows how to use the Pub/Sub Lite API C++ client library from a
+# larger CMake project.
+
+cmake_minimum_required(VERSION 3.5)
+project(google-cloud-cpp-pubsublite-quickstart CXX)
+
+find_package(google_cloud_cpp_pubsublite REQUIRED)
+
+# MSVC requires some additional code to select the correct runtime library
+if (VCPKG_TARGET_TRIPLET MATCHES "-static$")
+    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+else ()
+    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
+endif ()
+
+# Define your targets.
+add_executable(quickstart quickstart.cc)
+target_link_libraries(quickstart google-cloud-cpp::experimental-pubsublite)

--- a/google/cloud/pubsublite/quickstart/Makefile
+++ b/google/cloud/pubsublite/quickstart/Makefile
@@ -1,0 +1,35 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This is a minimal Makefile to show how to use the Pub/Sub Lite API C++ client
+# for developers that use make(1) as their build system.
+
+# The CXX, CXXFLAGS and CXXLD variables are hard-coded. These values work for
+# our tests, but applications would typically make them configurable parameters.
+CXX=g++
+CXXFLAGS=
+CXXLD=$(CXX)
+BIN=.
+
+all: $(BIN)/quickstart
+
+# Configuration variables to compile and link against the Pub/Sub Lite API C++
+# client library.
+CLIENT_MODULE     := google_cloud_cpp_pubsublite
+CLIENT_CXXFLAGS   := $(shell pkg-config $(CLIENT_MODULE) --cflags)
+CLIENT_CXXLDFLAGS := $(shell pkg-config $(CLIENT_MODULE) --libs-only-L)
+CLIENT_LIBS       := $(shell pkg-config $(CLIENT_MODULE) --libs-only-l)
+
+$(BIN)/quickstart: quickstart.cc
+	$(CXXLD) $(CXXFLAGS) $(CLIENT_CXXFLAGS) $(CLIENT_CXXLDFLAGS) -o $@ $^ $(CLIENT_LIBS)

--- a/google/cloud/pubsublite/quickstart/README.md
+++ b/google/cloud/pubsublite/quickstart/README.md
@@ -1,0 +1,168 @@
+# HOWTO: using the Pub/Sub Lite API C++ client in your project
+
+This directory contains small examples showing how to use the Pub/Sub Lite API C++
+client library in your own project. These instructions assume that you have
+some experience as a C++ developer and that you have a working C++ toolchain
+(compiler, linker, etc.) installed on your platform.
+
+* Packaging maintainers or developers that prefer to install the library in a
+  fixed directory (such as `/usr/local` or `/opt`) should consult the
+  [packaging guide](/doc/packaging.md).
+* Developers wanting to use the libraries as part of a larger CMake or Bazel
+  project should consult the current document. Note that there are similar
+  documents for each library in their corresponding directories.
+* Developers wanting to compile the library just to run some of the examples or
+  tests should consult the
+  [building and installing](/README.md#building-and-installing) section of the
+  top-level README file.
+* Contributors and developers to `google-cloud-cpp` should consult the guide to
+  [setup a development workstation][howto-setup-dev-workstation].
+
+[howto-setup-dev-workstation]: /doc/contributor/howto-guide-setup-development-workstation.md
+
+## Before you begin
+
+To run the quickstart examples you will need a working Google Cloud Platform
+(GCP) project, as well as a Cloud Spanner instance and database.
+The [quickstart][quickstart-link] covers the necessary
+steps in detail. Make a note of the GCP project id, the instance id, and the
+database id as you will need them below.
+
+## Configuring authentication for the C++ Client Library
+
+Like most Google Cloud Platform (GCP) services, Cloud Spanner requires that
+your application authenticates with the service before accessing any data. If
+you are not familiar with GCP authentication please take this opportunity to
+review the [Authentication Overview][authentication-quickstart]. This library
+uses the `GOOGLE_APPLICATION_CREDENTIALS` environment variable to find the
+credentials file. For example:
+
+| Shell              | Command                                        |
+| :----------------- | ---------------------------------------------- |
+| Bash/zsh/ksh/etc.  | `export GOOGLE_APPLICATION_CREDENTIALS=[PATH]` |
+| sh                 | `GOOGLE_APPLICATION_CREDENTIALS=[PATH];`<br> `export GOOGLE_APPLICATION_CREDENTIALS` |
+| csh/tsch           | `setenv GOOGLE_APPLICATION_CREDENTIALS [PATH]` |
+| Windows Powershell | `$env:GOOGLE_APPLICATION_CREDENTIALS=[PATH]`   |
+| Windows cmd.exe    | `set GOOGLE_APPLICATION_CREDENTIALS=[PATH]`    |
+
+Setting this environment variable is the recommended way to configure the
+authentication preferences, though if the environment variable is not set, the
+library searches for a credentials file in the same location as the [Cloud
+SDK](https://cloud.google.com/sdk/). For more information about *Application
+Default Credentials*, see
+https://cloud.google.com/docs/authentication/production
+
+## Using with Bazel
+
+> :warning: If you are using Windows or macOS there are additional instructions
+> at the end of this document.
+
+1. Install Bazel using [the instructions][bazel-install] from the `bazel.build`
+   website.
+
+2. Compile this example using Bazel:
+
+   ```bash
+   cd $HOME/google-cloud-cpp/google/cloud/pubsublite/quickstart
+   bazel build ...
+   ```
+
+   Note that Bazel automatically downloads and compiles all dependencies of the
+   project. As it is often the case with C++ libraries, compiling these
+   dependencies may take several minutes.
+
+3. Run the example, change the place holder(s) to appropriate values:
+
+   ```bash
+   bazel run :quickstart -- [...]
+   ```
+
+## Using with CMake
+
+> :warning: If you are using Windows or macOS there are additional instructions
+> at the end of this document.
+
+1. Install CMake. The package managers for most Linux distributions include a
+   package for CMake. Likewise, you can install CMake on Windows using a package
+   manager such as [chocolatey][choco-cmake-link], and on macOS using
+   [homebrew][homebrew-cmake-link]. You can also obtain the software directly
+   from the [cmake.org](https://cmake.org/download/).
+
+2. Install the dependencies with your favorite tools. As an example, if you use
+   [vcpkg](https://github.com/Microsoft/vcpkg.git):
+
+   ```bash
+   cd $HOME/vcpkg
+   ./vcpkg install google-cloud-cpp[core,pubsublite]
+   ```
+
+   Note that, as it is often the case with C++ libraries, compiling these
+   dependencies may take several minutes.
+
+3. Configure CMake, if necessary, configure the directory where you installed
+   the dependencies:
+
+   ```bash
+   cd $HOME/gooogle-cloud-cpp/google/cloud/pubsublite/quickstart
+   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake --build .build
+   ```
+
+4. Run the example, change the place holder to appropriate values:
+
+   ```bash
+   .build/quickstart [...]
+   ```
+
+## Platform Specific Notes
+
+### macOS
+
+gRPC [requires][grpc-roots-pem-bug] an environment variable to configure the
+trust store for SSL certificates, you can download and configure this using:
+
+```bash
+curl -Lo roots.pem https://pki.google.com/roots.pem
+export GRPC_DEFAULT_SSL_ROOTS_FILE_PATH="$PWD/roots.pem"
+```
+
+To workaround a [bug in Bazel][bazel-grpc-macos-bug], gRPC requires this flag on
+macOS builds, you can add the option manually or include it in your `.bazelrc`
+file:
+
+```bash
+bazel build --copt=-DGRPC_BAZEL_BUILD ...
+```
+
+### Windows
+
+To correctly configure the MSVC runtime you should change the CMake minimum
+required version to 3.15 or add `-DCMAKE_POLICY_DEFAULT_CMP0091=NEW` to the
+CMake configuration step.
+
+Bazel tends to create very long file names and paths. You may need to use a
+short directory to store the build output, such as `c:\b`, and instruct Bazel
+to use it via:
+
+```shell
+bazel --output_user_root=c:\b build ...
+```
+
+gRPC [requires][grpc-roots-pem-bug] an environment variable to configure the
+trust store for SSL certificates, you can download and configure this using:
+
+```console
+@powershell -NoProfile -ExecutionPolicy unrestricted -Command ^
+    (new-object System.Net.WebClient).Downloadfile( ^
+        'https://pki.google.com/roots.pem', 'roots.pem')
+set GRPC_DEFAULT_SSL_ROOTS_FILE_PATH=%cd%\roots.pem
+```
+
+[bazel-install]: https://docs.bazel.build/versions/main/install.html
+[quickstart-link]: https://cloud.google.com/pubsublite/docs
+[grpc-roots-pem-bug]: https://github.com/grpc/grpc/issues/16571
+[choco-cmake-link]: https://chocolatey.org/packages/cmake
+[homebrew-cmake-link]: https://formulae.brew.sh/formula/cmake
+[cmake-download-link]: https://cmake.org/download/
+[bazel-grpc-macos-bug]: https://github.com/bazelbuild/bazel/issues/4341
+[authentication-quickstart]: https://cloud.google.com/docs/authentication/getting-started 'Authentication Getting Started'

--- a/google/cloud/pubsublite/quickstart/WORKSPACE
+++ b/google/cloud/pubsublite/quickstart/WORKSPACE
@@ -1,0 +1,51 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A minimal WORKSPACE file showing how to use the Pub/Sub Lite API C++
+# client library in Bazel-based projects.
+workspace(name = "pubsublite_quickstart")
+
+# Add the necessary Starlark functions to fetch google-cloud-cpp.
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+# Fetch the Google Cloud C++ libraries.
+# NOTE: Update this version and SHA256 as needed.
+http_archive(
+    name = "com_github_googleapis_google_cloud_cpp",
+    sha256 = "b024dfde34efd328001d6446e1416fa008caa40d9020c424a8f8a3711061af35",
+    strip_prefix = "google-cloud-cpp-1.33.0",
+    url = "https://github.com/googleapis/google-cloud-cpp/archive/v1.33.0.tar.gz",
+)
+
+# Load indirect dependencies due to
+#     https://github.com/bazelbuild/bazel/issues/1943
+load("@com_github_googleapis_google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+
+google_cloud_cpp_deps()
+
+load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+
+switched_rules_by_language(
+    name = "com_google_googleapis_imports",
+    cc = True,
+    grpc = True,
+)
+
+load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+
+grpc_deps()
+
+load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+
+grpc_extra_deps()

--- a/google/cloud/pubsublite/quickstart/quickstart.cc
+++ b/google/cloud/pubsublite/quickstart/quickstart.cc
@@ -1,0 +1,37 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/pubsublite/admin_client.h"
+#include <iostream>
+#include <stdexcept>
+
+int main(int argc, char* argv[]) try {
+  if (argc != 4) {
+    std::cerr << "Usage: " << argv[0] << " project-id \n";
+    return 1;
+  }
+
+  namespace pubsublite = ::google::cloud::pubsublite;
+  auto client =
+      pubsublite::AdminServiceClient(pubsublite::MakeAdminServiceConnection());
+  auto const parent = std::string("projects/") + argv[1];
+  for (auto const& topic : client.ListTopics(parent)) {
+    std::cout << topic.value().DebugString() << "\n";
+  }
+
+  return 0;
+} catch (std::exception const& ex) {
+  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+  return 1;
+}

--- a/google/cloud/secretmanager/BUILD
+++ b/google/cloud/secretmanager/BUILD
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google/cloud/secretmanager/CMakeLists.txt
+++ b/google/cloud/secretmanager/CMakeLists.txt
@@ -5,7 +5,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google/cloud/secretmanager/CMakeLists.txt
+++ b/google/cloud/secretmanager/CMakeLists.txt
@@ -20,6 +20,7 @@ set(DOXYGEN_PROJECT_BRIEF "A C++ Client Library for the Secret Manager API")
 set(DOXYGEN_PROJECT_NUMBER "${PROJECT_VERSION} (Experimental)")
 set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "secretmanager_internal"
                             "secretmanager_testing" "examples")
+set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
 
 # Creates the proto headers needed by doxygen.
 set(GOOGLE_CLOUD_CPP_DOXYGEN_DEPS google-cloud-cpp::secretmanager_protos)
@@ -198,4 +199,4 @@ install(
     COMPONENT google_cloud_cpp_development)
 
 external_googleapis_install_pc("google_cloud_cpp_secretmanager_protos"
-                               "${CMAKE_CURRENT_LIST_DIR}")
+                               "${PROJECT_SOURCE_DIR}/external/googleapis")

--- a/google/cloud/secretmanager/config.cmake.in
+++ b/google/cloud/secretmanager/config.cmake.in
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google/cloud/secretmanager/config.pc.in
+++ b/google/cloud/secretmanager/config.pc.in
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google/cloud/secretmanager/doc/main.dox
+++ b/google/cloud/secretmanager/doc/main.dox
@@ -17,12 +17,13 @@ the client library.
 ### Setting up your repo
 
 In order to use the Secret Manager API C++ client library from your own code,
-you'll need to configure your build system how to fetch and compile the Cloud
-C++ client libraries. The Cloud C++ client libraries natively supports the
-[Bazel](https://bazel.build/) and [CMake](https://cmake.org/) build systems.
-We've created a minimal, "Hello World", [quickstart repo][quickstart-link] that
-includes detailed instructions on how to compile the library for use in your
-application. You can fetch the source from [GitHub][github-link] as normal:
+you'll need to configure your build system to discover and compile the Cloud
+C++ client libraries. In some cases your build system or package manager may
+need to download the libraries too. The Cloud C++ client libraries natively
+support [Bazel](https://bazel.build/) and [CMake](https://cmake.org/) as build
+systems. We've created a minimal, "Hello World", [quickstart][quickstart-link]
+that includes detailed instructions on how to compile the library for use in
+your application. You can fetch the source from [GitHub][github-link] as normal:
 
 @code{.sh}
 git clone https://github.com/googleapis/google-cloud-cpp.git
@@ -41,7 +42,7 @@ which should give you a taste of the Secret Manager API C++ client library API.
 
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC
-  request and response.  Unless you have configured you own logging backend,
+  request and response.  Unless you have configured your own logging backend,
   you should also set `GOOGLE_CLOUD_CPP_ENABLE_CLOG` to produce any output on
   the program's console.
 
@@ -54,9 +55,9 @@ which should give you a taste of the Secret Manager API C++ client library API.
   including whether messages will be output on multiple lines, or whether
   string/bytes fields will be truncated.
 
-- `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` turns on logging in the library, basically
+- `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` turns on logging in the library. Basically
   the library always "logs" but the logging infrastructure has no backend to
-  actually print anything until the application sets a backend or they set this
+  actually print anything until the application sets a backend or it sets this
   environment variable.
 
 ### Error Handling
@@ -68,9 +69,9 @@ to detect errors in the returned objects. In general, the library returns a
 [`StatusOr<T>`][status-or-header] if an error is possible. This is an "outcome"
 type, when the operation is successful a `StatusOr<T>` converts to `true` in
 boolean context (and its `.ok()` member function returns `true`), the
-application can then use `operator->` or `operator*` to access then `T` value.
+application can then use `operator->` or `operator*` to access the `T` value.
 When the operation fails a `StatusOr<T>` converts to `false` (and `.ok()`
-returns false). It is undefined behavior to use the value in this case.
+returns `false`). It is undefined behavior to use the value in this case.
 
 If you prefer to use exceptions on error, you can use the `.value()` accessor.
 It will return the `T` value or throw on error.
@@ -93,6 +94,6 @@ can override the default policies.
 [github-link]: https://github.com/googleapis/google-cloud-cpp 'GitHub Repository'
 <!-- The ugly %2E disables auto-linking in Doxygen -->
 [github-readme]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/secretmanager/README%2Emd
-[github-install]: https://github.com/googleapis/google-cloud-cpp/blob/main/doc/packagin%2Emd
+[github-install]: https://github.com/googleapis/google-cloud-cpp/blob/main/doc/packaging%2Emd
 
 */

--- a/google/cloud/secretmanager/doc/main.dox
+++ b/google/cloud/secretmanager/doc/main.dox
@@ -1,0 +1,98 @@
+/*!
+
+@mainpage Secret Manager API C++ Client Library
+
+An idiomatic C++ client library for
+[Secret Manager API](https://cloud.google.com/secretmanager/), a service that
+stores sensitive data such as API keys, passwords, and certificates.
+
+This library is **experimental**. Its APIS are subject to change without notice.
+
+This library requires a C++11 compiler, it is supported (and tested) on multiple
+Linux distributions, as well as Windows and macOS. The
+[README][github-readme] on [GitHub][github-link] provides detailed
+instructions to install the necessary dependencies, as well as how to compile
+the client library.
+
+### Setting up your repo
+
+In order to use the Secret Manager API C++ client library from your own code,
+you'll need to configure your build system how to fetch and compile the Cloud
+C++ client libraries. The Cloud C++ client libraries natively supports the
+[Bazel](https://bazel.build/) and [CMake](https://cmake.org/) build systems.
+We've created a minimal, "Hello World", [quickstart repo][quickstart-link] that
+includes detailed instructions on how to compile the library for use in your
+application. You can fetch the source from [GitHub][github-link] as normal:
+
+@code{.sh}
+git clone https://github.com/googleapis/google-cloud-cpp.git
+cd google-cloud-cpp/google/cloud/secretmanager/quickstart
+@endcode
+
+@par Example: Quickstart
+
+The following shows the code that you'll run in the
+`google/cloud/secretmanager/quickstart/` directory,
+which should give you a taste of the Secret Manager API C++ client library API.
+
+@include quickstart.cc
+
+## Environment Variables
+
+- `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
+  calls. The library injects an additional Stub decorator that prints each gRPC
+  request and response.  Unless you have configured you own logging backend,
+  you should also set `GOOGLE_CLOUD_CPP_ENABLE_CLOG` to produce any output on
+  the program's console.
+
+- `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc-streams` turns on tracing for streaming
+  gRPC calls, such as `Client::Read()`, `Client::ExecuteQuery()`, and
+  `Client::ProfileQuery()`. This can produce a lot of output, so use with
+  caution!
+
+- `GOOGLE_CLOUD_CPP_TRACING_OPTIONS=...` modifies the behavior of gRPC tracing,
+  including whether messages will be output on multiple lines, or whether
+  string/bytes fields will be truncated.
+
+- `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` turns on logging in the library, basically
+  the library always "logs" but the logging infrastructure has no backend to
+  actually print anything until the application sets a backend or they set this
+  environment variable.
+
+### Error Handling
+
+[status-or-header]: https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/status_or.h
+
+This library never throws exceptions to signal error, but you can use exceptions
+to detect errors in the returned objects. In general, the library returns a
+[`StatusOr<T>`][status-or-header] if an error is possible. This is an "outcome"
+type, when the operation is successful a `StatusOr<T>` converts to `true` in
+boolean context (and its `.ok()` member function returns `true`), the
+application can then use `operator->` or `operator*` to access then `T` value.
+When the operation fails a `StatusOr<T>` converts to `false` (and `.ok()`
+returns false). It is undefined behavior to use the value in this case.
+
+If you prefer to use exceptions on error, you can use the `.value()` accessor.
+It will return the `T` value or throw on error.
+
+For operations that do not return a value the library simply returns
+`google::cloud::Status`.
+
+### Retry, Backoff, and Idempotency Policies.
+
+The library automatically retries requests that fail with transient errors, and
+uses [exponential backoff] to backoff between retries. Application developers
+can override the default policies.
+
+[exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff
+[gcs-quickstart]: https://cloud.google.com/secretmanager/docs/quickstarts 'Quickstarts'
+[resource-link]: https://console.cloud.google.com/cloud-resource-manager 'Console Resource Manager'
+[billing-link]: https://cloud.google.com/billing/docs/how-to/modify-project 'How to: Modify Project'
+[authentication-quickstart]: https://cloud.google.com/docs/authentication/getting-started 'Authentication Getting Started'
+[gcloud-quickstart]: https://cloud.google.com/sdk/docs/quickstarts
+[github-link]: https://github.com/googleapis/google-cloud-cpp 'GitHub Repository'
+<!-- The ugly %2E disables auto-linking in Doxygen -->
+[github-readme]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/secretmanager/README%2Emd
+[github-install]: https://github.com/googleapis/google-cloud-cpp/blob/main/doc/packagin%2Emd
+
+*/

--- a/google/cloud/secretmanager/quickstart/BUILD
+++ b/google/cloud/secretmanager/quickstart/BUILD
@@ -1,0 +1,25 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+licenses(["notice"])  # Apache 2.0
+
+cc_binary(
+    name = "quickstart",
+    srcs = [
+        "quickstart.cc",
+    ],
+    deps = [
+        "@com_github_googleapis_google_cloud_cpp//:experimental-secretmanager",
+    ],
+)

--- a/google/cloud/secretmanager/quickstart/CMakeLists.txt
+++ b/google/cloud/secretmanager/quickstart/CMakeLists.txt
@@ -1,0 +1,32 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+# This file shows how to use the Secret Manager API C++ client library from a
+# larger CMake project.
+
+cmake_minimum_required(VERSION 3.5)
+project(google-cloud-cpp-secretmanager-quickstart CXX)
+
+find_package(google_cloud_cpp_secretmanager REQUIRED)
+
+# MSVC requires some additional code to select the correct runtime library
+if (VCPKG_TARGET_TRIPLET MATCHES "-static$")
+    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+else ()
+    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
+endif ()
+
+# Define your targets.
+add_executable(quickstart quickstart.cc)
+target_link_libraries(quickstart google-cloud-cpp::experimental-secretmanager)

--- a/google/cloud/secretmanager/quickstart/Makefile
+++ b/google/cloud/secretmanager/quickstart/Makefile
@@ -1,0 +1,35 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This is a minimal Makefile to show how to use the Secret Manager API C++ client
+# for developers that use make(1) as their build system.
+
+# The CXX, CXXFLAGS and CXXLD variables are hard-coded. These values work for
+# our tests, but applications would typically make them configurable parameters.
+CXX=g++
+CXXFLAGS=
+CXXLD=$(CXX)
+BIN=.
+
+all: $(BIN)/quickstart
+
+# Configuration variables to compile and link against the Secret Manager API C++
+# client library.
+CLIENT_MODULE     := google_cloud_cpp_secretmanager
+CLIENT_CXXFLAGS   := $(shell pkg-config $(CLIENT_MODULE) --cflags)
+CLIENT_CXXLDFLAGS := $(shell pkg-config $(CLIENT_MODULE) --libs-only-L)
+CLIENT_LIBS       := $(shell pkg-config $(CLIENT_MODULE) --libs-only-l)
+
+$(BIN)/quickstart: quickstart.cc
+	$(CXXLD) $(CXXFLAGS) $(CLIENT_CXXFLAGS) $(CLIENT_CXXLDFLAGS) -o $@ $^ $(CLIENT_LIBS)

--- a/google/cloud/secretmanager/quickstart/README.md
+++ b/google/cloud/secretmanager/quickstart/README.md
@@ -1,0 +1,168 @@
+# HOWTO: using the Secret Manager API C++ client in your project
+
+This directory contains small examples showing how to use the Secret Manager API C++
+client library in your own project. These instructions assume that you have
+some experience as a C++ developer and that you have a working C++ toolchain
+(compiler, linker, etc.) installed on your platform.
+
+* Packaging maintainers or developers that prefer to install the library in a
+  fixed directory (such as `/usr/local` or `/opt`) should consult the
+  [packaging guide](/doc/packaging.md).
+* Developers wanting to use the libraries as part of a larger CMake or Bazel
+  project should consult the current document. Note that there are similar
+  documents for each library in their corresponding directories.
+* Developers wanting to compile the library just to run some of the examples or
+  tests should consult the
+  [building and installing](/README.md#building-and-installing) section of the
+  top-level README file.
+* Contributors and developers to `google-cloud-cpp` should consult the guide to
+  [setup a development workstation][howto-setup-dev-workstation].
+
+[howto-setup-dev-workstation]: /doc/contributor/howto-guide-setup-development-workstation.md
+
+## Before you begin
+
+To run the quickstart examples you will need a working Google Cloud Platform
+(GCP) project, as well as a Cloud Spanner instance and database.
+The [quickstart][quickstart-link] covers the necessary
+steps in detail. Make a note of the GCP project id, the instance id, and the
+database id as you will need them below.
+
+## Configuring authentication for the C++ Client Library
+
+Like most Google Cloud Platform (GCP) services, Cloud Spanner requires that
+your application authenticates with the service before accessing any data. If
+you are not familiar with GCP authentication please take this opportunity to
+review the [Authentication Overview][authentication-quickstart]. This library
+uses the `GOOGLE_APPLICATION_CREDENTIALS` environment variable to find the
+credentials file. For example:
+
+| Shell              | Command                                        |
+| :----------------- | ---------------------------------------------- |
+| Bash/zsh/ksh/etc.  | `export GOOGLE_APPLICATION_CREDENTIALS=[PATH]` |
+| sh                 | `GOOGLE_APPLICATION_CREDENTIALS=[PATH];`<br> `export GOOGLE_APPLICATION_CREDENTIALS` |
+| csh/tsch           | `setenv GOOGLE_APPLICATION_CREDENTIALS [PATH]` |
+| Windows Powershell | `$env:GOOGLE_APPLICATION_CREDENTIALS=[PATH]`   |
+| Windows cmd.exe    | `set GOOGLE_APPLICATION_CREDENTIALS=[PATH]`    |
+
+Setting this environment variable is the recommended way to configure the
+authentication preferences, though if the environment variable is not set, the
+library searches for a credentials file in the same location as the [Cloud
+SDK](https://cloud.google.com/sdk/). For more information about *Application
+Default Credentials*, see
+https://cloud.google.com/docs/authentication/production
+
+## Using with Bazel
+
+> :warning: If you are using Windows or macOS there are additional instructions
+> at the end of this document.
+
+1. Install Bazel using [the instructions][bazel-install] from the `bazel.build`
+   website.
+
+2. Compile this example using Bazel:
+
+   ```bash
+   cd $HOME/google-cloud-cpp/google/cloud/secretmanager/quickstart
+   bazel build ...
+   ```
+
+   Note that Bazel automatically downloads and compiles all dependencies of the
+   project. As it is often the case with C++ libraries, compiling these
+   dependencies may take several minutes.
+
+3. Run the example, change the place holder(s) to appropriate values:
+
+   ```bash
+   bazel run :quickstart -- [...]
+   ```
+
+## Using with CMake
+
+> :warning: If you are using Windows or macOS there are additional instructions
+> at the end of this document.
+
+1. Install CMake. The package managers for most Linux distributions include a
+   package for CMake. Likewise, you can install CMake on Windows using a package
+   manager such as [chocolatey][choco-cmake-link], and on macOS using
+   [homebrew][homebrew-cmake-link]. You can also obtain the software directly
+   from the [cmake.org](https://cmake.org/download/).
+
+2. Install the dependencies with your favorite tools. As an example, if you use
+   [vcpkg](https://github.com/Microsoft/vcpkg.git):
+
+   ```bash
+   cd $HOME/vcpkg
+   ./vcpkg install google-cloud-cpp[core,secretmanager]
+   ```
+
+   Note that, as it is often the case with C++ libraries, compiling these
+   dependencies may take several minutes.
+
+3. Configure CMake, if necessary, configure the directory where you installed
+   the dependencies:
+
+   ```bash
+   cd $HOME/gooogle-cloud-cpp/google/cloud/secretmanager/quickstart
+   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake --build .build
+   ```
+
+4. Run the example, change the place holder to appropriate values:
+
+   ```bash
+   .build/quickstart [...]
+   ```
+
+## Platform Specific Notes
+
+### macOS
+
+gRPC [requires][grpc-roots-pem-bug] an environment variable to configure the
+trust store for SSL certificates, you can download and configure this using:
+
+```bash
+curl -Lo roots.pem https://pki.google.com/roots.pem
+export GRPC_DEFAULT_SSL_ROOTS_FILE_PATH="$PWD/roots.pem"
+```
+
+To workaround a [bug in Bazel][bazel-grpc-macos-bug], gRPC requires this flag on
+macOS builds, you can add the option manually or include it in your `.bazelrc`
+file:
+
+```bash
+bazel build --copt=-DGRPC_BAZEL_BUILD ...
+```
+
+### Windows
+
+To correctly configure the MSVC runtime you should change the CMake minimum
+required version to 3.15 or add `-DCMAKE_POLICY_DEFAULT_CMP0091=NEW` to the
+CMake configuration step.
+
+Bazel tends to create very long file names and paths. You may need to use a
+short directory to store the build output, such as `c:\b`, and instruct Bazel
+to use it via:
+
+```shell
+bazel --output_user_root=c:\b build ...
+```
+
+gRPC [requires][grpc-roots-pem-bug] an environment variable to configure the
+trust store for SSL certificates, you can download and configure this using:
+
+```console
+@powershell -NoProfile -ExecutionPolicy unrestricted -Command ^
+    (new-object System.Net.WebClient).Downloadfile( ^
+        'https://pki.google.com/roots.pem', 'roots.pem')
+set GRPC_DEFAULT_SSL_ROOTS_FILE_PATH=%cd%\roots.pem
+```
+
+[bazel-install]: https://docs.bazel.build/versions/main/install.html
+[quickstart-link]: https://cloud.google.com/secretmanager/docs
+[grpc-roots-pem-bug]: https://github.com/grpc/grpc/issues/16571
+[choco-cmake-link]: https://chocolatey.org/packages/cmake
+[homebrew-cmake-link]: https://formulae.brew.sh/formula/cmake
+[cmake-download-link]: https://cmake.org/download/
+[bazel-grpc-macos-bug]: https://github.com/bazelbuild/bazel/issues/4341
+[authentication-quickstart]: https://cloud.google.com/docs/authentication/getting-started 'Authentication Getting Started'

--- a/google/cloud/secretmanager/quickstart/WORKSPACE
+++ b/google/cloud/secretmanager/quickstart/WORKSPACE
@@ -1,0 +1,51 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A minimal WORKSPACE file showing how to use the Secret Manager API C++
+# client library in Bazel-based projects.
+workspace(name = "secretmanager_quickstart")
+
+# Add the necessary Starlark functions to fetch google-cloud-cpp.
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+# Fetch the Google Cloud C++ libraries.
+# NOTE: Update this version and SHA256 as needed.
+http_archive(
+    name = "com_github_googleapis_google_cloud_cpp",
+    sha256 = "b024dfde34efd328001d6446e1416fa008caa40d9020c424a8f8a3711061af35",
+    strip_prefix = "google-cloud-cpp-1.33.0",
+    url = "https://github.com/googleapis/google-cloud-cpp/archive/v1.33.0.tar.gz",
+)
+
+# Load indirect dependencies due to
+#     https://github.com/bazelbuild/bazel/issues/1943
+load("@com_github_googleapis_google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+
+google_cloud_cpp_deps()
+
+load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+
+switched_rules_by_language(
+    name = "com_google_googleapis_imports",
+    cc = True,
+    grpc = True,
+)
+
+load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+
+grpc_deps()
+
+load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+
+grpc_extra_deps()

--- a/google/cloud/secretmanager/quickstart/quickstart.cc
+++ b/google/cloud/secretmanager/quickstart/quickstart.cc
@@ -1,0 +1,38 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/secretmanager/secret_manager_client.h"
+#include <iostream>
+#include <stdexcept>
+
+int main(int argc, char* argv[]) try {
+  if (argc != 2) {
+    std::cerr << "Usage: " << argv[0] << " project-id \n";
+    return 1;
+  }
+
+  namespace secretmanager = ::google::cloud::secretmanager;
+  auto client = secretmanager::SecretManagerServiceClient(
+      secretmanager::MakeSecretManagerServiceConnection());
+
+  auto const parent = std::string("projects/") + argv[1];
+  for (auto const& secret : client.ListSecrets(parent)) {
+    std::cout << secret.value().DebugString() << "\n";
+  }
+
+  return 0;
+} catch (std::exception const& ex) {
+  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+  return 1;
+}

--- a/google/cloud/tasks/BUILD
+++ b/google/cloud/tasks/BUILD
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google/cloud/tasks/CMakeLists.txt
+++ b/google/cloud/tasks/CMakeLists.txt
@@ -20,6 +20,7 @@ set(DOXYGEN_PROJECT_BRIEF "A C++ Client Library for the Cloud Tasks API")
 set(DOXYGEN_PROJECT_NUMBER "${PROJECT_VERSION} (Experimental)")
 set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "tasks_internal" "tasks_testing"
                             "examples")
+set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
 
 # Creates the proto headers needed by doxygen.
 set(GOOGLE_CLOUD_CPP_DOXYGEN_DEPS google-cloud-cpp::tasks_protos)
@@ -195,4 +196,4 @@ install(
     COMPONENT google_cloud_cpp_development)
 
 external_googleapis_install_pc("google_cloud_cpp_tasks_protos"
-                               "${CMAKE_CURRENT_LIST_DIR}")
+                               "${PROJECT_SOURCE_DIR}/external/googleapis")

--- a/google/cloud/tasks/CMakeLists.txt
+++ b/google/cloud/tasks/CMakeLists.txt
@@ -5,7 +5,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -42,10 +42,10 @@ include(CompileProtos)
 google_cloud_cpp_grpcpp_library(
     google_cloud_cpp_tasks_protos
     # cmake-format: sort
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/tasks/v2/task.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/tasks/v2/target.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/tasks/v2/queue.proto
     ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/tasks/v2/cloudtasks.proto
+    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/tasks/v2/queue.proto
+    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/tasks/v2/target.proto
+    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/tasks/v2/task.proto
     PROTO_PATH_DIRECTORIES
     "${EXTERNAL_GOOGLEAPIS_SOURCE}"
     "${PROTO_INCLUDE_DIR}")
@@ -53,16 +53,16 @@ external_googleapis_set_version_and_alias(tasks_protos)
 target_link_libraries(
     google_cloud_cpp_tasks_protos
     PUBLIC #
-           google-cloud-cpp::rpc_status_protos
-           google-cloud-cpp::iam_v1_iam_policy_protos
-           google-cloud-cpp::iam_v1_policy_protos
-           google-cloud-cpp::type_expr_protos
-           google-cloud-cpp::iam_v1_options_protos
-           google-cloud-cpp::api_resource_protos
-           google-cloud-cpp::api_field_behavior_protos
-           google-cloud-cpp::api_client_protos
            google-cloud-cpp::api_annotations_protos
-           google-cloud-cpp::api_http_protos)
+           google-cloud-cpp::api_client_protos
+           google-cloud-cpp::api_field_behavior_protos
+           google-cloud-cpp::api_http_protos
+           google-cloud-cpp::api_resource_protos
+           google-cloud-cpp::iam_v1_iam_policy_protos
+           google-cloud-cpp::iam_v1_options_protos
+           google-cloud-cpp::iam_v1_policy_protos
+           google-cloud-cpp::rpc_status_protos
+           google-cloud-cpp::type_expr_protos)
 
 file(
     GLOB source_files

--- a/google/cloud/tasks/config.cmake.in
+++ b/google/cloud/tasks/config.cmake.in
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google/cloud/tasks/config.pc.in
+++ b/google/cloud/tasks/config.pc.in
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google/cloud/tasks/doc/main.dox
+++ b/google/cloud/tasks/doc/main.dox
@@ -17,12 +17,13 @@ the client library.
 ### Setting up your repo
 
 In order to use the Cloud Tasks API C++ client library from your own code,
-you'll need to configure your build system how to fetch and compile the Cloud
-C++ client libraries. The Cloud C++ client libraries natively supports the
-[Bazel](https://bazel.build/) and [CMake](https://cmake.org/) build systems.
-We've created a minimal, "Hello World", [quickstart repo][quickstart-link] that
-includes detailed instructions on how to compile the library for use in your
-application. You can fetch the source from [GitHub][github-link] as normal:
+you'll need to configure your build system to discover and compile the Cloud
+C++ client libraries. In some cases your build system or package manager may
+need to download the libraries too. The Cloud C++ client libraries natively
+support [Bazel](https://bazel.build/) and [CMake](https://cmake.org/) as build
+systems. We've created a minimal, "Hello World", [quickstart][quickstart-link]
+that includes detailed instructions on how to compile the library for use in
+your application. You can fetch the source from [GitHub][github-link] as normal:
 
 @code{.sh}
 git clone https://github.com/googleapis/google-cloud-cpp.git
@@ -41,7 +42,7 @@ which should give you a taste of the Cloud Tasks API C++ client library API.
 
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC
-  request and response.  Unless you have configured you own logging backend,
+  request and response.  Unless you have configured your own logging backend,
   you should also set `GOOGLE_CLOUD_CPP_ENABLE_CLOG` to produce any output on
   the program's console.
 
@@ -54,9 +55,9 @@ which should give you a taste of the Cloud Tasks API C++ client library API.
   including whether messages will be output on multiple lines, or whether
   string/bytes fields will be truncated.
 
-- `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` turns on logging in the library, basically
+- `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` turns on logging in the library. Basically
   the library always "logs" but the logging infrastructure has no backend to
-  actually print anything until the application sets a backend or they set this
+  actually print anything until the application sets a backend or it sets this
   environment variable.
 
 ### Error Handling
@@ -68,9 +69,9 @@ to detect errors in the returned objects. In general, the library returns a
 [`StatusOr<T>`][status-or-header] if an error is possible. This is an "outcome"
 type, when the operation is successful a `StatusOr<T>` converts to `true` in
 boolean context (and its `.ok()` member function returns `true`), the
-application can then use `operator->` or `operator*` to access then `T` value.
+application can then use `operator->` or `operator*` to access the `T` value.
 When the operation fails a `StatusOr<T>` converts to `false` (and `.ok()`
-returns false). It is undefined behavior to use the value in this case.
+returns `false`). It is undefined behavior to use the value in this case.
 
 If you prefer to use exceptions on error, you can use the `.value()` accessor.
 It will return the `T` value or throw on error.
@@ -93,6 +94,6 @@ can override the default policies.
 [github-link]: https://github.com/googleapis/google-cloud-cpp 'GitHub Repository'
 <!-- The ugly %2E disables auto-linking in Doxygen -->
 [github-readme]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/tasks/README%2Emd
-[github-install]: https://github.com/googleapis/google-cloud-cpp/blob/main/doc/packagin%2Emd
+[github-install]: https://github.com/googleapis/google-cloud-cpp/blob/main/doc/packaging%2Emd
 
 */

--- a/google/cloud/tasks/doc/main.dox
+++ b/google/cloud/tasks/doc/main.dox
@@ -1,0 +1,98 @@
+/*!
+
+@mainpage Cloud Tasks API C++ Client Library
+
+An idiomatic C++ client library for
+[Cloud Tasks API](https://cloud.google.com/tasks/), a service that
+manages the execution of large numbers of distributed requests.
+
+This library is **experimental**. Its APIS are subject to change without notice.
+
+This library requires a C++11 compiler, it is supported (and tested) on multiple
+Linux distributions, as well as Windows and macOS. The
+[README][github-readme] on [GitHub][github-link] provides detailed
+instructions to install the necessary dependencies, as well as how to compile
+the client library.
+
+### Setting up your repo
+
+In order to use the Cloud Tasks API C++ client library from your own code,
+you'll need to configure your build system how to fetch and compile the Cloud
+C++ client libraries. The Cloud C++ client libraries natively supports the
+[Bazel](https://bazel.build/) and [CMake](https://cmake.org/) build systems.
+We've created a minimal, "Hello World", [quickstart repo][quickstart-link] that
+includes detailed instructions on how to compile the library for use in your
+application. You can fetch the source from [GitHub][github-link] as normal:
+
+@code{.sh}
+git clone https://github.com/googleapis/google-cloud-cpp.git
+cd google-cloud-cpp/google/cloud/tasks/quickstart
+@endcode
+
+@par Example: Quickstart
+
+The following shows the code that you'll run in the
+`google/cloud/tasks/quickstart/` directory,
+which should give you a taste of the Cloud Tasks API C++ client library API.
+
+@include quickstart.cc
+
+## Environment Variables
+
+- `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
+  calls. The library injects an additional Stub decorator that prints each gRPC
+  request and response.  Unless you have configured you own logging backend,
+  you should also set `GOOGLE_CLOUD_CPP_ENABLE_CLOG` to produce any output on
+  the program's console.
+
+- `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc-streams` turns on tracing for streaming
+  gRPC calls, such as `Client::Read()`, `Client::ExecuteQuery()`, and
+  `Client::ProfileQuery()`. This can produce a lot of output, so use with
+  caution!
+
+- `GOOGLE_CLOUD_CPP_TRACING_OPTIONS=...` modifies the behavior of gRPC tracing,
+  including whether messages will be output on multiple lines, or whether
+  string/bytes fields will be truncated.
+
+- `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` turns on logging in the library, basically
+  the library always "logs" but the logging infrastructure has no backend to
+  actually print anything until the application sets a backend or they set this
+  environment variable.
+
+### Error Handling
+
+[status-or-header]: https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/status_or.h
+
+This library never throws exceptions to signal error, but you can use exceptions
+to detect errors in the returned objects. In general, the library returns a
+[`StatusOr<T>`][status-or-header] if an error is possible. This is an "outcome"
+type, when the operation is successful a `StatusOr<T>` converts to `true` in
+boolean context (and its `.ok()` member function returns `true`), the
+application can then use `operator->` or `operator*` to access then `T` value.
+When the operation fails a `StatusOr<T>` converts to `false` (and `.ok()`
+returns false). It is undefined behavior to use the value in this case.
+
+If you prefer to use exceptions on error, you can use the `.value()` accessor.
+It will return the `T` value or throw on error.
+
+For operations that do not return a value the library simply returns
+`google::cloud::Status`.
+
+### Retry, Backoff, and Idempotency Policies.
+
+The library automatically retries requests that fail with transient errors, and
+uses [exponential backoff] to backoff between retries. Application developers
+can override the default policies.
+
+[exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff
+[gcs-quickstart]: https://cloud.google.com/tasks/docs/quickstarts 'Quickstarts'
+[resource-link]: https://console.cloud.google.com/cloud-resource-manager 'Console Resource Manager'
+[billing-link]: https://cloud.google.com/billing/docs/how-to/modify-project 'How to: Modify Project'
+[authentication-quickstart]: https://cloud.google.com/docs/authentication/getting-started 'Authentication Getting Started'
+[gcloud-quickstart]: https://cloud.google.com/sdk/docs/quickstarts
+[github-link]: https://github.com/googleapis/google-cloud-cpp 'GitHub Repository'
+<!-- The ugly %2E disables auto-linking in Doxygen -->
+[github-readme]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/tasks/README%2Emd
+[github-install]: https://github.com/googleapis/google-cloud-cpp/blob/main/doc/packagin%2Emd
+
+*/

--- a/google/cloud/tasks/quickstart/BUILD
+++ b/google/cloud/tasks/quickstart/BUILD
@@ -1,0 +1,25 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+licenses(["notice"])  # Apache 2.0
+
+cc_binary(
+    name = "quickstart",
+    srcs = [
+        "quickstart.cc",
+    ],
+    deps = [
+        "@com_github_googleapis_google_cloud_cpp//:experimental-tasks",
+    ],
+)

--- a/google/cloud/tasks/quickstart/CMakeLists.txt
+++ b/google/cloud/tasks/quickstart/CMakeLists.txt
@@ -1,0 +1,32 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+# This file shows how to use the Cloud Tasks API C++ client library from a
+# larger CMake project.
+
+cmake_minimum_required(VERSION 3.5)
+project(google-cloud-cpp-tasks-quickstart CXX)
+
+find_package(google_cloud_cpp_tasks REQUIRED)
+
+# MSVC requires some additional code to select the correct runtime library
+if (VCPKG_TARGET_TRIPLET MATCHES "-static$")
+    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+else ()
+    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
+endif ()
+
+# Define your targets.
+add_executable(quickstart quickstart.cc)
+target_link_libraries(quickstart google-cloud-cpp::experimental-tasks)

--- a/google/cloud/tasks/quickstart/Makefile
+++ b/google/cloud/tasks/quickstart/Makefile
@@ -1,0 +1,35 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This is a minimal Makefile to show how to use the Cloud Tasks API C++ client
+# for developers that use make(1) as their build system.
+
+# The CXX, CXXFLAGS and CXXLD variables are hard-coded. These values work for
+# our tests, but applications would typically make them configurable parameters.
+CXX=g++
+CXXFLAGS=
+CXXLD=$(CXX)
+BIN=.
+
+all: $(BIN)/quickstart
+
+# Configuration variables to compile and link against the Cloud Tasks API C++
+# client library.
+CLIENT_MODULE     := google_cloud_cpp_tasks
+CLIENT_CXXFLAGS   := $(shell pkg-config $(CLIENT_MODULE) --cflags)
+CLIENT_CXXLDFLAGS := $(shell pkg-config $(CLIENT_MODULE) --libs-only-L)
+CLIENT_LIBS       := $(shell pkg-config $(CLIENT_MODULE) --libs-only-l)
+
+$(BIN)/quickstart: quickstart.cc
+	$(CXXLD) $(CXXFLAGS) $(CLIENT_CXXFLAGS) $(CLIENT_CXXLDFLAGS) -o $@ $^ $(CLIENT_LIBS)

--- a/google/cloud/tasks/quickstart/README.md
+++ b/google/cloud/tasks/quickstart/README.md
@@ -1,0 +1,168 @@
+# HOWTO: using the Cloud Tasks API C++ client in your project
+
+This directory contains small examples showing how to use the Cloud Tasks API C++
+client library in your own project. These instructions assume that you have
+some experience as a C++ developer and that you have a working C++ toolchain
+(compiler, linker, etc.) installed on your platform.
+
+* Packaging maintainers or developers that prefer to install the library in a
+  fixed directory (such as `/usr/local` or `/opt`) should consult the
+  [packaging guide](/doc/packaging.md).
+* Developers wanting to use the libraries as part of a larger CMake or Bazel
+  project should consult the current document. Note that there are similar
+  documents for each library in their corresponding directories.
+* Developers wanting to compile the library just to run some of the examples or
+  tests should consult the
+  [building and installing](/README.md#building-and-installing) section of the
+  top-level README file.
+* Contributors and developers to `google-cloud-cpp` should consult the guide to
+  [setup a development workstation][howto-setup-dev-workstation].
+
+[howto-setup-dev-workstation]: /doc/contributor/howto-guide-setup-development-workstation.md
+
+## Before you begin
+
+To run the quickstart examples you will need a working Google Cloud Platform
+(GCP) project, as well as a Cloud Spanner instance and database.
+The [quickstart][quickstart-link] covers the necessary
+steps in detail. Make a note of the GCP project id, the instance id, and the
+database id as you will need them below.
+
+## Configuring authentication for the C++ Client Library
+
+Like most Google Cloud Platform (GCP) services, Cloud Spanner requires that
+your application authenticates with the service before accessing any data. If
+you are not familiar with GCP authentication please take this opportunity to
+review the [Authentication Overview][authentication-quickstart]. This library
+uses the `GOOGLE_APPLICATION_CREDENTIALS` environment variable to find the
+credentials file. For example:
+
+| Shell              | Command                                        |
+| :----------------- | ---------------------------------------------- |
+| Bash/zsh/ksh/etc.  | `export GOOGLE_APPLICATION_CREDENTIALS=[PATH]` |
+| sh                 | `GOOGLE_APPLICATION_CREDENTIALS=[PATH];`<br> `export GOOGLE_APPLICATION_CREDENTIALS` |
+| csh/tsch           | `setenv GOOGLE_APPLICATION_CREDENTIALS [PATH]` |
+| Windows Powershell | `$env:GOOGLE_APPLICATION_CREDENTIALS=[PATH]`   |
+| Windows cmd.exe    | `set GOOGLE_APPLICATION_CREDENTIALS=[PATH]`    |
+
+Setting this environment variable is the recommended way to configure the
+authentication preferences, though if the environment variable is not set, the
+library searches for a credentials file in the same location as the [Cloud
+SDK](https://cloud.google.com/sdk/). For more information about *Application
+Default Credentials*, see
+https://cloud.google.com/docs/authentication/production
+
+## Using with Bazel
+
+> :warning: If you are using Windows or macOS there are additional instructions
+> at the end of this document.
+
+1. Install Bazel using [the instructions][bazel-install] from the `bazel.build`
+   website.
+
+2. Compile this example using Bazel:
+
+   ```bash
+   cd $HOME/google-cloud-cpp/google/cloud/tasks/quickstart
+   bazel build ...
+   ```
+
+   Note that Bazel automatically downloads and compiles all dependencies of the
+   project. As it is often the case with C++ libraries, compiling these
+   dependencies may take several minutes.
+
+3. Run the example, change the place holder(s) to appropriate values:
+
+   ```bash
+   bazel run :quickstart -- [...]
+   ```
+
+## Using with CMake
+
+> :warning: If you are using Windows or macOS there are additional instructions
+> at the end of this document.
+
+1. Install CMake. The package managers for most Linux distributions include a
+   package for CMake. Likewise, you can install CMake on Windows using a package
+   manager such as [chocolatey][choco-cmake-link], and on macOS using
+   [homebrew][homebrew-cmake-link]. You can also obtain the software directly
+   from the [cmake.org](https://cmake.org/download/).
+
+2. Install the dependencies with your favorite tools. As an example, if you use
+   [vcpkg](https://github.com/Microsoft/vcpkg.git):
+
+   ```bash
+   cd $HOME/vcpkg
+   ./vcpkg install google-cloud-cpp[core,tasks]
+   ```
+
+   Note that, as it is often the case with C++ libraries, compiling these
+   dependencies may take several minutes.
+
+3. Configure CMake, if necessary, configure the directory where you installed
+   the dependencies:
+
+   ```bash
+   cd $HOME/gooogle-cloud-cpp/google/cloud/tasks/quickstart
+   cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake --build .build
+   ```
+
+4. Run the example, change the place holder to appropriate values:
+
+   ```bash
+   .build/quickstart [...]
+   ```
+
+## Platform Specific Notes
+
+### macOS
+
+gRPC [requires][grpc-roots-pem-bug] an environment variable to configure the
+trust store for SSL certificates, you can download and configure this using:
+
+```bash
+curl -Lo roots.pem https://pki.google.com/roots.pem
+export GRPC_DEFAULT_SSL_ROOTS_FILE_PATH="$PWD/roots.pem"
+```
+
+To workaround a [bug in Bazel][bazel-grpc-macos-bug], gRPC requires this flag on
+macOS builds, you can add the option manually or include it in your `.bazelrc`
+file:
+
+```bash
+bazel build --copt=-DGRPC_BAZEL_BUILD ...
+```
+
+### Windows
+
+To correctly configure the MSVC runtime you should change the CMake minimum
+required version to 3.15 or add `-DCMAKE_POLICY_DEFAULT_CMP0091=NEW` to the
+CMake configuration step.
+
+Bazel tends to create very long file names and paths. You may need to use a
+short directory to store the build output, such as `c:\b`, and instruct Bazel
+to use it via:
+
+```shell
+bazel --output_user_root=c:\b build ...
+```
+
+gRPC [requires][grpc-roots-pem-bug] an environment variable to configure the
+trust store for SSL certificates, you can download and configure this using:
+
+```console
+@powershell -NoProfile -ExecutionPolicy unrestricted -Command ^
+    (new-object System.Net.WebClient).Downloadfile( ^
+        'https://pki.google.com/roots.pem', 'roots.pem')
+set GRPC_DEFAULT_SSL_ROOTS_FILE_PATH=%cd%\roots.pem
+```
+
+[bazel-install]: https://docs.bazel.build/versions/main/install.html
+[quickstart-link]: https://cloud.google.com/tasks/docs
+[grpc-roots-pem-bug]: https://github.com/grpc/grpc/issues/16571
+[choco-cmake-link]: https://chocolatey.org/packages/cmake
+[homebrew-cmake-link]: https://formulae.brew.sh/formula/cmake
+[cmake-download-link]: https://cmake.org/download/
+[bazel-grpc-macos-bug]: https://github.com/bazelbuild/bazel/issues/4341
+[authentication-quickstart]: https://cloud.google.com/docs/authentication/getting-started 'Authentication Getting Started'

--- a/google/cloud/tasks/quickstart/WORKSPACE
+++ b/google/cloud/tasks/quickstart/WORKSPACE
@@ -1,0 +1,51 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A minimal WORKSPACE file showing how to use the Cloud Tasks API C++
+# client library in Bazel-based projects.
+workspace(name = "tasks_quickstart")
+
+# Add the necessary Starlark functions to fetch google-cloud-cpp.
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+# Fetch the Google Cloud C++ libraries.
+# NOTE: Update this version and SHA256 as needed.
+http_archive(
+    name = "com_github_googleapis_google_cloud_cpp",
+    sha256 = "b024dfde34efd328001d6446e1416fa008caa40d9020c424a8f8a3711061af35",
+    strip_prefix = "google-cloud-cpp-1.33.0",
+    url = "https://github.com/googleapis/google-cloud-cpp/archive/v1.33.0.tar.gz",
+)
+
+# Load indirect dependencies due to
+#     https://github.com/bazelbuild/bazel/issues/1943
+load("@com_github_googleapis_google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+
+google_cloud_cpp_deps()
+
+load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+
+switched_rules_by_language(
+    name = "com_google_googleapis_imports",
+    cc = True,
+    grpc = True,
+)
+
+load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+
+grpc_deps()
+
+load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+
+grpc_extra_deps()

--- a/google/cloud/tasks/quickstart/quickstart.cc
+++ b/google/cloud/tasks/quickstart/quickstart.cc
@@ -1,0 +1,37 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/tasks/cloud_tasks_client.h"
+#include <iostream>
+#include <stdexcept>
+
+int main(int argc, char* argv[]) try {
+  if (argc != 3) {
+    std::cerr << "Usage: " << argv[0] << " project-id location\n";
+    return 1;
+  }
+
+  namespace tasks = ::google::cloud::tasks;
+  auto client = tasks::CloudTasksClient(tasks::MakeCloudTasksConnection());
+  auto const parent =
+      std::string("projects/") + argv[1] + "/locations/" + argv[2];
+  for (auto const& queue : client.ListQueues(parent)) {
+    std::cout << queue.value().DebugString() << "\n";
+  }
+
+  return 0;
+} catch (std::exception const& ex) {
+  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+  return 1;
+}


### PR DESCRIPTION
Modify the generator to also create a scaffold for the quickstart
program. Then I used the generator to create the scaffold for the
`logging`, `pubsublite`, `secretmanager`, and `tasks` libraries.

The generated code requires some editing, but these are fairly small.

These quickstarts are compiled in the `cmake-install` build, where we
can compile them in parallel. This was very useful, it found several
bugs in the generated CMake files.

Sorry for the gigantic PR.  Most of it is generated code, I think you
should pay attention to:

* Anything in `generator/`
* `google/cloud/*/doc/main.dox` had some light editing
* `google/cloud/*/quickstart/README.md` has some light editing
* `google/cloud/*/quickstart/quickstart.cc` has some significant editing
* Other files in `google/cloud/*/quickstart/*` are generated

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7676)
<!-- Reviewable:end -->
