### PR TITLE
chore: move non_constructible.h to google/cloud/internal

### DIFF
--- a/google/cloud/CMakeLists.txt
+++ b/google/cloud/CMakeLists.txt
@@ -98,6 +98,7 @@ add_library(
     internal/ios_flags_saver.h
     internal/log_impl.cc
     internal/log_impl.h
+    internal/non_constructible.h
     internal/pagination_range.h
     internal/parse_rfc3339.cc
     internal/parse_rfc3339.h

--- a/google/cloud/google_cloud_cpp_common.bzl
+++ b/google/cloud/google_cloud_cpp_common.bzl
@@ -53,6 +53,7 @@ google_cloud_cpp_common_hdrs = [
     "internal/invoke_result.h",
     "internal/ios_flags_saver.h",
     "internal/log_impl.h",
+    "internal/non_constructible.h",
     "internal/pagination_range.h",
     "internal/parse_rfc3339.h",
     "internal/port_platform.h",

--- a/google/cloud/internal/non_constructible.h
+++ b/google/cloud/internal/non_constructible.h
@@ -19,8 +19,8 @@
 
 namespace google {
 namespace cloud {
-namespace internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+namespace internal {
 
 /**
  * A type that is not constructible.
@@ -35,8 +35,8 @@ struct NonConstructible {
   NonConstructible(NonConstructible&&) = delete;
 };
 
-GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace internal
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace cloud
 }  // namespace google
 

--- a/google/cloud/internal/non_constructible.h
+++ b/google/cloud/internal/non_constructible.h
@@ -12,15 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PUBSUB_INTERNAL_NON_CONSTRUCTIBLE_H
-#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PUBSUB_INTERNAL_NON_CONSTRUCTIBLE_H
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_NON_CONSTRUCTIBLE_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_NON_CONSTRUCTIBLE_H
 
-#include "google/cloud/pubsub/version.h"
-#include "google/cloud/options.h"
+#include "google/cloud/version.h"
 
 namespace google {
 namespace cloud {
-namespace pubsub_internal {
+namespace internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /**
@@ -37,8 +36,8 @@ struct NonConstructible {
 };
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-}  // namespace pubsub_internal
+}  // namespace internal
 }  // namespace cloud
 }  // namespace google
 
-#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PUBSUB_INTERNAL_NON_CONSTRUCTIBLE_H
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_NON_CONSTRUCTIBLE_H

--- a/google/cloud/pubsub/CMakeLists.txt
+++ b/google/cloud/pubsub/CMakeLists.txt
@@ -55,7 +55,6 @@ add_library(
     internal/defaults.h
     internal/flow_controlled_publisher_connection.cc
     internal/flow_controlled_publisher_connection.h
-    internal/non_constructible.h
     internal/ordering_key_publisher_connection.cc
     internal/ordering_key_publisher_connection.h
     internal/publisher_auth.cc

--- a/google/cloud/pubsub/google_cloud_cpp_pubsub.bzl
+++ b/google/cloud/pubsub/google_cloud_cpp_pubsub.bzl
@@ -27,7 +27,6 @@ google_cloud_cpp_pubsub_hdrs = [
     "internal/default_batch_sink.h",
     "internal/defaults.h",
     "internal/flow_controlled_publisher_connection.h",
-    "internal/non_constructible.h",
     "internal/ordering_key_publisher_connection.h",
     "internal/publisher_auth.h",
     "internal/publisher_logging.h",

--- a/google/cloud/pubsub/publisher_connection.cc
+++ b/google/cloud/pubsub/publisher_connection.cc
@@ -18,7 +18,6 @@
 #include "google/cloud/pubsub/internal/default_batch_sink.h"
 #include "google/cloud/pubsub/internal/defaults.h"
 #include "google/cloud/pubsub/internal/flow_controlled_publisher_connection.h"
-#include "google/cloud/pubsub/internal/non_constructible.h"
 #include "google/cloud/pubsub/internal/ordering_key_publisher_connection.h"
 #include "google/cloud/pubsub/internal/publisher_auth.h"
 #include "google/cloud/pubsub/internal/publisher_logging.h"
@@ -29,6 +28,7 @@
 #include "google/cloud/pubsub/internal/sequential_batch_sink.h"
 #include "google/cloud/pubsub/options.h"
 #include "google/cloud/future_void.h"
+#include "google/cloud/internal/non_constructible.h"
 #include "google/cloud/log.h"
 #include <memory>
 
@@ -124,7 +124,7 @@ void PublisherConnection::Flush(FlushParams) {}
 void PublisherConnection::ResumePublish(ResumePublishParams) {}
 
 std::shared_ptr<PublisherConnection> MakePublisherConnection(
-    Topic topic, std::initializer_list<pubsub_internal::NonConstructible>) {
+    Topic topic, std::initializer_list<internal::NonConstructible>) {
   return MakePublisherConnection(std::move(topic));
 }
 

--- a/google/cloud/pubsub/publisher_connection.h
+++ b/google/cloud/pubsub/publisher_connection.h
@@ -17,7 +17,6 @@
 
 #include "google/cloud/pubsub/backoff_policy.h"
 #include "google/cloud/pubsub/connection_options.h"
-#include "google/cloud/pubsub/internal/non_constructible.h"
 #include "google/cloud/pubsub/internal/publisher_stub.h"
 #include "google/cloud/pubsub/message.h"
 #include "google/cloud/pubsub/publisher_options.h"
@@ -25,6 +24,7 @@
 #include "google/cloud/pubsub/topic.h"
 #include "google/cloud/pubsub/version.h"
 #include "google/cloud/future.h"
+#include "google/cloud/internal/non_constructible.h"
 #include "google/cloud/status_or.h"
 #include <initializer_list>
 #include <string>
@@ -90,7 +90,7 @@ class PublisherConnection {
  * @deprecated Please use `MakePublisherConnection(topic)` instead.
  */
 std::shared_ptr<PublisherConnection> MakePublisherConnection(
-    Topic topic, std::initializer_list<pubsub_internal::NonConstructible>);
+    Topic topic, std::initializer_list<internal::NonConstructible>);
 
 /**
  * Creates a new `PublisherConnection` object to work with `Publisher`.

--- a/google/cloud/pubsub/schema_admin_connection.cc
+++ b/google/cloud/pubsub/schema_admin_connection.cc
@@ -167,7 +167,7 @@ std::shared_ptr<pubsub_internal::SchemaStub> DecorateSchemaAdminStub(
 SchemaAdminConnection::~SchemaAdminConnection() = default;
 
 std::shared_ptr<SchemaAdminConnection> MakeSchemaAdminConnection(
-    std::initializer_list<pubsub_internal::NonConstructible>) {
+    std::initializer_list<internal::NonConstructible>) {
   return MakeSchemaAdminConnection();
 }
 

--- a/google/cloud/pubsub/schema_admin_connection.h
+++ b/google/cloud/pubsub/schema_admin_connection.h
@@ -17,10 +17,10 @@
 
 #include "google/cloud/pubsub/backoff_policy.h"
 #include "google/cloud/pubsub/connection_options.h"
-#include "google/cloud/pubsub/internal/non_constructible.h"
 #include "google/cloud/pubsub/internal/schema_stub.h"
 #include "google/cloud/pubsub/retry_policy.h"
 #include "google/cloud/pubsub/version.h"
+#include "google/cloud/internal/non_constructible.h"
 #include "google/cloud/internal/pagination_range.h"
 #include "google/cloud/status_or.h"
 #include <google/pubsub/v1/schema.pb.h>
@@ -102,7 +102,7 @@ class SchemaAdminConnection {
  * @deprecated Please use `MakeSchemaAdminConnection()` instead.
  */
 std::shared_ptr<SchemaAdminConnection> MakeSchemaAdminConnection(
-    std::initializer_list<pubsub_internal::NonConstructible>);
+    std::initializer_list<internal::NonConstructible>);
 
 /**
  * Creates a new `SchemaAdminConnection` object to work with

--- a/google/cloud/pubsub/subscriber_connection.cc
+++ b/google/cloud/pubsub/subscriber_connection.cc
@@ -101,7 +101,7 @@ future<Status> SubscriberConnection::Subscribe(SubscribeParams) {
 
 std::shared_ptr<SubscriberConnection> MakeSubscriberConnection(
     Subscription subscription,
-    std::initializer_list<pubsub_internal::NonConstructible>) {
+    std::initializer_list<internal::NonConstructible>) {
   return MakeSubscriberConnection(std::move(subscription));
 }
 

--- a/google/cloud/pubsub/subscriber_connection.h
+++ b/google/cloud/pubsub/subscriber_connection.h
@@ -19,13 +19,13 @@
 #include "google/cloud/pubsub/application_callback.h"
 #include "google/cloud/pubsub/backoff_policy.h"
 #include "google/cloud/pubsub/connection_options.h"
-#include "google/cloud/pubsub/internal/non_constructible.h"
 #include "google/cloud/pubsub/internal/subscriber_stub.h"
 #include "google/cloud/pubsub/message.h"
 #include "google/cloud/pubsub/retry_policy.h"
 #include "google/cloud/pubsub/subscriber_options.h"
 #include "google/cloud/pubsub/subscription.h"
 #include "google/cloud/pubsub/version.h"
+#include "google/cloud/internal/non_constructible.h"
 #include "google/cloud/status_or.h"
 #include <functional>
 #include <initializer_list>
@@ -79,7 +79,7 @@ class SubscriberConnection {
  */
 std::shared_ptr<SubscriberConnection> MakeSubscriberConnection(
     Subscription subscription,
-    std::initializer_list<pubsub_internal::NonConstructible>);
+    std::initializer_list<internal::NonConstructible>);
 
 /**
  * Creates a new `SubscriberConnection` object to work with `Subscriber`.

--- a/google/cloud/pubsub/subscription_admin_connection.cc
+++ b/google/cloud/pubsub/subscription_admin_connection.cc
@@ -341,7 +341,7 @@ StatusOr<google::pubsub::v1::SeekResponse> SubscriptionAdminConnection::Seek(
 }
 
 std::shared_ptr<SubscriptionAdminConnection> MakeSubscriptionAdminConnection(
-    std::initializer_list<pubsub_internal::NonConstructible>) {
+    std::initializer_list<internal::NonConstructible>) {
   return MakeSubscriptionAdminConnection();
 }
 

--- a/google/cloud/pubsub/subscription_admin_connection.h
+++ b/google/cloud/pubsub/subscription_admin_connection.h
@@ -17,12 +17,12 @@
 
 #include "google/cloud/pubsub/backoff_policy.h"
 #include "google/cloud/pubsub/connection_options.h"
-#include "google/cloud/pubsub/internal/non_constructible.h"
 #include "google/cloud/pubsub/internal/subscriber_stub.h"
 #include "google/cloud/pubsub/retry_policy.h"
 #include "google/cloud/pubsub/snapshot.h"
 #include "google/cloud/pubsub/subscription.h"
 #include "google/cloud/pubsub/version.h"
+#include "google/cloud/internal/non_constructible.h"
 #include "google/cloud/internal/pagination_range.h"
 #include "google/cloud/status_or.h"
 #include <google/pubsub/v1/pubsub.pb.h>
@@ -196,7 +196,7 @@ class SubscriptionAdminConnection {
  * @deprecated Please use `MakeSubscriptionAdminConnection()` instead.
  */
 std::shared_ptr<SubscriptionAdminConnection> MakeSubscriptionAdminConnection(
-    std::initializer_list<pubsub_internal::NonConstructible>);
+    std::initializer_list<internal::NonConstructible>);
 
 /**
  * Creates a new `SubscriptionAdminConnection` object to work with

--- a/google/cloud/pubsub/topic_admin_connection.cc
+++ b/google/cloud/pubsub/topic_admin_connection.cc
@@ -291,7 +291,7 @@ ListTopicSnapshotsRange TopicAdminConnection::ListTopicSnapshots(
 }
 
 std::shared_ptr<TopicAdminConnection> MakeTopicAdminConnection(
-    std::initializer_list<pubsub_internal::NonConstructible>) {
+    std::initializer_list<internal::NonConstructible>) {
   return MakeTopicAdminConnection();
 }
 

--- a/google/cloud/pubsub/topic_admin_connection.h
+++ b/google/cloud/pubsub/topic_admin_connection.h
@@ -17,12 +17,12 @@
 
 #include "google/cloud/pubsub/backoff_policy.h"
 #include "google/cloud/pubsub/connection_options.h"
-#include "google/cloud/pubsub/internal/non_constructible.h"
 #include "google/cloud/pubsub/internal/publisher_stub.h"
 #include "google/cloud/pubsub/retry_policy.h"
 #include "google/cloud/pubsub/subscription.h"
 #include "google/cloud/pubsub/topic.h"
 #include "google/cloud/pubsub/version.h"
+#include "google/cloud/internal/non_constructible.h"
 #include "google/cloud/internal/pagination_range.h"
 #include "google/cloud/status_or.h"
 #include <google/pubsub/v1/pubsub.pb.h>
@@ -169,7 +169,7 @@ class TopicAdminConnection {
  * @deprecated Please use `MakeTopicAdminConnection()` instead.
  */
 std::shared_ptr<TopicAdminConnection> MakeTopicAdminConnection(
-    std::initializer_list<pubsub_internal::NonConstructible>);
+    std::initializer_list<internal::NonConstructible>);
 
 /**
  * Creates a new `TopicAdminConnection` object to work with `TopicAdminClient`.


### PR DESCRIPTION
This type will be generally useful when converting interfaces to
use `google::cloud::Options`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7701)
<!-- Reviewable:end -->
