### PR TITLE
feat(generator): add options support to generated clients

### DIFF
--- a/ci/cloudbuild/builds/cmake-install.sh
+++ b/ci/cloudbuild/builds/cmake-install.sh
@@ -51,6 +51,9 @@ mapfile -t actual_dirs < <(env -C "${INSTALL_PREFIX}" find -type d)
 mapfile -t expected_dirs < <(cat ci/etc/expected_install_directories)
 expected_dirs+=(
   ./include/google/api
+  ./include/google/bigtable
+  ./include/google/bigtable/admin
+  ./include/google/bigtable/admin/v2
   ./include/google/bigtable/v2
   ./include/google/cloud/bigquery/connection
   ./include/google/cloud/bigquery/connection/v1
@@ -62,6 +65,7 @@ expected_dirs+=(
   ./include/google/cloud/bigquery/reservation
   ./include/google/cloud/bigquery/reservation/v1
   ./include/google/cloud/bigquery/v2
+  ./include/google/cloud/bigtable
   ./include/google/cloud/bigtable/internal
   ./include/google/cloud/dialogflow
   ./include/google/cloud/dialogflow/v2

--- a/ci/etc/expected_install_directories
+++ b/ci/etc/expected_install_directories
@@ -1,16 +1,12 @@
 .
 ./include
 ./include/google
-./include/google/bigtable
-./include/google/bigtable/admin
-./include/google/bigtable/admin/v2
 ./include/google/cloud
 ./include/google/cloud/bigquery
 ./include/google/cloud/bigquery/internal
 ./include/google/cloud/bigquery/mocks
 ./include/google/cloud/bigquery/storage
 ./include/google/cloud/bigquery/storage/v1
-./include/google/cloud/bigtable
 ./include/google/cloud/iam
 ./include/google/cloud/iam/internal
 ./include/google/cloud/iam/mocks

--- a/generator/integration_tests/golden/golden_kitchen_sink_client.cc
+++ b/generator/integration_tests/golden/golden_kitchen_sink_client.cc
@@ -17,6 +17,7 @@
 // source: generator/integration_tests/test.proto
 
 #include "generator/integration_tests/golden/golden_kitchen_sink_client.h"
+#include "generator/integration_tests/golden/internal/golden_kitchen_sink_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -24,11 +25,12 @@ namespace cloud {
 namespace golden {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-GoldenKitchenSinkClient::GoldenKitchenSinkClient(std::shared_ptr<GoldenKitchenSinkConnection> connection) : connection_(std::move(connection)) {}
+GoldenKitchenSinkClient::GoldenKitchenSinkClient(std::shared_ptr<GoldenKitchenSinkConnection> connection, Options options) : connection_(std::move(connection)), options_(golden_internal::GoldenKitchenSinkDefaultOptions(std::move(options))) {}
 GoldenKitchenSinkClient::~GoldenKitchenSinkClient() = default;
 
 StatusOr<google::test::admin::database::v1::GenerateAccessTokenResponse>
-GoldenKitchenSinkClient::GenerateAccessToken(std::string const& name, std::vector<std::string> const& delegates, std::vector<std::string> const& scope, google::protobuf::Duration const& lifetime) {
+GoldenKitchenSinkClient::GenerateAccessToken(std::string const& name, std::vector<std::string> const& delegates, std::vector<std::string> const& scope, google::protobuf::Duration const& lifetime, Options options) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
   google::test::admin::database::v1::GenerateAccessTokenRequest request;
   request.set_name(name);
   *request.mutable_delegates() = {delegates.begin(), delegates.end()};
@@ -38,7 +40,8 @@ GoldenKitchenSinkClient::GenerateAccessToken(std::string const& name, std::vecto
 }
 
 StatusOr<google::test::admin::database::v1::GenerateIdTokenResponse>
-GoldenKitchenSinkClient::GenerateIdToken(std::string const& name, std::vector<std::string> const& delegates, std::string const& audience, bool include_email) {
+GoldenKitchenSinkClient::GenerateIdToken(std::string const& name, std::vector<std::string> const& delegates, std::string const& audience, bool include_email, Options options) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
   google::test::admin::database::v1::GenerateIdTokenRequest request;
   request.set_name(name);
   *request.mutable_delegates() = {delegates.begin(), delegates.end()};
@@ -48,7 +51,8 @@ GoldenKitchenSinkClient::GenerateIdToken(std::string const& name, std::vector<st
 }
 
 StatusOr<google::test::admin::database::v1::WriteLogEntriesResponse>
-GoldenKitchenSinkClient::WriteLogEntries(std::string const& log_name, std::map<std::string, std::string> const& labels) {
+GoldenKitchenSinkClient::WriteLogEntries(std::string const& log_name, std::map<std::string, std::string> const& labels, Options options) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
   google::test::admin::database::v1::WriteLogEntriesRequest request;
   request.set_log_name(log_name);
   *request.mutable_labels() = {labels.begin(), labels.end()};
@@ -56,21 +60,24 @@ GoldenKitchenSinkClient::WriteLogEntries(std::string const& log_name, std::map<s
 }
 
 StreamRange<std::string>
-GoldenKitchenSinkClient::ListLogs(std::string const& parent) {
+GoldenKitchenSinkClient::ListLogs(std::string const& parent, Options options) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
   google::test::admin::database::v1::ListLogsRequest request;
   request.set_parent(parent);
   return connection_->ListLogs(request);
 }
 
 StreamRange<google::test::admin::database::v1::TailLogEntriesResponse>
-GoldenKitchenSinkClient::TailLogEntries(std::vector<std::string> const& resource_names) {
+GoldenKitchenSinkClient::TailLogEntries(std::vector<std::string> const& resource_names, Options options) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
   google::test::admin::database::v1::TailLogEntriesRequest request;
   *request.mutable_resource_names() = {resource_names.begin(), resource_names.end()};
   return connection_->TailLogEntries(request);
 }
 
 StatusOr<google::test::admin::database::v1::ListServiceAccountKeysResponse>
-GoldenKitchenSinkClient::ListServiceAccountKeys(std::string const& name, std::vector<google::test::admin::database::v1::ListServiceAccountKeysRequest::KeyType> const& key_types) {
+GoldenKitchenSinkClient::ListServiceAccountKeys(std::string const& name, std::vector<google::test::admin::database::v1::ListServiceAccountKeysRequest::KeyType> const& key_types, Options options) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
   google::test::admin::database::v1::ListServiceAccountKeysRequest request;
   request.set_name(name);
   *request.mutable_key_types() = {key_types.begin(), key_types.end()};
@@ -78,32 +85,38 @@ GoldenKitchenSinkClient::ListServiceAccountKeys(std::string const& name, std::ve
 }
 
 StatusOr<google::test::admin::database::v1::GenerateAccessTokenResponse>
-GoldenKitchenSinkClient::GenerateAccessToken(google::test::admin::database::v1::GenerateAccessTokenRequest const& request) {
+GoldenKitchenSinkClient::GenerateAccessToken(google::test::admin::database::v1::GenerateAccessTokenRequest const& request, Options options) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
   return connection_->GenerateAccessToken(request);
 }
 
 StatusOr<google::test::admin::database::v1::GenerateIdTokenResponse>
-GoldenKitchenSinkClient::GenerateIdToken(google::test::admin::database::v1::GenerateIdTokenRequest const& request) {
+GoldenKitchenSinkClient::GenerateIdToken(google::test::admin::database::v1::GenerateIdTokenRequest const& request, Options options) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
   return connection_->GenerateIdToken(request);
 }
 
 StatusOr<google::test::admin::database::v1::WriteLogEntriesResponse>
-GoldenKitchenSinkClient::WriteLogEntries(google::test::admin::database::v1::WriteLogEntriesRequest const& request) {
+GoldenKitchenSinkClient::WriteLogEntries(google::test::admin::database::v1::WriteLogEntriesRequest const& request, Options options) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
   return connection_->WriteLogEntries(request);
 }
 
 StreamRange<std::string>
-GoldenKitchenSinkClient::ListLogs(google::test::admin::database::v1::ListLogsRequest request) {
+GoldenKitchenSinkClient::ListLogs(google::test::admin::database::v1::ListLogsRequest request, Options options) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
   return connection_->ListLogs(std::move(request));
 }
 
 StreamRange<google::test::admin::database::v1::TailLogEntriesResponse>
-GoldenKitchenSinkClient::TailLogEntries(google::test::admin::database::v1::TailLogEntriesRequest const& request) {
+GoldenKitchenSinkClient::TailLogEntries(google::test::admin::database::v1::TailLogEntriesRequest const& request, Options options) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
   return connection_->TailLogEntries(request);
 }
 
 StatusOr<google::test::admin::database::v1::ListServiceAccountKeysResponse>
-GoldenKitchenSinkClient::ListServiceAccountKeys(google::test::admin::database::v1::ListServiceAccountKeysRequest const& request) {
+GoldenKitchenSinkClient::ListServiceAccountKeys(google::test::admin::database::v1::ListServiceAccountKeysRequest const& request, Options options) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
   return connection_->ListServiceAccountKeys(request);
 }
 

--- a/generator/integration_tests/golden/golden_kitchen_sink_client.h
+++ b/generator/integration_tests/golden/golden_kitchen_sink_client.h
@@ -21,6 +21,7 @@
 
 #include "generator/integration_tests/golden/golden_kitchen_sink_connection.h"
 #include "google/cloud/future.h"
+#include "google/cloud/options.h"
 #include "google/cloud/polling_policy.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
@@ -69,7 +70,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 ///
 class GoldenKitchenSinkClient {
  public:
-  explicit GoldenKitchenSinkClient(std::shared_ptr<GoldenKitchenSinkConnection> connection);
+  explicit GoldenKitchenSinkClient(std::shared_ptr<GoldenKitchenSinkConnection> connection, Options options = {});
   ~GoldenKitchenSinkClient();
 
   //@{
@@ -120,7 +121,7 @@ class GoldenKitchenSinkClient {
   /// [google.test.admin.database.v1.GenerateAccessTokenResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L872}
   ///
   StatusOr<google::test::admin::database::v1::GenerateAccessTokenResponse>
-  GenerateAccessToken(std::string const& name, std::vector<std::string> const& delegates, std::vector<std::string> const& scope, google::protobuf::Duration const& lifetime);
+  GenerateAccessToken(std::string const& name, std::vector<std::string> const& delegates, std::vector<std::string> const& scope, google::protobuf::Duration const& lifetime, Options options = {});
 
   ///
   /// Generates an OpenID Connect ID token for a service account.
@@ -148,7 +149,7 @@ class GoldenKitchenSinkClient {
   /// [google.test.admin.database.v1.GenerateIdTokenResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L914}
   ///
   StatusOr<google::test::admin::database::v1::GenerateIdTokenResponse>
-  GenerateIdToken(std::string const& name, std::vector<std::string> const& delegates, std::string const& audience, bool include_email);
+  GenerateIdToken(std::string const& name, std::vector<std::string> const& delegates, std::string const& audience, bool include_email, Options options = {});
 
   ///
   /// Writes log entries to Logging. This API method is the
@@ -182,7 +183,7 @@ class GoldenKitchenSinkClient {
   /// [google.test.admin.database.v1.WriteLogEntriesResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L953}
   ///
   StatusOr<google::test::admin::database::v1::WriteLogEntriesResponse>
-  WriteLogEntries(std::string const& log_name, std::map<std::string, std::string> const& labels);
+  WriteLogEntries(std::string const& log_name, std::map<std::string, std::string> const& labels, Options options = {});
 
   ///
   /// Lists the logs in projects, organizations, folders, or billing accounts.
@@ -198,7 +199,7 @@ class GoldenKitchenSinkClient {
   /// [google.test.admin.database.v1.ListLogsRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L956}
   ///
   StreamRange<std::string>
-  ListLogs(std::string const& parent);
+  ListLogs(std::string const& parent, Options options = {});
 
   ///
   /// Streaming read of log entries as they are ingested. Until the stream is
@@ -220,7 +221,7 @@ class GoldenKitchenSinkClient {
   /// [google.test.admin.database.v1.TailLogEntriesResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1214}
   ///
   StreamRange<google::test::admin::database::v1::TailLogEntriesResponse>
-  TailLogEntries(std::vector<std::string> const& resource_names);
+  TailLogEntries(std::vector<std::string> const& resource_names, Options options = {});
 
   ///
   /// Lists every [ServiceAccountKey][google.iam.admin.v1.ServiceAccountKey] for a service account.
@@ -239,7 +240,7 @@ class GoldenKitchenSinkClient {
   /// [google.test.admin.database.v1.ListServiceAccountKeysResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1286}
   ///
   StatusOr<google::test::admin::database::v1::ListServiceAccountKeysResponse>
-  ListServiceAccountKeys(std::string const& name, std::vector<google::test::admin::database::v1::ListServiceAccountKeysRequest::KeyType> const& key_types);
+  ListServiceAccountKeys(std::string const& name, std::vector<google::test::admin::database::v1::ListServiceAccountKeysRequest::KeyType> const& key_types, Options options = {});
 
   ///
   /// Generates an OAuth 2.0 access token for a service account.
@@ -251,7 +252,7 @@ class GoldenKitchenSinkClient {
   /// [google.test.admin.database.v1.GenerateAccessTokenResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L872}
   ///
   StatusOr<google::test::admin::database::v1::GenerateAccessTokenResponse>
-  GenerateAccessToken(google::test::admin::database::v1::GenerateAccessTokenRequest const& request);
+  GenerateAccessToken(google::test::admin::database::v1::GenerateAccessTokenRequest const& request, Options options = {});
 
   ///
   /// Generates an OpenID Connect ID token for a service account.
@@ -263,7 +264,7 @@ class GoldenKitchenSinkClient {
   /// [google.test.admin.database.v1.GenerateIdTokenResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L914}
   ///
   StatusOr<google::test::admin::database::v1::GenerateIdTokenResponse>
-  GenerateIdToken(google::test::admin::database::v1::GenerateIdTokenRequest const& request);
+  GenerateIdToken(google::test::admin::database::v1::GenerateIdTokenRequest const& request, Options options = {});
 
   ///
   /// Writes log entries to Logging. This API method is the
@@ -281,7 +282,7 @@ class GoldenKitchenSinkClient {
   /// [google.test.admin.database.v1.WriteLogEntriesResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L953}
   ///
   StatusOr<google::test::admin::database::v1::WriteLogEntriesResponse>
-  WriteLogEntries(google::test::admin::database::v1::WriteLogEntriesRequest const& request);
+  WriteLogEntries(google::test::admin::database::v1::WriteLogEntriesRequest const& request, Options options = {});
 
   ///
   /// Lists the logs in projects, organizations, folders, or billing accounts.
@@ -293,7 +294,7 @@ class GoldenKitchenSinkClient {
   /// [google.test.admin.database.v1.ListLogsRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L956}
   ///
   StreamRange<std::string>
-  ListLogs(google::test::admin::database::v1::ListLogsRequest request);
+  ListLogs(google::test::admin::database::v1::ListLogsRequest request, Options options = {});
 
   ///
   /// Streaming read of log entries as they are ingested. Until the stream is
@@ -306,7 +307,7 @@ class GoldenKitchenSinkClient {
   /// [google.test.admin.database.v1.TailLogEntriesResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1214}
   ///
   StreamRange<google::test::admin::database::v1::TailLogEntriesResponse>
-  TailLogEntries(google::test::admin::database::v1::TailLogEntriesRequest const& request);
+  TailLogEntries(google::test::admin::database::v1::TailLogEntriesRequest const& request, Options options = {});
 
   ///
   /// Lists every [ServiceAccountKey][google.iam.admin.v1.ServiceAccountKey] for a service account.
@@ -318,10 +319,11 @@ class GoldenKitchenSinkClient {
   /// [google.test.admin.database.v1.ListServiceAccountKeysResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1286}
   ///
   StatusOr<google::test::admin::database::v1::ListServiceAccountKeysResponse>
-  ListServiceAccountKeys(google::test::admin::database::v1::ListServiceAccountKeysRequest const& request);
+  ListServiceAccountKeys(google::test::admin::database::v1::ListServiceAccountKeysRequest const& request, Options options = {});
 
  private:
   std::shared_ptr<GoldenKitchenSinkConnection> connection_;
+  Options options_;
 };
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/generator/integration_tests/golden/golden_kitchen_sink_client.h
+++ b/generator/integration_tests/golden/golden_kitchen_sink_client.h
@@ -115,6 +115,7 @@ class GoldenKitchenSinkClient {
   ///  Must be set to a value less than or equal to 3600 (1 hour). If a value is
   ///  not specified, the token's lifetime will be set to a default value of one
   ///  hour.
+  /// @param options  Optional. Operation options.
   /// @return @googleapis_link{google::test::admin::database::v1::GenerateAccessTokenResponse,generator/integration_tests/test.proto#L872}
   ///
   /// [google.test.admin.database.v1.GenerateAccessTokenRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L835}
@@ -143,6 +144,7 @@ class GoldenKitchenSinkClient {
   ///  grants access to.
   /// @param include_email  Include the service account email in the token. If set to `true`, the
   ///  token will contain `email` and `email_verified` claims.
+  /// @param options  Optional. Operation options.
   /// @return @googleapis_link{google::test::admin::database::v1::GenerateIdTokenResponse,generator/integration_tests/test.proto#L914}
   ///
   /// [google.test.admin.database.v1.GenerateIdTokenRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L881}
@@ -177,6 +179,7 @@ class GoldenKitchenSinkClient {
   ///  entries in `entries`. If a log entry already has a label with the same key
   ///  as a label in this parameter, then the log entry's label is not changed.
   ///  See [LogEntry][google.logging.v2.LogEntry]. Test delimiter$
+  /// @param options  Optional. Operation options.
   /// @return @googleapis_link{google::test::admin::database::v1::WriteLogEntriesResponse,generator/integration_tests/test.proto#L953}
   ///
   /// [google.test.admin.database.v1.WriteLogEntriesRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L920}
@@ -194,6 +197,7 @@ class GoldenKitchenSinkClient {
   ///      "organizations/[ORGANIZATION_ID]"
   ///      "billingAccounts/[BILLING_ACCOUNT_ID]"
   ///      "folders/[FOLDER_ID]"
+  /// @param options  Optional. Operation options.
   /// @return std::string
   ///
   /// [google.test.admin.database.v1.ListLogsRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L956}
@@ -215,6 +219,7 @@ class GoldenKitchenSinkClient {
   ///      "organization/[ORGANIZATION_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]"
   ///      "billingAccounts/[BILLING_ACCOUNT_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]"
   ///      "folders/[FOLDER_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]"
+  /// @param options  Optional. Operation options.
   /// @return @googleapis_link{google::test::admin::database::v1::TailLogEntriesResponse,generator/integration_tests/test.proto#L1214}
   ///
   /// [google.test.admin.database.v1.TailLogEntriesRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1182}
@@ -234,6 +239,7 @@ class GoldenKitchenSinkClient {
   /// @param key_types  Filters the types of keys the user wants to include in the list
   ///  response. Duplicate key types are not allowed. If no key type
   ///  is provided, all keys are returned.
+  /// @param options  Optional. Operation options.
   /// @return @googleapis_link{google::test::admin::database::v1::ListServiceAccountKeysResponse,generator/integration_tests/test.proto#L1286}
   ///
   /// [google.test.admin.database.v1.ListServiceAccountKeysRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1254}
@@ -246,6 +252,7 @@ class GoldenKitchenSinkClient {
   /// Generates an OAuth 2.0 access token for a service account.
   ///
   /// @param request @googleapis_link{google::test::admin::database::v1::GenerateAccessTokenRequest,generator/integration_tests/test.proto#L835}
+  /// @param options  Optional. Operation options.
   /// @return @googleapis_link{google::test::admin::database::v1::GenerateAccessTokenResponse,generator/integration_tests/test.proto#L872}
   ///
   /// [google.test.admin.database.v1.GenerateAccessTokenRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L835}
@@ -258,6 +265,7 @@ class GoldenKitchenSinkClient {
   /// Generates an OpenID Connect ID token for a service account.
   ///
   /// @param request @googleapis_link{google::test::admin::database::v1::GenerateIdTokenRequest,generator/integration_tests/test.proto#L881}
+  /// @param options  Optional. Operation options.
   /// @return @googleapis_link{google::test::admin::database::v1::GenerateIdTokenResponse,generator/integration_tests/test.proto#L914}
   ///
   /// [google.test.admin.database.v1.GenerateIdTokenRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L881}
@@ -276,6 +284,7 @@ class GoldenKitchenSinkClient {
   /// folders)
   ///
   /// @param request @googleapis_link{google::test::admin::database::v1::WriteLogEntriesRequest,generator/integration_tests/test.proto#L920}
+  /// @param options  Optional. Operation options.
   /// @return @googleapis_link{google::test::admin::database::v1::WriteLogEntriesResponse,generator/integration_tests/test.proto#L953}
   ///
   /// [google.test.admin.database.v1.WriteLogEntriesRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L920}
@@ -289,6 +298,7 @@ class GoldenKitchenSinkClient {
   /// Only logs that have entries are listed.
   ///
   /// @param request @googleapis_link{google::test::admin::database::v1::ListLogsRequest,generator/integration_tests/test.proto#L956}
+  /// @param options  Optional. Operation options.
   /// @return std::string
   ///
   /// [google.test.admin.database.v1.ListLogsRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L956}
@@ -301,6 +311,7 @@ class GoldenKitchenSinkClient {
   /// terminated, it will continue reading logs.
   ///
   /// @param request @googleapis_link{google::test::admin::database::v1::TailLogEntriesRequest,generator/integration_tests/test.proto#L1182}
+  /// @param options  Optional. Operation options.
   /// @return @googleapis_link{google::test::admin::database::v1::TailLogEntriesResponse,generator/integration_tests/test.proto#L1214}
   ///
   /// [google.test.admin.database.v1.TailLogEntriesRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1182}
@@ -313,6 +324,7 @@ class GoldenKitchenSinkClient {
   /// Lists every [ServiceAccountKey][google.iam.admin.v1.ServiceAccountKey] for a service account.
   ///
   /// @param request @googleapis_link{google::test::admin::database::v1::ListServiceAccountKeysRequest,generator/integration_tests/test.proto#L1254}
+  /// @param options  Optional. Operation options.
   /// @return @googleapis_link{google::test::admin::database::v1::ListServiceAccountKeysResponse,generator/integration_tests/test.proto#L1286}
   ///
   /// [google.test.admin.database.v1.ListServiceAccountKeysRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1254}

--- a/generator/integration_tests/golden/golden_thing_admin_client.cc
+++ b/generator/integration_tests/golden/golden_thing_admin_client.cc
@@ -17,9 +17,9 @@
 // source: generator/integration_tests/test.proto
 
 #include "generator/integration_tests/golden/golden_thing_admin_client.h"
+#include "generator/integration_tests/golden/internal/golden_thing_admin_option_defaults.h"
 #include <memory>
 #include "generator/integration_tests/golden/golden_thing_admin_options.h"
-#include "generator/integration_tests/golden/internal/golden_thing_admin_option_defaults.h"
 #include <thread>
 
 namespace google {
@@ -27,18 +27,20 @@ namespace cloud {
 namespace golden {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-GoldenThingAdminClient::GoldenThingAdminClient(std::shared_ptr<GoldenThingAdminConnection> connection) : connection_(std::move(connection)) {}
+GoldenThingAdminClient::GoldenThingAdminClient(std::shared_ptr<GoldenThingAdminConnection> connection, Options options) : connection_(std::move(connection)), options_(golden_internal::GoldenThingAdminDefaultOptions(std::move(options))) {}
 GoldenThingAdminClient::~GoldenThingAdminClient() = default;
 
 StreamRange<google::test::admin::database::v1::Database>
-GoldenThingAdminClient::ListDatabases(std::string const& parent) {
+GoldenThingAdminClient::ListDatabases(std::string const& parent, Options options) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
   google::test::admin::database::v1::ListDatabasesRequest request;
   request.set_parent(parent);
   return connection_->ListDatabases(request);
 }
 
 future<StatusOr<google::test::admin::database::v1::Database>>
-GoldenThingAdminClient::CreateDatabase(std::string const& parent, std::string const& create_statement) {
+GoldenThingAdminClient::CreateDatabase(std::string const& parent, std::string const& create_statement, Options options) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
   google::test::admin::database::v1::CreateDatabaseRequest request;
   request.set_parent(parent);
   request.set_create_statement(create_statement);
@@ -46,14 +48,16 @@ GoldenThingAdminClient::CreateDatabase(std::string const& parent, std::string co
 }
 
 StatusOr<google::test::admin::database::v1::Database>
-GoldenThingAdminClient::GetDatabase(std::string const& name) {
+GoldenThingAdminClient::GetDatabase(std::string const& name, Options options) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
   google::test::admin::database::v1::GetDatabaseRequest request;
   request.set_name(name);
   return connection_->GetDatabase(request);
 }
 
 future<StatusOr<google::test::admin::database::v1::UpdateDatabaseDdlMetadata>>
-GoldenThingAdminClient::UpdateDatabaseDdl(std::string const& database, std::vector<std::string> const& statements) {
+GoldenThingAdminClient::UpdateDatabaseDdl(std::string const& database, std::vector<std::string> const& statements, Options options) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
   google::test::admin::database::v1::UpdateDatabaseDdlRequest request;
   request.set_database(database);
   *request.mutable_statements() = {statements.begin(), statements.end()};
@@ -61,21 +65,24 @@ GoldenThingAdminClient::UpdateDatabaseDdl(std::string const& database, std::vect
 }
 
 Status
-GoldenThingAdminClient::DropDatabase(std::string const& database) {
+GoldenThingAdminClient::DropDatabase(std::string const& database, Options options) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
   google::test::admin::database::v1::DropDatabaseRequest request;
   request.set_database(database);
   return connection_->DropDatabase(request);
 }
 
 StatusOr<google::test::admin::database::v1::GetDatabaseDdlResponse>
-GoldenThingAdminClient::GetDatabaseDdl(std::string const& database) {
+GoldenThingAdminClient::GetDatabaseDdl(std::string const& database, Options options) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
   google::test::admin::database::v1::GetDatabaseDdlRequest request;
   request.set_database(database);
   return connection_->GetDatabaseDdl(request);
 }
 
 StatusOr<google::iam::v1::Policy>
-GoldenThingAdminClient::SetIamPolicy(std::string const& resource, google::iam::v1::Policy const& policy) {
+GoldenThingAdminClient::SetIamPolicy(std::string const& resource, google::iam::v1::Policy const& policy, Options options) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
   google::iam::v1::SetIamPolicyRequest request;
   request.set_resource(resource);
   *request.mutable_policy() = policy;
@@ -85,8 +92,8 @@ GoldenThingAdminClient::SetIamPolicy(std::string const& resource, google::iam::v
 StatusOr<google::iam::v1::Policy>
 GoldenThingAdminClient::SetIamPolicy(std::string const& resource, IamUpdater const& updater, Options options) {
   internal::CheckExpectedOptions<GoldenThingAdminBackoffPolicyOption>(options, __func__);
-  options = golden_internal::GoldenThingAdminDefaultOptions(std::move(options));
-  auto backoff_policy = options.get<GoldenThingAdminBackoffPolicyOption>()->clone();
+  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
+  auto backoff_policy = internal::CurrentOptions().get<GoldenThingAdminBackoffPolicyOption>()->clone();
   for (;;) {
     auto recent = GetIamPolicy(resource);
     if (!recent) {
@@ -105,14 +112,16 @@ GoldenThingAdminClient::SetIamPolicy(std::string const& resource, IamUpdater con
 }
 
 StatusOr<google::iam::v1::Policy>
-GoldenThingAdminClient::GetIamPolicy(std::string const& resource) {
+GoldenThingAdminClient::GetIamPolicy(std::string const& resource, Options options) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
   google::iam::v1::GetIamPolicyRequest request;
   request.set_resource(resource);
   return connection_->GetIamPolicy(request);
 }
 
 StatusOr<google::iam::v1::TestIamPermissionsResponse>
-GoldenThingAdminClient::TestIamPermissions(std::string const& resource, std::vector<std::string> const& permissions) {
+GoldenThingAdminClient::TestIamPermissions(std::string const& resource, std::vector<std::string> const& permissions, Options options) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
   google::iam::v1::TestIamPermissionsRequest request;
   request.set_resource(resource);
   *request.mutable_permissions() = {permissions.begin(), permissions.end()};
@@ -120,7 +129,8 @@ GoldenThingAdminClient::TestIamPermissions(std::string const& resource, std::vec
 }
 
 future<StatusOr<google::test::admin::database::v1::Backup>>
-GoldenThingAdminClient::CreateBackup(std::string const& parent, google::test::admin::database::v1::Backup const& backup, std::string const& backup_id) {
+GoldenThingAdminClient::CreateBackup(std::string const& parent, google::test::admin::database::v1::Backup const& backup, std::string const& backup_id, Options options) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
   google::test::admin::database::v1::CreateBackupRequest request;
   request.set_parent(parent);
   *request.mutable_backup() = backup;
@@ -129,14 +139,16 @@ GoldenThingAdminClient::CreateBackup(std::string const& parent, google::test::ad
 }
 
 StatusOr<google::test::admin::database::v1::Backup>
-GoldenThingAdminClient::GetBackup(std::string const& name) {
+GoldenThingAdminClient::GetBackup(std::string const& name, Options options) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
   google::test::admin::database::v1::GetBackupRequest request;
   request.set_name(name);
   return connection_->GetBackup(request);
 }
 
 StatusOr<google::test::admin::database::v1::Backup>
-GoldenThingAdminClient::UpdateBackup(google::test::admin::database::v1::Backup const& backup, google::protobuf::FieldMask const& update_mask) {
+GoldenThingAdminClient::UpdateBackup(google::test::admin::database::v1::Backup const& backup, google::protobuf::FieldMask const& update_mask, Options options) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
   google::test::admin::database::v1::UpdateBackupRequest request;
   *request.mutable_backup() = backup;
   *request.mutable_update_mask() = update_mask;
@@ -144,21 +156,24 @@ GoldenThingAdminClient::UpdateBackup(google::test::admin::database::v1::Backup c
 }
 
 Status
-GoldenThingAdminClient::DeleteBackup(std::string const& name) {
+GoldenThingAdminClient::DeleteBackup(std::string const& name, Options options) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
   google::test::admin::database::v1::DeleteBackupRequest request;
   request.set_name(name);
   return connection_->DeleteBackup(request);
 }
 
 StreamRange<google::test::admin::database::v1::Backup>
-GoldenThingAdminClient::ListBackups(std::string const& parent) {
+GoldenThingAdminClient::ListBackups(std::string const& parent, Options options) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
   google::test::admin::database::v1::ListBackupsRequest request;
   request.set_parent(parent);
   return connection_->ListBackups(request);
 }
 
 future<StatusOr<google::test::admin::database::v1::Database>>
-GoldenThingAdminClient::RestoreDatabase(std::string const& parent, std::string const& database_id, std::string const& backup) {
+GoldenThingAdminClient::RestoreDatabase(std::string const& parent, std::string const& database_id, std::string const& backup, Options options) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
   google::test::admin::database::v1::RestoreDatabaseRequest request;
   request.set_parent(parent);
   request.set_database_id(database_id);
@@ -167,125 +182,148 @@ GoldenThingAdminClient::RestoreDatabase(std::string const& parent, std::string c
 }
 
 StreamRange<google::longrunning::Operation>
-GoldenThingAdminClient::ListDatabaseOperations(std::string const& parent) {
+GoldenThingAdminClient::ListDatabaseOperations(std::string const& parent, Options options) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
   google::test::admin::database::v1::ListDatabaseOperationsRequest request;
   request.set_parent(parent);
   return connection_->ListDatabaseOperations(request);
 }
 
 StreamRange<google::longrunning::Operation>
-GoldenThingAdminClient::ListBackupOperations(std::string const& parent) {
+GoldenThingAdminClient::ListBackupOperations(std::string const& parent, Options options) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
   google::test::admin::database::v1::ListBackupOperationsRequest request;
   request.set_parent(parent);
   return connection_->ListBackupOperations(request);
 }
 
 future<StatusOr<google::test::admin::database::v1::Database>>
-GoldenThingAdminClient::AsyncGetDatabase(std::string const& name) {
+GoldenThingAdminClient::AsyncGetDatabase(std::string const& name, Options options) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
   google::test::admin::database::v1::GetDatabaseRequest request;
   request.set_name(name);
   return connection_->AsyncGetDatabase(request);
 }
 
 future<Status>
-GoldenThingAdminClient::AsyncDropDatabase(std::string const& database) {
+GoldenThingAdminClient::AsyncDropDatabase(std::string const& database, Options options) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
   google::test::admin::database::v1::DropDatabaseRequest request;
   request.set_database(database);
   return connection_->AsyncDropDatabase(request);
 }
 
 StreamRange<google::test::admin::database::v1::Database>
-GoldenThingAdminClient::ListDatabases(google::test::admin::database::v1::ListDatabasesRequest request) {
+GoldenThingAdminClient::ListDatabases(google::test::admin::database::v1::ListDatabasesRequest request, Options options) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
   return connection_->ListDatabases(std::move(request));
 }
 
 future<StatusOr<google::test::admin::database::v1::Database>>
-GoldenThingAdminClient::CreateDatabase(google::test::admin::database::v1::CreateDatabaseRequest const& request) {
+GoldenThingAdminClient::CreateDatabase(google::test::admin::database::v1::CreateDatabaseRequest const& request, Options options) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
   return connection_->CreateDatabase(request);
 }
 
 StatusOr<google::test::admin::database::v1::Database>
-GoldenThingAdminClient::GetDatabase(google::test::admin::database::v1::GetDatabaseRequest const& request) {
+GoldenThingAdminClient::GetDatabase(google::test::admin::database::v1::GetDatabaseRequest const& request, Options options) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
   return connection_->GetDatabase(request);
 }
 
 future<StatusOr<google::test::admin::database::v1::UpdateDatabaseDdlMetadata>>
-GoldenThingAdminClient::UpdateDatabaseDdl(google::test::admin::database::v1::UpdateDatabaseDdlRequest const& request) {
+GoldenThingAdminClient::UpdateDatabaseDdl(google::test::admin::database::v1::UpdateDatabaseDdlRequest const& request, Options options) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
   return connection_->UpdateDatabaseDdl(request);
 }
 
 Status
-GoldenThingAdminClient::DropDatabase(google::test::admin::database::v1::DropDatabaseRequest const& request) {
+GoldenThingAdminClient::DropDatabase(google::test::admin::database::v1::DropDatabaseRequest const& request, Options options) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
   return connection_->DropDatabase(request);
 }
 
 StatusOr<google::test::admin::database::v1::GetDatabaseDdlResponse>
-GoldenThingAdminClient::GetDatabaseDdl(google::test::admin::database::v1::GetDatabaseDdlRequest const& request) {
+GoldenThingAdminClient::GetDatabaseDdl(google::test::admin::database::v1::GetDatabaseDdlRequest const& request, Options options) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
   return connection_->GetDatabaseDdl(request);
 }
 
 StatusOr<google::iam::v1::Policy>
-GoldenThingAdminClient::SetIamPolicy(google::iam::v1::SetIamPolicyRequest const& request) {
+GoldenThingAdminClient::SetIamPolicy(google::iam::v1::SetIamPolicyRequest const& request, Options options) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
   return connection_->SetIamPolicy(request);
 }
 
 StatusOr<google::iam::v1::Policy>
-GoldenThingAdminClient::GetIamPolicy(google::iam::v1::GetIamPolicyRequest const& request) {
+GoldenThingAdminClient::GetIamPolicy(google::iam::v1::GetIamPolicyRequest const& request, Options options) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
   return connection_->GetIamPolicy(request);
 }
 
 StatusOr<google::iam::v1::TestIamPermissionsResponse>
-GoldenThingAdminClient::TestIamPermissions(google::iam::v1::TestIamPermissionsRequest const& request) {
+GoldenThingAdminClient::TestIamPermissions(google::iam::v1::TestIamPermissionsRequest const& request, Options options) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
   return connection_->TestIamPermissions(request);
 }
 
 future<StatusOr<google::test::admin::database::v1::Backup>>
-GoldenThingAdminClient::CreateBackup(google::test::admin::database::v1::CreateBackupRequest const& request) {
+GoldenThingAdminClient::CreateBackup(google::test::admin::database::v1::CreateBackupRequest const& request, Options options) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
   return connection_->CreateBackup(request);
 }
 
 StatusOr<google::test::admin::database::v1::Backup>
-GoldenThingAdminClient::GetBackup(google::test::admin::database::v1::GetBackupRequest const& request) {
+GoldenThingAdminClient::GetBackup(google::test::admin::database::v1::GetBackupRequest const& request, Options options) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
   return connection_->GetBackup(request);
 }
 
 StatusOr<google::test::admin::database::v1::Backup>
-GoldenThingAdminClient::UpdateBackup(google::test::admin::database::v1::UpdateBackupRequest const& request) {
+GoldenThingAdminClient::UpdateBackup(google::test::admin::database::v1::UpdateBackupRequest const& request, Options options) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
   return connection_->UpdateBackup(request);
 }
 
 Status
-GoldenThingAdminClient::DeleteBackup(google::test::admin::database::v1::DeleteBackupRequest const& request) {
+GoldenThingAdminClient::DeleteBackup(google::test::admin::database::v1::DeleteBackupRequest const& request, Options options) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
   return connection_->DeleteBackup(request);
 }
 
 StreamRange<google::test::admin::database::v1::Backup>
-GoldenThingAdminClient::ListBackups(google::test::admin::database::v1::ListBackupsRequest request) {
+GoldenThingAdminClient::ListBackups(google::test::admin::database::v1::ListBackupsRequest request, Options options) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
   return connection_->ListBackups(std::move(request));
 }
 
 future<StatusOr<google::test::admin::database::v1::Database>>
-GoldenThingAdminClient::RestoreDatabase(google::test::admin::database::v1::RestoreDatabaseRequest const& request) {
+GoldenThingAdminClient::RestoreDatabase(google::test::admin::database::v1::RestoreDatabaseRequest const& request, Options options) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
   return connection_->RestoreDatabase(request);
 }
 
 StreamRange<google::longrunning::Operation>
-GoldenThingAdminClient::ListDatabaseOperations(google::test::admin::database::v1::ListDatabaseOperationsRequest request) {
+GoldenThingAdminClient::ListDatabaseOperations(google::test::admin::database::v1::ListDatabaseOperationsRequest request, Options options) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
   return connection_->ListDatabaseOperations(std::move(request));
 }
 
 StreamRange<google::longrunning::Operation>
-GoldenThingAdminClient::ListBackupOperations(google::test::admin::database::v1::ListBackupOperationsRequest request) {
+GoldenThingAdminClient::ListBackupOperations(google::test::admin::database::v1::ListBackupOperationsRequest request, Options options) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
   return connection_->ListBackupOperations(std::move(request));
 }
 
 future<StatusOr<google::test::admin::database::v1::Database>>
-GoldenThingAdminClient::AsyncGetDatabase(google::test::admin::database::v1::GetDatabaseRequest const& request) {
+GoldenThingAdminClient::AsyncGetDatabase(google::test::admin::database::v1::GetDatabaseRequest const& request, Options options) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
   return connection_->AsyncGetDatabase(request);
 }
 
 future<Status>
-GoldenThingAdminClient::AsyncDropDatabase(google::test::admin::database::v1::DropDatabaseRequest const& request) {
+GoldenThingAdminClient::AsyncDropDatabase(google::test::admin::database::v1::DropDatabaseRequest const& request, Options options) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
   return connection_->AsyncDropDatabase(request);
 }
 

--- a/generator/integration_tests/golden/golden_thing_admin_client.h
+++ b/generator/integration_tests/golden/golden_thing_admin_client.h
@@ -21,11 +21,11 @@
 
 #include "generator/integration_tests/golden/golden_thing_admin_connection.h"
 #include "google/cloud/future.h"
+#include "google/cloud/options.h"
 #include "google/cloud/polling_policy.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include "google/cloud/iam_updater.h"
-#include "google/cloud/options.h"
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
 
@@ -67,7 +67,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 ///
 class GoldenThingAdminClient {
  public:
-  explicit GoldenThingAdminClient(std::shared_ptr<GoldenThingAdminConnection> connection);
+  explicit GoldenThingAdminClient(std::shared_ptr<GoldenThingAdminConnection> connection, Options options = {});
   ~GoldenThingAdminClient();
 
   //@{
@@ -99,7 +99,7 @@ class GoldenThingAdminClient {
   /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L329}
   ///
   StreamRange<google::test::admin::database::v1::Database>
-  ListDatabases(std::string const& parent);
+  ListDatabases(std::string const& parent, Options options = {});
 
   ///
   /// Creates a new Cloud Test database and starts to prepare it for serving.
@@ -124,7 +124,7 @@ class GoldenThingAdminClient {
   /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L329}
   ///
   future<StatusOr<google::test::admin::database::v1::Database>>
-  CreateDatabase(std::string const& parent, std::string const& create_statement);
+  CreateDatabase(std::string const& parent, std::string const& create_statement, Options options = {});
 
   ///
   /// Gets the state of a Cloud Test database.
@@ -137,7 +137,7 @@ class GoldenThingAdminClient {
   /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L329}
   ///
   StatusOr<google::test::admin::database::v1::Database>
-  GetDatabase(std::string const& name);
+  GetDatabase(std::string const& name, Options options = {});
 
   ///
   /// Updates the schema of a Cloud Test database by
@@ -156,7 +156,7 @@ class GoldenThingAdminClient {
   /// [google.test.admin.database.v1.UpdateDatabaseDdlMetadata]: @googleapis_reference_link{generator/integration_tests/test.proto#L506}
   ///
   future<StatusOr<google::test::admin::database::v1::UpdateDatabaseDdlMetadata>>
-  UpdateDatabaseDdl(std::string const& database, std::vector<std::string> const& statements);
+  UpdateDatabaseDdl(std::string const& database, std::vector<std::string> const& statements, Options options = {});
 
   ///
   /// Drops (aka deletes) a Cloud Test database.
@@ -168,7 +168,7 @@ class GoldenThingAdminClient {
   /// [google.test.admin.database.v1.DropDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L523}
   ///
   Status
-  DropDatabase(std::string const& database);
+  DropDatabase(std::string const& database, Options options = {});
 
   ///
   /// Returns the schema of a Cloud Test database as a list of formatted
@@ -182,7 +182,7 @@ class GoldenThingAdminClient {
   /// [google.test.admin.database.v1.GetDatabaseDdlResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L545}
   ///
   StatusOr<google::test::admin::database::v1::GetDatabaseDdlResponse>
-  GetDatabaseDdl(std::string const& database);
+  GetDatabaseDdl(std::string const& database, Options options = {});
 
   ///
   /// Sets the access control policy on a database or backup resource.
@@ -205,7 +205,7 @@ class GoldenThingAdminClient {
   /// [google.iam.v1.Policy]: @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy>
-  SetIamPolicy(std::string const& resource, google::iam::v1::Policy const& policy);
+  SetIamPolicy(std::string const& resource, google::iam::v1::Policy const& policy, Options options = {});
 
   /**
    * Updates the IAM policy for @p resource using an optimistic concurrency
@@ -249,7 +249,7 @@ class GoldenThingAdminClient {
   /// [google.iam.v1.Policy]: @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy>
-  GetIamPolicy(std::string const& resource);
+  GetIamPolicy(std::string const& resource, Options options = {});
 
   ///
   /// Returns permissions that the caller has on the specified database or backup
@@ -275,7 +275,7 @@ class GoldenThingAdminClient {
   /// [google.iam.v1.TestIamPermissionsResponse]: @googleapis_reference_link{google/iam/v1/iam_policy.proto#L141}
   ///
   StatusOr<google::iam::v1::TestIamPermissionsResponse>
-  TestIamPermissions(std::string const& resource, std::vector<std::string> const& permissions);
+  TestIamPermissions(std::string const& resource, std::vector<std::string> const& permissions, Options options = {});
 
   ///
   /// Starts creating a new Cloud Test Backup.
@@ -307,7 +307,7 @@ class GoldenThingAdminClient {
   /// [google.test.admin.database.v1.Backup]: @googleapis_reference_link{generator/integration_tests/backup.proto#L36}
   ///
   future<StatusOr<google::test::admin::database::v1::Backup>>
-  CreateBackup(std::string const& parent, google::test::admin::database::v1::Backup const& backup, std::string const& backup_id);
+  CreateBackup(std::string const& parent, google::test::admin::database::v1::Backup const& backup, std::string const& backup_id, Options options = {});
 
   ///
   /// Gets metadata on a pending or completed [Backup][google.test.admin.database.v1.Backup].
@@ -321,7 +321,7 @@ class GoldenThingAdminClient {
   /// [google.test.admin.database.v1.Backup]: @googleapis_reference_link{generator/integration_tests/backup.proto#L36}
   ///
   StatusOr<google::test::admin::database::v1::Backup>
-  GetBackup(std::string const& name);
+  GetBackup(std::string const& name, Options options = {});
 
   ///
   /// Updates a pending or completed [Backup][google.test.admin.database.v1.Backup].
@@ -341,7 +341,7 @@ class GoldenThingAdminClient {
   /// [google.test.admin.database.v1.Backup]: @googleapis_reference_link{generator/integration_tests/backup.proto#L36}
   ///
   StatusOr<google::test::admin::database::v1::Backup>
-  UpdateBackup(google::test::admin::database::v1::Backup const& backup, google::protobuf::FieldMask const& update_mask);
+  UpdateBackup(google::test::admin::database::v1::Backup const& backup, google::protobuf::FieldMask const& update_mask, Options options = {});
 
   ///
   /// Deletes a pending or completed [Backup][google.test.admin.database.v1.Backup].
@@ -353,7 +353,7 @@ class GoldenThingAdminClient {
   /// [google.test.admin.database.v1.DeleteBackupRequest]: @googleapis_reference_link{generator/integration_tests/backup.proto#L190}
   ///
   Status
-  DeleteBackup(std::string const& name);
+  DeleteBackup(std::string const& name, Options options = {});
 
   ///
   /// Lists completed and pending backups.
@@ -368,7 +368,7 @@ class GoldenThingAdminClient {
   /// [google.test.admin.database.v1.Backup]: @googleapis_reference_link{generator/integration_tests/backup.proto#L36}
   ///
   StreamRange<google::test::admin::database::v1::Backup>
-  ListBackups(std::string const& parent);
+  ListBackups(std::string const& parent, Options options = {});
 
   ///
   /// Create a new database by restoring from a completed backup. The new
@@ -406,7 +406,7 @@ class GoldenThingAdminClient {
   /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L329}
   ///
   future<StatusOr<google::test::admin::database::v1::Database>>
-  RestoreDatabase(std::string const& parent, std::string const& database_id, std::string const& backup);
+  RestoreDatabase(std::string const& parent, std::string const& database_id, std::string const& backup, Options options = {});
 
   ///
   /// Lists database [longrunning-operations][google.longrunning.Operation].
@@ -426,7 +426,7 @@ class GoldenThingAdminClient {
   /// [google.longrunning.Operation]: @googleapis_reference_link{google/longrunning/operations.proto#L128}
   ///
   StreamRange<google::longrunning::Operation>
-  ListDatabaseOperations(std::string const& parent);
+  ListDatabaseOperations(std::string const& parent, Options options = {});
 
   ///
   /// Lists the backup [long-running operations][google.longrunning.Operation] in
@@ -448,7 +448,7 @@ class GoldenThingAdminClient {
   /// [google.longrunning.Operation]: @googleapis_reference_link{google/longrunning/operations.proto#L128}
   ///
   StreamRange<google::longrunning::Operation>
-  ListBackupOperations(std::string const& parent);
+  ListBackupOperations(std::string const& parent, Options options = {});
 
   ///
   /// Gets the state of a Cloud Test database.
@@ -461,7 +461,7 @@ class GoldenThingAdminClient {
   /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L329}
   ///
   future<StatusOr<google::test::admin::database::v1::Database>>
-  AsyncGetDatabase(std::string const& name);
+  AsyncGetDatabase(std::string const& name, Options options = {});
 
   ///
   /// Drops (aka deletes) a Cloud Test database.
@@ -473,7 +473,7 @@ class GoldenThingAdminClient {
   /// [google.test.admin.database.v1.DropDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L523}
   ///
   future<Status>
-  AsyncDropDatabase(std::string const& database);
+  AsyncDropDatabase(std::string const& database, Options options = {});
 
   ///
   /// Lists Cloud Test databases.
@@ -485,7 +485,7 @@ class GoldenThingAdminClient {
   /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L329}
   ///
   StreamRange<google::test::admin::database::v1::Database>
-  ListDatabases(google::test::admin::database::v1::ListDatabasesRequest request);
+  ListDatabases(google::test::admin::database::v1::ListDatabasesRequest request, Options options = {});
 
   ///
   /// Creates a new Cloud Test database and starts to prepare it for serving.
@@ -504,7 +504,7 @@ class GoldenThingAdminClient {
   /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L329}
   ///
   future<StatusOr<google::test::admin::database::v1::Database>>
-  CreateDatabase(google::test::admin::database::v1::CreateDatabaseRequest const& request);
+  CreateDatabase(google::test::admin::database::v1::CreateDatabaseRequest const& request, Options options = {});
 
   ///
   /// Gets the state of a Cloud Test database.
@@ -516,7 +516,7 @@ class GoldenThingAdminClient {
   /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L329}
   ///
   StatusOr<google::test::admin::database::v1::Database>
-  GetDatabase(google::test::admin::database::v1::GetDatabaseRequest const& request);
+  GetDatabase(google::test::admin::database::v1::GetDatabaseRequest const& request, Options options = {});
 
   ///
   /// Updates the schema of a Cloud Test database by
@@ -534,7 +534,7 @@ class GoldenThingAdminClient {
   /// [google.test.admin.database.v1.UpdateDatabaseDdlMetadata]: @googleapis_reference_link{generator/integration_tests/test.proto#L506}
   ///
   future<StatusOr<google::test::admin::database::v1::UpdateDatabaseDdlMetadata>>
-  UpdateDatabaseDdl(google::test::admin::database::v1::UpdateDatabaseDdlRequest const& request);
+  UpdateDatabaseDdl(google::test::admin::database::v1::UpdateDatabaseDdlRequest const& request, Options options = {});
 
   ///
   /// Drops (aka deletes) a Cloud Test database.
@@ -546,7 +546,7 @@ class GoldenThingAdminClient {
   /// [google.test.admin.database.v1.DropDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L523}
   ///
   Status
-  DropDatabase(google::test::admin::database::v1::DropDatabaseRequest const& request);
+  DropDatabase(google::test::admin::database::v1::DropDatabaseRequest const& request, Options options = {});
 
   ///
   /// Returns the schema of a Cloud Test database as a list of formatted
@@ -560,7 +560,7 @@ class GoldenThingAdminClient {
   /// [google.test.admin.database.v1.GetDatabaseDdlResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L545}
   ///
   StatusOr<google::test::admin::database::v1::GetDatabaseDdlResponse>
-  GetDatabaseDdl(google::test::admin::database::v1::GetDatabaseDdlRequest const& request);
+  GetDatabaseDdl(google::test::admin::database::v1::GetDatabaseDdlRequest const& request, Options options = {});
 
   ///
   /// Sets the access control policy on a database or backup resource.
@@ -578,7 +578,7 @@ class GoldenThingAdminClient {
   /// [google.iam.v1.Policy]: @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy>
-  SetIamPolicy(google::iam::v1::SetIamPolicyRequest const& request);
+  SetIamPolicy(google::iam::v1::SetIamPolicyRequest const& request, Options options = {});
 
   ///
   /// Gets the access control policy for a database or backup resource.
@@ -597,7 +597,7 @@ class GoldenThingAdminClient {
   /// [google.iam.v1.Policy]: @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy>
-  GetIamPolicy(google::iam::v1::GetIamPolicyRequest const& request);
+  GetIamPolicy(google::iam::v1::GetIamPolicyRequest const& request, Options options = {});
 
   ///
   /// Returns permissions that the caller has on the specified database or backup
@@ -618,7 +618,7 @@ class GoldenThingAdminClient {
   /// [google.iam.v1.TestIamPermissionsResponse]: @googleapis_reference_link{google/iam/v1/iam_policy.proto#L141}
   ///
   StatusOr<google::iam::v1::TestIamPermissionsResponse>
-  TestIamPermissions(google::iam::v1::TestIamPermissionsRequest const& request);
+  TestIamPermissions(google::iam::v1::TestIamPermissionsRequest const& request, Options options = {});
 
   ///
   /// Starts creating a new Cloud Test Backup.
@@ -641,7 +641,7 @@ class GoldenThingAdminClient {
   /// [google.test.admin.database.v1.Backup]: @googleapis_reference_link{generator/integration_tests/backup.proto#L36}
   ///
   future<StatusOr<google::test::admin::database::v1::Backup>>
-  CreateBackup(google::test::admin::database::v1::CreateBackupRequest const& request);
+  CreateBackup(google::test::admin::database::v1::CreateBackupRequest const& request, Options options = {});
 
   ///
   /// Gets metadata on a pending or completed [Backup][google.test.admin.database.v1.Backup].
@@ -653,7 +653,7 @@ class GoldenThingAdminClient {
   /// [google.test.admin.database.v1.Backup]: @googleapis_reference_link{generator/integration_tests/backup.proto#L36}
   ///
   StatusOr<google::test::admin::database::v1::Backup>
-  GetBackup(google::test::admin::database::v1::GetBackupRequest const& request);
+  GetBackup(google::test::admin::database::v1::GetBackupRequest const& request, Options options = {});
 
   ///
   /// Updates a pending or completed [Backup][google.test.admin.database.v1.Backup].
@@ -665,7 +665,7 @@ class GoldenThingAdminClient {
   /// [google.test.admin.database.v1.Backup]: @googleapis_reference_link{generator/integration_tests/backup.proto#L36}
   ///
   StatusOr<google::test::admin::database::v1::Backup>
-  UpdateBackup(google::test::admin::database::v1::UpdateBackupRequest const& request);
+  UpdateBackup(google::test::admin::database::v1::UpdateBackupRequest const& request, Options options = {});
 
   ///
   /// Deletes a pending or completed [Backup][google.test.admin.database.v1.Backup].
@@ -675,7 +675,7 @@ class GoldenThingAdminClient {
   /// [google.test.admin.database.v1.DeleteBackupRequest]: @googleapis_reference_link{generator/integration_tests/backup.proto#L190}
   ///
   Status
-  DeleteBackup(google::test::admin::database::v1::DeleteBackupRequest const& request);
+  DeleteBackup(google::test::admin::database::v1::DeleteBackupRequest const& request, Options options = {});
 
   ///
   /// Lists completed and pending backups.
@@ -689,7 +689,7 @@ class GoldenThingAdminClient {
   /// [google.test.admin.database.v1.Backup]: @googleapis_reference_link{generator/integration_tests/backup.proto#L36}
   ///
   StreamRange<google::test::admin::database::v1::Backup>
-  ListBackups(google::test::admin::database::v1::ListBackupsRequest request);
+  ListBackups(google::test::admin::database::v1::ListBackupsRequest request, Options options = {});
 
   ///
   /// Create a new database by restoring from a completed backup. The new
@@ -717,7 +717,7 @@ class GoldenThingAdminClient {
   /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L329}
   ///
   future<StatusOr<google::test::admin::database::v1::Database>>
-  RestoreDatabase(google::test::admin::database::v1::RestoreDatabaseRequest const& request);
+  RestoreDatabase(google::test::admin::database::v1::RestoreDatabaseRequest const& request, Options options = {});
 
   ///
   /// Lists database [longrunning-operations][google.longrunning.Operation].
@@ -736,7 +736,7 @@ class GoldenThingAdminClient {
   /// [google.longrunning.Operation]: @googleapis_reference_link{google/longrunning/operations.proto#L128}
   ///
   StreamRange<google::longrunning::Operation>
-  ListDatabaseOperations(google::test::admin::database::v1::ListDatabaseOperationsRequest request);
+  ListDatabaseOperations(google::test::admin::database::v1::ListDatabaseOperationsRequest request, Options options = {});
 
   ///
   /// Lists the backup [long-running operations][google.longrunning.Operation] in
@@ -757,7 +757,7 @@ class GoldenThingAdminClient {
   /// [google.longrunning.Operation]: @googleapis_reference_link{google/longrunning/operations.proto#L128}
   ///
   StreamRange<google::longrunning::Operation>
-  ListBackupOperations(google::test::admin::database::v1::ListBackupOperationsRequest request);
+  ListBackupOperations(google::test::admin::database::v1::ListBackupOperationsRequest request, Options options = {});
 
   ///
   /// Gets the state of a Cloud Test database.
@@ -769,7 +769,7 @@ class GoldenThingAdminClient {
   /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L329}
   ///
   future<StatusOr<google::test::admin::database::v1::Database>>
-  AsyncGetDatabase(google::test::admin::database::v1::GetDatabaseRequest const& request);
+  AsyncGetDatabase(google::test::admin::database::v1::GetDatabaseRequest const& request, Options options = {});
 
   ///
   /// Drops (aka deletes) a Cloud Test database.
@@ -781,10 +781,11 @@ class GoldenThingAdminClient {
   /// [google.test.admin.database.v1.DropDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L523}
   ///
   future<Status>
-  AsyncDropDatabase(google::test::admin::database::v1::DropDatabaseRequest const& request);
+  AsyncDropDatabase(google::test::admin::database::v1::DropDatabaseRequest const& request, Options options = {});
 
  private:
   std::shared_ptr<GoldenThingAdminConnection> connection_;
+  Options options_;
 };
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/generator/integration_tests/golden/golden_thing_admin_client.h
+++ b/generator/integration_tests/golden/golden_thing_admin_client.h
@@ -93,6 +93,7 @@ class GoldenThingAdminClient {
   ///
   /// @param parent  Required. The instance whose databases should be listed.
   ///  Values are of the form `projects/<project>/instances/<instance>`.
+  /// @param options  Optional. Operation options.
   /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
   ///
   /// [google.test.admin.database.v1.ListDatabasesRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L377}
@@ -118,6 +119,7 @@ class GoldenThingAdminClient {
   ///  `[a-z][a-z0-9_\-]*[a-z0-9]` and be between 2 and 30 characters in length.
   ///  If the database ID is a reserved word or if it contains a hyphen, the
   ///  database ID must be enclosed in backticks (`` ` ``).
+  /// @param options  Optional. Operation options.
   /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
   ///
   /// [google.test.admin.database.v1.CreateDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L409}
@@ -131,6 +133,7 @@ class GoldenThingAdminClient {
   ///
   /// @param name  Required. The name of the requested database. Values are of the form
   ///  `projects/<project>/instances/<instance>/databases/<database>`.
+  /// @param options  Optional. Operation options.
   /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
   ///
   /// [google.test.admin.database.v1.GetDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L443}
@@ -150,6 +153,7 @@ class GoldenThingAdminClient {
   ///
   /// @param database  Required. The database to update.
   /// @param statements  Required. DDL statements to be applied to the database.
+  /// @param options  Optional. Operation options.
   /// @return @googleapis_link{google::test::admin::database::v1::UpdateDatabaseDdlMetadata,generator/integration_tests/test.proto#L506}
   ///
   /// [google.test.admin.database.v1.UpdateDatabaseDdlRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L470}
@@ -164,6 +168,7 @@ class GoldenThingAdminClient {
   /// `expire_time`.
   ///
   /// @param database  Required. The database to be dropped.
+  /// @param options  Optional. Operation options.
   ///
   /// [google.test.admin.database.v1.DropDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L523}
   ///
@@ -176,6 +181,7 @@ class GoldenThingAdminClient {
   /// be queried using the [Operations][google.longrunning.Operations] API.
   ///
   /// @param database  Required. The database whose schema we wish to get.
+  /// @param options  Optional. Operation options.
   /// @return @googleapis_link{google::test::admin::database::v1::GetDatabaseDdlResponse,generator/integration_tests/test.proto#L545}
   ///
   /// [google.test.admin.database.v1.GetDatabaseDdlRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L534}
@@ -199,6 +205,7 @@ class GoldenThingAdminClient {
   ///  the policy is limited to a few 10s of KB. An empty policy is a
   ///  valid policy but certain Cloud Platform services (such as Projects)
   ///  might reject them.
+  /// @param options  Optional. Operation options.
   /// @return @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
   /// [google.iam.v1.SetIamPolicyRequest]: @googleapis_reference_link{google/iam/v1/iam_policy.proto#L98}
@@ -243,6 +250,7 @@ class GoldenThingAdminClient {
   ///
   /// @param resource  REQUIRED: The resource for which the policy is being requested.
   ///  See the operation documentation for the appropriate value for this field.
+  /// @param options  Optional. Operation options.
   /// @return @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
   /// [google.iam.v1.GetIamPolicyRequest]: @googleapis_reference_link{google/iam/v1/iam_policy.proto#L113}
@@ -269,6 +277,7 @@ class GoldenThingAdminClient {
   ///  wildcards (such as '*' or 'storage.*') are not allowed. For more
   ///  information see
   ///  [IAM Overview](https://cloud.google.com/iam/docs/overview#permissions).
+  /// @param options  Optional. Operation options.
   /// @return @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
   ///
   /// [google.iam.v1.TestIamPermissionsRequest]: @googleapis_reference_link{google/iam/v1/iam_policy.proto#L126}
@@ -301,6 +310,7 @@ class GoldenThingAdminClient {
   /// @param backup_id  Required. The id of the backup to be created. The `backup_id` appended to
   ///  `parent` forms the full backup name of the form
   ///  `projects/<project>/instances/<instance>/backups/<backup_id>`.
+  /// @param options  Optional. Operation options.
   /// @return @googleapis_link{google::test::admin::database::v1::Backup,generator/integration_tests/backup.proto#L36}
   ///
   /// [google.test.admin.database.v1.CreateBackupRequest]: @googleapis_reference_link{generator/integration_tests/backup.proto#L110}
@@ -315,6 +325,7 @@ class GoldenThingAdminClient {
   /// @param name  Required. Name of the backup.
   ///  Values are of the form
   ///  `projects/<project>/instances/<instance>/backups/<backup>`.
+  /// @param options  Optional. Operation options.
   /// @return @googleapis_link{google::test::admin::database::v1::Backup,generator/integration_tests/backup.proto#L36}
   ///
   /// [google.test.admin.database.v1.GetBackupRequest]: @googleapis_reference_link{generator/integration_tests/backup.proto#L177}
@@ -335,6 +346,7 @@ class GoldenThingAdminClient {
   ///  resource, not to the request message. The field mask must always be
   ///  specified; this prevents any future fields from being erased accidentally
   ///  by clients that do not know about them.
+  /// @param options  Optional. Operation options.
   /// @return @googleapis_link{google::test::admin::database::v1::Backup,generator/integration_tests/backup.proto#L36}
   ///
   /// [google.test.admin.database.v1.UpdateBackupRequest]: @googleapis_reference_link{generator/integration_tests/backup.proto#L161}
@@ -349,6 +361,7 @@ class GoldenThingAdminClient {
   /// @param name  Required. Name of the backup to delete.
   ///  Values are of the form
   ///  `projects/<project>/instances/<instance>/backups/<backup>`.
+  /// @param options  Optional. Operation options.
   ///
   /// [google.test.admin.database.v1.DeleteBackupRequest]: @googleapis_reference_link{generator/integration_tests/backup.proto#L190}
   ///
@@ -362,6 +375,7 @@ class GoldenThingAdminClient {
   ///
   /// @param parent  Required. The instance to list backups from.  Values are of the
   ///  form `projects/<project>/instances/<instance>`.
+  /// @param options  Optional. Operation options.
   /// @return @googleapis_link{google::test::admin::database::v1::Backup,generator/integration_tests/backup.proto#L36}
   ///
   /// [google.test.admin.database.v1.ListBackupsRequest]: @googleapis_reference_link{generator/integration_tests/backup.proto#L203}
@@ -400,6 +414,7 @@ class GoldenThingAdminClient {
   ///  `projects/<project>/instances/<instance>/databases/<database_id>`.
   /// @param backup  Name of the backup from which to restore.  Values are of the form
   ///  `projects/<project>/instances/<instance>/backups/<backup>`.
+  /// @param options  Optional. Operation options.
   /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
   ///
   /// [google.test.admin.database.v1.RestoreDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L634}
@@ -420,6 +435,7 @@ class GoldenThingAdminClient {
   ///
   /// @param parent  Required. The instance of the database operations.
   ///  Values are of the form `projects/<project>/instances/<instance>`.
+  /// @param options  Optional. Operation options.
   /// @return @googleapis_link{google::longrunning::Operation,google/longrunning/operations.proto#L128}
   ///
   /// [google.test.admin.database.v1.ListDatabaseOperationsRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L553}
@@ -442,6 +458,7 @@ class GoldenThingAdminClient {
   ///
   /// @param parent  Required. The instance of the backup operations. Values are of
   ///  the form `projects/<project>/instances/<instance>`.
+  /// @param options  Optional. Operation options.
   /// @return @googleapis_link{google::longrunning::Operation,google/longrunning/operations.proto#L128}
   ///
   /// [google.test.admin.database.v1.ListBackupOperationsRequest]: @googleapis_reference_link{generator/integration_tests/backup.proto#L274}
@@ -455,6 +472,7 @@ class GoldenThingAdminClient {
   ///
   /// @param name  Required. The name of the requested database. Values are of the form
   ///  `projects/<project>/instances/<instance>/databases/<database>`.
+  /// @param options  Optional. Operation options.
   /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
   ///
   /// [google.test.admin.database.v1.GetDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L443}
@@ -469,6 +487,7 @@ class GoldenThingAdminClient {
   /// `expire_time`.
   ///
   /// @param database  Required. The database to be dropped.
+  /// @param options  Optional. Operation options.
   ///
   /// [google.test.admin.database.v1.DropDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L523}
   ///
@@ -479,6 +498,7 @@ class GoldenThingAdminClient {
   /// Lists Cloud Test databases.
   ///
   /// @param request @googleapis_link{google::test::admin::database::v1::ListDatabasesRequest,generator/integration_tests/test.proto#L377}
+  /// @param options  Optional. Operation options.
   /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
   ///
   /// [google.test.admin.database.v1.ListDatabasesRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L377}
@@ -498,6 +518,7 @@ class GoldenThingAdminClient {
   /// [Database][google.test.admin.database.v1.Database], if successful.
   ///
   /// @param request @googleapis_link{google::test::admin::database::v1::CreateDatabaseRequest,generator/integration_tests/test.proto#L409}
+  /// @param options  Optional. Operation options.
   /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
   ///
   /// [google.test.admin.database.v1.CreateDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L409}
@@ -510,6 +531,7 @@ class GoldenThingAdminClient {
   /// Gets the state of a Cloud Test database.
   ///
   /// @param request @googleapis_link{google::test::admin::database::v1::GetDatabaseRequest,generator/integration_tests/test.proto#L443}
+  /// @param options  Optional. Operation options.
   /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
   ///
   /// [google.test.admin.database.v1.GetDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L443}
@@ -528,6 +550,7 @@ class GoldenThingAdminClient {
   /// [UpdateDatabaseDdlMetadata][google.test.admin.database.v1.UpdateDatabaseDdlMetadata].  The operation has no response.
   ///
   /// @param request @googleapis_link{google::test::admin::database::v1::UpdateDatabaseDdlRequest,generator/integration_tests/test.proto#L470}
+  /// @param options  Optional. Operation options.
   /// @return @googleapis_link{google::test::admin::database::v1::UpdateDatabaseDdlMetadata,generator/integration_tests/test.proto#L506}
   ///
   /// [google.test.admin.database.v1.UpdateDatabaseDdlRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L470}
@@ -542,6 +565,7 @@ class GoldenThingAdminClient {
   /// `expire_time`.
   ///
   /// @param request @googleapis_link{google::test::admin::database::v1::DropDatabaseRequest,generator/integration_tests/test.proto#L523}
+  /// @param options  Optional. Operation options.
   ///
   /// [google.test.admin.database.v1.DropDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L523}
   ///
@@ -554,6 +578,7 @@ class GoldenThingAdminClient {
   /// be queried using the [Operations][google.longrunning.Operations] API.
   ///
   /// @param request @googleapis_link{google::test::admin::database::v1::GetDatabaseDdlRequest,generator/integration_tests/test.proto#L534}
+  /// @param options  Optional. Operation options.
   /// @return @googleapis_link{google::test::admin::database::v1::GetDatabaseDdlResponse,generator/integration_tests/test.proto#L545}
   ///
   /// [google.test.admin.database.v1.GetDatabaseDdlRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L534}
@@ -572,6 +597,7 @@ class GoldenThingAdminClient {
   /// permission on [resource][google.iam.v1.SetIamPolicyRequest.resource].
   ///
   /// @param request @googleapis_link{google::iam::v1::SetIamPolicyRequest,google/iam/v1/iam_policy.proto#L98}
+  /// @param options  Optional. Operation options.
   /// @return @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
   /// [google.iam.v1.SetIamPolicyRequest]: @googleapis_reference_link{google/iam/v1/iam_policy.proto#L98}
@@ -591,6 +617,7 @@ class GoldenThingAdminClient {
   /// permission on [resource][google.iam.v1.GetIamPolicyRequest.resource].
   ///
   /// @param request @googleapis_link{google::iam::v1::GetIamPolicyRequest,google/iam/v1/iam_policy.proto#L113}
+  /// @param options  Optional. Operation options.
   /// @return @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
   /// [google.iam.v1.GetIamPolicyRequest]: @googleapis_reference_link{google/iam/v1/iam_policy.proto#L113}
@@ -612,6 +639,7 @@ class GoldenThingAdminClient {
   /// `test.backups.list` permission on the containing instance.
   ///
   /// @param request @googleapis_link{google::iam::v1::TestIamPermissionsRequest,google/iam/v1/iam_policy.proto#L126}
+  /// @param options  Optional. Operation options.
   /// @return @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
   ///
   /// [google.iam.v1.TestIamPermissionsRequest]: @googleapis_reference_link{google/iam/v1/iam_policy.proto#L126}
@@ -635,6 +663,7 @@ class GoldenThingAdminClient {
   /// of different databases can run concurrently.
   ///
   /// @param request @googleapis_link{google::test::admin::database::v1::CreateBackupRequest,generator/integration_tests/backup.proto#L110}
+  /// @param options  Optional. Operation options.
   /// @return @googleapis_link{google::test::admin::database::v1::Backup,generator/integration_tests/backup.proto#L36}
   ///
   /// [google.test.admin.database.v1.CreateBackupRequest]: @googleapis_reference_link{generator/integration_tests/backup.proto#L110}
@@ -647,6 +676,7 @@ class GoldenThingAdminClient {
   /// Gets metadata on a pending or completed [Backup][google.test.admin.database.v1.Backup].
   ///
   /// @param request @googleapis_link{google::test::admin::database::v1::GetBackupRequest,generator/integration_tests/backup.proto#L177}
+  /// @param options  Optional. Operation options.
   /// @return @googleapis_link{google::test::admin::database::v1::Backup,generator/integration_tests/backup.proto#L36}
   ///
   /// [google.test.admin.database.v1.GetBackupRequest]: @googleapis_reference_link{generator/integration_tests/backup.proto#L177}
@@ -659,6 +689,7 @@ class GoldenThingAdminClient {
   /// Updates a pending or completed [Backup][google.test.admin.database.v1.Backup].
   ///
   /// @param request @googleapis_link{google::test::admin::database::v1::UpdateBackupRequest,generator/integration_tests/backup.proto#L161}
+  /// @param options  Optional. Operation options.
   /// @return @googleapis_link{google::test::admin::database::v1::Backup,generator/integration_tests/backup.proto#L36}
   ///
   /// [google.test.admin.database.v1.UpdateBackupRequest]: @googleapis_reference_link{generator/integration_tests/backup.proto#L161}
@@ -671,6 +702,7 @@ class GoldenThingAdminClient {
   /// Deletes a pending or completed [Backup][google.test.admin.database.v1.Backup].
   ///
   /// @param request @googleapis_link{google::test::admin::database::v1::DeleteBackupRequest,generator/integration_tests/backup.proto#L190}
+  /// @param options  Optional. Operation options.
   ///
   /// [google.test.admin.database.v1.DeleteBackupRequest]: @googleapis_reference_link{generator/integration_tests/backup.proto#L190}
   ///
@@ -683,6 +715,7 @@ class GoldenThingAdminClient {
   /// starting from the most recent `create_time`.
   ///
   /// @param request @googleapis_link{google::test::admin::database::v1::ListBackupsRequest,generator/integration_tests/backup.proto#L203}
+  /// @param options  Optional. Operation options.
   /// @return @googleapis_link{google::test::admin::database::v1::Backup,generator/integration_tests/backup.proto#L36}
   ///
   /// [google.test.admin.database.v1.ListBackupsRequest]: @googleapis_reference_link{generator/integration_tests/backup.proto#L203}
@@ -711,6 +744,7 @@ class GoldenThingAdminClient {
   /// first restore to complete.
   ///
   /// @param request @googleapis_link{google::test::admin::database::v1::RestoreDatabaseRequest,generator/integration_tests/test.proto#L634}
+  /// @param options  Optional. Operation options.
   /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
   ///
   /// [google.test.admin.database.v1.RestoreDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L634}
@@ -730,6 +764,7 @@ class GoldenThingAdminClient {
   /// and pending operations.
   ///
   /// @param request @googleapis_link{google::test::admin::database::v1::ListDatabaseOperationsRequest,generator/integration_tests/test.proto#L553}
+  /// @param options  Optional. Operation options.
   /// @return @googleapis_link{google::longrunning::Operation,google/longrunning/operations.proto#L128}
   ///
   /// [google.test.admin.database.v1.ListDatabaseOperationsRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L553}
@@ -751,6 +786,7 @@ class GoldenThingAdminClient {
   /// from the most recently started operation.
   ///
   /// @param request @googleapis_link{google::test::admin::database::v1::ListBackupOperationsRequest,generator/integration_tests/backup.proto#L274}
+  /// @param options  Optional. Operation options.
   /// @return @googleapis_link{google::longrunning::Operation,google/longrunning/operations.proto#L128}
   ///
   /// [google.test.admin.database.v1.ListBackupOperationsRequest]: @googleapis_reference_link{generator/integration_tests/backup.proto#L274}
@@ -763,6 +799,7 @@ class GoldenThingAdminClient {
   /// Gets the state of a Cloud Test database.
   ///
   /// @param request @googleapis_link{google::test::admin::database::v1::GetDatabaseRequest,generator/integration_tests/test.proto#L443}
+  /// @param options  Optional. Operation options.
   /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
   ///
   /// [google.test.admin.database.v1.GetDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L443}
@@ -777,6 +814,7 @@ class GoldenThingAdminClient {
   /// `expire_time`.
   ///
   /// @param request @googleapis_link{google::test::admin::database::v1::DropDatabaseRequest,generator/integration_tests/test.proto#L523}
+  /// @param options  Optional. Operation options.
   ///
   /// [google.test.admin.database.v1.DropDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L523}
   ///

--- a/generator/internal/descriptor_utils.cc
+++ b/generator/internal/descriptor_utils.cc
@@ -442,6 +442,8 @@ std::string FormatMethodCommentsFromRpcComments(
   } else {
     parameter_comment_string = FormatProtobufRequestParameters(method);
   }
+  parameter_comment_string +=
+      absl::StrFormat("  /// @param options  Optional. Operation options.\n");
 
   std::string doxygen_formatted_function_comments = absl::StrReplaceAll(
       EscapePrinterDelimiter(method_source_location.leading_comments),

--- a/generator/internal/descriptor_utils_test.cc
+++ b/generator/internal/descriptor_utils_test.cc
@@ -503,6 +503,7 @@ TEST_F(CreateMethodVarsTest,
   /// Leading comments about rpc Method0$$.
   ///
   /// @param request @googleapis_link{google::protobuf::Bar,google/foo/v1/service.proto#L14}
+  /// @param options  Optional. Operation options.
   ///
 )"""));
 }
@@ -518,6 +519,7 @@ TEST_F(CreateMethodVarsTest,
   /// Leading comments about rpc $$Method6.
   ///
   /// @param labels  labels $$field comment.
+  /// @param options  Optional. Operation options.
   ///
 )"""));
 }

--- a/google/cloud/bigquery/bigquery_read_client.cc
+++ b/google/cloud/bigquery/bigquery_read_client.cc
@@ -17,6 +17,7 @@
 // source: google/cloud/bigquery/storage/v1/storage.proto
 
 #include "google/cloud/bigquery/bigquery_read_client.h"
+#include "google/cloud/bigquery/internal/bigquery_read_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -25,15 +26,19 @@ namespace bigquery {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 BigQueryReadClient::BigQueryReadClient(
-    std::shared_ptr<BigQueryReadConnection> connection)
-    : connection_(std::move(connection)) {}
+    std::shared_ptr<BigQueryReadConnection> connection, Options options)
+    : connection_(std::move(connection)),
+      options_(
+          bigquery_internal::BigQueryReadDefaultOptions(std::move(options))) {}
 BigQueryReadClient::~BigQueryReadClient() = default;
 
 StatusOr<google::cloud::bigquery::storage::v1::ReadSession>
 BigQueryReadClient::CreateReadSession(
     std::string const& parent,
     google::cloud::bigquery::storage::v1::ReadSession const& read_session,
-    std::int32_t max_stream_count) {
+    std::int32_t max_stream_count, Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   google::cloud::bigquery::storage::v1::CreateReadSessionRequest request;
   request.set_parent(parent);
   *request.mutable_read_session() = read_session;
@@ -43,7 +48,9 @@ BigQueryReadClient::CreateReadSession(
 
 StreamRange<google::cloud::bigquery::storage::v1::ReadRowsResponse>
 BigQueryReadClient::ReadRows(std::string const& read_stream,
-                             std::int64_t offset) {
+                             std::int64_t offset, Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   google::cloud::bigquery::storage::v1::ReadRowsRequest request;
   request.set_read_stream(read_stream);
   request.set_offset(offset);
@@ -53,20 +60,28 @@ BigQueryReadClient::ReadRows(std::string const& read_stream,
 StatusOr<google::cloud::bigquery::storage::v1::ReadSession>
 BigQueryReadClient::CreateReadSession(
     google::cloud::bigquery::storage::v1::CreateReadSessionRequest const&
-        request) {
+        request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->CreateReadSession(request);
 }
 
 StreamRange<google::cloud::bigquery::storage::v1::ReadRowsResponse>
 BigQueryReadClient::ReadRows(
-    google::cloud::bigquery::storage::v1::ReadRowsRequest const& request) {
+    google::cloud::bigquery::storage::v1::ReadRowsRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->ReadRows(request);
 }
 
 StatusOr<google::cloud::bigquery::storage::v1::SplitReadStreamResponse>
 BigQueryReadClient::SplitReadStream(
-    google::cloud::bigquery::storage::v1::SplitReadStreamRequest const&
-        request) {
+    google::cloud::bigquery::storage::v1::SplitReadStreamRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->SplitReadStream(request);
 }
 

--- a/google/cloud/bigquery/bigquery_read_client.h
+++ b/google/cloud/bigquery/bigquery_read_client.h
@@ -119,6 +119,7 @@ class BigQueryReadClient {
   ///  table. Error will be returned if the max count is greater than the
   ///  current system max limit of 1,000. Streams must be read starting from
   ///  offset 0.
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::cloud::bigquery::storage::v1::ReadSession,google/cloud/bigquery/storage/v1/stream.proto#L47}
   ///
@@ -146,6 +147,7 @@ class BigQueryReadClient {
   /// from Read.
   ///  Requesting a larger offset is undefined. If not specified, start reading
   ///  from offset zero.
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::cloud::bigquery::storage::v1::ReadRowsResponse,google/cloud/bigquery/storage/v1/storage.proto#L304}
   ///
@@ -181,6 +183,7 @@ class BigQueryReadClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::bigquery::storage::v1::CreateReadSessionRequest,google/cloud/bigquery/storage/v1/storage.proto#L229}
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::cloud::bigquery::storage::v1::ReadSession,google/cloud/bigquery/storage/v1/stream.proto#L47}
   ///
@@ -205,6 +208,7 @@ class BigQueryReadClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::bigquery::storage::v1::ReadRowsRequest,google/cloud/bigquery/storage/v1/storage.proto#L254}
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::cloud::bigquery::storage::v1::ReadRowsResponse,google/cloud/bigquery/storage/v1/storage.proto#L304}
   ///
@@ -233,6 +237,7 @@ class BigQueryReadClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::bigquery::storage::v1::SplitReadStreamRequest,google/cloud/bigquery/storage/v1/storage.proto#L339}
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::cloud::bigquery::storage::v1::SplitReadStreamResponse,google/cloud/bigquery/storage/v1/storage.proto#L359}
   ///

--- a/google/cloud/bigquery/bigquery_read_client.h
+++ b/google/cloud/bigquery/bigquery_read_client.h
@@ -21,6 +21,7 @@
 
 #include "google/cloud/bigquery/bigquery_read_connection.h"
 #include "google/cloud/future.h"
+#include "google/cloud/options.h"
 #include "google/cloud/polling_policy.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
@@ -62,7 +63,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class BigQueryReadClient {
  public:
   explicit BigQueryReadClient(
-      std::shared_ptr<BigQueryReadConnection> connection);
+      std::shared_ptr<BigQueryReadConnection> connection, Options options = {});
   ~BigQueryReadClient();
 
   //@{
@@ -129,7 +130,7 @@ class BigQueryReadClient {
   StatusOr<google::cloud::bigquery::storage::v1::ReadSession> CreateReadSession(
       std::string const& parent,
       google::cloud::bigquery::storage::v1::ReadSession const& read_session,
-      std::int32_t max_stream_count);
+      std::int32_t max_stream_count, Options options = {});
 
   ///
   /// Reads rows from the stream in the format prescribed by the ReadSession.
@@ -154,7 +155,8 @@ class BigQueryReadClient {
   /// @googleapis_reference_link{google/cloud/bigquery/storage/v1/storage.proto#L304}
   ///
   StreamRange<google::cloud::bigquery::storage::v1::ReadRowsResponse> ReadRows(
-      std::string const& read_stream, std::int64_t offset);
+      std::string const& read_stream, std::int64_t offset,
+      Options options = {});
 
   ///
   /// Creates a new read session. A read session divides the contents of a
@@ -189,7 +191,8 @@ class BigQueryReadClient {
   ///
   StatusOr<google::cloud::bigquery::storage::v1::ReadSession> CreateReadSession(
       google::cloud::bigquery::storage::v1::CreateReadSessionRequest const&
-          request);
+          request,
+      Options options = {});
 
   ///
   /// Reads rows from the stream in the format prescribed by the ReadSession.
@@ -211,7 +214,8 @@ class BigQueryReadClient {
   /// @googleapis_reference_link{google/cloud/bigquery/storage/v1/storage.proto#L304}
   ///
   StreamRange<google::cloud::bigquery::storage::v1::ReadRowsResponse> ReadRows(
-      google::cloud::bigquery::storage::v1::ReadRowsRequest const& request);
+      google::cloud::bigquery::storage::v1::ReadRowsRequest const& request,
+      Options options = {});
 
   ///
   /// Splits a given `ReadStream` into two `ReadStream` objects. These
@@ -240,10 +244,12 @@ class BigQueryReadClient {
   StatusOr<google::cloud::bigquery::storage::v1::SplitReadStreamResponse>
   SplitReadStream(
       google::cloud::bigquery::storage::v1::SplitReadStreamRequest const&
-          request);
+          request,
+      Options options = {});
 
  private:
   std::shared_ptr<BigQueryReadConnection> connection_;
+  Options options_;
 };
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/iam/iam_client.cc
+++ b/google/cloud/iam/iam_client.cc
@@ -27,19 +27,24 @@ namespace cloud {
 namespace iam {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-IAMClient::IAMClient(std::shared_ptr<IAMConnection> connection)
-    : connection_(std::move(connection)) {}
+IAMClient::IAMClient(std::shared_ptr<IAMConnection> connection, Options options)
+    : connection_(std::move(connection)),
+      options_(iam_internal::IAMDefaultOptions(std::move(options))) {}
 IAMClient::~IAMClient() = default;
 
 StreamRange<google::iam::admin::v1::ServiceAccount>
-IAMClient::ListServiceAccounts(std::string const& name) {
+IAMClient::ListServiceAccounts(std::string const& name, Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   google::iam::admin::v1::ListServiceAccountsRequest request;
   request.set_name(name);
   return connection_->ListServiceAccounts(request);
 }
 
 StatusOr<google::iam::admin::v1::ServiceAccount> IAMClient::GetServiceAccount(
-    std::string const& name) {
+    std::string const& name, Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   google::iam::admin::v1::GetServiceAccountRequest request;
   request.set_name(name);
   return connection_->GetServiceAccount(request);
@@ -48,7 +53,10 @@ StatusOr<google::iam::admin::v1::ServiceAccount> IAMClient::GetServiceAccount(
 StatusOr<google::iam::admin::v1::ServiceAccount>
 IAMClient::CreateServiceAccount(
     std::string const& name, std::string const& account_id,
-    google::iam::admin::v1::ServiceAccount const& service_account) {
+    google::iam::admin::v1::ServiceAccount const& service_account,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   google::iam::admin::v1::CreateServiceAccountRequest request;
   request.set_name(name);
   request.set_account_id(account_id);
@@ -56,7 +64,10 @@ IAMClient::CreateServiceAccount(
   return connection_->CreateServiceAccount(request);
 }
 
-Status IAMClient::DeleteServiceAccount(std::string const& name) {
+Status IAMClient::DeleteServiceAccount(std::string const& name,
+                                       Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   google::iam::admin::v1::DeleteServiceAccountRequest request;
   request.set_name(name);
   return connection_->DeleteServiceAccount(request);
@@ -67,7 +78,10 @@ IAMClient::ListServiceAccountKeys(
     std::string const& name,
     std::vector<
         google::iam::admin::v1::ListServiceAccountKeysRequest::KeyType> const&
-        key_types) {
+        key_types,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   google::iam::admin::v1::ListServiceAccountKeysRequest request;
   request.set_name(name);
   *request.mutable_key_types() = {key_types.begin(), key_types.end()};
@@ -77,7 +91,10 @@ IAMClient::ListServiceAccountKeys(
 StatusOr<google::iam::admin::v1::ServiceAccountKey>
 IAMClient::GetServiceAccountKey(
     std::string const& name,
-    google::iam::admin::v1::ServiceAccountPublicKeyType public_key_type) {
+    google::iam::admin::v1::ServiceAccountPublicKeyType public_key_type,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   google::iam::admin::v1::GetServiceAccountKeyRequest request;
   request.set_name(name);
   request.set_public_key_type(public_key_type);
@@ -88,7 +105,10 @@ StatusOr<google::iam::admin::v1::ServiceAccountKey>
 IAMClient::CreateServiceAccountKey(
     std::string const& name,
     google::iam::admin::v1::ServiceAccountPrivateKeyType private_key_type,
-    google::iam::admin::v1::ServiceAccountKeyAlgorithm key_algorithm) {
+    google::iam::admin::v1::ServiceAccountKeyAlgorithm key_algorithm,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   google::iam::admin::v1::CreateServiceAccountKeyRequest request;
   request.set_name(name);
   request.set_private_key_type(private_key_type);
@@ -96,21 +116,29 @@ IAMClient::CreateServiceAccountKey(
   return connection_->CreateServiceAccountKey(request);
 }
 
-Status IAMClient::DeleteServiceAccountKey(std::string const& name) {
+Status IAMClient::DeleteServiceAccountKey(std::string const& name,
+                                          Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   google::iam::admin::v1::DeleteServiceAccountKeyRequest request;
   request.set_name(name);
   return connection_->DeleteServiceAccountKey(request);
 }
 
 StatusOr<google::iam::v1::Policy> IAMClient::GetIamPolicy(
-    std::string const& resource) {
+    std::string const& resource, Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   google::iam::v1::GetIamPolicyRequest request;
   request.set_resource(resource);
   return connection_->GetIamPolicy(request);
 }
 
 StatusOr<google::iam::v1::Policy> IAMClient::SetIamPolicy(
-    std::string const& resource, google::iam::v1::Policy const& policy) {
+    std::string const& resource, google::iam::v1::Policy const& policy,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   google::iam::v1::SetIamPolicyRequest request;
   request.set_resource(resource);
   *request.mutable_policy() = policy;
@@ -120,8 +148,10 @@ StatusOr<google::iam::v1::Policy> IAMClient::SetIamPolicy(
 StatusOr<google::iam::v1::Policy> IAMClient::SetIamPolicy(
     std::string const& resource, IamUpdater const& updater, Options options) {
   internal::CheckExpectedOptions<IAMBackoffPolicyOption>(options, __func__);
-  options = iam_internal::IAMDefaultOptions(std::move(options));
-  auto backoff_policy = options.get<IAMBackoffPolicyOption>()->clone();
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
+  auto backoff_policy =
+      internal::CurrentOptions().get<IAMBackoffPolicyOption>()->clone();
   for (;;) {
     auto recent = GetIamPolicy(resource);
     if (!recent) {
@@ -141,7 +171,10 @@ StatusOr<google::iam::v1::Policy> IAMClient::SetIamPolicy(
 
 StatusOr<google::iam::v1::TestIamPermissionsResponse>
 IAMClient::TestIamPermissions(std::string const& resource,
-                              std::vector<std::string> const& permissions) {
+                              std::vector<std::string> const& permissions,
+                              Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   google::iam::v1::TestIamPermissionsRequest request;
   request.set_resource(resource);
   *request.mutable_permissions() = {permissions.begin(), permissions.end()};
@@ -149,7 +182,9 @@ IAMClient::TestIamPermissions(std::string const& resource,
 }
 
 StreamRange<google::iam::admin::v1::Role> IAMClient::QueryGrantableRoles(
-    std::string const& full_resource_name) {
+    std::string const& full_resource_name, Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   google::iam::admin::v1::QueryGrantableRolesRequest request;
   request.set_full_resource_name(full_resource_name);
   return connection_->QueryGrantableRoles(request);
@@ -157,141 +192,211 @@ StreamRange<google::iam::admin::v1::Role> IAMClient::QueryGrantableRoles(
 
 StreamRange<google::iam::admin::v1::ServiceAccount>
 IAMClient::ListServiceAccounts(
-    google::iam::admin::v1::ListServiceAccountsRequest request) {
+    google::iam::admin::v1::ListServiceAccountsRequest request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->ListServiceAccounts(std::move(request));
 }
 
 StatusOr<google::iam::admin::v1::ServiceAccount> IAMClient::GetServiceAccount(
-    google::iam::admin::v1::GetServiceAccountRequest const& request) {
+    google::iam::admin::v1::GetServiceAccountRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->GetServiceAccount(request);
 }
 
 StatusOr<google::iam::admin::v1::ServiceAccount>
 IAMClient::CreateServiceAccount(
-    google::iam::admin::v1::CreateServiceAccountRequest const& request) {
+    google::iam::admin::v1::CreateServiceAccountRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->CreateServiceAccount(request);
 }
 
 StatusOr<google::iam::admin::v1::ServiceAccount> IAMClient::PatchServiceAccount(
-    google::iam::admin::v1::PatchServiceAccountRequest const& request) {
+    google::iam::admin::v1::PatchServiceAccountRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->PatchServiceAccount(request);
 }
 
 Status IAMClient::DeleteServiceAccount(
-    google::iam::admin::v1::DeleteServiceAccountRequest const& request) {
+    google::iam::admin::v1::DeleteServiceAccountRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->DeleteServiceAccount(request);
 }
 
 StatusOr<google::iam::admin::v1::UndeleteServiceAccountResponse>
 IAMClient::UndeleteServiceAccount(
-    google::iam::admin::v1::UndeleteServiceAccountRequest const& request) {
+    google::iam::admin::v1::UndeleteServiceAccountRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->UndeleteServiceAccount(request);
 }
 
 Status IAMClient::EnableServiceAccount(
-    google::iam::admin::v1::EnableServiceAccountRequest const& request) {
+    google::iam::admin::v1::EnableServiceAccountRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->EnableServiceAccount(request);
 }
 
 Status IAMClient::DisableServiceAccount(
-    google::iam::admin::v1::DisableServiceAccountRequest const& request) {
+    google::iam::admin::v1::DisableServiceAccountRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->DisableServiceAccount(request);
 }
 
 StatusOr<google::iam::admin::v1::ListServiceAccountKeysResponse>
 IAMClient::ListServiceAccountKeys(
-    google::iam::admin::v1::ListServiceAccountKeysRequest const& request) {
+    google::iam::admin::v1::ListServiceAccountKeysRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->ListServiceAccountKeys(request);
 }
 
 StatusOr<google::iam::admin::v1::ServiceAccountKey>
 IAMClient::GetServiceAccountKey(
-    google::iam::admin::v1::GetServiceAccountKeyRequest const& request) {
+    google::iam::admin::v1::GetServiceAccountKeyRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->GetServiceAccountKey(request);
 }
 
 StatusOr<google::iam::admin::v1::ServiceAccountKey>
 IAMClient::CreateServiceAccountKey(
-    google::iam::admin::v1::CreateServiceAccountKeyRequest const& request) {
+    google::iam::admin::v1::CreateServiceAccountKeyRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->CreateServiceAccountKey(request);
 }
 
 StatusOr<google::iam::admin::v1::ServiceAccountKey>
 IAMClient::UploadServiceAccountKey(
-    google::iam::admin::v1::UploadServiceAccountKeyRequest const& request) {
+    google::iam::admin::v1::UploadServiceAccountKeyRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->UploadServiceAccountKey(request);
 }
 
 Status IAMClient::DeleteServiceAccountKey(
-    google::iam::admin::v1::DeleteServiceAccountKeyRequest const& request) {
+    google::iam::admin::v1::DeleteServiceAccountKeyRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->DeleteServiceAccountKey(request);
 }
 
 StatusOr<google::iam::v1::Policy> IAMClient::GetIamPolicy(
-    google::iam::v1::GetIamPolicyRequest const& request) {
+    google::iam::v1::GetIamPolicyRequest const& request, Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->GetIamPolicy(request);
 }
 
 StatusOr<google::iam::v1::Policy> IAMClient::SetIamPolicy(
-    google::iam::v1::SetIamPolicyRequest const& request) {
+    google::iam::v1::SetIamPolicyRequest const& request, Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->SetIamPolicy(request);
 }
 
 StatusOr<google::iam::v1::TestIamPermissionsResponse>
 IAMClient::TestIamPermissions(
-    google::iam::v1::TestIamPermissionsRequest const& request) {
+    google::iam::v1::TestIamPermissionsRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->TestIamPermissions(request);
 }
 
 StreamRange<google::iam::admin::v1::Role> IAMClient::QueryGrantableRoles(
-    google::iam::admin::v1::QueryGrantableRolesRequest request) {
+    google::iam::admin::v1::QueryGrantableRolesRequest request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->QueryGrantableRoles(std::move(request));
 }
 
 StreamRange<google::iam::admin::v1::Role> IAMClient::ListRoles(
-    google::iam::admin::v1::ListRolesRequest request) {
+    google::iam::admin::v1::ListRolesRequest request, Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->ListRoles(std::move(request));
 }
 
 StatusOr<google::iam::admin::v1::Role> IAMClient::GetRole(
-    google::iam::admin::v1::GetRoleRequest const& request) {
+    google::iam::admin::v1::GetRoleRequest const& request, Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->GetRole(request);
 }
 
 StatusOr<google::iam::admin::v1::Role> IAMClient::CreateRole(
-    google::iam::admin::v1::CreateRoleRequest const& request) {
+    google::iam::admin::v1::CreateRoleRequest const& request, Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->CreateRole(request);
 }
 
 StatusOr<google::iam::admin::v1::Role> IAMClient::UpdateRole(
-    google::iam::admin::v1::UpdateRoleRequest const& request) {
+    google::iam::admin::v1::UpdateRoleRequest const& request, Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->UpdateRole(request);
 }
 
 StatusOr<google::iam::admin::v1::Role> IAMClient::DeleteRole(
-    google::iam::admin::v1::DeleteRoleRequest const& request) {
+    google::iam::admin::v1::DeleteRoleRequest const& request, Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->DeleteRole(request);
 }
 
 StatusOr<google::iam::admin::v1::Role> IAMClient::UndeleteRole(
-    google::iam::admin::v1::UndeleteRoleRequest const& request) {
+    google::iam::admin::v1::UndeleteRoleRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->UndeleteRole(request);
 }
 
 StreamRange<google::iam::admin::v1::Permission>
 IAMClient::QueryTestablePermissions(
-    google::iam::admin::v1::QueryTestablePermissionsRequest request) {
+    google::iam::admin::v1::QueryTestablePermissionsRequest request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->QueryTestablePermissions(std::move(request));
 }
 
 StatusOr<google::iam::admin::v1::QueryAuditableServicesResponse>
 IAMClient::QueryAuditableServices(
-    google::iam::admin::v1::QueryAuditableServicesRequest const& request) {
+    google::iam::admin::v1::QueryAuditableServicesRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->QueryAuditableServices(request);
 }
 
 StatusOr<google::iam::admin::v1::LintPolicyResponse> IAMClient::LintPolicy(
-    google::iam::admin::v1::LintPolicyRequest const& request) {
+    google::iam::admin::v1::LintPolicyRequest const& request, Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->LintPolicy(request);
 }
 

--- a/google/cloud/iam/iam_client.h
+++ b/google/cloud/iam/iam_client.h
@@ -108,6 +108,7 @@ class IAMClient {
   /// @param name  Required. The resource name of the project associated with
   /// the service
   ///  accounts, such as `projects/my-project-123`.
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::iam::admin::v1::ServiceAccount,google/iam/admin/v1/iam.proto#L461}
   ///
@@ -128,6 +129,7 @@ class IAMClient {
   ///  Using `-` as a wildcard for the `PROJECT_ID` will infer the project from
   ///  the account. The `ACCOUNT` value can be the `email` address or the
   ///  `unique_id` of the service account.
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::iam::admin::v1::ServiceAccount,google/iam/admin/v1/iam.proto#L461}
   ///
@@ -154,6 +156,7 @@ class IAMClient {
   /// [ServiceAccount][google.iam.admin.v1.ServiceAccount] resource to
   ///  create. Currently, only the following values are user assignable:
   ///  `display_name` and `description`.
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::iam::admin::v1::ServiceAccount,google/iam/admin/v1/iam.proto#L461}
   ///
@@ -193,6 +196,7 @@ class IAMClient {
   ///  Using `-` as a wildcard for the `PROJECT_ID` will infer the project from
   ///  the account. The `ACCOUNT` value can be the `email` address or the
   ///  `unique_id` of the service account.
+  /// @param options  Optional. Operation options.
   ///
   /// [google.iam.admin.v1.DeleteServiceAccountRequest]:
   /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L594}
@@ -213,6 +217,7 @@ class IAMClient {
   /// the list
   ///  response. Duplicate key types are not allowed. If no key type
   ///  is provided, all keys are returned.
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::iam::admin::v1::ListServiceAccountKeysResponse,google/iam/admin/v1/iam.proto#L692}
   ///
@@ -240,6 +245,7 @@ class IAMClient {
   ///  `unique_id` of the service account.
   /// @param public_key_type  The output format of the public key requested.
   ///  X509_PEM is the default output format.
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::iam::admin::v1::ServiceAccountKey,google/iam/admin/v1/iam.proto#L741}
   ///
@@ -269,6 +275,7 @@ class IAMClient {
   /// @param key_algorithm  Which type of key and algorithm to use for the key.
   ///  The default is currently a 2K RSA key.  However this may change in the
   ///  future.
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::iam::admin::v1::ServiceAccountKey,google/iam/admin/v1/iam.proto#L741}
   ///
@@ -294,6 +301,7 @@ class IAMClient {
   ///  Using `-` as a wildcard for the `PROJECT_ID` will infer the project from
   ///  the account. The `ACCOUNT` value can be the `email` address or the
   ///  `unique_id` of the service account.
+  /// @param options  Optional. Operation options.
   ///
   /// [google.iam.admin.v1.DeleteServiceAccountKeyRequest]:
   /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L832}
@@ -316,6 +324,7 @@ class IAMClient {
   /// @param resource  REQUIRED: The resource for which the policy is being
   /// requested.
   ///  See the operation documentation for the appropriate value for this field.
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
@@ -356,6 +365,7 @@ class IAMClient {
   ///  the policy is limited to a few 10s of KB. An empty policy is a
   ///  valid policy but certain Cloud Platform services (such as Projects)
   ///  might reject them.
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
@@ -405,6 +415,7 @@ class IAMClient {
   ///  wildcards (such as '*' or 'storage.*') are not allowed. For more
   ///  information see
   ///  [IAM Overview](https://cloud.google.com/iam/docs/overview#permissions).
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
   ///
@@ -427,6 +438,7 @@ class IAMClient {
   ///  The name follows the Google Cloud Platform resource format.
   ///  For example, a Cloud Platform project with id `my-project` will be named
   ///  `//cloudresourcemanager.googleapis.com/projects/my-project`.
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::iam::admin::v1::Role,google/iam/admin/v1/iam.proto#L1004}
   ///
@@ -444,6 +456,7 @@ class IAMClient {
   ///
   /// @param request
   /// @googleapis_link{google::iam::admin::v1::ListServiceAccountsRequest,google/iam/admin/v1/iam.proto#L544}
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::iam::admin::v1::ServiceAccount,google/iam/admin/v1/iam.proto#L461}
   ///
@@ -461,6 +474,7 @@ class IAMClient {
   ///
   /// @param request
   /// @googleapis_link{google::iam::admin::v1::GetServiceAccountRequest,google/iam/admin/v1/iam.proto#L579}
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::iam::admin::v1::ServiceAccount,google/iam/admin/v1/iam.proto#L461}
   ///
@@ -478,6 +492,7 @@ class IAMClient {
   ///
   /// @param request
   /// @googleapis_link{google::iam::admin::v1::CreateServiceAccountRequest,google/iam/admin/v1/iam.proto#L521}
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::iam::admin::v1::ServiceAccount,google/iam/admin/v1/iam.proto#L461}
   ///
@@ -495,6 +510,7 @@ class IAMClient {
   ///
   /// @param request
   /// @googleapis_link{google::iam::admin::v1::PatchServiceAccountRequest,google/iam/admin/v1/iam.proto#L616}
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::iam::admin::v1::ServiceAccount,google/iam/admin/v1/iam.proto#L461}
   ///
@@ -529,6 +545,7 @@ class IAMClient {
   ///
   /// @param request
   /// @googleapis_link{google::iam::admin::v1::DeleteServiceAccountRequest,google/iam/admin/v1/iam.proto#L594}
+  /// @param options  Optional. Operation options.
   ///
   /// [google.iam.admin.v1.DeleteServiceAccountRequest]:
   /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L594}
@@ -549,6 +566,7 @@ class IAMClient {
   ///
   /// @param request
   /// @googleapis_link{google::iam::admin::v1::UndeleteServiceAccountRequest,google/iam/admin/v1/iam.proto#L623}
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::iam::admin::v1::UndeleteServiceAccountResponse,google/iam/admin/v1/iam.proto#L631}
   ///
@@ -575,6 +593,7 @@ class IAMClient {
   ///
   /// @param request
   /// @googleapis_link{google::iam::admin::v1::EnableServiceAccountRequest,google/iam/admin/v1/iam.proto#L637}
+  /// @param options  Optional. Operation options.
   ///
   /// [google.iam.admin.v1.EnableServiceAccountRequest]:
   /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L637}
@@ -606,6 +625,7 @@ class IAMClient {
   ///
   /// @param request
   /// @googleapis_link{google::iam::admin::v1::DisableServiceAccountRequest,google/iam/admin/v1/iam.proto#L647}
+  /// @param options  Optional. Operation options.
   ///
   /// [google.iam.admin.v1.DisableServiceAccountRequest]:
   /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L647}
@@ -620,6 +640,7 @@ class IAMClient {
   ///
   /// @param request
   /// @googleapis_link{google::iam::admin::v1::ListServiceAccountKeysRequest,google/iam/admin/v1/iam.proto#L657}
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::iam::admin::v1::ListServiceAccountKeysResponse,google/iam/admin/v1/iam.proto#L692}
   ///
@@ -638,6 +659,7 @@ class IAMClient {
   ///
   /// @param request
   /// @googleapis_link{google::iam::admin::v1::GetServiceAccountKeyRequest,google/iam/admin/v1/iam.proto#L698}
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::iam::admin::v1::ServiceAccountKey,google/iam/admin/v1/iam.proto#L741}
   ///
@@ -655,6 +677,7 @@ class IAMClient {
   ///
   /// @param request
   /// @googleapis_link{google::iam::admin::v1::CreateServiceAccountKeyRequest,google/iam/admin/v1/iam.proto#L791}
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::iam::admin::v1::ServiceAccountKey,google/iam/admin/v1/iam.proto#L741}
   ///
@@ -673,6 +696,7 @@ class IAMClient {
   ///
   /// @param request
   /// @googleapis_link{google::iam::admin::v1::UploadServiceAccountKeyRequest,google/iam/admin/v1/iam.proto#L816}
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::iam::admin::v1::ServiceAccountKey,google/iam/admin/v1/iam.proto#L741}
   ///
@@ -692,6 +716,7 @@ class IAMClient {
   ///
   /// @param request
   /// @googleapis_link{google::iam::admin::v1::DeleteServiceAccountKeyRequest,google/iam/admin/v1/iam.proto#L832}
+  /// @param options  Optional. Operation options.
   ///
   /// [google.iam.admin.v1.DeleteServiceAccountKeyRequest]:
   /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L832}
@@ -715,6 +740,7 @@ class IAMClient {
   ///
   /// @param request
   /// @googleapis_link{google::iam::v1::GetIamPolicyRequest,google/iam/v1/iam_policy.proto#L113}
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
@@ -750,6 +776,7 @@ class IAMClient {
   ///
   /// @param request
   /// @googleapis_link{google::iam::v1::SetIamPolicyRequest,google/iam/v1/iam_policy.proto#L98}
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
@@ -768,6 +795,7 @@ class IAMClient {
   ///
   /// @param request
   /// @googleapis_link{google::iam::v1::TestIamPermissionsRequest,google/iam/v1/iam_policy.proto#L126}
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
   ///
@@ -787,6 +815,7 @@ class IAMClient {
   ///
   /// @param request
   /// @googleapis_link{google::iam::admin::v1::QueryGrantableRolesRequest,google/iam/admin/v1/iam.proto#L1062}
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::iam::admin::v1::Role,google/iam/admin/v1/iam.proto#L1004}
   ///
@@ -805,6 +834,7 @@ class IAMClient {
   ///
   /// @param request
   /// @googleapis_link{google::iam::admin::v1::ListRolesRequest,google/iam/admin/v1/iam.proto#L1093}
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::iam::admin::v1::Role,google/iam/admin/v1/iam.proto#L1004}
   ///
@@ -821,6 +851,7 @@ class IAMClient {
   ///
   /// @param request
   /// @googleapis_link{google::iam::admin::v1::GetRoleRequest,google/iam/admin/v1/iam.proto#L1152}
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::iam::admin::v1::Role,google/iam/admin/v1/iam.proto#L1004}
   ///
@@ -838,6 +869,7 @@ class IAMClient {
   ///
   /// @param request
   /// @googleapis_link{google::iam::admin::v1::CreateRoleRequest,google/iam/admin/v1/iam.proto#L1184}
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::iam::admin::v1::Role,google/iam/admin/v1/iam.proto#L1004}
   ///
@@ -855,6 +887,7 @@ class IAMClient {
   ///
   /// @param request
   /// @googleapis_link{google::iam::admin::v1::UpdateRoleRequest,google/iam/admin/v1/iam.proto#L1219}
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::iam::admin::v1::Role,google/iam/admin/v1/iam.proto#L1004}
   ///
@@ -889,6 +922,7 @@ class IAMClient {
   ///
   /// @param request
   /// @googleapis_link{google::iam::admin::v1::DeleteRoleRequest,google/iam/admin/v1/iam.proto#L1250}
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::iam::admin::v1::Role,google/iam/admin/v1/iam.proto#L1004}
   ///
@@ -906,6 +940,7 @@ class IAMClient {
   ///
   /// @param request
   /// @googleapis_link{google::iam::admin::v1::UndeleteRoleRequest,google/iam/admin/v1/iam.proto#L1278}
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::iam::admin::v1::Role,google/iam/admin/v1/iam.proto#L1004}
   ///
@@ -925,6 +960,7 @@ class IAMClient {
   ///
   /// @param request
   /// @googleapis_link{google::iam::admin::v1::QueryTestablePermissionsRequest,google/iam/admin/v1/iam.proto#L1361}
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::iam::admin::v1::Permission,google/iam/admin/v1/iam.proto#L1306}
   ///
@@ -946,6 +982,7 @@ class IAMClient {
   ///
   /// @param request
   /// @googleapis_link{google::iam::admin::v1::QueryAuditableServicesRequest,google/iam/admin/v1/iam.proto#L1391}
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::iam::admin::v1::QueryAuditableServicesResponse,google/iam/admin/v1/iam.proto#L1402}
   ///
@@ -969,6 +1006,7 @@ class IAMClient {
   ///
   /// @param request
   /// @googleapis_link{google::iam::admin::v1::LintPolicyRequest,google/iam/admin/v1/iam.proto#L1415}
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::iam::admin::v1::LintPolicyResponse,google/iam/admin/v1/iam.proto#L1513}
   ///

--- a/google/cloud/iam/iam_client.h
+++ b/google/cloud/iam/iam_client.h
@@ -79,7 +79,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 ///
 class IAMClient {
  public:
-  explicit IAMClient(std::shared_ptr<IAMConnection> connection);
+  explicit IAMClient(std::shared_ptr<IAMConnection> connection,
+                     Options options = {});
   ~IAMClient();
 
   //@{
@@ -116,7 +117,7 @@ class IAMClient {
   /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L461}
   ///
   StreamRange<google::iam::admin::v1::ServiceAccount> ListServiceAccounts(
-      std::string const& name);
+      std::string const& name, Options options = {});
 
   ///
   /// Gets a [ServiceAccount][google.iam.admin.v1.ServiceAccount].
@@ -136,7 +137,7 @@ class IAMClient {
   /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L461}
   ///
   StatusOr<google::iam::admin::v1::ServiceAccount> GetServiceAccount(
-      std::string const& name);
+      std::string const& name, Options options = {});
 
   ///
   /// Creates a [ServiceAccount][google.iam.admin.v1.ServiceAccount].
@@ -163,7 +164,8 @@ class IAMClient {
   ///
   StatusOr<google::iam::admin::v1::ServiceAccount> CreateServiceAccount(
       std::string const& name, std::string const& account_id,
-      google::iam::admin::v1::ServiceAccount const& service_account);
+      google::iam::admin::v1::ServiceAccount const& service_account,
+      Options options = {});
 
   ///
   /// Deletes a [ServiceAccount][google.iam.admin.v1.ServiceAccount].
@@ -195,7 +197,7 @@ class IAMClient {
   /// [google.iam.admin.v1.DeleteServiceAccountRequest]:
   /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L594}
   ///
-  Status DeleteServiceAccount(std::string const& name);
+  Status DeleteServiceAccount(std::string const& name, Options options = {});
 
   ///
   /// Lists every [ServiceAccountKey][google.iam.admin.v1.ServiceAccountKey] for
@@ -224,7 +226,8 @@ class IAMClient {
       std::string const& name,
       std::vector<
           google::iam::admin::v1::ListServiceAccountKeysRequest::KeyType> const&
-          key_types);
+          key_types,
+      Options options = {});
 
   ///
   /// Gets a [ServiceAccountKey][google.iam.admin.v1.ServiceAccountKey].
@@ -247,7 +250,8 @@ class IAMClient {
   ///
   StatusOr<google::iam::admin::v1::ServiceAccountKey> GetServiceAccountKey(
       std::string const& name,
-      google::iam::admin::v1::ServiceAccountPublicKeyType public_key_type);
+      google::iam::admin::v1::ServiceAccountPublicKeyType public_key_type,
+      Options options = {});
 
   ///
   /// Creates a [ServiceAccountKey][google.iam.admin.v1.ServiceAccountKey].
@@ -276,7 +280,8 @@ class IAMClient {
   StatusOr<google::iam::admin::v1::ServiceAccountKey> CreateServiceAccountKey(
       std::string const& name,
       google::iam::admin::v1::ServiceAccountPrivateKeyType private_key_type,
-      google::iam::admin::v1::ServiceAccountKeyAlgorithm key_algorithm);
+      google::iam::admin::v1::ServiceAccountKeyAlgorithm key_algorithm,
+      Options options = {});
 
   ///
   /// Deletes a [ServiceAccountKey][google.iam.admin.v1.ServiceAccountKey].
@@ -293,7 +298,7 @@ class IAMClient {
   /// [google.iam.admin.v1.DeleteServiceAccountKeyRequest]:
   /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L832}
   ///
-  Status DeleteServiceAccountKey(std::string const& name);
+  Status DeleteServiceAccountKey(std::string const& name, Options options = {});
 
   ///
   /// Gets the IAM policy that is attached to a
@@ -319,7 +324,8 @@ class IAMClient {
   /// [google.iam.v1.Policy]:
   /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
-  StatusOr<google::iam::v1::Policy> GetIamPolicy(std::string const& resource);
+  StatusOr<google::iam::v1::Policy> GetIamPolicy(std::string const& resource,
+                                                 Options options = {});
 
   ///
   /// Sets the IAM policy that is attached to a
@@ -359,7 +365,8 @@ class IAMClient {
   /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
-      std::string const& resource, google::iam::v1::Policy const& policy);
+      std::string const& resource, google::iam::v1::Policy const& policy,
+      Options options = {});
 
   /**
    * Updates the IAM policy for @p resource using an optimistic concurrency
@@ -407,7 +414,8 @@ class IAMClient {
   /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L141}
   ///
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
-      std::string const& resource, std::vector<std::string> const& permissions);
+      std::string const& resource, std::vector<std::string> const& permissions,
+      Options options = {});
 
   ///
   /// Lists roles that can be granted on a Google Cloud resource. A role is
@@ -428,7 +436,7 @@ class IAMClient {
   /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L1004}
   ///
   StreamRange<google::iam::admin::v1::Role> QueryGrantableRoles(
-      std::string const& full_resource_name);
+      std::string const& full_resource_name, Options options = {});
 
   ///
   /// Lists every [ServiceAccount][google.iam.admin.v1.ServiceAccount] that
@@ -445,7 +453,8 @@ class IAMClient {
   /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L461}
   ///
   StreamRange<google::iam::admin::v1::ServiceAccount> ListServiceAccounts(
-      google::iam::admin::v1::ListServiceAccountsRequest request);
+      google::iam::admin::v1::ListServiceAccountsRequest request,
+      Options options = {});
 
   ///
   /// Gets a [ServiceAccount][google.iam.admin.v1.ServiceAccount].
@@ -461,7 +470,8 @@ class IAMClient {
   /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L461}
   ///
   StatusOr<google::iam::admin::v1::ServiceAccount> GetServiceAccount(
-      google::iam::admin::v1::GetServiceAccountRequest const& request);
+      google::iam::admin::v1::GetServiceAccountRequest const& request,
+      Options options = {});
 
   ///
   /// Creates a [ServiceAccount][google.iam.admin.v1.ServiceAccount].
@@ -477,7 +487,8 @@ class IAMClient {
   /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L461}
   ///
   StatusOr<google::iam::admin::v1::ServiceAccount> CreateServiceAccount(
-      google::iam::admin::v1::CreateServiceAccountRequest const& request);
+      google::iam::admin::v1::CreateServiceAccountRequest const& request,
+      Options options = {});
 
   ///
   /// Patches a [ServiceAccount][google.iam.admin.v1.ServiceAccount].
@@ -493,7 +504,8 @@ class IAMClient {
   /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L461}
   ///
   StatusOr<google::iam::admin::v1::ServiceAccount> PatchServiceAccount(
-      google::iam::admin::v1::PatchServiceAccountRequest const& request);
+      google::iam::admin::v1::PatchServiceAccountRequest const& request,
+      Options options = {});
 
   ///
   /// Deletes a [ServiceAccount][google.iam.admin.v1.ServiceAccount].
@@ -522,7 +534,8 @@ class IAMClient {
   /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L594}
   ///
   Status DeleteServiceAccount(
-      google::iam::admin::v1::DeleteServiceAccountRequest const& request);
+      google::iam::admin::v1::DeleteServiceAccountRequest const& request,
+      Options options = {});
 
   ///
   /// Restores a deleted [ServiceAccount][google.iam.admin.v1.ServiceAccount].
@@ -546,7 +559,8 @@ class IAMClient {
   ///
   StatusOr<google::iam::admin::v1::UndeleteServiceAccountResponse>
   UndeleteServiceAccount(
-      google::iam::admin::v1::UndeleteServiceAccountRequest const& request);
+      google::iam::admin::v1::UndeleteServiceAccountRequest const& request,
+      Options options = {});
 
   ///
   /// Enables a [ServiceAccount][google.iam.admin.v1.ServiceAccount] that was
@@ -566,7 +580,8 @@ class IAMClient {
   /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L637}
   ///
   Status EnableServiceAccount(
-      google::iam::admin::v1::EnableServiceAccountRequest const& request);
+      google::iam::admin::v1::EnableServiceAccountRequest const& request,
+      Options options = {});
 
   ///
   /// Disables a [ServiceAccount][google.iam.admin.v1.ServiceAccount]
@@ -596,7 +611,8 @@ class IAMClient {
   /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L647}
   ///
   Status DisableServiceAccount(
-      google::iam::admin::v1::DisableServiceAccountRequest const& request);
+      google::iam::admin::v1::DisableServiceAccountRequest const& request,
+      Options options = {});
 
   ///
   /// Lists every [ServiceAccountKey][google.iam.admin.v1.ServiceAccountKey] for
@@ -614,7 +630,8 @@ class IAMClient {
   ///
   StatusOr<google::iam::admin::v1::ListServiceAccountKeysResponse>
   ListServiceAccountKeys(
-      google::iam::admin::v1::ListServiceAccountKeysRequest const& request);
+      google::iam::admin::v1::ListServiceAccountKeysRequest const& request,
+      Options options = {});
 
   ///
   /// Gets a [ServiceAccountKey][google.iam.admin.v1.ServiceAccountKey].
@@ -630,7 +647,8 @@ class IAMClient {
   /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L741}
   ///
   StatusOr<google::iam::admin::v1::ServiceAccountKey> GetServiceAccountKey(
-      google::iam::admin::v1::GetServiceAccountKeyRequest const& request);
+      google::iam::admin::v1::GetServiceAccountKeyRequest const& request,
+      Options options = {});
 
   ///
   /// Creates a [ServiceAccountKey][google.iam.admin.v1.ServiceAccountKey].
@@ -646,7 +664,8 @@ class IAMClient {
   /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L741}
   ///
   StatusOr<google::iam::admin::v1::ServiceAccountKey> CreateServiceAccountKey(
-      google::iam::admin::v1::CreateServiceAccountKeyRequest const& request);
+      google::iam::admin::v1::CreateServiceAccountKeyRequest const& request,
+      Options options = {});
 
   ///
   /// Creates a [ServiceAccountKey][google.iam.admin.v1.ServiceAccountKey],
@@ -663,7 +682,8 @@ class IAMClient {
   /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L741}
   ///
   StatusOr<google::iam::admin::v1::ServiceAccountKey> UploadServiceAccountKey(
-      google::iam::admin::v1::UploadServiceAccountKeyRequest const& request);
+      google::iam::admin::v1::UploadServiceAccountKeyRequest const& request,
+      Options options = {});
 
   ///
   /// Deletes a [ServiceAccountKey][google.iam.admin.v1.ServiceAccountKey].
@@ -677,7 +697,8 @@ class IAMClient {
   /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L832}
   ///
   Status DeleteServiceAccountKey(
-      google::iam::admin::v1::DeleteServiceAccountKeyRequest const& request);
+      google::iam::admin::v1::DeleteServiceAccountKeyRequest const& request,
+      Options options = {});
 
   ///
   /// Gets the IAM policy that is attached to a
@@ -703,7 +724,8 @@ class IAMClient {
   /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> GetIamPolicy(
-      google::iam::v1::GetIamPolicyRequest const& request);
+      google::iam::v1::GetIamPolicyRequest const& request,
+      Options options = {});
 
   ///
   /// Sets the IAM policy that is attached to a
@@ -737,7 +759,8 @@ class IAMClient {
   /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
-      google::iam::v1::SetIamPolicyRequest const& request);
+      google::iam::v1::SetIamPolicyRequest const& request,
+      Options options = {});
 
   ///
   /// Tests whether the caller has the specified permissions on a
@@ -754,7 +777,8 @@ class IAMClient {
   /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L141}
   ///
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
-      google::iam::v1::TestIamPermissionsRequest const& request);
+      google::iam::v1::TestIamPermissionsRequest const& request,
+      Options options = {});
 
   ///
   /// Lists roles that can be granted on a Google Cloud resource. A role is
@@ -772,7 +796,8 @@ class IAMClient {
   /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L1004}
   ///
   StreamRange<google::iam::admin::v1::Role> QueryGrantableRoles(
-      google::iam::admin::v1::QueryGrantableRolesRequest request);
+      google::iam::admin::v1::QueryGrantableRolesRequest request,
+      Options options = {});
 
   ///
   /// Lists every predefined [Role][google.iam.admin.v1.Role] that IAM supports,
@@ -789,7 +814,7 @@ class IAMClient {
   /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L1004}
   ///
   StreamRange<google::iam::admin::v1::Role> ListRoles(
-      google::iam::admin::v1::ListRolesRequest request);
+      google::iam::admin::v1::ListRolesRequest request, Options options = {});
 
   ///
   /// Gets the definition of a [Role][google.iam.admin.v1.Role].
@@ -805,7 +830,8 @@ class IAMClient {
   /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L1004}
   ///
   StatusOr<google::iam::admin::v1::Role> GetRole(
-      google::iam::admin::v1::GetRoleRequest const& request);
+      google::iam::admin::v1::GetRoleRequest const& request,
+      Options options = {});
 
   ///
   /// Creates a new custom [Role][google.iam.admin.v1.Role].
@@ -821,7 +847,8 @@ class IAMClient {
   /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L1004}
   ///
   StatusOr<google::iam::admin::v1::Role> CreateRole(
-      google::iam::admin::v1::CreateRoleRequest const& request);
+      google::iam::admin::v1::CreateRoleRequest const& request,
+      Options options = {});
 
   ///
   /// Updates the definition of a custom [Role][google.iam.admin.v1.Role].
@@ -837,7 +864,8 @@ class IAMClient {
   /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L1004}
   ///
   StatusOr<google::iam::admin::v1::Role> UpdateRole(
-      google::iam::admin::v1::UpdateRoleRequest const& request);
+      google::iam::admin::v1::UpdateRoleRequest const& request,
+      Options options = {});
 
   ///
   /// Deletes a custom [Role][google.iam.admin.v1.Role].
@@ -870,7 +898,8 @@ class IAMClient {
   /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L1004}
   ///
   StatusOr<google::iam::admin::v1::Role> DeleteRole(
-      google::iam::admin::v1::DeleteRoleRequest const& request);
+      google::iam::admin::v1::DeleteRoleRequest const& request,
+      Options options = {});
 
   ///
   /// Undeletes a custom [Role][google.iam.admin.v1.Role].
@@ -886,7 +915,8 @@ class IAMClient {
   /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L1004}
   ///
   StatusOr<google::iam::admin::v1::Role> UndeleteRole(
-      google::iam::admin::v1::UndeleteRoleRequest const& request);
+      google::iam::admin::v1::UndeleteRoleRequest const& request,
+      Options options = {});
 
   ///
   /// Lists every permission that you can test on a resource. A permission is
@@ -904,7 +934,8 @@ class IAMClient {
   /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L1306}
   ///
   StreamRange<google::iam::admin::v1::Permission> QueryTestablePermissions(
-      google::iam::admin::v1::QueryTestablePermissionsRequest request);
+      google::iam::admin::v1::QueryTestablePermissionsRequest request,
+      Options options = {});
 
   ///
   /// Returns a list of services that allow you to opt into audit logs that are
@@ -925,7 +956,8 @@ class IAMClient {
   ///
   StatusOr<google::iam::admin::v1::QueryAuditableServicesResponse>
   QueryAuditableServices(
-      google::iam::admin::v1::QueryAuditableServicesRequest const& request);
+      google::iam::admin::v1::QueryAuditableServicesRequest const& request,
+      Options options = {});
 
   ///
   /// Lints, or validates, an IAM policy. Currently checks the
@@ -946,10 +978,12 @@ class IAMClient {
   /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L1513}
   ///
   StatusOr<google::iam::admin::v1::LintPolicyResponse> LintPolicy(
-      google::iam::admin::v1::LintPolicyRequest const& request);
+      google::iam::admin::v1::LintPolicyRequest const& request,
+      Options options = {});
 
  private:
   std::shared_ptr<IAMConnection> connection_;
+  Options options_;
 };
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/iam/iam_credentials_client.cc
+++ b/google/cloud/iam/iam_credentials_client.cc
@@ -17,6 +17,7 @@
 // source: google/iam/credentials/v1/iamcredentials.proto
 
 #include "google/cloud/iam/iam_credentials_client.h"
+#include "google/cloud/iam/internal/iam_credentials_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -25,15 +26,19 @@ namespace iam {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 IAMCredentialsClient::IAMCredentialsClient(
-    std::shared_ptr<IAMCredentialsConnection> connection)
-    : connection_(std::move(connection)) {}
+    std::shared_ptr<IAMCredentialsConnection> connection, Options options)
+    : connection_(std::move(connection)),
+      options_(iam_internal::IAMCredentialsDefaultOptions(std::move(options))) {
+}
 IAMCredentialsClient::~IAMCredentialsClient() = default;
 
 StatusOr<google::iam::credentials::v1::GenerateAccessTokenResponse>
 IAMCredentialsClient::GenerateAccessToken(
     std::string const& name, std::vector<std::string> const& delegates,
     std::vector<std::string> const& scope,
-    google::protobuf::Duration const& lifetime) {
+    google::protobuf::Duration const& lifetime, Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   google::iam::credentials::v1::GenerateAccessTokenRequest request;
   request.set_name(name);
   *request.mutable_delegates() = {delegates.begin(), delegates.end()};
@@ -46,7 +51,9 @@ StatusOr<google::iam::credentials::v1::GenerateIdTokenResponse>
 IAMCredentialsClient::GenerateIdToken(std::string const& name,
                                       std::vector<std::string> const& delegates,
                                       std::string const& audience,
-                                      bool include_email) {
+                                      bool include_email, Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   google::iam::credentials::v1::GenerateIdTokenRequest request;
   request.set_name(name);
   *request.mutable_delegates() = {delegates.begin(), delegates.end()};
@@ -58,7 +65,9 @@ IAMCredentialsClient::GenerateIdToken(std::string const& name,
 StatusOr<google::iam::credentials::v1::SignBlobResponse>
 IAMCredentialsClient::SignBlob(std::string const& name,
                                std::vector<std::string> const& delegates,
-                               std::string const& payload) {
+                               std::string const& payload, Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   google::iam::credentials::v1::SignBlobRequest request;
   request.set_name(name);
   *request.mutable_delegates() = {delegates.begin(), delegates.end()};
@@ -69,7 +78,9 @@ IAMCredentialsClient::SignBlob(std::string const& name,
 StatusOr<google::iam::credentials::v1::SignJwtResponse>
 IAMCredentialsClient::SignJwt(std::string const& name,
                               std::vector<std::string> const& delegates,
-                              std::string const& payload) {
+                              std::string const& payload, Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   google::iam::credentials::v1::SignJwtRequest request;
   request.set_name(name);
   *request.mutable_delegates() = {delegates.begin(), delegates.end()};
@@ -79,25 +90,37 @@ IAMCredentialsClient::SignJwt(std::string const& name,
 
 StatusOr<google::iam::credentials::v1::GenerateAccessTokenResponse>
 IAMCredentialsClient::GenerateAccessToken(
-    google::iam::credentials::v1::GenerateAccessTokenRequest const& request) {
+    google::iam::credentials::v1::GenerateAccessTokenRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->GenerateAccessToken(request);
 }
 
 StatusOr<google::iam::credentials::v1::GenerateIdTokenResponse>
 IAMCredentialsClient::GenerateIdToken(
-    google::iam::credentials::v1::GenerateIdTokenRequest const& request) {
+    google::iam::credentials::v1::GenerateIdTokenRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->GenerateIdToken(request);
 }
 
 StatusOr<google::iam::credentials::v1::SignBlobResponse>
 IAMCredentialsClient::SignBlob(
-    google::iam::credentials::v1::SignBlobRequest const& request) {
+    google::iam::credentials::v1::SignBlobRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->SignBlob(request);
 }
 
 StatusOr<google::iam::credentials::v1::SignJwtResponse>
 IAMCredentialsClient::SignJwt(
-    google::iam::credentials::v1::SignJwtRequest const& request) {
+    google::iam::credentials::v1::SignJwtRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->SignJwt(request);
 }
 

--- a/google/cloud/iam/iam_credentials_client.h
+++ b/google/cloud/iam/iam_credentials_client.h
@@ -123,6 +123,7 @@ class IAMCredentialsClient {
   ///  Must be set to a value less than or equal to 3600 (1 hour). If a value is
   ///  not specified, the token's lifetime will be set to a default value of one
   ///  hour.
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::iam::credentials::v1::GenerateAccessTokenResponse,google/iam/credentials/v1/common.proto#L72}
   ///
@@ -164,6 +165,7 @@ class IAMCredentialsClient {
   /// @param include_email  Include the service account email in the token. If
   /// set to `true`, the
   ///  token will contain `email` and `email_verified` claims.
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::iam::credentials::v1::GenerateIdTokenResponse,google/iam/credentials/v1/common.proto#L186}
   ///
@@ -199,6 +201,7 @@ class IAMCredentialsClient {
   ///  wildcard character is required; replacing it with a project ID is
   ///  invalid.
   /// @param payload  Required. The bytes to sign.
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::iam::credentials::v1::SignBlobResponse,google/iam/credentials/v1/common.proto#L109}
   ///
@@ -233,6 +236,7 @@ class IAMCredentialsClient {
   ///  invalid.
   /// @param payload  Required. The JWT payload to sign: a JSON object that
   /// contains a JWT Claims Set.
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::iam::credentials::v1::SignJwtResponse,google/iam/credentials/v1/common.proto#L145}
   ///
@@ -250,6 +254,7 @@ class IAMCredentialsClient {
   ///
   /// @param request
   /// @googleapis_link{google::iam::credentials::v1::GenerateAccessTokenRequest,google/iam/credentials/v1/common.proto#L35}
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::iam::credentials::v1::GenerateAccessTokenResponse,google/iam/credentials/v1/common.proto#L72}
   ///
@@ -268,6 +273,7 @@ class IAMCredentialsClient {
   ///
   /// @param request
   /// @googleapis_link{google::iam::credentials::v1::GenerateIdTokenRequest,google/iam/credentials/v1/common.proto#L153}
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::iam::credentials::v1::GenerateIdTokenResponse,google/iam/credentials/v1/common.proto#L186}
   ///
@@ -286,6 +292,7 @@ class IAMCredentialsClient {
   ///
   /// @param request
   /// @googleapis_link{google::iam::credentials::v1::SignBlobRequest,google/iam/credentials/v1/common.proto#L81}
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::iam::credentials::v1::SignBlobResponse,google/iam/credentials/v1/common.proto#L109}
   ///
@@ -303,6 +310,7 @@ class IAMCredentialsClient {
   ///
   /// @param request
   /// @googleapis_link{google::iam::credentials::v1::SignJwtRequest,google/iam/credentials/v1/common.proto#L117}
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::iam::credentials::v1::SignJwtResponse,google/iam/credentials/v1/common.proto#L145}
   ///

--- a/google/cloud/iam/iam_credentials_client.h
+++ b/google/cloud/iam/iam_credentials_client.h
@@ -21,6 +21,7 @@
 
 #include "google/cloud/iam/iam_credentials_connection.h"
 #include "google/cloud/future.h"
+#include "google/cloud/options.h"
 #include "google/cloud/polling_policy.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
@@ -69,7 +70,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class IAMCredentialsClient {
  public:
   explicit IAMCredentialsClient(
-      std::shared_ptr<IAMCredentialsConnection> connection);
+      std::shared_ptr<IAMCredentialsConnection> connection,
+      Options options = {});
   ~IAMCredentialsClient();
 
   //@{
@@ -133,7 +135,8 @@ class IAMCredentialsClient {
   GenerateAccessToken(std::string const& name,
                       std::vector<std::string> const& delegates,
                       std::vector<std::string> const& scope,
-                      google::protobuf::Duration const& lifetime);
+                      google::protobuf::Duration const& lifetime,
+                      Options options = {});
 
   ///
   /// Generates an OpenID Connect ID token for a service account.
@@ -172,7 +175,8 @@ class IAMCredentialsClient {
   StatusOr<google::iam::credentials::v1::GenerateIdTokenResponse>
   GenerateIdToken(std::string const& name,
                   std::vector<std::string> const& delegates,
-                  std::string const& audience, bool include_email);
+                  std::string const& audience, bool include_email,
+                  Options options = {});
 
   ///
   /// Signs a blob using a service account's system-managed private key.
@@ -205,7 +209,7 @@ class IAMCredentialsClient {
   ///
   StatusOr<google::iam::credentials::v1::SignBlobResponse> SignBlob(
       std::string const& name, std::vector<std::string> const& delegates,
-      std::string const& payload);
+      std::string const& payload, Options options = {});
 
   ///
   /// Signs a JWT using a service account's system-managed private key.
@@ -239,7 +243,7 @@ class IAMCredentialsClient {
   ///
   StatusOr<google::iam::credentials::v1::SignJwtResponse> SignJwt(
       std::string const& name, std::vector<std::string> const& delegates,
-      std::string const& payload);
+      std::string const& payload, Options options = {});
 
   ///
   /// Generates an OAuth 2.0 access token for a service account.
@@ -256,7 +260,8 @@ class IAMCredentialsClient {
   ///
   StatusOr<google::iam::credentials::v1::GenerateAccessTokenResponse>
   GenerateAccessToken(
-      google::iam::credentials::v1::GenerateAccessTokenRequest const& request);
+      google::iam::credentials::v1::GenerateAccessTokenRequest const& request,
+      Options options = {});
 
   ///
   /// Generates an OpenID Connect ID token for a service account.
@@ -273,7 +278,8 @@ class IAMCredentialsClient {
   ///
   StatusOr<google::iam::credentials::v1::GenerateIdTokenResponse>
   GenerateIdToken(
-      google::iam::credentials::v1::GenerateIdTokenRequest const& request);
+      google::iam::credentials::v1::GenerateIdTokenRequest const& request,
+      Options options = {});
 
   ///
   /// Signs a blob using a service account's system-managed private key.
@@ -289,7 +295,8 @@ class IAMCredentialsClient {
   /// @googleapis_reference_link{google/iam/credentials/v1/common.proto#L109}
   ///
   StatusOr<google::iam::credentials::v1::SignBlobResponse> SignBlob(
-      google::iam::credentials::v1::SignBlobRequest const& request);
+      google::iam::credentials::v1::SignBlobRequest const& request,
+      Options options = {});
 
   ///
   /// Signs a JWT using a service account's system-managed private key.
@@ -305,10 +312,12 @@ class IAMCredentialsClient {
   /// @googleapis_reference_link{google/iam/credentials/v1/common.proto#L145}
   ///
   StatusOr<google::iam::credentials::v1::SignJwtResponse> SignJwt(
-      google::iam::credentials::v1::SignJwtRequest const& request);
+      google::iam::credentials::v1::SignJwtRequest const& request,
+      Options options = {});
 
  private:
   std::shared_ptr<IAMCredentialsConnection> connection_;
+  Options options_;
 };
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/logging/logging_service_v2_client.cc
+++ b/google/cloud/logging/logging_service_v2_client.cc
@@ -17,6 +17,7 @@
 // source: google/logging/v2/logging.proto
 
 #include "google/cloud/logging/logging_service_v2_client.h"
+#include "google/cloud/logging/internal/logging_service_v2_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -25,11 +26,16 @@ namespace logging {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 LoggingServiceV2Client::LoggingServiceV2Client(
-    std::shared_ptr<LoggingServiceV2Connection> connection)
-    : connection_(std::move(connection)) {}
+    std::shared_ptr<LoggingServiceV2Connection> connection, Options options)
+    : connection_(std::move(connection)),
+      options_(logging_internal::LoggingServiceV2DefaultOptions(
+          std::move(options))) {}
 LoggingServiceV2Client::~LoggingServiceV2Client() = default;
 
-Status LoggingServiceV2Client::DeleteLog(std::string const& log_name) {
+Status LoggingServiceV2Client::DeleteLog(std::string const& log_name,
+                                         Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   google::logging::v2::DeleteLogRequest request;
   request.set_log_name(log_name);
   return connection_->DeleteLog(request);
@@ -39,7 +45,10 @@ StatusOr<google::logging::v2::WriteLogEntriesResponse>
 LoggingServiceV2Client::WriteLogEntries(
     std::string const& log_name, google::api::MonitoredResource const& resource,
     std::map<std::string, std::string> const& labels,
-    std::vector<google::logging::v2::LogEntry> const& entries) {
+    std::vector<google::logging::v2::LogEntry> const& entries,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   google::logging::v2::WriteLogEntriesRequest request;
   request.set_log_name(log_name);
   *request.mutable_resource() = resource;
@@ -51,7 +60,9 @@ LoggingServiceV2Client::WriteLogEntries(
 StreamRange<google::logging::v2::LogEntry>
 LoggingServiceV2Client::ListLogEntries(
     std::vector<std::string> const& resource_names, std::string const& filter,
-    std::string const& order_by) {
+    std::string const& order_by, Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   google::logging::v2::ListLogEntriesRequest request;
   *request.mutable_resource_names() = {resource_names.begin(),
                                        resource_names.end()};
@@ -61,37 +72,51 @@ LoggingServiceV2Client::ListLogEntries(
 }
 
 StreamRange<std::string> LoggingServiceV2Client::ListLogs(
-    std::string const& parent) {
+    std::string const& parent, Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   google::logging::v2::ListLogsRequest request;
   request.set_parent(parent);
   return connection_->ListLogs(request);
 }
 
 Status LoggingServiceV2Client::DeleteLog(
-    google::logging::v2::DeleteLogRequest const& request) {
+    google::logging::v2::DeleteLogRequest const& request, Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->DeleteLog(request);
 }
 
 StatusOr<google::logging::v2::WriteLogEntriesResponse>
 LoggingServiceV2Client::WriteLogEntries(
-    google::logging::v2::WriteLogEntriesRequest const& request) {
+    google::logging::v2::WriteLogEntriesRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->WriteLogEntries(request);
 }
 
 StreamRange<google::logging::v2::LogEntry>
 LoggingServiceV2Client::ListLogEntries(
-    google::logging::v2::ListLogEntriesRequest request) {
+    google::logging::v2::ListLogEntriesRequest request, Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->ListLogEntries(std::move(request));
 }
 
 StreamRange<google::api::MonitoredResourceDescriptor>
 LoggingServiceV2Client::ListMonitoredResourceDescriptors(
-    google::logging::v2::ListMonitoredResourceDescriptorsRequest request) {
+    google::logging::v2::ListMonitoredResourceDescriptorsRequest request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->ListMonitoredResourceDescriptors(std::move(request));
 }
 
 StreamRange<std::string> LoggingServiceV2Client::ListLogs(
-    google::logging::v2::ListLogsRequest request) {
+    google::logging::v2::ListLogsRequest request, Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->ListLogs(std::move(request));
 }
 

--- a/google/cloud/logging/logging_service_v2_client.h
+++ b/google/cloud/logging/logging_service_v2_client.h
@@ -21,6 +21,7 @@
 
 #include "google/cloud/logging/logging_service_v2_connection.h"
 #include "google/cloud/future.h"
+#include "google/cloud/options.h"
 #include "google/cloud/polling_policy.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
@@ -61,7 +62,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class LoggingServiceV2Client {
  public:
   explicit LoggingServiceV2Client(
-      std::shared_ptr<LoggingServiceV2Connection> connection);
+      std::shared_ptr<LoggingServiceV2Connection> connection,
+      Options options = {});
   ~LoggingServiceV2Client();
 
   //@{
@@ -104,7 +106,7 @@ class LoggingServiceV2Client {
   /// [google.logging.v2.DeleteLogRequest]:
   /// @googleapis_reference_link{google/logging/v2/logging.proto#L140}
   ///
-  Status DeleteLog(std::string const& log_name);
+  Status DeleteLog(std::string const& log_name, Options options = {});
 
   ///
   /// Writes log entries to Logging. This API method is the
@@ -175,7 +177,8 @@ class LoggingServiceV2Client {
       std::string const& log_name,
       google::api::MonitoredResource const& resource,
       std::map<std::string, std::string> const& labels,
-      std::vector<google::logging::v2::LogEntry> const& entries);
+      std::vector<google::logging::v2::LogEntry> const& entries,
+      Options options = {});
 
   ///
   /// Lists log entries.  Use this method to retrieve log entries that
@@ -222,7 +225,7 @@ class LoggingServiceV2Client {
   ///
   StreamRange<google::logging::v2::LogEntry> ListLogEntries(
       std::vector<std::string> const& resource_names, std::string const& filter,
-      std::string const& order_by);
+      std::string const& order_by, Options options = {});
 
   ///
   /// Lists the logs in projects, organizations, folders, or billing accounts.
@@ -238,7 +241,8 @@ class LoggingServiceV2Client {
   /// [google.logging.v2.ListLogsRequest]:
   /// @googleapis_reference_link{google/logging/v2/logging.proto#L356}
   ///
-  StreamRange<std::string> ListLogs(std::string const& parent);
+  StreamRange<std::string> ListLogs(std::string const& parent,
+                                    Options options = {});
 
   ///
   /// Deletes all the log entries in a log. The log reappears if it receives new
@@ -252,7 +256,8 @@ class LoggingServiceV2Client {
   /// [google.logging.v2.DeleteLogRequest]:
   /// @googleapis_reference_link{google/logging/v2/logging.proto#L140}
   ///
-  Status DeleteLog(google::logging::v2::DeleteLogRequest const& request);
+  Status DeleteLog(google::logging::v2::DeleteLogRequest const& request,
+                   Options options = {});
 
   ///
   /// Writes log entries to Logging. This API method is the
@@ -274,7 +279,8 @@ class LoggingServiceV2Client {
   /// @googleapis_reference_link{google/logging/v2/logging.proto#L243}
   ///
   StatusOr<google::logging::v2::WriteLogEntriesResponse> WriteLogEntries(
-      google::logging::v2::WriteLogEntriesRequest const& request);
+      google::logging::v2::WriteLogEntriesRequest const& request,
+      Options options = {});
 
   ///
   /// Lists log entries.  Use this method to retrieve log entries that
@@ -293,7 +299,7 @@ class LoggingServiceV2Client {
   /// @googleapis_reference_link{google/logging/v2/log_entry.proto#L42}
   ///
   StreamRange<google::logging::v2::LogEntry> ListLogEntries(
-      google::logging::v2::ListLogEntriesRequest request);
+      google::logging::v2::ListLogEntriesRequest request, Options options = {});
 
   ///
   /// Lists the descriptors for monitored resource types used by Logging.
@@ -310,7 +316,8 @@ class LoggingServiceV2Client {
   ///
   StreamRange<google::api::MonitoredResourceDescriptor>
   ListMonitoredResourceDescriptors(
-      google::logging::v2::ListMonitoredResourceDescriptorsRequest request);
+      google::logging::v2::ListMonitoredResourceDescriptorsRequest request,
+      Options options = {});
 
   ///
   /// Lists the logs in projects, organizations, folders, or billing accounts.
@@ -324,10 +331,11 @@ class LoggingServiceV2Client {
   /// @googleapis_reference_link{google/logging/v2/logging.proto#L356}
   ///
   StreamRange<std::string> ListLogs(
-      google::logging::v2::ListLogsRequest request);
+      google::logging::v2::ListLogsRequest request, Options options = {});
 
  private:
   std::shared_ptr<LoggingServiceV2Connection> connection_;
+  Options options_;
 };
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/logging/logging_service_v2_client.h
+++ b/google/cloud/logging/logging_service_v2_client.h
@@ -102,6 +102,7 @@ class LoggingServiceV2Client {
   ///  `"organizations/1234567890/logs/cloudresourcemanager.googleapis.com%2Factivity"`.
   ///  For more information about log names, see
   ///  [LogEntry][google.logging.v2.LogEntry].
+  /// @param options  Optional. Operation options.
   ///
   /// [google.logging.v2.DeleteLogRequest]:
   /// @googleapis_reference_link{google/logging/v2/logging.proto#L140}
@@ -165,6 +166,7 @@ class LoggingServiceV2Client {
   ///  [quota limit](https://cloud.google.com/logging/quota-policy) for calls to
   ///  `entries.write`, you should try to include several log entries in this
   ///  list, rather than calling this method for each individual log entry.
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::logging::v2::WriteLogEntriesResponse,google/logging/v2/logging.proto#L243}
   ///
@@ -215,6 +217,7 @@ class LoggingServiceV2Client {
   ///  `LogEntry.timestamp` (oldest first), and the second option returns
   ///  entries in order of decreasing timestamps (newest first).  Entries with
   ///  equal timestamps are returned in order of their `insert_id` values.
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::logging::v2::LogEntry,google/logging/v2/log_entry.proto#L42}
   ///
@@ -236,6 +239,7 @@ class LoggingServiceV2Client {
   ///      "organizations/[ORGANIZATION_ID]"
   ///      "billingAccounts/[BILLING_ACCOUNT_ID]"
   ///      "folders/[FOLDER_ID]"
+  /// @param options  Optional. Operation options.
   /// @return std::string
   ///
   /// [google.logging.v2.ListLogsRequest]:
@@ -252,6 +256,7 @@ class LoggingServiceV2Client {
   ///
   /// @param request
   /// @googleapis_link{google::logging::v2::DeleteLogRequest,google/logging/v2/logging.proto#L140}
+  /// @param options  Optional. Operation options.
   ///
   /// [google.logging.v2.DeleteLogRequest]:
   /// @googleapis_reference_link{google/logging/v2/logging.proto#L140}
@@ -270,6 +275,7 @@ class LoggingServiceV2Client {
   ///
   /// @param request
   /// @googleapis_link{google::logging::v2::WriteLogEntriesRequest,google/logging/v2/logging.proto#L162}
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::logging::v2::WriteLogEntriesResponse,google/logging/v2/logging.proto#L243}
   ///
@@ -290,6 +296,7 @@ class LoggingServiceV2Client {
   ///
   /// @param request
   /// @googleapis_link{google::logging::v2::ListLogEntriesRequest,google/logging/v2/logging.proto#L257}
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::logging::v2::LogEntry,google/logging/v2/log_entry.proto#L42}
   ///
@@ -306,6 +313,7 @@ class LoggingServiceV2Client {
   ///
   /// @param request
   /// @googleapis_link{google::logging::v2::ListMonitoredResourceDescriptorsRequest,google/logging/v2/logging.proto#L331}
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::api::MonitoredResourceDescriptor,google/api/monitored_resource.proto#L40}
   ///
@@ -325,6 +333,7 @@ class LoggingServiceV2Client {
   ///
   /// @param request
   /// @googleapis_link{google::logging::v2::ListLogsRequest,google/logging/v2/logging.proto#L356}
+  /// @param options  Optional. Operation options.
   /// @return std::string
   ///
   /// [google.logging.v2.ListLogsRequest]:

--- a/google/cloud/pubsublite/admin_client.cc
+++ b/google/cloud/pubsublite/admin_client.cc
@@ -17,6 +17,7 @@
 // source: google/cloud/pubsublite/v1/admin.proto
 
 #include "google/cloud/pubsublite/admin_client.h"
+#include "google/cloud/pubsublite/internal/admin_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -25,14 +26,19 @@ namespace pubsublite {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 AdminServiceClient::AdminServiceClient(
-    std::shared_ptr<AdminServiceConnection> connection)
-    : connection_(std::move(connection)) {}
+    std::shared_ptr<AdminServiceConnection> connection, Options options)
+    : connection_(std::move(connection)),
+      options_(
+          pubsublite_internal::AdminServiceDefaultOptions(std::move(options))) {
+}
 AdminServiceClient::~AdminServiceClient() = default;
 
 StatusOr<google::cloud::pubsublite::v1::Topic> AdminServiceClient::CreateTopic(
     std::string const& parent,
     google::cloud::pubsublite::v1::Topic const& topic,
-    std::string const& topic_id) {
+    std::string const& topic_id, Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   google::cloud::pubsublite::v1::CreateTopicRequest request;
   request.set_parent(parent);
   *request.mutable_topic() = topic;
@@ -41,21 +47,28 @@ StatusOr<google::cloud::pubsublite::v1::Topic> AdminServiceClient::CreateTopic(
 }
 
 StatusOr<google::cloud::pubsublite::v1::Topic> AdminServiceClient::GetTopic(
-    std::string const& name) {
+    std::string const& name, Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   google::cloud::pubsublite::v1::GetTopicRequest request;
   request.set_name(name);
   return connection_->GetTopic(request);
 }
 
 StatusOr<google::cloud::pubsublite::v1::TopicPartitions>
-AdminServiceClient::GetTopicPartitions(std::string const& name) {
+AdminServiceClient::GetTopicPartitions(std::string const& name,
+                                       Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   google::cloud::pubsublite::v1::GetTopicPartitionsRequest request;
   request.set_name(name);
   return connection_->GetTopicPartitions(request);
 }
 
 StreamRange<google::cloud::pubsublite::v1::Topic>
-AdminServiceClient::ListTopics(std::string const& parent) {
+AdminServiceClient::ListTopics(std::string const& parent, Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   google::cloud::pubsublite::v1::ListTopicsRequest request;
   request.set_parent(parent);
   return connection_->ListTopics(request);
@@ -63,21 +76,28 @@ AdminServiceClient::ListTopics(std::string const& parent) {
 
 StatusOr<google::cloud::pubsublite::v1::Topic> AdminServiceClient::UpdateTopic(
     google::cloud::pubsublite::v1::Topic const& topic,
-    google::protobuf::FieldMask const& update_mask) {
+    google::protobuf::FieldMask const& update_mask, Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   google::cloud::pubsublite::v1::UpdateTopicRequest request;
   *request.mutable_topic() = topic;
   *request.mutable_update_mask() = update_mask;
   return connection_->UpdateTopic(request);
 }
 
-Status AdminServiceClient::DeleteTopic(std::string const& name) {
+Status AdminServiceClient::DeleteTopic(std::string const& name,
+                                       Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   google::cloud::pubsublite::v1::DeleteTopicRequest request;
   request.set_name(name);
   return connection_->DeleteTopic(request);
 }
 
 StreamRange<std::string> AdminServiceClient::ListTopicSubscriptions(
-    std::string const& name) {
+    std::string const& name, Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   google::cloud::pubsublite::v1::ListTopicSubscriptionsRequest request;
   request.set_name(name);
   return connection_->ListTopicSubscriptions(request);
@@ -87,7 +107,9 @@ StatusOr<google::cloud::pubsublite::v1::Subscription>
 AdminServiceClient::CreateSubscription(
     std::string const& parent,
     google::cloud::pubsublite::v1::Subscription const& subscription,
-    std::string const& subscription_id) {
+    std::string const& subscription_id, Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   google::cloud::pubsublite::v1::CreateSubscriptionRequest request;
   request.set_parent(parent);
   *request.mutable_subscription() = subscription;
@@ -96,14 +118,19 @@ AdminServiceClient::CreateSubscription(
 }
 
 StatusOr<google::cloud::pubsublite::v1::Subscription>
-AdminServiceClient::GetSubscription(std::string const& name) {
+AdminServiceClient::GetSubscription(std::string const& name, Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   google::cloud::pubsublite::v1::GetSubscriptionRequest request;
   request.set_name(name);
   return connection_->GetSubscription(request);
 }
 
 StreamRange<google::cloud::pubsublite::v1::Subscription>
-AdminServiceClient::ListSubscriptions(std::string const& parent) {
+AdminServiceClient::ListSubscriptions(std::string const& parent,
+                                      Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   google::cloud::pubsublite::v1::ListSubscriptionsRequest request;
   request.set_parent(parent);
   return connection_->ListSubscriptions(request);
@@ -112,14 +139,19 @@ AdminServiceClient::ListSubscriptions(std::string const& parent) {
 StatusOr<google::cloud::pubsublite::v1::Subscription>
 AdminServiceClient::UpdateSubscription(
     google::cloud::pubsublite::v1::Subscription const& subscription,
-    google::protobuf::FieldMask const& update_mask) {
+    google::protobuf::FieldMask const& update_mask, Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   google::cloud::pubsublite::v1::UpdateSubscriptionRequest request;
   *request.mutable_subscription() = subscription;
   *request.mutable_update_mask() = update_mask;
   return connection_->UpdateSubscription(request);
 }
 
-Status AdminServiceClient::DeleteSubscription(std::string const& name) {
+Status AdminServiceClient::DeleteSubscription(std::string const& name,
+                                              Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   google::cloud::pubsublite::v1::DeleteSubscriptionRequest request;
   request.set_name(name);
   return connection_->DeleteSubscription(request);
@@ -129,7 +161,9 @@ StatusOr<google::cloud::pubsublite::v1::Reservation>
 AdminServiceClient::CreateReservation(
     std::string const& parent,
     google::cloud::pubsublite::v1::Reservation const& reservation,
-    std::string const& reservation_id) {
+    std::string const& reservation_id, Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   google::cloud::pubsublite::v1::CreateReservationRequest request;
   request.set_parent(parent);
   *request.mutable_reservation() = reservation;
@@ -138,14 +172,19 @@ AdminServiceClient::CreateReservation(
 }
 
 StatusOr<google::cloud::pubsublite::v1::Reservation>
-AdminServiceClient::GetReservation(std::string const& name) {
+AdminServiceClient::GetReservation(std::string const& name, Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   google::cloud::pubsublite::v1::GetReservationRequest request;
   request.set_name(name);
   return connection_->GetReservation(request);
 }
 
 StreamRange<google::cloud::pubsublite::v1::Reservation>
-AdminServiceClient::ListReservations(std::string const& parent) {
+AdminServiceClient::ListReservations(std::string const& parent,
+                                     Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   google::cloud::pubsublite::v1::ListReservationsRequest request;
   request.set_parent(parent);
   return connection_->ListReservations(request);
@@ -154,129 +193,192 @@ AdminServiceClient::ListReservations(std::string const& parent) {
 StatusOr<google::cloud::pubsublite::v1::Reservation>
 AdminServiceClient::UpdateReservation(
     google::cloud::pubsublite::v1::Reservation const& reservation,
-    google::protobuf::FieldMask const& update_mask) {
+    google::protobuf::FieldMask const& update_mask, Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   google::cloud::pubsublite::v1::UpdateReservationRequest request;
   *request.mutable_reservation() = reservation;
   *request.mutable_update_mask() = update_mask;
   return connection_->UpdateReservation(request);
 }
 
-Status AdminServiceClient::DeleteReservation(std::string const& name) {
+Status AdminServiceClient::DeleteReservation(std::string const& name,
+                                             Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   google::cloud::pubsublite::v1::DeleteReservationRequest request;
   request.set_name(name);
   return connection_->DeleteReservation(request);
 }
 
 StreamRange<std::string> AdminServiceClient::ListReservationTopics(
-    std::string const& name) {
+    std::string const& name, Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   google::cloud::pubsublite::v1::ListReservationTopicsRequest request;
   request.set_name(name);
   return connection_->ListReservationTopics(request);
 }
 
 StatusOr<google::cloud::pubsublite::v1::Topic> AdminServiceClient::CreateTopic(
-    google::cloud::pubsublite::v1::CreateTopicRequest const& request) {
+    google::cloud::pubsublite::v1::CreateTopicRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->CreateTopic(request);
 }
 
 StatusOr<google::cloud::pubsublite::v1::Topic> AdminServiceClient::GetTopic(
-    google::cloud::pubsublite::v1::GetTopicRequest const& request) {
+    google::cloud::pubsublite::v1::GetTopicRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->GetTopic(request);
 }
 
 StatusOr<google::cloud::pubsublite::v1::TopicPartitions>
 AdminServiceClient::GetTopicPartitions(
-    google::cloud::pubsublite::v1::GetTopicPartitionsRequest const& request) {
+    google::cloud::pubsublite::v1::GetTopicPartitionsRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->GetTopicPartitions(request);
 }
 
 StreamRange<google::cloud::pubsublite::v1::Topic>
 AdminServiceClient::ListTopics(
-    google::cloud::pubsublite::v1::ListTopicsRequest request) {
+    google::cloud::pubsublite::v1::ListTopicsRequest request, Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->ListTopics(std::move(request));
 }
 
 StatusOr<google::cloud::pubsublite::v1::Topic> AdminServiceClient::UpdateTopic(
-    google::cloud::pubsublite::v1::UpdateTopicRequest const& request) {
+    google::cloud::pubsublite::v1::UpdateTopicRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->UpdateTopic(request);
 }
 
 Status AdminServiceClient::DeleteTopic(
-    google::cloud::pubsublite::v1::DeleteTopicRequest const& request) {
+    google::cloud::pubsublite::v1::DeleteTopicRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->DeleteTopic(request);
 }
 
 StreamRange<std::string> AdminServiceClient::ListTopicSubscriptions(
-    google::cloud::pubsublite::v1::ListTopicSubscriptionsRequest request) {
+    google::cloud::pubsublite::v1::ListTopicSubscriptionsRequest request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->ListTopicSubscriptions(std::move(request));
 }
 
 StatusOr<google::cloud::pubsublite::v1::Subscription>
 AdminServiceClient::CreateSubscription(
-    google::cloud::pubsublite::v1::CreateSubscriptionRequest const& request) {
+    google::cloud::pubsublite::v1::CreateSubscriptionRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->CreateSubscription(request);
 }
 
 StatusOr<google::cloud::pubsublite::v1::Subscription>
 AdminServiceClient::GetSubscription(
-    google::cloud::pubsublite::v1::GetSubscriptionRequest const& request) {
+    google::cloud::pubsublite::v1::GetSubscriptionRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->GetSubscription(request);
 }
 
 StreamRange<google::cloud::pubsublite::v1::Subscription>
 AdminServiceClient::ListSubscriptions(
-    google::cloud::pubsublite::v1::ListSubscriptionsRequest request) {
+    google::cloud::pubsublite::v1::ListSubscriptionsRequest request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->ListSubscriptions(std::move(request));
 }
 
 StatusOr<google::cloud::pubsublite::v1::Subscription>
 AdminServiceClient::UpdateSubscription(
-    google::cloud::pubsublite::v1::UpdateSubscriptionRequest const& request) {
+    google::cloud::pubsublite::v1::UpdateSubscriptionRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->UpdateSubscription(request);
 }
 
 Status AdminServiceClient::DeleteSubscription(
-    google::cloud::pubsublite::v1::DeleteSubscriptionRequest const& request) {
+    google::cloud::pubsublite::v1::DeleteSubscriptionRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->DeleteSubscription(request);
 }
 
 future<StatusOr<google::cloud::pubsublite::v1::SeekSubscriptionResponse>>
 AdminServiceClient::SeekSubscription(
-    google::cloud::pubsublite::v1::SeekSubscriptionRequest const& request) {
+    google::cloud::pubsublite::v1::SeekSubscriptionRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->SeekSubscription(request);
 }
 
 StatusOr<google::cloud::pubsublite::v1::Reservation>
 AdminServiceClient::CreateReservation(
-    google::cloud::pubsublite::v1::CreateReservationRequest const& request) {
+    google::cloud::pubsublite::v1::CreateReservationRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->CreateReservation(request);
 }
 
 StatusOr<google::cloud::pubsublite::v1::Reservation>
 AdminServiceClient::GetReservation(
-    google::cloud::pubsublite::v1::GetReservationRequest const& request) {
+    google::cloud::pubsublite::v1::GetReservationRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->GetReservation(request);
 }
 
 StreamRange<google::cloud::pubsublite::v1::Reservation>
 AdminServiceClient::ListReservations(
-    google::cloud::pubsublite::v1::ListReservationsRequest request) {
+    google::cloud::pubsublite::v1::ListReservationsRequest request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->ListReservations(std::move(request));
 }
 
 StatusOr<google::cloud::pubsublite::v1::Reservation>
 AdminServiceClient::UpdateReservation(
-    google::cloud::pubsublite::v1::UpdateReservationRequest const& request) {
+    google::cloud::pubsublite::v1::UpdateReservationRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->UpdateReservation(request);
 }
 
 Status AdminServiceClient::DeleteReservation(
-    google::cloud::pubsublite::v1::DeleteReservationRequest const& request) {
+    google::cloud::pubsublite::v1::DeleteReservationRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->DeleteReservation(request);
 }
 
 StreamRange<std::string> AdminServiceClient::ListReservationTopics(
-    google::cloud::pubsublite::v1::ListReservationTopicsRequest request) {
+    google::cloud::pubsublite::v1::ListReservationTopicsRequest request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->ListReservationTopics(std::move(request));
 }
 

--- a/google/cloud/pubsublite/admin_client.h
+++ b/google/cloud/pubsublite/admin_client.h
@@ -98,6 +98,7 @@ class AdminServiceClient {
   /// the final component of
   ///  the topic's name.
   ///  This value is structured like: `my-topic-name`.
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::cloud::pubsublite::v1::Topic,google/cloud/pubsublite/v1/common.proto#L102}
   ///
@@ -116,6 +117,7 @@ class AdminServiceClient {
   ///
   /// @param name  Required. The name of the topic whose configuration to
   /// return.
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::cloud::pubsublite::v1::Topic,google/cloud/pubsublite/v1/common.proto#L102}
   ///
@@ -131,6 +133,7 @@ class AdminServiceClient {
   /// Returns the partition information for the requested topic.
   ///
   /// @param name  Required. The topic whose partition information to return.
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::cloud::pubsublite::v1::TopicPartitions,google/cloud/pubsublite/v1/admin.proto#L270}
   ///
@@ -147,6 +150,7 @@ class AdminServiceClient {
   ///
   /// @param parent  Required. The parent whose topics are to be listed.
   ///  Structured like `projects/{project_number}/locations/{location}`.
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::cloud::pubsublite::v1::Topic,google/cloud/pubsublite/v1/common.proto#L102}
   ///
@@ -165,6 +169,7 @@ class AdminServiceClient {
   /// populated.
   /// @param update_mask  Required. A mask specifying the topic fields to
   /// change.
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::cloud::pubsublite::v1::Topic,google/cloud/pubsublite/v1/common.proto#L102}
   ///
@@ -181,6 +186,7 @@ class AdminServiceClient {
   /// Deletes the specified topic.
   ///
   /// @param name  Required. The name of the topic to delete.
+  /// @param options  Optional. Operation options.
   ///
   /// [google.cloud.pubsublite.v1.DeleteTopicRequest]:
   /// @googleapis_reference_link{google/cloud/pubsublite/v1/admin.proto#L320}
@@ -191,6 +197,7 @@ class AdminServiceClient {
   /// Lists the subscriptions attached to the specified topic.
   ///
   /// @param name  Required. The name of the topic whose subscriptions to list.
+  /// @param options  Optional. Operation options.
   /// @return std::string
   ///
   /// [google.cloud.pubsublite.v1.ListTopicSubscriptionsRequest]:
@@ -211,6 +218,7 @@ class AdminServiceClient {
   /// which will become the final component
   ///  of the subscription's name.
   ///  This value is structured like: `my-sub-name`.
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::cloud::pubsublite::v1::Subscription,google/cloud/pubsublite/v1/common.proto#L186}
   ///
@@ -229,6 +237,7 @@ class AdminServiceClient {
   ///
   /// @param name  Required. The name of the subscription whose configuration to
   /// return.
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::cloud::pubsublite::v1::Subscription,google/cloud/pubsublite/v1/common.proto#L186}
   ///
@@ -245,6 +254,7 @@ class AdminServiceClient {
   ///
   /// @param parent  Required. The parent whose subscriptions are to be listed.
   ///  Structured like `projects/{project_number}/locations/{location}`.
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::cloud::pubsublite::v1::Subscription,google/cloud/pubsublite/v1/common.proto#L186}
   ///
@@ -264,6 +274,7 @@ class AdminServiceClient {
   ///  Topic field must not be populated.
   /// @param update_mask  Required. A mask specifying the subscription fields to
   /// change.
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::cloud::pubsublite::v1::Subscription,google/cloud/pubsublite/v1/common.proto#L186}
   ///
@@ -280,6 +291,7 @@ class AdminServiceClient {
   /// Deletes the specified subscription.
   ///
   /// @param name  Required. The name of the subscription to delete.
+  /// @param options  Optional. Operation options.
   ///
   /// [google.cloud.pubsublite.v1.DeleteSubscriptionRequest]:
   /// @googleapis_reference_link{google/cloud/pubsublite/v1/admin.proto#L447}
@@ -298,6 +310,7 @@ class AdminServiceClient {
   /// will become the final component of
   ///  the reservation's name.
   ///  This value is structured like: `my-reservation-name`.
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::cloud::pubsublite::v1::Reservation,google/cloud/pubsublite/v1/common.proto#L80}
   ///
@@ -318,6 +331,7 @@ class AdminServiceClient {
   /// return.
   ///  Structured like:
   ///  projects/{project_number}/locations/{location}/reservations/{reservation_id}
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::cloud::pubsublite::v1::Reservation,google/cloud/pubsublite/v1/common.proto#L80}
   ///
@@ -334,6 +348,7 @@ class AdminServiceClient {
   ///
   /// @param parent  Required. The parent whose reservations are to be listed.
   ///  Structured like `projects/{project_number}/locations/{location}`.
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::cloud::pubsublite::v1::Reservation,google/cloud/pubsublite/v1/common.proto#L80}
   ///
@@ -352,6 +367,7 @@ class AdminServiceClient {
   /// must be populated.
   /// @param update_mask  Required. A mask specifying the reservation fields to
   /// change.
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::cloud::pubsublite::v1::Reservation,google/cloud/pubsublite/v1/common.proto#L80}
   ///
@@ -370,6 +386,7 @@ class AdminServiceClient {
   /// @param name  Required. The name of the reservation to delete.
   ///  Structured like:
   ///  projects/{project_number}/locations/{location}/reservations/{reservation_id}
+  /// @param options  Optional. Operation options.
   ///
   /// [google.cloud.pubsublite.v1.DeleteReservationRequest]:
   /// @googleapis_reference_link{google/cloud/pubsublite/v1/admin.proto#L594}
@@ -382,6 +399,7 @@ class AdminServiceClient {
   /// @param name  Required. The name of the reservation whose topics to list.
   ///  Structured like:
   ///  projects/{project_number}/locations/{location}/reservations/{reservation_id}
+  /// @param options  Optional. Operation options.
   /// @return std::string
   ///
   /// [google.cloud.pubsublite.v1.ListReservationTopicsRequest]:
@@ -395,6 +413,7 @@ class AdminServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::pubsublite::v1::CreateTopicRequest,google/cloud/pubsublite/v1/admin.proto#L227}
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::cloud::pubsublite::v1::Topic,google/cloud/pubsublite/v1/common.proto#L102}
   ///
@@ -412,6 +431,7 @@ class AdminServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::pubsublite::v1::GetTopicRequest,google/cloud/pubsublite/v1/admin.proto#L248}
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::cloud::pubsublite::v1::Topic,google/cloud/pubsublite/v1/common.proto#L102}
   ///
@@ -429,6 +449,7 @@ class AdminServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::pubsublite::v1::GetTopicPartitionsRequest,google/cloud/pubsublite/v1/admin.proto#L259}
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::cloud::pubsublite::v1::TopicPartitions,google/cloud/pubsublite/v1/admin.proto#L270}
   ///
@@ -446,6 +467,7 @@ class AdminServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::pubsublite::v1::ListTopicsRequest,google/cloud/pubsublite/v1/admin.proto#L276}
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::cloud::pubsublite::v1::Topic,google/cloud/pubsublite/v1/common.proto#L102}
   ///
@@ -463,6 +485,7 @@ class AdminServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::pubsublite::v1::UpdateTopicRequest,google/cloud/pubsublite/v1/admin.proto#L311}
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::cloud::pubsublite::v1::Topic,google/cloud/pubsublite/v1/common.proto#L102}
   ///
@@ -480,6 +503,7 @@ class AdminServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::pubsublite::v1::DeleteTopicRequest,google/cloud/pubsublite/v1/admin.proto#L320}
+  /// @param options  Optional. Operation options.
   ///
   /// [google.cloud.pubsublite.v1.DeleteTopicRequest]:
   /// @googleapis_reference_link{google/cloud/pubsublite/v1/admin.proto#L320}
@@ -493,6 +517,7 @@ class AdminServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::pubsublite::v1::ListTopicSubscriptionsRequest,google/cloud/pubsublite/v1/admin.proto#L331}
+  /// @param options  Optional. Operation options.
   /// @return std::string
   ///
   /// [google.cloud.pubsublite.v1.ListTopicSubscriptionsRequest]:
@@ -507,6 +532,7 @@ class AdminServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::pubsublite::v1::CreateSubscriptionRequest,google/cloud/pubsublite/v1/admin.proto#L365}
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::cloud::pubsublite::v1::Subscription,google/cloud/pubsublite/v1/common.proto#L186}
   ///
@@ -524,6 +550,7 @@ class AdminServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::pubsublite::v1::GetSubscriptionRequest,google/cloud/pubsublite/v1/admin.proto#L391}
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::cloud::pubsublite::v1::Subscription,google/cloud/pubsublite/v1/common.proto#L186}
   ///
@@ -541,6 +568,7 @@ class AdminServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::pubsublite::v1::ListSubscriptionsRequest,google/cloud/pubsublite/v1/admin.proto#L402}
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::cloud::pubsublite::v1::Subscription,google/cloud/pubsublite/v1/common.proto#L186}
   ///
@@ -558,6 +586,7 @@ class AdminServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::pubsublite::v1::UpdateSubscriptionRequest,google/cloud/pubsublite/v1/admin.proto#L437}
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::cloud::pubsublite::v1::Subscription,google/cloud/pubsublite/v1/common.proto#L186}
   ///
@@ -575,6 +604,7 @@ class AdminServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::pubsublite::v1::DeleteSubscriptionRequest,google/cloud/pubsublite/v1/admin.proto#L447}
+  /// @param options  Optional. Operation options.
   ///
   /// [google.cloud.pubsublite.v1.DeleteSubscriptionRequest]:
   /// @googleapis_reference_link{google/cloud/pubsublite/v1/admin.proto#L447}
@@ -608,6 +638,7 @@ class AdminServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::pubsublite::v1::SeekSubscriptionRequest,google/cloud/pubsublite/v1/admin.proto#L458}
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::cloud::pubsublite::v1::SeekSubscriptionResponse,google/cloud/pubsublite/v1/admin.proto#L493}
   ///
@@ -626,6 +657,7 @@ class AdminServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::pubsublite::v1::CreateReservationRequest,google/cloud/pubsublite/v1/admin.proto#L516}
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::cloud::pubsublite::v1::Reservation,google/cloud/pubsublite/v1/common.proto#L80}
   ///
@@ -643,6 +675,7 @@ class AdminServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::pubsublite::v1::GetReservationRequest,google/cloud/pubsublite/v1/admin.proto#L537}
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::cloud::pubsublite::v1::Reservation,google/cloud/pubsublite/v1/common.proto#L80}
   ///
@@ -660,6 +693,7 @@ class AdminServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::pubsublite::v1::ListReservationsRequest,google/cloud/pubsublite/v1/admin.proto#L550}
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::cloud::pubsublite::v1::Reservation,google/cloud/pubsublite/v1/common.proto#L80}
   ///
@@ -677,6 +711,7 @@ class AdminServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::pubsublite::v1::UpdateReservationRequest,google/cloud/pubsublite/v1/admin.proto#L585}
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::cloud::pubsublite::v1::Reservation,google/cloud/pubsublite/v1/common.proto#L80}
   ///
@@ -694,6 +729,7 @@ class AdminServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::pubsublite::v1::DeleteReservationRequest,google/cloud/pubsublite/v1/admin.proto#L594}
+  /// @param options  Optional. Operation options.
   ///
   /// [google.cloud.pubsublite.v1.DeleteReservationRequest]:
   /// @googleapis_reference_link{google/cloud/pubsublite/v1/admin.proto#L594}
@@ -707,6 +743,7 @@ class AdminServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::pubsublite::v1::ListReservationTopicsRequest,google/cloud/pubsublite/v1/admin.proto#L607}
+  /// @param options  Optional. Operation options.
   /// @return std::string
   ///
   /// [google.cloud.pubsublite.v1.ListReservationTopicsRequest]:

--- a/google/cloud/pubsublite/admin_client.h
+++ b/google/cloud/pubsublite/admin_client.h
@@ -21,6 +21,7 @@
 
 #include "google/cloud/pubsublite/admin_connection.h"
 #include "google/cloud/future.h"
+#include "google/cloud/options.h"
 #include "google/cloud/polling_policy.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
@@ -63,7 +64,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class AdminServiceClient {
  public:
   explicit AdminServiceClient(
-      std::shared_ptr<AdminServiceConnection> connection);
+      std::shared_ptr<AdminServiceConnection> connection, Options options = {});
   ~AdminServiceClient();
 
   //@{
@@ -108,7 +109,7 @@ class AdminServiceClient {
   StatusOr<google::cloud::pubsublite::v1::Topic> CreateTopic(
       std::string const& parent,
       google::cloud::pubsublite::v1::Topic const& topic,
-      std::string const& topic_id);
+      std::string const& topic_id, Options options = {});
 
   ///
   /// Returns the topic configuration.
@@ -124,7 +125,7 @@ class AdminServiceClient {
   /// @googleapis_reference_link{google/cloud/pubsublite/v1/common.proto#L102}
   ///
   StatusOr<google::cloud::pubsublite::v1::Topic> GetTopic(
-      std::string const& name);
+      std::string const& name, Options options = {});
 
   ///
   /// Returns the partition information for the requested topic.
@@ -139,7 +140,7 @@ class AdminServiceClient {
   /// @googleapis_reference_link{google/cloud/pubsublite/v1/admin.proto#L270}
   ///
   StatusOr<google::cloud::pubsublite::v1::TopicPartitions> GetTopicPartitions(
-      std::string const& name);
+      std::string const& name, Options options = {});
 
   ///
   /// Returns the list of topics for the given project.
@@ -155,7 +156,7 @@ class AdminServiceClient {
   /// @googleapis_reference_link{google/cloud/pubsublite/v1/common.proto#L102}
   ///
   StreamRange<google::cloud::pubsublite::v1::Topic> ListTopics(
-      std::string const& parent);
+      std::string const& parent, Options options = {});
 
   ///
   /// Updates properties of the specified topic.
@@ -174,7 +175,7 @@ class AdminServiceClient {
   ///
   StatusOr<google::cloud::pubsublite::v1::Topic> UpdateTopic(
       google::cloud::pubsublite::v1::Topic const& topic,
-      google::protobuf::FieldMask const& update_mask);
+      google::protobuf::FieldMask const& update_mask, Options options = {});
 
   ///
   /// Deletes the specified topic.
@@ -184,7 +185,7 @@ class AdminServiceClient {
   /// [google.cloud.pubsublite.v1.DeleteTopicRequest]:
   /// @googleapis_reference_link{google/cloud/pubsublite/v1/admin.proto#L320}
   ///
-  Status DeleteTopic(std::string const& name);
+  Status DeleteTopic(std::string const& name, Options options = {});
 
   ///
   /// Lists the subscriptions attached to the specified topic.
@@ -195,7 +196,8 @@ class AdminServiceClient {
   /// [google.cloud.pubsublite.v1.ListTopicSubscriptionsRequest]:
   /// @googleapis_reference_link{google/cloud/pubsublite/v1/admin.proto#L331}
   ///
-  StreamRange<std::string> ListTopicSubscriptions(std::string const& name);
+  StreamRange<std::string> ListTopicSubscriptions(std::string const& name,
+                                                  Options options = {});
 
   ///
   /// Creates a new subscription.
@@ -220,7 +222,7 @@ class AdminServiceClient {
   StatusOr<google::cloud::pubsublite::v1::Subscription> CreateSubscription(
       std::string const& parent,
       google::cloud::pubsublite::v1::Subscription const& subscription,
-      std::string const& subscription_id);
+      std::string const& subscription_id, Options options = {});
 
   ///
   /// Returns the subscription configuration.
@@ -236,7 +238,7 @@ class AdminServiceClient {
   /// @googleapis_reference_link{google/cloud/pubsublite/v1/common.proto#L186}
   ///
   StatusOr<google::cloud::pubsublite::v1::Subscription> GetSubscription(
-      std::string const& name);
+      std::string const& name, Options options = {});
 
   ///
   /// Returns the list of subscriptions for the given project.
@@ -252,7 +254,7 @@ class AdminServiceClient {
   /// @googleapis_reference_link{google/cloud/pubsublite/v1/common.proto#L186}
   ///
   StreamRange<google::cloud::pubsublite::v1::Subscription> ListSubscriptions(
-      std::string const& parent);
+      std::string const& parent, Options options = {});
 
   ///
   /// Updates properties of the specified subscription.
@@ -272,7 +274,7 @@ class AdminServiceClient {
   ///
   StatusOr<google::cloud::pubsublite::v1::Subscription> UpdateSubscription(
       google::cloud::pubsublite::v1::Subscription const& subscription,
-      google::protobuf::FieldMask const& update_mask);
+      google::protobuf::FieldMask const& update_mask, Options options = {});
 
   ///
   /// Deletes the specified subscription.
@@ -282,7 +284,7 @@ class AdminServiceClient {
   /// [google.cloud.pubsublite.v1.DeleteSubscriptionRequest]:
   /// @googleapis_reference_link{google/cloud/pubsublite/v1/admin.proto#L447}
   ///
-  Status DeleteSubscription(std::string const& name);
+  Status DeleteSubscription(std::string const& name, Options options = {});
 
   ///
   /// Creates a new reservation.
@@ -307,7 +309,7 @@ class AdminServiceClient {
   StatusOr<google::cloud::pubsublite::v1::Reservation> CreateReservation(
       std::string const& parent,
       google::cloud::pubsublite::v1::Reservation const& reservation,
-      std::string const& reservation_id);
+      std::string const& reservation_id, Options options = {});
 
   ///
   /// Returns the reservation configuration.
@@ -325,7 +327,7 @@ class AdminServiceClient {
   /// @googleapis_reference_link{google/cloud/pubsublite/v1/common.proto#L80}
   ///
   StatusOr<google::cloud::pubsublite::v1::Reservation> GetReservation(
-      std::string const& name);
+      std::string const& name, Options options = {});
 
   ///
   /// Returns the list of reservations for the given project.
@@ -341,7 +343,7 @@ class AdminServiceClient {
   /// @googleapis_reference_link{google/cloud/pubsublite/v1/common.proto#L80}
   ///
   StreamRange<google::cloud::pubsublite::v1::Reservation> ListReservations(
-      std::string const& parent);
+      std::string const& parent, Options options = {});
 
   ///
   /// Updates properties of the specified reservation.
@@ -360,7 +362,7 @@ class AdminServiceClient {
   ///
   StatusOr<google::cloud::pubsublite::v1::Reservation> UpdateReservation(
       google::cloud::pubsublite::v1::Reservation const& reservation,
-      google::protobuf::FieldMask const& update_mask);
+      google::protobuf::FieldMask const& update_mask, Options options = {});
 
   ///
   /// Deletes the specified reservation.
@@ -372,7 +374,7 @@ class AdminServiceClient {
   /// [google.cloud.pubsublite.v1.DeleteReservationRequest]:
   /// @googleapis_reference_link{google/cloud/pubsublite/v1/admin.proto#L594}
   ///
-  Status DeleteReservation(std::string const& name);
+  Status DeleteReservation(std::string const& name, Options options = {});
 
   ///
   /// Lists the topics attached to the specified reservation.
@@ -385,7 +387,8 @@ class AdminServiceClient {
   /// [google.cloud.pubsublite.v1.ListReservationTopicsRequest]:
   /// @googleapis_reference_link{google/cloud/pubsublite/v1/admin.proto#L607}
   ///
-  StreamRange<std::string> ListReservationTopics(std::string const& name);
+  StreamRange<std::string> ListReservationTopics(std::string const& name,
+                                                 Options options = {});
 
   ///
   /// Creates a new topic.
@@ -401,7 +404,8 @@ class AdminServiceClient {
   /// @googleapis_reference_link{google/cloud/pubsublite/v1/common.proto#L102}
   ///
   StatusOr<google::cloud::pubsublite::v1::Topic> CreateTopic(
-      google::cloud::pubsublite::v1::CreateTopicRequest const& request);
+      google::cloud::pubsublite::v1::CreateTopicRequest const& request,
+      Options options = {});
 
   ///
   /// Returns the topic configuration.
@@ -417,7 +421,8 @@ class AdminServiceClient {
   /// @googleapis_reference_link{google/cloud/pubsublite/v1/common.proto#L102}
   ///
   StatusOr<google::cloud::pubsublite::v1::Topic> GetTopic(
-      google::cloud::pubsublite::v1::GetTopicRequest const& request);
+      google::cloud::pubsublite::v1::GetTopicRequest const& request,
+      Options options = {});
 
   ///
   /// Returns the partition information for the requested topic.
@@ -433,7 +438,8 @@ class AdminServiceClient {
   /// @googleapis_reference_link{google/cloud/pubsublite/v1/admin.proto#L270}
   ///
   StatusOr<google::cloud::pubsublite::v1::TopicPartitions> GetTopicPartitions(
-      google::cloud::pubsublite::v1::GetTopicPartitionsRequest const& request);
+      google::cloud::pubsublite::v1::GetTopicPartitionsRequest const& request,
+      Options options = {});
 
   ///
   /// Returns the list of topics for the given project.
@@ -449,7 +455,8 @@ class AdminServiceClient {
   /// @googleapis_reference_link{google/cloud/pubsublite/v1/common.proto#L102}
   ///
   StreamRange<google::cloud::pubsublite::v1::Topic> ListTopics(
-      google::cloud::pubsublite::v1::ListTopicsRequest request);
+      google::cloud::pubsublite::v1::ListTopicsRequest request,
+      Options options = {});
 
   ///
   /// Updates properties of the specified topic.
@@ -465,7 +472,8 @@ class AdminServiceClient {
   /// @googleapis_reference_link{google/cloud/pubsublite/v1/common.proto#L102}
   ///
   StatusOr<google::cloud::pubsublite::v1::Topic> UpdateTopic(
-      google::cloud::pubsublite::v1::UpdateTopicRequest const& request);
+      google::cloud::pubsublite::v1::UpdateTopicRequest const& request,
+      Options options = {});
 
   ///
   /// Deletes the specified topic.
@@ -477,7 +485,8 @@ class AdminServiceClient {
   /// @googleapis_reference_link{google/cloud/pubsublite/v1/admin.proto#L320}
   ///
   Status DeleteTopic(
-      google::cloud::pubsublite::v1::DeleteTopicRequest const& request);
+      google::cloud::pubsublite::v1::DeleteTopicRequest const& request,
+      Options options = {});
 
   ///
   /// Lists the subscriptions attached to the specified topic.
@@ -490,7 +499,8 @@ class AdminServiceClient {
   /// @googleapis_reference_link{google/cloud/pubsublite/v1/admin.proto#L331}
   ///
   StreamRange<std::string> ListTopicSubscriptions(
-      google::cloud::pubsublite::v1::ListTopicSubscriptionsRequest request);
+      google::cloud::pubsublite::v1::ListTopicSubscriptionsRequest request,
+      Options options = {});
 
   ///
   /// Creates a new subscription.
@@ -506,7 +516,8 @@ class AdminServiceClient {
   /// @googleapis_reference_link{google/cloud/pubsublite/v1/common.proto#L186}
   ///
   StatusOr<google::cloud::pubsublite::v1::Subscription> CreateSubscription(
-      google::cloud::pubsublite::v1::CreateSubscriptionRequest const& request);
+      google::cloud::pubsublite::v1::CreateSubscriptionRequest const& request,
+      Options options = {});
 
   ///
   /// Returns the subscription configuration.
@@ -522,7 +533,8 @@ class AdminServiceClient {
   /// @googleapis_reference_link{google/cloud/pubsublite/v1/common.proto#L186}
   ///
   StatusOr<google::cloud::pubsublite::v1::Subscription> GetSubscription(
-      google::cloud::pubsublite::v1::GetSubscriptionRequest const& request);
+      google::cloud::pubsublite::v1::GetSubscriptionRequest const& request,
+      Options options = {});
 
   ///
   /// Returns the list of subscriptions for the given project.
@@ -538,7 +550,8 @@ class AdminServiceClient {
   /// @googleapis_reference_link{google/cloud/pubsublite/v1/common.proto#L186}
   ///
   StreamRange<google::cloud::pubsublite::v1::Subscription> ListSubscriptions(
-      google::cloud::pubsublite::v1::ListSubscriptionsRequest request);
+      google::cloud::pubsublite::v1::ListSubscriptionsRequest request,
+      Options options = {});
 
   ///
   /// Updates properties of the specified subscription.
@@ -554,7 +567,8 @@ class AdminServiceClient {
   /// @googleapis_reference_link{google/cloud/pubsublite/v1/common.proto#L186}
   ///
   StatusOr<google::cloud::pubsublite::v1::Subscription> UpdateSubscription(
-      google::cloud::pubsublite::v1::UpdateSubscriptionRequest const& request);
+      google::cloud::pubsublite::v1::UpdateSubscriptionRequest const& request,
+      Options options = {});
 
   ///
   /// Deletes the specified subscription.
@@ -566,7 +580,8 @@ class AdminServiceClient {
   /// @googleapis_reference_link{google/cloud/pubsublite/v1/admin.proto#L447}
   ///
   Status DeleteSubscription(
-      google::cloud::pubsublite::v1::DeleteSubscriptionRequest const& request);
+      google::cloud::pubsublite::v1::DeleteSubscriptionRequest const& request,
+      Options options = {});
 
   ///
   /// Performs an out-of-band seek for a subscription to a specified target,
@@ -603,7 +618,8 @@ class AdminServiceClient {
   ///
   future<StatusOr<google::cloud::pubsublite::v1::SeekSubscriptionResponse>>
   SeekSubscription(
-      google::cloud::pubsublite::v1::SeekSubscriptionRequest const& request);
+      google::cloud::pubsublite::v1::SeekSubscriptionRequest const& request,
+      Options options = {});
 
   ///
   /// Creates a new reservation.
@@ -619,7 +635,8 @@ class AdminServiceClient {
   /// @googleapis_reference_link{google/cloud/pubsublite/v1/common.proto#L80}
   ///
   StatusOr<google::cloud::pubsublite::v1::Reservation> CreateReservation(
-      google::cloud::pubsublite::v1::CreateReservationRequest const& request);
+      google::cloud::pubsublite::v1::CreateReservationRequest const& request,
+      Options options = {});
 
   ///
   /// Returns the reservation configuration.
@@ -635,7 +652,8 @@ class AdminServiceClient {
   /// @googleapis_reference_link{google/cloud/pubsublite/v1/common.proto#L80}
   ///
   StatusOr<google::cloud::pubsublite::v1::Reservation> GetReservation(
-      google::cloud::pubsublite::v1::GetReservationRequest const& request);
+      google::cloud::pubsublite::v1::GetReservationRequest const& request,
+      Options options = {});
 
   ///
   /// Returns the list of reservations for the given project.
@@ -651,7 +669,8 @@ class AdminServiceClient {
   /// @googleapis_reference_link{google/cloud/pubsublite/v1/common.proto#L80}
   ///
   StreamRange<google::cloud::pubsublite::v1::Reservation> ListReservations(
-      google::cloud::pubsublite::v1::ListReservationsRequest request);
+      google::cloud::pubsublite::v1::ListReservationsRequest request,
+      Options options = {});
 
   ///
   /// Updates properties of the specified reservation.
@@ -667,7 +686,8 @@ class AdminServiceClient {
   /// @googleapis_reference_link{google/cloud/pubsublite/v1/common.proto#L80}
   ///
   StatusOr<google::cloud::pubsublite::v1::Reservation> UpdateReservation(
-      google::cloud::pubsublite::v1::UpdateReservationRequest const& request);
+      google::cloud::pubsublite::v1::UpdateReservationRequest const& request,
+      Options options = {});
 
   ///
   /// Deletes the specified reservation.
@@ -679,7 +699,8 @@ class AdminServiceClient {
   /// @googleapis_reference_link{google/cloud/pubsublite/v1/admin.proto#L594}
   ///
   Status DeleteReservation(
-      google::cloud::pubsublite::v1::DeleteReservationRequest const& request);
+      google::cloud::pubsublite::v1::DeleteReservationRequest const& request,
+      Options options = {});
 
   ///
   /// Lists the topics attached to the specified reservation.
@@ -692,10 +713,12 @@ class AdminServiceClient {
   /// @googleapis_reference_link{google/cloud/pubsublite/v1/admin.proto#L607}
   ///
   StreamRange<std::string> ListReservationTopics(
-      google::cloud::pubsublite::v1::ListReservationTopicsRequest request);
+      google::cloud::pubsublite::v1::ListReservationTopicsRequest request,
+      Options options = {});
 
  private:
   std::shared_ptr<AdminServiceConnection> connection_;
+  Options options_;
 };
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/secretmanager/secret_manager_client.cc
+++ b/google/cloud/secretmanager/secret_manager_client.cc
@@ -17,6 +17,7 @@
 // source: google/cloud/secretmanager/v1/service.proto
 
 #include "google/cloud/secretmanager/secret_manager_client.h"
+#include "google/cloud/secretmanager/internal/secret_manager_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -25,12 +26,17 @@ namespace secretmanager {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 SecretManagerServiceClient::SecretManagerServiceClient(
-    std::shared_ptr<SecretManagerServiceConnection> connection)
-    : connection_(std::move(connection)) {}
+    std::shared_ptr<SecretManagerServiceConnection> connection, Options options)
+    : connection_(std::move(connection)),
+      options_(secretmanager_internal::SecretManagerServiceDefaultOptions(
+          std::move(options))) {}
 SecretManagerServiceClient::~SecretManagerServiceClient() = default;
 
 StreamRange<google::cloud::secretmanager::v1::Secret>
-SecretManagerServiceClient::ListSecrets(std::string const& parent) {
+SecretManagerServiceClient::ListSecrets(std::string const& parent,
+                                        Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   google::cloud::secretmanager::v1::ListSecretsRequest request;
   request.set_parent(parent);
   return connection_->ListSecrets(request);
@@ -39,7 +45,9 @@ SecretManagerServiceClient::ListSecrets(std::string const& parent) {
 StatusOr<google::cloud::secretmanager::v1::Secret>
 SecretManagerServiceClient::CreateSecret(
     std::string const& parent, std::string const& secret_id,
-    google::cloud::secretmanager::v1::Secret const& secret) {
+    google::cloud::secretmanager::v1::Secret const& secret, Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   google::cloud::secretmanager::v1::CreateSecretRequest request;
   request.set_parent(parent);
   request.set_secret_id(secret_id);
@@ -50,7 +58,10 @@ SecretManagerServiceClient::CreateSecret(
 StatusOr<google::cloud::secretmanager::v1::SecretVersion>
 SecretManagerServiceClient::AddSecretVersion(
     std::string const& parent,
-    google::cloud::secretmanager::v1::SecretPayload const& payload) {
+    google::cloud::secretmanager::v1::SecretPayload const& payload,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   google::cloud::secretmanager::v1::AddSecretVersionRequest request;
   request.set_parent(parent);
   *request.mutable_payload() = payload;
@@ -58,7 +69,10 @@ SecretManagerServiceClient::AddSecretVersion(
 }
 
 StatusOr<google::cloud::secretmanager::v1::Secret>
-SecretManagerServiceClient::GetSecret(std::string const& name) {
+SecretManagerServiceClient::GetSecret(std::string const& name,
+                                      Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   google::cloud::secretmanager::v1::GetSecretRequest request;
   request.set_name(name);
   return connection_->GetSecret(request);
@@ -67,56 +81,79 @@ SecretManagerServiceClient::GetSecret(std::string const& name) {
 StatusOr<google::cloud::secretmanager::v1::Secret>
 SecretManagerServiceClient::UpdateSecret(
     google::cloud::secretmanager::v1::Secret const& secret,
-    google::protobuf::FieldMask const& update_mask) {
+    google::protobuf::FieldMask const& update_mask, Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   google::cloud::secretmanager::v1::UpdateSecretRequest request;
   *request.mutable_secret() = secret;
   *request.mutable_update_mask() = update_mask;
   return connection_->UpdateSecret(request);
 }
 
-Status SecretManagerServiceClient::DeleteSecret(std::string const& name) {
+Status SecretManagerServiceClient::DeleteSecret(std::string const& name,
+                                                Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   google::cloud::secretmanager::v1::DeleteSecretRequest request;
   request.set_name(name);
   return connection_->DeleteSecret(request);
 }
 
 StreamRange<google::cloud::secretmanager::v1::SecretVersion>
-SecretManagerServiceClient::ListSecretVersions(std::string const& parent) {
+SecretManagerServiceClient::ListSecretVersions(std::string const& parent,
+                                               Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   google::cloud::secretmanager::v1::ListSecretVersionsRequest request;
   request.set_parent(parent);
   return connection_->ListSecretVersions(request);
 }
 
 StatusOr<google::cloud::secretmanager::v1::SecretVersion>
-SecretManagerServiceClient::GetSecretVersion(std::string const& name) {
+SecretManagerServiceClient::GetSecretVersion(std::string const& name,
+                                             Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   google::cloud::secretmanager::v1::GetSecretVersionRequest request;
   request.set_name(name);
   return connection_->GetSecretVersion(request);
 }
 
 StatusOr<google::cloud::secretmanager::v1::AccessSecretVersionResponse>
-SecretManagerServiceClient::AccessSecretVersion(std::string const& name) {
+SecretManagerServiceClient::AccessSecretVersion(std::string const& name,
+                                                Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   google::cloud::secretmanager::v1::AccessSecretVersionRequest request;
   request.set_name(name);
   return connection_->AccessSecretVersion(request);
 }
 
 StatusOr<google::cloud::secretmanager::v1::SecretVersion>
-SecretManagerServiceClient::DisableSecretVersion(std::string const& name) {
+SecretManagerServiceClient::DisableSecretVersion(std::string const& name,
+                                                 Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   google::cloud::secretmanager::v1::DisableSecretVersionRequest request;
   request.set_name(name);
   return connection_->DisableSecretVersion(request);
 }
 
 StatusOr<google::cloud::secretmanager::v1::SecretVersion>
-SecretManagerServiceClient::EnableSecretVersion(std::string const& name) {
+SecretManagerServiceClient::EnableSecretVersion(std::string const& name,
+                                                Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   google::cloud::secretmanager::v1::EnableSecretVersionRequest request;
   request.set_name(name);
   return connection_->EnableSecretVersion(request);
 }
 
 StatusOr<google::cloud::secretmanager::v1::SecretVersion>
-SecretManagerServiceClient::DestroySecretVersion(std::string const& name) {
+SecretManagerServiceClient::DestroySecretVersion(std::string const& name,
+                                                 Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   google::cloud::secretmanager::v1::DestroySecretVersionRequest request;
   request.set_name(name);
   return connection_->DestroySecretVersion(request);
@@ -124,92 +161,133 @@ SecretManagerServiceClient::DestroySecretVersion(std::string const& name) {
 
 StreamRange<google::cloud::secretmanager::v1::Secret>
 SecretManagerServiceClient::ListSecrets(
-    google::cloud::secretmanager::v1::ListSecretsRequest request) {
+    google::cloud::secretmanager::v1::ListSecretsRequest request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->ListSecrets(std::move(request));
 }
 
 StatusOr<google::cloud::secretmanager::v1::Secret>
 SecretManagerServiceClient::CreateSecret(
-    google::cloud::secretmanager::v1::CreateSecretRequest const& request) {
+    google::cloud::secretmanager::v1::CreateSecretRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->CreateSecret(request);
 }
 
 StatusOr<google::cloud::secretmanager::v1::SecretVersion>
 SecretManagerServiceClient::AddSecretVersion(
-    google::cloud::secretmanager::v1::AddSecretVersionRequest const& request) {
+    google::cloud::secretmanager::v1::AddSecretVersionRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->AddSecretVersion(request);
 }
 
 StatusOr<google::cloud::secretmanager::v1::Secret>
 SecretManagerServiceClient::GetSecret(
-    google::cloud::secretmanager::v1::GetSecretRequest const& request) {
+    google::cloud::secretmanager::v1::GetSecretRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->GetSecret(request);
 }
 
 StatusOr<google::cloud::secretmanager::v1::Secret>
 SecretManagerServiceClient::UpdateSecret(
-    google::cloud::secretmanager::v1::UpdateSecretRequest const& request) {
+    google::cloud::secretmanager::v1::UpdateSecretRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->UpdateSecret(request);
 }
 
 Status SecretManagerServiceClient::DeleteSecret(
-    google::cloud::secretmanager::v1::DeleteSecretRequest const& request) {
+    google::cloud::secretmanager::v1::DeleteSecretRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->DeleteSecret(request);
 }
 
 StreamRange<google::cloud::secretmanager::v1::SecretVersion>
 SecretManagerServiceClient::ListSecretVersions(
-    google::cloud::secretmanager::v1::ListSecretVersionsRequest request) {
+    google::cloud::secretmanager::v1::ListSecretVersionsRequest request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->ListSecretVersions(std::move(request));
 }
 
 StatusOr<google::cloud::secretmanager::v1::SecretVersion>
 SecretManagerServiceClient::GetSecretVersion(
-    google::cloud::secretmanager::v1::GetSecretVersionRequest const& request) {
+    google::cloud::secretmanager::v1::GetSecretVersionRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->GetSecretVersion(request);
 }
 
 StatusOr<google::cloud::secretmanager::v1::AccessSecretVersionResponse>
 SecretManagerServiceClient::AccessSecretVersion(
-    google::cloud::secretmanager::v1::AccessSecretVersionRequest const&
-        request) {
+    google::cloud::secretmanager::v1::AccessSecretVersionRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->AccessSecretVersion(request);
 }
 
 StatusOr<google::cloud::secretmanager::v1::SecretVersion>
 SecretManagerServiceClient::DisableSecretVersion(
     google::cloud::secretmanager::v1::DisableSecretVersionRequest const&
-        request) {
+        request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->DisableSecretVersion(request);
 }
 
 StatusOr<google::cloud::secretmanager::v1::SecretVersion>
 SecretManagerServiceClient::EnableSecretVersion(
-    google::cloud::secretmanager::v1::EnableSecretVersionRequest const&
-        request) {
+    google::cloud::secretmanager::v1::EnableSecretVersionRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->EnableSecretVersion(request);
 }
 
 StatusOr<google::cloud::secretmanager::v1::SecretVersion>
 SecretManagerServiceClient::DestroySecretVersion(
     google::cloud::secretmanager::v1::DestroySecretVersionRequest const&
-        request) {
+        request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->DestroySecretVersion(request);
 }
 
 StatusOr<google::iam::v1::Policy> SecretManagerServiceClient::SetIamPolicy(
-    google::iam::v1::SetIamPolicyRequest const& request) {
+    google::iam::v1::SetIamPolicyRequest const& request, Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->SetIamPolicy(request);
 }
 
 StatusOr<google::iam::v1::Policy> SecretManagerServiceClient::GetIamPolicy(
-    google::iam::v1::GetIamPolicyRequest const& request) {
+    google::iam::v1::GetIamPolicyRequest const& request, Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->GetIamPolicy(request);
 }
 
 StatusOr<google::iam::v1::TestIamPermissionsResponse>
 SecretManagerServiceClient::TestIamPermissions(
-    google::iam::v1::TestIamPermissionsRequest const& request) {
+    google::iam::v1::TestIamPermissionsRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->TestIamPermissions(request);
 }
 

--- a/google/cloud/secretmanager/secret_manager_client.h
+++ b/google/cloud/secretmanager/secret_manager_client.h
@@ -21,6 +21,7 @@
 
 #include "google/cloud/secretmanager/secret_manager_connection.h"
 #include "google/cloud/future.h"
+#include "google/cloud/options.h"
 #include "google/cloud/polling_policy.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
@@ -67,7 +68,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class SecretManagerServiceClient {
  public:
   explicit SecretManagerServiceClient(
-      std::shared_ptr<SecretManagerServiceConnection> connection);
+      std::shared_ptr<SecretManagerServiceConnection> connection,
+      Options options = {});
   ~SecretManagerServiceClient();
 
   //@{
@@ -107,7 +109,7 @@ class SecretManagerServiceClient {
   /// @googleapis_reference_link{google/cloud/secretmanager/v1/resources.proto#L40}
   ///
   StreamRange<google::cloud::secretmanager::v1::Secret> ListSecrets(
-      std::string const& parent);
+      std::string const& parent, Options options = {});
 
   ///
   /// Creates a new [Secret][google.cloud.secretmanager.v1.Secret] containing no
@@ -133,7 +135,8 @@ class SecretManagerServiceClient {
   ///
   StatusOr<google::cloud::secretmanager::v1::Secret> CreateSecret(
       std::string const& parent, std::string const& secret_id,
-      google::cloud::secretmanager::v1::Secret const& secret);
+      google::cloud::secretmanager::v1::Secret const& secret,
+      Options options = {});
 
   ///
   /// Creates a new [SecretVersion][google.cloud.secretmanager.v1.SecretVersion]
@@ -156,7 +159,8 @@ class SecretManagerServiceClient {
   ///
   StatusOr<google::cloud::secretmanager::v1::SecretVersion> AddSecretVersion(
       std::string const& parent,
-      google::cloud::secretmanager::v1::SecretPayload const& payload);
+      google::cloud::secretmanager::v1::SecretPayload const& payload,
+      Options options = {});
 
   ///
   /// Gets metadata for a given [Secret][google.cloud.secretmanager.v1.Secret].
@@ -173,7 +177,7 @@ class SecretManagerServiceClient {
   /// @googleapis_reference_link{google/cloud/secretmanager/v1/resources.proto#L40}
   ///
   StatusOr<google::cloud::secretmanager::v1::Secret> GetSecret(
-      std::string const& name);
+      std::string const& name, Options options = {});
 
   ///
   /// Updates metadata of an existing
@@ -192,7 +196,7 @@ class SecretManagerServiceClient {
   ///
   StatusOr<google::cloud::secretmanager::v1::Secret> UpdateSecret(
       google::cloud::secretmanager::v1::Secret const& secret,
-      google::protobuf::FieldMask const& update_mask);
+      google::protobuf::FieldMask const& update_mask, Options options = {});
 
   ///
   /// Deletes a [Secret][google.cloud.secretmanager.v1.Secret].
@@ -204,7 +208,7 @@ class SecretManagerServiceClient {
   /// [google.cloud.secretmanager.v1.DeleteSecretRequest]:
   /// @googleapis_reference_link{google/cloud/secretmanager/v1/service.proto#L390}
   ///
-  Status DeleteSecret(std::string const& name);
+  Status DeleteSecret(std::string const& name, Options options = {});
 
   ///
   /// Lists [SecretVersions][google.cloud.secretmanager.v1.SecretVersion]. This
@@ -223,7 +227,7 @@ class SecretManagerServiceClient {
   /// @googleapis_reference_link{google/cloud/secretmanager/v1/resources.proto#L103}
   ///
   StreamRange<google::cloud::secretmanager::v1::SecretVersion>
-  ListSecretVersions(std::string const& parent);
+  ListSecretVersions(std::string const& parent, Options options = {});
 
   ///
   /// Gets metadata for a
@@ -246,7 +250,7 @@ class SecretManagerServiceClient {
   /// @googleapis_reference_link{google/cloud/secretmanager/v1/resources.proto#L103}
   ///
   StatusOr<google::cloud::secretmanager::v1::SecretVersion> GetSecretVersion(
-      std::string const& name);
+      std::string const& name, Options options = {});
 
   ///
   /// Accesses a [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
@@ -269,7 +273,7 @@ class SecretManagerServiceClient {
   /// @googleapis_reference_link{google/cloud/secretmanager/v1/service.proto#L378}
   ///
   StatusOr<google::cloud::secretmanager::v1::AccessSecretVersionResponse>
-  AccessSecretVersion(std::string const& name);
+  AccessSecretVersion(std::string const& name, Options options = {});
 
   ///
   /// Disables a [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
@@ -291,7 +295,7 @@ class SecretManagerServiceClient {
   /// @googleapis_reference_link{google/cloud/secretmanager/v1/resources.proto#L103}
   ///
   StatusOr<google::cloud::secretmanager::v1::SecretVersion>
-  DisableSecretVersion(std::string const& name);
+  DisableSecretVersion(std::string const& name, Options options = {});
 
   ///
   /// Enables a [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
@@ -313,7 +317,7 @@ class SecretManagerServiceClient {
   /// @googleapis_reference_link{google/cloud/secretmanager/v1/resources.proto#L103}
   ///
   StatusOr<google::cloud::secretmanager::v1::SecretVersion> EnableSecretVersion(
-      std::string const& name);
+      std::string const& name, Options options = {});
 
   ///
   /// Destroys a [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
@@ -336,7 +340,7 @@ class SecretManagerServiceClient {
   /// @googleapis_reference_link{google/cloud/secretmanager/v1/resources.proto#L103}
   ///
   StatusOr<google::cloud::secretmanager::v1::SecretVersion>
-  DestroySecretVersion(std::string const& name);
+  DestroySecretVersion(std::string const& name, Options options = {});
 
   ///
   /// Lists [Secrets][google.cloud.secretmanager.v1.Secret].
@@ -352,7 +356,8 @@ class SecretManagerServiceClient {
   /// @googleapis_reference_link{google/cloud/secretmanager/v1/resources.proto#L40}
   ///
   StreamRange<google::cloud::secretmanager::v1::Secret> ListSecrets(
-      google::cloud::secretmanager::v1::ListSecretsRequest request);
+      google::cloud::secretmanager::v1::ListSecretsRequest request,
+      Options options = {});
 
   ///
   /// Creates a new [Secret][google.cloud.secretmanager.v1.Secret] containing no
@@ -369,7 +374,8 @@ class SecretManagerServiceClient {
   /// @googleapis_reference_link{google/cloud/secretmanager/v1/resources.proto#L40}
   ///
   StatusOr<google::cloud::secretmanager::v1::Secret> CreateSecret(
-      google::cloud::secretmanager::v1::CreateSecretRequest const& request);
+      google::cloud::secretmanager::v1::CreateSecretRequest const& request,
+      Options options = {});
 
   ///
   /// Creates a new [SecretVersion][google.cloud.secretmanager.v1.SecretVersion]
@@ -387,7 +393,8 @@ class SecretManagerServiceClient {
   /// @googleapis_reference_link{google/cloud/secretmanager/v1/resources.proto#L103}
   ///
   StatusOr<google::cloud::secretmanager::v1::SecretVersion> AddSecretVersion(
-      google::cloud::secretmanager::v1::AddSecretVersionRequest const& request);
+      google::cloud::secretmanager::v1::AddSecretVersionRequest const& request,
+      Options options = {});
 
   ///
   /// Gets metadata for a given [Secret][google.cloud.secretmanager.v1.Secret].
@@ -403,7 +410,8 @@ class SecretManagerServiceClient {
   /// @googleapis_reference_link{google/cloud/secretmanager/v1/resources.proto#L40}
   ///
   StatusOr<google::cloud::secretmanager::v1::Secret> GetSecret(
-      google::cloud::secretmanager::v1::GetSecretRequest const& request);
+      google::cloud::secretmanager::v1::GetSecretRequest const& request,
+      Options options = {});
 
   ///
   /// Updates metadata of an existing
@@ -420,7 +428,8 @@ class SecretManagerServiceClient {
   /// @googleapis_reference_link{google/cloud/secretmanager/v1/resources.proto#L40}
   ///
   StatusOr<google::cloud::secretmanager::v1::Secret> UpdateSecret(
-      google::cloud::secretmanager::v1::UpdateSecretRequest const& request);
+      google::cloud::secretmanager::v1::UpdateSecretRequest const& request,
+      Options options = {});
 
   ///
   /// Deletes a [Secret][google.cloud.secretmanager.v1.Secret].
@@ -432,7 +441,8 @@ class SecretManagerServiceClient {
   /// @googleapis_reference_link{google/cloud/secretmanager/v1/service.proto#L390}
   ///
   Status DeleteSecret(
-      google::cloud::secretmanager::v1::DeleteSecretRequest const& request);
+      google::cloud::secretmanager::v1::DeleteSecretRequest const& request,
+      Options options = {});
 
   ///
   /// Lists [SecretVersions][google.cloud.secretmanager.v1.SecretVersion]. This
@@ -450,7 +460,8 @@ class SecretManagerServiceClient {
   ///
   StreamRange<google::cloud::secretmanager::v1::SecretVersion>
   ListSecretVersions(
-      google::cloud::secretmanager::v1::ListSecretVersionsRequest request);
+      google::cloud::secretmanager::v1::ListSecretVersionsRequest request,
+      Options options = {});
 
   ///
   /// Gets metadata for a
@@ -470,7 +481,8 @@ class SecretManagerServiceClient {
   /// @googleapis_reference_link{google/cloud/secretmanager/v1/resources.proto#L103}
   ///
   StatusOr<google::cloud::secretmanager::v1::SecretVersion> GetSecretVersion(
-      google::cloud::secretmanager::v1::GetSecretVersionRequest const& request);
+      google::cloud::secretmanager::v1::GetSecretVersionRequest const& request,
+      Options options = {});
 
   ///
   /// Accesses a [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
@@ -492,7 +504,8 @@ class SecretManagerServiceClient {
   StatusOr<google::cloud::secretmanager::v1::AccessSecretVersionResponse>
   AccessSecretVersion(
       google::cloud::secretmanager::v1::AccessSecretVersionRequest const&
-          request);
+          request,
+      Options options = {});
 
   ///
   /// Disables a [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
@@ -514,7 +527,8 @@ class SecretManagerServiceClient {
   StatusOr<google::cloud::secretmanager::v1::SecretVersion>
   DisableSecretVersion(
       google::cloud::secretmanager::v1::DisableSecretVersionRequest const&
-          request);
+          request,
+      Options options = {});
 
   ///
   /// Enables a [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
@@ -535,7 +549,8 @@ class SecretManagerServiceClient {
   ///
   StatusOr<google::cloud::secretmanager::v1::SecretVersion> EnableSecretVersion(
       google::cloud::secretmanager::v1::EnableSecretVersionRequest const&
-          request);
+          request,
+      Options options = {});
 
   ///
   /// Destroys a [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
@@ -558,7 +573,8 @@ class SecretManagerServiceClient {
   StatusOr<google::cloud::secretmanager::v1::SecretVersion>
   DestroySecretVersion(
       google::cloud::secretmanager::v1::DestroySecretVersionRequest const&
-          request);
+          request,
+      Options options = {});
 
   ///
   /// Sets the access control policy on the specified secret. Replaces any
@@ -580,7 +596,8 @@ class SecretManagerServiceClient {
   /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
-      google::iam::v1::SetIamPolicyRequest const& request);
+      google::iam::v1::SetIamPolicyRequest const& request,
+      Options options = {});
 
   ///
   /// Gets the access control policy for a secret.
@@ -597,7 +614,8 @@ class SecretManagerServiceClient {
   /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> GetIamPolicy(
-      google::iam::v1::GetIamPolicyRequest const& request);
+      google::iam::v1::GetIamPolicyRequest const& request,
+      Options options = {});
 
   ///
   /// Returns permissions that a caller has for the specified secret.
@@ -619,10 +637,12 @@ class SecretManagerServiceClient {
   /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L141}
   ///
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
-      google::iam::v1::TestIamPermissionsRequest const& request);
+      google::iam::v1::TestIamPermissionsRequest const& request,
+      Options options = {});
 
  private:
   std::shared_ptr<SecretManagerServiceConnection> connection_;
+  Options options_;
 };
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/secretmanager/secret_manager_client.h
+++ b/google/cloud/secretmanager/secret_manager_client.h
@@ -100,6 +100,7 @@ class SecretManagerServiceClient {
   /// the
   ///  [Secrets][google.cloud.secretmanager.v1.Secret], in the format
   ///  `projects/*`.
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::cloud::secretmanager::v1::Secret,google/cloud/secretmanager/v1/resources.proto#L40}
   ///
@@ -125,6 +126,7 @@ class SecretManagerServiceClient {
   ///  and underscore (`_`) characters.
   /// @param secret  Required. A [Secret][google.cloud.secretmanager.v1.Secret]
   /// with initial field values.
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::cloud::secretmanager::v1::Secret,google/cloud/secretmanager/v1/resources.proto#L40}
   ///
@@ -149,6 +151,7 @@ class SecretManagerServiceClient {
   ///  format `projects/*/secrets/*`.
   /// @param payload  Required. The secret payload of the
   /// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::cloud::secretmanager::v1::SecretVersion,google/cloud/secretmanager/v1/resources.proto#L103}
   ///
@@ -168,6 +171,7 @@ class SecretManagerServiceClient {
   /// @param name  Required. The resource name of the
   /// [Secret][google.cloud.secretmanager.v1.Secret], in the format
   /// `projects/*/secrets/*`.
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::cloud::secretmanager::v1::Secret,google/cloud/secretmanager/v1/resources.proto#L40}
   ///
@@ -186,6 +190,7 @@ class SecretManagerServiceClient {
   /// @param secret  Required. [Secret][google.cloud.secretmanager.v1.Secret]
   /// with updated field values.
   /// @param update_mask  Required. Specifies the fields to be updated.
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::cloud::secretmanager::v1::Secret,google/cloud/secretmanager/v1/resources.proto#L40}
   ///
@@ -204,6 +209,7 @@ class SecretManagerServiceClient {
   /// @param name  Required. The resource name of the
   /// [Secret][google.cloud.secretmanager.v1.Secret] to delete in the format
   ///  `projects/*/secrets/*`.
+  /// @param options  Optional. Operation options.
   ///
   /// [google.cloud.secretmanager.v1.DeleteSecretRequest]:
   /// @googleapis_reference_link{google/cloud/secretmanager/v1/service.proto#L390}
@@ -218,6 +224,7 @@ class SecretManagerServiceClient {
   /// [Secret][google.cloud.secretmanager.v1.Secret] associated with the
   ///  [SecretVersions][google.cloud.secretmanager.v1.SecretVersion] to list, in
   ///  the format `projects/*/secrets/*`.
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::cloud::secretmanager::v1::SecretVersion,google/cloud/secretmanager/v1/resources.proto#L103}
   ///
@@ -241,6 +248,7 @@ class SecretManagerServiceClient {
   ///  `projects/*/secrets/*/versions/*`.
   ///  `projects/*/secrets/*/versions/latest` is an alias to the most recently
   ///  created [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::cloud::secretmanager::v1::SecretVersion,google/cloud/secretmanager/v1/resources.proto#L103}
   ///
@@ -264,6 +272,7 @@ class SecretManagerServiceClient {
   ///  `projects/*/secrets/*/versions/*`.
   ///  `projects/*/secrets/*/versions/latest` is an alias to the most recently
   ///  created [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::cloud::secretmanager::v1::AccessSecretVersionResponse,google/cloud/secretmanager/v1/service.proto#L378}
   ///
@@ -286,6 +295,7 @@ class SecretManagerServiceClient {
   /// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] to disable in
   /// the format
   ///  `projects/*/secrets/*/versions/*`.
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::cloud::secretmanager::v1::SecretVersion,google/cloud/secretmanager/v1/resources.proto#L103}
   ///
@@ -308,6 +318,7 @@ class SecretManagerServiceClient {
   /// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] to enable in
   /// the format
   ///  `projects/*/secrets/*/versions/*`.
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::cloud::secretmanager::v1::SecretVersion,google/cloud/secretmanager/v1/resources.proto#L103}
   ///
@@ -331,6 +342,7 @@ class SecretManagerServiceClient {
   /// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] to destroy in
   /// the format
   ///  `projects/*/secrets/*/versions/*`.
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::cloud::secretmanager::v1::SecretVersion,google/cloud/secretmanager/v1/resources.proto#L103}
   ///
@@ -347,6 +359,7 @@ class SecretManagerServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::secretmanager::v1::ListSecretsRequest,google/cloud/secretmanager/v1/service.proto#L206}
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::cloud::secretmanager::v1::Secret,google/cloud/secretmanager/v1/resources.proto#L40}
   ///
@@ -365,6 +378,7 @@ class SecretManagerServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::secretmanager::v1::CreateSecretRequest,google/cloud/secretmanager/v1/service.proto#L248}
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::cloud::secretmanager::v1::Secret,google/cloud/secretmanager/v1/resources.proto#L40}
   ///
@@ -384,6 +398,7 @@ class SecretManagerServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::secretmanager::v1::AddSecretVersionRequest,google/cloud/secretmanager/v1/service.proto#L270}
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::cloud::secretmanager::v1::SecretVersion,google/cloud/secretmanager/v1/resources.proto#L103}
   ///
@@ -401,6 +416,7 @@ class SecretManagerServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::secretmanager::v1::GetSecretRequest,google/cloud/secretmanager/v1/service.proto#L285}
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::cloud::secretmanager::v1::Secret,google/cloud/secretmanager/v1/resources.proto#L40}
   ///
@@ -419,6 +435,7 @@ class SecretManagerServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::secretmanager::v1::UpdateSecretRequest,google/cloud/secretmanager/v1/service.proto#L354}
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::cloud::secretmanager::v1::Secret,google/cloud/secretmanager/v1/resources.proto#L40}
   ///
@@ -436,6 +453,7 @@ class SecretManagerServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::secretmanager::v1::DeleteSecretRequest,google/cloud/secretmanager/v1/service.proto#L390}
+  /// @param options  Optional. Operation options.
   ///
   /// [google.cloud.secretmanager.v1.DeleteSecretRequest]:
   /// @googleapis_reference_link{google/cloud/secretmanager/v1/service.proto#L390}
@@ -450,6 +468,7 @@ class SecretManagerServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::secretmanager::v1::ListSecretVersionsRequest,google/cloud/secretmanager/v1/service.proto#L296}
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::cloud::secretmanager::v1::SecretVersion,google/cloud/secretmanager/v1/resources.proto#L103}
   ///
@@ -472,6 +491,7 @@ class SecretManagerServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::secretmanager::v1::GetSecretVersionRequest,google/cloud/secretmanager/v1/service.proto#L339}
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::cloud::secretmanager::v1::SecretVersion,google/cloud/secretmanager/v1/resources.proto#L103}
   ///
@@ -493,6 +513,7 @@ class SecretManagerServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::secretmanager::v1::AccessSecretVersionRequest,google/cloud/secretmanager/v1/service.proto#L363}
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::cloud::secretmanager::v1::AccessSecretVersionResponse,google/cloud/secretmanager/v1/service.proto#L378}
   ///
@@ -516,6 +537,7 @@ class SecretManagerServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::secretmanager::v1::DisableSecretVersionRequest,google/cloud/secretmanager/v1/service.proto#L407}
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::cloud::secretmanager::v1::SecretVersion,google/cloud/secretmanager/v1/resources.proto#L103}
   ///
@@ -539,6 +561,7 @@ class SecretManagerServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::secretmanager::v1::EnableSecretVersionRequest,google/cloud/secretmanager/v1/service.proto#L424}
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::cloud::secretmanager::v1::SecretVersion,google/cloud/secretmanager/v1/resources.proto#L103}
   ///
@@ -562,6 +585,7 @@ class SecretManagerServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::secretmanager::v1::DestroySecretVersionRequest,google/cloud/secretmanager/v1/service.proto#L441}
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::cloud::secretmanager::v1::SecretVersion,google/cloud/secretmanager/v1/resources.proto#L103}
   ///
@@ -587,6 +611,7 @@ class SecretManagerServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::iam::v1::SetIamPolicyRequest,google/iam/v1/iam_policy.proto#L98}
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
@@ -605,6 +630,7 @@ class SecretManagerServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::iam::v1::GetIamPolicyRequest,google/iam/v1/iam_policy.proto#L113}
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
@@ -628,6 +654,7 @@ class SecretManagerServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::iam::v1::TestIamPermissionsRequest,google/iam/v1/iam_policy.proto#L126}
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
   ///

--- a/google/cloud/spanner/admin/database_admin_client.cc
+++ b/google/cloud/spanner/admin/database_admin_client.cc
@@ -28,12 +28,16 @@ namespace spanner_admin {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 DatabaseAdminClient::DatabaseAdminClient(
-    std::shared_ptr<DatabaseAdminConnection> connection)
-    : connection_(std::move(connection)) {}
+    std::shared_ptr<DatabaseAdminConnection> connection, Options options)
+    : connection_(std::move(connection)),
+      options_(spanner_admin_internal::DatabaseAdminDefaultOptions(
+          std::move(options))) {}
 DatabaseAdminClient::~DatabaseAdminClient() = default;
 
 StreamRange<google::spanner::admin::database::v1::Database>
-DatabaseAdminClient::ListDatabases(std::string const& parent) {
+DatabaseAdminClient::ListDatabases(std::string const& parent, Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   google::spanner::admin::database::v1::ListDatabasesRequest request;
   request.set_parent(parent);
   return connection_->ListDatabases(request);
@@ -41,7 +45,10 @@ DatabaseAdminClient::ListDatabases(std::string const& parent) {
 
 future<StatusOr<google::spanner::admin::database::v1::Database>>
 DatabaseAdminClient::CreateDatabase(std::string const& parent,
-                                    std::string const& create_statement) {
+                                    std::string const& create_statement,
+                                    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   google::spanner::admin::database::v1::CreateDatabaseRequest request;
   request.set_parent(parent);
   request.set_create_statement(create_statement);
@@ -49,7 +56,9 @@ DatabaseAdminClient::CreateDatabase(std::string const& parent,
 }
 
 StatusOr<google::spanner::admin::database::v1::Database>
-DatabaseAdminClient::GetDatabase(std::string const& name) {
+DatabaseAdminClient::GetDatabase(std::string const& name, Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   google::spanner::admin::database::v1::GetDatabaseRequest request;
   request.set_name(name);
   return connection_->GetDatabase(request);
@@ -58,28 +67,40 @@ DatabaseAdminClient::GetDatabase(std::string const& name) {
 future<
     StatusOr<google::spanner::admin::database::v1::UpdateDatabaseDdlMetadata>>
 DatabaseAdminClient::UpdateDatabaseDdl(
-    std::string const& database, std::vector<std::string> const& statements) {
+    std::string const& database, std::vector<std::string> const& statements,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   google::spanner::admin::database::v1::UpdateDatabaseDdlRequest request;
   request.set_database(database);
   *request.mutable_statements() = {statements.begin(), statements.end()};
   return connection_->UpdateDatabaseDdl(request);
 }
 
-Status DatabaseAdminClient::DropDatabase(std::string const& database) {
+Status DatabaseAdminClient::DropDatabase(std::string const& database,
+                                         Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   google::spanner::admin::database::v1::DropDatabaseRequest request;
   request.set_database(database);
   return connection_->DropDatabase(request);
 }
 
 StatusOr<google::spanner::admin::database::v1::GetDatabaseDdlResponse>
-DatabaseAdminClient::GetDatabaseDdl(std::string const& database) {
+DatabaseAdminClient::GetDatabaseDdl(std::string const& database,
+                                    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   google::spanner::admin::database::v1::GetDatabaseDdlRequest request;
   request.set_database(database);
   return connection_->GetDatabaseDdl(request);
 }
 
 StatusOr<google::iam::v1::Policy> DatabaseAdminClient::SetIamPolicy(
-    std::string const& resource, google::iam::v1::Policy const& policy) {
+    std::string const& resource, google::iam::v1::Policy const& policy,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   google::iam::v1::SetIamPolicyRequest request;
   request.set_resource(resource);
   *request.mutable_policy() = policy;
@@ -90,10 +111,11 @@ StatusOr<google::iam::v1::Policy> DatabaseAdminClient::SetIamPolicy(
     std::string const& resource, IamUpdater const& updater, Options options) {
   internal::CheckExpectedOptions<DatabaseAdminBackoffPolicyOption>(options,
                                                                    __func__);
-  options =
-      spanner_admin_internal::DatabaseAdminDefaultOptions(std::move(options));
-  auto backoff_policy =
-      options.get<DatabaseAdminBackoffPolicyOption>()->clone();
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
+  auto backoff_policy = internal::CurrentOptions()
+                            .get<DatabaseAdminBackoffPolicyOption>()
+                            ->clone();
   for (;;) {
     auto recent = GetIamPolicy(resource);
     if (!recent) {
@@ -112,7 +134,9 @@ StatusOr<google::iam::v1::Policy> DatabaseAdminClient::SetIamPolicy(
 }
 
 StatusOr<google::iam::v1::Policy> DatabaseAdminClient::GetIamPolicy(
-    std::string const& resource) {
+    std::string const& resource, Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   google::iam::v1::GetIamPolicyRequest request;
   request.set_resource(resource);
   return connection_->GetIamPolicy(request);
@@ -120,7 +144,10 @@ StatusOr<google::iam::v1::Policy> DatabaseAdminClient::GetIamPolicy(
 
 StatusOr<google::iam::v1::TestIamPermissionsResponse>
 DatabaseAdminClient::TestIamPermissions(
-    std::string const& resource, std::vector<std::string> const& permissions) {
+    std::string const& resource, std::vector<std::string> const& permissions,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   google::iam::v1::TestIamPermissionsRequest request;
   request.set_resource(resource);
   *request.mutable_permissions() = {permissions.begin(), permissions.end()};
@@ -131,7 +158,9 @@ future<StatusOr<google::spanner::admin::database::v1::Backup>>
 DatabaseAdminClient::CreateBackup(
     std::string const& parent,
     google::spanner::admin::database::v1::Backup const& backup,
-    std::string const& backup_id) {
+    std::string const& backup_id, Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   google::spanner::admin::database::v1::CreateBackupRequest request;
   request.set_parent(parent);
   *request.mutable_backup() = backup;
@@ -140,7 +169,9 @@ DatabaseAdminClient::CreateBackup(
 }
 
 StatusOr<google::spanner::admin::database::v1::Backup>
-DatabaseAdminClient::GetBackup(std::string const& name) {
+DatabaseAdminClient::GetBackup(std::string const& name, Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   google::spanner::admin::database::v1::GetBackupRequest request;
   request.set_name(name);
   return connection_->GetBackup(request);
@@ -149,21 +180,28 @@ DatabaseAdminClient::GetBackup(std::string const& name) {
 StatusOr<google::spanner::admin::database::v1::Backup>
 DatabaseAdminClient::UpdateBackup(
     google::spanner::admin::database::v1::Backup const& backup,
-    google::protobuf::FieldMask const& update_mask) {
+    google::protobuf::FieldMask const& update_mask, Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   google::spanner::admin::database::v1::UpdateBackupRequest request;
   *request.mutable_backup() = backup;
   *request.mutable_update_mask() = update_mask;
   return connection_->UpdateBackup(request);
 }
 
-Status DatabaseAdminClient::DeleteBackup(std::string const& name) {
+Status DatabaseAdminClient::DeleteBackup(std::string const& name,
+                                         Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   google::spanner::admin::database::v1::DeleteBackupRequest request;
   request.set_name(name);
   return connection_->DeleteBackup(request);
 }
 
 StreamRange<google::spanner::admin::database::v1::Backup>
-DatabaseAdminClient::ListBackups(std::string const& parent) {
+DatabaseAdminClient::ListBackups(std::string const& parent, Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   google::spanner::admin::database::v1::ListBackupsRequest request;
   request.set_parent(parent);
   return connection_->ListBackups(request);
@@ -172,7 +210,10 @@ DatabaseAdminClient::ListBackups(std::string const& parent) {
 future<StatusOr<google::spanner::admin::database::v1::Database>>
 DatabaseAdminClient::RestoreDatabase(std::string const& parent,
                                      std::string const& database_id,
-                                     std::string const& backup) {
+                                     std::string const& backup,
+                                     Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   google::spanner::admin::database::v1::RestoreDatabaseRequest request;
   request.set_parent(parent);
   request.set_database_id(database_id);
@@ -181,14 +222,20 @@ DatabaseAdminClient::RestoreDatabase(std::string const& parent,
 }
 
 StreamRange<google::longrunning::Operation>
-DatabaseAdminClient::ListDatabaseOperations(std::string const& parent) {
+DatabaseAdminClient::ListDatabaseOperations(std::string const& parent,
+                                            Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   google::spanner::admin::database::v1::ListDatabaseOperationsRequest request;
   request.set_parent(parent);
   return connection_->ListDatabaseOperations(request);
 }
 
 StreamRange<google::longrunning::Operation>
-DatabaseAdminClient::ListBackupOperations(std::string const& parent) {
+DatabaseAdminClient::ListBackupOperations(std::string const& parent,
+                                          Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   google::spanner::admin::database::v1::ListBackupOperationsRequest request;
   request.set_parent(parent);
   return connection_->ListBackupOperations(request);
@@ -196,20 +243,28 @@ DatabaseAdminClient::ListBackupOperations(std::string const& parent) {
 
 StreamRange<google::spanner::admin::database::v1::Database>
 DatabaseAdminClient::ListDatabases(
-    google::spanner::admin::database::v1::ListDatabasesRequest request) {
+    google::spanner::admin::database::v1::ListDatabasesRequest request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->ListDatabases(std::move(request));
 }
 
 future<StatusOr<google::spanner::admin::database::v1::Database>>
 DatabaseAdminClient::CreateDatabase(
-    google::spanner::admin::database::v1::CreateDatabaseRequest const&
-        request) {
+    google::spanner::admin::database::v1::CreateDatabaseRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->CreateDatabase(request);
 }
 
 StatusOr<google::spanner::admin::database::v1::Database>
 DatabaseAdminClient::GetDatabase(
-    google::spanner::admin::database::v1::GetDatabaseRequest const& request) {
+    google::spanner::admin::database::v1::GetDatabaseRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->GetDatabase(request);
 }
 
@@ -217,84 +272,121 @@ future<
     StatusOr<google::spanner::admin::database::v1::UpdateDatabaseDdlMetadata>>
 DatabaseAdminClient::UpdateDatabaseDdl(
     google::spanner::admin::database::v1::UpdateDatabaseDdlRequest const&
-        request) {
+        request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->UpdateDatabaseDdl(request);
 }
 
 Status DatabaseAdminClient::DropDatabase(
-    google::spanner::admin::database::v1::DropDatabaseRequest const& request) {
+    google::spanner::admin::database::v1::DropDatabaseRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->DropDatabase(request);
 }
 
 StatusOr<google::spanner::admin::database::v1::GetDatabaseDdlResponse>
 DatabaseAdminClient::GetDatabaseDdl(
-    google::spanner::admin::database::v1::GetDatabaseDdlRequest const&
-        request) {
+    google::spanner::admin::database::v1::GetDatabaseDdlRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->GetDatabaseDdl(request);
 }
 
 StatusOr<google::iam::v1::Policy> DatabaseAdminClient::SetIamPolicy(
-    google::iam::v1::SetIamPolicyRequest const& request) {
+    google::iam::v1::SetIamPolicyRequest const& request, Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->SetIamPolicy(request);
 }
 
 StatusOr<google::iam::v1::Policy> DatabaseAdminClient::GetIamPolicy(
-    google::iam::v1::GetIamPolicyRequest const& request) {
+    google::iam::v1::GetIamPolicyRequest const& request, Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->GetIamPolicy(request);
 }
 
 StatusOr<google::iam::v1::TestIamPermissionsResponse>
 DatabaseAdminClient::TestIamPermissions(
-    google::iam::v1::TestIamPermissionsRequest const& request) {
+    google::iam::v1::TestIamPermissionsRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->TestIamPermissions(request);
 }
 
 future<StatusOr<google::spanner::admin::database::v1::Backup>>
 DatabaseAdminClient::CreateBackup(
-    google::spanner::admin::database::v1::CreateBackupRequest const& request) {
+    google::spanner::admin::database::v1::CreateBackupRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->CreateBackup(request);
 }
 
 StatusOr<google::spanner::admin::database::v1::Backup>
 DatabaseAdminClient::GetBackup(
-    google::spanner::admin::database::v1::GetBackupRequest const& request) {
+    google::spanner::admin::database::v1::GetBackupRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->GetBackup(request);
 }
 
 StatusOr<google::spanner::admin::database::v1::Backup>
 DatabaseAdminClient::UpdateBackup(
-    google::spanner::admin::database::v1::UpdateBackupRequest const& request) {
+    google::spanner::admin::database::v1::UpdateBackupRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->UpdateBackup(request);
 }
 
 Status DatabaseAdminClient::DeleteBackup(
-    google::spanner::admin::database::v1::DeleteBackupRequest const& request) {
+    google::spanner::admin::database::v1::DeleteBackupRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->DeleteBackup(request);
 }
 
 StreamRange<google::spanner::admin::database::v1::Backup>
 DatabaseAdminClient::ListBackups(
-    google::spanner::admin::database::v1::ListBackupsRequest request) {
+    google::spanner::admin::database::v1::ListBackupsRequest request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->ListBackups(std::move(request));
 }
 
 future<StatusOr<google::spanner::admin::database::v1::Database>>
 DatabaseAdminClient::RestoreDatabase(
-    google::spanner::admin::database::v1::RestoreDatabaseRequest const&
-        request) {
+    google::spanner::admin::database::v1::RestoreDatabaseRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->RestoreDatabase(request);
 }
 
 StreamRange<google::longrunning::Operation>
 DatabaseAdminClient::ListDatabaseOperations(
-    google::spanner::admin::database::v1::ListDatabaseOperationsRequest
-        request) {
+    google::spanner::admin::database::v1::ListDatabaseOperationsRequest request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->ListDatabaseOperations(std::move(request));
 }
 
 StreamRange<google::longrunning::Operation>
 DatabaseAdminClient::ListBackupOperations(
-    google::spanner::admin::database::v1::ListBackupOperationsRequest request) {
+    google::spanner::admin::database::v1::ListBackupOperationsRequest request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->ListBackupOperations(std::move(request));
 }
 

--- a/google/cloud/spanner/admin/database_admin_client.h
+++ b/google/cloud/spanner/admin/database_admin_client.h
@@ -97,6 +97,7 @@ class DatabaseAdminClient {
   ///
   /// @param parent  Required. The instance whose databases should be listed.
   ///  Values are of the form `projects/<project>/instances/<instance>`.
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::spanner::admin::database::v1::Database,google/spanner/admin/database/v1/spanner_database_admin.proto#L326}
   ///
@@ -127,6 +128,7 @@ class DatabaseAdminClient {
   ///  `[a-z][a-z0-9_\-]*[a-z0-9]` and be between 2 and 30 characters in length.
   ///  If the database ID is a reserved word or if it contains a hyphen, the
   ///  database ID must be enclosed in backticks (`` ` ``).
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::spanner::admin::database::v1::Database,google/spanner/admin/database/v1/spanner_database_admin.proto#L326}
   ///
@@ -145,6 +147,7 @@ class DatabaseAdminClient {
   /// @param name  Required. The name of the requested database. Values are of
   /// the form
   ///  `projects/<project>/instances/<instance>/databases/<database>`.
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::spanner::admin::database::v1::Database,google/spanner/admin/database/v1/spanner_database_admin.proto#L326}
   ///
@@ -168,6 +171,7 @@ class DatabaseAdminClient {
   ///
   /// @param database  Required. The database to update.
   /// @param statements  Required. DDL statements to be applied to the database.
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::spanner::admin::database::v1::UpdateDatabaseDdlMetadata,google/spanner/admin/database/v1/spanner_database_admin.proto#L547}
   ///
@@ -188,6 +192,7 @@ class DatabaseAdminClient {
   /// `expire_time`.
   ///
   /// @param database  Required. The database to be dropped.
+  /// @param options  Optional. Operation options.
   ///
   /// [google.spanner.admin.database.v1.DropDatabaseRequest]:
   /// @googleapis_reference_link{google/spanner/admin/database/v1/spanner_database_admin.proto#L579}
@@ -202,6 +207,7 @@ class DatabaseAdminClient {
   /// @param database  Required. The database whose schema we wish to get.
   ///  Values are of the form
   ///  `projects/<project>/instances/<instance>/databases/<database>`
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::spanner::admin::database::v1::GetDatabaseDdlResponse,google/spanner/admin/database/v1/spanner_database_admin.proto#L603}
   ///
@@ -230,6 +236,7 @@ class DatabaseAdminClient {
   ///  the policy is limited to a few 10s of KB. An empty policy is a
   ///  valid policy but certain Cloud Platform services (such as Projects)
   ///  might reject them.
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
@@ -280,6 +287,7 @@ class DatabaseAdminClient {
   /// @param resource  REQUIRED: The resource for which the policy is being
   /// requested.
   ///  See the operation documentation for the appropriate value for this field.
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
@@ -311,6 +319,7 @@ class DatabaseAdminClient {
   ///  wildcards (such as '*' or 'storage.*') are not allowed. For more
   ///  information see
   ///  [IAM Overview](https://cloud.google.com/iam/docs/overview#permissions).
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
   ///
@@ -349,6 +358,7 @@ class DatabaseAdminClient {
   /// `backup_id` appended to
   ///  `parent` forms the full backup name of the form
   ///  `projects/<project>/instances/<instance>/backups/<backup_id>`.
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::spanner::admin::database::v1::Backup,google/spanner/admin/database/v1/backup.proto#L36}
   ///
@@ -369,6 +379,7 @@ class DatabaseAdminClient {
   /// @param name  Required. Name of the backup.
   ///  Values are of the form
   ///  `projects/<project>/instances/<instance>/backups/<backup>`.
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::spanner::admin::database::v1::Backup,google/spanner/admin/database/v1/backup.proto#L36}
   ///
@@ -395,6 +406,7 @@ class DatabaseAdminClient {
   ///  resource, not to the request message. The field mask must always be
   ///  specified; this prevents any future fields from being erased accidentally
   ///  by clients that do not know about them.
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::spanner::admin::database::v1::Backup,google/spanner/admin/database/v1/backup.proto#L36}
   ///
@@ -414,6 +426,7 @@ class DatabaseAdminClient {
   /// @param name  Required. Name of the backup to delete.
   ///  Values are of the form
   ///  `projects/<project>/instances/<instance>/backups/<backup>`.
+  /// @param options  Optional. Operation options.
   ///
   /// [google.spanner.admin.database.v1.DeleteBackupRequest]:
   /// @googleapis_reference_link{google/spanner/admin/database/v1/backup.proto#L215}
@@ -428,6 +441,7 @@ class DatabaseAdminClient {
   /// @param parent  Required. The instance to list backups from.  Values are of
   /// the
   ///  form `projects/<project>/instances/<instance>`.
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::spanner::admin::database::v1::Backup,google/spanner/admin/database/v1/backup.proto#L36}
   ///
@@ -471,6 +485,7 @@ class DatabaseAdminClient {
   /// @param backup  Name of the backup from which to restore.  Values are of
   /// the form
   ///  `projects/<project>/instances/<instance>/backups/<backup>`.
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::spanner::admin::database::v1::Database,google/spanner/admin/database/v1/spanner_database_admin.proto#L326}
   ///
@@ -495,6 +510,7 @@ class DatabaseAdminClient {
   ///
   /// @param parent  Required. The instance of the database operations.
   ///  Values are of the form `projects/<project>/instances/<instance>`.
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::longrunning::Operation,google/longrunning/operations.proto#L128}
   ///
@@ -521,6 +537,7 @@ class DatabaseAdminClient {
   /// @param parent  Required. The instance of the backup operations. Values are
   /// of
   ///  the form `projects/<project>/instances/<instance>`.
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::longrunning::Operation,google/longrunning/operations.proto#L128}
   ///
@@ -537,6 +554,7 @@ class DatabaseAdminClient {
   ///
   /// @param request
   /// @googleapis_link{google::spanner::admin::database::v1::ListDatabasesRequest,google/spanner/admin/database/v1/spanner_database_admin.proto#L413}
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::spanner::admin::database::v1::Database,google/spanner/admin/database/v1/spanner_database_admin.proto#L326}
   ///
@@ -561,6 +579,7 @@ class DatabaseAdminClient {
   ///
   /// @param request
   /// @googleapis_link{google::spanner::admin::database::v1::CreateDatabaseRequest,google/spanner/admin/database/v1/spanner_database_admin.proto#L445}
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::spanner::admin::database::v1::Database,google/spanner/admin/database/v1/spanner_database_admin.proto#L326}
   ///
@@ -580,6 +599,7 @@ class DatabaseAdminClient {
   ///
   /// @param request
   /// @googleapis_link{google::spanner::admin::database::v1::GetDatabaseRequest,google/spanner/admin/database/v1/spanner_database_admin.proto#L484}
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::spanner::admin::database::v1::Database,google/spanner/admin/database/v1/spanner_database_admin.proto#L326}
   ///
@@ -604,6 +624,7 @@ class DatabaseAdminClient {
   ///
   /// @param request
   /// @googleapis_link{google::spanner::admin::database::v1::UpdateDatabaseDdlRequest,google/spanner/admin/database/v1/spanner_database_admin.proto#L511}
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::spanner::admin::database::v1::UpdateDatabaseDdlMetadata,google/spanner/admin/database/v1/spanner_database_admin.proto#L547}
   ///
@@ -626,6 +647,7 @@ class DatabaseAdminClient {
   ///
   /// @param request
   /// @googleapis_link{google::spanner::admin::database::v1::DropDatabaseRequest,google/spanner/admin/database/v1/spanner_database_admin.proto#L579}
+  /// @param options  Optional. Operation options.
   ///
   /// [google.spanner.admin.database.v1.DropDatabaseRequest]:
   /// @googleapis_reference_link{google/spanner/admin/database/v1/spanner_database_admin.proto#L579}
@@ -641,6 +663,7 @@ class DatabaseAdminClient {
   ///
   /// @param request
   /// @googleapis_link{google::spanner::admin::database::v1::GetDatabaseDdlRequest,google/spanner/admin/database/v1/spanner_database_admin.proto#L590}
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::spanner::admin::database::v1::GetDatabaseDdlResponse,google/spanner/admin/database/v1/spanner_database_admin.proto#L603}
   ///
@@ -666,6 +689,7 @@ class DatabaseAdminClient {
   ///
   /// @param request
   /// @googleapis_link{google::iam::v1::SetIamPolicyRequest,google/iam/v1/iam_policy.proto#L98}
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
@@ -690,6 +714,7 @@ class DatabaseAdminClient {
   ///
   /// @param request
   /// @googleapis_link{google::iam::v1::GetIamPolicyRequest,google/iam/v1/iam_policy.proto#L113}
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
@@ -716,6 +741,7 @@ class DatabaseAdminClient {
   ///
   /// @param request
   /// @googleapis_link{google::iam::v1::TestIamPermissionsRequest,google/iam/v1/iam_policy.proto#L126}
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
   ///
@@ -744,6 +770,7 @@ class DatabaseAdminClient {
   ///
   /// @param request
   /// @googleapis_link{google::spanner::admin::database::v1::CreateBackupRequest,google/spanner/admin/database/v1/backup.proto#L123}
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::spanner::admin::database::v1::Backup,google/spanner/admin/database/v1/backup.proto#L36}
   ///
@@ -762,6 +789,7 @@ class DatabaseAdminClient {
   ///
   /// @param request
   /// @googleapis_link{google::spanner::admin::database::v1::GetBackupRequest,google/spanner/admin/database/v1/backup.proto#L202}
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::spanner::admin::database::v1::Backup,google/spanner/admin/database/v1/backup.proto#L36}
   ///
@@ -780,6 +808,7 @@ class DatabaseAdminClient {
   ///
   /// @param request
   /// @googleapis_link{google::spanner::admin::database::v1::UpdateBackupRequest,google/spanner/admin/database/v1/backup.proto#L186}
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::spanner::admin::database::v1::Backup,google/spanner/admin/database/v1/backup.proto#L36}
   ///
@@ -798,6 +827,7 @@ class DatabaseAdminClient {
   ///
   /// @param request
   /// @googleapis_link{google::spanner::admin::database::v1::DeleteBackupRequest,google/spanner/admin/database/v1/backup.proto#L215}
+  /// @param options  Optional. Operation options.
   ///
   /// [google.spanner.admin.database.v1.DeleteBackupRequest]:
   /// @googleapis_reference_link{google/spanner/admin/database/v1/backup.proto#L215}
@@ -813,6 +843,7 @@ class DatabaseAdminClient {
   ///
   /// @param request
   /// @googleapis_link{google::spanner::admin::database::v1::ListBackupsRequest,google/spanner/admin/database/v1/backup.proto#L228}
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::spanner::admin::database::v1::Backup,google/spanner/admin/database/v1/backup.proto#L36}
   ///
@@ -846,6 +877,7 @@ class DatabaseAdminClient {
   ///
   /// @param request
   /// @googleapis_link{google::spanner::admin::database::v1::RestoreDatabaseRequest,google/spanner/admin/database/v1/spanner_database_admin.proto#L692}
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::spanner::admin::database::v1::Database,google/spanner/admin/database/v1/spanner_database_admin.proto#L326}
   ///
@@ -872,6 +904,7 @@ class DatabaseAdminClient {
   ///
   /// @param request
   /// @googleapis_link{google::spanner::admin::database::v1::ListDatabaseOperationsRequest,google/spanner/admin/database/v1/spanner_database_admin.proto#L611}
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::longrunning::Operation,google/longrunning/operations.proto#L128}
   ///
@@ -899,6 +932,7 @@ class DatabaseAdminClient {
   ///
   /// @param request
   /// @googleapis_link{google::spanner::admin::database::v1::ListBackupOperationsRequest,google/spanner/admin/database/v1/backup.proto#L300}
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::longrunning::Operation,google/longrunning/operations.proto#L128}
   ///

--- a/google/cloud/spanner/admin/database_admin_client.h
+++ b/google/cloud/spanner/admin/database_admin_client.h
@@ -68,7 +68,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class DatabaseAdminClient {
  public:
   explicit DatabaseAdminClient(
-      std::shared_ptr<DatabaseAdminConnection> connection);
+      std::shared_ptr<DatabaseAdminConnection> connection,
+      Options options = {});
   ~DatabaseAdminClient();
 
   //@{
@@ -105,7 +106,7 @@ class DatabaseAdminClient {
   /// @googleapis_reference_link{google/spanner/admin/database/v1/spanner_database_admin.proto#L326}
   ///
   StreamRange<google::spanner::admin::database::v1::Database> ListDatabases(
-      std::string const& parent);
+      std::string const& parent, Options options = {});
 
   ///
   /// Creates a new Cloud Spanner database and starts to prepare it for serving.
@@ -135,8 +136,8 @@ class DatabaseAdminClient {
   /// @googleapis_reference_link{google/spanner/admin/database/v1/spanner_database_admin.proto#L326}
   ///
   future<StatusOr<google::spanner::admin::database::v1::Database>>
-  CreateDatabase(std::string const& parent,
-                 std::string const& create_statement);
+  CreateDatabase(std::string const& parent, std::string const& create_statement,
+                 Options options = {});
 
   ///
   /// Gets the state of a Cloud Spanner database.
@@ -153,7 +154,7 @@ class DatabaseAdminClient {
   /// @googleapis_reference_link{google/spanner/admin/database/v1/spanner_database_admin.proto#L326}
   ///
   StatusOr<google::spanner::admin::database::v1::Database> GetDatabase(
-      std::string const& name);
+      std::string const& name, Options options = {});
 
   ///
   /// Updates the schema of a Cloud Spanner database by
@@ -178,7 +179,8 @@ class DatabaseAdminClient {
   future<
       StatusOr<google::spanner::admin::database::v1::UpdateDatabaseDdlMetadata>>
   UpdateDatabaseDdl(std::string const& database,
-                    std::vector<std::string> const& statements);
+                    std::vector<std::string> const& statements,
+                    Options options = {});
 
   ///
   /// Drops (aka deletes) a Cloud Spanner database.
@@ -190,7 +192,7 @@ class DatabaseAdminClient {
   /// [google.spanner.admin.database.v1.DropDatabaseRequest]:
   /// @googleapis_reference_link{google/spanner/admin/database/v1/spanner_database_admin.proto#L579}
   ///
-  Status DropDatabase(std::string const& database);
+  Status DropDatabase(std::string const& database, Options options = {});
 
   ///
   /// Returns the schema of a Cloud Spanner database as a list of formatted
@@ -209,7 +211,7 @@ class DatabaseAdminClient {
   /// @googleapis_reference_link{google/spanner/admin/database/v1/spanner_database_admin.proto#L603}
   ///
   StatusOr<google::spanner::admin::database::v1::GetDatabaseDdlResponse>
-  GetDatabaseDdl(std::string const& database);
+  GetDatabaseDdl(std::string const& database, Options options = {});
 
   ///
   /// Sets the access control policy on a database or backup resource.
@@ -237,7 +239,8 @@ class DatabaseAdminClient {
   /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
-      std::string const& resource, google::iam::v1::Policy const& policy);
+      std::string const& resource, google::iam::v1::Policy const& policy,
+      Options options = {});
 
   /**
    * Updates the IAM policy for @p resource using an optimistic concurrency
@@ -285,7 +288,8 @@ class DatabaseAdminClient {
   /// [google.iam.v1.Policy]:
   /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
-  StatusOr<google::iam::v1::Policy> GetIamPolicy(std::string const& resource);
+  StatusOr<google::iam::v1::Policy> GetIamPolicy(std::string const& resource,
+                                                 Options options = {});
 
   ///
   /// Returns permissions that the caller has on the specified database or
@@ -316,7 +320,8 @@ class DatabaseAdminClient {
   /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L141}
   ///
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
-      std::string const& resource, std::vector<std::string> const& permissions);
+      std::string const& resource, std::vector<std::string> const& permissions,
+      Options options = {});
 
   ///
   /// Starts creating a new Cloud Spanner Backup.
@@ -355,7 +360,7 @@ class DatabaseAdminClient {
   future<StatusOr<google::spanner::admin::database::v1::Backup>> CreateBackup(
       std::string const& parent,
       google::spanner::admin::database::v1::Backup const& backup,
-      std::string const& backup_id);
+      std::string const& backup_id, Options options = {});
 
   ///
   /// Gets metadata on a pending or completed
@@ -373,7 +378,7 @@ class DatabaseAdminClient {
   /// @googleapis_reference_link{google/spanner/admin/database/v1/backup.proto#L36}
   ///
   StatusOr<google::spanner::admin::database::v1::Backup> GetBackup(
-      std::string const& name);
+      std::string const& name, Options options = {});
 
   ///
   /// Updates a pending or completed
@@ -400,7 +405,7 @@ class DatabaseAdminClient {
   ///
   StatusOr<google::spanner::admin::database::v1::Backup> UpdateBackup(
       google::spanner::admin::database::v1::Backup const& backup,
-      google::protobuf::FieldMask const& update_mask);
+      google::protobuf::FieldMask const& update_mask, Options options = {});
 
   ///
   /// Deletes a pending or completed
@@ -413,7 +418,7 @@ class DatabaseAdminClient {
   /// [google.spanner.admin.database.v1.DeleteBackupRequest]:
   /// @googleapis_reference_link{google/spanner/admin/database/v1/backup.proto#L215}
   ///
-  Status DeleteBackup(std::string const& name);
+  Status DeleteBackup(std::string const& name, Options options = {});
 
   ///
   /// Lists completed and pending backups.
@@ -432,7 +437,7 @@ class DatabaseAdminClient {
   /// @googleapis_reference_link{google/spanner/admin/database/v1/backup.proto#L36}
   ///
   StreamRange<google::spanner::admin::database::v1::Backup> ListBackups(
-      std::string const& parent);
+      std::string const& parent, Options options = {});
 
   ///
   /// Create a new database by restoring from a completed backup. The new
@@ -476,7 +481,7 @@ class DatabaseAdminClient {
   ///
   future<StatusOr<google::spanner::admin::database::v1::Database>>
   RestoreDatabase(std::string const& parent, std::string const& database_id,
-                  std::string const& backup);
+                  std::string const& backup, Options options = {});
 
   ///
   /// Lists database [longrunning-operations][google.longrunning.Operation].
@@ -499,7 +504,7 @@ class DatabaseAdminClient {
   /// @googleapis_reference_link{google/longrunning/operations.proto#L128}
   ///
   StreamRange<google::longrunning::Operation> ListDatabaseOperations(
-      std::string const& parent);
+      std::string const& parent, Options options = {});
 
   ///
   /// Lists the backup [long-running operations][google.longrunning.Operation]
@@ -525,7 +530,7 @@ class DatabaseAdminClient {
   /// @googleapis_reference_link{google/longrunning/operations.proto#L128}
   ///
   StreamRange<google::longrunning::Operation> ListBackupOperations(
-      std::string const& parent);
+      std::string const& parent, Options options = {});
 
   ///
   /// Lists Cloud Spanner databases.
@@ -541,7 +546,8 @@ class DatabaseAdminClient {
   /// @googleapis_reference_link{google/spanner/admin/database/v1/spanner_database_admin.proto#L326}
   ///
   StreamRange<google::spanner::admin::database::v1::Database> ListDatabases(
-      google::spanner::admin::database::v1::ListDatabasesRequest request);
+      google::spanner::admin::database::v1::ListDatabasesRequest request,
+      Options options = {});
 
   ///
   /// Creates a new Cloud Spanner database and starts to prepare it for serving.
@@ -566,7 +572,8 @@ class DatabaseAdminClient {
   future<StatusOr<google::spanner::admin::database::v1::Database>>
   CreateDatabase(
       google::spanner::admin::database::v1::CreateDatabaseRequest const&
-          request);
+          request,
+      Options options = {});
 
   ///
   /// Gets the state of a Cloud Spanner database.
@@ -582,7 +589,8 @@ class DatabaseAdminClient {
   /// @googleapis_reference_link{google/spanner/admin/database/v1/spanner_database_admin.proto#L326}
   ///
   StatusOr<google::spanner::admin::database::v1::Database> GetDatabase(
-      google::spanner::admin::database::v1::GetDatabaseRequest const& request);
+      google::spanner::admin::database::v1::GetDatabaseRequest const& request,
+      Options options = {});
 
   ///
   /// Updates the schema of a Cloud Spanner database by
@@ -608,7 +616,8 @@ class DatabaseAdminClient {
       StatusOr<google::spanner::admin::database::v1::UpdateDatabaseDdlMetadata>>
   UpdateDatabaseDdl(
       google::spanner::admin::database::v1::UpdateDatabaseDdlRequest const&
-          request);
+          request,
+      Options options = {});
 
   ///
   /// Drops (aka deletes) a Cloud Spanner database.
@@ -622,7 +631,8 @@ class DatabaseAdminClient {
   /// @googleapis_reference_link{google/spanner/admin/database/v1/spanner_database_admin.proto#L579}
   ///
   Status DropDatabase(
-      google::spanner::admin::database::v1::DropDatabaseRequest const& request);
+      google::spanner::admin::database::v1::DropDatabaseRequest const& request,
+      Options options = {});
 
   ///
   /// Returns the schema of a Cloud Spanner database as a list of formatted
@@ -642,7 +652,8 @@ class DatabaseAdminClient {
   StatusOr<google::spanner::admin::database::v1::GetDatabaseDdlResponse>
   GetDatabaseDdl(
       google::spanner::admin::database::v1::GetDatabaseDdlRequest const&
-          request);
+          request,
+      Options options = {});
 
   ///
   /// Sets the access control policy on a database or backup resource.
@@ -664,7 +675,8 @@ class DatabaseAdminClient {
   /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
-      google::iam::v1::SetIamPolicyRequest const& request);
+      google::iam::v1::SetIamPolicyRequest const& request,
+      Options options = {});
 
   ///
   /// Gets the access control policy for a database or backup resource.
@@ -687,7 +699,8 @@ class DatabaseAdminClient {
   /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> GetIamPolicy(
-      google::iam::v1::GetIamPolicyRequest const& request);
+      google::iam::v1::GetIamPolicyRequest const& request,
+      Options options = {});
 
   ///
   /// Returns permissions that the caller has on the specified database or
@@ -712,7 +725,8 @@ class DatabaseAdminClient {
   /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L141}
   ///
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
-      google::iam::v1::TestIamPermissionsRequest const& request);
+      google::iam::v1::TestIamPermissionsRequest const& request,
+      Options options = {});
 
   ///
   /// Starts creating a new Cloud Spanner Backup.
@@ -739,7 +753,8 @@ class DatabaseAdminClient {
   /// @googleapis_reference_link{google/spanner/admin/database/v1/backup.proto#L36}
   ///
   future<StatusOr<google::spanner::admin::database::v1::Backup>> CreateBackup(
-      google::spanner::admin::database::v1::CreateBackupRequest const& request);
+      google::spanner::admin::database::v1::CreateBackupRequest const& request,
+      Options options = {});
 
   ///
   /// Gets metadata on a pending or completed
@@ -756,7 +771,8 @@ class DatabaseAdminClient {
   /// @googleapis_reference_link{google/spanner/admin/database/v1/backup.proto#L36}
   ///
   StatusOr<google::spanner::admin::database::v1::Backup> GetBackup(
-      google::spanner::admin::database::v1::GetBackupRequest const& request);
+      google::spanner::admin::database::v1::GetBackupRequest const& request,
+      Options options = {});
 
   ///
   /// Updates a pending or completed
@@ -773,7 +789,8 @@ class DatabaseAdminClient {
   /// @googleapis_reference_link{google/spanner/admin/database/v1/backup.proto#L36}
   ///
   StatusOr<google::spanner::admin::database::v1::Backup> UpdateBackup(
-      google::spanner::admin::database::v1::UpdateBackupRequest const& request);
+      google::spanner::admin::database::v1::UpdateBackupRequest const& request,
+      Options options = {});
 
   ///
   /// Deletes a pending or completed
@@ -786,7 +803,8 @@ class DatabaseAdminClient {
   /// @googleapis_reference_link{google/spanner/admin/database/v1/backup.proto#L215}
   ///
   Status DeleteBackup(
-      google::spanner::admin::database::v1::DeleteBackupRequest const& request);
+      google::spanner::admin::database::v1::DeleteBackupRequest const& request,
+      Options options = {});
 
   ///
   /// Lists completed and pending backups.
@@ -804,7 +822,8 @@ class DatabaseAdminClient {
   /// @googleapis_reference_link{google/spanner/admin/database/v1/backup.proto#L36}
   ///
   StreamRange<google::spanner::admin::database::v1::Backup> ListBackups(
-      google::spanner::admin::database::v1::ListBackupsRequest request);
+      google::spanner::admin::database::v1::ListBackupsRequest request,
+      Options options = {});
 
   ///
   /// Create a new database by restoring from a completed backup. The new
@@ -838,7 +857,8 @@ class DatabaseAdminClient {
   future<StatusOr<google::spanner::admin::database::v1::Database>>
   RestoreDatabase(
       google::spanner::admin::database::v1::RestoreDatabaseRequest const&
-          request);
+          request,
+      Options options = {});
 
   ///
   /// Lists database [longrunning-operations][google.longrunning.Operation].
@@ -862,7 +882,8 @@ class DatabaseAdminClient {
   ///
   StreamRange<google::longrunning::Operation> ListDatabaseOperations(
       google::spanner::admin::database::v1::ListDatabaseOperationsRequest
-          request);
+          request,
+      Options options = {});
 
   ///
   /// Lists the backup [long-running operations][google.longrunning.Operation]
@@ -887,11 +908,12 @@ class DatabaseAdminClient {
   /// @googleapis_reference_link{google/longrunning/operations.proto#L128}
   ///
   StreamRange<google::longrunning::Operation> ListBackupOperations(
-      google::spanner::admin::database::v1::ListBackupOperationsRequest
-          request);
+      google::spanner::admin::database::v1::ListBackupOperationsRequest request,
+      Options options = {});
 
  private:
   std::shared_ptr<DatabaseAdminConnection> connection_;
+  Options options_;
 };
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/spanner/admin/instance_admin_client.cc
+++ b/google/cloud/spanner/admin/instance_admin_client.cc
@@ -28,33 +28,45 @@ namespace spanner_admin {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 InstanceAdminClient::InstanceAdminClient(
-    std::shared_ptr<InstanceAdminConnection> connection)
-    : connection_(std::move(connection)) {}
+    std::shared_ptr<InstanceAdminConnection> connection, Options options)
+    : connection_(std::move(connection)),
+      options_(spanner_admin_internal::InstanceAdminDefaultOptions(
+          std::move(options))) {}
 InstanceAdminClient::~InstanceAdminClient() = default;
 
 StreamRange<google::spanner::admin::instance::v1::InstanceConfig>
-InstanceAdminClient::ListInstanceConfigs(std::string const& parent) {
+InstanceAdminClient::ListInstanceConfigs(std::string const& parent,
+                                         Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   google::spanner::admin::instance::v1::ListInstanceConfigsRequest request;
   request.set_parent(parent);
   return connection_->ListInstanceConfigs(request);
 }
 
 StatusOr<google::spanner::admin::instance::v1::InstanceConfig>
-InstanceAdminClient::GetInstanceConfig(std::string const& name) {
+InstanceAdminClient::GetInstanceConfig(std::string const& name,
+                                       Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   google::spanner::admin::instance::v1::GetInstanceConfigRequest request;
   request.set_name(name);
   return connection_->GetInstanceConfig(request);
 }
 
 StreamRange<google::spanner::admin::instance::v1::Instance>
-InstanceAdminClient::ListInstances(std::string const& parent) {
+InstanceAdminClient::ListInstances(std::string const& parent, Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   google::spanner::admin::instance::v1::ListInstancesRequest request;
   request.set_parent(parent);
   return connection_->ListInstances(request);
 }
 
 StatusOr<google::spanner::admin::instance::v1::Instance>
-InstanceAdminClient::GetInstance(std::string const& name) {
+InstanceAdminClient::GetInstance(std::string const& name, Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   google::spanner::admin::instance::v1::GetInstanceRequest request;
   request.set_name(name);
   return connection_->GetInstance(request);
@@ -63,7 +75,10 @@ InstanceAdminClient::GetInstance(std::string const& name) {
 future<StatusOr<google::spanner::admin::instance::v1::Instance>>
 InstanceAdminClient::CreateInstance(
     std::string const& parent, std::string const& instance_id,
-    google::spanner::admin::instance::v1::Instance const& instance) {
+    google::spanner::admin::instance::v1::Instance const& instance,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   google::spanner::admin::instance::v1::CreateInstanceRequest request;
   request.set_parent(parent);
   request.set_instance_id(instance_id);
@@ -74,21 +89,29 @@ InstanceAdminClient::CreateInstance(
 future<StatusOr<google::spanner::admin::instance::v1::Instance>>
 InstanceAdminClient::UpdateInstance(
     google::spanner::admin::instance::v1::Instance const& instance,
-    google::protobuf::FieldMask const& field_mask) {
+    google::protobuf::FieldMask const& field_mask, Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   google::spanner::admin::instance::v1::UpdateInstanceRequest request;
   *request.mutable_instance() = instance;
   *request.mutable_field_mask() = field_mask;
   return connection_->UpdateInstance(request);
 }
 
-Status InstanceAdminClient::DeleteInstance(std::string const& name) {
+Status InstanceAdminClient::DeleteInstance(std::string const& name,
+                                           Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   google::spanner::admin::instance::v1::DeleteInstanceRequest request;
   request.set_name(name);
   return connection_->DeleteInstance(request);
 }
 
 StatusOr<google::iam::v1::Policy> InstanceAdminClient::SetIamPolicy(
-    std::string const& resource, google::iam::v1::Policy const& policy) {
+    std::string const& resource, google::iam::v1::Policy const& policy,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   google::iam::v1::SetIamPolicyRequest request;
   request.set_resource(resource);
   *request.mutable_policy() = policy;
@@ -99,10 +122,11 @@ StatusOr<google::iam::v1::Policy> InstanceAdminClient::SetIamPolicy(
     std::string const& resource, IamUpdater const& updater, Options options) {
   internal::CheckExpectedOptions<InstanceAdminBackoffPolicyOption>(options,
                                                                    __func__);
-  options =
-      spanner_admin_internal::InstanceAdminDefaultOptions(std::move(options));
-  auto backoff_policy =
-      options.get<InstanceAdminBackoffPolicyOption>()->clone();
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
+  auto backoff_policy = internal::CurrentOptions()
+                            .get<InstanceAdminBackoffPolicyOption>()
+                            ->clone();
   for (;;) {
     auto recent = GetIamPolicy(resource);
     if (!recent) {
@@ -121,7 +145,9 @@ StatusOr<google::iam::v1::Policy> InstanceAdminClient::SetIamPolicy(
 }
 
 StatusOr<google::iam::v1::Policy> InstanceAdminClient::GetIamPolicy(
-    std::string const& resource) {
+    std::string const& resource, Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   google::iam::v1::GetIamPolicyRequest request;
   request.set_resource(resource);
   return connection_->GetIamPolicy(request);
@@ -129,7 +155,10 @@ StatusOr<google::iam::v1::Policy> InstanceAdminClient::GetIamPolicy(
 
 StatusOr<google::iam::v1::TestIamPermissionsResponse>
 InstanceAdminClient::TestIamPermissions(
-    std::string const& resource, std::vector<std::string> const& permissions) {
+    std::string const& resource, std::vector<std::string> const& permissions,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   google::iam::v1::TestIamPermissionsRequest request;
   request.set_resource(resource);
   *request.mutable_permissions() = {permissions.begin(), permissions.end()};
@@ -138,62 +167,87 @@ InstanceAdminClient::TestIamPermissions(
 
 StreamRange<google::spanner::admin::instance::v1::InstanceConfig>
 InstanceAdminClient::ListInstanceConfigs(
-    google::spanner::admin::instance::v1::ListInstanceConfigsRequest request) {
+    google::spanner::admin::instance::v1::ListInstanceConfigsRequest request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->ListInstanceConfigs(std::move(request));
 }
 
 StatusOr<google::spanner::admin::instance::v1::InstanceConfig>
 InstanceAdminClient::GetInstanceConfig(
     google::spanner::admin::instance::v1::GetInstanceConfigRequest const&
-        request) {
+        request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->GetInstanceConfig(request);
 }
 
 StreamRange<google::spanner::admin::instance::v1::Instance>
 InstanceAdminClient::ListInstances(
-    google::spanner::admin::instance::v1::ListInstancesRequest request) {
+    google::spanner::admin::instance::v1::ListInstancesRequest request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->ListInstances(std::move(request));
 }
 
 StatusOr<google::spanner::admin::instance::v1::Instance>
 InstanceAdminClient::GetInstance(
-    google::spanner::admin::instance::v1::GetInstanceRequest const& request) {
+    google::spanner::admin::instance::v1::GetInstanceRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->GetInstance(request);
 }
 
 future<StatusOr<google::spanner::admin::instance::v1::Instance>>
 InstanceAdminClient::CreateInstance(
-    google::spanner::admin::instance::v1::CreateInstanceRequest const&
-        request) {
+    google::spanner::admin::instance::v1::CreateInstanceRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->CreateInstance(request);
 }
 
 future<StatusOr<google::spanner::admin::instance::v1::Instance>>
 InstanceAdminClient::UpdateInstance(
-    google::spanner::admin::instance::v1::UpdateInstanceRequest const&
-        request) {
+    google::spanner::admin::instance::v1::UpdateInstanceRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->UpdateInstance(request);
 }
 
 Status InstanceAdminClient::DeleteInstance(
-    google::spanner::admin::instance::v1::DeleteInstanceRequest const&
-        request) {
+    google::spanner::admin::instance::v1::DeleteInstanceRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->DeleteInstance(request);
 }
 
 StatusOr<google::iam::v1::Policy> InstanceAdminClient::SetIamPolicy(
-    google::iam::v1::SetIamPolicyRequest const& request) {
+    google::iam::v1::SetIamPolicyRequest const& request, Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->SetIamPolicy(request);
 }
 
 StatusOr<google::iam::v1::Policy> InstanceAdminClient::GetIamPolicy(
-    google::iam::v1::GetIamPolicyRequest const& request) {
+    google::iam::v1::GetIamPolicyRequest const& request, Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->GetIamPolicy(request);
 }
 
 StatusOr<google::iam::v1::TestIamPermissionsResponse>
 InstanceAdminClient::TestIamPermissions(
-    google::iam::v1::TestIamPermissionsRequest const& request) {
+    google::iam::v1::TestIamPermissionsRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->TestIamPermissions(request);
 }
 

--- a/google/cloud/spanner/admin/instance_admin_client.h
+++ b/google/cloud/spanner/admin/instance_admin_client.h
@@ -115,6 +115,7 @@ class InstanceAdminClient {
   /// supported instance
   ///  configurations is requested. Values are of the form
   ///  `projects/<project>`.
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::spanner::admin::instance::v1::InstanceConfig,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L304}
   ///
@@ -132,6 +133,7 @@ class InstanceAdminClient {
   /// @param name  Required. The name of the requested instance configuration.
   /// Values are of
   ///  the form `projects/<project>/instanceConfigs/<config>`.
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::spanner::admin::instance::v1::InstanceConfig,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L304}
   ///
@@ -149,6 +151,7 @@ class InstanceAdminClient {
   /// @param parent  Required. The name of the project for which a list of
   /// instances is
   ///  requested. Values are of the form `projects/<project>`.
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::spanner::admin::instance::v1::Instance,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328}
   ///
@@ -166,6 +169,7 @@ class InstanceAdminClient {
   /// @param name  Required. The name of the requested instance. Values are of
   /// the form
   ///  `projects/<project>/instances/<instance>`.
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::spanner::admin::instance::v1::Instance,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328}
   ///
@@ -223,6 +227,7 @@ class InstanceAdminClient {
   /// @param instance  Required. The instance to create.  The name may be
   /// omitted, but if
   ///  specified must be `<parent>/instances/<instance_id>`.
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::spanner::admin::instance::v1::Instance,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328}
   ///
@@ -288,6 +293,7 @@ class InstanceAdminClient {
   ///  The field mask must always be specified; this prevents any future fields
   ///  in [Instance][google.spanner.admin.instance.v1.Instance] from being
   ///  erased accidentally by clients that do not know about them.
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::spanner::admin::instance::v1::Instance,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328}
   ///
@@ -317,6 +323,7 @@ class InstanceAdminClient {
   /// @param name  Required. The name of the instance to be deleted. Values are
   /// of the form
   ///  `projects/<project>/instances/<instance>`
+  /// @param options  Optional. Operation options.
   ///
   /// [google.spanner.admin.instance.v1.DeleteInstanceRequest]:
   /// @googleapis_reference_link{google/spanner/admin/instance/v1/spanner_instance_admin.proto#L565}
@@ -338,6 +345,7 @@ class InstanceAdminClient {
   ///  the policy is limited to a few 10s of KB. An empty policy is a
   ///  valid policy but certain Cloud Platform services (such as Projects)
   ///  might reject them.
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
@@ -385,6 +393,7 @@ class InstanceAdminClient {
   /// @param resource  REQUIRED: The resource for which the policy is being
   /// requested.
   ///  See the operation documentation for the appropriate value for this field.
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
@@ -413,6 +422,7 @@ class InstanceAdminClient {
   ///  wildcards (such as '*' or 'storage.*') are not allowed. For more
   ///  information see
   ///  [IAM Overview](https://cloud.google.com/iam/docs/overview#permissions).
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
   ///
@@ -430,6 +440,7 @@ class InstanceAdminClient {
   ///
   /// @param request
   /// @googleapis_link{google::spanner::admin::instance::v1::ListInstanceConfigsRequest,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L415}
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::spanner::admin::instance::v1::InstanceConfig,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L304}
   ///
@@ -448,6 +459,7 @@ class InstanceAdminClient {
   ///
   /// @param request
   /// @googleapis_link{google::spanner::admin::instance::v1::GetInstanceConfigRequest,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L449}
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::spanner::admin::instance::v1::InstanceConfig,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L304}
   ///
@@ -467,6 +479,7 @@ class InstanceAdminClient {
   ///
   /// @param request
   /// @googleapis_link{google::spanner::admin::instance::v1::ListInstancesRequest,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L499}
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::spanner::admin::instance::v1::Instance,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328}
   ///
@@ -484,6 +497,7 @@ class InstanceAdminClient {
   ///
   /// @param request
   /// @googleapis_link{google::spanner::admin::instance::v1::GetInstanceRequest,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L461}
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::spanner::admin::instance::v1::Instance,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328}
   ///
@@ -534,6 +548,7 @@ class InstanceAdminClient {
   ///
   /// @param request
   /// @googleapis_link{google::spanner::admin::instance::v1::CreateInstanceRequest,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L478}
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::spanner::admin::instance::v1::Instance,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328}
   ///
@@ -592,6 +607,7 @@ class InstanceAdminClient {
   ///
   /// @param request
   /// @googleapis_link{google::spanner::admin::instance::v1::UpdateInstanceRequest,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L552}
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::spanner::admin::instance::v1::Instance,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328}
   ///
@@ -621,6 +637,7 @@ class InstanceAdminClient {
   ///
   /// @param request
   /// @googleapis_link{google::spanner::admin::instance::v1::DeleteInstanceRequest,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L565}
+  /// @param options  Optional. Operation options.
   ///
   /// [google.spanner.admin.instance.v1.DeleteInstanceRequest]:
   /// @googleapis_reference_link{google/spanner/admin/instance/v1/spanner_instance_admin.proto#L565}
@@ -639,6 +656,7 @@ class InstanceAdminClient {
   ///
   /// @param request
   /// @googleapis_link{google::iam::v1::SetIamPolicyRequest,google/iam/v1/iam_policy.proto#L98}
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
@@ -660,6 +678,7 @@ class InstanceAdminClient {
   ///
   /// @param request
   /// @googleapis_link{google::iam::v1::GetIamPolicyRequest,google/iam/v1/iam_policy.proto#L113}
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
@@ -683,6 +702,7 @@ class InstanceAdminClient {
   ///
   /// @param request
   /// @googleapis_link{google::iam::v1::TestIamPermissionsRequest,google/iam/v1/iam_policy.proto#L126}
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
   ///

--- a/google/cloud/spanner/admin/instance_admin_client.h
+++ b/google/cloud/spanner/admin/instance_admin_client.h
@@ -84,7 +84,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class InstanceAdminClient {
  public:
   explicit InstanceAdminClient(
-      std::shared_ptr<InstanceAdminConnection> connection);
+      std::shared_ptr<InstanceAdminConnection> connection,
+      Options options = {});
   ~InstanceAdminClient();
 
   //@{
@@ -123,7 +124,7 @@ class InstanceAdminClient {
   /// @googleapis_reference_link{google/spanner/admin/instance/v1/spanner_instance_admin.proto#L304}
   ///
   StreamRange<google::spanner::admin::instance::v1::InstanceConfig>
-  ListInstanceConfigs(std::string const& parent);
+  ListInstanceConfigs(std::string const& parent, Options options = {});
 
   ///
   /// Gets information about a particular instance configuration.
@@ -140,7 +141,7 @@ class InstanceAdminClient {
   /// @googleapis_reference_link{google/spanner/admin/instance/v1/spanner_instance_admin.proto#L304}
   ///
   StatusOr<google::spanner::admin::instance::v1::InstanceConfig>
-  GetInstanceConfig(std::string const& name);
+  GetInstanceConfig(std::string const& name, Options options = {});
 
   ///
   /// Lists all instances in the given project.
@@ -157,7 +158,7 @@ class InstanceAdminClient {
   /// @googleapis_reference_link{google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328}
   ///
   StreamRange<google::spanner::admin::instance::v1::Instance> ListInstances(
-      std::string const& parent);
+      std::string const& parent, Options options = {});
 
   ///
   /// Gets information about a particular instance.
@@ -174,7 +175,7 @@ class InstanceAdminClient {
   /// @googleapis_reference_link{google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328}
   ///
   StatusOr<google::spanner::admin::instance::v1::Instance> GetInstance(
-      std::string const& name);
+      std::string const& name, Options options = {});
 
   ///
   /// Creates an instance and begins preparing it to begin serving. The
@@ -231,9 +232,9 @@ class InstanceAdminClient {
   /// @googleapis_reference_link{google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328}
   ///
   future<StatusOr<google::spanner::admin::instance::v1::Instance>>
-  CreateInstance(
-      std::string const& parent, std::string const& instance_id,
-      google::spanner::admin::instance::v1::Instance const& instance);
+  CreateInstance(std::string const& parent, std::string const& instance_id,
+                 google::spanner::admin::instance::v1::Instance const& instance,
+                 Options options = {});
 
   ///
   /// Updates an instance, and begins allocating or releasing resources
@@ -297,7 +298,8 @@ class InstanceAdminClient {
   ///
   future<StatusOr<google::spanner::admin::instance::v1::Instance>>
   UpdateInstance(google::spanner::admin::instance::v1::Instance const& instance,
-                 google::protobuf::FieldMask const& field_mask);
+                 google::protobuf::FieldMask const& field_mask,
+                 Options options = {});
 
   ///
   /// Deletes an instance.
@@ -319,7 +321,7 @@ class InstanceAdminClient {
   /// [google.spanner.admin.instance.v1.DeleteInstanceRequest]:
   /// @googleapis_reference_link{google/spanner/admin/instance/v1/spanner_instance_admin.proto#L565}
   ///
-  Status DeleteInstance(std::string const& name);
+  Status DeleteInstance(std::string const& name, Options options = {});
 
   ///
   /// Sets the access control policy on an instance resource. Replaces any
@@ -345,7 +347,8 @@ class InstanceAdminClient {
   /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
-      std::string const& resource, google::iam::v1::Policy const& policy);
+      std::string const& resource, google::iam::v1::Policy const& policy,
+      Options options = {});
 
   /**
    * Updates the IAM policy for @p resource using an optimistic concurrency
@@ -390,7 +393,8 @@ class InstanceAdminClient {
   /// [google.iam.v1.Policy]:
   /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
-  StatusOr<google::iam::v1::Policy> GetIamPolicy(std::string const& resource);
+  StatusOr<google::iam::v1::Policy> GetIamPolicy(std::string const& resource,
+                                                 Options options = {});
 
   ///
   /// Returns permissions that the caller has on the specified instance
@@ -418,7 +422,8 @@ class InstanceAdminClient {
   /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L141}
   ///
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
-      std::string const& resource, std::vector<std::string> const& permissions);
+      std::string const& resource, std::vector<std::string> const& permissions,
+      Options options = {});
 
   ///
   /// Lists the supported instance configurations for a given project.
@@ -435,7 +440,8 @@ class InstanceAdminClient {
   ///
   StreamRange<google::spanner::admin::instance::v1::InstanceConfig>
   ListInstanceConfigs(
-      google::spanner::admin::instance::v1::ListInstanceConfigsRequest request);
+      google::spanner::admin::instance::v1::ListInstanceConfigsRequest request,
+      Options options = {});
 
   ///
   /// Gets information about a particular instance configuration.
@@ -453,7 +459,8 @@ class InstanceAdminClient {
   StatusOr<google::spanner::admin::instance::v1::InstanceConfig>
   GetInstanceConfig(
       google::spanner::admin::instance::v1::GetInstanceConfigRequest const&
-          request);
+          request,
+      Options options = {});
 
   ///
   /// Lists all instances in the given project.
@@ -469,7 +476,8 @@ class InstanceAdminClient {
   /// @googleapis_reference_link{google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328}
   ///
   StreamRange<google::spanner::admin::instance::v1::Instance> ListInstances(
-      google::spanner::admin::instance::v1::ListInstancesRequest request);
+      google::spanner::admin::instance::v1::ListInstancesRequest request,
+      Options options = {});
 
   ///
   /// Gets information about a particular instance.
@@ -485,7 +493,8 @@ class InstanceAdminClient {
   /// @googleapis_reference_link{google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328}
   ///
   StatusOr<google::spanner::admin::instance::v1::Instance> GetInstance(
-      google::spanner::admin::instance::v1::GetInstanceRequest const& request);
+      google::spanner::admin::instance::v1::GetInstanceRequest const& request,
+      Options options = {});
 
   ///
   /// Creates an instance and begins preparing it to begin serving. The
@@ -536,7 +545,8 @@ class InstanceAdminClient {
   future<StatusOr<google::spanner::admin::instance::v1::Instance>>
   CreateInstance(
       google::spanner::admin::instance::v1::CreateInstanceRequest const&
-          request);
+          request,
+      Options options = {});
 
   ///
   /// Updates an instance, and begins allocating or releasing resources
@@ -593,7 +603,8 @@ class InstanceAdminClient {
   future<StatusOr<google::spanner::admin::instance::v1::Instance>>
   UpdateInstance(
       google::spanner::admin::instance::v1::UpdateInstanceRequest const&
-          request);
+          request,
+      Options options = {});
 
   ///
   /// Deletes an instance.
@@ -616,7 +627,8 @@ class InstanceAdminClient {
   ///
   Status DeleteInstance(
       google::spanner::admin::instance::v1::DeleteInstanceRequest const&
-          request);
+          request,
+      Options options = {});
 
   ///
   /// Sets the access control policy on an instance resource. Replaces any
@@ -636,7 +648,8 @@ class InstanceAdminClient {
   /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
-      google::iam::v1::SetIamPolicyRequest const& request);
+      google::iam::v1::SetIamPolicyRequest const& request,
+      Options options = {});
 
   ///
   /// Gets the access control policy for an instance resource. Returns an empty
@@ -656,7 +669,8 @@ class InstanceAdminClient {
   /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> GetIamPolicy(
-      google::iam::v1::GetIamPolicyRequest const& request);
+      google::iam::v1::GetIamPolicyRequest const& request,
+      Options options = {});
 
   ///
   /// Returns permissions that the caller has on the specified instance
@@ -678,10 +692,12 @@ class InstanceAdminClient {
   /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L141}
   ///
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
-      google::iam::v1::TestIamPermissionsRequest const& request);
+      google::iam::v1::TestIamPermissionsRequest const& request,
+      Options options = {});
 
  private:
   std::shared_ptr<InstanceAdminConnection> connection_;
+  Options options_;
 };
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/tasks/cloud_tasks_client.cc
+++ b/google/cloud/tasks/cloud_tasks_client.cc
@@ -28,26 +28,34 @@ namespace tasks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 CloudTasksClient::CloudTasksClient(
-    std::shared_ptr<CloudTasksConnection> connection)
-    : connection_(std::move(connection)) {}
+    std::shared_ptr<CloudTasksConnection> connection, Options options)
+    : connection_(std::move(connection)),
+      options_(tasks_internal::CloudTasksDefaultOptions(std::move(options))) {}
 CloudTasksClient::~CloudTasksClient() = default;
 
 StreamRange<google::cloud::tasks::v2::Queue> CloudTasksClient::ListQueues(
-    std::string const& parent) {
+    std::string const& parent, Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   google::cloud::tasks::v2::ListQueuesRequest request;
   request.set_parent(parent);
   return connection_->ListQueues(request);
 }
 
 StatusOr<google::cloud::tasks::v2::Queue> CloudTasksClient::GetQueue(
-    std::string const& name) {
+    std::string const& name, Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   google::cloud::tasks::v2::GetQueueRequest request;
   request.set_name(name);
   return connection_->GetQueue(request);
 }
 
 StatusOr<google::cloud::tasks::v2::Queue> CloudTasksClient::CreateQueue(
-    std::string const& parent, google::cloud::tasks::v2::Queue const& queue) {
+    std::string const& parent, google::cloud::tasks::v2::Queue const& queue,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   google::cloud::tasks::v2::CreateQueueRequest request;
   request.set_parent(parent);
   *request.mutable_queue() = queue;
@@ -56,49 +64,64 @@ StatusOr<google::cloud::tasks::v2::Queue> CloudTasksClient::CreateQueue(
 
 StatusOr<google::cloud::tasks::v2::Queue> CloudTasksClient::UpdateQueue(
     google::cloud::tasks::v2::Queue const& queue,
-    google::protobuf::FieldMask const& update_mask) {
+    google::protobuf::FieldMask const& update_mask, Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   google::cloud::tasks::v2::UpdateQueueRequest request;
   *request.mutable_queue() = queue;
   *request.mutable_update_mask() = update_mask;
   return connection_->UpdateQueue(request);
 }
 
-Status CloudTasksClient::DeleteQueue(std::string const& name) {
+Status CloudTasksClient::DeleteQueue(std::string const& name, Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   google::cloud::tasks::v2::DeleteQueueRequest request;
   request.set_name(name);
   return connection_->DeleteQueue(request);
 }
 
 StatusOr<google::cloud::tasks::v2::Queue> CloudTasksClient::PurgeQueue(
-    std::string const& name) {
+    std::string const& name, Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   google::cloud::tasks::v2::PurgeQueueRequest request;
   request.set_name(name);
   return connection_->PurgeQueue(request);
 }
 
 StatusOr<google::cloud::tasks::v2::Queue> CloudTasksClient::PauseQueue(
-    std::string const& name) {
+    std::string const& name, Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   google::cloud::tasks::v2::PauseQueueRequest request;
   request.set_name(name);
   return connection_->PauseQueue(request);
 }
 
 StatusOr<google::cloud::tasks::v2::Queue> CloudTasksClient::ResumeQueue(
-    std::string const& name) {
+    std::string const& name, Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   google::cloud::tasks::v2::ResumeQueueRequest request;
   request.set_name(name);
   return connection_->ResumeQueue(request);
 }
 
 StatusOr<google::iam::v1::Policy> CloudTasksClient::GetIamPolicy(
-    std::string const& resource) {
+    std::string const& resource, Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   google::iam::v1::GetIamPolicyRequest request;
   request.set_resource(resource);
   return connection_->GetIamPolicy(request);
 }
 
 StatusOr<google::iam::v1::Policy> CloudTasksClient::SetIamPolicy(
-    std::string const& resource, google::iam::v1::Policy const& policy) {
+    std::string const& resource, google::iam::v1::Policy const& policy,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   google::iam::v1::SetIamPolicyRequest request;
   request.set_resource(resource);
   *request.mutable_policy() = policy;
@@ -109,8 +132,10 @@ StatusOr<google::iam::v1::Policy> CloudTasksClient::SetIamPolicy(
     std::string const& resource, IamUpdater const& updater, Options options) {
   internal::CheckExpectedOptions<CloudTasksBackoffPolicyOption>(options,
                                                                 __func__);
-  options = tasks_internal::CloudTasksDefaultOptions(std::move(options));
-  auto backoff_policy = options.get<CloudTasksBackoffPolicyOption>()->clone();
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
+  auto backoff_policy =
+      internal::CurrentOptions().get<CloudTasksBackoffPolicyOption>()->clone();
   for (;;) {
     auto recent = GetIamPolicy(resource);
     if (!recent) {
@@ -130,7 +155,10 @@ StatusOr<google::iam::v1::Policy> CloudTasksClient::SetIamPolicy(
 
 StatusOr<google::iam::v1::TestIamPermissionsResponse>
 CloudTasksClient::TestIamPermissions(
-    std::string const& resource, std::vector<std::string> const& permissions) {
+    std::string const& resource, std::vector<std::string> const& permissions,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   google::iam::v1::TestIamPermissionsRequest request;
   request.set_resource(resource);
   *request.mutable_permissions() = {permissions.begin(), permissions.end()};
@@ -138,118 +166,170 @@ CloudTasksClient::TestIamPermissions(
 }
 
 StreamRange<google::cloud::tasks::v2::Task> CloudTasksClient::ListTasks(
-    std::string const& parent) {
+    std::string const& parent, Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   google::cloud::tasks::v2::ListTasksRequest request;
   request.set_parent(parent);
   return connection_->ListTasks(request);
 }
 
 StatusOr<google::cloud::tasks::v2::Task> CloudTasksClient::GetTask(
-    std::string const& name) {
+    std::string const& name, Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   google::cloud::tasks::v2::GetTaskRequest request;
   request.set_name(name);
   return connection_->GetTask(request);
 }
 
 StatusOr<google::cloud::tasks::v2::Task> CloudTasksClient::CreateTask(
-    std::string const& parent, google::cloud::tasks::v2::Task const& task) {
+    std::string const& parent, google::cloud::tasks::v2::Task const& task,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   google::cloud::tasks::v2::CreateTaskRequest request;
   request.set_parent(parent);
   *request.mutable_task() = task;
   return connection_->CreateTask(request);
 }
 
-Status CloudTasksClient::DeleteTask(std::string const& name) {
+Status CloudTasksClient::DeleteTask(std::string const& name, Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   google::cloud::tasks::v2::DeleteTaskRequest request;
   request.set_name(name);
   return connection_->DeleteTask(request);
 }
 
 StatusOr<google::cloud::tasks::v2::Task> CloudTasksClient::RunTask(
-    std::string const& name) {
+    std::string const& name, Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   google::cloud::tasks::v2::RunTaskRequest request;
   request.set_name(name);
   return connection_->RunTask(request);
 }
 
 StreamRange<google::cloud::tasks::v2::Queue> CloudTasksClient::ListQueues(
-    google::cloud::tasks::v2::ListQueuesRequest request) {
+    google::cloud::tasks::v2::ListQueuesRequest request, Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->ListQueues(std::move(request));
 }
 
 StatusOr<google::cloud::tasks::v2::Queue> CloudTasksClient::GetQueue(
-    google::cloud::tasks::v2::GetQueueRequest const& request) {
+    google::cloud::tasks::v2::GetQueueRequest const& request, Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->GetQueue(request);
 }
 
 StatusOr<google::cloud::tasks::v2::Queue> CloudTasksClient::CreateQueue(
-    google::cloud::tasks::v2::CreateQueueRequest const& request) {
+    google::cloud::tasks::v2::CreateQueueRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->CreateQueue(request);
 }
 
 StatusOr<google::cloud::tasks::v2::Queue> CloudTasksClient::UpdateQueue(
-    google::cloud::tasks::v2::UpdateQueueRequest const& request) {
+    google::cloud::tasks::v2::UpdateQueueRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->UpdateQueue(request);
 }
 
 Status CloudTasksClient::DeleteQueue(
-    google::cloud::tasks::v2::DeleteQueueRequest const& request) {
+    google::cloud::tasks::v2::DeleteQueueRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->DeleteQueue(request);
 }
 
 StatusOr<google::cloud::tasks::v2::Queue> CloudTasksClient::PurgeQueue(
-    google::cloud::tasks::v2::PurgeQueueRequest const& request) {
+    google::cloud::tasks::v2::PurgeQueueRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->PurgeQueue(request);
 }
 
 StatusOr<google::cloud::tasks::v2::Queue> CloudTasksClient::PauseQueue(
-    google::cloud::tasks::v2::PauseQueueRequest const& request) {
+    google::cloud::tasks::v2::PauseQueueRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->PauseQueue(request);
 }
 
 StatusOr<google::cloud::tasks::v2::Queue> CloudTasksClient::ResumeQueue(
-    google::cloud::tasks::v2::ResumeQueueRequest const& request) {
+    google::cloud::tasks::v2::ResumeQueueRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->ResumeQueue(request);
 }
 
 StatusOr<google::iam::v1::Policy> CloudTasksClient::GetIamPolicy(
-    google::iam::v1::GetIamPolicyRequest const& request) {
+    google::iam::v1::GetIamPolicyRequest const& request, Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->GetIamPolicy(request);
 }
 
 StatusOr<google::iam::v1::Policy> CloudTasksClient::SetIamPolicy(
-    google::iam::v1::SetIamPolicyRequest const& request) {
+    google::iam::v1::SetIamPolicyRequest const& request, Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->SetIamPolicy(request);
 }
 
 StatusOr<google::iam::v1::TestIamPermissionsResponse>
 CloudTasksClient::TestIamPermissions(
-    google::iam::v1::TestIamPermissionsRequest const& request) {
+    google::iam::v1::TestIamPermissionsRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->TestIamPermissions(request);
 }
 
 StreamRange<google::cloud::tasks::v2::Task> CloudTasksClient::ListTasks(
-    google::cloud::tasks::v2::ListTasksRequest request) {
+    google::cloud::tasks::v2::ListTasksRequest request, Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->ListTasks(std::move(request));
 }
 
 StatusOr<google::cloud::tasks::v2::Task> CloudTasksClient::GetTask(
-    google::cloud::tasks::v2::GetTaskRequest const& request) {
+    google::cloud::tasks::v2::GetTaskRequest const& request, Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->GetTask(request);
 }
 
 StatusOr<google::cloud::tasks::v2::Task> CloudTasksClient::CreateTask(
-    google::cloud::tasks::v2::CreateTaskRequest const& request) {
+    google::cloud::tasks::v2::CreateTaskRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->CreateTask(request);
 }
 
 Status CloudTasksClient::DeleteTask(
-    google::cloud::tasks::v2::DeleteTaskRequest const& request) {
+    google::cloud::tasks::v2::DeleteTaskRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->DeleteTask(request);
 }
 
 StatusOr<google::cloud::tasks::v2::Task> CloudTasksClient::RunTask(
-    google::cloud::tasks::v2::RunTaskRequest const& request) {
+    google::cloud::tasks::v2::RunTaskRequest const& request, Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->RunTask(request);
 }
 

--- a/google/cloud/tasks/cloud_tasks_client.h
+++ b/google/cloud/tasks/cloud_tasks_client.h
@@ -91,6 +91,7 @@ class CloudTasksClient {
   ///
   /// @param parent  Required. The location name.
   ///  For example: `projects/PROJECT_ID/locations/LOCATION_ID`
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
   ///
@@ -107,6 +108,7 @@ class CloudTasksClient {
   ///
   /// @param name  Required. The resource name of the queue. For example:
   ///  `projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID`
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
   ///
@@ -140,6 +142,7 @@ class CloudTasksClient {
   /// @param queue  Required. The queue to create.
   ///  [Queue's name][google.cloud.tasks.v2.Queue.name] cannot be the same as an
   ///  existing queue.
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
   ///
@@ -176,6 +179,7 @@ class CloudTasksClient {
   /// @param update_mask  A mask used to specify which fields of the queue are
   /// being updated.
   ///  If empty, then all fields will be updated.
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
   ///
@@ -204,6 +208,7 @@ class CloudTasksClient {
   ///
   /// @param name  Required. The queue name. For example:
   ///  `projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID`
+  /// @param options  Optional. Operation options.
   ///
   /// [google.cloud.tasks.v2.DeleteQueueRequest]:
   /// @googleapis_reference_link{google/cloud/tasks/v2/cloudtasks.proto#L419}
@@ -221,6 +226,7 @@ class CloudTasksClient {
   ///
   /// @param name  Required. The queue name. For example:
   ///  `projects/PROJECT_ID/location/LOCATION_ID/queues/QUEUE_ID`
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
   ///
@@ -244,6 +250,7 @@ class CloudTasksClient {
   ///
   /// @param name  Required. The queue name. For example:
   ///  `projects/PROJECT_ID/location/LOCATION_ID/queues/QUEUE_ID`
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
   ///
@@ -273,6 +280,7 @@ class CloudTasksClient {
   ///
   /// @param name  Required. The queue name. For example:
   ///  `projects/PROJECT_ID/location/LOCATION_ID/queues/QUEUE_ID`
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
   ///
@@ -298,6 +306,7 @@ class CloudTasksClient {
   /// @param resource  REQUIRED: The resource for which the policy is being
   /// requested.
   ///  See the operation documentation for the appropriate value for this field.
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
@@ -330,6 +339,7 @@ class CloudTasksClient {
   ///  the policy is limited to a few 10s of KB. An empty policy is a
   ///  valid policy but certain Cloud Platform services (such as Projects)
   ///  might reject them.
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
@@ -385,6 +395,7 @@ class CloudTasksClient {
   ///  wildcards (such as '*' or 'storage.*') are not allowed. For more
   ///  information see
   ///  [IAM Overview](https://cloud.google.com/iam/docs/overview#permissions).
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
   ///
@@ -410,6 +421,7 @@ class CloudTasksClient {
   ///
   /// @param parent  Required. The queue name. For example:
   ///  `projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID`
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::cloud::tasks::v2::Task,google/cloud/tasks/v2/task.proto#L33}
   ///
@@ -426,6 +438,7 @@ class CloudTasksClient {
   ///
   /// @param name  Required. The task name. For example:
   ///  `projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID/tasks/TASK_ID`
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::cloud::tasks::v2::Task,google/cloud/tasks/v2/task.proto#L33}
   ///
@@ -474,6 +487,7 @@ class CloudTasksClient {
   ///  task commands. The infrastructure relies on an approximately
   ///  uniform distribution of task ids to store and serve tasks
   ///  efficiently.
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::cloud::tasks::v2::Task,google/cloud/tasks/v2/task.proto#L33}
   ///
@@ -495,6 +509,7 @@ class CloudTasksClient {
   ///
   /// @param name  Required. The task name. For example:
   ///  `projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID/tasks/TASK_ID`
+  /// @param options  Optional. Operation options.
   ///
   /// [google.cloud.tasks.v2.DeleteTaskRequest]:
   /// @googleapis_reference_link{google/cloud/tasks/v2/cloudtasks.proto#L619}
@@ -531,6 +546,7 @@ class CloudTasksClient {
   ///
   /// @param name  Required. The task name. For example:
   ///  `projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID/tasks/TASK_ID`
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::cloud::tasks::v2::Task,google/cloud/tasks/v2/task.proto#L33}
   ///
@@ -549,6 +565,7 @@ class CloudTasksClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::tasks::v2::ListQueuesRequest,google/cloud/tasks/v2/cloudtasks.proto#L308}
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
   ///
@@ -566,6 +583,7 @@ class CloudTasksClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::tasks::v2::GetQueueRequest,google/cloud/tasks/v2/cloudtasks.proto#L369}
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
   ///
@@ -593,6 +611,7 @@ class CloudTasksClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::tasks::v2::CreateQueueRequest,google/cloud/tasks/v2/cloudtasks.proto#L381}
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
   ///
@@ -623,6 +642,7 @@ class CloudTasksClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::tasks::v2::UpdateQueueRequest,google/cloud/tasks/v2/cloudtasks.proto#L402}
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
   ///
@@ -651,6 +671,7 @@ class CloudTasksClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::tasks::v2::DeleteQueueRequest,google/cloud/tasks/v2/cloudtasks.proto#L419}
+  /// @param options  Optional. Operation options.
   ///
   /// [google.cloud.tasks.v2.DeleteQueueRequest]:
   /// @googleapis_reference_link{google/cloud/tasks/v2/cloudtasks.proto#L419}
@@ -670,6 +691,7 @@ class CloudTasksClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::tasks::v2::PurgeQueueRequest,google/cloud/tasks/v2/cloudtasks.proto#L431}
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
   ///
@@ -694,6 +716,7 @@ class CloudTasksClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::tasks::v2::PauseQueueRequest,google/cloud/tasks/v2/cloudtasks.proto#L443}
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
   ///
@@ -724,6 +747,7 @@ class CloudTasksClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::tasks::v2::ResumeQueueRequest,google/cloud/tasks/v2/cloudtasks.proto#L455}
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
   ///
@@ -749,6 +773,7 @@ class CloudTasksClient {
   ///
   /// @param request
   /// @googleapis_link{google::iam::v1::GetIamPolicyRequest,google/iam/v1/iam_policy.proto#L113}
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
@@ -776,6 +801,7 @@ class CloudTasksClient {
   ///
   /// @param request
   /// @googleapis_link{google::iam::v1::SetIamPolicyRequest,google/iam/v1/iam_policy.proto#L98}
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
@@ -800,6 +826,7 @@ class CloudTasksClient {
   ///
   /// @param request
   /// @googleapis_link{google::iam::v1::TestIamPermissionsRequest,google/iam/v1/iam_policy.proto#L126}
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
   ///
@@ -825,6 +852,7 @@ class CloudTasksClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::tasks::v2::ListTasksRequest,google/cloud/tasks/v2/cloudtasks.proto#L467}
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::cloud::tasks::v2::Task,google/cloud/tasks/v2/task.proto#L33}
   ///
@@ -841,6 +869,7 @@ class CloudTasksClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::tasks::v2::GetTaskRequest,google/cloud/tasks/v2/cloudtasks.proto#L529}
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::cloud::tasks::v2::Task,google/cloud/tasks/v2/task.proto#L33}
   ///
@@ -862,6 +891,7 @@ class CloudTasksClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::tasks::v2::CreateTaskRequest,google/cloud/tasks/v2/cloudtasks.proto#L555}
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::cloud::tasks::v2::Task,google/cloud/tasks/v2/task.proto#L33}
   ///
@@ -883,6 +913,7 @@ class CloudTasksClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::tasks::v2::DeleteTaskRequest,google/cloud/tasks/v2/cloudtasks.proto#L619}
+  /// @param options  Optional. Operation options.
   ///
   /// [google.cloud.tasks.v2.DeleteTaskRequest]:
   /// @googleapis_reference_link{google/cloud/tasks/v2/cloudtasks.proto#L619}
@@ -920,6 +951,7 @@ class CloudTasksClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::tasks::v2::RunTaskRequest,google/cloud/tasks/v2/cloudtasks.proto#L632}
+  /// @param options  Optional. Operation options.
   /// @return
   /// @googleapis_link{google::cloud::tasks::v2::Task,google/cloud/tasks/v2/task.proto#L33}
   ///

--- a/google/cloud/tasks/cloud_tasks_client.h
+++ b/google/cloud/tasks/cloud_tasks_client.h
@@ -62,7 +62,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 ///
 class CloudTasksClient {
  public:
-  explicit CloudTasksClient(std::shared_ptr<CloudTasksConnection> connection);
+  explicit CloudTasksClient(std::shared_ptr<CloudTasksConnection> connection,
+                            Options options = {});
   ~CloudTasksClient();
 
   //@{
@@ -99,7 +100,7 @@ class CloudTasksClient {
   /// @googleapis_reference_link{google/cloud/tasks/v2/queue.proto#L34}
   ///
   StreamRange<google::cloud::tasks::v2::Queue> ListQueues(
-      std::string const& parent);
+      std::string const& parent, Options options = {});
 
   ///
   /// Gets a queue.
@@ -114,7 +115,8 @@ class CloudTasksClient {
   /// [google.cloud.tasks.v2.Queue]:
   /// @googleapis_reference_link{google/cloud/tasks/v2/queue.proto#L34}
   ///
-  StatusOr<google::cloud::tasks::v2::Queue> GetQueue(std::string const& name);
+  StatusOr<google::cloud::tasks::v2::Queue> GetQueue(std::string const& name,
+                                                     Options options = {});
 
   ///
   /// Creates a queue.
@@ -147,7 +149,8 @@ class CloudTasksClient {
   /// @googleapis_reference_link{google/cloud/tasks/v2/queue.proto#L34}
   ///
   StatusOr<google::cloud::tasks::v2::Queue> CreateQueue(
-      std::string const& parent, google::cloud::tasks::v2::Queue const& queue);
+      std::string const& parent, google::cloud::tasks::v2::Queue const& queue,
+      Options options = {});
 
   ///
   /// Updates a queue.
@@ -183,7 +186,7 @@ class CloudTasksClient {
   ///
   StatusOr<google::cloud::tasks::v2::Queue> UpdateQueue(
       google::cloud::tasks::v2::Queue const& queue,
-      google::protobuf::FieldMask const& update_mask);
+      google::protobuf::FieldMask const& update_mask, Options options = {});
 
   ///
   /// Deletes a queue.
@@ -205,7 +208,7 @@ class CloudTasksClient {
   /// [google.cloud.tasks.v2.DeleteQueueRequest]:
   /// @googleapis_reference_link{google/cloud/tasks/v2/cloudtasks.proto#L419}
   ///
-  Status DeleteQueue(std::string const& name);
+  Status DeleteQueue(std::string const& name, Options options = {});
 
   ///
   /// Purges a queue by deleting all of its tasks.
@@ -226,7 +229,8 @@ class CloudTasksClient {
   /// [google.cloud.tasks.v2.Queue]:
   /// @googleapis_reference_link{google/cloud/tasks/v2/queue.proto#L34}
   ///
-  StatusOr<google::cloud::tasks::v2::Queue> PurgeQueue(std::string const& name);
+  StatusOr<google::cloud::tasks::v2::Queue> PurgeQueue(std::string const& name,
+                                                       Options options = {});
 
   ///
   /// Pauses the queue.
@@ -248,7 +252,8 @@ class CloudTasksClient {
   /// [google.cloud.tasks.v2.Queue]:
   /// @googleapis_reference_link{google/cloud/tasks/v2/queue.proto#L34}
   ///
-  StatusOr<google::cloud::tasks::v2::Queue> PauseQueue(std::string const& name);
+  StatusOr<google::cloud::tasks::v2::Queue> PauseQueue(std::string const& name,
+                                                       Options options = {});
 
   ///
   /// Resume a queue.
@@ -276,8 +281,8 @@ class CloudTasksClient {
   /// [google.cloud.tasks.v2.Queue]:
   /// @googleapis_reference_link{google/cloud/tasks/v2/queue.proto#L34}
   ///
-  StatusOr<google::cloud::tasks::v2::Queue> ResumeQueue(
-      std::string const& name);
+  StatusOr<google::cloud::tasks::v2::Queue> ResumeQueue(std::string const& name,
+                                                        Options options = {});
 
   ///
   /// Gets the access control policy for a [Queue][google.cloud.tasks.v2.Queue].
@@ -301,7 +306,8 @@ class CloudTasksClient {
   /// [google.iam.v1.Policy]:
   /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
-  StatusOr<google::iam::v1::Policy> GetIamPolicy(std::string const& resource);
+  StatusOr<google::iam::v1::Policy> GetIamPolicy(std::string const& resource,
+                                                 Options options = {});
 
   ///
   /// Sets the access control policy for a [Queue][google.cloud.tasks.v2.Queue].
@@ -333,7 +339,8 @@ class CloudTasksClient {
   /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
-      std::string const& resource, google::iam::v1::Policy const& policy);
+      std::string const& resource, google::iam::v1::Policy const& policy,
+      Options options = {});
 
   /**
    * Updates the IAM policy for @p resource using an optimistic concurrency
@@ -387,7 +394,8 @@ class CloudTasksClient {
   /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L141}
   ///
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
-      std::string const& resource, std::vector<std::string> const& permissions);
+      std::string const& resource, std::vector<std::string> const& permissions,
+      Options options = {});
 
   ///
   /// Lists the tasks in a queue.
@@ -411,7 +419,7 @@ class CloudTasksClient {
   /// @googleapis_reference_link{google/cloud/tasks/v2/task.proto#L33}
   ///
   StreamRange<google::cloud::tasks::v2::Task> ListTasks(
-      std::string const& parent);
+      std::string const& parent, Options options = {});
 
   ///
   /// Gets a task.
@@ -426,7 +434,8 @@ class CloudTasksClient {
   /// [google.cloud.tasks.v2.Task]:
   /// @googleapis_reference_link{google/cloud/tasks/v2/task.proto#L33}
   ///
-  StatusOr<google::cloud::tasks::v2::Task> GetTask(std::string const& name);
+  StatusOr<google::cloud::tasks::v2::Task> GetTask(std::string const& name,
+                                                   Options options = {});
 
   ///
   /// Creates a task and adds it to a queue.
@@ -474,7 +483,8 @@ class CloudTasksClient {
   /// @googleapis_reference_link{google/cloud/tasks/v2/task.proto#L33}
   ///
   StatusOr<google::cloud::tasks::v2::Task> CreateTask(
-      std::string const& parent, google::cloud::tasks::v2::Task const& task);
+      std::string const& parent, google::cloud::tasks::v2::Task const& task,
+      Options options = {});
 
   ///
   /// Deletes a task.
@@ -489,7 +499,7 @@ class CloudTasksClient {
   /// [google.cloud.tasks.v2.DeleteTaskRequest]:
   /// @googleapis_reference_link{google/cloud/tasks/v2/cloudtasks.proto#L619}
   ///
-  Status DeleteTask(std::string const& name);
+  Status DeleteTask(std::string const& name, Options options = {});
 
   ///
   /// Forces a task to run now.
@@ -529,7 +539,8 @@ class CloudTasksClient {
   /// [google.cloud.tasks.v2.Task]:
   /// @googleapis_reference_link{google/cloud/tasks/v2/task.proto#L33}
   ///
-  StatusOr<google::cloud::tasks::v2::Task> RunTask(std::string const& name);
+  StatusOr<google::cloud::tasks::v2::Task> RunTask(std::string const& name,
+                                                   Options options = {});
 
   ///
   /// Lists queues.
@@ -547,7 +558,8 @@ class CloudTasksClient {
   /// @googleapis_reference_link{google/cloud/tasks/v2/queue.proto#L34}
   ///
   StreamRange<google::cloud::tasks::v2::Queue> ListQueues(
-      google::cloud::tasks::v2::ListQueuesRequest request);
+      google::cloud::tasks::v2::ListQueuesRequest request,
+      Options options = {});
 
   ///
   /// Gets a queue.
@@ -563,7 +575,8 @@ class CloudTasksClient {
   /// @googleapis_reference_link{google/cloud/tasks/v2/queue.proto#L34}
   ///
   StatusOr<google::cloud::tasks::v2::Queue> GetQueue(
-      google::cloud::tasks::v2::GetQueueRequest const& request);
+      google::cloud::tasks::v2::GetQueueRequest const& request,
+      Options options = {});
 
   ///
   /// Creates a queue.
@@ -589,7 +602,8 @@ class CloudTasksClient {
   /// @googleapis_reference_link{google/cloud/tasks/v2/queue.proto#L34}
   ///
   StatusOr<google::cloud::tasks::v2::Queue> CreateQueue(
-      google::cloud::tasks::v2::CreateQueueRequest const& request);
+      google::cloud::tasks::v2::CreateQueueRequest const& request,
+      Options options = {});
 
   ///
   /// Updates a queue.
@@ -618,7 +632,8 @@ class CloudTasksClient {
   /// @googleapis_reference_link{google/cloud/tasks/v2/queue.proto#L34}
   ///
   StatusOr<google::cloud::tasks::v2::Queue> UpdateQueue(
-      google::cloud::tasks::v2::UpdateQueueRequest const& request);
+      google::cloud::tasks::v2::UpdateQueueRequest const& request,
+      Options options = {});
 
   ///
   /// Deletes a queue.
@@ -641,7 +656,8 @@ class CloudTasksClient {
   /// @googleapis_reference_link{google/cloud/tasks/v2/cloudtasks.proto#L419}
   ///
   Status DeleteQueue(
-      google::cloud::tasks::v2::DeleteQueueRequest const& request);
+      google::cloud::tasks::v2::DeleteQueueRequest const& request,
+      Options options = {});
 
   ///
   /// Purges a queue by deleting all of its tasks.
@@ -663,7 +679,8 @@ class CloudTasksClient {
   /// @googleapis_reference_link{google/cloud/tasks/v2/queue.proto#L34}
   ///
   StatusOr<google::cloud::tasks::v2::Queue> PurgeQueue(
-      google::cloud::tasks::v2::PurgeQueueRequest const& request);
+      google::cloud::tasks::v2::PurgeQueueRequest const& request,
+      Options options = {});
 
   ///
   /// Pauses the queue.
@@ -686,7 +703,8 @@ class CloudTasksClient {
   /// @googleapis_reference_link{google/cloud/tasks/v2/queue.proto#L34}
   ///
   StatusOr<google::cloud::tasks::v2::Queue> PauseQueue(
-      google::cloud::tasks::v2::PauseQueueRequest const& request);
+      google::cloud::tasks::v2::PauseQueueRequest const& request,
+      Options options = {});
 
   ///
   /// Resume a queue.
@@ -715,7 +733,8 @@ class CloudTasksClient {
   /// @googleapis_reference_link{google/cloud/tasks/v2/queue.proto#L34}
   ///
   StatusOr<google::cloud::tasks::v2::Queue> ResumeQueue(
-      google::cloud::tasks::v2::ResumeQueueRequest const& request);
+      google::cloud::tasks::v2::ResumeQueueRequest const& request,
+      Options options = {});
 
   ///
   /// Gets the access control policy for a [Queue][google.cloud.tasks.v2.Queue].
@@ -739,7 +758,8 @@ class CloudTasksClient {
   /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> GetIamPolicy(
-      google::iam::v1::GetIamPolicyRequest const& request);
+      google::iam::v1::GetIamPolicyRequest const& request,
+      Options options = {});
 
   ///
   /// Sets the access control policy for a [Queue][google.cloud.tasks.v2.Queue].
@@ -765,7 +785,8 @@ class CloudTasksClient {
   /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
-      google::iam::v1::SetIamPolicyRequest const& request);
+      google::iam::v1::SetIamPolicyRequest const& request,
+      Options options = {});
 
   ///
   /// Returns permissions that a caller has on a
@@ -788,7 +809,8 @@ class CloudTasksClient {
   /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L141}
   ///
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
-      google::iam::v1::TestIamPermissionsRequest const& request);
+      google::iam::v1::TestIamPermissionsRequest const& request,
+      Options options = {});
 
   ///
   /// Lists the tasks in a queue.
@@ -812,7 +834,7 @@ class CloudTasksClient {
   /// @googleapis_reference_link{google/cloud/tasks/v2/task.proto#L33}
   ///
   StreamRange<google::cloud::tasks::v2::Task> ListTasks(
-      google::cloud::tasks::v2::ListTasksRequest request);
+      google::cloud::tasks::v2::ListTasksRequest request, Options options = {});
 
   ///
   /// Gets a task.
@@ -828,7 +850,8 @@ class CloudTasksClient {
   /// @googleapis_reference_link{google/cloud/tasks/v2/task.proto#L33}
   ///
   StatusOr<google::cloud::tasks::v2::Task> GetTask(
-      google::cloud::tasks::v2::GetTaskRequest const& request);
+      google::cloud::tasks::v2::GetTaskRequest const& request,
+      Options options = {});
 
   ///
   /// Creates a task and adds it to a queue.
@@ -848,7 +871,8 @@ class CloudTasksClient {
   /// @googleapis_reference_link{google/cloud/tasks/v2/task.proto#L33}
   ///
   StatusOr<google::cloud::tasks::v2::Task> CreateTask(
-      google::cloud::tasks::v2::CreateTaskRequest const& request);
+      google::cloud::tasks::v2::CreateTaskRequest const& request,
+      Options options = {});
 
   ///
   /// Deletes a task.
@@ -863,7 +887,8 @@ class CloudTasksClient {
   /// [google.cloud.tasks.v2.DeleteTaskRequest]:
   /// @googleapis_reference_link{google/cloud/tasks/v2/cloudtasks.proto#L619}
   ///
-  Status DeleteTask(google::cloud::tasks::v2::DeleteTaskRequest const& request);
+  Status DeleteTask(google::cloud::tasks::v2::DeleteTaskRequest const& request,
+                    Options options = {});
 
   ///
   /// Forces a task to run now.
@@ -904,10 +929,12 @@ class CloudTasksClient {
   /// @googleapis_reference_link{google/cloud/tasks/v2/task.proto#L33}
   ///
   StatusOr<google::cloud::tasks::v2::Task> RunTask(
-      google::cloud::tasks::v2::RunTaskRequest const& request);
+      google::cloud::tasks::v2::RunTaskRequest const& request,
+      Options options = {});
 
  private:
   std::shared_ptr<CloudTasksConnection> connection_;
+  Options options_;
 };
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END


### PR DESCRIPTION
The generated client constructor now takes a defaulted `Options` argument,
which is merged with the default options for the service, and then stored
as a member.

Similarly, the generated client operations also take a defaulted `Options`
argument, which is then merged with the client options from above, and
installed as the prevailing options for the duration of the operation by
instantiating an `OptionsSpan`.

Any module within the scope of that operation, or its continuations, can
then retrieve those prevailing options.  So, for example, a metadata
decorator could add a header based on a per-operation option, or a retry
policy might modify its behavior based on another option.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7683)
<!-- Reviewable:end -->
