### PR TITLE
fix(pubsub): Change AsyncReadWriteStreamAuth to be usable with unique_ptr

### DIFF
--- a/google/cloud/bigtable/testing/table_test_fixture.h
+++ b/google/cloud/bigtable/testing/table_test_fixture.h
@@ -28,7 +28,7 @@ namespace testing {
 /// Common fixture for the bigtable::Table tests.
 class TableTestFixture : public ::testing::Test {
  protected:
-  explicit TableTestFixture(CompletionQueue const& cq);
+  explicit TableTestFixture(CompletionQueue cq);
   std::shared_ptr<MockDataClient> SetupMockClient();
 
   static char const kProjectId[];

--- a/google/cloud/bigtable/testing/table_test_fixture.h
+++ b/google/cloud/bigtable/testing/table_test_fixture.h
@@ -28,7 +28,7 @@ namespace testing {
 /// Common fixture for the bigtable::Table tests.
 class TableTestFixture : public ::testing::Test {
  protected:
-  explicit TableTestFixture(CompletionQueue cq);
+  explicit TableTestFixture(CompletionQueue const& cq);
   std::shared_ptr<MockDataClient> SetupMockClient();
 
   static char const kProjectId[];

--- a/google/cloud/internal/async_read_write_stream_auth_test.cc
+++ b/google/cloud/internal/async_read_write_stream_auth_test.cc
@@ -55,7 +55,8 @@ class MockStream : public BaseStream {
 };
 
 TEST(AsyncStreamReadWriteAuth, Start) {
-  auto factory = AuthStream::StreamFactory([](std::unique_ptr<grpc::ClientContext>) {
+  auto factory = AuthStream::StreamFactory([](std::unique_ptr<
+                                               grpc::ClientContext>) {
     auto mock = absl::make_unique<StrictMock<MockStream>>();
     EXPECT_CALL(*mock, Start).WillOnce([] { return make_ready_future(true); });
     EXPECT_CALL(*mock, Write)

--- a/google/cloud/pubsub/internal/streaming_subscription_batch_source_test.cc
+++ b/google/cloud/pubsub/internal/streaming_subscription_batch_source_test.cc
@@ -325,7 +325,7 @@ TEST(StreamingSubscriptionBatchSourceTest, StartUnexpected) {
       .WillRepeatedly([](google::cloud::CompletionQueue&,
                          std::unique_ptr<grpc::ClientContext>,
                          google::pubsub::v1::StreamingPullRequest const&) {
-        return std::shared_ptr<SubscriberStub::AsyncPullStream>{};
+        return std::unique_ptr<SubscriberStub::AsyncPullStream>{};
       });
 
   auto shutdown = std::make_shared<SessionShutdownManager>();

--- a/google/cloud/pubsub/internal/subscriber_auth.cc
+++ b/google/cloud/pubsub/internal/subscriber_auth.cc
@@ -69,7 +69,7 @@ Status SubscriberAuth::ModifyPushConfig(
   return child_->ModifyPushConfig(context, request);
 }
 
-std::shared_ptr<SubscriberStub::AsyncPullStream>
+std::unique_ptr<SubscriberStub::AsyncPullStream>
 SubscriberAuth::AsyncStreamingPull(
     google::cloud::CompletionQueue& cq,
     std::unique_ptr<grpc::ClientContext> context,
@@ -83,9 +83,8 @@ SubscriberAuth::AsyncStreamingPull(
                request](std::unique_ptr<grpc::ClientContext> ctx) mutable {
     return child->AsyncStreamingPull(cq, std::move(ctx), request);
   };
-  auto factory = StreamAuth::StreamFactory(std::move(call));
-  return std::make_shared<StreamAuth>(std::move(context), auth_,
-                                      std::move(factory));
+  return absl::make_unique<StreamAuth>(
+      std::move(context), auth_, StreamAuth::StreamFactory(std::move(call)));
 }
 
 future<Status> SubscriberAuth::AsyncAcknowledge(

--- a/google/cloud/pubsub/internal/subscriber_auth.h
+++ b/google/cloud/pubsub/internal/subscriber_auth.h
@@ -56,7 +56,7 @@ class SubscriberAuth : public SubscriberStub {
       grpc::ClientContext& context,
       google::pubsub::v1::ModifyPushConfigRequest const& request) override;
 
-  std::shared_ptr<AsyncPullStream> AsyncStreamingPull(
+  std::unique_ptr<AsyncPullStream> AsyncStreamingPull(
       google::cloud::CompletionQueue& cq,
       std::unique_ptr<grpc::ClientContext> context,
       google::pubsub::v1::StreamingPullRequest const& request) override;

--- a/google/cloud/pubsub/internal/subscriber_auth_test.cc
+++ b/google/cloud/pubsub/internal/subscriber_auth_test.cc
@@ -130,10 +130,12 @@ TEST(SubscriberAuthTest, ModifyPushConfig) {
 }
 
 TEST(SubscriberAuthTest, AsyncStreamingPullFailedAuth) {
-  auto mock = std::make_shared<StrictMock<pubsub_testing::MockSubscriberStub>>();
+  auto mock =
+      std::make_shared<StrictMock<pubsub_testing::MockSubscriberStub>>();
   auto auth = std::make_shared<testing_util::MockAuthenticationStrategy>();
   EXPECT_CALL(*auth, AsyncConfigureContext)
-      .WillOnce([](std::unique_ptr<grpc::ClientContext>) -> future<StatusOr<std::unique_ptr<grpc::ClientContext>>> {
+      .WillOnce([](std::unique_ptr<grpc::ClientContext>)
+                    -> future<StatusOr<std::unique_ptr<grpc::ClientContext>>> {
         return make_ready_future(StatusOr<std::unique_ptr<grpc::ClientContext>>(
             Status(StatusCode::kInvalidArgument, "cannot-set-credentials")));
       });
@@ -153,7 +155,8 @@ TEST(SubscriberAuthTest, AsyncStreamingPullAuthSuccess) {
           google::pubsub::v1::StreamingPullRequest,
           google::pubsub::v1::StreamingPullResponse>;
 
-  auto mock = std::make_shared<StrictMock<pubsub_testing::MockSubscriberStub>>();
+  auto mock =
+      std::make_shared<StrictMock<pubsub_testing::MockSubscriberStub>>();
   EXPECT_CALL(*mock, AsyncStreamingPull)
       .WillOnce([](::testing::Unused, ::testing::Unused, ::testing::Unused) {
         return absl::make_unique<ErrorStream>(

--- a/google/cloud/pubsub/internal/subscriber_logging.cc
+++ b/google/cloud/pubsub/internal/subscriber_logging.cc
@@ -92,7 +92,7 @@ Status SubscriberLogging::ModifyPushConfig(
       context, request, __func__, tracing_options_);
 }
 
-std::shared_ptr<SubscriberStub::AsyncPullStream>
+std::unique_ptr<SubscriberStub::AsyncPullStream>
 SubscriberLogging::AsyncStreamingPull(
     google::cloud::CompletionQueue& cq,
     std::unique_ptr<grpc::ClientContext> context,
@@ -103,7 +103,7 @@ SubscriberLogging::AsyncStreamingPull(
                  << " << request=" << DebugString(request, tracing_options_);
   auto stream = child_->AsyncStreamingPull(cq, std::move(context), request);
   if (!trace_streams_) return stream;
-  return std::make_shared<LoggingAsyncPullStream>(std::move(stream),
+  return absl::make_unique<LoggingAsyncPullStream>(std::move(stream),
                                                   tracing_options_, request_id);
 }
 

--- a/google/cloud/pubsub/internal/subscriber_logging.cc
+++ b/google/cloud/pubsub/internal/subscriber_logging.cc
@@ -103,8 +103,8 @@ SubscriberLogging::AsyncStreamingPull(
                  << " << request=" << DebugString(request, tracing_options_);
   auto stream = child_->AsyncStreamingPull(cq, std::move(context), request);
   if (!trace_streams_) return stream;
-  return absl::make_unique<LoggingAsyncPullStream>(std::move(stream),
-                                                  tracing_options_, request_id);
+  return absl::make_unique<LoggingAsyncPullStream>(
+      std::move(stream), tracing_options_, request_id);
 }
 
 future<Status> SubscriberLogging::AsyncAcknowledge(

--- a/google/cloud/pubsub/internal/subscriber_logging.h
+++ b/google/cloud/pubsub/internal/subscriber_logging.h
@@ -58,7 +58,7 @@ class SubscriberLogging : public SubscriberStub {
       grpc::ClientContext& context,
       google::pubsub::v1::ModifyPushConfigRequest const& request) override;
 
-  std::shared_ptr<AsyncPullStream> AsyncStreamingPull(
+  std::unique_ptr<AsyncPullStream> AsyncStreamingPull(
       google::cloud::CompletionQueue& cq,
       std::unique_ptr<grpc::ClientContext> context,
       google::pubsub::v1::StreamingPullRequest const& request) override;

--- a/google/cloud/pubsub/internal/subscriber_metadata.cc
+++ b/google/cloud/pubsub/internal/subscriber_metadata.cc
@@ -70,7 +70,7 @@ Status SubscriberMetadata::ModifyPushConfig(
   return child_->ModifyPushConfig(context, request);
 }
 
-std::shared_ptr<SubscriberStub::AsyncPullStream>
+std::unique_ptr<SubscriberStub::AsyncPullStream>
 SubscriberMetadata::AsyncStreamingPull(
     google::cloud::CompletionQueue& cq,
     std::unique_ptr<grpc::ClientContext> context,

--- a/google/cloud/pubsub/internal/subscriber_metadata.h
+++ b/google/cloud/pubsub/internal/subscriber_metadata.h
@@ -54,7 +54,7 @@ class SubscriberMetadata : public SubscriberStub {
       grpc::ClientContext& context,
       google::pubsub::v1::ModifyPushConfigRequest const& request) override;
 
-  std::shared_ptr<AsyncPullStream> AsyncStreamingPull(
+  std::unique_ptr<AsyncPullStream> AsyncStreamingPull(
       google::cloud::CompletionQueue& cq,
       std::unique_ptr<grpc::ClientContext> context,
       google::pubsub::v1::StreamingPullRequest const& request) override;

--- a/google/cloud/pubsub/internal/subscriber_round_robin.cc
+++ b/google/cloud/pubsub/internal/subscriber_round_robin.cc
@@ -59,7 +59,7 @@ Status SubscriberRoundRobin::ModifyPushConfig(
   return Child()->ModifyPushConfig(context, request);
 }
 
-std::shared_ptr<SubscriberStub::AsyncPullStream>
+std::unique_ptr<SubscriberStub::AsyncPullStream>
 SubscriberRoundRobin::AsyncStreamingPull(
     google::cloud::CompletionQueue& cq,
     std::unique_ptr<grpc::ClientContext> context,

--- a/google/cloud/pubsub/internal/subscriber_round_robin.h
+++ b/google/cloud/pubsub/internal/subscriber_round_robin.h
@@ -56,7 +56,7 @@ class SubscriberRoundRobin : public SubscriberStub {
       grpc::ClientContext& context,
       google::pubsub::v1::ModifyPushConfigRequest const& request) override;
 
-  std::shared_ptr<AsyncPullStream> AsyncStreamingPull(
+  std::unique_ptr<AsyncPullStream> AsyncStreamingPull(
       google::cloud::CompletionQueue& cq,
       std::unique_ptr<grpc::ClientContext> context,
       google::pubsub::v1::StreamingPullRequest const& request) override;

--- a/google/cloud/pubsub/internal/subscriber_stub.cc
+++ b/google/cloud/pubsub/internal/subscriber_stub.cc
@@ -84,7 +84,7 @@ class DefaultSubscriberStub : public SubscriberStub {
     return {};
   }
 
-  std::shared_ptr<AsyncPullStream> AsyncStreamingPull(
+  std::unique_ptr<AsyncPullStream> AsyncStreamingPull(
       google::cloud::CompletionQueue& cq,
       std::unique_ptr<grpc::ClientContext> context,
       google::pubsub::v1::StreamingPullRequest const&) override {

--- a/google/cloud/pubsub/internal/subscriber_stub.h
+++ b/google/cloud/pubsub/internal/subscriber_stub.h
@@ -76,7 +76,7 @@ class SubscriberStub {
       google::pubsub::v1::StreamingPullResponse>;
 
   /// Start a bi-directional stream to read messages and send ack/nacks.
-  virtual std::shared_ptr<AsyncPullStream> AsyncStreamingPull(
+  virtual std::unique_ptr<AsyncPullStream> AsyncStreamingPull(
       google::cloud::CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
       google::pubsub::v1::StreamingPullRequest const& request) = 0;
 

--- a/google/cloud/pubsub/testing/mock_subscriber_stub.h
+++ b/google/cloud/pubsub/testing/mock_subscriber_stub.h
@@ -61,7 +61,7 @@ class MockSubscriberStub : public pubsub_internal::SubscriberStub {
                google::pubsub::v1::ModifyPushConfigRequest const& request),
               (override));
 
-  MOCK_METHOD(std::shared_ptr<pubsub_internal::SubscriberStub::AsyncPullStream>,
+  MOCK_METHOD(std::unique_ptr<pubsub_internal::SubscriberStub::AsyncPullStream>,
               AsyncStreamingPull,
               (google::cloud::CompletionQueue&,
                std::unique_ptr<grpc::ClientContext>,


### PR DESCRIPTION
Also fix a bug where if it was cancelled while auth was being set up, neither the spawning context nor the created stream would be cancelled.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7692)
<!-- Reviewable:end -->
