### PR TITLE
ci: always print emulator log on errors

### DIFF
--- a/google/cloud/storage/tools/run_emulator_utils.sh
+++ b/google/cloud/storage/tools/run_emulator_utils.sh
@@ -91,7 +91,7 @@ start_emulator() {
   if [[ "${connected}" == "no" ]]; then
     io::log_red "Cannot connect to emulator; aborting test."
     io::log_red "curl connection test result."
-    curl "${HTTPBIN_ENDPOINT}/get"
+    curl "${HTTPBIN_ENDPOINT}/get" || true
     io::log_red "emulator log."
     cat gcs_emulator.log
     exit 1


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7712)
<!-- Reviewable:end -->
