### PR TITLE
feat(spanner): add per-operation options to Commit() and Rollback()

### DIFF
--- a/google/cloud/spanner/CMakeLists.txt
+++ b/google/cloud/spanner/CMakeLists.txt
@@ -83,6 +83,7 @@ add_library(
     client.h
     client_options.cc
     client_options.h
+    commit_options.cc
     commit_options.h
     commit_result.h
     connection.h

--- a/google/cloud/spanner/client_test.cc
+++ b/google/cloud/spanner/client_test.cc
@@ -822,7 +822,7 @@ TEST(ClientTest, CommitMutatorWithTags) {
     return Mutations{};
   };
   auto result = client.Commit(
-      mutator, CommitOptions{}.set_transaction_tag(transaction_tag));
+      mutator, Options{}.set<TransactionTagOption>(transaction_tag));
   EXPECT_STATUS_OK(result);
   EXPECT_EQ(*timestamp, result->commit_timestamp);
 }
@@ -946,7 +946,7 @@ TEST(ClientTest, CommitStats) {
 
   Client client(conn);
   auto result =
-      client.Commit(Mutations{}, CommitOptions{}.set_return_stats(true));
+      client.Commit(Mutations{}, Options{}.set<CommitReturnStatsOption>(true));
   ASSERT_STATUS_OK(result);
   EXPECT_EQ(*timestamp, result->commit_timestamp);
   ASSERT_TRUE(result->commit_stats.has_value());

--- a/google/cloud/spanner/commit_options.cc
+++ b/google/cloud/spanner/commit_options.cc
@@ -1,0 +1,46 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/spanner/commit_options.h"
+#include "google/cloud/spanner/options.h"
+
+namespace google {
+namespace cloud {
+namespace spanner {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+
+CommitOptions::CommitOptions(Options const& opts)
+    : return_stats_(opts.has<CommitReturnStatsOption>()
+                        ? opts.get<CommitReturnStatsOption>()
+                        : false) {
+  if (opts.has<RequestPriorityOption>()) {
+    request_priority_ = opts.get<RequestPriorityOption>();
+  }
+  if (opts.has<TransactionTagOption>()) {
+    transaction_tag_ = opts.get<TransactionTagOption>();
+  }
+}
+
+CommitOptions::operator Options() const {
+  Options opts;
+  if (return_stats_) opts.set<CommitReturnStatsOption>(true);
+  if (request_priority_) opts.set<RequestPriorityOption>(*request_priority_);
+  if (transaction_tag_) opts.set<TransactionTagOption>(*transaction_tag_);
+  return opts;
+}
+
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace spanner
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/spanner/commit_options.h
+++ b/google/cloud/spanner/commit_options.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/spanner/request_priority.h"
 #include "google/cloud/spanner/version.h"
+#include "google/cloud/options.h"
 #include "absl/types/optional.h"
 #include <string>
 
@@ -35,6 +36,18 @@ class CommitOptions {
  public:
   /// Default options: no stats.
   CommitOptions() = default;
+
+  /**
+   * Constructs from the the new, recommended way to represent options
+   * of all varieties, `google::cloud::Options`.
+   */
+  explicit CommitOptions(Options const& opts);
+
+  /**
+   * Converts to the new, recommended way to represent options of all
+   * varieties, `google::cloud::Options`.
+   */
+  explicit operator Options() const;
 
   /// Set whether the `CommitResult` should contain `CommitStats`.
   CommitOptions& set_return_stats(bool return_stats) {

--- a/google/cloud/spanner/commit_options_test.cc
+++ b/google/cloud/spanner/commit_options_test.cc
@@ -39,6 +39,17 @@ TEST(CommitOptionsTest, SetValues) {
   EXPECT_EQ("tag", options.transaction_tag());
 }
 
+TEST(CommitOptionsTest, OptionsRoundTrip) {
+  CommitOptions options;
+  options.set_return_stats(true);
+  options.set_request_priority(RequestPriority::kLow);
+  options.set_transaction_tag("tag");
+  CommitOptions rt_options(Options{options});
+  EXPECT_TRUE(rt_options.return_stats());
+  EXPECT_EQ(RequestPriority::kLow, rt_options.request_priority());
+  EXPECT_EQ("tag", rt_options.transaction_tag());
+}
+
 }  // namespace
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace spanner

--- a/google/cloud/spanner/google_cloud_cpp_spanner.bzl
+++ b/google/cloud/spanner/google_cloud_cpp_spanner.bzl
@@ -133,6 +133,7 @@ google_cloud_cpp_spanner_srcs = [
     "bytes.cc",
     "client.cc",
     "client_options.cc",
+    "commit_options.cc",
     "connection_options.cc",
     "database.cc",
     "database_admin_client.cc",

--- a/google/cloud/spanner/options.h
+++ b/google/cloud/spanner/options.h
@@ -187,6 +187,21 @@ struct RequestTagOption {
 };
 
 /**
+ * Option for `google::cloud::Options` to set a per-transaction tag.
+ */
+struct TransactionTagOption {
+  using Type = std::string;
+};
+
+/**
+ * Option for `google::cloud::Options` to return additional statistics
+ * about the committed transaction in a `spanner::CommitResult`.
+ */
+struct CommitReturnStatsOption {
+  using Type = bool;
+};
+
+/**
  * List of Request options for `client::ExecuteBatchDml()`.
  */
 using RequestOptionList = OptionList<RequestPriorityOption, RequestTagOption>;

--- a/google/cloud/spanner/samples/samples.cc
+++ b/google/cloud/spanner/samples/samples.cc
@@ -2059,7 +2059,8 @@ void SetTransactionTag(google::cloud::spanner::Client client) {
   // Sets the transaction tag to "app=concert,env=dev". This will be
   // applied to all the individual operations inside this transaction.
   auto commit_options =
-      spanner::CommitOptions{}.set_transaction_tag("app=concert,env=dev");
+      google::cloud::Options{}.set<spanner::TransactionTagOption>(
+          "app=concert,env=dev");
   auto commit = client.Commit(
       [&client](
           spanner::Transaction const& txn) -> StatusOr<spanner::Mutations> {
@@ -2379,7 +2380,7 @@ void GetCommitStatistics(google::cloud::spanner::Client client) {
               .EmplaceRow(1, 1, 200000)
               .EmplaceRow(2, 2, 400000)
               .Build()},
-      spanner::CommitOptions{}.set_return_stats(true));
+      google::cloud::Options{}.set<spanner::CommitReturnStatsOption>(true));
   //! [commit-options]
 
   if (!commit) throw std::runtime_error(commit.status().message());


### PR DESCRIPTION
Part of #7690 to add an `Options opts = {}` argument to `Commit()`
and `Rollback()` operations.  Add new `TransactionTagOption` and
`CommitReturnStatsOption` types to accompany `RequestPriorityOption`.
This means the caller no longer needs `CommitOptions` (although it is
still used in the `Connection` layer).

Run the `Client` options through `spanner_internal::DefaultOptions()`.
Note that per-operation options strictly override those client-level
options.

Add `OptionsSpan` local variables to `Commit()` and `Rollback()`
(and also `ExecuteBatchDml()`, which already took plain `Options`).

Clarify which constructor and operation overloads are for backwards
compatibility so that they will be easier to deprecate/remove later.
Also clarify some doxygen comments about `Options` parameters.

Finally, update the `Client` test and sample code to use the new
options.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7714)
<!-- Reviewable:end -->
