### PR TITLE
ore(spanner): rename spanner optimizer options

### DIFF
--- a/google/cloud/spanner/client_options.cc
+++ b/google/cloud/spanner/client_options.cc
@@ -24,12 +24,12 @@ ClientOptions::operator Options() const {
   Options opts;
   auto optimizer_version = query_options_.optimizer_version();
   if (optimizer_version) {
-    opts.set<RequestOptimizerVersionOption>(*optimizer_version);
+    opts.set<QueryOptimizerVersionOption>(*optimizer_version);
   }
   auto optimizer_statistics_package =
       query_options_.optimizer_statistics_package();
   if (optimizer_statistics_package) {
-    opts.set<RequestOptimizerStatisticsPackageOption>(
+    opts.set<QueryOptimizerStatisticsPackageOption>(
         *optimizer_statistics_package);
   }
   auto request_priority = query_options_.request_priority();

--- a/google/cloud/spanner/client_options_test.cc
+++ b/google/cloud/spanner/client_options_test.cc
@@ -41,8 +41,8 @@ TEST(ClientOptionsTest, OptimizerVersion) {
 TEST(ClientOptionsTest, OptionsConversionEmpty) {
   ClientOptions const client_options;
   auto const options = Options(client_options);
-  EXPECT_FALSE(options.has<RequestOptimizerVersionOption>());
-  EXPECT_FALSE(options.has<RequestOptimizerStatisticsPackageOption>());
+  EXPECT_FALSE(options.has<QueryOptimizerVersionOption>());
+  EXPECT_FALSE(options.has<QueryOptimizerStatisticsPackageOption>());
   EXPECT_FALSE(options.has<RequestPriorityOption>());
   EXPECT_FALSE(options.has<RequestTagOption>());
 }
@@ -56,10 +56,10 @@ TEST(ClientOptionsTest, OptionsConversionFull) {
   ClientOptions client_options;
   client_options.set_query_options(std::move(query_options));
   auto const options = Options(client_options);
-  EXPECT_TRUE(options.has<RequestOptimizerVersionOption>());
-  EXPECT_EQ(options.get<RequestOptimizerVersionOption>(), "1");
-  EXPECT_TRUE(options.has<RequestOptimizerStatisticsPackageOption>());
-  EXPECT_EQ(options.get<RequestOptimizerStatisticsPackageOption>(), "latest");
+  EXPECT_TRUE(options.has<QueryOptimizerVersionOption>());
+  EXPECT_EQ(options.get<QueryOptimizerVersionOption>(), "1");
+  EXPECT_TRUE(options.has<QueryOptimizerStatisticsPackageOption>());
+  EXPECT_EQ(options.get<QueryOptimizerStatisticsPackageOption>(), "latest");
   EXPECT_TRUE(options.has<RequestPriorityOption>());
   EXPECT_EQ(options.get<RequestPriorityOption>(), RequestPriority::kHigh);
   EXPECT_TRUE(options.has<RequestTagOption>());

--- a/google/cloud/spanner/options.h
+++ b/google/cloud/spanner/options.h
@@ -160,7 +160,7 @@ using SessionPoolOptionList = OptionList<
  * Option for `google::cloud::Options` to set the optimizer version used in an
  * SQL query.
  */
-struct RequestOptimizerVersionOption {
+struct QueryOptimizerVersionOption {
   using Type = std::string;
 };
 
@@ -168,7 +168,7 @@ struct RequestOptimizerVersionOption {
  * Option for `google::cloud::Options` to set the optimizer statistics package
  * used in an SQL query.
  */
-struct RequestOptimizerStatisticsPackageOption {
+struct QueryOptimizerStatisticsPackageOption {
   using Type = std::string;
 };
 

--- a/google/cloud/spanner/query_options.cc
+++ b/google/cloud/spanner/query_options.cc
@@ -21,12 +21,12 @@ namespace spanner {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 QueryOptions::QueryOptions(Options const& opts) {
-  if (opts.has<RequestOptimizerVersionOption>()) {
-    optimizer_version_ = opts.get<RequestOptimizerVersionOption>();
+  if (opts.has<QueryOptimizerVersionOption>()) {
+    optimizer_version_ = opts.get<QueryOptimizerVersionOption>();
   }
-  if (opts.has<RequestOptimizerStatisticsPackageOption>()) {
+  if (opts.has<QueryOptimizerStatisticsPackageOption>()) {
     optimizer_statistics_package_ =
-        opts.get<RequestOptimizerStatisticsPackageOption>();
+        opts.get<QueryOptimizerStatisticsPackageOption>();
   }
   if (opts.has<RequestPriorityOption>()) {
     request_priority_ = opts.get<RequestPriorityOption>();

--- a/google/cloud/spanner/query_options_test.cc
+++ b/google/cloud/spanner/query_options_test.cc
@@ -95,8 +95,8 @@ TEST(QueryOptionsTest, FromOptionsEmpty) {
 
 TEST(QueryOptionsTest, FromOptionsFull) {
   auto const opts = Options{}
-                        .set<RequestOptimizerVersionOption>("1")
-                        .set<RequestOptimizerStatisticsPackageOption>("latest")
+                        .set<QueryOptimizerVersionOption>("1")
+                        .set<QueryOptimizerStatisticsPackageOption>("latest")
                         .set<RequestPriorityOption>(RequestPriority::kHigh)
                         .set<RequestTagOption>("tag");
   QueryOptions const query_opts(opts);


### PR DESCRIPTION
Revisit a decision from a few days ago on the naming of the Spanner
optimizer options, before they find more widespread release.  To wit,
```
s/RequestOptimizer/QueryOptimizer/
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7728)
<!-- Reviewable:end -->
