### PR TITLE
ci: storage emulator and caching

### DIFF
--- a/ci/cloudbuild/builds/lib/integration.sh
+++ b/ci/cloudbuild/builds/lib/integration.sh
@@ -28,8 +28,9 @@ source module ci/lib/io.sh
 
 # To run the integration tests we need to install the dependencies for the storage emulator
 export PATH="${HOME}/.local/bin:${PATH}"
-rm -fr "${HOME}/.local"
-python3 -m pip install --user --quiet "git+https://github.com/googleapis/storage-testbench@v0.10.0"
+python3 -m pip uninstall -y --quiet googleapis-storage-testbench
+python3 -m pip uninstall -y --user --quiet googleapis-storage-testbench
+python3 -m pip install --upgrade --user --quiet "git+https://github.com/googleapis/storage-testbench@v0.10.0"
 
 # Some of the tests will need a valid roots.pem file.
 rm -f /dev/shm/roots.pem

--- a/ci/cloudbuild/builds/lib/integration.sh
+++ b/ci/cloudbuild/builds/lib/integration.sh
@@ -29,7 +29,6 @@ source module ci/lib/io.sh
 # To run the integration tests we need to install the dependencies for the storage emulator
 export PATH="${HOME}/.local/bin:${PATH}"
 python3 -m pip uninstall -y --quiet googleapis-storage-testbench
-python3 -m pip uninstall -y --user --quiet googleapis-storage-testbench
 python3 -m pip install --upgrade --user --quiet "git+https://github.com/googleapis/storage-testbench@v0.10.0"
 
 # Some of the tests will need a valid roots.pem file.

--- a/ci/cloudbuild/builds/lib/integration.sh
+++ b/ci/cloudbuild/builds/lib/integration.sh
@@ -28,7 +28,8 @@ source module ci/lib/io.sh
 
 # To run the integration tests we need to install the dependencies for the storage emulator
 export PATH="${HOME}/.local/bin:${PATH}"
-python3 -m pip install --quiet "git+https://github.com/googleapis/storage-testbench@v0.9.0"
+rm -fr "${HOME}/.local"
+python3 -m pip install --user --quiet "git+https://github.com/googleapis/storage-testbench@v0.10.0"
 
 # Some of the tests will need a valid roots.pem file.
 rm -f /dev/shm/roots.pem

--- a/google/cloud/storage/ci/run_integration_tests_emulator_bazel.sh
+++ b/google/cloud/storage/ci/run_integration_tests_emulator_bazel.sh
@@ -89,7 +89,7 @@ printf '{"name": "%s"}' "${GOOGLE_CLOUD_CPP_STORAGE_TEST_DESTINATION_BUCKET_NAME
 # version and other info, but no details about the contents.
 TESTBENCH_SHA="$(pip show googleapis-storage-testbench | sha256sum)"
 # With these two commands we extract the SHA of the testbench contents. It
-# excludes the contents of its deps (say gRPC, or Flask), those are unlikely
+# excludes the contents of its deps (say gRPC, or Flask), as those are unlikely
 # to affect the results of the test.
 TESTBENCH_LOCATION="$(pip show googleapis-storage-testbench | sed -n 's/^Location: //p')"
 TESTBENCH_CONTENTS_SHA="$(

--- a/google/cloud/storage/ci/run_integration_tests_emulator_bazel.sh
+++ b/google/cloud/storage/ci/run_integration_tests_emulator_bazel.sh
@@ -30,7 +30,14 @@ shift
 BAZEL_VERB="$1"
 shift
 
-bazel_test_args=()
+EMULATOR_SHA="$(find "${HOME}/.local/" -type f -name '*.py' -print0 |
+  xargs -0 sha256sum | sort | sha256sum -)"
+readonly EMULATOR_SHA
+
+bazel_test_args=(
+  # Run the tests again if the emulator has changed
+  --test_env=CLOUD_STORAGE_EMULATOR_SHA="${EMULATOR_SHA}"
+)
 excluded_targets=()
 
 # Separate caller-provided excluded targets (starting with "-//..."), so that


### PR DESCRIPTION
Always install the storage emulator in $HOME/.local, so we can predict
where all its files are, and we can clean up before an install.  Ensure
the test cache is invalidated by newer versions of the storage emulator.

Part of the work for #7677

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7713)
<!-- Reviewable:end -->
