### PR TITLE
cleanup(bigtable): prefer generated instance admin API

### DIFF
--- a/google/cloud/bigtable/CMakeLists.txt
+++ b/google/cloud/bigtable/CMakeLists.txt
@@ -211,6 +211,8 @@ create_bazel_config(google_cloud_cpp_bigtable)
 if (BUILD_TESTING)
     add_library(
         bigtable_client_testing # cmake-format: sort
+        admin/mocks/mock_bigtable_instance_admin_connection.h
+        admin/mocks/mock_bigtable_table_admin_connection.h
         testing/cleanup_stale_resources.cc
         testing/cleanup_stale_resources.h
         testing/embedded_server_test_fixture.cc

--- a/google/cloud/bigtable/bigtable_client_testing.bzl
+++ b/google/cloud/bigtable/bigtable_client_testing.bzl
@@ -17,6 +17,8 @@
 """Automatically generated source lists for bigtable_client_testing - DO NOT EDIT."""
 
 bigtable_client_testing_hdrs = [
+    "admin/mocks/mock_bigtable_instance_admin_connection.h",
+    "admin/mocks/mock_bigtable_table_admin_connection.h",
     "testing/cleanup_stale_resources.h",
     "testing/embedded_server_test_fixture.h",
     "testing/inprocess_admin_client.h",

--- a/google/cloud/bigtable/doc/bigtable-samples-grpc-credentials.dox
+++ b/google/cloud/bigtable/doc/bigtable-samples-grpc-credentials.dox
@@ -30,11 +30,11 @@ The following code shows how to use access token to connect to an `InstanceAdmin
 Sample code to connect to InstanceAdmin endpoint
 
 ```
-#include "google/cloud/bigtable/instance_admin.h"
-#include "google/cloud/bigtable/instance_admin_client.h"
+#include "google/cloud/bigtable/admin/bigtable_instance_admin_client.h"
 
 int main(int argc, char* argv[]) try {
   namespace cbt = ::google::cloud::bigtable;
+  namespace cbta = ::google::cloud::bigtable_admin;
   namespace gc = ::google::cloud;
   std::string const project_id = argv[1];
   grpc::string refresh_token = R"""({
@@ -48,10 +48,10 @@ int main(int argc, char* argv[]) try {
       grpc::SslCredentials(grpc::SslCredentialsOptions());
   auto credentials =
       grpc::CompositeChannelCredentials(channel_credentials, call_credentials);
-  auto instance_admin_client(cbt::MakeInstanceAdminClient(
-      project_id, gc::Options{}.set<gc::GrpcCredentialOption>(credentials)));
-  cbt::InstanceAdmin instance_admin(instance_admin_client);
-  auto instances = instance_admin.ListInstances();
+  auto client = cbta::BigtableInstanceAdminClient(
+      cbta::MakeBigtableInstanceAdminConnection(
+          gc::Options{}.set<gc::GrpcCredentialOption>(credentials)));
+  auto instances = client.ListInstances(cbt::InstanceName(project_id, "-"));
   return 0;
 } catch (std::exception const& ex) {
   std::cerr << "Standard C++ exception raised: " << ex.what() << std::endl;

--- a/google/cloud/bigtable/examples/bigtable_examples_common.cc
+++ b/google/cloud/bigtable/examples/bigtable_examples_common.cc
@@ -42,9 +42,9 @@ bool RunAdminIntegrationTests() {
              .value_or("") == "yes";
 }
 
-google::cloud::bigtable::examples::Commands::value_type MakeCommandEntry(
-    std::string const& name, std::vector<std::string> const& args,
-    TableCommandType const& function) {
+Commands::value_type MakeCommandEntry(std::string const& name,
+                                      std::vector<std::string> const& args,
+                                      TableCommandType const& function) {
   auto command = [=](std::vector<std::string> argv) {
     if ((argv.size() == 1 && argv[0] == "--help") ||
         argv.size() != 3 + args.size()) {
@@ -93,10 +93,9 @@ Commands::value_type MakeCommandEntry(
       if (!args.empty()) os << " " << absl::StrJoin(args, " ");
       throw Usage{std::move(os).str()};
     }
-    google::cloud::bigtable::InstanceAdmin instance(
-        google::cloud::bigtable::MakeInstanceAdminClient(argv[0]));
-    argv.erase(argv.begin(), argv.begin() + kFixedArguments);
-    function(instance, argv);
+    auto client = bigtable_admin::BigtableInstanceAdminClient(
+        bigtable_admin::MakeBigtableInstanceAdminConnection());
+    function(client, argv);
   };
   return {name, command};
 }

--- a/google/cloud/bigtable/examples/bigtable_examples_common.h
+++ b/google/cloud/bigtable/examples/bigtable_examples_common.h
@@ -15,7 +15,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_EXAMPLES_BIGTABLE_EXAMPLES_COMMON_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_EXAMPLES_BIGTABLE_EXAMPLES_COMMON_H
 
-#include "google/cloud/bigtable/instance_admin.h"
+#include "google/cloud/bigtable/admin/bigtable_instance_admin_client.h"
 #include "google/cloud/bigtable/table.h"
 #include "google/cloud/bigtable/table_admin.h"
 #include "google/cloud/internal/random.h"
@@ -70,7 +70,7 @@ Commands::value_type MakeCommandEntry(std::string const& name,
                                       TableAdminCommandType const& function);
 
 using InstanceAdminCommandType = std::function<void(
-    google::cloud::bigtable::InstanceAdmin, std::vector<std::string>)>;
+    bigtable_admin::BigtableInstanceAdminClient, std::vector<std::string>)>;
 
 Commands::value_type MakeCommandEntry(std::string const& name,
                                       std::vector<std::string> const& args,

--- a/google/cloud/bigtable/examples/bigtable_examples_common_test.cc
+++ b/google/cloud/bigtable/examples/bigtable_examples_common_test.cc
@@ -84,12 +84,14 @@ TEST(BigtableExamplesCommon, MakeInstanceAdminCommandEntry) {
       "BIGTABLE_EMULATOR_HOST", "localhost:9090");
 
   int call_count = 0;
-  auto command = [&call_count](bigtable::InstanceAdmin const&,
-                               std::vector<std::string> const& argv) {
+  auto command = [&call_count](
+                     bigtable_admin::BigtableInstanceAdminClient const&,
+                     std::vector<std::string> const& argv) {
     ++call_count;
-    ASSERT_EQ(2, argv.size());
-    EXPECT_EQ("a", argv[0]);
-    EXPECT_EQ("b", argv[1]);
+    ASSERT_EQ(3, argv.size());
+    EXPECT_EQ("project", argv[0]);
+    EXPECT_EQ("a", argv[1]);
+    EXPECT_EQ("b", argv[2]);
   };
   auto const actual = MakeCommandEntry("command-name", {"foo", "bar"}, command);
   EXPECT_EQ("command-name", actual.first);
@@ -102,7 +104,7 @@ TEST(BigtableExamplesCommon, MakeInstanceAdminCommandEntry) {
       },
       Usage);
 
-  ASSERT_NO_FATAL_FAILURE(actual.second({"unused", "a", "b"}));
+  ASSERT_NO_FATAL_FAILURE(actual.second({"project", "a", "b"}));
   EXPECT_EQ(1, call_count);
 }
 

--- a/google/cloud/bigtable/examples/bigtable_instance_admin_snippets.cc
+++ b/google/cloud/bigtable/examples/bigtable_instance_admin_snippets.cc
@@ -12,35 +12,49 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "google/cloud/bigtable/admin/bigtable_instance_admin_client.h"
 #include "google/cloud/bigtable/examples/bigtable_examples_common.h"
-#include "google/cloud/bigtable/instance_admin.h"
 #include "google/cloud/bigtable/testing/cleanup_stale_resources.h"
 #include "google/cloud/bigtable/testing/random_names.h"
 #include "google/cloud/internal/absl_str_join_quiet.h"
 #include "google/cloud/internal/getenv.h"
+#include "google/cloud/project.h"
 #include "google/cloud/testing_util/crash_handler.h"
+#include <iterator>
 
 namespace {
 
 using ::google::cloud::bigtable::examples::Usage;
 
-void CreateInstance(google::cloud::bigtable::InstanceAdmin instance_admin,
-                    std::vector<std::string> const& argv) {
+void CreateInstance(
+    google::cloud::bigtable_admin::BigtableInstanceAdminClient instance_admin,
+    std::vector<std::string> const& argv) {
   //! [create instance] [START bigtable_create_prod_instance]
-  namespace cbt = ::google::cloud::bigtable;
+  namespace cbta = ::google::cloud::bigtable_admin;
   using ::google::cloud::future;
+  using ::google::cloud::Project;
   using ::google::cloud::StatusOr;
-  [](cbt::InstanceAdmin instance_admin, std::string const& instance_id,
+  [](cbta::BigtableInstanceAdminClient instance_admin,
+     std::string const& project_id, std::string const& instance_id,
      std::string const& zone) {
-    std::string display_name("Put description here");
+    std::string project_name = Project(project_id).FullName();
     std::string cluster_id = instance_id + "-c1";
-    auto cluster_config = cbt::ClusterConfig(zone, 3, cbt::ClusterConfig::HDD);
-    cbt::InstanceConfig config(instance_id, display_name,
-                               {{cluster_id, cluster_config}});
-    config.set_type(cbt::InstanceConfig::PRODUCTION);
+
+    google::bigtable::admin::v2::Instance in;
+    in.set_type(google::bigtable::admin::v2::Instance::PRODUCTION);
+    in.set_display_name("Put description here");
+
+    google::bigtable::admin::v2::Cluster cluster;
+    cluster.set_location(project_name + "/locations/" + zone);
+    cluster.set_serve_nodes(3);
+    cluster.set_default_storage_type(google::bigtable::admin::v2::HDD);
+
+    std::map<std::string, google::bigtable::admin::v2::Cluster> cluster_map = {
+        {cluster_id, std::move(cluster)}};
 
     future<StatusOr<google::bigtable::admin::v2::Instance>> instance_future =
-        instance_admin.CreateInstance(config);
+        instance_admin.CreateInstance(project_name, instance_id, std::move(in),
+                                      std::move(cluster_map));
     // Show how to perform additional work while the long running operation
     // completes. The application could use future.then() instead.
     std::cout << "Waiting for instance creation to complete " << std::flush;
@@ -51,26 +65,39 @@ void CreateInstance(google::cloud::bigtable::InstanceAdmin instance_admin,
     std::cout << "DONE, details=" << instance->DebugString() << "\n";
   }
   //! [create instance] [END bigtable_create_prod_instance]
-  (std::move(instance_admin), argv.at(0), argv.at(1));
+  (std::move(instance_admin), argv.at(0), argv.at(1), argv.at(2));
 }
 
-void CreateDevInstance(google::cloud::bigtable::InstanceAdmin instance_admin,
-                       std::vector<std::string> const& argv) {
+void CreateDevInstance(
+    google::cloud::bigtable_admin::BigtableInstanceAdminClient instance_admin,
+    std::vector<std::string> const& argv) {
   //! [create dev instance] [START bigtable_create_dev_instance]
-  namespace cbt = ::google::cloud::bigtable;
+  namespace cbta = ::google::cloud::bigtable_admin;
   using ::google::cloud::future;
+  using ::google::cloud::Project;
   using ::google::cloud::StatusOr;
-  [](cbt::InstanceAdmin instance_admin, std::string const& instance_id,
+
+  [](cbta::BigtableInstanceAdminClient instance_admin,
+     std::string const& project_id, std::string const& instance_id,
      std::string const& zone) {
-    std::string display_name("Put description here");
+    std::string project_name = Project(project_id).FullName();
     std::string cluster_id = instance_id + "-c1";
-    auto cluster_config = cbt::ClusterConfig(zone, 0, cbt::ClusterConfig::HDD);
-    cbt::InstanceConfig config(instance_id, display_name,
-                               {{cluster_id, cluster_config}});
-    config.set_type(cbt::InstanceConfig::DEVELOPMENT);
+
+    google::bigtable::admin::v2::Instance in;
+    in.set_type(google::bigtable::admin::v2::Instance::DEVELOPMENT);
+    in.set_display_name("Put description here");
+
+    google::bigtable::admin::v2::Cluster cluster;
+    cluster.set_location(project_name + "/locations/" + zone);
+    cluster.set_serve_nodes(0);
+    cluster.set_default_storage_type(google::bigtable::admin::v2::HDD);
+
+    std::map<std::string, google::bigtable::admin::v2::Cluster> cluster_map = {
+        {cluster_id, std::move(cluster)}};
 
     future<StatusOr<google::bigtable::admin::v2::Instance>> instance_future =
-        instance_admin.CreateInstance(config);
+        instance_admin.CreateInstance(project_name, instance_id, std::move(in),
+                                      std::move(cluster_map));
     // Show how to perform additional work while the long running operation
     // completes. The application could use future.then() instead.
     std::cout << "Waiting for instance creation to complete " << std::flush;
@@ -81,29 +108,45 @@ void CreateDevInstance(google::cloud::bigtable::InstanceAdmin instance_admin,
     std::cout << "DONE, details=" << instance->DebugString() << "\n";
   }
   //! [create dev instance] [END bigtable_create_dev_instance]
-  (std::move(instance_admin), argv.at(0), argv.at(1));
+  (std::move(instance_admin), argv.at(0), argv.at(1), argv.at(2));
 }
 
 void CreateReplicatedInstance(
-    google::cloud::bigtable::InstanceAdmin instance_admin,
+    google::cloud::bigtable_admin::BigtableInstanceAdminClient instance_admin,
     std::vector<std::string> const& argv) {
   // [START bigtable_create_replicated_cluster]
-  namespace cbt = ::google::cloud::bigtable;
+  namespace cbta = ::google::cloud::bigtable_admin;
   using ::google::cloud::future;
+  using ::google::cloud::Project;
   using ::google::cloud::StatusOr;
-  [](cbt::InstanceAdmin instance_admin, std::string const& instance_id,
+
+  [](cbta::BigtableInstanceAdminClient instance_admin,
+     std::string const& project_id, std::string const& instance_id,
      std::string const& zone_a, std::string const& zone_b) {
-    std::string display_name("Put description here");
-    auto c1 = instance_id + "-c1";
-    auto c2 = instance_id + "-c2";
-    cbt::InstanceConfig config(
-        instance_id, display_name,
-        {{c1, cbt::ClusterConfig(zone_a, 3, cbt::ClusterConfig::HDD)},
-         {c2, cbt::ClusterConfig(zone_b, 3, cbt::ClusterConfig::HDD)}});
-    config.set_type(cbt::InstanceConfig::PRODUCTION);
+    std::string project_name = Project(project_id).FullName();
+    std::string c1 = instance_id + "-c1";
+    std::string c2 = instance_id + "-c2";
+
+    google::bigtable::admin::v2::Instance in;
+    in.set_type(google::bigtable::admin::v2::Instance::PRODUCTION);
+    in.set_display_name("Put description here");
+
+    google::bigtable::admin::v2::Cluster cluster1;
+    cluster1.set_location(project_name + "/locations/" + zone_a);
+    cluster1.set_serve_nodes(3);
+    cluster1.set_default_storage_type(google::bigtable::admin::v2::HDD);
+
+    google::bigtable::admin::v2::Cluster cluster2;
+    cluster2.set_location(project_name + "/locations/" + zone_b);
+    cluster2.set_serve_nodes(3);
+    cluster2.set_default_storage_type(google::bigtable::admin::v2::HDD);
+
+    std::map<std::string, google::bigtable::admin::v2::Cluster> cluster_map = {
+        {c1, std::move(cluster1)}, {c2, std::move(cluster2)}};
 
     future<StatusOr<google::bigtable::admin::v2::Instance>> instance_future =
-        instance_admin.CreateInstance(config);
+        instance_admin.CreateInstance(project_name, instance_id, std::move(in),
+                                      std::move(cluster_map));
     // Show how to perform additional work while the long running operation
     // completes. The application could use future.then() instead.
     std::cout << "Waiting for instance creation to complete " << std::flush;
@@ -114,24 +157,31 @@ void CreateReplicatedInstance(
     std::cout << "DONE, details=" << instance->DebugString() << "\n";
   }
   // [END bigtable_create_replicated_cluster]
-  (std::move(instance_admin), argv.at(0), argv.at(1), argv.at(2));
+  (std::move(instance_admin), argv.at(0), argv.at(1), argv.at(2), argv.at(3));
 }
 
-void UpdateInstance(google::cloud::bigtable::InstanceAdmin instance_admin,
-                    std::vector<std::string> const& argv) {
+void UpdateInstance(
+    google::cloud::bigtable_admin::BigtableInstanceAdminClient instance_admin,
+    std::vector<std::string> const& argv) {
   //! [update instance]
   namespace cbt = ::google::cloud::bigtable;
+  namespace cbta = ::google::cloud::bigtable_admin;
   using ::google::cloud::future;
   using ::google::cloud::StatusOr;
-  [](cbt::InstanceAdmin instance_admin, std::string const& instance_id) {
-    auto instance = instance_admin.GetInstance(instance_id);
+  [](cbta::BigtableInstanceAdminClient instance_admin,
+     std::string const& project_id, std::string const& instance_id) {
+    std::string instance_name = cbt::InstanceName(project_id, instance_id);
+    StatusOr<google::bigtable::admin::v2::Instance> instance =
+        instance_admin.GetInstance(instance_name);
     if (!instance) throw std::runtime_error(instance.status().message());
-    // Modify the instance and prepare the mask with modified field
-    cbt::InstanceUpdateConfig instance_update_config(std::move(*instance));
-    instance_update_config.set_display_name("Modified Display Name");
+    // Modify the instance and prepare the mask with the modified field
+    instance->set_display_name("Modified Display Name");
+    google::protobuf::FieldMask mask;
+    mask.add_paths("display_name");
 
     future<StatusOr<google::bigtable::admin::v2::Instance>> instance_future =
-        instance_admin.UpdateInstance(std::move(instance_update_config));
+        instance_admin.PartialUpdateInstance(std::move(*instance),
+                                             std::move(mask));
     instance_future
         .then([](future<StatusOr<google::bigtable::admin::v2::Instance>> f) {
           auto updated_instance = f.get();
@@ -144,41 +194,49 @@ void UpdateInstance(google::cloud::bigtable::InstanceAdmin instance_admin,
         .get();  // block until done to simplify example
   }
   //! [update instance]
-  (std::move(instance_admin), argv.at(0));
+  (std::move(instance_admin), argv.at(0), argv.at(1));
 }
 
-void ListInstances(google::cloud::bigtable::InstanceAdmin instance_admin,
-                   std::vector<std::string> const&) {
+void ListInstances(
+    google::cloud::bigtable_admin::BigtableInstanceAdminClient instance_admin,
+    std::vector<std::string> const& argv) {
   //! [list instances] [START bigtable_list_instances]
-  namespace cbt = ::google::cloud::bigtable;
+  namespace cbta = ::google::cloud::bigtable_admin;
+  using ::google::cloud::Project;
   using ::google::cloud::StatusOr;
-  [](cbt::InstanceAdmin instance_admin) {
-    StatusOr<cbt::InstanceList> instances = instance_admin.ListInstances();
+  [](cbta::BigtableInstanceAdminClient instance_admin,
+     std::string const& project_id) {
+    std::string project_name = Project(project_id).FullName();
+    StatusOr<google::bigtable::admin::v2::ListInstancesResponse> instances =
+        instance_admin.ListInstances(project_name);
     if (!instances) throw std::runtime_error(instances.status().message());
-    for (auto const& instance : instances->instances) {
+    for (auto const& instance : instances->instances()) {
       std::cout << instance.name() << "\n";
     }
-    if (!instances->failed_locations.empty()) {
+    if (!instances->failed_locations().empty()) {
       std::cout << "The Cloud Bigtable service reports that the following "
                    "locations are temporarily unavailable and no information "
                    "about instances in these locations can be obtained:\n";
-      for (auto const& failed_location : instances->failed_locations) {
+      for (auto const& failed_location : instances->failed_locations()) {
         std::cout << failed_location << "\n";
       }
     }
   }
   //! [list instances] [END bigtable_list_instances]
-  (std::move(instance_admin));
+  (std::move(instance_admin), argv.at(0));
 }
 
-void CheckInstanceExists(google::cloud::bigtable::InstanceAdmin instance_admin,
-                         std::vector<std::string> const& argv) {
+void CheckInstanceExists(
+    google::cloud::bigtable_admin::BigtableInstanceAdminClient instance_admin,
+    std::vector<std::string> const& argv) {
   // [START bigtable_check_instance_exists]
   namespace cbt = ::google::cloud::bigtable;
+  namespace cbta = ::google::cloud::bigtable_admin;
   using ::google::cloud::StatusOr;
-  [](cbt::InstanceAdmin instance_admin, std::string const& instance_id) {
-    StatusOr<google::bigtable::admin::v2::Instance> instance =
-        instance_admin.GetInstance(instance_id);
+  [](cbta::BigtableInstanceAdminClient instance_admin,
+     std::string const& project_id, std::string const& instance_id) {
+    std::string instance_name = cbt::InstanceName(project_id, instance_id);
+    auto instance = instance_admin.GetInstance(instance_name);
     if (!instance) {
       if (instance.status().code() == google::cloud::StatusCode::kNotFound) {
         std::cout << "Instance " + instance_id + " does not exist\n";
@@ -189,48 +247,68 @@ void CheckInstanceExists(google::cloud::bigtable::InstanceAdmin instance_admin,
     std::cout << "Instance " << instance->name() << " was found\n";
   }
   // [END bigtable_check_instance_exists]
-  (std::move(instance_admin), argv.at(0));
+  (std::move(instance_admin), argv.at(0), argv.at(1));
 }
 
-void GetInstance(google::cloud::bigtable::InstanceAdmin instance_admin,
-                 std::vector<std::string> const& argv) {
+void GetInstance(
+    google::cloud::bigtable_admin::BigtableInstanceAdminClient instance_admin,
+    std::vector<std::string> const& argv) {
   //! [get instance] [START bigtable_get_instance]
   namespace cbt = ::google::cloud::bigtable;
+  namespace cbta = ::google::cloud::bigtable_admin;
   using ::google::cloud::StatusOr;
-  [](cbt::InstanceAdmin instance_admin, std::string const& instance_id) {
+  [](cbta::BigtableInstanceAdminClient instance_admin,
+     std::string const& project_id, std::string const& instance_id) {
+    std::string instance_name = cbt::InstanceName(project_id, instance_id);
     StatusOr<google::bigtable::admin::v2::Instance> instance =
-        instance_admin.GetInstance(instance_id);
+        instance_admin.GetInstance(instance_name);
     if (!instance) throw std::runtime_error(instance.status().message());
     std::cout << "GetInstance details : " << instance->DebugString() << "\n";
   }
   //! [get instance] [END bigtable_get_instance]
-  (std::move(instance_admin), argv.at(0));
+  (std::move(instance_admin), argv.at(0), argv.at(1));
 }
 
-void DeleteInstance(google::cloud::bigtable::InstanceAdmin instance_admin,
-                    std::vector<std::string> const& argv) {
+void DeleteInstance(
+    google::cloud::bigtable_admin::BigtableInstanceAdminClient instance_admin,
+    std::vector<std::string> const& argv) {
   //! [delete instance] [START bigtable_delete_instance]
   namespace cbt = ::google::cloud::bigtable;
-  [](cbt::InstanceAdmin instance_admin, std::string const& instance_id) {
-    google::cloud::Status status = instance_admin.DeleteInstance(instance_id);
+  namespace cbta = ::google::cloud::bigtable_admin;
+  using ::google::cloud::Status;
+  [](cbta::BigtableInstanceAdminClient instance_admin,
+     std::string const& project_id, std::string const& instance_id) {
+    std::string instance_name = cbt::InstanceName(project_id, instance_id);
+    Status status = instance_admin.DeleteInstance(instance_name);
     if (!status.ok()) throw std::runtime_error(status.message());
     std::cout << "Successfully deleted the instance " << instance_id << "\n";
   }
   //! [delete instance] [END bigtable_delete_instance]
-  (std::move(instance_admin), argv.at(0));
+  (std::move(instance_admin), argv.at(0), argv.at(1));
 }
 
-void CreateCluster(google::cloud::bigtable::InstanceAdmin instance_admin,
-                   std::vector<std::string> const& argv) {
+void CreateCluster(
+    google::cloud::bigtable_admin::BigtableInstanceAdminClient instance_admin,
+    std::vector<std::string> const& argv) {
   //! [create cluster] [START bigtable_create_cluster]
   namespace cbt = ::google::cloud::bigtable;
+  namespace cbta = ::google::cloud::bigtable_admin;
   using ::google::cloud::future;
+  using ::google::cloud::Project;
   using ::google::cloud::StatusOr;
-  [](cbt::InstanceAdmin instance_admin, std::string const& instance_id,
+  [](cbta::BigtableInstanceAdminClient instance_admin,
+     std::string const& project_id, std::string const& instance_id,
      std::string const& cluster_id, std::string const& zone) {
-    auto cluster_config = cbt::ClusterConfig(zone, 3, cbt::ClusterConfig::HDD);
+    std::string project_name = Project(project_id).FullName();
+    std::string instance_name = cbt::InstanceName(project_id, instance_id);
+
+    google::bigtable::admin::v2::Cluster c;
+    c.set_location(project_name + "/locations/" + zone);
+    c.set_serve_nodes(3);
+    c.set_default_storage_type(google::bigtable::admin::v2::HDD);
+
     future<StatusOr<google::bigtable::admin::v2::Cluster>> cluster_future =
-        instance_admin.CreateCluster(cluster_config, instance_id, cluster_id);
+        instance_admin.CreateCluster(instance_name, cluster_id, std::move(c));
 
     // Applications can wait asynchronously, in this example we just block.
     auto cluster = cluster_future.get();
@@ -238,255 +316,334 @@ void CreateCluster(google::cloud::bigtable::InstanceAdmin instance_admin,
     std::cout << "Successfully created cluster " << cluster->name() << "\n";
   }
   //! [create cluster] [END bigtable_create_cluster]
-  (std::move(instance_admin), argv.at(0), argv.at(1), argv.at(2));
+  (std::move(instance_admin), argv.at(0), argv.at(1), argv.at(2), argv.at(3));
 }
 
-void ListClusters(google::cloud::bigtable::InstanceAdmin instance_admin,
-                  std::vector<std::string> const& argv) {
+void ListClusters(
+    google::cloud::bigtable_admin::BigtableInstanceAdminClient instance_admin,
+    std::vector<std::string> const& argv) {
   //! [list clusters] [START bigtable_get_clusters]
   namespace cbt = ::google::cloud::bigtable;
+  namespace cbta = ::google::cloud::bigtable_admin;
   using ::google::cloud::StatusOr;
-  [](cbt::InstanceAdmin instance_admin, std::string const& instance_id) {
-    StatusOr<cbt::ClusterList> clusters =
-        instance_admin.ListClusters(instance_id);
+  [](cbta::BigtableInstanceAdminClient instance_admin,
+     std::string const& project_id, std::string const& instance_id) {
+    std::string instance_name = cbt::InstanceName(project_id, instance_id);
+    StatusOr<google::bigtable::admin::v2::ListClustersResponse> clusters =
+        instance_admin.ListClusters(instance_name);
     if (!clusters) throw std::runtime_error(clusters.status().message());
     std::cout << "Cluster Name List\n";
-    for (auto const& cluster : clusters->clusters) {
+    for (auto const& cluster : clusters->clusters()) {
       std::cout << "Cluster Name:" << cluster.name() << "\n";
     }
-    if (!clusters->failed_locations.empty()) {
+    if (!clusters->failed_locations().empty()) {
       std::cout << "The Cloud Bigtable service reports that the following "
                    "locations are temporarily unavailable and no information "
                    "about clusters in these locations can be obtained:\n";
-      for (auto const& failed_location : clusters->failed_locations) {
+      for (auto const& failed_location : clusters->failed_locations()) {
         std::cout << failed_location << "\n";
       }
     }
   }
   //! [list clusters] [END bigtable_get_clusters]
-  (std::move(instance_admin), argv.at(0));
+  (std::move(instance_admin), argv.at(0), argv.at(1));
 }
 
-void ListAllClusters(google::cloud::bigtable::InstanceAdmin instance_admin,
-                     std::vector<std::string> const&) {
+void ListAllClusters(
+    google::cloud::bigtable_admin::BigtableInstanceAdminClient instance_admin,
+    std::vector<std::string> const& argv) {
   //! [list all clusters] [START bigtable_get_clusters]
   namespace cbt = ::google::cloud::bigtable;
+  namespace cbta = ::google::cloud::bigtable_admin;
   using ::google::cloud::StatusOr;
-  [](cbt::InstanceAdmin instance_admin) {
-    StatusOr<cbt::ClusterList> clusters = instance_admin.ListClusters();
+  [](cbta::BigtableInstanceAdminClient instance_admin,
+     std::string const& project_id) {
+    std::string instance_name = cbt::InstanceName(project_id, "-");
+    StatusOr<google::bigtable::admin::v2::ListClustersResponse> clusters =
+        instance_admin.ListClusters(instance_name);
     if (!clusters) throw std::runtime_error(clusters.status().message());
     std::cout << "Cluster Name List\n";
-    for (auto const& cluster : clusters->clusters) {
+    for (auto const& cluster : clusters->clusters()) {
       std::cout << "Cluster Name:" << cluster.name() << "\n";
     }
-    if (!clusters->failed_locations.empty()) {
+    if (!clusters->failed_locations().empty()) {
       std::cout << "The Cloud Bigtable service reports that the following "
                    "locations are temporarily unavailable and no information "
                    "about clusters in these locations can be obtained:\n";
-      for (auto const& failed_location : clusters->failed_locations) {
+      for (auto const& failed_location : clusters->failed_locations()) {
         std::cout << failed_location << "\n";
       }
     }
   }
   //! [list all clusters] [END bigtable_get_clusters]
-  (std::move(instance_admin));
+  (std::move(instance_admin), argv.at(0));
 }
 
-void UpdateCluster(google::cloud::bigtable::InstanceAdmin instance_admin,
-                   std::vector<std::string> const& argv) {
+void UpdateCluster(
+    google::cloud::bigtable_admin::BigtableInstanceAdminClient instance_admin,
+    std::vector<std::string> const& argv) {
   //! [update cluster]
   namespace cbt = ::google::cloud::bigtable;
+  namespace cbta = ::google::cloud::bigtable_admin;
   using ::google::cloud::StatusOr;
-  [](cbt::InstanceAdmin instance_admin, std::string const& instance_id,
+  [](cbta::BigtableInstanceAdminClient instance_admin,
+     std::string const& project_id, std::string const& instance_id,
      std::string const& cluster_id) {
+    std::string cluster_name =
+        cbt::ClusterName(project_id, instance_id, cluster_id);
     // GetCluster first and then modify it.
     StatusOr<google::bigtable::admin::v2::Cluster> cluster =
-        instance_admin.GetCluster(instance_id, cluster_id);
+        instance_admin.GetCluster(cluster_name);
     if (!cluster) throw std::runtime_error(cluster.status().message());
 
     // The state cannot be sent on updates, so clear it first.
     cluster->clear_state();
     // Set the desired cluster configuration.
     cluster->set_serve_nodes(4);
-    auto modified_config = cbt::ClusterConfig(std::move(*cluster));
 
-    StatusOr<google::bigtable::admin::v2::Cluster> modified_cluster =
-        instance_admin.UpdateCluster(modified_config).get();
+    auto modified_cluster =
+        instance_admin.UpdateCluster(std::move(*cluster)).get();
     if (!modified_cluster) {
       throw std::runtime_error(modified_cluster.status().message());
     }
     std::cout << "cluster details : " << cluster->DebugString() << "\n";
   }
   //! [update cluster]
-  (std::move(instance_admin), argv.at(0), argv.at(1));
+  (std::move(instance_admin), argv.at(0), argv.at(1), argv.at(2));
 }
 
-void GetCluster(google::cloud::bigtable::InstanceAdmin instance_admin,
-                std::vector<std::string> const& argv) {
+void GetCluster(
+    google::cloud::bigtable_admin::BigtableInstanceAdminClient instance_admin,
+    std::vector<std::string> const& argv) {
   //! [get cluster] [START bigtable_get_cluster]
   namespace cbt = ::google::cloud::bigtable;
+  namespace cbta = ::google::cloud::bigtable_admin;
   using ::google::cloud::StatusOr;
-  [](cbt::InstanceAdmin instance_admin, std::string const& instance_id,
+  [](cbta::BigtableInstanceAdminClient instance_admin,
+     std::string const& project_id, std::string const& instance_id,
      std::string const& cluster_id) {
+    std::string cluster_name =
+        cbt::ClusterName(project_id, instance_id, cluster_id);
     StatusOr<google::bigtable::admin::v2::Cluster> cluster =
-        instance_admin.GetCluster(instance_id, cluster_id);
+        instance_admin.GetCluster(cluster_name);
     if (!cluster) throw std::runtime_error(cluster.status().message());
     std::cout << "GetCluster details : " << cluster->DebugString() << "\n";
   }
   //! [get cluster] [END bigtable_get_cluster]
-  (std::move(instance_admin), argv.at(0), argv.at(1));
+  (std::move(instance_admin), argv.at(0), argv.at(1), argv.at(2));
 }
 
-void DeleteCluster(google::cloud::bigtable::InstanceAdmin instance_admin,
-                   std::vector<std::string> const& argv) {
+void DeleteCluster(
+    google::cloud::bigtable_admin::BigtableInstanceAdminClient instance_admin,
+    std::vector<std::string> const& argv) {
   //! [delete cluster] [START bigtable_delete_cluster]
   namespace cbt = ::google::cloud::bigtable;
-  [](cbt::InstanceAdmin instance_admin, std::string const& instance_id,
+  namespace cbta = ::google::cloud::bigtable_admin;
+  using ::google::cloud::Status;
+  [](cbta::BigtableInstanceAdminClient instance_admin,
+     std::string const& project_id, std::string const& instance_id,
      std::string const& cluster_id) {
-    google::cloud::Status status =
-        instance_admin.DeleteCluster(instance_id, cluster_id);
+    std::string cluster_name =
+        cbt::ClusterName(project_id, instance_id, cluster_id);
+    Status status = instance_admin.DeleteCluster(cluster_name);
     if (!status.ok()) throw std::runtime_error(status.message());
   }
   //! [delete cluster] [END bigtable_delete_cluster]
-  (std::move(instance_admin), argv.at(0), argv.at(1));
+  (std::move(instance_admin), argv.at(0), argv.at(1), argv.at(2));
 }
 
-void CreateAppProfile(google::cloud::bigtable::InstanceAdmin instance_admin,
-                      std::vector<std::string> const& argv) {
+void CreateAppProfile(
+    google::cloud::bigtable_admin::BigtableInstanceAdminClient instance_admin,
+    std::vector<std::string> const& argv) {
   //! [create app profile] [START bigtable_create_app_profile]
   namespace cbt = ::google::cloud::bigtable;
+  namespace cbta = ::google::cloud::bigtable_admin;
   using ::google::cloud::StatusOr;
-  [](cbt::InstanceAdmin instance_admin, std::string const& instance_id,
+  [](cbta::BigtableInstanceAdminClient instance_admin,
+     std::string const& project_id, std::string const& instance_id,
      std::string const& profile_id) {
-    auto config = cbt::AppProfileConfig::MultiClusterUseAny(profile_id);
+    std::string instance_name = cbt::InstanceName(project_id, instance_id);
+
+    google::bigtable::admin::v2::AppProfile ap;
+    ap.mutable_multi_cluster_routing_use_any()->Clear();
+
     StatusOr<google::bigtable::admin::v2::AppProfile> profile =
-        instance_admin.CreateAppProfile(instance_id, config);
+        instance_admin.CreateAppProfile(instance_name, profile_id,
+                                        std::move(ap));
     if (!profile) throw std::runtime_error(profile.status().message());
     std::cout << "New profile created with name=" << profile->name() << "\n";
   }
   //! [create app profile] [END bigtable_create_app_profile]
-  (std::move(instance_admin), argv.at(0), argv.at(1));
+  (std::move(instance_admin), argv.at(0), argv.at(1), argv.at(2));
 }
 
 void CreateAppProfileCluster(
-    google::cloud::bigtable::InstanceAdmin instance_admin,
+    google::cloud::bigtable_admin::BigtableInstanceAdminClient instance_admin,
     std::vector<std::string> const& argv) {
   //! [create app profile cluster]
   namespace cbt = ::google::cloud::bigtable;
+  namespace cbta = ::google::cloud::bigtable_admin;
   using ::google::cloud::StatusOr;
-  [](cbt::InstanceAdmin instance_admin, std::string const& instance_id,
+  [](cbta::BigtableInstanceAdminClient instance_admin,
+     std::string const& project_id, std::string const& instance_id,
      std::string const& profile_id, std::string const& cluster_id) {
-    auto config =
-        cbt::AppProfileConfig::SingleClusterRouting(profile_id, cluster_id);
+    std::string instance_name = cbt::InstanceName(project_id, instance_id);
+
+    google::bigtable::admin::v2::AppProfile ap;
+    ap.mutable_single_cluster_routing()->set_cluster_id(cluster_id);
+
     StatusOr<google::bigtable::admin::v2::AppProfile> profile =
-        instance_admin.CreateAppProfile(instance_id, config);
+        instance_admin.CreateAppProfile(instance_name, profile_id,
+                                        std::move(ap));
     if (!profile) throw std::runtime_error(profile.status().message());
     std::cout << "New profile created with name=" << profile->name() << "\n";
   }
   //! [create app profile cluster]
-  (std::move(instance_admin), argv.at(0), argv.at(1), argv.at(2));
+  (std::move(instance_admin), argv.at(0), argv.at(1), argv.at(2), argv.at(3));
 }
 
-void GetAppProfile(google::cloud::bigtable::InstanceAdmin instance_admin,
-                   std::vector<std::string> const& argv) {
+void GetAppProfile(
+    google::cloud::bigtable_admin::BigtableInstanceAdminClient instance_admin,
+    std::vector<std::string> const& argv) {
   //! [get app profile] [START bigtable_get_app_profile]
   namespace cbt = ::google::cloud::bigtable;
+  namespace cbta = ::google::cloud::bigtable_admin;
   using ::google::cloud::StatusOr;
-  [](cbt::InstanceAdmin instance_admin, std::string const& instance_id,
+  [](cbta::BigtableInstanceAdminClient instance_admin,
+     std::string const& project_id, std::string const& instance_id,
      std::string const& profile_id) {
+    std::string profile_name =
+        cbt::AppProfileName(project_id, instance_id, profile_id);
     StatusOr<google::bigtable::admin::v2::AppProfile> profile =
-        instance_admin.GetAppProfile(instance_id, profile_id);
+        instance_admin.GetAppProfile(profile_name);
     if (!profile) throw std::runtime_error(profile.status().message());
     std::cout << "Application Profile details=" << profile->DebugString()
               << "\n";
   }
   //! [get app profile] [END bigtable_get_app_profile]
-  (std::move(instance_admin), argv.at(0), argv.at(1));
+  (std::move(instance_admin), argv.at(0), argv.at(1), argv.at(2));
 }
 
 void UpdateAppProfileDescription(
-    google::cloud::bigtable::InstanceAdmin instance_admin,
+    google::cloud::bigtable_admin::BigtableInstanceAdminClient instance_admin,
     std::vector<std::string> const& argv) {
   //! [update app profile description] [START bigtable_update_app_profile]
   namespace cbt = ::google::cloud::bigtable;
+  namespace cbta = ::google::cloud::bigtable_admin;
   using ::google::cloud::future;
   using ::google::cloud::StatusOr;
-  [](cbt::InstanceAdmin instance_admin, std::string const& instance_id,
+  [](cbta::BigtableInstanceAdminClient instance_admin,
+     std::string const& project_id, std::string const& instance_id,
      std::string const& profile_id, std::string const& description) {
+    std::string profile_name =
+        cbt::AppProfileName(project_id, instance_id, profile_id);
+
+    google::bigtable::admin::v2::AppProfile profile;
+    profile.set_name(profile_name);
+    profile.set_description(description);
+
+    google::protobuf::FieldMask mask;
+    mask.add_paths("description");
+
     future<StatusOr<google::bigtable::admin::v2::AppProfile>> profile_future =
-        instance_admin.UpdateAppProfile(
-            instance_id, profile_id,
-            cbt::AppProfileUpdateConfig().set_description(description));
-    auto profile = profile_future.get();
-    if (!profile) throw std::runtime_error(profile.status().message());
-    std::cout << "Updated AppProfile: " << profile->DebugString() << "\n";
+        instance_admin.UpdateAppProfile(std::move(profile), std::move(mask));
+    auto modified_profile = profile_future.get();
+    if (!modified_profile)
+      throw std::runtime_error(modified_profile.status().message());
+    std::cout << "Updated AppProfile: " << modified_profile->DebugString()
+              << "\n";
   }
   //! [update app profile description] [END bigtable_update_app_profile]
-  (std::move(instance_admin), argv.at(0), argv.at(1), argv.at(2));
+  (std::move(instance_admin), argv.at(0), argv.at(1), argv.at(2), argv.at(3));
 }
 
 void UpdateAppProfileRoutingAny(
-    google::cloud::bigtable::InstanceAdmin instance_admin,
+    google::cloud::bigtable_admin::BigtableInstanceAdminClient instance_admin,
     std::vector<std::string> const& argv) {
   //! [update app profile routing any] [START bigtable_update_app_profile]
   namespace cbt = ::google::cloud::bigtable;
+  namespace cbta = ::google::cloud::bigtable_admin;
   using ::google::cloud::future;
   using ::google::cloud::StatusOr;
-  [](cbt::InstanceAdmin instance_admin, std::string const& instance_id,
+  [](cbta::BigtableInstanceAdminClient instance_admin,
+     std::string const& project_id, std::string const& instance_id,
      std::string const& profile_id) {
+    std::string profile_name =
+        cbt::AppProfileName(project_id, instance_id, profile_id);
+
+    google::bigtable::admin::v2::UpdateAppProfileRequest req;
+    req.mutable_app_profile()->set_name(profile_name);
+    req.mutable_app_profile()->mutable_multi_cluster_routing_use_any()->Clear();
+    req.mutable_update_mask()->add_paths("multi_cluster_routing_use_any");
+    req.set_ignore_warnings(true);
+
     future<StatusOr<google::bigtable::admin::v2::AppProfile>> profile_future =
-        instance_admin.UpdateAppProfile(instance_id, profile_id,
-                                        cbt::AppProfileUpdateConfig()
-                                            .set_multi_cluster_use_any()
-                                            .set_ignore_warnings(true));
-    auto profile = profile_future.get();
-    if (!profile) throw std::runtime_error(profile.status().message());
-    std::cout << "Updated AppProfile: " << profile->DebugString() << "\n";
+        instance_admin.UpdateAppProfile(std::move(req));
+    auto modified_profile = profile_future.get();
+    if (!modified_profile)
+      throw std::runtime_error(modified_profile.status().message());
+    std::cout << "Updated AppProfile: " << modified_profile->DebugString()
+              << "\n";
   }
   //! [update app profile routing any] [END bigtable_update_app_profile]
-  (std::move(instance_admin), argv.at(0), argv.at(1));
-}
-
-void UpdateAppProfileRoutingSingleCluster(
-    google::cloud::bigtable::InstanceAdmin instance_admin,
-    std::vector<std::string> const& argv) {
-  //! [update app profile routing]
-  namespace cbt = ::google::cloud::bigtable;
-  using ::google::cloud::future;
-  using ::google::cloud::StatusOr;
-  [](cbt::InstanceAdmin instance_admin, std::string const& instance_id,
-     std::string const& profile_id, std::string const& cluster_id) {
-    future<StatusOr<google::bigtable::admin::v2::AppProfile>> profile_future =
-        instance_admin.UpdateAppProfile(
-            instance_id, profile_id,
-            cbt::AppProfileUpdateConfig()
-                .set_single_cluster_routing(cluster_id)
-                .set_ignore_warnings(true));
-    auto profile = profile_future.get();
-    if (!profile) throw std::runtime_error(profile.status().message());
-    std::cout << "Updated AppProfile: " << profile->DebugString() << "\n";
-  }
-  //! [update app profile routing]
   (std::move(instance_admin), argv.at(0), argv.at(1), argv.at(2));
 }
 
-void ListAppProfiles(google::cloud::bigtable::InstanceAdmin instance_admin,
-                     std::vector<std::string> const& argv) {
+void UpdateAppProfileRoutingSingleCluster(
+    google::cloud::bigtable_admin::BigtableInstanceAdminClient instance_admin,
+    std::vector<std::string> const& argv) {
+  //! [update app profile routing]
+  namespace cbt = ::google::cloud::bigtable;
+  namespace cbta = ::google::cloud::bigtable_admin;
+  using ::google::cloud::future;
+  using ::google::cloud::StatusOr;
+  [](cbta::BigtableInstanceAdminClient instance_admin,
+     std::string const& project_id, std::string const& instance_id,
+     std::string const& profile_id, std::string const& cluster_id) {
+    std::string profile_name =
+        cbt::AppProfileName(project_id, instance_id, profile_id);
+
+    google::bigtable::admin::v2::UpdateAppProfileRequest req;
+    req.mutable_app_profile()->set_name(profile_name);
+    req.mutable_app_profile()->mutable_single_cluster_routing()->set_cluster_id(
+        cluster_id);
+    req.mutable_update_mask()->add_paths("single_cluster_routing");
+    req.set_ignore_warnings(true);
+
+    future<StatusOr<google::bigtable::admin::v2::AppProfile>> profile_future =
+        instance_admin.UpdateAppProfile(std::move(req));
+    auto modified_profile = profile_future.get();
+    if (!modified_profile)
+      throw std::runtime_error(modified_profile.status().message());
+    std::cout << "Updated AppProfile: " << modified_profile->DebugString()
+              << "\n";
+  }
+  //! [update app profile routing]
+  (std::move(instance_admin), argv.at(0), argv.at(1), argv.at(2), argv.at(3));
+}
+
+void ListAppProfiles(
+    google::cloud::bigtable_admin::BigtableInstanceAdminClient instance_admin,
+    std::vector<std::string> const& argv) {
   //! [list app profiles]
   namespace cbt = ::google::cloud::bigtable;
-  using ::google::cloud::StatusOr;
-  [](cbt::InstanceAdmin instance_admin, std::string const& instance_id) {
-    StatusOr<std::vector<google::bigtable::admin::v2::AppProfile>> profiles =
-        instance_admin.ListAppProfiles(instance_id);
-    if (!profiles) throw std::runtime_error(profiles.status().message());
-    std::cout << "The " << instance_id << " instance has " << profiles->size()
+  namespace cbta = ::google::cloud::bigtable_admin;
+  using ::google::cloud::StreamRange;
+  [](cbta::BigtableInstanceAdminClient instance_admin,
+     std::string const& project_id, std::string const& instance_id) {
+    std::string instance_name = cbt::InstanceName(project_id, instance_id);
+    StreamRange<google::bigtable::admin::v2::AppProfile> profiles =
+        instance_admin.ListAppProfiles(instance_name);
+    std::cout << "The " << instance_id << " instance has "
+              << std::distance(profiles.begin(), profiles.end())
               << " application profiles\n";
-    for (auto const& profile : *profiles) {
-      std::cout << profile.DebugString() << "\n";
+    for (auto const& profile : profiles) {
+      if (!profile) throw std::runtime_error(profile.status().message());
+      std::cout << profile->DebugString() << "\n";
     }
   }
   //! [list app profiles]
-  (std::move(instance_admin), argv.at(0));
+  (std::move(instance_admin), argv.at(0), argv.at(1));
 }
 
 void DeleteAppProfile(std::vector<std::string> const& argv) {
@@ -512,47 +669,67 @@ void DeleteAppProfile(std::vector<std::string> const& argv) {
       throw Usage{msg};
     }
   }
-  google::cloud::bigtable::InstanceAdmin instance(
-      google::cloud::bigtable::MakeInstanceAdminClient(argv[0]));
+
+  auto instance_admin =
+      google::cloud::bigtable_admin::BigtableInstanceAdminClient(
+          google::cloud::bigtable_admin::MakeBigtableInstanceAdminConnection());
 
   //! [delete app profile] [START bigtable_delete_app_profile]
   namespace cbt = ::google::cloud::bigtable;
-  [](cbt::InstanceAdmin instance_admin, std::string const& instance_id,
+  namespace cbta = ::google::cloud::bigtable_admin;
+  using ::google::cloud::Status;
+  [](cbta::BigtableInstanceAdminClient instance_admin,
+     std::string const& project_id, std::string const& instance_id,
      std::string const& profile_id, bool ignore_warnings) {
-    google::cloud::Status status = instance_admin.DeleteAppProfile(
-        instance_id, profile_id, ignore_warnings);
+    std::string profile_name =
+        cbt::AppProfileName(project_id, instance_id, profile_id);
+
+    google::bigtable::admin::v2::DeleteAppProfileRequest req;
+    req.set_name(profile_name);
+    req.set_ignore_warnings(ignore_warnings);
+
+    Status status = instance_admin.DeleteAppProfile(std::move(req));
     if (!status.ok()) throw std::runtime_error(status.message());
     std::cout << "Application Profile deleted\n";
   }
   //! [delete app profile] [END bigtable_delete_app_profile]
-  (std::move(instance), argv[1], argv[2], ignore_warnings);
+  (std::move(instance_admin), argv.at(0), argv.at(1), argv.at(2),
+   ignore_warnings);
 }
 
-void GetNativeIamPolicy(google::cloud::bigtable::InstanceAdmin instance_admin,
-                        std::vector<std::string> const& argv) {
+void GetIamPolicy(
+    google::cloud::bigtable_admin::BigtableInstanceAdminClient instance_admin,
+    std::vector<std::string> const& argv) {
   //! [get native iam policy]
   namespace cbt = ::google::cloud::bigtable;
+  namespace cbta = ::google::cloud::bigtable_admin;
   using ::google::cloud::StatusOr;
-  [](cbt::InstanceAdmin instance_admin, std::string const& instance_id) {
+  [](cbta::BigtableInstanceAdminClient instance_admin,
+     std::string const& project_id, std::string const& instance_id) {
+    std::string instance_name = cbt::InstanceName(project_id, instance_id);
     StatusOr<google::iam::v1::Policy> policy =
-        instance_admin.GetNativeIamPolicy(instance_id);
+        instance_admin.GetIamPolicy(instance_name);
     if (!policy) throw std::runtime_error(policy.status().message());
     std::cout << "The IAM Policy for " << instance_id << " is\n"
               << policy->DebugString() << "\n";
   }
   //! [get native iam policy]
-  (std::move(instance_admin), argv.at(0));
+  (std::move(instance_admin), argv.at(0), argv.at(1));
 }
 
-void SetNativeIamPolicy(google::cloud::bigtable::InstanceAdmin instance_admin,
-                        std::vector<std::string> const& argv) {
+void SetIamPolicy(
+    google::cloud::bigtable_admin::BigtableInstanceAdminClient instance_admin,
+    std::vector<std::string> const& argv) {
   //! [set native iam policy]
   namespace cbt = ::google::cloud::bigtable;
+  namespace cbta = ::google::cloud::bigtable_admin;
   using ::google::cloud::StatusOr;
-  [](cbt::InstanceAdmin instance_admin, std::string const& instance_id,
+  [](cbta::BigtableInstanceAdminClient instance_admin,
+     std::string const& project_id, std::string const& instance_id,
      std::string const& role, std::string const& member) {
+    std::string instance_name = cbt::InstanceName(project_id, instance_id);
     StatusOr<google::iam::v1::Policy> current =
-        instance_admin.GetNativeIamPolicy(instance_id);
+        instance_admin.GetIamPolicy(instance_name);
     if (!current) throw std::runtime_error(current.status().message());
     // This example adds the member to all existing bindings for that role. If
     // there are no such bindings, it adds a new one. This might not be what the
@@ -568,48 +745,54 @@ void SetNativeIamPolicy(google::cloud::bigtable::InstanceAdmin instance_admin,
       *current->add_bindings() = cbt::IamBinding(role, {member});
     }
     StatusOr<google::iam::v1::Policy> policy =
-        instance_admin.SetIamPolicy(instance_id, *current);
+        instance_admin.SetIamPolicy(instance_name, *current);
     if (!policy) throw std::runtime_error(policy.status().message());
     std::cout << "The IAM Policy for " << instance_id << " is\n"
               << policy->DebugString() << "\n";
   }
   //! [set native iam policy]
-  (std::move(instance_admin), argv.at(0), argv.at(1), argv.at(2));
+  (std::move(instance_admin), argv.at(0), argv.at(1), argv.at(2), argv.at(3));
 }
 
 void TestIamPermissions(std::vector<std::string> const& argv) {
-  if (argv.size() < 3) {
-    throw Usage{
-        "test-iam-permissions <project-id> <resource-id>"
-        " <permission> [<permission>...]"};
+  std::string usage =
+      "test-iam-permissions <resource-name> <permission> [<permission>...]";
+  if (argv.size() < 2) {
+    throw Usage{usage};
   }
   auto it = argv.cbegin();
-  auto const project_id = *it++;
-  auto const resource = *it++;
+  auto const resource_name = *it++;
+  if (resource_name.rfind("projects/", 0) != 0) {
+    throw Usage{usage +
+                "\nresource-name should be fully qualified. For example: "
+                "'projects/my-project/instances/my-instance'"};
+  }
   std::vector<std::string> const permissions(it, argv.cend());
 
-  google::cloud::bigtable::InstanceAdmin instance(
-      google::cloud::bigtable::MakeInstanceAdminClient(project_id));
+  auto instance_admin =
+      google::cloud::bigtable_admin::BigtableInstanceAdminClient(
+          google::cloud::bigtable_admin::MakeBigtableInstanceAdminConnection());
 
   //! [test iam permissions]
-  namespace cbt = ::google::cloud::bigtable;
+  namespace cbta = ::google::cloud::bigtable_admin;
   using ::google::cloud::StatusOr;
-  [](cbt::InstanceAdmin instance_admin, std::string const& resource,
+  [](cbta::BigtableInstanceAdminClient instance_admin,
+     std::string const& resource_name,
      std::vector<std::string> const& permissions) {
-    StatusOr<std::vector<std::string>> result =
-        instance_admin.TestIamPermissions(resource, permissions);
+    auto result = instance_admin.TestIamPermissions(resource_name, permissions);
     if (!result) throw std::runtime_error(result.status().message());
     std::cout << "The current user has the following permissions [";
-    std::cout << absl::StrJoin(*result, ", ");
+    std::cout << absl::StrJoin(result->permissions(), ", ");
     std::cout << "]\n";
   }
   //! [test iam permissions]
-  (std::move(instance), std::move(resource), std::move(permissions));
+  (std::move(instance_admin), std::move(resource_name), std::move(permissions));
 }
 
 void RunAll(std::vector<std::string> const& argv) {
   namespace examples = ::google::cloud::bigtable::examples;
   namespace cbt = ::google::cloud::bigtable;
+  namespace cbta = ::google::cloud::bigtable_admin;
 
   if (!argv.empty()) throw Usage{"auto"};
   if (!examples::RunAdminIntegrationTests()) return;
@@ -632,20 +815,20 @@ void RunAll(std::vector<std::string> const& argv) {
       google::cloud::internal::GetEnv("GOOGLE_CLOUD_CPP_BIGTABLE_TEST_ZONE_B")
           .value();
 
-  cbt::InstanceAdmin admin(cbt::MakeInstanceAdminClient(project_id));
-
   auto generator = google::cloud::internal::DefaultPRNG(std::random_device{}());
-  google::cloud::bigtable::testing::CleanupStaleInstances(admin);
+  auto conn = cbta::MakeBigtableInstanceAdminConnection();
+  google::cloud::bigtable::testing::CleanupStaleInstances(conn, project_id);
+  cbta::BigtableInstanceAdminClient admin(std::move(conn));
 
   // Create a different instance id to run the replicated instance example.
   {
     auto const id =
         google::cloud::bigtable::testing::RandomInstanceId(generator);
     std::cout << "\nRunning CreateReplicatedInstance() example" << std::endl;
-    CreateReplicatedInstance(admin, {id, zone_a, zone_b});
+    CreateReplicatedInstance(admin, {project_id, id, zone_a, zone_b});
     std::cout << "\nRunning GetInstance() example" << std::endl;
-    GetInstance(admin, {id});
-    (void)admin.DeleteInstance(id);
+    GetInstance(admin, {project_id, id});
+    (void)admin.DeleteInstance(cbt::InstanceName(project_id, id));
   }
 
   // Create a different instance id to run the development instance example.
@@ -653,71 +836,71 @@ void RunAll(std::vector<std::string> const& argv) {
     auto const id =
         google::cloud::bigtable::testing::RandomInstanceId(generator);
     std::cout << "\nRunning CreateDevInstance() example" << std::endl;
-    CreateDevInstance(admin, {id, zone_a});
+    CreateDevInstance(admin, {project_id, id, zone_a});
     std::cout << "\nRunning UpdateInstance() example" << std::endl;
-    UpdateInstance(admin, {id});
-    (void)admin.DeleteInstance(id);
+    UpdateInstance(admin, {project_id, id});
+    (void)admin.DeleteInstance(cbt::InstanceName(project_id, id));
   }
 
   auto const instance_id =
       google::cloud::bigtable::testing::RandomInstanceId(generator);
 
   std::cout << "\nRunning CheckInstanceExists() example [1]" << std::endl;
-  CheckInstanceExists(admin, {instance_id});
+  CheckInstanceExists(admin, {project_id, instance_id});
 
   std::cout << "\nRunning CreateInstance() example" << std::endl;
-  CreateInstance(admin, {instance_id, zone_a});
+  CreateInstance(admin, {project_id, instance_id, zone_a});
 
   std::cout << "\nRunning CheckInstanceExists() example [2]" << std::endl;
-  CheckInstanceExists(admin, {instance_id});
+  CheckInstanceExists(admin, {project_id, instance_id});
 
   std::cout << "\nRunning ListInstances() example" << std::endl;
-  ListInstances(admin, {});
+  ListInstances(admin, {project_id});
 
   std::cout << "\nRunning GetInstance() example" << std::endl;
-  GetInstance(admin, {instance_id});
+  GetInstance(admin, {project_id, instance_id});
 
   std::cout << "\nRunning ListClusters() example" << std::endl;
-  ListClusters(admin, {instance_id});
+  ListClusters(admin, {project_id, instance_id});
 
   std::cout << "\nRunning ListAllClusters() example" << std::endl;
-  ListAllClusters(admin, {});
+  ListAllClusters(admin, {project_id});
 
   std::cout << "\nRunning CreateCluster() example" << std::endl;
-  CreateCluster(admin, {instance_id, instance_id + "-c2", zone_b});
+  CreateCluster(admin, {project_id, instance_id, instance_id + "-c2", zone_b});
 
   std::cout << "\nRunning UpdateCluster() example" << std::endl;
-  UpdateCluster(admin, {instance_id, instance_id + "-c2"});
+  UpdateCluster(admin, {project_id, instance_id, instance_id + "-c2"});
 
   std::cout << "\nRunning GetCluster() example" << std::endl;
-  GetCluster(admin, {instance_id, instance_id + "-c2"});
+  GetCluster(admin, {project_id, instance_id, instance_id + "-c2"});
 
   std::cout << "\nRunning CreateAppProfile example" << std::endl;
-  CreateAppProfile(admin, {instance_id, "profile-p1"});
+  CreateAppProfile(admin, {project_id, instance_id, "profile-p1"});
 
   std::cout << "\nRunning DeleteAppProfile() example [1]" << std::endl;
   DeleteAppProfile({project_id, instance_id, "profile-p1", "true"});
 
   std::cout << "\nRunning CreateAppProfileCluster() example" << std::endl;
-  CreateAppProfileCluster(admin,
-                          {instance_id, "profile-p2", instance_id + "-c2"});
+  CreateAppProfileCluster(
+      admin, {project_id, instance_id, "profile-p2", instance_id + "-c2"});
 
   std::cout << "\nRunning ListAppProfiles() example" << std::endl;
-  ListAppProfiles(admin, {instance_id});
+  ListAppProfiles(admin, {project_id, instance_id});
 
   std::cout << "\nRunning GetAppProfile() example" << std::endl;
-  GetAppProfile(admin, {instance_id, "profile-p2"});
+  GetAppProfile(admin, {project_id, instance_id, "profile-p2"});
 
   std::cout << "\nRunning UpdateAppProfileDescription() example" << std::endl;
   UpdateAppProfileDescription(
-      admin, {instance_id, "profile-p2", "A profile for examples"});
+      admin, {project_id, instance_id, "profile-p2", "A profile for examples"});
 
   std::cout << "\nRunning UpdateProfileRoutingAny() example" << std::endl;
-  UpdateAppProfileRoutingAny(admin, {instance_id, "profile-p2"});
+  UpdateAppProfileRoutingAny(admin, {project_id, instance_id, "profile-p2"});
 
   std::cout << "\nRunning UpdateProfileRouting() example" << std::endl;
   UpdateAppProfileRoutingSingleCluster(
-      admin, {instance_id, "profile-p2", instance_id + "-c2"});
+      admin, {project_id, instance_id, "profile-p2", instance_id + "-c2"});
 
   std::cout << "\nRunning DeleteAppProfile() example [2]" << std::endl;
   try {
@@ -737,20 +920,21 @@ void RunAll(std::vector<std::string> const& argv) {
   }
 
   std::cout << "\nRunning DeleteCluster() example" << std::endl;
-  DeleteCluster(admin, {instance_id, instance_id + "-c2"});
+  DeleteCluster(admin, {project_id, instance_id, instance_id + "-c2"});
 
-  std::cout << "\nRunning GetNativeIamPolicy() example" << std::endl;
-  GetNativeIamPolicy(admin, {instance_id});
+  std::cout << "\nRunning GetIamPolicy() example" << std::endl;
+  GetIamPolicy(admin, {project_id, instance_id});
 
-  std::cout << "\nRunning SetNativeIamPolicy() example" << std::endl;
-  SetNativeIamPolicy(admin, {instance_id, "roles/bigtable.user",
-                             "serviceAccount:" + service_account});
+  std::cout << "\nRunning SetIamPolicy() example" << std::endl;
+  SetIamPolicy(admin, {project_id, instance_id, "roles/bigtable.user",
+                       "serviceAccount:" + service_account});
 
   std::cout << "\nRunning TestIamPermissions() example" << std::endl;
-  TestIamPermissions({project_id, instance_id, "bigtable.instances.delete"});
+  TestIamPermissions({cbt::InstanceName(project_id, instance_id),
+                      "bigtable.instances.delete"});
 
   std::cout << "\nRunning DeleteInstance() example" << std::endl;
-  DeleteInstance(admin, {instance_id});
+  DeleteInstance(admin, {project_id, instance_id});
 }
 
 }  // anonymous namespace
@@ -812,11 +996,11 @@ int main(int argc, char* argv[]) {
       examples::MakeCommandEntry("list-app-profiles", {"<instance-id>"},
                                  ListAppProfiles),
       {"delete-app-profile", DeleteAppProfile},
-      examples::MakeCommandEntry("get-native-iam-policy", {"<instance-id>"},
-                                 GetNativeIamPolicy),
-      examples::MakeCommandEntry("set-native-iam-policy",
+      examples::MakeCommandEntry("get-iam-policy", {"<instance-id>"},
+                                 GetIamPolicy),
+      examples::MakeCommandEntry("set-iam-policy",
                                  {"<instance-id>", "<role>", "<member>"},
-                                 SetNativeIamPolicy),
+                                 SetIamPolicy),
       {"test-iam-permissions", TestIamPermissions},
       {"auto", RunAll},
   });

--- a/google/cloud/bigtable/testing/cleanup_stale_resources.h
+++ b/google/cloud/bigtable/testing/cleanup_stale_resources.h
@@ -15,7 +15,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_TESTING_CLEANUP_STALE_RESOURCES_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_TESTING_CLEANUP_STALE_RESOURCES_H
 
-#include "google/cloud/bigtable/instance_admin.h"
+#include "google/cloud/bigtable/admin/bigtable_instance_admin_client.h"
 #include "google/cloud/bigtable/table_admin.h"
 
 namespace google {
@@ -33,7 +33,7 @@ namespace testing {
  * times out, and (b) avoiding flakes caused by quota exhaustion is necessary
  * for healthy builds.
  */
-Status CleanupStaleTables(google::cloud::bigtable::TableAdmin admin);
+Status CleanupStaleTables(TableAdmin admin);
 
 /**
  * Remove stale test backups.
@@ -45,7 +45,7 @@ Status CleanupStaleTables(google::cloud::bigtable::TableAdmin admin);
  * times out, and (b) avoiding flakes caused by quota exhaustion is necessary
  * for healthy builds.
  */
-Status CleanupStaleBackups(google::cloud::bigtable::TableAdmin admin);
+Status CleanupStaleBackups(TableAdmin admin);
 
 /**
  * Remove stale test instances.
@@ -57,7 +57,9 @@ Status CleanupStaleBackups(google::cloud::bigtable::TableAdmin admin);
  * crashes or times out, and (b) avoiding flakes caused by quota exhaustion is
  * necessary for healthy builds.
  */
-Status CleanupStaleInstances(google::cloud::bigtable::InstanceAdmin admin);
+Status CleanupStaleInstances(
+    std::shared_ptr<bigtable_admin::BigtableInstanceAdminConnection> c,
+    std::string const& project_id);
 
 }  // namespace testing
 }  // namespace bigtable


### PR DESCRIPTION
Part of the work for #7528 

Some things to note:
* In `examples/bigtable_instance_admin_snippets.cc`, the project ID was previously consumed by `InstanceAdmin`. With the generated APIs, we have to pass it to each command. This explains some of the changes around the argument parsing.
* Funcitonal change to `TestIamPermissions`. Previously it was only used for testing permissions on an instance (so the inputs were project ID, instance ID). Now we test permissions on any resource by passing in the fully qualified resource name. (so you can test permissions for a cluster).
* Oh and I decided to just add the Table Admin mocks now alongside the Instance Admin mocks, even though they aren't used yet.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7729)
<!-- Reviewable:end -->
