### PR TITLE
ci: workaround bigtable table admin snippets bug

### DIFF
--- a/ci/cloudbuild/builds/lib/integration.sh
+++ b/ci/cloudbuild/builds/lib/integration.sh
@@ -181,10 +181,8 @@ function integration::bazel_with_emulators() {
   "google/cloud/spanner/ci/${EMULATOR_SCRIPT}" \
     bazel "${verb}" "${args[@]}"
 
-  # We retry these tests because the emulator crashes due to #441.
   io::log_h2 "Running Bigtable integration tests (with emulator)"
-  ci/retry-command.sh 3 0 \
-    "google/cloud/bigtable/ci/${EMULATOR_SCRIPT}" \
+  "google/cloud/bigtable/ci/${EMULATOR_SCRIPT}" \
     bazel "${verb}" "${args[@]}"
 
   # This test is run separately because the access token changes every time and
@@ -260,7 +258,6 @@ function integration::ctest_with_emulators() {
     "${cmake_out}" "${ctest_args[@]}" -L integration-test-emulator
 
   io::log_h2 "Running Bigtable integration tests (with emulator)"
-  ci/retry-command.sh 3 0 \
-    "google/cloud/bigtable/ci/${EMULATOR_SCRIPT}" \
+  "google/cloud/bigtable/ci/${EMULATOR_SCRIPT}" \
     "${cmake_out}" "${ctest_args[@]}" -L integration-test-emulator
 }

--- a/google/cloud/bigtable/examples/table_admin_snippets.cc
+++ b/google/cloud/bigtable/examples/table_admin_snippets.cc
@@ -694,7 +694,13 @@ void WaitForConsistencyCheck(
     fut.get();  // simplify example by blocking until operation is done.
   }
   //! [wait for consistency check]
-  (std::move(old_admin), argv.at(2));
+  (old_admin, argv.at(2));
+
+  // TODO(#7740) - remove this extra call when lifetime issues are fixed.
+  //
+  // Use old_admin outside of the lambda to extend its lifetime long enough to
+  // avoid a crash.
+  (void)old_admin.ListTables(google::bigtable::admin::v2::Table::NAME_ONLY);
 }
 
 void CheckConsistency(

--- a/google/cloud/bigtable/examples/table_admin_snippets.cc
+++ b/google/cloud/bigtable/examples/table_admin_snippets.cc
@@ -20,7 +20,9 @@
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/crash_handler.h"
 #include "google/bigtable/admin/v2/bigtable_table_admin.pb.h"
+#include <chrono>
 #include <sstream>
+#include <thread>
 
 namespace {
 
@@ -696,11 +698,9 @@ void WaitForConsistencyCheck(
   //! [wait for consistency check]
   (old_admin, argv.at(2));
 
-  // TODO(#7740) - remove this extra call when lifetime issues are fixed.
-  //
-  // Use old_admin outside of the lambda to extend its lifetime long enough to
-  // avoid a crash.
-  (void)old_admin.ListTables(google::bigtable::admin::v2::Table::NAME_ONLY);
+  // TODO(#7740) - remove this sleep when lifetime issues are fixed.
+  // Extend the lifetime of old_admin long enough to avoid a crash.
+  std::this_thread::sleep_for(std::chrono::milliseconds(500));
 }
 
 void CheckConsistency(


### PR DESCRIPTION
There seems to be lifetime issues around calling `TableAdmin::WaitForConsistency()`. Before #7733, the object's lifetime existed outside the scope of the sample method, so we never saw the bug surface. See #7740 for more details.

This PR adds a workaround for that bug. It is a dumb band-aid, but it seems more appropriate than retrying the entire CI build for Bigtable when the error is encountered.

I think the wisest course of action, moving forward, is to:
1. Implement #7732. This will not fix the lifetime issues, but it will allow us to drop the workaround.
2. Fix the lifetime issues, by reimplementing `TableAdmin` on top of the generated APIs (#7530), naturally as part of the effort to Modernize Bigtable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7742)
<!-- Reviewable:end -->
