### PR TITLE
fix: missing dependency for WIN32

### DIFF
--- a/google/cloud/storage/CMakeLists.txt
+++ b/google/cloud/storage/CMakeLists.txt
@@ -267,6 +267,11 @@ target_link_libraries(
            OpenSSL::SSL
            OpenSSL::Crypto
            ZLIB::ZLIB)
+if (WIN32)
+    # We use `setsockopt()` directly, which requires the ws2_32 (Winsock2 for
+    # Windows32?) library on Windows.
+    target_link_libraries(google_cloud_cpp_storage PUBLIC ws2_32)
+endif ()
 google_cloud_cpp_add_common_options(google_cloud_cpp_storage)
 target_include_directories(
     google_cloud_cpp_storage PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>


### PR DESCRIPTION
We were missing a direct dependency on Windows. It probably went
unnoticed because in our tests we get this dependency indirectly. It is
important for Conda support.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7718)
<!-- Reviewable:end -->
