### PR TITLE
cleanup(storage): remove old workaround for HMAC keys

### DIFF
--- a/google/cloud/storage/tests/service_account_integration_test.cc
+++ b/google/cloud/storage/tests/service_account_integration_test.cc
@@ -111,11 +111,7 @@ TEST_F(ServiceAccountIntegrationTest, HmacKeyCRUD) {
   ASSERT_STATUS_OK(get_details);
 
   EXPECT_EQ(access_id, get_details->access_id());
-  HmacKeyMetadata original = key->first;
-  // TODO(#3806) - remove this workaround: the etag may have changed since the
-  // key was created.
-  original.set_etag(get_details->etag());
-  EXPECT_EQ(original, *get_details);
+  EXPECT_EQ(key->first, *get_details);
 
   StatusOr<HmacKeyMetadata> update_details =
       client.UpdateHmacKey(access_id, HmacKeyMetadata().set_state("INACTIVE"));


### PR DESCRIPTION
Fixes #3806.  The internal bug was fixed circa 2019-07-01

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7723)
<!-- Reviewable:end -->
