### PR TITLE
test(bigtable): ignore warning when deleting app profile

### DIFF
--- a/google/cloud/bigtable/admin/integration_tests/instance_admin_integration_test.cc
+++ b/google/cloud/bigtable/admin/integration_tests/instance_admin_integration_test.cc
@@ -257,13 +257,21 @@ TEST_F(InstanceAdminIntegrationTest, CreateListGetDeleteAppProfile) {
   ASSERT_STATUS_OK(profile_2);
   EXPECT_EQ("new description", profile_2->description());
 
-  ASSERT_STATUS_OK(client_.DeleteAppProfile(name_1));
+  btadmin::DeleteAppProfileRequest req_1;
+  req_1.set_ignore_warnings(true);
+  req_1.set_name(name_1);
+
+  ASSERT_STATUS_OK(client_.DeleteAppProfile(std::move(req_1)));
   profiles = profile_names(client_.ListAppProfiles(instance_name));
   ASSERT_STATUS_OK(profiles);
   EXPECT_THAT(*profiles, Not(Contains(name_1)));
   EXPECT_THAT(*profiles, ContainsOnce(name_2));
 
-  ASSERT_STATUS_OK(client_.DeleteAppProfile(name_2));
+  btadmin::DeleteAppProfileRequest req_2;
+  req_2.set_ignore_warnings(true);
+  req_2.set_name(name_2);
+
+  ASSERT_STATUS_OK(client_.DeleteAppProfile(std::move(req_2)));
   profiles = profile_names(client_.ListAppProfiles(instance_name));
   ASSERT_STATUS_OK(profiles);
   EXPECT_THAT(*profiles, Not(Contains(name_1)));

--- a/google/cloud/bigtable/tests/instance_admin_emulator.cc
+++ b/google/cloud/bigtable/tests/instance_admin_emulator.cc
@@ -444,6 +444,11 @@ class InstanceAdminEmulator final
     if (i == app_profiles_.end()) {
       return grpc::Status(grpc::StatusCode::NOT_FOUND, "app profile not found");
     }
+    if (!request->ignore_warnings()) {
+      return grpc::Status(
+          grpc::StatusCode::FAILED_PRECONDITION,
+          "Deleting an app profile will cause all requests using it to fail.");
+    }
     app_profiles_.erase(i);
     return grpc::Status::OK;
   }


### PR DESCRIPTION
If you try to delete an app profile, the Bigtable service will not take you seriously unless you set ignore warnings to true.

This change makes the instance admin emulator better reflect the functionality of the service. It also updates the integration test to set ignore warnings. (I did not realize this before, because the test is not run against production; only the emulator).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7725)
<!-- Reviewable:end -->
