### PR TITLE
refactor(bigtable): prefer generated Table Admin

### DIFF
--- a/google/cloud/bigtable/admin/integration_tests/admin_backup_integration_test.cc
+++ b/google/cloud/bigtable/admin/integration_tests/admin_backup_integration_test.cc
@@ -14,6 +14,7 @@
 
 #include "google/cloud/bigtable/admin/bigtable_instance_admin_client.h"
 #include "google/cloud/bigtable/admin/bigtable_table_admin_client.h"
+#include "google/cloud/bigtable/resource_names.h"
 #include "google/cloud/bigtable/testing/table_integration_test.h"
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/internal/random.h"
@@ -79,8 +80,6 @@ protobuf::FieldMask Mask(std::string const& path) {
   return mask;
 }
 
-/// @test Verify that `bigtable::TableAdmin` Backup CRUD operations work as
-/// expected.
 TEST_F(AdminBackupIntegrationTest, CreateListGetUpdateRestoreDeleteBackup) {
   auto const table_id = bigtable::testing::TableTestEnvironment::table_id();
   auto const instance_name =

--- a/google/cloud/bigtable/admin/integration_tests/admin_iam_policy_integration_test.cc
+++ b/google/cloud/bigtable/admin/integration_tests/admin_iam_policy_integration_test.cc
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 #include "google/cloud/bigtable/admin/bigtable_table_admin_client.h"
+#include "google/cloud/bigtable/iam_policy.h"
+#include "google/cloud/bigtable/resource_names.h"
 #include "google/cloud/bigtable/testing/table_integration_test.h"
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/chrono_literals.h"

--- a/google/cloud/bigtable/admin/integration_tests/table_admin_integration_test.cc
+++ b/google/cloud/bigtable/admin/integration_tests/table_admin_integration_test.cc
@@ -14,6 +14,7 @@
 
 #include "google/cloud/bigtable/admin/bigtable_instance_admin_client.h"
 #include "google/cloud/bigtable/admin/bigtable_table_admin_client.h"
+#include "google/cloud/bigtable/resource_names.h"
 #include "google/cloud/bigtable/testing/table_integration_test.h"
 #include "google/cloud/internal/backoff_policy.h"
 #include "google/cloud/internal/getenv.h"
@@ -157,7 +158,6 @@ TEST_F(TableAdminIntegrationTest, DropAllRows) {
   ASSERT_TRUE(actual_cells.empty());
 }
 
-/// @test Verify that `bigtable::TableAdmin` CRUD operations work as expected.
 TEST_F(TableAdminIntegrationTest, CreateListGetDeleteTable) {
   auto const table_id = RandomTableId();
   auto const instance_name =
@@ -257,8 +257,6 @@ TEST_F(TableAdminIntegrationTest, CreateListGetDeleteTable) {
   EXPECT_THAT(*tables, Not(Contains(table_name)));
 }
 
-/// @test Verify that `bigtable::TableAdmin` WaitForConsistencyCheck works as
-/// expected.
 TEST_F(TableAdminIntegrationTest, WaitForConsistencyCheck) {
   // WaitForConsistencyCheck() only makes sense on a replicated table, we need
   // to create an instance with at least 2 clusters to test it.
@@ -380,7 +378,6 @@ TEST_F(TableAdminIntegrationTest, WaitForConsistencyCheck) {
   EXPECT_STATUS_OK(instance_admin_client.DeleteInstance(instance_name));
 }
 
-/// @test Verify rpc logging for `bigtable::TableAdmin`
 TEST_F(TableAdminIntegrationTest, CreateListGetDeleteTableWithLogging) {
   // In our ci builds, we set GOOGLE_CLOUD_CPP_ENABLE_TRACING to log our tests,
   // by default. We should unset this variable and create a fresh client in

--- a/google/cloud/bigtable/doc/bigtable-hello-instance-admin.dox
+++ b/google/cloud/bigtable/doc/bigtable-hello-instance-admin.dox
@@ -32,7 +32,7 @@ To make the example less verbose we define some aliases:
 
 @snippet bigtable_hello_instance_admin.cc aliases
 
-## Connect to the Cloud Bigtable instance admin endpoint.
+## Connect to the Cloud Bigtable Instance Admin Endpoint.
 
 Create an object of type [bigtable::InstanceAdmin][InstanceAdmin] to obtain
 information about *Instances*, *Clusters*, *Application Profiles*, and to change

--- a/google/cloud/bigtable/doc/bigtable-hello-table-admin.dox
+++ b/google/cloud/bigtable/doc/bigtable-hello-table-admin.dox
@@ -1,7 +1,7 @@
 /*!
-@page bigtable-hello-table-admin Example: C++ Hello World for TableAdmin
+@page bigtable-hello-table-admin Example: C++ Hello World for Table Admin
 
-This example illustrates how to use the `TableAdmin` class to:
+This example illustrates how to use the `BigtableTableAdminClient` class to:
 
 - Create a table.
 - List tables.
@@ -33,10 +33,10 @@ To make the example less verbose we define some aliases:
 
 @snippet bigtable_hello_table_admin.cc aliases
 
-## Connect to the TableAdmin API
+## Connect to the Cloud Bigtable Table Admin Endpoint.
 
-Use the [bigtable::TableAdmin][TableAdmin] class to obtain information about
-Cloud Bigtable *tables* and to modify them:
+Use the [bigtable_admin::BigtableTableAdminClient][TableAdmin] class to obtain
+information about Cloud Bigtable *tables* and to modify them:
 
 @snippet bigtable_hello_table_admin.cc connect admin
 
@@ -47,13 +47,14 @@ Cloud Bigtable *tables* and to modify them:
 
 ## Creating a Table
 
-Use [TableAdmin::CreateTable()][TableAdmin-CreateTable] to create a new table:
+Use [BigtableTableAdminClient::CreateTable()][TableAdmin-CreateTable] to create
+a new table:
 
 @snippet bigtable_hello_table_admin.cc create table
 
-Note that when you create a table you can define one or more
-column families for the table, and each column families is configured with
-a garbage collection rule to automatically delete excess cells.
+Note that when you create a table you can define one or more column families for
+the table, and each column families is configured with a garbage collection rule
+to automatically delete excess cells.
 
 @see [bigtable::GcRule][GcRule] to learn about the garbage collection rules,
     including how to delete cells that are [too old][GcRule-MaxAge],
@@ -63,7 +64,7 @@ a garbage collection rule to automatically delete excess cells.
 ## Listing Tables in an Instance
 
 Get all the tables in an instance using
-[TableAdmin::ListTables()][TableAdmin-ListTables]:
+[BigtableTableAdminClient::ListTables()][TableAdmin-ListTables]:
 
 @snippet bigtable_hello_table_admin.cc listing tables
 
@@ -73,7 +74,7 @@ query only a subset of the table metadata.
 ## Retrieve Table Metadata
 
 Or retrieve the metadata, including column family definitions, using
-[TableAdmin::GetTable()][TableAdmin-GetTable]:
+[BigtableTableAdminClient::GetTable()][TableAdmin-GetTable]:
 
 @snippet bigtable_hello_table_admin.cc retrieve table metadata
 
@@ -97,17 +98,14 @@ You can also [add][ColumnFamilyModification-Create] new column families,
 
 ## Delete all the Rows in a Table
 
-Use [TableAdmin::DropAllRows()][TableAdmin-DropAllRows] to delete all the rows
+Use [BigtableTableAdminClient::DropRowRange()][TableAdmin-DropRowRange] to delete all the rows
 in a table:
 
 @snippet bigtable_hello_table_admin.cc drop all rows
 
-@see [TableAdmin::DropRowsByPrefix()][TableAdmin-DropRowsByPrefix] to only
-    delete the rows whose key starts with a give prefix.
-
 ## Delete a Table
 
-Finally use [TableAdmin::DeleteTable()][TableAdmin-DeleteTable] to delete a
+Finally use [BigtableTableAdminClient::DeleteTable()][TableAdmin-DeleteTable] to delete a
 a table:
 
 @snippet bigtable_hello_table_admin.cc delete table
@@ -130,14 +128,13 @@ Here is the full example
 [ColumnFamilyModification-Create]: @ref google::cloud::bigtable::ColumnFamilyModification::Create()
 [ColumnFamilyModification-Update]: @ref google::cloud::bigtable::ColumnFamilyModification::Update()
 [ColumnFamilyModification-Drop]: @ref google::cloud::bigtable::ColumnFamilyModification::Drop()
-[TableAdmin]:              @ref google::cloud::bigtable::TableAdmin
-[TableAdmin-CreateTable]:  @ref google::cloud::bigtable::TableAdmin::CreateTable()
-[TableAdmin-DeleteTable]:  @ref google::cloud::bigtable::TableAdmin::DeleteTable()
-[TableAdmin-GetTable]:     @ref google::cloud::bigtable::TableAdmin::GetTable()
-[TableAdmin-ListTables]:   @ref google::cloud::bigtable::TableAdmin::ListTables()
-[TableAdmin-ModifyColumnFamilies]:  @ref google::cloud::bigtable::TableAdmin::ModifyColumnFamilies()
-[TableAdmin-DropAllRows]:  @ref google::cloud::bigtable::TableAdmin::DropAllRows()
-[TableAdmin-DropRowsByPrefix]:  @ref google::cloud::bigtable::TableAdmin::DropRowsByPrefix()
+[TableAdmin]:              @ref google::cloud::bigtable_admin::BigtableTableAdminClient
+[TableAdmin-CreateTable]:  @ref google::cloud::bigtable_admin::BigtableTableAdminClient::CreateTable()
+[TableAdmin-DeleteTable]:  @ref google::cloud::bigtable_admin::BigtableTableAdminClient::DeleteTable()
+[TableAdmin-GetTable]:     @ref google::cloud::bigtable_admin::BigtableTableAdminClient::GetTable()
+[TableAdmin-ListTables]:   @ref google::cloud::bigtable_admin::BigtableTableAdminClient::ListTables()
+[TableAdmin-ModifyColumnFamilies]:  @ref google::cloud::bigtable_admin::BigtableTableAdminClient::ModifyColumnFamilies()
+[TableAdmin-DropRowRange]:  @ref google::cloud::bigtable_admin::BigtableTableAdminClient::DropRowRange()
 
 [TableView-proto]: https://cloud.google.com/bigtable/docs/reference/admin/rpc/google.bigtable.admin.v2#google.bigtable.admin.v2.Table.View
 */

--- a/google/cloud/bigtable/doc/bigtable-hello-world.dox
+++ b/google/cloud/bigtable/doc/bigtable-hello-world.dox
@@ -38,17 +38,17 @@ To manage tables, connect to Cloud Bigtable using
 
 @snippet bigtable_hello_world.cc connect admin
 
-@see [bigtable::TableAdmin][TableAdmin] for more information on how to perform
-    administrative operations on tables.
+@see [bigtable_admin::BigtableTableAdminClient][TableAdmin] for more information
+    on how to perform administrative operations on tables.
 
 ## Creating a table
 
-Create a table with [TableAdmin::CreateTable()][TableAdmin-CreateTable]:
+Create a table with [BigtableTableAdminClient::CreateTable()][TableAdmin-CreateTable]:
 
 @snippet bigtable_hello_world.cc create table
 
-@see [bigtable::TableAdmin][TableAdmin] for additional operations to list,
-    read, modify, and delete tables.
+@see [bigtable::BigtableTableAdminClient][TableAdmin] for additional operations
+    to list, read, modify, and delete tables.
 @see https://cloud.google.com/bigtable/docs/overview for an overview of the
     Cloud Bigtable storage model, including an introduction to important
     Cloud Bigtable concepts, such as *row keys*, *column families*, *columns*,
@@ -114,7 +114,7 @@ Use [Table::ReadRows()][Table-ReadRows] to scan all of the rows in a table.
 
 ## Deleting a table
 
-Delete a table with [TableAdmin::DeleteTable()][TableAdmin-DeleteTable].
+Delete a table with [BigtableTableAdminClient::DeleteTable()][TableAdmin-DeleteTable].
 
 @snippet bigtable_hello_world.cc delete table
 
@@ -135,8 +135,8 @@ Here is the full example
 [Table-BulkApply]: @ref google::cloud::bigtable::Table::BulkApply
 [Table-ReadRow]:   @ref google::cloud::bigtable::Table::ReadRow
 [Table-ReadRows]:  @ref google::cloud::bigtable::Table::ReadRows
-[TableAdmin]:      @ref google::cloud::bigtable::TableAdmin
-[TableAdmin-CreateTable]:  @ref google::cloud::bigtable::TableAdmin::CreateTable
-[TableAdmin-DeleteTable]:  @ref google::cloud::bigtable::TableAdmin::DeleteTable
+[TableAdmin]:      @ref google::cloud::bigtable_admin::BigtableTableAdminClient
+[TableAdmin-CreateTable]:  @ref google::cloud::bigtable_admin::BigtableTableAdminClient::CreateTable
+[TableAdmin-DeleteTable]:  @ref google::cloud::bigtable_admin::BigtableTableAdminClient::DeleteTable
 
 */

--- a/google/cloud/bigtable/examples/README.md
+++ b/google/cloud/bigtable/examples/README.md
@@ -65,13 +65,13 @@ $ ./bigtable_hello_world hello-world <project_id> <instance_id> <table_id>
 
 ## Administer Instances
 
-### Hello World - `InstanceAdmin`
+### Hello World - Instance Admin
 
 View the [Hello Instance Admin][instance-admin-code] example to see sample usage of instance
 administration of the Bigtable client library. More details on this sample code can be found
 [here][doxygen-instance-admin].
 
-### Running `InstanceAdmin` Samples
+### Running Instance Admin Samples
 
 | Target                               | Description                         |
 | ------------------------------------ | ----------------------------------- |
@@ -88,12 +88,12 @@ $ ./bigtable_instance_admin_snippets create-instance <project-id> <instance-id> 
 
 ## Administer Tables
 
-### Hello World - `TableAdmin`
+### Hello World - Table Admin
 
 View the [Hello Table Admin][table-admin-code] example to see sample usage of table
 administration of the Bigtable client library. More details on this sample code can be found [here][doxygen-table-admin].
 
-### Running `TableAdmin` Samples
+### Running Table Admin Samples
 
 | Target                                   | Description                         |
 | ---------------------------------------- | ----------------------------------- |

--- a/google/cloud/bigtable/examples/bigtable_examples_common.cc
+++ b/google/cloud/bigtable/examples/bigtable_examples_common.cc
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include "google/cloud/bigtable/examples/bigtable_examples_common.h"
-#include "google/cloud/bigtable/table_admin.h"
 #include "google/cloud/internal/absl_str_join_quiet.h"
 #include "google/cloud/internal/getenv.h"
 #include <google/protobuf/util/time_util.h>
@@ -73,10 +72,9 @@ Commands::value_type MakeCommandEntry(std::string const& name,
       if (!args.empty()) os << " " << absl::StrJoin(args, " ");
       throw Usage{std::move(os).str()};
     }
-    google::cloud::bigtable::TableAdmin table(
-        google::cloud::bigtable::MakeAdminClient(argv[0]), argv[1]);
-    argv.erase(argv.begin(), argv.begin() + kFixedArguments);
-    function(table, argv);
+    auto client = bigtable_admin::BigtableTableAdminClient(
+        bigtable_admin::MakeBigtableTableAdminConnection());
+    function(client, argv);
   };
   return {name, command};
 }

--- a/google/cloud/bigtable/examples/bigtable_examples_common.h
+++ b/google/cloud/bigtable/examples/bigtable_examples_common.h
@@ -16,8 +16,8 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_EXAMPLES_BIGTABLE_EXAMPLES_COMMON_H
 
 #include "google/cloud/bigtable/admin/bigtable_instance_admin_client.h"
+#include "google/cloud/bigtable/admin/bigtable_table_admin_client.h"
 #include "google/cloud/bigtable/table.h"
-#include "google/cloud/bigtable/table_admin.h"
 #include "google/cloud/internal/random.h"
 #include "google/cloud/testing_util/example_driver.h"
 #include <chrono>
@@ -62,8 +62,9 @@ google::cloud::bigtable::examples::Commands::value_type MakeCommandEntry(
     std::string const& name, std::vector<std::string> const& args,
     TableCommandType const& function);
 
-using TableAdminCommandType = std::function<void(
-    google::cloud::bigtable::TableAdmin, std::vector<std::string>)>;
+using TableAdminCommandType =
+    std::function<void(google::cloud::bigtable_admin::BigtableTableAdminClient,
+                       std::vector<std::string>)>;
 
 Commands::value_type MakeCommandEntry(std::string const& name,
                                       std::vector<std::string> const& args,

--- a/google/cloud/bigtable/examples/bigtable_examples_common_test.cc
+++ b/google/cloud/bigtable/examples/bigtable_examples_common_test.cc
@@ -55,12 +55,14 @@ TEST(BigtableExamplesCommon, MakeTableAdminCommandEntry) {
   google::cloud::testing_util::ScopedEnvironment emulator(
       "BIGTABLE_EMULATOR_HOST", "localhost:9090");
   int call_count = 0;
-  auto command = [&call_count](bigtable::TableAdmin const&,
+  auto command = [&call_count](bigtable_admin::BigtableTableAdminClient const&,
                                std::vector<std::string> const& argv) {
     ++call_count;
-    ASSERT_EQ(2, argv.size());
-    EXPECT_EQ("a", argv[0]);
-    EXPECT_EQ("b", argv[1]);
+    ASSERT_EQ(4, argv.size());
+    EXPECT_EQ("project", argv[0]);
+    EXPECT_EQ("instance", argv[1]);
+    EXPECT_EQ("a", argv[2]);
+    EXPECT_EQ("b", argv[3]);
   };
   auto const actual = MakeCommandEntry("command-name", {"foo", "bar"}, command);
   EXPECT_EQ("command-name", actual.first);
@@ -73,7 +75,7 @@ TEST(BigtableExamplesCommon, MakeTableAdminCommandEntry) {
       },
       Usage);
 
-  ASSERT_NO_FATAL_FAILURE(actual.second({"unused", "unused", "a", "b"}));
+  ASSERT_NO_FATAL_FAILURE(actual.second({"project", "instance", "a", "b"}));
   EXPECT_EQ(1, call_count);
 }
 

--- a/google/cloud/bigtable/examples/bigtable_grpc_credentials.cc
+++ b/google/cloud/bigtable/examples/bigtable_grpc_credentials.cc
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "google/cloud/bigtable/admin/bigtable_table_admin_client.h"
 #include "google/cloud/bigtable/examples/bigtable_examples_common.h"
-#include "google/cloud/bigtable/table_admin.h"
+#include "google/cloud/bigtable/resource_names.h"
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/crash_handler.h"
 #include <fstream>
@@ -30,6 +31,7 @@ void AccessToken(std::vector<std::string> const& argv) {
 
   // Create a namespace alias to make the code easier to read.
   namespace cbt = ::google::cloud::bigtable;
+  namespace cbta = ::google::cloud::bigtable_admin;
   using ::google::cloud::GrpcCredentialOption;
   using ::google::cloud::Options;
   using ::google::cloud::StatusOr;
@@ -44,11 +46,16 @@ void AccessToken(std::vector<std::string> const& argv) {
                                                          call_credentials);
     auto options = Options{}.set<GrpcCredentialOption>(credentials);
 
-    cbt::TableAdmin admin(cbt::MakeAdminClient(project_id, options),
-                          instance_id);
+    cbta::BigtableTableAdminClient admin(
+        cbta::MakeBigtableTableAdminConnection(options));
 
-    auto tables = admin.ListTables(cbt::TableAdmin::NAME_ONLY);
-    if (!tables) throw std::runtime_error(tables.status().message());
+    google::bigtable::admin::v2::ListTablesRequest r;
+    r.set_parent(cbt::InstanceName(project_id, instance_id));
+    r.set_view(google::bigtable::admin::v2::Table::NAME_ONLY);
+    auto tables = admin.ListTables(std::move(r));
+    for (auto const& table : tables) {
+      if (!table) throw std::runtime_error(table.status().message());
+    }
   }
   //! [test access token]
   (argv.at(0), argv.at(1), argv.at(2));
@@ -62,6 +69,7 @@ void JWTAccessToken(std::vector<std::string> const& argv) {
   }
   // Create a namespace alias to make the code easier to read.
   namespace cbt = ::google::cloud::bigtable;
+  namespace cbta = ::google::cloud::bigtable_admin;
   using ::google::cloud::GrpcCredentialOption;
   using ::google::cloud::Options;
   using ::google::cloud::StatusOr;
@@ -86,11 +94,16 @@ void JWTAccessToken(std::vector<std::string> const& argv) {
                                                          call_credentials);
     auto options = Options{}.set<GrpcCredentialOption>(credentials);
 
-    cbt::TableAdmin admin(cbt::MakeAdminClient(project_id, options),
-                          instance_id);
+    cbta::BigtableTableAdminClient admin(
+        cbta::MakeBigtableTableAdminConnection(options));
 
-    auto tables = admin.ListTables(cbt::TableAdmin::NAME_ONLY);
-    if (!tables) throw std::runtime_error(tables.status().message());
+    google::bigtable::admin::v2::ListTablesRequest r;
+    r.set_parent(cbt::InstanceName(project_id, instance_id));
+    r.set_view(google::bigtable::admin::v2::Table::NAME_ONLY);
+    auto tables = admin.ListTables(std::move(r));
+    for (auto const& table : tables) {
+      if (!table) throw std::runtime_error(table.status().message());
+    }
   }
   //! [test jwt access token]
   (argv.at(0), argv.at(1), argv.at(2));
@@ -102,6 +115,7 @@ void GCECredentials(std::vector<std::string> const& argv) {
   }
   // Create a namespace alias to make the code easier to read.
   namespace cbt = ::google::cloud::bigtable;
+  namespace cbta = ::google::cloud::bigtable_admin;
   using ::google::cloud::GrpcCredentialOption;
   using ::google::cloud::Options;
   using ::google::cloud::StatusOr;
@@ -115,11 +129,16 @@ void GCECredentials(std::vector<std::string> const& argv) {
                                                          call_credentials);
     auto options = Options{}.set<GrpcCredentialOption>(credentials);
 
-    cbt::TableAdmin admin(cbt::MakeAdminClient(project_id, options),
-                          instance_id);
+    cbta::BigtableTableAdminClient admin(
+        cbta::MakeBigtableTableAdminConnection(options));
 
-    auto tables = admin.ListTables(cbt::TableAdmin::NAME_ONLY);
-    if (!tables) throw std::runtime_error(tables.status().message());
+    google::bigtable::admin::v2::ListTablesRequest r;
+    r.set_parent(cbt::InstanceName(project_id, instance_id));
+    r.set_view(google::bigtable::admin::v2::Table::NAME_ONLY);
+    auto tables = admin.ListTables(std::move(r));
+    for (auto const& table : tables) {
+      if (!table) throw std::runtime_error(table.status().message());
+    }
   }
   //! [test gce credentials]
   (argv.at(0), argv.at(1));

--- a/google/cloud/bigtable/examples/bigtable_hello_instance_admin.cc
+++ b/google/cloud/bigtable/examples/bigtable_hello_instance_admin.cc
@@ -18,6 +18,7 @@
 #include "google/cloud/bigtable/admin/bigtable_instance_admin_client.h"
 //! [bigtable includes]
 #include "google/cloud/bigtable/examples/bigtable_examples_common.h"
+#include "google/cloud/bigtable/resource_names.h"
 #include "google/cloud/bigtable/testing/cleanup_stale_resources.h"
 #include "google/cloud/bigtable/testing/random_names.h"
 #include "google/cloud/internal/algorithm.h"

--- a/google/cloud/bigtable/examples/bigtable_instance_admin_snippets.cc
+++ b/google/cloud/bigtable/examples/bigtable_instance_admin_snippets.cc
@@ -14,6 +14,8 @@
 
 #include "google/cloud/bigtable/admin/bigtable_instance_admin_client.h"
 #include "google/cloud/bigtable/examples/bigtable_examples_common.h"
+#include "google/cloud/bigtable/iam_binding.h"
+#include "google/cloud/bigtable/resource_names.h"
 #include "google/cloud/bigtable/testing/cleanup_stale_resources.h"
 #include "google/cloud/bigtable/testing/random_names.h"
 #include "google/cloud/internal/absl_str_join_quiet.h"
@@ -817,13 +819,12 @@ void RunAll(std::vector<std::string> const& argv) {
 
   auto generator = google::cloud::internal::DefaultPRNG(std::random_device{}());
   auto conn = cbta::MakeBigtableInstanceAdminConnection();
-  google::cloud::bigtable::testing::CleanupStaleInstances(conn, project_id);
+  cbt::testing::CleanupStaleInstances(conn, project_id);
   cbta::BigtableInstanceAdminClient admin(std::move(conn));
 
   // Create a different instance id to run the replicated instance example.
   {
-    auto const id =
-        google::cloud::bigtable::testing::RandomInstanceId(generator);
+    auto const id = cbt::testing::RandomInstanceId(generator);
     std::cout << "\nRunning CreateReplicatedInstance() example" << std::endl;
     CreateReplicatedInstance(admin, {project_id, id, zone_a, zone_b});
     std::cout << "\nRunning GetInstance() example" << std::endl;
@@ -833,8 +834,7 @@ void RunAll(std::vector<std::string> const& argv) {
 
   // Create a different instance id to run the development instance example.
   {
-    auto const id =
-        google::cloud::bigtable::testing::RandomInstanceId(generator);
+    auto const id = cbt::testing::RandomInstanceId(generator);
     std::cout << "\nRunning CreateDevInstance() example" << std::endl;
     CreateDevInstance(admin, {project_id, id, zone_a});
     std::cout << "\nRunning UpdateInstance() example" << std::endl;
@@ -842,8 +842,7 @@ void RunAll(std::vector<std::string> const& argv) {
     (void)admin.DeleteInstance(cbt::InstanceName(project_id, id));
   }
 
-  auto const instance_id =
-      google::cloud::bigtable::testing::RandomInstanceId(generator);
+  auto const instance_id = cbt::testing::RandomInstanceId(generator);
 
   std::cout << "\nRunning CheckInstanceExists() example [1]" << std::endl;
   CheckInstanceExists(admin, {project_id, instance_id});

--- a/google/cloud/bigtable/examples/bigtable_table_admin_backup_snippets.cc
+++ b/google/cloud/bigtable/examples/bigtable_table_admin_backup_snippets.cc
@@ -12,26 +12,30 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "google/cloud/bigtable/admin/bigtable_table_admin_client.h"
 #include "google/cloud/bigtable/examples/bigtable_examples_common.h"
-#include "google/cloud/bigtable/table_admin.h"
+#include "google/cloud/bigtable/iam_binding.h"
+#include "google/cloud/bigtable/resource_names.h"
 #include "google/cloud/bigtable/testing/cleanup_stale_resources.h"
 #include "google/cloud/bigtable/testing/random_names.h"
 #include "google/cloud/internal/getenv.h"
 #include "absl/time/clock.h"
 #include "absl/time/time.h"
-#include <google/protobuf/util/time_util.h>
 #include <sstream>
 
 namespace {
 
 using ::google::cloud::bigtable::examples::Usage;
 
-void CreateBackup(google::cloud::bigtable::TableAdmin const& admin,
+void CreateBackup(google::cloud::bigtable_admin::BigtableTableAdminClient admin,
                   std::vector<std::string> const& argv) {
   //! [create backup]
   namespace cbt = ::google::cloud::bigtable;
+  namespace cbta = ::google::cloud::bigtable_admin;
+  using ::google::cloud::future;
   using ::google::cloud::StatusOr;
-  [](cbt::TableAdmin admin, std::string const& table_id,
+  [](cbta::BigtableTableAdminClient admin, std::string const& project_id,
+     std::string const& instance_id, std::string const& table_id,
      std::string const& cluster_id, std::string const& backup_id,
      std::string const& expire_time_string) {
     absl::Time t;
@@ -39,159 +43,226 @@ void CreateBackup(google::cloud::bigtable::TableAdmin const& admin,
     if (!absl::ParseTime(absl::RFC3339_full, expire_time_string, &t, &err)) {
       throw std::runtime_error("Unable to parse expire_time:" + err);
     }
-    auto expire_time = absl::ToChronoTime(t);
-    StatusOr<google::bigtable::admin::v2::Backup> backup =
-        admin.CreateBackup(cbt::TableAdmin::CreateBackupParams(
-            cluster_id, backup_id, table_id, expire_time));
+    std::string cluster_name =
+        cbt::ClusterName(project_id, instance_id, cluster_id);
+    std::string table_name = cbt::TableName(project_id, instance_id, table_id);
+
+    google::bigtable::admin::v2::Backup b;
+    b.set_source_table(table_name);
+    b.mutable_expire_time()->set_seconds(absl::ToUnixSeconds(t));
+
+    future<StatusOr<google::bigtable::admin::v2::Backup>> backup_future =
+        admin.CreateBackup(cluster_name, backup_id, std::move(b));
+    auto backup = backup_future.get();
     if (!backup) throw std::runtime_error(backup.status().message());
     std::cout << "Backup successfully created: " << backup->DebugString()
               << "\n";
   }
   //! [create backup]
-  (admin, argv.at(0), argv.at(1), argv.at(2), argv.at(3));
+  (std::move(admin), argv.at(0), argv.at(1), argv.at(2), argv.at(3), argv.at(4),
+   argv.at(5));
 }
 
-void ListBackups(google::cloud::bigtable::TableAdmin const& admin,
+void ListBackups(google::cloud::bigtable_admin::BigtableTableAdminClient admin,
                  std::vector<std::string> const& argv) {
   //! [list backups]
   namespace cbt = ::google::cloud::bigtable;
-  using ::google::cloud::StatusOr;
-  [](cbt::TableAdmin admin, std::string const& cluster_id,
+  namespace cbta = ::google::cloud::bigtable_admin;
+  using ::google::cloud::StreamRange;
+  [](cbta::BigtableTableAdminClient admin, std::string const& project_id,
+     std::string const& instance_id, std::string const& cluster_id,
      std::string const& filter, std::string const& order_by) {
-    cbt::TableAdmin::ListBackupsParams list_backups_params;
-    list_backups_params.set_cluster(cluster_id);
-    list_backups_params.set_filter(filter);
-    list_backups_params.set_order_by(order_by);
-    StatusOr<std::vector<google::bigtable::admin::v2::Backup>> backups =
-        admin.ListBackups(std::move(list_backups_params));
-    if (!backups) throw std::runtime_error(backups.status().message());
-    for (auto const& backup : *backups) {
-      std::cout << backup.name() << "\n";
+    std::string cluster_name =
+        cbt::ClusterName(project_id, instance_id, cluster_id);
+
+    google::bigtable::admin::v2::ListBackupsRequest r;
+    r.set_parent(cluster_name);
+    r.set_filter(filter);
+    r.set_order_by(order_by);
+
+    StreamRange<google::bigtable::admin::v2::Backup> backups =
+        admin.ListBackups(std::move(r));
+    for (auto const& backup : backups) {
+      if (!backup) throw std::runtime_error(backup.status().message());
+      std::cout << backup->name() << "\n";
     }
   }
   //! [list backups]
-  (admin, argv.at(0), argv.at(1), argv.at(2));
+  (std::move(admin), argv.at(0), argv.at(1), argv.at(2), argv.at(3),
+   argv.at(4));
 }
 
-void GetBackup(google::cloud::bigtable::TableAdmin const& admin,
+void GetBackup(google::cloud::bigtable_admin::BigtableTableAdminClient admin,
                std::vector<std::string> const& argv) {
   //! [get backup]
   namespace cbt = ::google::cloud::bigtable;
+  namespace cbta = ::google::cloud::bigtable_admin;
   using ::google::cloud::StatusOr;
-  [](cbt::TableAdmin admin, std::string const& cluster_id,
+  [](cbta::BigtableTableAdminClient admin, std::string const& project_id,
+     std::string const& instance_id, std::string const& cluster_id,
      std::string const& backup_id) {
+    std::string backup_name =
+        cbt::BackupName(project_id, instance_id, cluster_id, backup_id);
     StatusOr<google::bigtable::admin::v2::Backup> backup =
-        admin.GetBackup(cluster_id, backup_id);
+        admin.GetBackup(backup_name);
     if (!backup) throw std::runtime_error(backup.status().message());
     std::cout << backup->name() << " details=\n"
               << backup->DebugString() << "\n";
   }
   //! [get backup]
-  (admin, argv.at(0), argv.at(1));
+  (std::move(admin), argv.at(0), argv.at(1), argv.at(2), argv.at(3));
 }
 
-void DeleteBackup(google::cloud::bigtable::TableAdmin const& admin,
+void DeleteBackup(google::cloud::bigtable_admin::BigtableTableAdminClient admin,
                   std::vector<std::string> const& argv) {
   //! [delete backup]
   namespace cbt = ::google::cloud::bigtable;
-  [](cbt::TableAdmin admin, std::string const& cluster_id,
+  namespace cbta = ::google::cloud::bigtable_admin;
+  using ::google::cloud::Status;
+  [](cbta::BigtableTableAdminClient admin, std::string const& project_id,
+     std::string const& instance_id, std::string const& cluster_id,
      std::string const& backup_id) {
-    google::cloud::Status status = admin.DeleteBackup(cluster_id, backup_id);
+    std::string backup_name =
+        cbt::BackupName(project_id, instance_id, cluster_id, backup_id);
+    Status status = admin.DeleteBackup(backup_name);
     if (!status.ok()) throw std::runtime_error(status.message());
     std::cout << "Backup successfully deleted\n";
   }
   //! [delete backup]
-  (admin, argv.at(0), argv.at(1));
+  (std::move(admin), argv.at(0), argv.at(1), argv.at(2), argv.at(3));
 }
 
-void UpdateBackup(google::cloud::bigtable::TableAdmin const& admin,
+void UpdateBackup(google::cloud::bigtable_admin::BigtableTableAdminClient admin,
                   std::vector<std::string> const& argv) {
   //! [update backup]
   namespace cbt = ::google::cloud::bigtable;
+  namespace cbta = ::google::cloud::bigtable_admin;
   using ::google::cloud::StatusOr;
-  [](cbt::TableAdmin admin, std::string const& cluster_id,
+  [](cbta::BigtableTableAdminClient admin, std::string const& project_id,
+     std::string const& instance_id, std::string const& cluster_id,
      std::string const& backup_id, std::string const& expire_time_string) {
     absl::Time t;
     std::string err;
     if (!absl::ParseTime(absl::RFC3339_full, expire_time_string, &t, &err)) {
       throw std::runtime_error("Unable to parse expire_time:" + err);
     }
-    auto expire_time = absl::ToChronoTime(t);
+    std::string backup_name =
+        cbt::BackupName(project_id, instance_id, cluster_id, backup_id);
+
+    google::bigtable::admin::v2::Backup b;
+    b.set_name(backup_name);
+    b.mutable_expire_time()->set_seconds(absl::ToUnixSeconds(t));
+
+    google::protobuf::FieldMask mask;
+    mask.add_paths("expire_time");
 
     StatusOr<google::bigtable::admin::v2::Backup> backup =
-        admin.UpdateBackup(cbt::TableAdmin::UpdateBackupParams(
-            cluster_id, backup_id, expire_time));
+        admin.UpdateBackup(std::move(b), std::move(mask));
     if (!backup) throw std::runtime_error(backup.status().message());
     std::cout << backup->name() << " details=\n"
               << backup->DebugString() << "\n";
   }
   //! [update backup]
-  (admin, argv.at(0), argv.at(1), argv.at(2));
+  (std::move(admin), argv.at(0), argv.at(1), argv.at(2), argv.at(3),
+   argv.at(4));
 }
 
-void RestoreTable(google::cloud::bigtable::TableAdmin const& admin,
+void RestoreTable(google::cloud::bigtable_admin::BigtableTableAdminClient admin,
                   std::vector<std::string> const& argv) {
   //! [restore table]
   namespace cbt = ::google::cloud::bigtable;
+  namespace cbta = ::google::cloud::bigtable_admin;
+  using ::google::cloud::future;
   using ::google::cloud::StatusOr;
-  [](cbt::TableAdmin admin, std::string const& table_id,
+  [](cbta::BigtableTableAdminClient admin, std::string const& project_id,
+     std::string const& instance_id, std::string const& table_id,
      std::string const& cluster_id, std::string const& backup_id) {
-    StatusOr<google::bigtable::admin::v2::Table> table = admin.RestoreTable(
-        cbt::TableAdmin::RestoreTableParams(table_id, cluster_id, backup_id));
+    std::string instance_name = cbt::InstanceName(project_id, instance_id);
+    std::string backup_name =
+        cbt::BackupName(project_id, instance_id, cluster_id, backup_id);
+
+    google::bigtable::admin::v2::RestoreTableRequest r;
+    r.set_parent(instance_name);
+    r.set_table_id(table_id);
+    r.set_backup(backup_name);
+
+    future<StatusOr<google::bigtable::admin::v2::Table>> table_future =
+        admin.RestoreTable(std::move(r));
+    auto table = table_future.get();
     if (!table) throw std::runtime_error(table.status().message());
     std::cout << "Table successfully restored: " << table->DebugString()
               << "\n";
   }
   //! [restore table]
-  (admin, argv.at(0), argv.at(1), argv.at(2));
+  (std::move(admin), argv.at(0), argv.at(1), argv.at(2), argv.at(3),
+   argv.at(4));
 }
 
-void RestoreTableFromInstance(google::cloud::bigtable::TableAdmin const& admin,
-                              std::vector<std::string> const& argv) {
+void RestoreTableFromInstance(
+    google::cloud::bigtable_admin::BigtableTableAdminClient admin,
+    std::vector<std::string> const& argv) {
   //! [restore2]
   namespace cbt = ::google::cloud::bigtable;
+  namespace cbta = ::google::cloud::bigtable_admin;
+  using ::google::cloud::future;
   using ::google::cloud::StatusOr;
-  [](cbt::TableAdmin admin, std::string const& table_id,
+  [](cbta::BigtableTableAdminClient admin, std::string const& project_id,
+     std::string const& instance_id, std::string const& table_id,
      std::string const& other_instance_id, std::string const& cluster_id,
      std::string const& backup_id) {
-    StatusOr<google::bigtable::admin::v2::Table> table =
-        admin.RestoreTable(cbt::TableAdmin::RestoreTableFromInstanceParams{
-            table_id, cbt::BackupName(admin.project(), other_instance_id,
-                                      cluster_id, backup_id)});
+    std::string instance_name = cbt::InstanceName(project_id, instance_id);
+    std::string backup_name =
+        cbt::BackupName(project_id, other_instance_id, cluster_id, backup_id);
+
+    google::bigtable::admin::v2::RestoreTableRequest r;
+    r.set_parent(instance_name);
+    r.set_table_id(table_id);
+    r.set_backup(backup_name);
+
+    future<StatusOr<google::bigtable::admin::v2::Table>> table_future =
+        admin.RestoreTable(std::move(r));
+    auto table = table_future.get();
     if (!table) throw std::runtime_error(table.status().message());
     std::cout << "Table successfully restored: " << table->DebugString()
               << "\n";
   }
   //! [restore2]
-  (admin, argv.at(0), argv.at(1), argv.at(2), argv.at(3));
+  (std::move(admin), argv.at(0), argv.at(1), argv.at(2), argv.at(3), argv.at(4),
+   argv.at(5));
 }
 
-void GetIamPolicy(google::cloud::bigtable::TableAdmin const& admin,
+void GetIamPolicy(google::cloud::bigtable_admin::BigtableTableAdminClient admin,
                   std::vector<std::string> const& argv) {
   //! [get backup iam policy]
   namespace cbt = ::google::cloud::bigtable;
+  namespace cbta = ::google::cloud::bigtable_admin;
   using ::google::cloud::StatusOr;
-  [](cbt::TableAdmin admin, std::string const& cluster_id,
+  [](cbta::BigtableTableAdminClient admin, std::string const& project_id,
+     std::string const& instance_id, std::string const& cluster_id,
      std::string const& backup_id) {
-    StatusOr<google::iam::v1::Policy> policy =
-        admin.GetIamPolicy(cluster_id, backup_id);
+    std::string backup_name =
+        cbt::BackupName(project_id, instance_id, cluster_id, backup_id);
+    StatusOr<google::iam::v1::Policy> policy = admin.GetIamPolicy(backup_name);
     if (!policy) throw std::runtime_error(policy.status().message());
     std::cout << "The IAM Policy is:\n" << policy->DebugString() << "\n";
   }
   //! [get backup iam policy]
-  (admin, argv.at(0), argv.at(1));
+  (std::move(admin), argv.at(0), argv.at(1), argv.at(2), argv.at(3));
 }
 
-void SetIamPolicy(google::cloud::bigtable::TableAdmin const& admin,
+void SetIamPolicy(google::cloud::bigtable_admin::BigtableTableAdminClient admin,
                   std::vector<std::string> const& argv) {
   //! [set backup iam policy]
   namespace cbt = ::google::cloud::bigtable;
+  namespace cbta = ::google::cloud::bigtable_admin;
   using ::google::cloud::StatusOr;
-  [](cbt::TableAdmin admin, std::string const& cluster_id,
+  [](cbta::BigtableTableAdminClient admin, std::string const& project_id,
+     std::string const& instance_id, std::string const& cluster_id,
      std::string const& backup_id, std::string const& role,
      std::string const& member) {
-    StatusOr<google::iam::v1::Policy> current =
-        admin.GetIamPolicy(cluster_id, backup_id);
+    std::string backup_name =
+        cbt::BackupName(project_id, instance_id, cluster_id, backup_id);
+    StatusOr<google::iam::v1::Policy> current = admin.GetIamPolicy(backup_name);
     if (!current) throw std::runtime_error(current.status().message());
     // This example adds the member to all existing bindings for that role. If
     // there are no such bindings, it adds a new one. This might not be what the
@@ -207,17 +278,19 @@ void SetIamPolicy(google::cloud::bigtable::TableAdmin const& admin,
       *current->add_bindings() = cbt::IamBinding(role, {member});
     }
     StatusOr<google::iam::v1::Policy> policy =
-        admin.SetIamPolicy(cluster_id, backup_id, *current);
+        admin.SetIamPolicy(backup_name, *current);
     if (!policy) throw std::runtime_error(policy.status().message());
     std::cout << "The IAM Policy is:\n" << policy->DebugString() << "\n";
   }
   //! [set backup iam policy]
-  (std::move(admin), argv.at(0), argv.at(1), argv.at(2), argv.at(3));
+  (std::move(admin), argv.at(0), argv.at(1), argv.at(2), argv.at(3), argv.at(4),
+   argv.at(5));
 }
 
 void RunAll(std::vector<std::string> const& argv) {
   namespace examples = ::google::cloud::bigtable::examples;
   namespace cbt = ::google::cloud::bigtable;
+  namespace cbta = ::google::cloud::bigtable_admin;
 
   if (!argv.empty()) throw examples::Usage{"auto"};
   if (!examples::RunAdminIntegrationTests()) return;
@@ -241,68 +314,71 @@ void RunAll(std::vector<std::string> const& argv) {
                               "GOOGLE_CLOUD_CPP_BIGTABLE_TEST_CLUSTER_ID")
                               .value();
 
-  cbt::TableAdmin admin(cbt::MakeAdminClient(project_id), instance_id);
-
+  auto conn = cbta::MakeBigtableTableAdminConnection();
   // If a previous run of these samples crashes before cleaning up there may be
   // old tables left over. As there are quotas on the total number of tables we
   // remove stale tables after 48 hours.
   std::cout << "\nCleaning up old tables" << std::endl;
-  std::string const prefix = "table-admin-snippets-";
-  google::cloud::bigtable::testing::CleanupStaleTables(admin);
-  std::string const backup_prefix = "table-admin-snippets-backup-";
-  google::cloud::bigtable::testing::CleanupStaleBackups(admin);
+  cbt::testing::CleanupStaleTables(conn, project_id, instance_id);
+  cbt::testing::CleanupStaleBackups(conn, project_id, instance_id);
+  auto admin = cbta::BigtableTableAdminClient(std::move(conn));
 
   auto generator = google::cloud::internal::DefaultPRNG(std::random_device{}());
-  // This table is actually created and used to test the positive case (e.g.
-  // GetTable() and "table does exist")
-  auto table_id = google::cloud::bigtable::testing::RandomTableId(generator);
+  auto table_id = cbt::testing::RandomTableId(generator);
 
-  auto table = admin.CreateTable(
-      table_id, cbt::TableConfig(
-                    {
-                        {"fam", cbt::GcRule::MaxNumVersions(10)},
-                        {"foo", cbt::GcRule::MaxNumVersions(3)},
-                    },
-                    {}));
+  // Create a table to run the tests on.
+  google::bigtable::admin::v2::Table t;
+  auto& families = *t.mutable_column_families();
+  google::bigtable::admin::v2::GcRule gc1;
+  gc1.set_max_num_versions(10);
+  *families["fam"].mutable_gc_rule() = std::move(gc1);
+  google::bigtable::admin::v2::GcRule gc2;
+  gc2.set_max_num_versions(3);
+  *families["foo"].mutable_gc_rule() = std::move(gc2);
+
+  auto table = admin.CreateTable(cbt::InstanceName(project_id, instance_id),
+                                 table_id, std::move(t));
   if (!table) throw std::runtime_error(table.status().message());
 
   std::cout << "\nRunning CreateBackup() example" << std::endl;
   auto backup_id = google::cloud::bigtable::testing::RandomTableId(generator);
-  CreateBackup(admin, {table_id, cluster_id, backup_id,
+  CreateBackup(admin, {project_id, instance_id, table_id, cluster_id, backup_id,
                        absl::FormatTime(absl::Now() + absl::Hours(12))});
 
   std::cout << "\nRunning ListBackups() example" << std::endl;
-  ListBackups(admin, {"-", {}, {}});
+  ListBackups(admin, {project_id, instance_id, "-", {}, {}});
 
   std::cout << "\nRunning GetBackup() example" << std::endl;
-  GetBackup(admin, {cluster_id, backup_id});
+  GetBackup(admin, {project_id, instance_id, cluster_id, backup_id});
 
   std::cout << "\nRunning UpdateBackup() example" << std::endl;
-  UpdateBackup(admin, {cluster_id, backup_id,
+  UpdateBackup(admin, {project_id, instance_id, cluster_id, backup_id,
                        absl::FormatTime(absl::Now() + absl::Hours(24))});
 
   std::cout << "\nRunning SetIamPolicy() example" << std::endl;
-  SetIamPolicy(admin, {cluster_id, backup_id, "roles/bigtable.user",
-                       "serviceAccount:" + service_account});
+  SetIamPolicy(admin,
+               {project_id, instance_id, cluster_id, backup_id,
+                "roles/bigtable.user", "serviceAccount:" + service_account});
 
   std::cout << "\nRunning GetIamPolicy() example" << std::endl;
-  GetIamPolicy(admin, {cluster_id, backup_id});
+  GetIamPolicy(admin, {project_id, instance_id, cluster_id, backup_id});
 
-  (void)admin.DeleteTable(table_id);
+  (void)admin.DeleteTable(table->name());
 
   std::cout << "\nRunning RestoreTable() example" << std::endl;
-  RestoreTable(admin, {table_id, cluster_id, backup_id});
+  RestoreTable(admin,
+               {project_id, instance_id, table_id, cluster_id, backup_id});
 
-  (void)admin.DeleteTable(table_id);
+  (void)admin.DeleteTable(table->name());
 
   std::cout << "\nRunning RestoreTableFromInstance() example" << std::endl;
-  RestoreTableFromInstance(admin,
-                           {table_id, instance_id, cluster_id, backup_id});
+  RestoreTableFromInstance(admin, {project_id, instance_id, table_id,
+                                   instance_id, cluster_id, backup_id});
 
   std::cout << "\nRunning DeleteBackup() example" << std::endl;
-  DeleteBackup(admin, {cluster_id, backup_id});
+  DeleteBackup(admin, {project_id, instance_id, cluster_id, backup_id});
 
-  (void)admin.DeleteTable(table_id);
+  (void)admin.DeleteTable(table->name());
 }
 
 }  // anonymous namespace
@@ -310,12 +386,12 @@ void RunAll(std::vector<std::string> const& argv) {
 int main(int argc, char* argv[]) {
   namespace examples = ::google::cloud::bigtable::examples;
   google::cloud::bigtable::examples::Example example({
-      examples::MakeCommandEntry(
-          "create-backup",
-          {"<table-id>", "<cluster-id>", "<backup-id>", "<expire_time>"},
-          CreateBackup),
+      examples::MakeCommandEntry("create-backup",
+                                 {"<table-id>", "<cluster-id>", "<backup-id>",
+                                  "<expire-time(1980-06-20T00:00:00Z)>"},
+                                 CreateBackup),
       examples::MakeCommandEntry("list-backups",
-                                 {"<cluster-id>", "<filter>", "<order_by>"},
+                                 {"<cluster-id>", "<filter>", "<order-by>"},
                                  ListBackups),
       examples::MakeCommandEntry("get-backup", {"<cluster-id>", "<backup-id>"},
                                  GetBackup),
@@ -333,10 +409,10 @@ int main(int argc, char* argv[]) {
           {"<table-id>", "<other-instance-id>", "<cluster-id>", "<backup-id>"},
           RestoreTableFromInstance),
       examples::MakeCommandEntry("get-iam-policy",
-                                 {"<cluster-id>", "<backup_id>"}, GetIamPolicy),
+                                 {"<cluster-id>", "<backup-id>"}, GetIamPolicy),
       examples::MakeCommandEntry(
           "set-iam-policy",
-          {"<cluster-id>", "<backup_id>", "<role>", "<member>"}, SetIamPolicy),
+          {"<cluster-id>", "<backup-id>", "<role>", "<member>"}, SetIamPolicy),
       {"auto", RunAll},
   });
   return example.Run(argc, argv);

--- a/google/cloud/bigtable/examples/data_async_snippets.cc
+++ b/google/cloud/bigtable/examples/data_async_snippets.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/bigtable/examples/bigtable_examples_common.h"
+#include "google/cloud/bigtable/resource_names.h"
 #include "google/cloud/bigtable/table.h"
 #include "google/cloud/bigtable/testing/cleanup_stale_resources.h"
 #include "google/cloud/bigtable/testing/random_names.h"
@@ -314,6 +315,7 @@ void AsyncReadModifyWrite(google::cloud::bigtable::Table table,
 void RunAll(std::vector<std::string> const& argv) {
   namespace examples = ::google::cloud::bigtable::examples;
   namespace cbt = ::google::cloud::bigtable;
+  namespace cbta = ::google::cloud::bigtable_admin;
 
   if (!argv.empty()) throw examples::Usage{"auto"};
   examples::CheckEnvironmentVariablesAreSet({
@@ -326,29 +328,31 @@ void RunAll(std::vector<std::string> const& argv) {
                                "GOOGLE_CLOUD_CPP_BIGTABLE_TEST_INSTANCE_ID")
                                .value();
 
-  cbt::TableAdmin admin(cbt::MakeAdminClient(project_id), instance_id);
-
+  auto conn = cbta::MakeBigtableTableAdminConnection();
   // If a previous run of these samples crashes before cleaning up there may be
   // old tables left over. As there are quotas on the total number of tables we
   // remove stale tables after 48 hours.
-  google::cloud::bigtable::testing::CleanupStaleTables(admin);
+  cbt::testing::CleanupStaleTables(conn, project_id, instance_id);
+  auto admin = cbta::BigtableTableAdminClient(std::move(conn));
 
   // Initialize a generator with some amount of entropy.
   auto generator = google::cloud::internal::DefaultPRNG(std::random_device{}());
-  auto const table_id =
-      google::cloud::bigtable::testing::RandomTableId(generator);
+  auto const table_id = cbt::testing::RandomTableId(generator);
 
+  // Create a table to run the tests on
   std::cout << "\nCreating table to run the examples (" << table_id << ")"
             << std::endl;
-  auto schema = admin.CreateTable(
-      table_id,
-      cbt::TableConfig({{"fam", cbt::GcRule::MaxNumVersions(10)}}, {}));
+  google::bigtable::admin::v2::GcRule gc;
+  gc.set_max_num_versions(10);
+  google::bigtable::admin::v2::Table t;
+  auto& families = *t.mutable_column_families();
+  *families["fam"].mutable_gc_rule() = std::move(gc);
+  auto schema = admin.CreateTable(cbt::InstanceName(project_id, instance_id),
+                                  table_id, std::move(t));
   if (!schema) throw std::runtime_error(schema.status().message());
 
-  google::cloud::bigtable::Table table(
-      google::cloud::bigtable::MakeDataClient(admin.project(),
-                                              admin.instance_id()),
-      table_id, cbt::AlwaysRetryMutationPolicy());
+  cbt::Table table(cbt::MakeDataClient(project_id, instance_id), table_id,
+                   cbt::AlwaysRetryMutationPolicy());
 
   std::cout << "\nRunning the AsyncApply() example" << std::endl;
   AsyncApply(table, {"row-0001"});

--- a/google/cloud/bigtable/examples/read_snippets.cc
+++ b/google/cloud/bigtable/examples/read_snippets.cc
@@ -13,13 +13,13 @@
 // limitations under the License.
 
 #include "google/cloud/bigtable/examples/bigtable_examples_common.h"
+#include "google/cloud/bigtable/resource_names.h"
 #include "google/cloud/bigtable/testing/cleanup_stale_resources.h"
 #include "google/cloud/bigtable/testing/random_names.h"
-#include "google/cloud/internal/format_time_point.h"
 //! [bigtable includes]
 #include "google/cloud/bigtable/table.h"
-#include "google/cloud/bigtable/table_admin.h"
 //! [bigtable includes]
+#include "google/cloud/internal/format_time_point.h"
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/internal/random.h"
 #include "google/cloud/testing_util/crash_handler.h"
@@ -336,8 +336,9 @@ void ReadFilter(google::cloud::bigtable::Table table,
 void RunAll(std::vector<std::string> const& argv) {
   namespace examples = ::google::cloud::bigtable::examples;
   namespace cbt = ::google::cloud::bigtable;
+  namespace cbta = ::google::cloud::bigtable_admin;
 
-  if (!argv.empty()) throw google::cloud::bigtable::examples::Usage{"auto"};
+  if (!argv.empty()) throw examples::Usage{"auto"};
   examples::CheckEnvironmentVariablesAreSet({
       "GOOGLE_CLOUD_PROJECT",
       "GOOGLE_CLOUD_CPP_BIGTABLE_TEST_INSTANCE_ID",
@@ -348,28 +349,29 @@ void RunAll(std::vector<std::string> const& argv) {
                                "GOOGLE_CLOUD_CPP_BIGTABLE_TEST_INSTANCE_ID")
                                .value();
 
-  cbt::TableAdmin admin(cbt::MakeAdminClient(project_id), instance_id);
-
+  auto conn = cbta::MakeBigtableTableAdminConnection();
   // If a previous run of these samples crashes before cleaning up there may be
   // old tables left over. As there are quotas on the total number of tables we
   // remove stale tables after 48 hours.
-  google::cloud::bigtable::testing::CleanupStaleTables(admin);
-  google::cloud::bigtable::testing::CleanupStaleTables(admin);
+  cbt::testing::CleanupStaleTables(conn, project_id, instance_id);
+  auto admin = cbta::BigtableTableAdminClient(std::move(conn));
 
   // Initialize a generator with some amount of entropy.
   auto generator = google::cloud::internal::DefaultPRNG(std::random_device{}());
+  auto table_id = cbt::testing::RandomTableId(generator);
 
-  auto table_id = google::cloud::bigtable::testing::RandomTableId(generator);
+  // Create a table to run the tests on
   std::cout << "Creating table " << table_id << std::endl;
-  auto schema = admin.CreateTable(
-      table_id, cbt::TableConfig(
-                    {{"stats_summary", cbt::GcRule::MaxNumVersions(10)}}, {}));
+  google::bigtable::admin::v2::GcRule gc;
+  gc.set_max_num_versions(10);
+  google::bigtable::admin::v2::Table t;
+  auto& families = *t.mutable_column_families();
+  *families["stats_summary"].mutable_gc_rule() = std::move(gc);
+  auto schema = admin.CreateTable(cbt::InstanceName(project_id, instance_id),
+                                  table_id, std::move(t));
   if (!schema) throw std::runtime_error(schema.status().message());
 
-  google::cloud::bigtable::Table table(
-      google::cloud::bigtable::MakeDataClient(admin.project(),
-                                              admin.instance_id()),
-      table_id);
+  cbt::Table table(cbt::MakeDataClient(project_id, instance_id), table_id);
 
   std::cout << "Preparing data for read examples" << std::endl;
   PrepareReadSamples(table);
@@ -396,7 +398,7 @@ void RunAll(std::vector<std::string> const& argv) {
   std::cout << "Running ReadPrefixList() example" << std::endl;
   ReadPrefixList(table, {"root/0/1/", "root/2/1/"});
 
-  admin.DeleteTable(table_id);
+  admin.DeleteTable(schema->name());
 }
 
 }  // anonymous namespace

--- a/google/cloud/bigtable/testing/cleanup_stale_resources.h
+++ b/google/cloud/bigtable/testing/cleanup_stale_resources.h
@@ -16,7 +16,7 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_TESTING_CLEANUP_STALE_RESOURCES_H
 
 #include "google/cloud/bigtable/admin/bigtable_instance_admin_client.h"
-#include "google/cloud/bigtable/table_admin.h"
+#include "google/cloud/bigtable/admin/bigtable_table_admin_client.h"
 
 namespace google {
 namespace cloud {
@@ -33,7 +33,9 @@ namespace testing {
  * times out, and (b) avoiding flakes caused by quota exhaustion is necessary
  * for healthy builds.
  */
-Status CleanupStaleTables(TableAdmin admin);
+Status CleanupStaleTables(
+    std::shared_ptr<bigtable_admin::BigtableTableAdminConnection> c,
+    std::string const& project_id, std::string const& instance_id);
 
 /**
  * Remove stale test backups.
@@ -45,7 +47,9 @@ Status CleanupStaleTables(TableAdmin admin);
  * times out, and (b) avoiding flakes caused by quota exhaustion is necessary
  * for healthy builds.
  */
-Status CleanupStaleBackups(TableAdmin admin);
+Status CleanupStaleBackups(
+    std::shared_ptr<bigtable_admin::BigtableTableAdminConnection> c,
+    std::string const& project_id, std::string const& instance_id);
 
 /**
  * Remove stale test instances.

--- a/google/cloud/bigtable/testing/table_integration_test.h
+++ b/google/cloud/bigtable/testing/table_integration_test.h
@@ -19,7 +19,6 @@
 #include "google/cloud/bigtable/cell.h"
 #include "google/cloud/bigtable/data_client.h"
 #include "google/cloud/bigtable/table.h"
-#include "google/cloud/bigtable/table_admin.h"
 #include "google/cloud/internal/random.h"
 #include "google/cloud/testing_util/integration_test.h"
 #include <gmock/gmock.h>

--- a/google/cloud/bigtable/tests/admin_backup_integration_test.cc
+++ b/google/cloud/bigtable/tests/admin_backup_integration_test.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/bigtable/instance_admin.h"
+#include "google/cloud/bigtable/table_admin.h"
 #include "google/cloud/bigtable/testing/table_integration_test.h"
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/internal/random.h"

--- a/google/cloud/bigtable/tests/admin_iam_policy_integration_test.cc
+++ b/google/cloud/bigtable/tests/admin_iam_policy_integration_test.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/bigtable/instance_admin.h"
+#include "google/cloud/bigtable/table_admin.h"
 #include "google/cloud/bigtable/testing/table_integration_test.h"
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/chrono_literals.h"

--- a/google/cloud/bigtable/tests/admin_integration_test.cc
+++ b/google/cloud/bigtable/tests/admin_integration_test.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/bigtable/instance_admin.h"
+#include "google/cloud/bigtable/table_admin.h"
 #include "google/cloud/bigtable/testing/table_integration_test.h"
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/internal/random.h"


### PR DESCRIPTION
Part of the work for #7528 

Same story as #7729, except with `TableAdmin`. `TableAdmin` holds a project ID and an instance ID. 

Some things to note:
* I passed on redoing the `WaitForConsistency` test now.
* There are still references to `TableAdmin` in `testing/embedded_test_fixture.*`. I do not yet have a plan for what to do with that class.
* I am not going to call the issue done yet, because I think I should take another pass at the documentation. (e.g. `bigtable-hello-table-admin.dox` references `g::c::bigtable::GcRule`. It should reference the proto.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7733)
<!-- Reviewable:end -->
