### PR TITLE
feat: file_status supports op==

### DIFF
--- a/google/cloud/internal/filesystem.h
+++ b/google/cloud/internal/filesystem.h
@@ -116,6 +116,13 @@ class file_status {  // NOLINT(readability-identifier-naming)
   perms permissions() const noexcept { return permissions_; }
   void permissions(perms permissions) noexcept { permissions_ = permissions; }
 
+  friend bool operator==(file_status const& a, file_status const& b) noexcept {
+    return a.type_ == b.type_ && a.permissions_ == b.permissions_;
+  }
+  friend bool operator!=(file_status const& a, file_status const& b) noexcept {
+    return !(a == b);
+  }
+
  private:
   file_type type_;
   perms permissions_;

--- a/google/cloud/internal/filesystem_test.cc
+++ b/google/cloud/internal/filesystem_test.cc
@@ -77,6 +77,16 @@ TEST(FilesystemTest, PermissionsOperatorBitxorEquals) {
   EXPECT_EQ(0600, static_cast<unsigned>(lhs));
 }
 
+TEST(FilesystemTest, Equality) {
+  auto a = file_status(file_type::socket, perms::group_read);
+  auto b = a;
+  EXPECT_EQ(a, b);
+  auto c = file_status(file_type::regular, perms::group_read);
+  EXPECT_NE(c, a);
+  c = file_status(file_type::socket, perms::owner_read);
+  EXPECT_NE(c, a);
+}
+
 TEST(FilesystemTest, StatusDirectory) {
   std::error_code ec;
   auto file_status = status(".", ec);


### PR DESCRIPTION
Part of: https://github.com/googleapis/google-cloud-cpp/issues/2310

`google::cloud::internal::file_status` is a value type supporing
assignment and therefore should also support equality. And indeed since
C++20, the std version does as well: https://en.cppreference.com/w/cpp/filesystem/file_status/operator%3D%3D

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7724)
<!-- Reviewable:end -->
