### PR TITLE
chore(generator): use an escape sequence instead of a literal tab

### DIFF
--- a/generator/internal/scaffold_generator.cc
+++ b/generator/internal/scaffold_generator.cc
@@ -971,7 +971,7 @@ CLIENT_CXXLDFLAGS := $$(shell pkg-config $$(CLIENT_MODULE) --libs-only-L)
 CLIENT_LIBS       := $$(shell pkg-config $$(CLIENT_MODULE) --libs-only-l)
 
 $$(BIN)/quickstart: quickstart.cc
-	$$(CXXLD) $$(CXXFLAGS) $$(CLIENT_CXXFLAGS) $$(CLIENT_CXXLDFLAGS) -o $$@ $$^ $$(CLIENT_LIBS)
+\t$$(CXXLD) $$(CXXFLAGS) $$(CLIENT_CXXFLAGS) $$(CLIENT_CXXLDFLAGS) -o $$@ $$^ $$(CLIENT_LIBS)
 )""";
   google::protobuf::io::OstreamOutputStream output(&os);
   google::protobuf::io::Printer printer(&output, '$');


### PR DESCRIPTION
Some simple tools won't like (what looks like) a line in a cc file
beginning with a horizontal tab.  Here it is really part of a multi-
line raw string literal, so we can simply replace it with `\t`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7726)
<!-- Reviewable:end -->
