### PR TITLE
ci: remove bigtable emulator retry loop

### DIFF
--- a/ci/cloudbuild/builds/lib/integration.sh
+++ b/ci/cloudbuild/builds/lib/integration.sh
@@ -181,10 +181,8 @@ function integration::bazel_with_emulators() {
   "google/cloud/spanner/ci/${EMULATOR_SCRIPT}" \
     bazel "${verb}" "${args[@]}"
 
-  # We retry these tests because the emulator crashes due to #441.
   io::log_h2 "Running Bigtable integration tests (with emulator)"
-  ci/retry-command.sh 3 0 \
-    "google/cloud/bigtable/ci/${EMULATOR_SCRIPT}" \
+  "google/cloud/bigtable/ci/${EMULATOR_SCRIPT}" \
     bazel "${verb}" "${args[@]}"
 
   # This test is run separately because the access token changes every time and
@@ -260,7 +258,6 @@ function integration::ctest_with_emulators() {
     "${cmake_out}" "${ctest_args[@]}" -L integration-test-emulator
 
   io::log_h2 "Running Bigtable integration tests (with emulator)"
-  ci/retry-command.sh 3 0 \
-    "google/cloud/bigtable/ci/${EMULATOR_SCRIPT}" \
+  "google/cloud/bigtable/ci/${EMULATOR_SCRIPT}" \
     "${cmake_out}" "${ctest_args[@]}" -L integration-test-emulator
 }


### PR DESCRIPTION
Since, #7737, Cloud SDK now has @coryan's bigtable emulator fixes. It should be safe to remove the workaround now.

Fixes #441 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7738)
<!-- Reviewable:end -->
