### PR TITLE
refactor(spanner): prefer AsyncRetryLoop to StartRetryAsyncUnaryRpc

### DIFF
--- a/google/cloud/spanner/integration_tests/session_pool_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/session_pool_integration_test.cc
@@ -36,7 +36,7 @@ struct SessionPoolFriendForTest {
                                                   num_sessions);
   }
 
-  static future<StatusOr<google::protobuf::Empty>> AsyncDeleteSession(
+  static future<Status> AsyncDeleteSession(
       std::shared_ptr<SessionPool> const& session_pool, CompletionQueue& cq,
       std::shared_ptr<SpannerStub> const& stub, std::string session_name) {
     return session_pool->AsyncDeleteSession(cq, stub, std::move(session_name));
@@ -100,12 +100,8 @@ TEST_F(SessionPoolIntegrationTest, SessionAsyncCRUD) {
   std::vector<future<Status>> async_delete;
   for (auto const& s : create_response->session()) {
     auto const& session_name = s.name();
-    async_delete.push_back(
-        SessionPoolFriendForTest::AsyncDeleteSession(session_pool, cq, stub,
-                                                     session_name)
-            .then([](future<StatusOr<google::protobuf::Empty>> f) {
-              return f.get().status();
-            }));
+    async_delete.push_back(SessionPoolFriendForTest::AsyncDeleteSession(
+        session_pool, cq, stub, session_name));
   }
   for (auto& ad : async_delete) {
     auto status = ad.get();

--- a/google/cloud/spanner/internal/logging_spanner_stub.cc
+++ b/google/cloud/spanner/internal/logging_spanner_stub.cc
@@ -47,19 +47,18 @@ LoggingSpannerStub::BatchCreateSessions(
       client_context, request, __func__, tracing_options_);
 }
 
-std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<
-    spanner_proto::BatchCreateSessionsResponse>>
+future<StatusOr<spanner_proto::BatchCreateSessionsResponse>>
 LoggingSpannerStub::AsyncBatchCreateSessions(
-    grpc::ClientContext& client_context,
-    spanner_proto::BatchCreateSessionsRequest const& request,
-    grpc::CompletionQueue* cq) {
+    google::cloud::CompletionQueue& cq,
+    std::unique_ptr<grpc::ClientContext> context,
+    spanner_proto::BatchCreateSessionsRequest const& request) {
   return LogWrapper(
-      [this](grpc::ClientContext& context,
-             spanner_proto::BatchCreateSessionsRequest const& request,
-             grpc::CompletionQueue* cq) {
-        return child_->AsyncBatchCreateSessions(context, request, cq);
+      [this](CompletionQueue& cq, std::unique_ptr<grpc::ClientContext> context,
+             spanner_proto::BatchCreateSessionsRequest const& request) {
+        return child_->AsyncBatchCreateSessions(cq, std::move(context),
+                                                request);
       },
-      client_context, request, cq, __func__, tracing_options_);
+      cq, std::move(context), request, __func__, tracing_options_);
 }
 
 StatusOr<spanner_proto::Session> LoggingSpannerStub::GetSession(
@@ -95,19 +94,16 @@ Status LoggingSpannerStub::DeleteSession(
       client_context, request, __func__, tracing_options_);
 }
 
-std::unique_ptr<
-    grpc::ClientAsyncResponseReaderInterface<google::protobuf::Empty>>
-LoggingSpannerStub::AsyncDeleteSession(
-    grpc::ClientContext& client_context,
-    spanner_proto::DeleteSessionRequest const& request,
-    grpc::CompletionQueue* cq) {
+future<Status> LoggingSpannerStub::AsyncDeleteSession(
+    google::cloud::CompletionQueue& cq,
+    std::unique_ptr<grpc::ClientContext> context,
+    spanner_proto::DeleteSessionRequest const& request) {
   return LogWrapper(
-      [this](grpc::ClientContext& context,
-             spanner_proto::DeleteSessionRequest const& request,
-             grpc::CompletionQueue* cq) {
-        return child_->AsyncDeleteSession(context, request, cq);
+      [this](CompletionQueue& cq, std::unique_ptr<grpc::ClientContext> context,
+             spanner_proto::DeleteSessionRequest const& request) {
+        return child_->AsyncDeleteSession(cq, std::move(context), request);
       },
-      client_context, request, cq, __func__, tracing_options_);
+      cq, std::move(context), request, __func__, tracing_options_);
 }
 
 StatusOr<spanner_proto::ResultSet> LoggingSpannerStub::ExecuteSql(
@@ -121,19 +117,16 @@ StatusOr<spanner_proto::ResultSet> LoggingSpannerStub::ExecuteSql(
       client_context, request, __func__, tracing_options_);
 }
 
-std::unique_ptr<
-    grpc::ClientAsyncResponseReaderInterface<spanner_proto::ResultSet>>
-LoggingSpannerStub::AsyncExecuteSql(
-    grpc::ClientContext& client_context,
-    spanner_proto::ExecuteSqlRequest const& request,
-    grpc::CompletionQueue* cq) {
+future<StatusOr<spanner_proto::ResultSet>> LoggingSpannerStub::AsyncExecuteSql(
+    google::cloud::CompletionQueue& cq,
+    std::unique_ptr<grpc::ClientContext> context,
+    spanner_proto::ExecuteSqlRequest const& request) {
   return LogWrapper(
-      [this](grpc::ClientContext& context,
-             spanner_proto::ExecuteSqlRequest const& request,
-             grpc::CompletionQueue* cq) {
-        return child_->AsyncExecuteSql(context, request, cq);
+      [this](CompletionQueue& cq, std::unique_ptr<grpc::ClientContext> context,
+             spanner_proto::ExecuteSqlRequest const& request) {
+        return child_->AsyncExecuteSql(cq, std::move(context), request);
       },
-      client_context, request, cq, __func__, tracing_options_);
+      cq, std::move(context), request, __func__, tracing_options_);
 }
 
 std::unique_ptr<grpc::ClientReaderInterface<spanner_proto::PartialResultSet>>

--- a/google/cloud/spanner/internal/logging_spanner_stub.h
+++ b/google/cloud/spanner/internal/logging_spanner_stub.h
@@ -44,12 +44,11 @@ class LoggingSpannerStub : public SpannerStub {
   BatchCreateSessions(
       grpc::ClientContext& client_context,
       google::spanner::v1::BatchCreateSessionsRequest const& request) override;
-  std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<
-      google::spanner::v1::BatchCreateSessionsResponse>>
+  future<StatusOr<google::spanner::v1::BatchCreateSessionsResponse>>
   AsyncBatchCreateSessions(
-      grpc::ClientContext& client_context,
-      google::spanner::v1::BatchCreateSessionsRequest const& request,
-      grpc::CompletionQueue* cq) override;
+      google::cloud::CompletionQueue& cq,
+      std::unique_ptr<grpc::ClientContext> context,
+      google::spanner::v1::BatchCreateSessionsRequest const& request) override;
   StatusOr<google::spanner::v1::Session> GetSession(
       grpc::ClientContext& client_context,
       google::spanner::v1::GetSessionRequest const& request) override;
@@ -59,19 +58,17 @@ class LoggingSpannerStub : public SpannerStub {
   Status DeleteSession(
       grpc::ClientContext& client_context,
       google::spanner::v1::DeleteSessionRequest const& request) override;
-  std::unique_ptr<
-      grpc::ClientAsyncResponseReaderInterface<google::protobuf::Empty>>
-  AsyncDeleteSession(grpc::ClientContext& client_context,
-                     google::spanner::v1::DeleteSessionRequest const& request,
-                     grpc::CompletionQueue* cq) override;
+  future<Status> AsyncDeleteSession(
+      google::cloud::CompletionQueue& cq,
+      std::unique_ptr<grpc::ClientContext> context,
+      google::spanner::v1::DeleteSessionRequest const& request) override;
   StatusOr<google::spanner::v1::ResultSet> ExecuteSql(
       grpc::ClientContext& client_context,
       google::spanner::v1::ExecuteSqlRequest const& request) override;
-  std::unique_ptr<
-      grpc::ClientAsyncResponseReaderInterface<google::spanner::v1::ResultSet>>
-  AsyncExecuteSql(grpc::ClientContext& client_context,
-                  google::spanner::v1::ExecuteSqlRequest const& request,
-                  grpc::CompletionQueue* cq) override;
+  future<StatusOr<google::spanner::v1::ResultSet>> AsyncExecuteSql(
+      google::cloud::CompletionQueue& cq,
+      std::unique_ptr<grpc::ClientContext> context,
+      google::spanner::v1::ExecuteSqlRequest const& request) override;
   std::unique_ptr<
       grpc::ClientReaderInterface<google::spanner::v1::PartialResultSet>>
   ExecuteStreamingSql(

--- a/google/cloud/spanner/internal/metadata_spanner_stub.cc
+++ b/google/cloud/spanner/internal/metadata_spanner_stub.cc
@@ -46,14 +46,13 @@ MetadataSpannerStub::BatchCreateSessions(
   return child_->BatchCreateSessions(client_context, request);
 }
 
-std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<
-    spanner_proto::BatchCreateSessionsResponse>>
+future<StatusOr<spanner_proto::BatchCreateSessionsResponse>>
 MetadataSpannerStub::AsyncBatchCreateSessions(
-    grpc::ClientContext& client_context,
-    spanner_proto::BatchCreateSessionsRequest const& request,
-    grpc::CompletionQueue* cq) {
-  SetMetadata(client_context, "database=" + request.database());
-  return child_->AsyncBatchCreateSessions(client_context, request, cq);
+    google::cloud::CompletionQueue& cq,
+    std::unique_ptr<grpc::ClientContext> context,
+    spanner_proto::BatchCreateSessionsRequest const& request) {
+  SetMetadata(*context, "database=" + request.database());
+  return child_->AsyncBatchCreateSessions(cq, std::move(context), request);
 }
 
 StatusOr<spanner_proto::Session> MetadataSpannerStub::GetSession(
@@ -77,14 +76,12 @@ Status MetadataSpannerStub::DeleteSession(
   return child_->DeleteSession(client_context, request);
 }
 
-std::unique_ptr<
-    grpc::ClientAsyncResponseReaderInterface<google::protobuf::Empty>>
-MetadataSpannerStub::AsyncDeleteSession(
-    grpc::ClientContext& client_context,
-    spanner_proto::DeleteSessionRequest const& request,
-    grpc::CompletionQueue* cq) {
-  SetMetadata(client_context, "name=" + request.name());
-  return child_->AsyncDeleteSession(client_context, request, cq);
+future<Status> MetadataSpannerStub::AsyncDeleteSession(
+    google::cloud::CompletionQueue& cq,
+    std::unique_ptr<grpc::ClientContext> context,
+    spanner_proto::DeleteSessionRequest const& request) {
+  SetMetadata(*context, "name=" + request.name());
+  return child_->AsyncDeleteSession(cq, std::move(context), request);
 }
 
 StatusOr<spanner_proto::ResultSet> MetadataSpannerStub::ExecuteSql(
@@ -94,14 +91,12 @@ StatusOr<spanner_proto::ResultSet> MetadataSpannerStub::ExecuteSql(
   return child_->ExecuteSql(client_context, request);
 }
 
-std::unique_ptr<
-    grpc::ClientAsyncResponseReaderInterface<spanner_proto::ResultSet>>
-MetadataSpannerStub::AsyncExecuteSql(
-    grpc::ClientContext& client_context,
-    spanner_proto::ExecuteSqlRequest const& request,
-    grpc::CompletionQueue* cq) {
-  SetMetadata(client_context, "session=" + request.session());
-  return child_->AsyncExecuteSql(client_context, request, cq);
+future<StatusOr<spanner_proto::ResultSet>> MetadataSpannerStub::AsyncExecuteSql(
+    google::cloud::CompletionQueue& cq,
+    std::unique_ptr<grpc::ClientContext> context,
+    spanner_proto::ExecuteSqlRequest const& request) {
+  SetMetadata(*context, "session=" + request.session());
+  return child_->AsyncExecuteSql(cq, std::move(context), request);
 }
 
 std::unique_ptr<grpc::ClientReaderInterface<spanner_proto::PartialResultSet>>

--- a/google/cloud/spanner/internal/metadata_spanner_stub.h
+++ b/google/cloud/spanner/internal/metadata_spanner_stub.h
@@ -41,12 +41,11 @@ class MetadataSpannerStub : public SpannerStub {
   BatchCreateSessions(
       grpc::ClientContext& client_context,
       google::spanner::v1::BatchCreateSessionsRequest const& request) override;
-  std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<
-      google::spanner::v1::BatchCreateSessionsResponse>>
+  future<StatusOr<google::spanner::v1::BatchCreateSessionsResponse>>
   AsyncBatchCreateSessions(
-      grpc::ClientContext& client_context,
-      google::spanner::v1::BatchCreateSessionsRequest const& request,
-      grpc::CompletionQueue* cq) override;
+      google::cloud::CompletionQueue& cq,
+      std::unique_ptr<grpc::ClientContext> context,
+      google::spanner::v1::BatchCreateSessionsRequest const& request) override;
   StatusOr<google::spanner::v1::Session> GetSession(
       grpc::ClientContext& client_context,
       google::spanner::v1::GetSessionRequest const& request) override;
@@ -56,19 +55,17 @@ class MetadataSpannerStub : public SpannerStub {
   Status DeleteSession(
       grpc::ClientContext& client_context,
       google::spanner::v1::DeleteSessionRequest const& request) override;
-  std::unique_ptr<
-      grpc::ClientAsyncResponseReaderInterface<google::protobuf::Empty>>
-  AsyncDeleteSession(grpc::ClientContext& client_context,
-                     google::spanner::v1::DeleteSessionRequest const& request,
-                     grpc::CompletionQueue* cq) override;
+  future<Status> AsyncDeleteSession(
+      google::cloud::CompletionQueue& cq,
+      std::unique_ptr<grpc::ClientContext> context,
+      google::spanner::v1::DeleteSessionRequest const& request) override;
   StatusOr<google::spanner::v1::ResultSet> ExecuteSql(
       grpc::ClientContext& client_context,
       google::spanner::v1::ExecuteSqlRequest const& request) override;
-  std::unique_ptr<
-      grpc::ClientAsyncResponseReaderInterface<google::spanner::v1::ResultSet>>
-  AsyncExecuteSql(grpc::ClientContext& client_context,
-                  google::spanner::v1::ExecuteSqlRequest const& request,
-                  grpc::CompletionQueue* cq) override;
+  future<StatusOr<google::spanner::v1::ResultSet>> AsyncExecuteSql(
+      google::cloud::CompletionQueue& cq,
+      std::unique_ptr<grpc::ClientContext> context,
+      google::spanner::v1::ExecuteSqlRequest const& request) override;
   std::unique_ptr<
       grpc::ClientReaderInterface<google::spanner::v1::PartialResultSet>>
   ExecuteStreamingSql(

--- a/google/cloud/spanner/internal/session_pool.h
+++ b/google/cloud/spanner/internal/session_pool.h
@@ -159,9 +159,9 @@ class SessionPool : public std::enable_shared_from_this<SessionPool> {
                            std::shared_ptr<SpannerStub> const& stub,
                            std::map<std::string, std::string> const& labels,
                            int num_sessions);
-  future<StatusOr<google::protobuf::Empty>> AsyncDeleteSession(
-      CompletionQueue& cq, std::shared_ptr<SpannerStub> const& stub,
-      std::string session_name);
+  future<Status> AsyncDeleteSession(CompletionQueue& cq,
+                                    std::shared_ptr<SpannerStub> const& stub,
+                                    std::string session_name);
   future<StatusOr<google::spanner::v1::ResultSet>> AsyncRefreshSession(
       CompletionQueue& cq, std::shared_ptr<SpannerStub> const& stub,
       std::string session_name);

--- a/google/cloud/spanner/internal/spanner_stub.h
+++ b/google/cloud/spanner/internal/spanner_stub.h
@@ -55,12 +55,12 @@ class SpannerStub {
   BatchCreateSessions(
       grpc::ClientContext& client_context,
       google::spanner::v1::BatchCreateSessionsRequest const& request) = 0;
-  virtual std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<
-      google::spanner::v1::BatchCreateSessionsResponse>>
+
+  virtual future<StatusOr<google::spanner::v1::BatchCreateSessionsResponse>>
   AsyncBatchCreateSessions(
-      grpc::ClientContext& client_context,
-      google::spanner::v1::BatchCreateSessionsRequest const& request,
-      grpc::CompletionQueue* cq) = 0;
+      google::cloud::CompletionQueue& cq,
+      std::unique_ptr<grpc::ClientContext> context,
+      google::spanner::v1::BatchCreateSessionsRequest const& request) = 0;
   virtual StatusOr<google::spanner::v1::Session> GetSession(
       grpc::ClientContext& client_context,
       google::spanner::v1::GetSessionRequest const& request) = 0;
@@ -70,19 +70,17 @@ class SpannerStub {
   virtual Status DeleteSession(
       grpc::ClientContext& client_context,
       google::spanner::v1::DeleteSessionRequest const& request) = 0;
-  virtual std::unique_ptr<
-      grpc::ClientAsyncResponseReaderInterface<google::protobuf::Empty>>
-  AsyncDeleteSession(grpc::ClientContext& client_context,
-                     google::spanner::v1::DeleteSessionRequest const& request,
-                     grpc::CompletionQueue* cq) = 0;
+  virtual future<Status> AsyncDeleteSession(
+      google::cloud::CompletionQueue& cq,
+      std::unique_ptr<grpc::ClientContext> context,
+      google::spanner::v1::DeleteSessionRequest const& request) = 0;
   virtual StatusOr<google::spanner::v1::ResultSet> ExecuteSql(
       grpc::ClientContext& client_context,
       google::spanner::v1::ExecuteSqlRequest const& request) = 0;
-  virtual std::unique_ptr<
-      grpc::ClientAsyncResponseReaderInterface<google::spanner::v1::ResultSet>>
-  AsyncExecuteSql(grpc::ClientContext& client_context,
-                  google::spanner::v1::ExecuteSqlRequest const& request,
-                  grpc::CompletionQueue* cq) = 0;
+  virtual future<StatusOr<google::spanner::v1::ResultSet>> AsyncExecuteSql(
+      google::cloud::CompletionQueue& cq,
+      std::unique_ptr<grpc::ClientContext> context,
+      google::spanner::v1::ExecuteSqlRequest const& request) = 0;
   virtual std::unique_ptr<
       grpc::ClientReaderInterface<google::spanner::v1::PartialResultSet>>
   ExecuteStreamingSql(

--- a/google/cloud/spanner/testing/mock_spanner_stub.h
+++ b/google/cloud/spanner/testing/mock_spanner_stub.h
@@ -38,13 +38,12 @@ class MockSpannerStub : public google::cloud::spanner_internal::SpannerStub {
                google::spanner::v1::BatchCreateSessionsRequest const&),
               (override));
 
-  MOCK_METHOD(std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<
-                  google::spanner::v1::BatchCreateSessionsResponse>>,
-              AsyncBatchCreateSessions,
-              (grpc::ClientContext&,
-               google::spanner::v1::BatchCreateSessionsRequest const&,
-               grpc::CompletionQueue*),
-              (override));
+  MOCK_METHOD(
+      future<StatusOr<google::spanner::v1::BatchCreateSessionsResponse>>,
+      AsyncBatchCreateSessions,
+      (CompletionQueue & cq, std::unique_ptr<grpc::ClientContext> context,
+       google::spanner::v1::BatchCreateSessionsRequest const& request),
+      (override));
 
   MOCK_METHOD(StatusOr<google::spanner::v1::Session>, GetSession,
               (grpc::ClientContext&,
@@ -61,25 +60,19 @@ class MockSpannerStub : public google::cloud::spanner_internal::SpannerStub {
                google::spanner::v1::DeleteSessionRequest const&),
               (override));
 
-  MOCK_METHOD(
-      std::unique_ptr<
-          grpc::ClientAsyncResponseReaderInterface<google::protobuf::Empty>>,
-      AsyncDeleteSession,
-      (grpc::ClientContext&, google::spanner::v1::DeleteSessionRequest const&,
-       grpc::CompletionQueue*),
-      (override));
+  MOCK_METHOD(future<Status>, AsyncDeleteSession,
+              (CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
+               google::spanner::v1::DeleteSessionRequest const&),
+              (override));
 
   MOCK_METHOD(StatusOr<google::spanner::v1::ResultSet>, ExecuteSql,
               (grpc::ClientContext&,
                google::spanner::v1::ExecuteSqlRequest const&),
               (override));
 
-  MOCK_METHOD(std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<
-                  google::spanner::v1::ResultSet>>,
-              AsyncExecuteSql,
-              (grpc::ClientContext&,
-               google::spanner::v1::ExecuteSqlRequest const&,
-               grpc::CompletionQueue*),
+  MOCK_METHOD(future<StatusOr<google::spanner::v1::ResultSet>>, AsyncExecuteSql,
+              (CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
+               google::spanner::v1::ExecuteSqlRequest const&),
               (override));
 
   MOCK_METHOD(


### PR DESCRIPTION
Prefer `AsyncRetryLoop` which uses our `CompletionQueue` instead of the `grpc::CompletionQueue`. The mocks are also nicer.

With this PR, the only remaining uses of `StartRetryAsyncUnaryRpc` are in Bigtable. Eventually they will be removed as part of the effort to modernize Bigtable.

Also change the return type of `SessionPool::AsyncDeleteSession` to drop the `protobuf::Empty`. This function is not called outside of an integration test at the moment, but we plan to use it later.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7704)
<!-- Reviewable:end -->
