### PR TITLE
chore(generator): colocate client operation overloads

### DIFF
--- a/generator/integration_tests/golden/golden_kitchen_sink_client.cc
+++ b/generator/integration_tests/golden/golden_kitchen_sink_client.cc
@@ -39,6 +39,12 @@ GoldenKitchenSinkClient::GenerateAccessToken(std::string const& name, std::vecto
   return connection_->GenerateAccessToken(request);
 }
 
+StatusOr<google::test::admin::database::v1::GenerateAccessTokenResponse>
+GoldenKitchenSinkClient::GenerateAccessToken(google::test::admin::database::v1::GenerateAccessTokenRequest const& request, Options options) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
+  return connection_->GenerateAccessToken(request);
+}
+
 StatusOr<google::test::admin::database::v1::GenerateIdTokenResponse>
 GoldenKitchenSinkClient::GenerateIdToken(std::string const& name, std::vector<std::string> const& delegates, std::string const& audience, bool include_email, Options options) {
   internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
@@ -47,6 +53,12 @@ GoldenKitchenSinkClient::GenerateIdToken(std::string const& name, std::vector<st
   *request.mutable_delegates() = {delegates.begin(), delegates.end()};
   request.set_audience(audience);
   request.set_include_email(include_email);
+  return connection_->GenerateIdToken(request);
+}
+
+StatusOr<google::test::admin::database::v1::GenerateIdTokenResponse>
+GoldenKitchenSinkClient::GenerateIdToken(google::test::admin::database::v1::GenerateIdTokenRequest const& request, Options options) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
   return connection_->GenerateIdToken(request);
 }
 
@@ -59,12 +71,24 @@ GoldenKitchenSinkClient::WriteLogEntries(std::string const& log_name, std::map<s
   return connection_->WriteLogEntries(request);
 }
 
+StatusOr<google::test::admin::database::v1::WriteLogEntriesResponse>
+GoldenKitchenSinkClient::WriteLogEntries(google::test::admin::database::v1::WriteLogEntriesRequest const& request, Options options) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
+  return connection_->WriteLogEntries(request);
+}
+
 StreamRange<std::string>
 GoldenKitchenSinkClient::ListLogs(std::string const& parent, Options options) {
   internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
   google::test::admin::database::v1::ListLogsRequest request;
   request.set_parent(parent);
   return connection_->ListLogs(request);
+}
+
+StreamRange<std::string>
+GoldenKitchenSinkClient::ListLogs(google::test::admin::database::v1::ListLogsRequest request, Options options) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
+  return connection_->ListLogs(std::move(request));
 }
 
 StreamRange<google::test::admin::database::v1::TailLogEntriesResponse>
@@ -75,6 +99,12 @@ GoldenKitchenSinkClient::TailLogEntries(std::vector<std::string> const& resource
   return connection_->TailLogEntries(request);
 }
 
+StreamRange<google::test::admin::database::v1::TailLogEntriesResponse>
+GoldenKitchenSinkClient::TailLogEntries(google::test::admin::database::v1::TailLogEntriesRequest const& request, Options options) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
+  return connection_->TailLogEntries(request);
+}
+
 StatusOr<google::test::admin::database::v1::ListServiceAccountKeysResponse>
 GoldenKitchenSinkClient::ListServiceAccountKeys(std::string const& name, std::vector<google::test::admin::database::v1::ListServiceAccountKeysRequest::KeyType> const& key_types, Options options) {
   internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
@@ -82,36 +112,6 @@ GoldenKitchenSinkClient::ListServiceAccountKeys(std::string const& name, std::ve
   request.set_name(name);
   *request.mutable_key_types() = {key_types.begin(), key_types.end()};
   return connection_->ListServiceAccountKeys(request);
-}
-
-StatusOr<google::test::admin::database::v1::GenerateAccessTokenResponse>
-GoldenKitchenSinkClient::GenerateAccessToken(google::test::admin::database::v1::GenerateAccessTokenRequest const& request, Options options) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
-  return connection_->GenerateAccessToken(request);
-}
-
-StatusOr<google::test::admin::database::v1::GenerateIdTokenResponse>
-GoldenKitchenSinkClient::GenerateIdToken(google::test::admin::database::v1::GenerateIdTokenRequest const& request, Options options) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
-  return connection_->GenerateIdToken(request);
-}
-
-StatusOr<google::test::admin::database::v1::WriteLogEntriesResponse>
-GoldenKitchenSinkClient::WriteLogEntries(google::test::admin::database::v1::WriteLogEntriesRequest const& request, Options options) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
-  return connection_->WriteLogEntries(request);
-}
-
-StreamRange<std::string>
-GoldenKitchenSinkClient::ListLogs(google::test::admin::database::v1::ListLogsRequest request, Options options) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
-  return connection_->ListLogs(std::move(request));
-}
-
-StreamRange<google::test::admin::database::v1::TailLogEntriesResponse>
-GoldenKitchenSinkClient::TailLogEntries(google::test::admin::database::v1::TailLogEntriesRequest const& request, Options options) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
-  return connection_->TailLogEntries(request);
 }
 
 StatusOr<google::test::admin::database::v1::ListServiceAccountKeysResponse>

--- a/generator/integration_tests/golden/golden_kitchen_sink_client.h
+++ b/generator/integration_tests/golden/golden_kitchen_sink_client.h
@@ -125,6 +125,19 @@ class GoldenKitchenSinkClient {
   GenerateAccessToken(std::string const& name, std::vector<std::string> const& delegates, std::vector<std::string> const& scope, google::protobuf::Duration const& lifetime, Options options = {});
 
   ///
+  /// Generates an OAuth 2.0 access token for a service account.
+  ///
+  /// @param request @googleapis_link{google::test::admin::database::v1::GenerateAccessTokenRequest,generator/integration_tests/test.proto#L835}
+  /// @param options  Optional. Operation options.
+  /// @return @googleapis_link{google::test::admin::database::v1::GenerateAccessTokenResponse,generator/integration_tests/test.proto#L872}
+  ///
+  /// [google.test.admin.database.v1.GenerateAccessTokenRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L835}
+  /// [google.test.admin.database.v1.GenerateAccessTokenResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L872}
+  ///
+  StatusOr<google::test::admin::database::v1::GenerateAccessTokenResponse>
+  GenerateAccessToken(google::test::admin::database::v1::GenerateAccessTokenRequest const& request, Options options = {});
+
+  ///
   /// Generates an OpenID Connect ID token for a service account.
   ///
   /// @param name  Required. The resource name of the service account for which the credentials
@@ -152,6 +165,19 @@ class GoldenKitchenSinkClient {
   ///
   StatusOr<google::test::admin::database::v1::GenerateIdTokenResponse>
   GenerateIdToken(std::string const& name, std::vector<std::string> const& delegates, std::string const& audience, bool include_email, Options options = {});
+
+  ///
+  /// Generates an OpenID Connect ID token for a service account.
+  ///
+  /// @param request @googleapis_link{google::test::admin::database::v1::GenerateIdTokenRequest,generator/integration_tests/test.proto#L881}
+  /// @param options  Optional. Operation options.
+  /// @return @googleapis_link{google::test::admin::database::v1::GenerateIdTokenResponse,generator/integration_tests/test.proto#L914}
+  ///
+  /// [google.test.admin.database.v1.GenerateIdTokenRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L881}
+  /// [google.test.admin.database.v1.GenerateIdTokenResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L914}
+  ///
+  StatusOr<google::test::admin::database::v1::GenerateIdTokenResponse>
+  GenerateIdToken(google::test::admin::database::v1::GenerateIdTokenRequest const& request, Options options = {});
 
   ///
   /// Writes log entries to Logging. This API method is the
@@ -189,6 +215,25 @@ class GoldenKitchenSinkClient {
   WriteLogEntries(std::string const& log_name, std::map<std::string, std::string> const& labels, Options options = {});
 
   ///
+  /// Writes log entries to Logging. This API method is the
+  /// only way to send log entries to Logging. This method
+  /// is used, directly or indirectly, by the Logging agent
+  /// (fluentd) and all logging libraries configured to use Logging.
+  /// A single request may contain log entries for a maximum of 1000
+  /// different resources (projects, organizations, billing accounts or
+  /// folders)
+  ///
+  /// @param request @googleapis_link{google::test::admin::database::v1::WriteLogEntriesRequest,generator/integration_tests/test.proto#L920}
+  /// @param options  Optional. Operation options.
+  /// @return @googleapis_link{google::test::admin::database::v1::WriteLogEntriesResponse,generator/integration_tests/test.proto#L953}
+  ///
+  /// [google.test.admin.database.v1.WriteLogEntriesRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L920}
+  /// [google.test.admin.database.v1.WriteLogEntriesResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L953}
+  ///
+  StatusOr<google::test::admin::database::v1::WriteLogEntriesResponse>
+  WriteLogEntries(google::test::admin::database::v1::WriteLogEntriesRequest const& request, Options options = {});
+
+  ///
   /// Lists the logs in projects, organizations, folders, or billing accounts.
   /// Only logs that have entries are listed.
   ///
@@ -204,6 +249,19 @@ class GoldenKitchenSinkClient {
   ///
   StreamRange<std::string>
   ListLogs(std::string const& parent, Options options = {});
+
+  ///
+  /// Lists the logs in projects, organizations, folders, or billing accounts.
+  /// Only logs that have entries are listed.
+  ///
+  /// @param request @googleapis_link{google::test::admin::database::v1::ListLogsRequest,generator/integration_tests/test.proto#L956}
+  /// @param options  Optional. Operation options.
+  /// @return std::string
+  ///
+  /// [google.test.admin.database.v1.ListLogsRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L956}
+  ///
+  StreamRange<std::string>
+  ListLogs(google::test::admin::database::v1::ListLogsRequest request, Options options = {});
 
   ///
   /// Streaming read of log entries as they are ingested. Until the stream is
@@ -229,6 +287,20 @@ class GoldenKitchenSinkClient {
   TailLogEntries(std::vector<std::string> const& resource_names, Options options = {});
 
   ///
+  /// Streaming read of log entries as they are ingested. Until the stream is
+  /// terminated, it will continue reading logs.
+  ///
+  /// @param request @googleapis_link{google::test::admin::database::v1::TailLogEntriesRequest,generator/integration_tests/test.proto#L1182}
+  /// @param options  Optional. Operation options.
+  /// @return @googleapis_link{google::test::admin::database::v1::TailLogEntriesResponse,generator/integration_tests/test.proto#L1214}
+  ///
+  /// [google.test.admin.database.v1.TailLogEntriesRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1182}
+  /// [google.test.admin.database.v1.TailLogEntriesResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1214}
+  ///
+  StreamRange<google::test::admin::database::v1::TailLogEntriesResponse>
+  TailLogEntries(google::test::admin::database::v1::TailLogEntriesRequest const& request, Options options = {});
+
+  ///
   /// Lists every [ServiceAccountKey][google.iam.admin.v1.ServiceAccountKey] for a service account.
   ///
   /// @param name  Required. The resource name of the service account in the following format:
@@ -247,78 +319,6 @@ class GoldenKitchenSinkClient {
   ///
   StatusOr<google::test::admin::database::v1::ListServiceAccountKeysResponse>
   ListServiceAccountKeys(std::string const& name, std::vector<google::test::admin::database::v1::ListServiceAccountKeysRequest::KeyType> const& key_types, Options options = {});
-
-  ///
-  /// Generates an OAuth 2.0 access token for a service account.
-  ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::GenerateAccessTokenRequest,generator/integration_tests/test.proto#L835}
-  /// @param options  Optional. Operation options.
-  /// @return @googleapis_link{google::test::admin::database::v1::GenerateAccessTokenResponse,generator/integration_tests/test.proto#L872}
-  ///
-  /// [google.test.admin.database.v1.GenerateAccessTokenRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L835}
-  /// [google.test.admin.database.v1.GenerateAccessTokenResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L872}
-  ///
-  StatusOr<google::test::admin::database::v1::GenerateAccessTokenResponse>
-  GenerateAccessToken(google::test::admin::database::v1::GenerateAccessTokenRequest const& request, Options options = {});
-
-  ///
-  /// Generates an OpenID Connect ID token for a service account.
-  ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::GenerateIdTokenRequest,generator/integration_tests/test.proto#L881}
-  /// @param options  Optional. Operation options.
-  /// @return @googleapis_link{google::test::admin::database::v1::GenerateIdTokenResponse,generator/integration_tests/test.proto#L914}
-  ///
-  /// [google.test.admin.database.v1.GenerateIdTokenRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L881}
-  /// [google.test.admin.database.v1.GenerateIdTokenResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L914}
-  ///
-  StatusOr<google::test::admin::database::v1::GenerateIdTokenResponse>
-  GenerateIdToken(google::test::admin::database::v1::GenerateIdTokenRequest const& request, Options options = {});
-
-  ///
-  /// Writes log entries to Logging. This API method is the
-  /// only way to send log entries to Logging. This method
-  /// is used, directly or indirectly, by the Logging agent
-  /// (fluentd) and all logging libraries configured to use Logging.
-  /// A single request may contain log entries for a maximum of 1000
-  /// different resources (projects, organizations, billing accounts or
-  /// folders)
-  ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::WriteLogEntriesRequest,generator/integration_tests/test.proto#L920}
-  /// @param options  Optional. Operation options.
-  /// @return @googleapis_link{google::test::admin::database::v1::WriteLogEntriesResponse,generator/integration_tests/test.proto#L953}
-  ///
-  /// [google.test.admin.database.v1.WriteLogEntriesRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L920}
-  /// [google.test.admin.database.v1.WriteLogEntriesResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L953}
-  ///
-  StatusOr<google::test::admin::database::v1::WriteLogEntriesResponse>
-  WriteLogEntries(google::test::admin::database::v1::WriteLogEntriesRequest const& request, Options options = {});
-
-  ///
-  /// Lists the logs in projects, organizations, folders, or billing accounts.
-  /// Only logs that have entries are listed.
-  ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::ListLogsRequest,generator/integration_tests/test.proto#L956}
-  /// @param options  Optional. Operation options.
-  /// @return std::string
-  ///
-  /// [google.test.admin.database.v1.ListLogsRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L956}
-  ///
-  StreamRange<std::string>
-  ListLogs(google::test::admin::database::v1::ListLogsRequest request, Options options = {});
-
-  ///
-  /// Streaming read of log entries as they are ingested. Until the stream is
-  /// terminated, it will continue reading logs.
-  ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::TailLogEntriesRequest,generator/integration_tests/test.proto#L1182}
-  /// @param options  Optional. Operation options.
-  /// @return @googleapis_link{google::test::admin::database::v1::TailLogEntriesResponse,generator/integration_tests/test.proto#L1214}
-  ///
-  /// [google.test.admin.database.v1.TailLogEntriesRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1182}
-  /// [google.test.admin.database.v1.TailLogEntriesResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1214}
-  ///
-  StreamRange<google::test::admin::database::v1::TailLogEntriesResponse>
-  TailLogEntries(google::test::admin::database::v1::TailLogEntriesRequest const& request, Options options = {});
 
   ///
   /// Lists every [ServiceAccountKey][google.iam.admin.v1.ServiceAccountKey] for a service account.

--- a/generator/integration_tests/golden/golden_thing_admin_client.cc
+++ b/generator/integration_tests/golden/golden_thing_admin_client.cc
@@ -38,6 +38,12 @@ GoldenThingAdminClient::ListDatabases(std::string const& parent, Options options
   return connection_->ListDatabases(request);
 }
 
+StreamRange<google::test::admin::database::v1::Database>
+GoldenThingAdminClient::ListDatabases(google::test::admin::database::v1::ListDatabasesRequest request, Options options) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
+  return connection_->ListDatabases(std::move(request));
+}
+
 future<StatusOr<google::test::admin::database::v1::Database>>
 GoldenThingAdminClient::CreateDatabase(std::string const& parent, std::string const& create_statement, Options options) {
   internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
@@ -47,11 +53,23 @@ GoldenThingAdminClient::CreateDatabase(std::string const& parent, std::string co
   return connection_->CreateDatabase(request);
 }
 
+future<StatusOr<google::test::admin::database::v1::Database>>
+GoldenThingAdminClient::CreateDatabase(google::test::admin::database::v1::CreateDatabaseRequest const& request, Options options) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
+  return connection_->CreateDatabase(request);
+}
+
 StatusOr<google::test::admin::database::v1::Database>
 GoldenThingAdminClient::GetDatabase(std::string const& name, Options options) {
   internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
   google::test::admin::database::v1::GetDatabaseRequest request;
   request.set_name(name);
+  return connection_->GetDatabase(request);
+}
+
+StatusOr<google::test::admin::database::v1::Database>
+GoldenThingAdminClient::GetDatabase(google::test::admin::database::v1::GetDatabaseRequest const& request, Options options) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
   return connection_->GetDatabase(request);
 }
 
@@ -64,6 +82,12 @@ GoldenThingAdminClient::UpdateDatabaseDdl(std::string const& database, std::vect
   return connection_->UpdateDatabaseDdl(request);
 }
 
+future<StatusOr<google::test::admin::database::v1::UpdateDatabaseDdlMetadata>>
+GoldenThingAdminClient::UpdateDatabaseDdl(google::test::admin::database::v1::UpdateDatabaseDdlRequest const& request, Options options) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
+  return connection_->UpdateDatabaseDdl(request);
+}
+
 Status
 GoldenThingAdminClient::DropDatabase(std::string const& database, Options options) {
   internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
@@ -72,11 +96,23 @@ GoldenThingAdminClient::DropDatabase(std::string const& database, Options option
   return connection_->DropDatabase(request);
 }
 
+Status
+GoldenThingAdminClient::DropDatabase(google::test::admin::database::v1::DropDatabaseRequest const& request, Options options) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
+  return connection_->DropDatabase(request);
+}
+
 StatusOr<google::test::admin::database::v1::GetDatabaseDdlResponse>
 GoldenThingAdminClient::GetDatabaseDdl(std::string const& database, Options options) {
   internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
   google::test::admin::database::v1::GetDatabaseDdlRequest request;
   request.set_database(database);
+  return connection_->GetDatabaseDdl(request);
+}
+
+StatusOr<google::test::admin::database::v1::GetDatabaseDdlResponse>
+GoldenThingAdminClient::GetDatabaseDdl(google::test::admin::database::v1::GetDatabaseDdlRequest const& request, Options options) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
   return connection_->GetDatabaseDdl(request);
 }
 
@@ -112,10 +148,22 @@ GoldenThingAdminClient::SetIamPolicy(std::string const& resource, IamUpdater con
 }
 
 StatusOr<google::iam::v1::Policy>
+GoldenThingAdminClient::SetIamPolicy(google::iam::v1::SetIamPolicyRequest const& request, Options options) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
+  return connection_->SetIamPolicy(request);
+}
+
+StatusOr<google::iam::v1::Policy>
 GoldenThingAdminClient::GetIamPolicy(std::string const& resource, Options options) {
   internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
   google::iam::v1::GetIamPolicyRequest request;
   request.set_resource(resource);
+  return connection_->GetIamPolicy(request);
+}
+
+StatusOr<google::iam::v1::Policy>
+GoldenThingAdminClient::GetIamPolicy(google::iam::v1::GetIamPolicyRequest const& request, Options options) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
   return connection_->GetIamPolicy(request);
 }
 
@@ -125,6 +173,12 @@ GoldenThingAdminClient::TestIamPermissions(std::string const& resource, std::vec
   google::iam::v1::TestIamPermissionsRequest request;
   request.set_resource(resource);
   *request.mutable_permissions() = {permissions.begin(), permissions.end()};
+  return connection_->TestIamPermissions(request);
+}
+
+StatusOr<google::iam::v1::TestIamPermissionsResponse>
+GoldenThingAdminClient::TestIamPermissions(google::iam::v1::TestIamPermissionsRequest const& request, Options options) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
   return connection_->TestIamPermissions(request);
 }
 
@@ -138,11 +192,23 @@ GoldenThingAdminClient::CreateBackup(std::string const& parent, google::test::ad
   return connection_->CreateBackup(request);
 }
 
+future<StatusOr<google::test::admin::database::v1::Backup>>
+GoldenThingAdminClient::CreateBackup(google::test::admin::database::v1::CreateBackupRequest const& request, Options options) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
+  return connection_->CreateBackup(request);
+}
+
 StatusOr<google::test::admin::database::v1::Backup>
 GoldenThingAdminClient::GetBackup(std::string const& name, Options options) {
   internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
   google::test::admin::database::v1::GetBackupRequest request;
   request.set_name(name);
+  return connection_->GetBackup(request);
+}
+
+StatusOr<google::test::admin::database::v1::Backup>
+GoldenThingAdminClient::GetBackup(google::test::admin::database::v1::GetBackupRequest const& request, Options options) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
   return connection_->GetBackup(request);
 }
 
@@ -155,11 +221,23 @@ GoldenThingAdminClient::UpdateBackup(google::test::admin::database::v1::Backup c
   return connection_->UpdateBackup(request);
 }
 
+StatusOr<google::test::admin::database::v1::Backup>
+GoldenThingAdminClient::UpdateBackup(google::test::admin::database::v1::UpdateBackupRequest const& request, Options options) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
+  return connection_->UpdateBackup(request);
+}
+
 Status
 GoldenThingAdminClient::DeleteBackup(std::string const& name, Options options) {
   internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
   google::test::admin::database::v1::DeleteBackupRequest request;
   request.set_name(name);
+  return connection_->DeleteBackup(request);
+}
+
+Status
+GoldenThingAdminClient::DeleteBackup(google::test::admin::database::v1::DeleteBackupRequest const& request, Options options) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
   return connection_->DeleteBackup(request);
 }
 
@@ -169,6 +247,12 @@ GoldenThingAdminClient::ListBackups(std::string const& parent, Options options) 
   google::test::admin::database::v1::ListBackupsRequest request;
   request.set_parent(parent);
   return connection_->ListBackups(request);
+}
+
+StreamRange<google::test::admin::database::v1::Backup>
+GoldenThingAdminClient::ListBackups(google::test::admin::database::v1::ListBackupsRequest request, Options options) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
+  return connection_->ListBackups(std::move(request));
 }
 
 future<StatusOr<google::test::admin::database::v1::Database>>
@@ -181,12 +265,24 @@ GoldenThingAdminClient::RestoreDatabase(std::string const& parent, std::string c
   return connection_->RestoreDatabase(request);
 }
 
+future<StatusOr<google::test::admin::database::v1::Database>>
+GoldenThingAdminClient::RestoreDatabase(google::test::admin::database::v1::RestoreDatabaseRequest const& request, Options options) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
+  return connection_->RestoreDatabase(request);
+}
+
 StreamRange<google::longrunning::Operation>
 GoldenThingAdminClient::ListDatabaseOperations(std::string const& parent, Options options) {
   internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
   google::test::admin::database::v1::ListDatabaseOperationsRequest request;
   request.set_parent(parent);
   return connection_->ListDatabaseOperations(request);
+}
+
+StreamRange<google::longrunning::Operation>
+GoldenThingAdminClient::ListDatabaseOperations(google::test::admin::database::v1::ListDatabaseOperationsRequest request, Options options) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
+  return connection_->ListDatabaseOperations(std::move(request));
 }
 
 StreamRange<google::longrunning::Operation>
@@ -197,11 +293,23 @@ GoldenThingAdminClient::ListBackupOperations(std::string const& parent, Options 
   return connection_->ListBackupOperations(request);
 }
 
+StreamRange<google::longrunning::Operation>
+GoldenThingAdminClient::ListBackupOperations(google::test::admin::database::v1::ListBackupOperationsRequest request, Options options) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
+  return connection_->ListBackupOperations(std::move(request));
+}
+
 future<StatusOr<google::test::admin::database::v1::Database>>
 GoldenThingAdminClient::AsyncGetDatabase(std::string const& name, Options options) {
   internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
   google::test::admin::database::v1::GetDatabaseRequest request;
   request.set_name(name);
+  return connection_->AsyncGetDatabase(request);
+}
+
+future<StatusOr<google::test::admin::database::v1::Database>>
+GoldenThingAdminClient::AsyncGetDatabase(google::test::admin::database::v1::GetDatabaseRequest const& request, Options options) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
   return connection_->AsyncGetDatabase(request);
 }
 
@@ -211,114 +319,6 @@ GoldenThingAdminClient::AsyncDropDatabase(std::string const& database, Options o
   google::test::admin::database::v1::DropDatabaseRequest request;
   request.set_database(database);
   return connection_->AsyncDropDatabase(request);
-}
-
-StreamRange<google::test::admin::database::v1::Database>
-GoldenThingAdminClient::ListDatabases(google::test::admin::database::v1::ListDatabasesRequest request, Options options) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
-  return connection_->ListDatabases(std::move(request));
-}
-
-future<StatusOr<google::test::admin::database::v1::Database>>
-GoldenThingAdminClient::CreateDatabase(google::test::admin::database::v1::CreateDatabaseRequest const& request, Options options) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
-  return connection_->CreateDatabase(request);
-}
-
-StatusOr<google::test::admin::database::v1::Database>
-GoldenThingAdminClient::GetDatabase(google::test::admin::database::v1::GetDatabaseRequest const& request, Options options) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
-  return connection_->GetDatabase(request);
-}
-
-future<StatusOr<google::test::admin::database::v1::UpdateDatabaseDdlMetadata>>
-GoldenThingAdminClient::UpdateDatabaseDdl(google::test::admin::database::v1::UpdateDatabaseDdlRequest const& request, Options options) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
-  return connection_->UpdateDatabaseDdl(request);
-}
-
-Status
-GoldenThingAdminClient::DropDatabase(google::test::admin::database::v1::DropDatabaseRequest const& request, Options options) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
-  return connection_->DropDatabase(request);
-}
-
-StatusOr<google::test::admin::database::v1::GetDatabaseDdlResponse>
-GoldenThingAdminClient::GetDatabaseDdl(google::test::admin::database::v1::GetDatabaseDdlRequest const& request, Options options) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
-  return connection_->GetDatabaseDdl(request);
-}
-
-StatusOr<google::iam::v1::Policy>
-GoldenThingAdminClient::SetIamPolicy(google::iam::v1::SetIamPolicyRequest const& request, Options options) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
-  return connection_->SetIamPolicy(request);
-}
-
-StatusOr<google::iam::v1::Policy>
-GoldenThingAdminClient::GetIamPolicy(google::iam::v1::GetIamPolicyRequest const& request, Options options) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
-  return connection_->GetIamPolicy(request);
-}
-
-StatusOr<google::iam::v1::TestIamPermissionsResponse>
-GoldenThingAdminClient::TestIamPermissions(google::iam::v1::TestIamPermissionsRequest const& request, Options options) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
-  return connection_->TestIamPermissions(request);
-}
-
-future<StatusOr<google::test::admin::database::v1::Backup>>
-GoldenThingAdminClient::CreateBackup(google::test::admin::database::v1::CreateBackupRequest const& request, Options options) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
-  return connection_->CreateBackup(request);
-}
-
-StatusOr<google::test::admin::database::v1::Backup>
-GoldenThingAdminClient::GetBackup(google::test::admin::database::v1::GetBackupRequest const& request, Options options) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
-  return connection_->GetBackup(request);
-}
-
-StatusOr<google::test::admin::database::v1::Backup>
-GoldenThingAdminClient::UpdateBackup(google::test::admin::database::v1::UpdateBackupRequest const& request, Options options) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
-  return connection_->UpdateBackup(request);
-}
-
-Status
-GoldenThingAdminClient::DeleteBackup(google::test::admin::database::v1::DeleteBackupRequest const& request, Options options) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
-  return connection_->DeleteBackup(request);
-}
-
-StreamRange<google::test::admin::database::v1::Backup>
-GoldenThingAdminClient::ListBackups(google::test::admin::database::v1::ListBackupsRequest request, Options options) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
-  return connection_->ListBackups(std::move(request));
-}
-
-future<StatusOr<google::test::admin::database::v1::Database>>
-GoldenThingAdminClient::RestoreDatabase(google::test::admin::database::v1::RestoreDatabaseRequest const& request, Options options) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
-  return connection_->RestoreDatabase(request);
-}
-
-StreamRange<google::longrunning::Operation>
-GoldenThingAdminClient::ListDatabaseOperations(google::test::admin::database::v1::ListDatabaseOperationsRequest request, Options options) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
-  return connection_->ListDatabaseOperations(std::move(request));
-}
-
-StreamRange<google::longrunning::Operation>
-GoldenThingAdminClient::ListBackupOperations(google::test::admin::database::v1::ListBackupOperationsRequest request, Options options) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
-  return connection_->ListBackupOperations(std::move(request));
-}
-
-future<StatusOr<google::test::admin::database::v1::Database>>
-GoldenThingAdminClient::AsyncGetDatabase(google::test::admin::database::v1::GetDatabaseRequest const& request, Options options) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
-  return connection_->AsyncGetDatabase(request);
 }
 
 future<Status>

--- a/generator/integration_tests/golden/golden_thing_admin_client.h
+++ b/generator/integration_tests/golden/golden_thing_admin_client.h
@@ -103,6 +103,19 @@ class GoldenThingAdminClient {
   ListDatabases(std::string const& parent, Options options = {});
 
   ///
+  /// Lists Cloud Test databases.
+  ///
+  /// @param request @googleapis_link{google::test::admin::database::v1::ListDatabasesRequest,generator/integration_tests/test.proto#L377}
+  /// @param options  Optional. Operation options.
+  /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
+  ///
+  /// [google.test.admin.database.v1.ListDatabasesRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L377}
+  /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L329}
+  ///
+  StreamRange<google::test::admin::database::v1::Database>
+  ListDatabases(google::test::admin::database::v1::ListDatabasesRequest request, Options options = {});
+
+  ///
   /// Creates a new Cloud Test database and starts to prepare it for serving.
   /// The returned [long-running operation][google.longrunning.Operation] will
   /// have a name of the format `<database_name>/operations/<operation_id>` and
@@ -129,6 +142,26 @@ class GoldenThingAdminClient {
   CreateDatabase(std::string const& parent, std::string const& create_statement, Options options = {});
 
   ///
+  /// Creates a new Cloud Test database and starts to prepare it for serving.
+  /// The returned [long-running operation][google.longrunning.Operation] will
+  /// have a name of the format `<database_name>/operations/<operation_id>` and
+  /// can be used to track preparation of the database. The
+  /// [metadata][google.longrunning.Operation.metadata] field type is
+  /// [CreateDatabaseMetadata][google.test.admin.database.v1.CreateDatabaseMetadata]. The
+  /// [response][google.longrunning.Operation.response] field type is
+  /// [Database][google.test.admin.database.v1.Database], if successful.
+  ///
+  /// @param request @googleapis_link{google::test::admin::database::v1::CreateDatabaseRequest,generator/integration_tests/test.proto#L409}
+  /// @param options  Optional. Operation options.
+  /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
+  ///
+  /// [google.test.admin.database.v1.CreateDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L409}
+  /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L329}
+  ///
+  future<StatusOr<google::test::admin::database::v1::Database>>
+  CreateDatabase(google::test::admin::database::v1::CreateDatabaseRequest const& request, Options options = {});
+
+  ///
   /// Gets the state of a Cloud Test database.
   ///
   /// @param name  Required. The name of the requested database. Values are of the form
@@ -141,6 +174,19 @@ class GoldenThingAdminClient {
   ///
   StatusOr<google::test::admin::database::v1::Database>
   GetDatabase(std::string const& name, Options options = {});
+
+  ///
+  /// Gets the state of a Cloud Test database.
+  ///
+  /// @param request @googleapis_link{google::test::admin::database::v1::GetDatabaseRequest,generator/integration_tests/test.proto#L443}
+  /// @param options  Optional. Operation options.
+  /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
+  ///
+  /// [google.test.admin.database.v1.GetDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L443}
+  /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L329}
+  ///
+  StatusOr<google::test::admin::database::v1::Database>
+  GetDatabase(google::test::admin::database::v1::GetDatabaseRequest const& request, Options options = {});
 
   ///
   /// Updates the schema of a Cloud Test database by
@@ -163,6 +209,25 @@ class GoldenThingAdminClient {
   UpdateDatabaseDdl(std::string const& database, std::vector<std::string> const& statements, Options options = {});
 
   ///
+  /// Updates the schema of a Cloud Test database by
+  /// creating/altering/dropping tables, columns, indexes, etc. The returned
+  /// [long-running operation][google.longrunning.Operation] will have a name of
+  /// the format `<database_name>/operations/<operation_id>` and can be used to
+  /// track execution of the schema change(s). The
+  /// [metadata][google.longrunning.Operation.metadata] field type is
+  /// [UpdateDatabaseDdlMetadata][google.test.admin.database.v1.UpdateDatabaseDdlMetadata].  The operation has no response.
+  ///
+  /// @param request @googleapis_link{google::test::admin::database::v1::UpdateDatabaseDdlRequest,generator/integration_tests/test.proto#L470}
+  /// @param options  Optional. Operation options.
+  /// @return @googleapis_link{google::test::admin::database::v1::UpdateDatabaseDdlMetadata,generator/integration_tests/test.proto#L506}
+  ///
+  /// [google.test.admin.database.v1.UpdateDatabaseDdlRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L470}
+  /// [google.test.admin.database.v1.UpdateDatabaseDdlMetadata]: @googleapis_reference_link{generator/integration_tests/test.proto#L506}
+  ///
+  future<StatusOr<google::test::admin::database::v1::UpdateDatabaseDdlMetadata>>
+  UpdateDatabaseDdl(google::test::admin::database::v1::UpdateDatabaseDdlRequest const& request, Options options = {});
+
+  ///
   /// Drops (aka deletes) a Cloud Test database.
   /// Completed backups for the database will be retained according to their
   /// `expire_time`.
@@ -174,6 +239,19 @@ class GoldenThingAdminClient {
   ///
   Status
   DropDatabase(std::string const& database, Options options = {});
+
+  ///
+  /// Drops (aka deletes) a Cloud Test database.
+  /// Completed backups for the database will be retained according to their
+  /// `expire_time`.
+  ///
+  /// @param request @googleapis_link{google::test::admin::database::v1::DropDatabaseRequest,generator/integration_tests/test.proto#L523}
+  /// @param options  Optional. Operation options.
+  ///
+  /// [google.test.admin.database.v1.DropDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L523}
+  ///
+  Status
+  DropDatabase(google::test::admin::database::v1::DropDatabaseRequest const& request, Options options = {});
 
   ///
   /// Returns the schema of a Cloud Test database as a list of formatted
@@ -189,6 +267,21 @@ class GoldenThingAdminClient {
   ///
   StatusOr<google::test::admin::database::v1::GetDatabaseDdlResponse>
   GetDatabaseDdl(std::string const& database, Options options = {});
+
+  ///
+  /// Returns the schema of a Cloud Test database as a list of formatted
+  /// DDL statements. This method does not show pending schema updates, those may
+  /// be queried using the [Operations][google.longrunning.Operations] API.
+  ///
+  /// @param request @googleapis_link{google::test::admin::database::v1::GetDatabaseDdlRequest,generator/integration_tests/test.proto#L534}
+  /// @param options  Optional. Operation options.
+  /// @return @googleapis_link{google::test::admin::database::v1::GetDatabaseDdlResponse,generator/integration_tests/test.proto#L545}
+  ///
+  /// [google.test.admin.database.v1.GetDatabaseDdlRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L534}
+  /// [google.test.admin.database.v1.GetDatabaseDdlResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L545}
+  ///
+  StatusOr<google::test::admin::database::v1::GetDatabaseDdlResponse>
+  GetDatabaseDdl(google::test::admin::database::v1::GetDatabaseDdlRequest const& request, Options options = {});
 
   ///
   /// Sets the access control policy on a database or backup resource.
@@ -239,6 +332,25 @@ class GoldenThingAdminClient {
   SetIamPolicy(std::string const& resource, IamUpdater const& updater, Options options = {});
 
   ///
+  /// Sets the access control policy on a database or backup resource.
+  /// Replaces any existing policy.
+  ///
+  /// Authorization requires `test.databases.setIamPolicy`
+  /// permission on [resource][google.iam.v1.SetIamPolicyRequest.resource].
+  /// For backups, authorization requires `test.backups.setIamPolicy`
+  /// permission on [resource][google.iam.v1.SetIamPolicyRequest.resource].
+  ///
+  /// @param request @googleapis_link{google::iam::v1::SetIamPolicyRequest,google/iam/v1/iam_policy.proto#L98}
+  /// @param options  Optional. Operation options.
+  /// @return @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
+  ///
+  /// [google.iam.v1.SetIamPolicyRequest]: @googleapis_reference_link{google/iam/v1/iam_policy.proto#L98}
+  /// [google.iam.v1.Policy]: @googleapis_reference_link{google/iam/v1/policy.proto#L88}
+  ///
+  StatusOr<google::iam::v1::Policy>
+  SetIamPolicy(google::iam::v1::SetIamPolicyRequest const& request, Options options = {});
+
+  ///
   /// Gets the access control policy for a database or backup resource.
   /// Returns an empty policy if a database or backup exists but does not have a
   /// policy set.
@@ -258,6 +370,26 @@ class GoldenThingAdminClient {
   ///
   StatusOr<google::iam::v1::Policy>
   GetIamPolicy(std::string const& resource, Options options = {});
+
+  ///
+  /// Gets the access control policy for a database or backup resource.
+  /// Returns an empty policy if a database or backup exists but does not have a
+  /// policy set.
+  ///
+  /// Authorization requires `test.databases.getIamPolicy` permission on
+  /// [resource][google.iam.v1.GetIamPolicyRequest.resource].
+  /// For backups, authorization requires `test.backups.getIamPolicy`
+  /// permission on [resource][google.iam.v1.GetIamPolicyRequest.resource].
+  ///
+  /// @param request @googleapis_link{google::iam::v1::GetIamPolicyRequest,google/iam/v1/iam_policy.proto#L113}
+  /// @param options  Optional. Operation options.
+  /// @return @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
+  ///
+  /// [google.iam.v1.GetIamPolicyRequest]: @googleapis_reference_link{google/iam/v1/iam_policy.proto#L113}
+  /// [google.iam.v1.Policy]: @googleapis_reference_link{google/iam/v1/policy.proto#L88}
+  ///
+  StatusOr<google::iam::v1::Policy>
+  GetIamPolicy(google::iam::v1::GetIamPolicyRequest const& request, Options options = {});
 
   ///
   /// Returns permissions that the caller has on the specified database or backup
@@ -285,6 +417,28 @@ class GoldenThingAdminClient {
   ///
   StatusOr<google::iam::v1::TestIamPermissionsResponse>
   TestIamPermissions(std::string const& resource, std::vector<std::string> const& permissions, Options options = {});
+
+  ///
+  /// Returns permissions that the caller has on the specified database or backup
+  /// resource.
+  ///
+  /// Attempting this RPC on a non-existent Cloud Test database will
+  /// result in a NOT_FOUND error if the user has
+  /// `test.databases.list` permission on the containing Cloud
+  /// Test instance. Otherwise returns an empty set of permissions.
+  /// Calling this method on a backup that does not exist will
+  /// result in a NOT_FOUND error if the user has
+  /// `test.backups.list` permission on the containing instance.
+  ///
+  /// @param request @googleapis_link{google::iam::v1::TestIamPermissionsRequest,google/iam/v1/iam_policy.proto#L126}
+  /// @param options  Optional. Operation options.
+  /// @return @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
+  ///
+  /// [google.iam.v1.TestIamPermissionsRequest]: @googleapis_reference_link{google/iam/v1/iam_policy.proto#L126}
+  /// [google.iam.v1.TestIamPermissionsResponse]: @googleapis_reference_link{google/iam/v1/iam_policy.proto#L141}
+  ///
+  StatusOr<google::iam::v1::TestIamPermissionsResponse>
+  TestIamPermissions(google::iam::v1::TestIamPermissionsRequest const& request, Options options = {});
 
   ///
   /// Starts creating a new Cloud Test Backup.
@@ -320,6 +474,30 @@ class GoldenThingAdminClient {
   CreateBackup(std::string const& parent, google::test::admin::database::v1::Backup const& backup, std::string const& backup_id, Options options = {});
 
   ///
+  /// Starts creating a new Cloud Test Backup.
+  /// The returned backup [long-running operation][google.longrunning.Operation]
+  /// will have a name of the format
+  /// `projects/<project>/instances/<instance>/backups/<backup>/operations/<operation_id>`
+  /// and can be used to track creation of the backup. The
+  /// [metadata][google.longrunning.Operation.metadata] field type is
+  /// [CreateBackupMetadata][google.test.admin.database.v1.CreateBackupMetadata]. The
+  /// [response][google.longrunning.Operation.response] field type is
+  /// [Backup][google.test.admin.database.v1.Backup], if successful. Cancelling the returned operation will stop the
+  /// creation and delete the backup.
+  /// There can be only one pending backup creation per database. Backup creation
+  /// of different databases can run concurrently.
+  ///
+  /// @param request @googleapis_link{google::test::admin::database::v1::CreateBackupRequest,generator/integration_tests/backup.proto#L110}
+  /// @param options  Optional. Operation options.
+  /// @return @googleapis_link{google::test::admin::database::v1::Backup,generator/integration_tests/backup.proto#L36}
+  ///
+  /// [google.test.admin.database.v1.CreateBackupRequest]: @googleapis_reference_link{generator/integration_tests/backup.proto#L110}
+  /// [google.test.admin.database.v1.Backup]: @googleapis_reference_link{generator/integration_tests/backup.proto#L36}
+  ///
+  future<StatusOr<google::test::admin::database::v1::Backup>>
+  CreateBackup(google::test::admin::database::v1::CreateBackupRequest const& request, Options options = {});
+
+  ///
   /// Gets metadata on a pending or completed [Backup][google.test.admin.database.v1.Backup].
   ///
   /// @param name  Required. Name of the backup.
@@ -333,6 +511,19 @@ class GoldenThingAdminClient {
   ///
   StatusOr<google::test::admin::database::v1::Backup>
   GetBackup(std::string const& name, Options options = {});
+
+  ///
+  /// Gets metadata on a pending or completed [Backup][google.test.admin.database.v1.Backup].
+  ///
+  /// @param request @googleapis_link{google::test::admin::database::v1::GetBackupRequest,generator/integration_tests/backup.proto#L177}
+  /// @param options  Optional. Operation options.
+  /// @return @googleapis_link{google::test::admin::database::v1::Backup,generator/integration_tests/backup.proto#L36}
+  ///
+  /// [google.test.admin.database.v1.GetBackupRequest]: @googleapis_reference_link{generator/integration_tests/backup.proto#L177}
+  /// [google.test.admin.database.v1.Backup]: @googleapis_reference_link{generator/integration_tests/backup.proto#L36}
+  ///
+  StatusOr<google::test::admin::database::v1::Backup>
+  GetBackup(google::test::admin::database::v1::GetBackupRequest const& request, Options options = {});
 
   ///
   /// Updates a pending or completed [Backup][google.test.admin.database.v1.Backup].
@@ -356,6 +547,19 @@ class GoldenThingAdminClient {
   UpdateBackup(google::test::admin::database::v1::Backup const& backup, google::protobuf::FieldMask const& update_mask, Options options = {});
 
   ///
+  /// Updates a pending or completed [Backup][google.test.admin.database.v1.Backup].
+  ///
+  /// @param request @googleapis_link{google::test::admin::database::v1::UpdateBackupRequest,generator/integration_tests/backup.proto#L161}
+  /// @param options  Optional. Operation options.
+  /// @return @googleapis_link{google::test::admin::database::v1::Backup,generator/integration_tests/backup.proto#L36}
+  ///
+  /// [google.test.admin.database.v1.UpdateBackupRequest]: @googleapis_reference_link{generator/integration_tests/backup.proto#L161}
+  /// [google.test.admin.database.v1.Backup]: @googleapis_reference_link{generator/integration_tests/backup.proto#L36}
+  ///
+  StatusOr<google::test::admin::database::v1::Backup>
+  UpdateBackup(google::test::admin::database::v1::UpdateBackupRequest const& request, Options options = {});
+
+  ///
   /// Deletes a pending or completed [Backup][google.test.admin.database.v1.Backup].
   ///
   /// @param name  Required. Name of the backup to delete.
@@ -367,6 +571,17 @@ class GoldenThingAdminClient {
   ///
   Status
   DeleteBackup(std::string const& name, Options options = {});
+
+  ///
+  /// Deletes a pending or completed [Backup][google.test.admin.database.v1.Backup].
+  ///
+  /// @param request @googleapis_link{google::test::admin::database::v1::DeleteBackupRequest,generator/integration_tests/backup.proto#L190}
+  /// @param options  Optional. Operation options.
+  ///
+  /// [google.test.admin.database.v1.DeleteBackupRequest]: @googleapis_reference_link{generator/integration_tests/backup.proto#L190}
+  ///
+  Status
+  DeleteBackup(google::test::admin::database::v1::DeleteBackupRequest const& request, Options options = {});
 
   ///
   /// Lists completed and pending backups.
@@ -383,6 +598,21 @@ class GoldenThingAdminClient {
   ///
   StreamRange<google::test::admin::database::v1::Backup>
   ListBackups(std::string const& parent, Options options = {});
+
+  ///
+  /// Lists completed and pending backups.
+  /// Backups returned are ordered by `create_time` in descending order,
+  /// starting from the most recent `create_time`.
+  ///
+  /// @param request @googleapis_link{google::test::admin::database::v1::ListBackupsRequest,generator/integration_tests/backup.proto#L203}
+  /// @param options  Optional. Operation options.
+  /// @return @googleapis_link{google::test::admin::database::v1::Backup,generator/integration_tests/backup.proto#L36}
+  ///
+  /// [google.test.admin.database.v1.ListBackupsRequest]: @googleapis_reference_link{generator/integration_tests/backup.proto#L203}
+  /// [google.test.admin.database.v1.Backup]: @googleapis_reference_link{generator/integration_tests/backup.proto#L36}
+  ///
+  StreamRange<google::test::admin::database::v1::Backup>
+  ListBackups(google::test::admin::database::v1::ListBackupsRequest request, Options options = {});
 
   ///
   /// Create a new database by restoring from a completed backup. The new
@@ -424,307 +654,6 @@ class GoldenThingAdminClient {
   RestoreDatabase(std::string const& parent, std::string const& database_id, std::string const& backup, Options options = {});
 
   ///
-  /// Lists database [longrunning-operations][google.longrunning.Operation].
-  /// A database operation has a name of the form
-  /// `projects/<project>/instances/<instance>/databases/<database>/operations/<operation>`.
-  /// The long-running operation
-  /// [metadata][google.longrunning.Operation.metadata] field type
-  /// `metadata.type_url` describes the type of the metadata. Operations returned
-  /// include those that have completed/failed/canceled within the last 7 days,
-  /// and pending operations.
-  ///
-  /// @param parent  Required. The instance of the database operations.
-  ///  Values are of the form `projects/<project>/instances/<instance>`.
-  /// @param options  Optional. Operation options.
-  /// @return @googleapis_link{google::longrunning::Operation,google/longrunning/operations.proto#L128}
-  ///
-  /// [google.test.admin.database.v1.ListDatabaseOperationsRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L553}
-  /// [google.longrunning.Operation]: @googleapis_reference_link{google/longrunning/operations.proto#L128}
-  ///
-  StreamRange<google::longrunning::Operation>
-  ListDatabaseOperations(std::string const& parent, Options options = {});
-
-  ///
-  /// Lists the backup [long-running operations][google.longrunning.Operation] in
-  /// the given instance. A backup operation has a name of the form
-  /// `projects/<project>/instances/<instance>/backups/<backup>/operations/<operation>`.
-  /// The long-running operation
-  /// [metadata][google.longrunning.Operation.metadata] field type
-  /// `metadata.type_url` describes the type of the metadata. Operations returned
-  /// include those that have completed/failed/canceled within the last 7 days,
-  /// and pending operations. Operations returned are ordered by
-  /// `operation.metadata.value.progress.start_time` in descending order starting
-  /// from the most recently started operation.
-  ///
-  /// @param parent  Required. The instance of the backup operations. Values are of
-  ///  the form `projects/<project>/instances/<instance>`.
-  /// @param options  Optional. Operation options.
-  /// @return @googleapis_link{google::longrunning::Operation,google/longrunning/operations.proto#L128}
-  ///
-  /// [google.test.admin.database.v1.ListBackupOperationsRequest]: @googleapis_reference_link{generator/integration_tests/backup.proto#L274}
-  /// [google.longrunning.Operation]: @googleapis_reference_link{google/longrunning/operations.proto#L128}
-  ///
-  StreamRange<google::longrunning::Operation>
-  ListBackupOperations(std::string const& parent, Options options = {});
-
-  ///
-  /// Gets the state of a Cloud Test database.
-  ///
-  /// @param name  Required. The name of the requested database. Values are of the form
-  ///  `projects/<project>/instances/<instance>/databases/<database>`.
-  /// @param options  Optional. Operation options.
-  /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
-  ///
-  /// [google.test.admin.database.v1.GetDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L443}
-  /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L329}
-  ///
-  future<StatusOr<google::test::admin::database::v1::Database>>
-  AsyncGetDatabase(std::string const& name, Options options = {});
-
-  ///
-  /// Drops (aka deletes) a Cloud Test database.
-  /// Completed backups for the database will be retained according to their
-  /// `expire_time`.
-  ///
-  /// @param database  Required. The database to be dropped.
-  /// @param options  Optional. Operation options.
-  ///
-  /// [google.test.admin.database.v1.DropDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L523}
-  ///
-  future<Status>
-  AsyncDropDatabase(std::string const& database, Options options = {});
-
-  ///
-  /// Lists Cloud Test databases.
-  ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::ListDatabasesRequest,generator/integration_tests/test.proto#L377}
-  /// @param options  Optional. Operation options.
-  /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
-  ///
-  /// [google.test.admin.database.v1.ListDatabasesRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L377}
-  /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L329}
-  ///
-  StreamRange<google::test::admin::database::v1::Database>
-  ListDatabases(google::test::admin::database::v1::ListDatabasesRequest request, Options options = {});
-
-  ///
-  /// Creates a new Cloud Test database and starts to prepare it for serving.
-  /// The returned [long-running operation][google.longrunning.Operation] will
-  /// have a name of the format `<database_name>/operations/<operation_id>` and
-  /// can be used to track preparation of the database. The
-  /// [metadata][google.longrunning.Operation.metadata] field type is
-  /// [CreateDatabaseMetadata][google.test.admin.database.v1.CreateDatabaseMetadata]. The
-  /// [response][google.longrunning.Operation.response] field type is
-  /// [Database][google.test.admin.database.v1.Database], if successful.
-  ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::CreateDatabaseRequest,generator/integration_tests/test.proto#L409}
-  /// @param options  Optional. Operation options.
-  /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
-  ///
-  /// [google.test.admin.database.v1.CreateDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L409}
-  /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L329}
-  ///
-  future<StatusOr<google::test::admin::database::v1::Database>>
-  CreateDatabase(google::test::admin::database::v1::CreateDatabaseRequest const& request, Options options = {});
-
-  ///
-  /// Gets the state of a Cloud Test database.
-  ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::GetDatabaseRequest,generator/integration_tests/test.proto#L443}
-  /// @param options  Optional. Operation options.
-  /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
-  ///
-  /// [google.test.admin.database.v1.GetDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L443}
-  /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L329}
-  ///
-  StatusOr<google::test::admin::database::v1::Database>
-  GetDatabase(google::test::admin::database::v1::GetDatabaseRequest const& request, Options options = {});
-
-  ///
-  /// Updates the schema of a Cloud Test database by
-  /// creating/altering/dropping tables, columns, indexes, etc. The returned
-  /// [long-running operation][google.longrunning.Operation] will have a name of
-  /// the format `<database_name>/operations/<operation_id>` and can be used to
-  /// track execution of the schema change(s). The
-  /// [metadata][google.longrunning.Operation.metadata] field type is
-  /// [UpdateDatabaseDdlMetadata][google.test.admin.database.v1.UpdateDatabaseDdlMetadata].  The operation has no response.
-  ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::UpdateDatabaseDdlRequest,generator/integration_tests/test.proto#L470}
-  /// @param options  Optional. Operation options.
-  /// @return @googleapis_link{google::test::admin::database::v1::UpdateDatabaseDdlMetadata,generator/integration_tests/test.proto#L506}
-  ///
-  /// [google.test.admin.database.v1.UpdateDatabaseDdlRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L470}
-  /// [google.test.admin.database.v1.UpdateDatabaseDdlMetadata]: @googleapis_reference_link{generator/integration_tests/test.proto#L506}
-  ///
-  future<StatusOr<google::test::admin::database::v1::UpdateDatabaseDdlMetadata>>
-  UpdateDatabaseDdl(google::test::admin::database::v1::UpdateDatabaseDdlRequest const& request, Options options = {});
-
-  ///
-  /// Drops (aka deletes) a Cloud Test database.
-  /// Completed backups for the database will be retained according to their
-  /// `expire_time`.
-  ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::DropDatabaseRequest,generator/integration_tests/test.proto#L523}
-  /// @param options  Optional. Operation options.
-  ///
-  /// [google.test.admin.database.v1.DropDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L523}
-  ///
-  Status
-  DropDatabase(google::test::admin::database::v1::DropDatabaseRequest const& request, Options options = {});
-
-  ///
-  /// Returns the schema of a Cloud Test database as a list of formatted
-  /// DDL statements. This method does not show pending schema updates, those may
-  /// be queried using the [Operations][google.longrunning.Operations] API.
-  ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::GetDatabaseDdlRequest,generator/integration_tests/test.proto#L534}
-  /// @param options  Optional. Operation options.
-  /// @return @googleapis_link{google::test::admin::database::v1::GetDatabaseDdlResponse,generator/integration_tests/test.proto#L545}
-  ///
-  /// [google.test.admin.database.v1.GetDatabaseDdlRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L534}
-  /// [google.test.admin.database.v1.GetDatabaseDdlResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L545}
-  ///
-  StatusOr<google::test::admin::database::v1::GetDatabaseDdlResponse>
-  GetDatabaseDdl(google::test::admin::database::v1::GetDatabaseDdlRequest const& request, Options options = {});
-
-  ///
-  /// Sets the access control policy on a database or backup resource.
-  /// Replaces any existing policy.
-  ///
-  /// Authorization requires `test.databases.setIamPolicy`
-  /// permission on [resource][google.iam.v1.SetIamPolicyRequest.resource].
-  /// For backups, authorization requires `test.backups.setIamPolicy`
-  /// permission on [resource][google.iam.v1.SetIamPolicyRequest.resource].
-  ///
-  /// @param request @googleapis_link{google::iam::v1::SetIamPolicyRequest,google/iam/v1/iam_policy.proto#L98}
-  /// @param options  Optional. Operation options.
-  /// @return @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
-  ///
-  /// [google.iam.v1.SetIamPolicyRequest]: @googleapis_reference_link{google/iam/v1/iam_policy.proto#L98}
-  /// [google.iam.v1.Policy]: @googleapis_reference_link{google/iam/v1/policy.proto#L88}
-  ///
-  StatusOr<google::iam::v1::Policy>
-  SetIamPolicy(google::iam::v1::SetIamPolicyRequest const& request, Options options = {});
-
-  ///
-  /// Gets the access control policy for a database or backup resource.
-  /// Returns an empty policy if a database or backup exists but does not have a
-  /// policy set.
-  ///
-  /// Authorization requires `test.databases.getIamPolicy` permission on
-  /// [resource][google.iam.v1.GetIamPolicyRequest.resource].
-  /// For backups, authorization requires `test.backups.getIamPolicy`
-  /// permission on [resource][google.iam.v1.GetIamPolicyRequest.resource].
-  ///
-  /// @param request @googleapis_link{google::iam::v1::GetIamPolicyRequest,google/iam/v1/iam_policy.proto#L113}
-  /// @param options  Optional. Operation options.
-  /// @return @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
-  ///
-  /// [google.iam.v1.GetIamPolicyRequest]: @googleapis_reference_link{google/iam/v1/iam_policy.proto#L113}
-  /// [google.iam.v1.Policy]: @googleapis_reference_link{google/iam/v1/policy.proto#L88}
-  ///
-  StatusOr<google::iam::v1::Policy>
-  GetIamPolicy(google::iam::v1::GetIamPolicyRequest const& request, Options options = {});
-
-  ///
-  /// Returns permissions that the caller has on the specified database or backup
-  /// resource.
-  ///
-  /// Attempting this RPC on a non-existent Cloud Test database will
-  /// result in a NOT_FOUND error if the user has
-  /// `test.databases.list` permission on the containing Cloud
-  /// Test instance. Otherwise returns an empty set of permissions.
-  /// Calling this method on a backup that does not exist will
-  /// result in a NOT_FOUND error if the user has
-  /// `test.backups.list` permission on the containing instance.
-  ///
-  /// @param request @googleapis_link{google::iam::v1::TestIamPermissionsRequest,google/iam/v1/iam_policy.proto#L126}
-  /// @param options  Optional. Operation options.
-  /// @return @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
-  ///
-  /// [google.iam.v1.TestIamPermissionsRequest]: @googleapis_reference_link{google/iam/v1/iam_policy.proto#L126}
-  /// [google.iam.v1.TestIamPermissionsResponse]: @googleapis_reference_link{google/iam/v1/iam_policy.proto#L141}
-  ///
-  StatusOr<google::iam::v1::TestIamPermissionsResponse>
-  TestIamPermissions(google::iam::v1::TestIamPermissionsRequest const& request, Options options = {});
-
-  ///
-  /// Starts creating a new Cloud Test Backup.
-  /// The returned backup [long-running operation][google.longrunning.Operation]
-  /// will have a name of the format
-  /// `projects/<project>/instances/<instance>/backups/<backup>/operations/<operation_id>`
-  /// and can be used to track creation of the backup. The
-  /// [metadata][google.longrunning.Operation.metadata] field type is
-  /// [CreateBackupMetadata][google.test.admin.database.v1.CreateBackupMetadata]. The
-  /// [response][google.longrunning.Operation.response] field type is
-  /// [Backup][google.test.admin.database.v1.Backup], if successful. Cancelling the returned operation will stop the
-  /// creation and delete the backup.
-  /// There can be only one pending backup creation per database. Backup creation
-  /// of different databases can run concurrently.
-  ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::CreateBackupRequest,generator/integration_tests/backup.proto#L110}
-  /// @param options  Optional. Operation options.
-  /// @return @googleapis_link{google::test::admin::database::v1::Backup,generator/integration_tests/backup.proto#L36}
-  ///
-  /// [google.test.admin.database.v1.CreateBackupRequest]: @googleapis_reference_link{generator/integration_tests/backup.proto#L110}
-  /// [google.test.admin.database.v1.Backup]: @googleapis_reference_link{generator/integration_tests/backup.proto#L36}
-  ///
-  future<StatusOr<google::test::admin::database::v1::Backup>>
-  CreateBackup(google::test::admin::database::v1::CreateBackupRequest const& request, Options options = {});
-
-  ///
-  /// Gets metadata on a pending or completed [Backup][google.test.admin.database.v1.Backup].
-  ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::GetBackupRequest,generator/integration_tests/backup.proto#L177}
-  /// @param options  Optional. Operation options.
-  /// @return @googleapis_link{google::test::admin::database::v1::Backup,generator/integration_tests/backup.proto#L36}
-  ///
-  /// [google.test.admin.database.v1.GetBackupRequest]: @googleapis_reference_link{generator/integration_tests/backup.proto#L177}
-  /// [google.test.admin.database.v1.Backup]: @googleapis_reference_link{generator/integration_tests/backup.proto#L36}
-  ///
-  StatusOr<google::test::admin::database::v1::Backup>
-  GetBackup(google::test::admin::database::v1::GetBackupRequest const& request, Options options = {});
-
-  ///
-  /// Updates a pending or completed [Backup][google.test.admin.database.v1.Backup].
-  ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::UpdateBackupRequest,generator/integration_tests/backup.proto#L161}
-  /// @param options  Optional. Operation options.
-  /// @return @googleapis_link{google::test::admin::database::v1::Backup,generator/integration_tests/backup.proto#L36}
-  ///
-  /// [google.test.admin.database.v1.UpdateBackupRequest]: @googleapis_reference_link{generator/integration_tests/backup.proto#L161}
-  /// [google.test.admin.database.v1.Backup]: @googleapis_reference_link{generator/integration_tests/backup.proto#L36}
-  ///
-  StatusOr<google::test::admin::database::v1::Backup>
-  UpdateBackup(google::test::admin::database::v1::UpdateBackupRequest const& request, Options options = {});
-
-  ///
-  /// Deletes a pending or completed [Backup][google.test.admin.database.v1.Backup].
-  ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::DeleteBackupRequest,generator/integration_tests/backup.proto#L190}
-  /// @param options  Optional. Operation options.
-  ///
-  /// [google.test.admin.database.v1.DeleteBackupRequest]: @googleapis_reference_link{generator/integration_tests/backup.proto#L190}
-  ///
-  Status
-  DeleteBackup(google::test::admin::database::v1::DeleteBackupRequest const& request, Options options = {});
-
-  ///
-  /// Lists completed and pending backups.
-  /// Backups returned are ordered by `create_time` in descending order,
-  /// starting from the most recent `create_time`.
-  ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::ListBackupsRequest,generator/integration_tests/backup.proto#L203}
-  /// @param options  Optional. Operation options.
-  /// @return @googleapis_link{google::test::admin::database::v1::Backup,generator/integration_tests/backup.proto#L36}
-  ///
-  /// [google.test.admin.database.v1.ListBackupsRequest]: @googleapis_reference_link{generator/integration_tests/backup.proto#L203}
-  /// [google.test.admin.database.v1.Backup]: @googleapis_reference_link{generator/integration_tests/backup.proto#L36}
-  ///
-  StreamRange<google::test::admin::database::v1::Backup>
-  ListBackups(google::test::admin::database::v1::ListBackupsRequest request, Options options = {});
-
-  ///
   /// Create a new database by restoring from a completed backup. The new
   /// database must be in the same project and in an instance with the same
   /// instance configuration as the instance containing
@@ -763,6 +692,27 @@ class GoldenThingAdminClient {
   /// include those that have completed/failed/canceled within the last 7 days,
   /// and pending operations.
   ///
+  /// @param parent  Required. The instance of the database operations.
+  ///  Values are of the form `projects/<project>/instances/<instance>`.
+  /// @param options  Optional. Operation options.
+  /// @return @googleapis_link{google::longrunning::Operation,google/longrunning/operations.proto#L128}
+  ///
+  /// [google.test.admin.database.v1.ListDatabaseOperationsRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L553}
+  /// [google.longrunning.Operation]: @googleapis_reference_link{google/longrunning/operations.proto#L128}
+  ///
+  StreamRange<google::longrunning::Operation>
+  ListDatabaseOperations(std::string const& parent, Options options = {});
+
+  ///
+  /// Lists database [longrunning-operations][google.longrunning.Operation].
+  /// A database operation has a name of the form
+  /// `projects/<project>/instances/<instance>/databases/<database>/operations/<operation>`.
+  /// The long-running operation
+  /// [metadata][google.longrunning.Operation.metadata] field type
+  /// `metadata.type_url` describes the type of the metadata. Operations returned
+  /// include those that have completed/failed/canceled within the last 7 days,
+  /// and pending operations.
+  ///
   /// @param request @googleapis_link{google::test::admin::database::v1::ListDatabaseOperationsRequest,generator/integration_tests/test.proto#L553}
   /// @param options  Optional. Operation options.
   /// @return @googleapis_link{google::longrunning::Operation,google/longrunning/operations.proto#L128}
@@ -772,6 +722,29 @@ class GoldenThingAdminClient {
   ///
   StreamRange<google::longrunning::Operation>
   ListDatabaseOperations(google::test::admin::database::v1::ListDatabaseOperationsRequest request, Options options = {});
+
+  ///
+  /// Lists the backup [long-running operations][google.longrunning.Operation] in
+  /// the given instance. A backup operation has a name of the form
+  /// `projects/<project>/instances/<instance>/backups/<backup>/operations/<operation>`.
+  /// The long-running operation
+  /// [metadata][google.longrunning.Operation.metadata] field type
+  /// `metadata.type_url` describes the type of the metadata. Operations returned
+  /// include those that have completed/failed/canceled within the last 7 days,
+  /// and pending operations. Operations returned are ordered by
+  /// `operation.metadata.value.progress.start_time` in descending order starting
+  /// from the most recently started operation.
+  ///
+  /// @param parent  Required. The instance of the backup operations. Values are of
+  ///  the form `projects/<project>/instances/<instance>`.
+  /// @param options  Optional. Operation options.
+  /// @return @googleapis_link{google::longrunning::Operation,google/longrunning/operations.proto#L128}
+  ///
+  /// [google.test.admin.database.v1.ListBackupOperationsRequest]: @googleapis_reference_link{generator/integration_tests/backup.proto#L274}
+  /// [google.longrunning.Operation]: @googleapis_reference_link{google/longrunning/operations.proto#L128}
+  ///
+  StreamRange<google::longrunning::Operation>
+  ListBackupOperations(std::string const& parent, Options options = {});
 
   ///
   /// Lists the backup [long-running operations][google.longrunning.Operation] in
@@ -798,6 +771,20 @@ class GoldenThingAdminClient {
   ///
   /// Gets the state of a Cloud Test database.
   ///
+  /// @param name  Required. The name of the requested database. Values are of the form
+  ///  `projects/<project>/instances/<instance>/databases/<database>`.
+  /// @param options  Optional. Operation options.
+  /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
+  ///
+  /// [google.test.admin.database.v1.GetDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L443}
+  /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L329}
+  ///
+  future<StatusOr<google::test::admin::database::v1::Database>>
+  AsyncGetDatabase(std::string const& name, Options options = {});
+
+  ///
+  /// Gets the state of a Cloud Test database.
+  ///
   /// @param request @googleapis_link{google::test::admin::database::v1::GetDatabaseRequest,generator/integration_tests/test.proto#L443}
   /// @param options  Optional. Operation options.
   /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
@@ -807,6 +794,19 @@ class GoldenThingAdminClient {
   ///
   future<StatusOr<google::test::admin::database::v1::Database>>
   AsyncGetDatabase(google::test::admin::database::v1::GetDatabaseRequest const& request, Options options = {});
+
+  ///
+  /// Drops (aka deletes) a Cloud Test database.
+  /// Completed backups for the database will be retained according to their
+  /// `expire_time`.
+  ///
+  /// @param database  Required. The database to be dropped.
+  /// @param options  Optional. Operation options.
+  ///
+  /// [google.test.admin.database.v1.DropDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L523}
+  ///
+  future<Status>
+  AsyncDropDatabase(std::string const& database, Options options = {});
 
   ///
   /// Drops (aka deletes) a Cloud Test database.

--- a/generator/internal/client_generator.cc
+++ b/generator/internal/client_generator.cc
@@ -207,35 +207,6 @@ Status ClientGenerator::GenerateHeader() {
         });
       }
     }
-  }
-
-  for (google::protobuf::MethodDescriptor const& method : async_methods()) {
-    auto method_signature_extension =
-        method.options().GetRepeatedExtension(google::api::method_signature);
-    for (int i = 0; i < method_signature_extension.size(); ++i) {
-      std::string method_string =
-          absl::StrCat("  Async$method_name$($method_signature", i,
-                       "$, Options options = {});\n\n");
-      HeaderPrintMethod(
-          method,
-          {MethodPattern(
-              {
-                  {FormatMethodCommentsFromRpcComments(
-                      method, MethodParameterStyle::kApiMethodSignature)},
-                  {IsResponseTypeEmpty,
-                   // clang-format off
-                   "  future<Status>\n",
-                   "  future<StatusOr<$response_type$>>\n"},
-                  {method_string}
-                  // clang-format on
-              },
-              All(IsNonStreaming, Not(IsLongrunningOperation),
-                  Not(IsPaginated)))},
-          __FILE__, __LINE__);
-    }
-  }
-
-  for (auto const& method : methods()) {
     HeaderPrintMethod(
         method,
         {MethodPattern(
@@ -288,7 +259,30 @@ Status ClientGenerator::GenerateHeader() {
         __FILE__, __LINE__);
   }
 
-  for (auto const& method : async_methods()) {
+  for (google::protobuf::MethodDescriptor const& method : async_methods()) {
+    auto method_signature_extension =
+        method.options().GetRepeatedExtension(google::api::method_signature);
+    for (int i = 0; i < method_signature_extension.size(); ++i) {
+      std::string method_string =
+          absl::StrCat("  Async$method_name$($method_signature", i,
+                       "$, Options options = {});\n\n");
+      HeaderPrintMethod(
+          method,
+          {MethodPattern(
+              {
+                  {FormatMethodCommentsFromRpcComments(
+                      method, MethodParameterStyle::kApiMethodSignature)},
+                  {IsResponseTypeEmpty,
+                   // clang-format off
+                   "  future<Status>\n",
+                   "  future<StatusOr<$response_type$>>\n"},
+                  {method_string}
+                  // clang-format on
+              },
+              All(IsNonStreaming, Not(IsLongrunningOperation),
+                  Not(IsPaginated)))},
+          __FILE__, __LINE__);
+    }
     HeaderPrintMethod(
         method,
         {MethodPattern(
@@ -473,41 +467,6 @@ Status ClientGenerator::GenerateCc() {
         });
       }
     }
-  }
-
-  for (google::protobuf::MethodDescriptor const& method : async_methods()) {
-    auto method_signature_extension =
-        method.options().GetRepeatedExtension(google::api::method_signature);
-    for (int i = 0; i < method_signature_extension.size(); ++i) {
-      std::string method_string = absl::StrCat(
-          "$client_class_name$::Async$method_name$($method_signature", i,
-          "$, Options options) {\n");
-      std::string method_request_string =
-          absl::StrCat("$method_request_setters", i, "$");
-      CcPrintMethod(
-          method,
-          {MethodPattern(
-              {
-                  {IsResponseTypeEmpty,
-                   // clang-format off
-                   "future<Status>\n",
-                   "future<StatusOr<$response_type$>>\n"},
-                  {method_string},
-                  {"  internal::OptionsSpan span(internal::MergeOptions("
-                   "std::move(options), options_));\n"},
-                  {"  $request_type$ request;\n"},
-                   {method_request_string},
-                  {"  return connection_->Async$method_name$(request);\n"
-                   "}\n\n"}
-                  // clang-format on
-              },
-              All(IsNonStreaming, Not(IsLongrunningOperation),
-                  Not(IsPaginated)))},
-          __FILE__, __LINE__);
-    }
-  }
-
-  for (auto const& method : methods()) {
     CcPrintMethod(
         method,
         {MethodPattern(
@@ -570,7 +529,36 @@ Status ClientGenerator::GenerateCc() {
         __FILE__, __LINE__);
   }
 
-  for (auto const& method : async_methods()) {
+  for (google::protobuf::MethodDescriptor const& method : async_methods()) {
+    auto method_signature_extension =
+        method.options().GetRepeatedExtension(google::api::method_signature);
+    for (int i = 0; i < method_signature_extension.size(); ++i) {
+      std::string method_string = absl::StrCat(
+          "$client_class_name$::Async$method_name$($method_signature", i,
+          "$, Options options) {\n");
+      std::string method_request_string =
+          absl::StrCat("$method_request_setters", i, "$");
+      CcPrintMethod(
+          method,
+          {MethodPattern(
+              {
+                  {IsResponseTypeEmpty,
+                   // clang-format off
+                   "future<Status>\n",
+                   "future<StatusOr<$response_type$>>\n"},
+                  {method_string},
+                  {"  internal::OptionsSpan span(internal::MergeOptions("
+                   "std::move(options), options_));\n"},
+                  {"  $request_type$ request;\n"},
+                   {method_request_string},
+                  {"  return connection_->Async$method_name$(request);\n"
+                   "}\n\n"}
+                  // clang-format on
+              },
+              All(IsNonStreaming, Not(IsLongrunningOperation),
+                  Not(IsPaginated)))},
+          __FILE__, __LINE__);
+    }
     CcPrintMethod(
         method,
         {MethodPattern(

--- a/google/cloud/bigquery/bigquery_read_client.cc
+++ b/google/cloud/bigquery/bigquery_read_client.cc
@@ -46,6 +46,16 @@ BigQueryReadClient::CreateReadSession(
   return connection_->CreateReadSession(request);
 }
 
+StatusOr<google::cloud::bigquery::storage::v1::ReadSession>
+BigQueryReadClient::CreateReadSession(
+    google::cloud::bigquery::storage::v1::CreateReadSessionRequest const&
+        request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
+  return connection_->CreateReadSession(request);
+}
+
 StreamRange<google::cloud::bigquery::storage::v1::ReadRowsResponse>
 BigQueryReadClient::ReadRows(std::string const& read_stream,
                              std::int64_t offset, Options options) {
@@ -55,16 +65,6 @@ BigQueryReadClient::ReadRows(std::string const& read_stream,
   request.set_read_stream(read_stream);
   request.set_offset(offset);
   return connection_->ReadRows(request);
-}
-
-StatusOr<google::cloud::bigquery::storage::v1::ReadSession>
-BigQueryReadClient::CreateReadSession(
-    google::cloud::bigquery::storage::v1::CreateReadSessionRequest const&
-        request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->CreateReadSession(request);
 }
 
 StreamRange<google::cloud::bigquery::storage::v1::ReadRowsResponse>

--- a/google/cloud/bigquery/bigquery_read_client.h
+++ b/google/cloud/bigquery/bigquery_read_client.h
@@ -134,33 +134,6 @@ class BigQueryReadClient {
       std::int32_t max_stream_count, Options options = {});
 
   ///
-  /// Reads rows from the stream in the format prescribed by the ReadSession.
-  /// Each response contains one or more table rows, up to a maximum of 100 MiB
-  /// per response; read requests which attempt to read individual rows larger
-  /// than 100 MiB will fail.
-  ///
-  /// Each request also returns a set of stream statistics reflecting the
-  /// current state of the stream.
-  ///
-  /// @param read_stream  Required. Stream to read rows from.
-  /// @param offset  The offset requested must be less than the last row read
-  /// from Read.
-  ///  Requesting a larger offset is undefined. If not specified, start reading
-  ///  from offset zero.
-  /// @param options  Optional. Operation options.
-  /// @return
-  /// @googleapis_link{google::cloud::bigquery::storage::v1::ReadRowsResponse,google/cloud/bigquery/storage/v1/storage.proto#L304}
-  ///
-  /// [google.cloud.bigquery.storage.v1.ReadRowsRequest]:
-  /// @googleapis_reference_link{google/cloud/bigquery/storage/v1/storage.proto#L254}
-  /// [google.cloud.bigquery.storage.v1.ReadRowsResponse]:
-  /// @googleapis_reference_link{google/cloud/bigquery/storage/v1/storage.proto#L304}
-  ///
-  StreamRange<google::cloud::bigquery::storage::v1::ReadRowsResponse> ReadRows(
-      std::string const& read_stream, std::int64_t offset,
-      Options options = {});
-
-  ///
   /// Creates a new read session. A read session divides the contents of a
   /// BigQuery table into one or more streams, which can then be used to read
   /// data from the table. The read session also specifies properties of the
@@ -195,6 +168,33 @@ class BigQueryReadClient {
   StatusOr<google::cloud::bigquery::storage::v1::ReadSession> CreateReadSession(
       google::cloud::bigquery::storage::v1::CreateReadSessionRequest const&
           request,
+      Options options = {});
+
+  ///
+  /// Reads rows from the stream in the format prescribed by the ReadSession.
+  /// Each response contains one or more table rows, up to a maximum of 100 MiB
+  /// per response; read requests which attempt to read individual rows larger
+  /// than 100 MiB will fail.
+  ///
+  /// Each request also returns a set of stream statistics reflecting the
+  /// current state of the stream.
+  ///
+  /// @param read_stream  Required. Stream to read rows from.
+  /// @param offset  The offset requested must be less than the last row read
+  /// from Read.
+  ///  Requesting a larger offset is undefined. If not specified, start reading
+  ///  from offset zero.
+  /// @param options  Optional. Operation options.
+  /// @return
+  /// @googleapis_link{google::cloud::bigquery::storage::v1::ReadRowsResponse,google/cloud/bigquery/storage/v1/storage.proto#L304}
+  ///
+  /// [google.cloud.bigquery.storage.v1.ReadRowsRequest]:
+  /// @googleapis_reference_link{google/cloud/bigquery/storage/v1/storage.proto#L254}
+  /// [google.cloud.bigquery.storage.v1.ReadRowsResponse]:
+  /// @googleapis_reference_link{google/cloud/bigquery/storage/v1/storage.proto#L304}
+  ///
+  StreamRange<google::cloud::bigquery::storage::v1::ReadRowsResponse> ReadRows(
+      std::string const& read_stream, std::int64_t offset,
       Options options = {});
 
   ///

--- a/google/cloud/bigtable/admin/bigtable_instance_admin_client.cc
+++ b/google/cloud/bigtable/admin/bigtable_instance_admin_client.cc
@@ -51,6 +51,15 @@ BigtableInstanceAdminClient::CreateInstance(
   return connection_->CreateInstance(request);
 }
 
+future<StatusOr<google::bigtable::admin::v2::Instance>>
+BigtableInstanceAdminClient::CreateInstance(
+    google::bigtable::admin::v2::CreateInstanceRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
+  return connection_->CreateInstance(request);
+}
+
 StatusOr<google::bigtable::admin::v2::Instance>
 BigtableInstanceAdminClient::GetInstance(std::string const& name,
                                          Options options) {
@@ -58,6 +67,15 @@ BigtableInstanceAdminClient::GetInstance(std::string const& name,
       internal::MergeOptions(std::move(options), options_));
   google::bigtable::admin::v2::GetInstanceRequest request;
   request.set_name(name);
+  return connection_->GetInstance(request);
+}
+
+StatusOr<google::bigtable::admin::v2::Instance>
+BigtableInstanceAdminClient::GetInstance(
+    google::bigtable::admin::v2::GetInstanceRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->GetInstance(request);
 }
 
@@ -69,6 +87,23 @@ BigtableInstanceAdminClient::ListInstances(std::string const& parent,
   google::bigtable::admin::v2::ListInstancesRequest request;
   request.set_parent(parent);
   return connection_->ListInstances(request);
+}
+
+StatusOr<google::bigtable::admin::v2::ListInstancesResponse>
+BigtableInstanceAdminClient::ListInstances(
+    google::bigtable::admin::v2::ListInstancesRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
+  return connection_->ListInstances(request);
+}
+
+StatusOr<google::bigtable::admin::v2::Instance>
+BigtableInstanceAdminClient::UpdateInstance(
+    google::bigtable::admin::v2::Instance const& request, Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
+  return connection_->UpdateInstance(request);
 }
 
 future<StatusOr<google::bigtable::admin::v2::Instance>>
@@ -83,12 +118,29 @@ BigtableInstanceAdminClient::PartialUpdateInstance(
   return connection_->PartialUpdateInstance(request);
 }
 
+future<StatusOr<google::bigtable::admin::v2::Instance>>
+BigtableInstanceAdminClient::PartialUpdateInstance(
+    google::bigtable::admin::v2::PartialUpdateInstanceRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
+  return connection_->PartialUpdateInstance(request);
+}
+
 Status BigtableInstanceAdminClient::DeleteInstance(std::string const& name,
                                                    Options options) {
   internal::OptionsSpan span(
       internal::MergeOptions(std::move(options), options_));
   google::bigtable::admin::v2::DeleteInstanceRequest request;
   request.set_name(name);
+  return connection_->DeleteInstance(request);
+}
+
+Status BigtableInstanceAdminClient::DeleteInstance(
+    google::bigtable::admin::v2::DeleteInstanceRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->DeleteInstance(request);
 }
 
@@ -105,6 +157,15 @@ BigtableInstanceAdminClient::CreateCluster(
   return connection_->CreateCluster(request);
 }
 
+future<StatusOr<google::bigtable::admin::v2::Cluster>>
+BigtableInstanceAdminClient::CreateCluster(
+    google::bigtable::admin::v2::CreateClusterRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
+  return connection_->CreateCluster(request);
+}
+
 StatusOr<google::bigtable::admin::v2::Cluster>
 BigtableInstanceAdminClient::GetCluster(std::string const& name,
                                         Options options) {
@@ -112,6 +173,15 @@ BigtableInstanceAdminClient::GetCluster(std::string const& name,
       internal::MergeOptions(std::move(options), options_));
   google::bigtable::admin::v2::GetClusterRequest request;
   request.set_name(name);
+  return connection_->GetCluster(request);
+}
+
+StatusOr<google::bigtable::admin::v2::Cluster>
+BigtableInstanceAdminClient::GetCluster(
+    google::bigtable::admin::v2::GetClusterRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->GetCluster(request);
 }
 
@@ -123,6 +193,23 @@ BigtableInstanceAdminClient::ListClusters(std::string const& parent,
   google::bigtable::admin::v2::ListClustersRequest request;
   request.set_parent(parent);
   return connection_->ListClusters(request);
+}
+
+StatusOr<google::bigtable::admin::v2::ListClustersResponse>
+BigtableInstanceAdminClient::ListClusters(
+    google::bigtable::admin::v2::ListClustersRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
+  return connection_->ListClusters(request);
+}
+
+future<StatusOr<google::bigtable::admin::v2::Cluster>>
+BigtableInstanceAdminClient::UpdateCluster(
+    google::bigtable::admin::v2::Cluster const& request, Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
+  return connection_->UpdateCluster(request);
 }
 
 future<StatusOr<google::bigtable::admin::v2::Cluster>>
@@ -137,12 +224,29 @@ BigtableInstanceAdminClient::PartialUpdateCluster(
   return connection_->PartialUpdateCluster(request);
 }
 
+future<StatusOr<google::bigtable::admin::v2::Cluster>>
+BigtableInstanceAdminClient::PartialUpdateCluster(
+    google::bigtable::admin::v2::PartialUpdateClusterRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
+  return connection_->PartialUpdateCluster(request);
+}
+
 Status BigtableInstanceAdminClient::DeleteCluster(std::string const& name,
                                                   Options options) {
   internal::OptionsSpan span(
       internal::MergeOptions(std::move(options), options_));
   google::bigtable::admin::v2::DeleteClusterRequest request;
   request.set_name(name);
+  return connection_->DeleteCluster(request);
+}
+
+Status BigtableInstanceAdminClient::DeleteCluster(
+    google::bigtable::admin::v2::DeleteClusterRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->DeleteCluster(request);
 }
 
@@ -161,12 +265,30 @@ BigtableInstanceAdminClient::CreateAppProfile(
 }
 
 StatusOr<google::bigtable::admin::v2::AppProfile>
+BigtableInstanceAdminClient::CreateAppProfile(
+    google::bigtable::admin::v2::CreateAppProfileRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
+  return connection_->CreateAppProfile(request);
+}
+
+StatusOr<google::bigtable::admin::v2::AppProfile>
 BigtableInstanceAdminClient::GetAppProfile(std::string const& name,
                                            Options options) {
   internal::OptionsSpan span(
       internal::MergeOptions(std::move(options), options_));
   google::bigtable::admin::v2::GetAppProfileRequest request;
   request.set_name(name);
+  return connection_->GetAppProfile(request);
+}
+
+StatusOr<google::bigtable::admin::v2::AppProfile>
+BigtableInstanceAdminClient::GetAppProfile(
+    google::bigtable::admin::v2::GetAppProfileRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->GetAppProfile(request);
 }
 
@@ -178,6 +300,15 @@ BigtableInstanceAdminClient::ListAppProfiles(std::string const& parent,
   google::bigtable::admin::v2::ListAppProfilesRequest request;
   request.set_parent(parent);
   return connection_->ListAppProfiles(request);
+}
+
+StreamRange<google::bigtable::admin::v2::AppProfile>
+BigtableInstanceAdminClient::ListAppProfiles(
+    google::bigtable::admin::v2::ListAppProfilesRequest request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
+  return connection_->ListAppProfiles(std::move(request));
 }
 
 future<StatusOr<google::bigtable::admin::v2::AppProfile>>
@@ -192,6 +323,15 @@ BigtableInstanceAdminClient::UpdateAppProfile(
   return connection_->UpdateAppProfile(request);
 }
 
+future<StatusOr<google::bigtable::admin::v2::AppProfile>>
+BigtableInstanceAdminClient::UpdateAppProfile(
+    google::bigtable::admin::v2::UpdateAppProfileRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
+  return connection_->UpdateAppProfile(request);
+}
+
 Status BigtableInstanceAdminClient::DeleteAppProfile(std::string const& name,
                                                      Options options) {
   internal::OptionsSpan span(
@@ -201,12 +341,27 @@ Status BigtableInstanceAdminClient::DeleteAppProfile(std::string const& name,
   return connection_->DeleteAppProfile(request);
 }
 
+Status BigtableInstanceAdminClient::DeleteAppProfile(
+    google::bigtable::admin::v2::DeleteAppProfileRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
+  return connection_->DeleteAppProfile(request);
+}
+
 StatusOr<google::iam::v1::Policy> BigtableInstanceAdminClient::GetIamPolicy(
     std::string const& resource, Options options) {
   internal::OptionsSpan span(
       internal::MergeOptions(std::move(options), options_));
   google::iam::v1::GetIamPolicyRequest request;
   request.set_resource(resource);
+  return connection_->GetIamPolicy(request);
+}
+
+StatusOr<google::iam::v1::Policy> BigtableInstanceAdminClient::GetIamPolicy(
+    google::iam::v1::GetIamPolicyRequest const& request, Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->GetIamPolicy(request);
 }
 
@@ -247,6 +402,13 @@ StatusOr<google::iam::v1::Policy> BigtableInstanceAdminClient::SetIamPolicy(
   }
 }
 
+StatusOr<google::iam::v1::Policy> BigtableInstanceAdminClient::SetIamPolicy(
+    google::iam::v1::SetIamPolicyRequest const& request, Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
+  return connection_->SetIamPolicy(request);
+}
+
 StatusOr<google::iam::v1::TestIamPermissionsResponse>
 BigtableInstanceAdminClient::TestIamPermissions(
     std::string const& resource, std::vector<std::string> const& permissions,
@@ -257,168 +419,6 @@ BigtableInstanceAdminClient::TestIamPermissions(
   request.set_resource(resource);
   *request.mutable_permissions() = {permissions.begin(), permissions.end()};
   return connection_->TestIamPermissions(request);
-}
-
-future<StatusOr<google::bigtable::admin::v2::Instance>>
-BigtableInstanceAdminClient::CreateInstance(
-    google::bigtable::admin::v2::CreateInstanceRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->CreateInstance(request);
-}
-
-StatusOr<google::bigtable::admin::v2::Instance>
-BigtableInstanceAdminClient::GetInstance(
-    google::bigtable::admin::v2::GetInstanceRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->GetInstance(request);
-}
-
-StatusOr<google::bigtable::admin::v2::ListInstancesResponse>
-BigtableInstanceAdminClient::ListInstances(
-    google::bigtable::admin::v2::ListInstancesRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->ListInstances(request);
-}
-
-StatusOr<google::bigtable::admin::v2::Instance>
-BigtableInstanceAdminClient::UpdateInstance(
-    google::bigtable::admin::v2::Instance const& request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->UpdateInstance(request);
-}
-
-future<StatusOr<google::bigtable::admin::v2::Instance>>
-BigtableInstanceAdminClient::PartialUpdateInstance(
-    google::bigtable::admin::v2::PartialUpdateInstanceRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->PartialUpdateInstance(request);
-}
-
-Status BigtableInstanceAdminClient::DeleteInstance(
-    google::bigtable::admin::v2::DeleteInstanceRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->DeleteInstance(request);
-}
-
-future<StatusOr<google::bigtable::admin::v2::Cluster>>
-BigtableInstanceAdminClient::CreateCluster(
-    google::bigtable::admin::v2::CreateClusterRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->CreateCluster(request);
-}
-
-StatusOr<google::bigtable::admin::v2::Cluster>
-BigtableInstanceAdminClient::GetCluster(
-    google::bigtable::admin::v2::GetClusterRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->GetCluster(request);
-}
-
-StatusOr<google::bigtable::admin::v2::ListClustersResponse>
-BigtableInstanceAdminClient::ListClusters(
-    google::bigtable::admin::v2::ListClustersRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->ListClusters(request);
-}
-
-future<StatusOr<google::bigtable::admin::v2::Cluster>>
-BigtableInstanceAdminClient::UpdateCluster(
-    google::bigtable::admin::v2::Cluster const& request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->UpdateCluster(request);
-}
-
-future<StatusOr<google::bigtable::admin::v2::Cluster>>
-BigtableInstanceAdminClient::PartialUpdateCluster(
-    google::bigtable::admin::v2::PartialUpdateClusterRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->PartialUpdateCluster(request);
-}
-
-Status BigtableInstanceAdminClient::DeleteCluster(
-    google::bigtable::admin::v2::DeleteClusterRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->DeleteCluster(request);
-}
-
-StatusOr<google::bigtable::admin::v2::AppProfile>
-BigtableInstanceAdminClient::CreateAppProfile(
-    google::bigtable::admin::v2::CreateAppProfileRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->CreateAppProfile(request);
-}
-
-StatusOr<google::bigtable::admin::v2::AppProfile>
-BigtableInstanceAdminClient::GetAppProfile(
-    google::bigtable::admin::v2::GetAppProfileRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->GetAppProfile(request);
-}
-
-StreamRange<google::bigtable::admin::v2::AppProfile>
-BigtableInstanceAdminClient::ListAppProfiles(
-    google::bigtable::admin::v2::ListAppProfilesRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->ListAppProfiles(std::move(request));
-}
-
-future<StatusOr<google::bigtable::admin::v2::AppProfile>>
-BigtableInstanceAdminClient::UpdateAppProfile(
-    google::bigtable::admin::v2::UpdateAppProfileRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->UpdateAppProfile(request);
-}
-
-Status BigtableInstanceAdminClient::DeleteAppProfile(
-    google::bigtable::admin::v2::DeleteAppProfileRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->DeleteAppProfile(request);
-}
-
-StatusOr<google::iam::v1::Policy> BigtableInstanceAdminClient::GetIamPolicy(
-    google::iam::v1::GetIamPolicyRequest const& request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->GetIamPolicy(request);
-}
-
-StatusOr<google::iam::v1::Policy> BigtableInstanceAdminClient::SetIamPolicy(
-    google::iam::v1::SetIamPolicyRequest const& request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->SetIamPolicy(request);
 }
 
 StatusOr<google::iam::v1::TestIamPermissionsResponse>

--- a/google/cloud/bigtable/admin/bigtable_instance_admin_client.h
+++ b/google/cloud/bigtable/admin/bigtable_instance_admin_client.h
@@ -133,386 +133,6 @@ class BigtableInstanceAdminClient {
       Options options = {});
 
   ///
-  /// Gets information about an instance.
-  ///
-  /// @param name  Required. The unique name of the requested instance. Values
-  /// are of the form
-  ///  `projects/{project}/instances/{instance}`.
-  /// @param options  Optional. Operation options.
-  /// @return
-  /// @googleapis_link{google::bigtable::admin::v2::Instance,google/bigtable/admin/v2/instance.proto#L41}
-  ///
-  /// [google.bigtable.admin.v2.GetInstanceRequest]:
-  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_instance_admin.proto#L308}
-  /// [google.bigtable.admin.v2.Instance]:
-  /// @googleapis_reference_link{google/bigtable/admin/v2/instance.proto#L41}
-  ///
-  StatusOr<google::bigtable::admin::v2::Instance> GetInstance(
-      std::string const& name, Options options = {});
-
-  ///
-  /// Lists information about instances in a project.
-  ///
-  /// @param parent  Required. The unique name of the project for which a list
-  /// of instances is requested.
-  ///  Values are of the form `projects/{project}`.
-  /// @param options  Optional. Operation options.
-  /// @return
-  /// @googleapis_link{google::bigtable::admin::v2::ListInstancesResponse,google/bigtable/admin/v2/bigtable_instance_admin.proto#L335}
-  ///
-  /// [google.bigtable.admin.v2.ListInstancesRequest]:
-  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_instance_admin.proto#L320}
-  /// [google.bigtable.admin.v2.ListInstancesResponse]:
-  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_instance_admin.proto#L335}
-  ///
-  StatusOr<google::bigtable::admin::v2::ListInstancesResponse> ListInstances(
-      std::string const& parent, Options options = {});
-
-  ///
-  /// Partially updates an instance within a project. This method can modify all
-  /// fields of an Instance and is the preferred way to update an Instance.
-  ///
-  /// @param instance  Required. The Instance which will (partially) replace the
-  /// current value.
-  /// @param update_mask  Required. The subset of Instance fields which should
-  /// be replaced.
-  ///  Must be explicitly set.
-  /// @param options  Optional. Operation options.
-  /// @return
-  /// @googleapis_link{google::bigtable::admin::v2::Instance,google/bigtable/admin/v2/instance.proto#L41}
-  ///
-  /// [google.bigtable.admin.v2.PartialUpdateInstanceRequest]:
-  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_instance_admin.proto#L352}
-  /// [google.bigtable.admin.v2.Instance]:
-  /// @googleapis_reference_link{google/bigtable/admin/v2/instance.proto#L41}
-  ///
-  future<StatusOr<google::bigtable::admin::v2::Instance>> PartialUpdateInstance(
-      google::bigtable::admin::v2::Instance const& instance,
-      google::protobuf::FieldMask const& update_mask, Options options = {});
-
-  ///
-  /// Delete an instance from a project.
-  ///
-  /// @param name  Required. The unique name of the instance to be deleted.
-  ///  Values are of the form `projects/{project}/instances/{instance}`.
-  /// @param options  Optional. Operation options.
-  ///
-  /// [google.bigtable.admin.v2.DeleteInstanceRequest]:
-  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_instance_admin.proto#L362}
-  ///
-  Status DeleteInstance(std::string const& name, Options options = {});
-
-  ///
-  /// Creates a cluster within an instance.
-  ///
-  /// Note that exactly one of Cluster.serve_nodes and
-  /// Cluster.cluster_config.cluster_autoscaling_config can be set. If
-  /// serve_nodes is set to non-zero, then the cluster is manually scaled. If
-  /// cluster_config.cluster_autoscaling_config is non-empty, then autoscaling
-  /// is enabled.
-  ///
-  /// @param parent  Required. The unique name of the instance in which to
-  /// create the new cluster.
-  ///  Values are of the form
-  ///  `projects/{project}/instances/{instance}`.
-  /// @param cluster_id  Required. The ID to be used when referring to the new
-  /// cluster within its instance,
-  ///  e.g., just `mycluster` rather than
-  ///  `projects/myproject/instances/myinstance/clusters/mycluster`.
-  /// @param cluster  Required. The cluster to be created.
-  ///  Fields marked `OutputOnly` must be left blank.
-  /// @param options  Optional. Operation options.
-  /// @return
-  /// @googleapis_link{google::bigtable::admin::v2::Cluster,google/bigtable/admin/v2/instance.proto#L137}
-  ///
-  /// [google.bigtable.admin.v2.CreateClusterRequest]:
-  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_instance_admin.proto#L374}
-  /// [google.bigtable.admin.v2.Cluster]:
-  /// @googleapis_reference_link{google/bigtable/admin/v2/instance.proto#L137}
-  ///
-  future<StatusOr<google::bigtable::admin::v2::Cluster>> CreateCluster(
-      std::string const& parent, std::string const& cluster_id,
-      google::bigtable::admin::v2::Cluster const& cluster,
-      Options options = {});
-
-  ///
-  /// Gets information about a cluster.
-  ///
-  /// @param name  Required. The unique name of the requested cluster. Values
-  /// are of the form
-  ///  `projects/{project}/instances/{instance}/clusters/{cluster}`.
-  /// @param options  Optional. Operation options.
-  /// @return
-  /// @googleapis_link{google::bigtable::admin::v2::Cluster,google/bigtable/admin/v2/instance.proto#L137}
-  ///
-  /// [google.bigtable.admin.v2.GetClusterRequest]:
-  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_instance_admin.proto#L396}
-  /// [google.bigtable.admin.v2.Cluster]:
-  /// @googleapis_reference_link{google/bigtable/admin/v2/instance.proto#L137}
-  ///
-  StatusOr<google::bigtable::admin::v2::Cluster> GetCluster(
-      std::string const& name, Options options = {});
-
-  ///
-  /// Lists information about clusters in an instance.
-  ///
-  /// @param parent  Required. The unique name of the instance for which a list
-  /// of clusters is requested.
-  ///  Values are of the form `projects/{project}/instances/{instance}`.
-  ///  Use `{instance} = '-'` to list Clusters for all Instances in a project,
-  ///  e.g., `projects/myproject/instances/-`.
-  /// @param options  Optional. Operation options.
-  /// @return
-  /// @googleapis_link{google::bigtable::admin::v2::ListClustersResponse,google/bigtable/admin/v2/bigtable_instance_admin.proto#L425}
-  ///
-  /// [google.bigtable.admin.v2.ListClustersRequest]:
-  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_instance_admin.proto#L408}
-  /// [google.bigtable.admin.v2.ListClustersResponse]:
-  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_instance_admin.proto#L425}
-  ///
-  StatusOr<google::bigtable::admin::v2::ListClustersResponse> ListClusters(
-      std::string const& parent, Options options = {});
-
-  ///
-  /// Partially updates a cluster within a project. This method is the preferred
-  /// way to update a Cluster.
-  ///
-  /// To enable and update autoscaling, set
-  /// cluster_config.cluster_autoscaling_config. When autoscaling is enabled,
-  /// serve_nodes is treated as an OUTPUT_ONLY field, meaning that updates to it
-  /// are ignored. Note that an update cannot simultaneously set serve_nodes to
-  /// non-zero and cluster_config.cluster_autoscaling_config to non-empty, and
-  /// also specify both in the update_mask.
-  ///
-  /// To disable autoscaling, clear cluster_config.cluster_autoscaling_config,
-  /// and explicitly set a serve_node count via the update_mask.
-  ///
-  /// @param cluster  Required. The Cluster which contains the partial updates
-  /// to be applied, subject to
-  ///  the update_mask.
-  /// @param update_mask  Required. The subset of Cluster fields which should be
-  /// replaced.
-  /// @param options  Optional. Operation options.
-  /// @return
-  /// @googleapis_link{google::bigtable::admin::v2::Cluster,google/bigtable/admin/v2/instance.proto#L137}
-  ///
-  /// [google.bigtable.admin.v2.PartialUpdateClusterRequest]:
-  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_instance_admin.proto#L513}
-  /// [google.bigtable.admin.v2.Cluster]:
-  /// @googleapis_reference_link{google/bigtable/admin/v2/instance.proto#L137}
-  ///
-  future<StatusOr<google::bigtable::admin::v2::Cluster>> PartialUpdateCluster(
-      google::bigtable::admin::v2::Cluster const& cluster,
-      google::protobuf::FieldMask const& update_mask, Options options = {});
-
-  ///
-  /// Deletes a cluster from an instance.
-  ///
-  /// @param name  Required. The unique name of the cluster to be deleted.
-  /// Values are of the form
-  ///  `projects/{project}/instances/{instance}/clusters/{cluster}`.
-  /// @param options  Optional. Operation options.
-  ///
-  /// [google.bigtable.admin.v2.DeleteClusterRequest]:
-  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_instance_admin.proto#L441}
-  ///
-  Status DeleteCluster(std::string const& name, Options options = {});
-
-  ///
-  /// Creates an app profile within an instance.
-  ///
-  /// @param parent  Required. The unique name of the instance in which to
-  /// create the new app profile.
-  ///  Values are of the form
-  ///  `projects/{project}/instances/{instance}`.
-  /// @param app_profile_id  Required. The ID to be used when referring to the
-  /// new app profile within its
-  ///  instance, e.g., just `myprofile` rather than
-  ///  `projects/myproject/instances/myinstance/appProfiles/myprofile`.
-  /// @param app_profile  Required. The app profile to be created.
-  ///  Fields marked `OutputOnly` will be ignored.
-  /// @param options  Optional. Operation options.
-  /// @return
-  /// @googleapis_link{google::bigtable::admin::v2::AppProfile,google/bigtable/admin/v2/instance.proto#L236}
-  ///
-  /// [google.bigtable.admin.v2.CreateAppProfileRequest]:
-  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_instance_admin.proto#L523}
-  /// [google.bigtable.admin.v2.AppProfile]:
-  /// @googleapis_reference_link{google/bigtable/admin/v2/instance.proto#L236}
-  ///
-  StatusOr<google::bigtable::admin::v2::AppProfile> CreateAppProfile(
-      std::string const& parent, std::string const& app_profile_id,
-      google::bigtable::admin::v2::AppProfile const& app_profile,
-      Options options = {});
-
-  ///
-  /// Gets information about an app profile.
-  ///
-  /// @param name  Required. The unique name of the requested app profile.
-  /// Values are of the form
-  ///  `projects/{project}/instances/{instance}/appProfiles/{app_profile}`.
-  /// @param options  Optional. Operation options.
-  /// @return
-  /// @googleapis_link{google::bigtable::admin::v2::AppProfile,google/bigtable/admin/v2/instance.proto#L236}
-  ///
-  /// [google.bigtable.admin.v2.GetAppProfileRequest]:
-  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_instance_admin.proto#L548}
-  /// [google.bigtable.admin.v2.AppProfile]:
-  /// @googleapis_reference_link{google/bigtable/admin/v2/instance.proto#L236}
-  ///
-  StatusOr<google::bigtable::admin::v2::AppProfile> GetAppProfile(
-      std::string const& name, Options options = {});
-
-  ///
-  /// Lists information about app profiles in an instance.
-  ///
-  /// @param parent  Required. The unique name of the instance for which a list
-  /// of app profiles is
-  ///  requested. Values are of the form
-  ///  `projects/{project}/instances/{instance}`.
-  ///  Use `{instance} = '-'` to list AppProfiles for all Instances in a
-  ///  project, e.g., `projects/myproject/instances/-`.
-  /// @param options  Optional. Operation options.
-  /// @return
-  /// @googleapis_link{google::bigtable::admin::v2::AppProfile,google/bigtable/admin/v2/instance.proto#L236}
-  ///
-  /// [google.bigtable.admin.v2.ListAppProfilesRequest]:
-  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_instance_admin.proto#L560}
-  /// [google.bigtable.admin.v2.AppProfile]:
-  /// @googleapis_reference_link{google/bigtable/admin/v2/instance.proto#L236}
-  ///
-  StreamRange<google::bigtable::admin::v2::AppProfile> ListAppProfiles(
-      std::string const& parent, Options options = {});
-
-  ///
-  /// Updates an app profile within an instance.
-  ///
-  /// @param app_profile  Required. The app profile which will (partially)
-  /// replace the current value.
-  /// @param update_mask  Required. The subset of app profile fields which
-  /// should be replaced.
-  ///  If unset, all fields will be replaced.
-  /// @param options  Optional. Operation options.
-  /// @return
-  /// @googleapis_link{google::bigtable::admin::v2::AppProfile,google/bigtable/admin/v2/instance.proto#L236}
-  ///
-  /// [google.bigtable.admin.v2.UpdateAppProfileRequest]:
-  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_instance_admin.proto#L606}
-  /// [google.bigtable.admin.v2.AppProfile]:
-  /// @googleapis_reference_link{google/bigtable/admin/v2/instance.proto#L236}
-  ///
-  future<StatusOr<google::bigtable::admin::v2::AppProfile>> UpdateAppProfile(
-      google::bigtable::admin::v2::AppProfile const& app_profile,
-      google::protobuf::FieldMask const& update_mask, Options options = {});
-
-  ///
-  /// Deletes an app profile from an instance.
-  ///
-  /// @param name  Required. The unique name of the app profile to be deleted.
-  /// Values are of the form
-  ///  `projects/{project}/instances/{instance}/appProfiles/{app_profile}`.
-  /// @param options  Optional. Operation options.
-  ///
-  /// [google.bigtable.admin.v2.DeleteAppProfileRequest]:
-  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_instance_admin.proto#L619}
-  ///
-  Status DeleteAppProfile(std::string const& name, Options options = {});
-
-  ///
-  /// Gets the access control policy for an instance resource. Returns an empty
-  /// policy if an instance exists but does not have a policy set.
-  ///
-  /// @param resource  REQUIRED: The resource for which the policy is being
-  /// requested.
-  ///  See the operation documentation for the appropriate value for this field.
-  /// @param options  Optional. Operation options.
-  /// @return
-  /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
-  ///
-  /// [google.iam.v1.GetIamPolicyRequest]:
-  /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L113}
-  /// [google.iam.v1.Policy]:
-  /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
-  ///
-  StatusOr<google::iam::v1::Policy> GetIamPolicy(std::string const& resource,
-                                                 Options options = {});
-
-  ///
-  /// Sets the access control policy on an instance resource. Replaces any
-  /// existing policy.
-  ///
-  /// @param resource  REQUIRED: The resource for which the policy is being
-  /// specified.
-  ///  See the operation documentation for the appropriate value for this field.
-  /// @param policy  REQUIRED: The complete policy to be applied to the
-  /// `resource`. The size of
-  ///  the policy is limited to a few 10s of KB. An empty policy is a
-  ///  valid policy but certain Cloud Platform services (such as Projects)
-  ///  might reject them.
-  /// @param options  Optional. Operation options.
-  /// @return
-  /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
-  ///
-  /// [google.iam.v1.SetIamPolicyRequest]:
-  /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L98}
-  /// [google.iam.v1.Policy]:
-  /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
-  ///
-  StatusOr<google::iam::v1::Policy> SetIamPolicy(
-      std::string const& resource, google::iam::v1::Policy const& policy,
-      Options options = {});
-
-  /**
-   * Updates the IAM policy for @p resource using an optimistic concurrency
-   * control loop.
-   *
-   * The loop fetches the current policy for @p resource, and passes it to @p
-   * updater, which should return the new policy. This new policy should use the
-   * current etag so that the read-modify-write cycle can detect races and rerun
-   * the update when there is a mismatch. If the new policy does not have an
-   * etag, the existing policy will be blindly overwritten. If @p updater does
-   * not yield a policy, the control loop is terminated and kCancelled is
-   * returned.
-   *
-   * @param resource  Required. The resource for which the policy is being
-   * specified. See the operation documentation for the appropriate value for
-   * this field.
-   * @param updater  Required. Functor to map the current policy to a new one.
-   * @param options  Optional. Options to control the loop. Expected options
-   * are:
-   *       - `BigtableInstanceAdminBackoffPolicyOption`
-   * @return google::iam::v1::Policy
-   */
-  StatusOr<google::iam::v1::Policy> SetIamPolicy(std::string const& resource,
-                                                 IamUpdater const& updater,
-                                                 Options options = {});
-
-  ///
-  /// Returns permissions that the caller has on the specified instance
-  /// resource.
-  ///
-  /// @param resource  REQUIRED: The resource for which the policy detail is
-  /// being requested.
-  ///  See the operation documentation for the appropriate value for this field.
-  /// @param permissions  The set of permissions to check for the `resource`.
-  /// Permissions with
-  ///  wildcards (such as '*' or 'storage.*') are not allowed. For more
-  ///  information see
-  ///  [IAM Overview](https://cloud.google.com/iam/docs/overview#permissions).
-  /// @param options  Optional. Operation options.
-  /// @return
-  /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
-  ///
-  /// [google.iam.v1.TestIamPermissionsRequest]:
-  /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L126}
-  /// [google.iam.v1.TestIamPermissionsResponse]:
-  /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L141}
-  ///
-  StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
-      std::string const& resource, std::vector<std::string> const& permissions,
-      Options options = {});
-
-  ///
   /// Create an instance within a project.
   ///
   /// Note that exactly one of Cluster.serve_nodes and
@@ -539,6 +159,24 @@ class BigtableInstanceAdminClient {
   ///
   /// Gets information about an instance.
   ///
+  /// @param name  Required. The unique name of the requested instance. Values
+  /// are of the form
+  ///  `projects/{project}/instances/{instance}`.
+  /// @param options  Optional. Operation options.
+  /// @return
+  /// @googleapis_link{google::bigtable::admin::v2::Instance,google/bigtable/admin/v2/instance.proto#L41}
+  ///
+  /// [google.bigtable.admin.v2.GetInstanceRequest]:
+  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_instance_admin.proto#L308}
+  /// [google.bigtable.admin.v2.Instance]:
+  /// @googleapis_reference_link{google/bigtable/admin/v2/instance.proto#L41}
+  ///
+  StatusOr<google::bigtable::admin::v2::Instance> GetInstance(
+      std::string const& name, Options options = {});
+
+  ///
+  /// Gets information about an instance.
+  ///
   /// @param request
   /// @googleapis_link{google::bigtable::admin::v2::GetInstanceRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L308}
   /// @param options  Optional. Operation options.
@@ -553,6 +191,24 @@ class BigtableInstanceAdminClient {
   StatusOr<google::bigtable::admin::v2::Instance> GetInstance(
       google::bigtable::admin::v2::GetInstanceRequest const& request,
       Options options = {});
+
+  ///
+  /// Lists information about instances in a project.
+  ///
+  /// @param parent  Required. The unique name of the project for which a list
+  /// of instances is requested.
+  ///  Values are of the form `projects/{project}`.
+  /// @param options  Optional. Operation options.
+  /// @return
+  /// @googleapis_link{google::bigtable::admin::v2::ListInstancesResponse,google/bigtable/admin/v2/bigtable_instance_admin.proto#L335}
+  ///
+  /// [google.bigtable.admin.v2.ListInstancesRequest]:
+  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_instance_admin.proto#L320}
+  /// [google.bigtable.admin.v2.ListInstancesResponse]:
+  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_instance_admin.proto#L335}
+  ///
+  StatusOr<google::bigtable::admin::v2::ListInstancesResponse> ListInstances(
+      std::string const& parent, Options options = {});
 
   ///
   /// Lists information about instances in a project.
@@ -596,6 +252,28 @@ class BigtableInstanceAdminClient {
   /// Partially updates an instance within a project. This method can modify all
   /// fields of an Instance and is the preferred way to update an Instance.
   ///
+  /// @param instance  Required. The Instance which will (partially) replace the
+  /// current value.
+  /// @param update_mask  Required. The subset of Instance fields which should
+  /// be replaced.
+  ///  Must be explicitly set.
+  /// @param options  Optional. Operation options.
+  /// @return
+  /// @googleapis_link{google::bigtable::admin::v2::Instance,google/bigtable/admin/v2/instance.proto#L41}
+  ///
+  /// [google.bigtable.admin.v2.PartialUpdateInstanceRequest]:
+  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_instance_admin.proto#L352}
+  /// [google.bigtable.admin.v2.Instance]:
+  /// @googleapis_reference_link{google/bigtable/admin/v2/instance.proto#L41}
+  ///
+  future<StatusOr<google::bigtable::admin::v2::Instance>> PartialUpdateInstance(
+      google::bigtable::admin::v2::Instance const& instance,
+      google::protobuf::FieldMask const& update_mask, Options options = {});
+
+  ///
+  /// Partially updates an instance within a project. This method can modify all
+  /// fields of an Instance and is the preferred way to update an Instance.
+  ///
   /// @param request
   /// @googleapis_link{google::bigtable::admin::v2::PartialUpdateInstanceRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L352}
   /// @param options  Optional. Operation options.
@@ -614,6 +292,18 @@ class BigtableInstanceAdminClient {
   ///
   /// Delete an instance from a project.
   ///
+  /// @param name  Required. The unique name of the instance to be deleted.
+  ///  Values are of the form `projects/{project}/instances/{instance}`.
+  /// @param options  Optional. Operation options.
+  ///
+  /// [google.bigtable.admin.v2.DeleteInstanceRequest]:
+  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_instance_admin.proto#L362}
+  ///
+  Status DeleteInstance(std::string const& name, Options options = {});
+
+  ///
+  /// Delete an instance from a project.
+  ///
   /// @param request
   /// @googleapis_link{google::bigtable::admin::v2::DeleteInstanceRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L362}
   /// @param options  Optional. Operation options.
@@ -623,6 +313,39 @@ class BigtableInstanceAdminClient {
   ///
   Status DeleteInstance(
       google::bigtable::admin::v2::DeleteInstanceRequest const& request,
+      Options options = {});
+
+  ///
+  /// Creates a cluster within an instance.
+  ///
+  /// Note that exactly one of Cluster.serve_nodes and
+  /// Cluster.cluster_config.cluster_autoscaling_config can be set. If
+  /// serve_nodes is set to non-zero, then the cluster is manually scaled. If
+  /// cluster_config.cluster_autoscaling_config is non-empty, then autoscaling
+  /// is enabled.
+  ///
+  /// @param parent  Required. The unique name of the instance in which to
+  /// create the new cluster.
+  ///  Values are of the form
+  ///  `projects/{project}/instances/{instance}`.
+  /// @param cluster_id  Required. The ID to be used when referring to the new
+  /// cluster within its instance,
+  ///  e.g., just `mycluster` rather than
+  ///  `projects/myproject/instances/myinstance/clusters/mycluster`.
+  /// @param cluster  Required. The cluster to be created.
+  ///  Fields marked `OutputOnly` must be left blank.
+  /// @param options  Optional. Operation options.
+  /// @return
+  /// @googleapis_link{google::bigtable::admin::v2::Cluster,google/bigtable/admin/v2/instance.proto#L137}
+  ///
+  /// [google.bigtable.admin.v2.CreateClusterRequest]:
+  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_instance_admin.proto#L374}
+  /// [google.bigtable.admin.v2.Cluster]:
+  /// @googleapis_reference_link{google/bigtable/admin/v2/instance.proto#L137}
+  ///
+  future<StatusOr<google::bigtable::admin::v2::Cluster>> CreateCluster(
+      std::string const& parent, std::string const& cluster_id,
+      google::bigtable::admin::v2::Cluster const& cluster,
       Options options = {});
 
   ///
@@ -652,6 +375,24 @@ class BigtableInstanceAdminClient {
   ///
   /// Gets information about a cluster.
   ///
+  /// @param name  Required. The unique name of the requested cluster. Values
+  /// are of the form
+  ///  `projects/{project}/instances/{instance}/clusters/{cluster}`.
+  /// @param options  Optional. Operation options.
+  /// @return
+  /// @googleapis_link{google::bigtable::admin::v2::Cluster,google/bigtable/admin/v2/instance.proto#L137}
+  ///
+  /// [google.bigtable.admin.v2.GetClusterRequest]:
+  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_instance_admin.proto#L396}
+  /// [google.bigtable.admin.v2.Cluster]:
+  /// @googleapis_reference_link{google/bigtable/admin/v2/instance.proto#L137}
+  ///
+  StatusOr<google::bigtable::admin::v2::Cluster> GetCluster(
+      std::string const& name, Options options = {});
+
+  ///
+  /// Gets information about a cluster.
+  ///
   /// @param request
   /// @googleapis_link{google::bigtable::admin::v2::GetClusterRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L396}
   /// @param options  Optional. Operation options.
@@ -666,6 +407,26 @@ class BigtableInstanceAdminClient {
   StatusOr<google::bigtable::admin::v2::Cluster> GetCluster(
       google::bigtable::admin::v2::GetClusterRequest const& request,
       Options options = {});
+
+  ///
+  /// Lists information about clusters in an instance.
+  ///
+  /// @param parent  Required. The unique name of the instance for which a list
+  /// of clusters is requested.
+  ///  Values are of the form `projects/{project}/instances/{instance}`.
+  ///  Use `{instance} = '-'` to list Clusters for all Instances in a project,
+  ///  e.g., `projects/myproject/instances/-`.
+  /// @param options  Optional. Operation options.
+  /// @return
+  /// @googleapis_link{google::bigtable::admin::v2::ListClustersResponse,google/bigtable/admin/v2/bigtable_instance_admin.proto#L425}
+  ///
+  /// [google.bigtable.admin.v2.ListClustersRequest]:
+  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_instance_admin.proto#L408}
+  /// [google.bigtable.admin.v2.ListClustersResponse]:
+  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_instance_admin.proto#L425}
+  ///
+  StatusOr<google::bigtable::admin::v2::ListClustersResponse> ListClusters(
+      std::string const& parent, Options options = {});
 
   ///
   /// Lists information about clusters in an instance.
@@ -721,6 +482,38 @@ class BigtableInstanceAdminClient {
   /// To disable autoscaling, clear cluster_config.cluster_autoscaling_config,
   /// and explicitly set a serve_node count via the update_mask.
   ///
+  /// @param cluster  Required. The Cluster which contains the partial updates
+  /// to be applied, subject to
+  ///  the update_mask.
+  /// @param update_mask  Required. The subset of Cluster fields which should be
+  /// replaced.
+  /// @param options  Optional. Operation options.
+  /// @return
+  /// @googleapis_link{google::bigtable::admin::v2::Cluster,google/bigtable/admin/v2/instance.proto#L137}
+  ///
+  /// [google.bigtable.admin.v2.PartialUpdateClusterRequest]:
+  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_instance_admin.proto#L513}
+  /// [google.bigtable.admin.v2.Cluster]:
+  /// @googleapis_reference_link{google/bigtable/admin/v2/instance.proto#L137}
+  ///
+  future<StatusOr<google::bigtable::admin::v2::Cluster>> PartialUpdateCluster(
+      google::bigtable::admin::v2::Cluster const& cluster,
+      google::protobuf::FieldMask const& update_mask, Options options = {});
+
+  ///
+  /// Partially updates a cluster within a project. This method is the preferred
+  /// way to update a Cluster.
+  ///
+  /// To enable and update autoscaling, set
+  /// cluster_config.cluster_autoscaling_config. When autoscaling is enabled,
+  /// serve_nodes is treated as an OUTPUT_ONLY field, meaning that updates to it
+  /// are ignored. Note that an update cannot simultaneously set serve_nodes to
+  /// non-zero and cluster_config.cluster_autoscaling_config to non-empty, and
+  /// also specify both in the update_mask.
+  ///
+  /// To disable autoscaling, clear cluster_config.cluster_autoscaling_config,
+  /// and explicitly set a serve_node count via the update_mask.
+  ///
   /// @param request
   /// @googleapis_link{google::bigtable::admin::v2::PartialUpdateClusterRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L513}
   /// @param options  Optional. Operation options.
@@ -739,6 +532,19 @@ class BigtableInstanceAdminClient {
   ///
   /// Deletes a cluster from an instance.
   ///
+  /// @param name  Required. The unique name of the cluster to be deleted.
+  /// Values are of the form
+  ///  `projects/{project}/instances/{instance}/clusters/{cluster}`.
+  /// @param options  Optional. Operation options.
+  ///
+  /// [google.bigtable.admin.v2.DeleteClusterRequest]:
+  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_instance_admin.proto#L441}
+  ///
+  Status DeleteCluster(std::string const& name, Options options = {});
+
+  ///
+  /// Deletes a cluster from an instance.
+  ///
   /// @param request
   /// @googleapis_link{google::bigtable::admin::v2::DeleteClusterRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L441}
   /// @param options  Optional. Operation options.
@@ -748,6 +554,33 @@ class BigtableInstanceAdminClient {
   ///
   Status DeleteCluster(
       google::bigtable::admin::v2::DeleteClusterRequest const& request,
+      Options options = {});
+
+  ///
+  /// Creates an app profile within an instance.
+  ///
+  /// @param parent  Required. The unique name of the instance in which to
+  /// create the new app profile.
+  ///  Values are of the form
+  ///  `projects/{project}/instances/{instance}`.
+  /// @param app_profile_id  Required. The ID to be used when referring to the
+  /// new app profile within its
+  ///  instance, e.g., just `myprofile` rather than
+  ///  `projects/myproject/instances/myinstance/appProfiles/myprofile`.
+  /// @param app_profile  Required. The app profile to be created.
+  ///  Fields marked `OutputOnly` will be ignored.
+  /// @param options  Optional. Operation options.
+  /// @return
+  /// @googleapis_link{google::bigtable::admin::v2::AppProfile,google/bigtable/admin/v2/instance.proto#L236}
+  ///
+  /// [google.bigtable.admin.v2.CreateAppProfileRequest]:
+  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_instance_admin.proto#L523}
+  /// [google.bigtable.admin.v2.AppProfile]:
+  /// @googleapis_reference_link{google/bigtable/admin/v2/instance.proto#L236}
+  ///
+  StatusOr<google::bigtable::admin::v2::AppProfile> CreateAppProfile(
+      std::string const& parent, std::string const& app_profile_id,
+      google::bigtable::admin::v2::AppProfile const& app_profile,
       Options options = {});
 
   ///
@@ -771,6 +604,24 @@ class BigtableInstanceAdminClient {
   ///
   /// Gets information about an app profile.
   ///
+  /// @param name  Required. The unique name of the requested app profile.
+  /// Values are of the form
+  ///  `projects/{project}/instances/{instance}/appProfiles/{app_profile}`.
+  /// @param options  Optional. Operation options.
+  /// @return
+  /// @googleapis_link{google::bigtable::admin::v2::AppProfile,google/bigtable/admin/v2/instance.proto#L236}
+  ///
+  /// [google.bigtable.admin.v2.GetAppProfileRequest]:
+  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_instance_admin.proto#L548}
+  /// [google.bigtable.admin.v2.AppProfile]:
+  /// @googleapis_reference_link{google/bigtable/admin/v2/instance.proto#L236}
+  ///
+  StatusOr<google::bigtable::admin::v2::AppProfile> GetAppProfile(
+      std::string const& name, Options options = {});
+
+  ///
+  /// Gets information about an app profile.
+  ///
   /// @param request
   /// @googleapis_link{google::bigtable::admin::v2::GetAppProfileRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L548}
   /// @param options  Optional. Operation options.
@@ -785,6 +636,27 @@ class BigtableInstanceAdminClient {
   StatusOr<google::bigtable::admin::v2::AppProfile> GetAppProfile(
       google::bigtable::admin::v2::GetAppProfileRequest const& request,
       Options options = {});
+
+  ///
+  /// Lists information about app profiles in an instance.
+  ///
+  /// @param parent  Required. The unique name of the instance for which a list
+  /// of app profiles is
+  ///  requested. Values are of the form
+  ///  `projects/{project}/instances/{instance}`.
+  ///  Use `{instance} = '-'` to list AppProfiles for all Instances in a
+  ///  project, e.g., `projects/myproject/instances/-`.
+  /// @param options  Optional. Operation options.
+  /// @return
+  /// @googleapis_link{google::bigtable::admin::v2::AppProfile,google/bigtable/admin/v2/instance.proto#L236}
+  ///
+  /// [google.bigtable.admin.v2.ListAppProfilesRequest]:
+  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_instance_admin.proto#L560}
+  /// [google.bigtable.admin.v2.AppProfile]:
+  /// @googleapis_reference_link{google/bigtable/admin/v2/instance.proto#L236}
+  ///
+  StreamRange<google::bigtable::admin::v2::AppProfile> ListAppProfiles(
+      std::string const& parent, Options options = {});
 
   ///
   /// Lists information about app profiles in an instance.
@@ -807,6 +679,27 @@ class BigtableInstanceAdminClient {
   ///
   /// Updates an app profile within an instance.
   ///
+  /// @param app_profile  Required. The app profile which will (partially)
+  /// replace the current value.
+  /// @param update_mask  Required. The subset of app profile fields which
+  /// should be replaced.
+  ///  If unset, all fields will be replaced.
+  /// @param options  Optional. Operation options.
+  /// @return
+  /// @googleapis_link{google::bigtable::admin::v2::AppProfile,google/bigtable/admin/v2/instance.proto#L236}
+  ///
+  /// [google.bigtable.admin.v2.UpdateAppProfileRequest]:
+  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_instance_admin.proto#L606}
+  /// [google.bigtable.admin.v2.AppProfile]:
+  /// @googleapis_reference_link{google/bigtable/admin/v2/instance.proto#L236}
+  ///
+  future<StatusOr<google::bigtable::admin::v2::AppProfile>> UpdateAppProfile(
+      google::bigtable::admin::v2::AppProfile const& app_profile,
+      google::protobuf::FieldMask const& update_mask, Options options = {});
+
+  ///
+  /// Updates an app profile within an instance.
+  ///
   /// @param request
   /// @googleapis_link{google::bigtable::admin::v2::UpdateAppProfileRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L606}
   /// @param options  Optional. Operation options.
@@ -825,6 +718,19 @@ class BigtableInstanceAdminClient {
   ///
   /// Deletes an app profile from an instance.
   ///
+  /// @param name  Required. The unique name of the app profile to be deleted.
+  /// Values are of the form
+  ///  `projects/{project}/instances/{instance}/appProfiles/{app_profile}`.
+  /// @param options  Optional. Operation options.
+  ///
+  /// [google.bigtable.admin.v2.DeleteAppProfileRequest]:
+  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_instance_admin.proto#L619}
+  ///
+  Status DeleteAppProfile(std::string const& name, Options options = {});
+
+  ///
+  /// Deletes an app profile from an instance.
+  ///
   /// @param request
   /// @googleapis_link{google::bigtable::admin::v2::DeleteAppProfileRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L619}
   /// @param options  Optional. Operation options.
@@ -835,6 +741,25 @@ class BigtableInstanceAdminClient {
   Status DeleteAppProfile(
       google::bigtable::admin::v2::DeleteAppProfileRequest const& request,
       Options options = {});
+
+  ///
+  /// Gets the access control policy for an instance resource. Returns an empty
+  /// policy if an instance exists but does not have a policy set.
+  ///
+  /// @param resource  REQUIRED: The resource for which the policy is being
+  /// requested.
+  ///  See the operation documentation for the appropriate value for this field.
+  /// @param options  Optional. Operation options.
+  /// @return
+  /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
+  ///
+  /// [google.iam.v1.GetIamPolicyRequest]:
+  /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L113}
+  /// [google.iam.v1.Policy]:
+  /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
+  ///
+  StatusOr<google::iam::v1::Policy> GetIamPolicy(std::string const& resource,
+                                                 Options options = {});
 
   ///
   /// Gets the access control policy for an instance resource. Returns an empty
@@ -859,6 +784,56 @@ class BigtableInstanceAdminClient {
   /// Sets the access control policy on an instance resource. Replaces any
   /// existing policy.
   ///
+  /// @param resource  REQUIRED: The resource for which the policy is being
+  /// specified.
+  ///  See the operation documentation for the appropriate value for this field.
+  /// @param policy  REQUIRED: The complete policy to be applied to the
+  /// `resource`. The size of
+  ///  the policy is limited to a few 10s of KB. An empty policy is a
+  ///  valid policy but certain Cloud Platform services (such as Projects)
+  ///  might reject them.
+  /// @param options  Optional. Operation options.
+  /// @return
+  /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
+  ///
+  /// [google.iam.v1.SetIamPolicyRequest]:
+  /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L98}
+  /// [google.iam.v1.Policy]:
+  /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
+  ///
+  StatusOr<google::iam::v1::Policy> SetIamPolicy(
+      std::string const& resource, google::iam::v1::Policy const& policy,
+      Options options = {});
+
+  /**
+   * Updates the IAM policy for @p resource using an optimistic concurrency
+   * control loop.
+   *
+   * The loop fetches the current policy for @p resource, and passes it to @p
+   * updater, which should return the new policy. This new policy should use the
+   * current etag so that the read-modify-write cycle can detect races and rerun
+   * the update when there is a mismatch. If the new policy does not have an
+   * etag, the existing policy will be blindly overwritten. If @p updater does
+   * not yield a policy, the control loop is terminated and kCancelled is
+   * returned.
+   *
+   * @param resource  Required. The resource for which the policy is being
+   * specified. See the operation documentation for the appropriate value for
+   * this field.
+   * @param updater  Required. Functor to map the current policy to a new one.
+   * @param options  Optional. Options to control the loop. Expected options
+   * are:
+   *       - `BigtableInstanceAdminBackoffPolicyOption`
+   * @return google::iam::v1::Policy
+   */
+  StatusOr<google::iam::v1::Policy> SetIamPolicy(std::string const& resource,
+                                                 IamUpdater const& updater,
+                                                 Options options = {});
+
+  ///
+  /// Sets the access control policy on an instance resource. Replaces any
+  /// existing policy.
+  ///
   /// @param request
   /// @googleapis_link{google::iam::v1::SetIamPolicyRequest,google/iam/v1/iam_policy.proto#L98}
   /// @param options  Optional. Operation options.
@@ -872,6 +847,31 @@ class BigtableInstanceAdminClient {
   ///
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
       google::iam::v1::SetIamPolicyRequest const& request,
+      Options options = {});
+
+  ///
+  /// Returns permissions that the caller has on the specified instance
+  /// resource.
+  ///
+  /// @param resource  REQUIRED: The resource for which the policy detail is
+  /// being requested.
+  ///  See the operation documentation for the appropriate value for this field.
+  /// @param permissions  The set of permissions to check for the `resource`.
+  /// Permissions with
+  ///  wildcards (such as '*' or 'storage.*') are not allowed. For more
+  ///  information see
+  ///  [IAM Overview](https://cloud.google.com/iam/docs/overview#permissions).
+  /// @param options  Optional. Operation options.
+  /// @return
+  /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
+  ///
+  /// [google.iam.v1.TestIamPermissionsRequest]:
+  /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L126}
+  /// [google.iam.v1.TestIamPermissionsResponse]:
+  /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L141}
+  ///
+  StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
+      std::string const& resource, std::vector<std::string> const& permissions,
       Options options = {});
 
   ///

--- a/google/cloud/bigtable/admin/bigtable_table_admin_client.cc
+++ b/google/cloud/bigtable/admin/bigtable_table_admin_client.cc
@@ -47,6 +47,15 @@ BigtableTableAdminClient::CreateTable(
   return connection_->CreateTable(request);
 }
 
+StatusOr<google::bigtable::admin::v2::Table>
+BigtableTableAdminClient::CreateTable(
+    google::bigtable::admin::v2::CreateTableRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
+  return connection_->CreateTable(request);
+}
+
 StreamRange<google::bigtable::admin::v2::Table>
 BigtableTableAdminClient::ListTables(std::string const& parent,
                                      Options options) {
@@ -55,6 +64,14 @@ BigtableTableAdminClient::ListTables(std::string const& parent,
   google::bigtable::admin::v2::ListTablesRequest request;
   request.set_parent(parent);
   return connection_->ListTables(request);
+}
+
+StreamRange<google::bigtable::admin::v2::Table>
+BigtableTableAdminClient::ListTables(
+    google::bigtable::admin::v2::ListTablesRequest request, Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
+  return connection_->ListTables(std::move(request));
 }
 
 StatusOr<google::bigtable::admin::v2::Table> BigtableTableAdminClient::GetTable(
@@ -66,12 +83,28 @@ StatusOr<google::bigtable::admin::v2::Table> BigtableTableAdminClient::GetTable(
   return connection_->GetTable(request);
 }
 
+StatusOr<google::bigtable::admin::v2::Table> BigtableTableAdminClient::GetTable(
+    google::bigtable::admin::v2::GetTableRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
+  return connection_->GetTable(request);
+}
+
 Status BigtableTableAdminClient::DeleteTable(std::string const& name,
                                              Options options) {
   internal::OptionsSpan span(
       internal::MergeOptions(std::move(options), options_));
   google::bigtable::admin::v2::DeleteTableRequest request;
   request.set_name(name);
+  return connection_->DeleteTable(request);
+}
+
+Status BigtableTableAdminClient::DeleteTable(
+    google::bigtable::admin::v2::DeleteTableRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->DeleteTable(request);
 }
 
@@ -90,6 +123,23 @@ BigtableTableAdminClient::ModifyColumnFamilies(
   return connection_->ModifyColumnFamilies(request);
 }
 
+StatusOr<google::bigtable::admin::v2::Table>
+BigtableTableAdminClient::ModifyColumnFamilies(
+    google::bigtable::admin::v2::ModifyColumnFamiliesRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
+  return connection_->ModifyColumnFamilies(request);
+}
+
+Status BigtableTableAdminClient::DropRowRange(
+    google::bigtable::admin::v2::DropRowRangeRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
+  return connection_->DropRowRange(request);
+}
+
 StatusOr<google::bigtable::admin::v2::GenerateConsistencyTokenResponse>
 BigtableTableAdminClient::GenerateConsistencyToken(std::string const& name,
                                                    Options options) {
@@ -97,6 +147,15 @@ BigtableTableAdminClient::GenerateConsistencyToken(std::string const& name,
       internal::MergeOptions(std::move(options), options_));
   google::bigtable::admin::v2::GenerateConsistencyTokenRequest request;
   request.set_name(name);
+  return connection_->GenerateConsistencyToken(request);
+}
+
+StatusOr<google::bigtable::admin::v2::GenerateConsistencyTokenResponse>
+BigtableTableAdminClient::GenerateConsistencyToken(
+    google::bigtable::admin::v2::GenerateConsistencyTokenRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->GenerateConsistencyToken(request);
 }
 
@@ -109,6 +168,15 @@ BigtableTableAdminClient::CheckConsistency(std::string const& name,
   google::bigtable::admin::v2::CheckConsistencyRequest request;
   request.set_name(name);
   request.set_consistency_token(consistency_token);
+  return connection_->CheckConsistency(request);
+}
+
+StatusOr<google::bigtable::admin::v2::CheckConsistencyResponse>
+BigtableTableAdminClient::CheckConsistency(
+    google::bigtable::admin::v2::CheckConsistencyRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->CheckConsistency(request);
 }
 
@@ -125,12 +193,30 @@ BigtableTableAdminClient::CreateBackup(
   return connection_->CreateBackup(request);
 }
 
+future<StatusOr<google::bigtable::admin::v2::Backup>>
+BigtableTableAdminClient::CreateBackup(
+    google::bigtable::admin::v2::CreateBackupRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
+  return connection_->CreateBackup(request);
+}
+
 StatusOr<google::bigtable::admin::v2::Backup>
 BigtableTableAdminClient::GetBackup(std::string const& name, Options options) {
   internal::OptionsSpan span(
       internal::MergeOptions(std::move(options), options_));
   google::bigtable::admin::v2::GetBackupRequest request;
   request.set_name(name);
+  return connection_->GetBackup(request);
+}
+
+StatusOr<google::bigtable::admin::v2::Backup>
+BigtableTableAdminClient::GetBackup(
+    google::bigtable::admin::v2::GetBackupRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->GetBackup(request);
 }
 
@@ -146,12 +232,29 @@ BigtableTableAdminClient::UpdateBackup(
   return connection_->UpdateBackup(request);
 }
 
+StatusOr<google::bigtable::admin::v2::Backup>
+BigtableTableAdminClient::UpdateBackup(
+    google::bigtable::admin::v2::UpdateBackupRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
+  return connection_->UpdateBackup(request);
+}
+
 Status BigtableTableAdminClient::DeleteBackup(std::string const& name,
                                               Options options) {
   internal::OptionsSpan span(
       internal::MergeOptions(std::move(options), options_));
   google::bigtable::admin::v2::DeleteBackupRequest request;
   request.set_name(name);
+  return connection_->DeleteBackup(request);
+}
+
+Status BigtableTableAdminClient::DeleteBackup(
+    google::bigtable::admin::v2::DeleteBackupRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->DeleteBackup(request);
 }
 
@@ -165,12 +268,36 @@ BigtableTableAdminClient::ListBackups(std::string const& parent,
   return connection_->ListBackups(request);
 }
 
+StreamRange<google::bigtable::admin::v2::Backup>
+BigtableTableAdminClient::ListBackups(
+    google::bigtable::admin::v2::ListBackupsRequest request, Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
+  return connection_->ListBackups(std::move(request));
+}
+
+future<StatusOr<google::bigtable::admin::v2::Table>>
+BigtableTableAdminClient::RestoreTable(
+    google::bigtable::admin::v2::RestoreTableRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
+  return connection_->RestoreTable(request);
+}
+
 StatusOr<google::iam::v1::Policy> BigtableTableAdminClient::GetIamPolicy(
     std::string const& resource, Options options) {
   internal::OptionsSpan span(
       internal::MergeOptions(std::move(options), options_));
   google::iam::v1::GetIamPolicyRequest request;
   request.set_resource(resource);
+  return connection_->GetIamPolicy(request);
+}
+
+StatusOr<google::iam::v1::Policy> BigtableTableAdminClient::GetIamPolicy(
+    google::iam::v1::GetIamPolicyRequest const& request, Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->GetIamPolicy(request);
 }
 
@@ -211,6 +338,13 @@ StatusOr<google::iam::v1::Policy> BigtableTableAdminClient::SetIamPolicy(
   }
 }
 
+StatusOr<google::iam::v1::Policy> BigtableTableAdminClient::SetIamPolicy(
+    google::iam::v1::SetIamPolicyRequest const& request, Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
+  return connection_->SetIamPolicy(request);
+}
+
 StatusOr<google::iam::v1::TestIamPermissionsResponse>
 BigtableTableAdminClient::TestIamPermissions(
     std::string const& resource, std::vector<std::string> const& permissions,
@@ -220,6 +354,15 @@ BigtableTableAdminClient::TestIamPermissions(
   google::iam::v1::TestIamPermissionsRequest request;
   request.set_resource(resource);
   *request.mutable_permissions() = {permissions.begin(), permissions.end()};
+  return connection_->TestIamPermissions(request);
+}
+
+StatusOr<google::iam::v1::TestIamPermissionsResponse>
+BigtableTableAdminClient::TestIamPermissions(
+    google::iam::v1::TestIamPermissionsRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->TestIamPermissions(request);
 }
 
@@ -233,149 +376,6 @@ BigtableTableAdminClient::AsyncCheckConsistency(
   request.set_name(name);
   request.set_consistency_token(consistency_token);
   return connection_->AsyncCheckConsistency(request);
-}
-
-StatusOr<google::bigtable::admin::v2::Table>
-BigtableTableAdminClient::CreateTable(
-    google::bigtable::admin::v2::CreateTableRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->CreateTable(request);
-}
-
-StreamRange<google::bigtable::admin::v2::Table>
-BigtableTableAdminClient::ListTables(
-    google::bigtable::admin::v2::ListTablesRequest request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->ListTables(std::move(request));
-}
-
-StatusOr<google::bigtable::admin::v2::Table> BigtableTableAdminClient::GetTable(
-    google::bigtable::admin::v2::GetTableRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->GetTable(request);
-}
-
-Status BigtableTableAdminClient::DeleteTable(
-    google::bigtable::admin::v2::DeleteTableRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->DeleteTable(request);
-}
-
-StatusOr<google::bigtable::admin::v2::Table>
-BigtableTableAdminClient::ModifyColumnFamilies(
-    google::bigtable::admin::v2::ModifyColumnFamiliesRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->ModifyColumnFamilies(request);
-}
-
-Status BigtableTableAdminClient::DropRowRange(
-    google::bigtable::admin::v2::DropRowRangeRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->DropRowRange(request);
-}
-
-StatusOr<google::bigtable::admin::v2::GenerateConsistencyTokenResponse>
-BigtableTableAdminClient::GenerateConsistencyToken(
-    google::bigtable::admin::v2::GenerateConsistencyTokenRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->GenerateConsistencyToken(request);
-}
-
-StatusOr<google::bigtable::admin::v2::CheckConsistencyResponse>
-BigtableTableAdminClient::CheckConsistency(
-    google::bigtable::admin::v2::CheckConsistencyRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->CheckConsistency(request);
-}
-
-future<StatusOr<google::bigtable::admin::v2::Backup>>
-BigtableTableAdminClient::CreateBackup(
-    google::bigtable::admin::v2::CreateBackupRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->CreateBackup(request);
-}
-
-StatusOr<google::bigtable::admin::v2::Backup>
-BigtableTableAdminClient::GetBackup(
-    google::bigtable::admin::v2::GetBackupRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->GetBackup(request);
-}
-
-StatusOr<google::bigtable::admin::v2::Backup>
-BigtableTableAdminClient::UpdateBackup(
-    google::bigtable::admin::v2::UpdateBackupRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->UpdateBackup(request);
-}
-
-Status BigtableTableAdminClient::DeleteBackup(
-    google::bigtable::admin::v2::DeleteBackupRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->DeleteBackup(request);
-}
-
-StreamRange<google::bigtable::admin::v2::Backup>
-BigtableTableAdminClient::ListBackups(
-    google::bigtable::admin::v2::ListBackupsRequest request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->ListBackups(std::move(request));
-}
-
-future<StatusOr<google::bigtable::admin::v2::Table>>
-BigtableTableAdminClient::RestoreTable(
-    google::bigtable::admin::v2::RestoreTableRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->RestoreTable(request);
-}
-
-StatusOr<google::iam::v1::Policy> BigtableTableAdminClient::GetIamPolicy(
-    google::iam::v1::GetIamPolicyRequest const& request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->GetIamPolicy(request);
-}
-
-StatusOr<google::iam::v1::Policy> BigtableTableAdminClient::SetIamPolicy(
-    google::iam::v1::SetIamPolicyRequest const& request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->SetIamPolicy(request);
-}
-
-StatusOr<google::iam::v1::TestIamPermissionsResponse>
-BigtableTableAdminClient::TestIamPermissions(
-    google::iam::v1::TestIamPermissionsRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->TestIamPermissions(request);
 }
 
 future<StatusOr<google::bigtable::admin::v2::CheckConsistencyResponse>>

--- a/google/cloud/bigtable/admin/bigtable_table_admin_client.h
+++ b/google/cloud/bigtable/admin/bigtable_table_admin_client.h
@@ -120,6 +120,26 @@ class BigtableTableAdminClient {
       google::bigtable::admin::v2::Table const& table, Options options = {});
 
   ///
+  /// Creates a new table in the specified instance.
+  /// The table can be created with a full set of initial column families,
+  /// specified in the request.
+  ///
+  /// @param request
+  /// @googleapis_link{google::bigtable::admin::v2::CreateTableRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L408}
+  /// @param options  Optional. Operation options.
+  /// @return
+  /// @googleapis_link{google::bigtable::admin::v2::Table,google/bigtable/admin/v2/table.proto#L61}
+  ///
+  /// [google.bigtable.admin.v2.CreateTableRequest]:
+  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_table_admin.proto#L408}
+  /// [google.bigtable.admin.v2.Table]:
+  /// @googleapis_reference_link{google/bigtable/admin/v2/table.proto#L61}
+  ///
+  StatusOr<google::bigtable::admin::v2::Table> CreateTable(
+      google::bigtable::admin::v2::CreateTableRequest const& request,
+      Options options = {});
+
+  ///
   /// Lists all tables served from a specified instance.
   ///
   /// @param parent  Required. The unique name of the instance for which tables
@@ -136,6 +156,24 @@ class BigtableTableAdminClient {
   ///
   StreamRange<google::bigtable::admin::v2::Table> ListTables(
       std::string const& parent, Options options = {});
+
+  ///
+  /// Lists all tables served from a specified instance.
+  ///
+  /// @param request
+  /// @googleapis_link{google::bigtable::admin::v2::ListTablesRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L510}
+  /// @param options  Optional. Operation options.
+  /// @return
+  /// @googleapis_link{google::bigtable::admin::v2::Table,google/bigtable/admin/v2/table.proto#L61}
+  ///
+  /// [google.bigtable.admin.v2.ListTablesRequest]:
+  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_table_admin.proto#L510}
+  /// [google.bigtable.admin.v2.Table]:
+  /// @googleapis_reference_link{google/bigtable/admin/v2/table.proto#L61}
+  ///
+  StreamRange<google::bigtable::admin::v2::Table> ListTables(
+      google::bigtable::admin::v2::ListTablesRequest request,
+      Options options = {});
 
   ///
   /// Gets metadata information about the specified table.
@@ -156,6 +194,24 @@ class BigtableTableAdminClient {
                                                         Options options = {});
 
   ///
+  /// Gets metadata information about the specified table.
+  ///
+  /// @param request
+  /// @googleapis_link{google::bigtable::admin::v2::GetTableRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L553}
+  /// @param options  Optional. Operation options.
+  /// @return
+  /// @googleapis_link{google::bigtable::admin::v2::Table,google/bigtable/admin/v2/table.proto#L61}
+  ///
+  /// [google.bigtable.admin.v2.GetTableRequest]:
+  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_table_admin.proto#L553}
+  /// [google.bigtable.admin.v2.Table]:
+  /// @googleapis_reference_link{google/bigtable/admin/v2/table.proto#L61}
+  ///
+  StatusOr<google::bigtable::admin::v2::Table> GetTable(
+      google::bigtable::admin::v2::GetTableRequest const& request,
+      Options options = {});
+
+  ///
   /// Permanently deletes a specified table and all of its data.
   ///
   /// @param name  Required. The unique name of the table to be deleted.
@@ -167,6 +223,20 @@ class BigtableTableAdminClient {
   /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_table_admin.proto#L571}
   ///
   Status DeleteTable(std::string const& name, Options options = {});
+
+  ///
+  /// Permanently deletes a specified table and all of its data.
+  ///
+  /// @param request
+  /// @googleapis_link{google::bigtable::admin::v2::DeleteTableRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L571}
+  /// @param options  Optional. Operation options.
+  ///
+  /// [google.bigtable.admin.v2.DeleteTableRequest]:
+  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_table_admin.proto#L571}
+  ///
+  Status DeleteTable(
+      google::bigtable::admin::v2::DeleteTableRequest const& request,
+      Options options = {});
 
   ///
   /// Performs a series of column family modifications on the specified table.
@@ -199,6 +269,43 @@ class BigtableTableAdminClient {
       Options options = {});
 
   ///
+  /// Performs a series of column family modifications on the specified table.
+  /// Either all or none of the modifications will occur before this method
+  /// returns, but data requests received prior to that point may see a table
+  /// where only some modifications have taken effect.
+  ///
+  /// @param request
+  /// @googleapis_link{google::bigtable::admin::v2::ModifyColumnFamiliesRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L585}
+  /// @param options  Optional. Operation options.
+  /// @return
+  /// @googleapis_link{google::bigtable::admin::v2::Table,google/bigtable/admin/v2/table.proto#L61}
+  ///
+  /// [google.bigtable.admin.v2.ModifyColumnFamiliesRequest]:
+  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_table_admin.proto#L585}
+  /// [google.bigtable.admin.v2.Table]:
+  /// @googleapis_reference_link{google/bigtable/admin/v2/table.proto#L61}
+  ///
+  StatusOr<google::bigtable::admin::v2::Table> ModifyColumnFamilies(
+      google::bigtable::admin::v2::ModifyColumnFamiliesRequest const& request,
+      Options options = {});
+
+  ///
+  /// Permanently drop/delete a row range from a specified table. The request
+  /// can specify whether to delete all rows in a table, or only those that
+  /// match a particular prefix.
+  ///
+  /// @param request
+  /// @googleapis_link{google::bigtable::admin::v2::DropRowRangeRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L486}
+  /// @param options  Optional. Operation options.
+  ///
+  /// [google.bigtable.admin.v2.DropRowRangeRequest]:
+  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_table_admin.proto#L486}
+  ///
+  Status DropRowRange(
+      google::bigtable::admin::v2::DropRowRangeRequest const& request,
+      Options options = {});
+
+  ///
   /// Generates a consistency token for a Table, which can be used in
   /// CheckConsistency to check whether mutations to the table that finished
   /// before this call started have been replicated. The tokens will be
@@ -219,6 +326,29 @@ class BigtableTableAdminClient {
   ///
   StatusOr<google::bigtable::admin::v2::GenerateConsistencyTokenResponse>
   GenerateConsistencyToken(std::string const& name, Options options = {});
+
+  ///
+  /// Generates a consistency token for a Table, which can be used in
+  /// CheckConsistency to check whether mutations to the table that finished
+  /// before this call started have been replicated. The tokens will be
+  /// available for 90 days.
+  ///
+  /// @param request
+  /// @googleapis_link{google::bigtable::admin::v2::GenerateConsistencyTokenRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L626}
+  /// @param options  Optional. Operation options.
+  /// @return
+  /// @googleapis_link{google::bigtable::admin::v2::GenerateConsistencyTokenResponse,google/bigtable/admin/v2/bigtable_table_admin.proto#L640}
+  ///
+  /// [google.bigtable.admin.v2.GenerateConsistencyTokenRequest]:
+  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_table_admin.proto#L626}
+  /// [google.bigtable.admin.v2.GenerateConsistencyTokenResponse]:
+  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_table_admin.proto#L640}
+  ///
+  StatusOr<google::bigtable::admin::v2::GenerateConsistencyTokenResponse>
+  GenerateConsistencyToken(
+      google::bigtable::admin::v2::GenerateConsistencyTokenRequest const&
+          request,
+      Options options = {});
 
   ///
   /// Checks replication consistency based on a consistency token, that is, if
@@ -243,6 +373,27 @@ class BigtableTableAdminClient {
   StatusOr<google::bigtable::admin::v2::CheckConsistencyResponse>
   CheckConsistency(std::string const& name,
                    std::string const& consistency_token, Options options = {});
+
+  ///
+  /// Checks replication consistency based on a consistency token, that is, if
+  /// replication has caught up based on the conditions specified in the token
+  /// and the check request.
+  ///
+  /// @param request
+  /// @googleapis_link{google::bigtable::admin::v2::CheckConsistencyRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L647}
+  /// @param options  Optional. Operation options.
+  /// @return
+  /// @googleapis_link{google::bigtable::admin::v2::CheckConsistencyResponse,google/bigtable/admin/v2/bigtable_table_admin.proto#L664}
+  ///
+  /// [google.bigtable.admin.v2.CheckConsistencyRequest]:
+  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_table_admin.proto#L647}
+  /// [google.bigtable.admin.v2.CheckConsistencyResponse]:
+  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_table_admin.proto#L664}
+  ///
+  StatusOr<google::bigtable::admin::v2::CheckConsistencyResponse>
+  CheckConsistency(
+      google::bigtable::admin::v2::CheckConsistencyRequest const& request,
+      Options options = {});
 
   ///
   /// Starts creating a new Cloud Bigtable Backup.  The returned backup
@@ -280,6 +431,31 @@ class BigtableTableAdminClient {
       google::bigtable::admin::v2::Backup const& backup, Options options = {});
 
   ///
+  /// Starts creating a new Cloud Bigtable Backup.  The returned backup
+  /// [long-running operation][google.longrunning.Operation] can be used to
+  /// track creation of the backup. The
+  /// [metadata][google.longrunning.Operation.metadata] field type is
+  /// [CreateBackupMetadata][google.bigtable.admin.v2.CreateBackupMetadata]. The
+  /// [response][google.longrunning.Operation.response] field type is
+  /// [Backup][google.bigtable.admin.v2.Backup], if successful. Cancelling the
+  /// returned operation will stop the creation and delete the backup.
+  ///
+  /// @param request
+  /// @googleapis_link{google::bigtable::admin::v2::CreateBackupRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L833}
+  /// @param options  Optional. Operation options.
+  /// @return
+  /// @googleapis_link{google::bigtable::admin::v2::Backup,google/bigtable/admin/v2/table.proto#L317}
+  ///
+  /// [google.bigtable.admin.v2.CreateBackupRequest]:
+  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_table_admin.proto#L833}
+  /// [google.bigtable.admin.v2.Backup]:
+  /// @googleapis_reference_link{google/bigtable/admin/v2/table.proto#L317}
+  ///
+  future<StatusOr<google::bigtable::admin::v2::Backup>> CreateBackup(
+      google::bigtable::admin::v2::CreateBackupRequest const& request,
+      Options options = {});
+
+  ///
   /// Gets metadata on a pending or completed Cloud Bigtable Backup.
   ///
   /// @param name  Required. Name of the backup.
@@ -296,6 +472,24 @@ class BigtableTableAdminClient {
   ///
   StatusOr<google::bigtable::admin::v2::Backup> GetBackup(
       std::string const& name, Options options = {});
+
+  ///
+  /// Gets metadata on a pending or completed Cloud Bigtable Backup.
+  ///
+  /// @param request
+  /// @googleapis_link{google::bigtable::admin::v2::GetBackupRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L889}
+  /// @param options  Optional. Operation options.
+  /// @return
+  /// @googleapis_link{google::bigtable::admin::v2::Backup,google/bigtable/admin/v2/table.proto#L317}
+  ///
+  /// [google.bigtable.admin.v2.GetBackupRequest]:
+  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_table_admin.proto#L889}
+  /// [google.bigtable.admin.v2.Backup]:
+  /// @googleapis_reference_link{google/bigtable/admin/v2/table.proto#L317}
+  ///
+  StatusOr<google::bigtable::admin::v2::Backup> GetBackup(
+      google::bigtable::admin::v2::GetBackupRequest const& request,
+      Options options = {});
 
   ///
   /// Updates a pending or completed Cloud Bigtable Backup.
@@ -325,6 +519,24 @@ class BigtableTableAdminClient {
       google::protobuf::FieldMask const& update_mask, Options options = {});
 
   ///
+  /// Updates a pending or completed Cloud Bigtable Backup.
+  ///
+  /// @param request
+  /// @googleapis_link{google::bigtable::admin::v2::UpdateBackupRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L873}
+  /// @param options  Optional. Operation options.
+  /// @return
+  /// @googleapis_link{google::bigtable::admin::v2::Backup,google/bigtable/admin/v2/table.proto#L317}
+  ///
+  /// [google.bigtable.admin.v2.UpdateBackupRequest]:
+  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_table_admin.proto#L873}
+  /// [google.bigtable.admin.v2.Backup]:
+  /// @googleapis_reference_link{google/bigtable/admin/v2/table.proto#L317}
+  ///
+  StatusOr<google::bigtable::admin::v2::Backup> UpdateBackup(
+      google::bigtable::admin::v2::UpdateBackupRequest const& request,
+      Options options = {});
+
+  ///
   /// Deletes a pending or completed Cloud Bigtable backup.
   ///
   /// @param name  Required. Name of the backup to delete.
@@ -336,6 +548,20 @@ class BigtableTableAdminClient {
   /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_table_admin.proto#L902}
   ///
   Status DeleteBackup(std::string const& name, Options options = {});
+
+  ///
+  /// Deletes a pending or completed Cloud Bigtable backup.
+  ///
+  /// @param request
+  /// @googleapis_link{google::bigtable::admin::v2::DeleteBackupRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L902}
+  /// @param options  Optional. Operation options.
+  ///
+  /// [google.bigtable.admin.v2.DeleteBackupRequest]:
+  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_table_admin.proto#L902}
+  ///
+  Status DeleteBackup(
+      google::bigtable::admin::v2::DeleteBackupRequest const& request,
+      Options options = {});
 
   ///
   /// Lists Cloud Bigtable backups. Returns both completed and pending
@@ -359,6 +585,50 @@ class BigtableTableAdminClient {
       std::string const& parent, Options options = {});
 
   ///
+  /// Lists Cloud Bigtable backups. Returns both completed and pending
+  /// backups.
+  ///
+  /// @param request
+  /// @googleapis_link{google::bigtable::admin::v2::ListBackupsRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L915}
+  /// @param options  Optional. Operation options.
+  /// @return
+  /// @googleapis_link{google::bigtable::admin::v2::Backup,google/bigtable/admin/v2/table.proto#L317}
+  ///
+  /// [google.bigtable.admin.v2.ListBackupsRequest]:
+  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_table_admin.proto#L915}
+  /// [google.bigtable.admin.v2.Backup]:
+  /// @googleapis_reference_link{google/bigtable/admin/v2/table.proto#L317}
+  ///
+  StreamRange<google::bigtable::admin::v2::Backup> ListBackups(
+      google::bigtable::admin::v2::ListBackupsRequest request,
+      Options options = {});
+
+  ///
+  /// Create a new table by restoring from a completed backup. The new table
+  /// must be in the same project as the instance containing the backup.  The
+  /// returned table [long-running operation][google.longrunning.Operation] can
+  /// be used to track the progress of the operation, and to cancel it.  The
+  /// [metadata][google.longrunning.Operation.metadata] field type is
+  /// [RestoreTableMetadata][google.bigtable.admin.RestoreTableMetadata].  The
+  /// [response][google.longrunning.Operation.response] type is
+  /// [Table][google.bigtable.admin.v2.Table], if successful.
+  ///
+  /// @param request
+  /// @googleapis_link{google::bigtable::admin::v2::RestoreTableRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L336}
+  /// @param options  Optional. Operation options.
+  /// @return
+  /// @googleapis_link{google::bigtable::admin::v2::Table,google/bigtable/admin/v2/table.proto#L61}
+  ///
+  /// [google.bigtable.admin.v2.RestoreTableRequest]:
+  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_table_admin.proto#L336}
+  /// [google.bigtable.admin.v2.Table]:
+  /// @googleapis_reference_link{google/bigtable/admin/v2/table.proto#L61}
+  ///
+  future<StatusOr<google::bigtable::admin::v2::Table>> RestoreTable(
+      google::bigtable::admin::v2::RestoreTableRequest const& request,
+      Options options = {});
+
+  ///
   /// Gets the access control policy for a Table or Backup resource.
   /// Returns an empty policy if the resource exists but does not have a policy
   /// set.
@@ -377,6 +647,26 @@ class BigtableTableAdminClient {
   ///
   StatusOr<google::iam::v1::Policy> GetIamPolicy(std::string const& resource,
                                                  Options options = {});
+
+  ///
+  /// Gets the access control policy for a Table or Backup resource.
+  /// Returns an empty policy if the resource exists but does not have a policy
+  /// set.
+  ///
+  /// @param request
+  /// @googleapis_link{google::iam::v1::GetIamPolicyRequest,google/iam/v1/iam_policy.proto#L113}
+  /// @param options  Optional. Operation options.
+  /// @return
+  /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
+  ///
+  /// [google.iam.v1.GetIamPolicyRequest]:
+  /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L113}
+  /// [google.iam.v1.Policy]:
+  /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
+  ///
+  StatusOr<google::iam::v1::Policy> GetIamPolicy(
+      google::iam::v1::GetIamPolicyRequest const& request,
+      Options options = {});
 
   ///
   /// Sets the access control policy on a Table or Backup resource.
@@ -429,6 +719,25 @@ class BigtableTableAdminClient {
                                                  Options options = {});
 
   ///
+  /// Sets the access control policy on a Table or Backup resource.
+  /// Replaces any existing policy.
+  ///
+  /// @param request
+  /// @googleapis_link{google::iam::v1::SetIamPolicyRequest,google/iam/v1/iam_policy.proto#L98}
+  /// @param options  Optional. Operation options.
+  /// @return
+  /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
+  ///
+  /// [google.iam.v1.SetIamPolicyRequest]:
+  /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L98}
+  /// [google.iam.v1.Policy]:
+  /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
+  ///
+  StatusOr<google::iam::v1::Policy> SetIamPolicy(
+      google::iam::v1::SetIamPolicyRequest const& request,
+      Options options = {});
+
+  ///
   /// Returns permissions that the caller has on the specified Table or Backup
   /// resource.
   ///
@@ -451,6 +760,25 @@ class BigtableTableAdminClient {
   ///
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
       std::string const& resource, std::vector<std::string> const& permissions,
+      Options options = {});
+
+  ///
+  /// Returns permissions that the caller has on the specified Table or Backup
+  /// resource.
+  ///
+  /// @param request
+  /// @googleapis_link{google::iam::v1::TestIamPermissionsRequest,google/iam/v1/iam_policy.proto#L126}
+  /// @param options  Optional. Operation options.
+  /// @return
+  /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
+  ///
+  /// [google.iam.v1.TestIamPermissionsRequest]:
+  /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L126}
+  /// [google.iam.v1.TestIamPermissionsResponse]:
+  /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L141}
+  ///
+  StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
+      google::iam::v1::TestIamPermissionsRequest const& request,
       Options options = {});
 
   ///
@@ -477,334 +805,6 @@ class BigtableTableAdminClient {
   AsyncCheckConsistency(std::string const& name,
                         std::string const& consistency_token,
                         Options options = {});
-
-  ///
-  /// Creates a new table in the specified instance.
-  /// The table can be created with a full set of initial column families,
-  /// specified in the request.
-  ///
-  /// @param request
-  /// @googleapis_link{google::bigtable::admin::v2::CreateTableRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L408}
-  /// @param options  Optional. Operation options.
-  /// @return
-  /// @googleapis_link{google::bigtable::admin::v2::Table,google/bigtable/admin/v2/table.proto#L61}
-  ///
-  /// [google.bigtable.admin.v2.CreateTableRequest]:
-  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_table_admin.proto#L408}
-  /// [google.bigtable.admin.v2.Table]:
-  /// @googleapis_reference_link{google/bigtable/admin/v2/table.proto#L61}
-  ///
-  StatusOr<google::bigtable::admin::v2::Table> CreateTable(
-      google::bigtable::admin::v2::CreateTableRequest const& request,
-      Options options = {});
-
-  ///
-  /// Lists all tables served from a specified instance.
-  ///
-  /// @param request
-  /// @googleapis_link{google::bigtable::admin::v2::ListTablesRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L510}
-  /// @param options  Optional. Operation options.
-  /// @return
-  /// @googleapis_link{google::bigtable::admin::v2::Table,google/bigtable/admin/v2/table.proto#L61}
-  ///
-  /// [google.bigtable.admin.v2.ListTablesRequest]:
-  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_table_admin.proto#L510}
-  /// [google.bigtable.admin.v2.Table]:
-  /// @googleapis_reference_link{google/bigtable/admin/v2/table.proto#L61}
-  ///
-  StreamRange<google::bigtable::admin::v2::Table> ListTables(
-      google::bigtable::admin::v2::ListTablesRequest request,
-      Options options = {});
-
-  ///
-  /// Gets metadata information about the specified table.
-  ///
-  /// @param request
-  /// @googleapis_link{google::bigtable::admin::v2::GetTableRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L553}
-  /// @param options  Optional. Operation options.
-  /// @return
-  /// @googleapis_link{google::bigtable::admin::v2::Table,google/bigtable/admin/v2/table.proto#L61}
-  ///
-  /// [google.bigtable.admin.v2.GetTableRequest]:
-  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_table_admin.proto#L553}
-  /// [google.bigtable.admin.v2.Table]:
-  /// @googleapis_reference_link{google/bigtable/admin/v2/table.proto#L61}
-  ///
-  StatusOr<google::bigtable::admin::v2::Table> GetTable(
-      google::bigtable::admin::v2::GetTableRequest const& request,
-      Options options = {});
-
-  ///
-  /// Permanently deletes a specified table and all of its data.
-  ///
-  /// @param request
-  /// @googleapis_link{google::bigtable::admin::v2::DeleteTableRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L571}
-  /// @param options  Optional. Operation options.
-  ///
-  /// [google.bigtable.admin.v2.DeleteTableRequest]:
-  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_table_admin.proto#L571}
-  ///
-  Status DeleteTable(
-      google::bigtable::admin::v2::DeleteTableRequest const& request,
-      Options options = {});
-
-  ///
-  /// Performs a series of column family modifications on the specified table.
-  /// Either all or none of the modifications will occur before this method
-  /// returns, but data requests received prior to that point may see a table
-  /// where only some modifications have taken effect.
-  ///
-  /// @param request
-  /// @googleapis_link{google::bigtable::admin::v2::ModifyColumnFamiliesRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L585}
-  /// @param options  Optional. Operation options.
-  /// @return
-  /// @googleapis_link{google::bigtable::admin::v2::Table,google/bigtable/admin/v2/table.proto#L61}
-  ///
-  /// [google.bigtable.admin.v2.ModifyColumnFamiliesRequest]:
-  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_table_admin.proto#L585}
-  /// [google.bigtable.admin.v2.Table]:
-  /// @googleapis_reference_link{google/bigtable/admin/v2/table.proto#L61}
-  ///
-  StatusOr<google::bigtable::admin::v2::Table> ModifyColumnFamilies(
-      google::bigtable::admin::v2::ModifyColumnFamiliesRequest const& request,
-      Options options = {});
-
-  ///
-  /// Permanently drop/delete a row range from a specified table. The request
-  /// can specify whether to delete all rows in a table, or only those that
-  /// match a particular prefix.
-  ///
-  /// @param request
-  /// @googleapis_link{google::bigtable::admin::v2::DropRowRangeRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L486}
-  /// @param options  Optional. Operation options.
-  ///
-  /// [google.bigtable.admin.v2.DropRowRangeRequest]:
-  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_table_admin.proto#L486}
-  ///
-  Status DropRowRange(
-      google::bigtable::admin::v2::DropRowRangeRequest const& request,
-      Options options = {});
-
-  ///
-  /// Generates a consistency token for a Table, which can be used in
-  /// CheckConsistency to check whether mutations to the table that finished
-  /// before this call started have been replicated. The tokens will be
-  /// available for 90 days.
-  ///
-  /// @param request
-  /// @googleapis_link{google::bigtable::admin::v2::GenerateConsistencyTokenRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L626}
-  /// @param options  Optional. Operation options.
-  /// @return
-  /// @googleapis_link{google::bigtable::admin::v2::GenerateConsistencyTokenResponse,google/bigtable/admin/v2/bigtable_table_admin.proto#L640}
-  ///
-  /// [google.bigtable.admin.v2.GenerateConsistencyTokenRequest]:
-  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_table_admin.proto#L626}
-  /// [google.bigtable.admin.v2.GenerateConsistencyTokenResponse]:
-  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_table_admin.proto#L640}
-  ///
-  StatusOr<google::bigtable::admin::v2::GenerateConsistencyTokenResponse>
-  GenerateConsistencyToken(
-      google::bigtable::admin::v2::GenerateConsistencyTokenRequest const&
-          request,
-      Options options = {});
-
-  ///
-  /// Checks replication consistency based on a consistency token, that is, if
-  /// replication has caught up based on the conditions specified in the token
-  /// and the check request.
-  ///
-  /// @param request
-  /// @googleapis_link{google::bigtable::admin::v2::CheckConsistencyRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L647}
-  /// @param options  Optional. Operation options.
-  /// @return
-  /// @googleapis_link{google::bigtable::admin::v2::CheckConsistencyResponse,google/bigtable/admin/v2/bigtable_table_admin.proto#L664}
-  ///
-  /// [google.bigtable.admin.v2.CheckConsistencyRequest]:
-  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_table_admin.proto#L647}
-  /// [google.bigtable.admin.v2.CheckConsistencyResponse]:
-  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_table_admin.proto#L664}
-  ///
-  StatusOr<google::bigtable::admin::v2::CheckConsistencyResponse>
-  CheckConsistency(
-      google::bigtable::admin::v2::CheckConsistencyRequest const& request,
-      Options options = {});
-
-  ///
-  /// Starts creating a new Cloud Bigtable Backup.  The returned backup
-  /// [long-running operation][google.longrunning.Operation] can be used to
-  /// track creation of the backup. The
-  /// [metadata][google.longrunning.Operation.metadata] field type is
-  /// [CreateBackupMetadata][google.bigtable.admin.v2.CreateBackupMetadata]. The
-  /// [response][google.longrunning.Operation.response] field type is
-  /// [Backup][google.bigtable.admin.v2.Backup], if successful. Cancelling the
-  /// returned operation will stop the creation and delete the backup.
-  ///
-  /// @param request
-  /// @googleapis_link{google::bigtable::admin::v2::CreateBackupRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L833}
-  /// @param options  Optional. Operation options.
-  /// @return
-  /// @googleapis_link{google::bigtable::admin::v2::Backup,google/bigtable/admin/v2/table.proto#L317}
-  ///
-  /// [google.bigtable.admin.v2.CreateBackupRequest]:
-  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_table_admin.proto#L833}
-  /// [google.bigtable.admin.v2.Backup]:
-  /// @googleapis_reference_link{google/bigtable/admin/v2/table.proto#L317}
-  ///
-  future<StatusOr<google::bigtable::admin::v2::Backup>> CreateBackup(
-      google::bigtable::admin::v2::CreateBackupRequest const& request,
-      Options options = {});
-
-  ///
-  /// Gets metadata on a pending or completed Cloud Bigtable Backup.
-  ///
-  /// @param request
-  /// @googleapis_link{google::bigtable::admin::v2::GetBackupRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L889}
-  /// @param options  Optional. Operation options.
-  /// @return
-  /// @googleapis_link{google::bigtable::admin::v2::Backup,google/bigtable/admin/v2/table.proto#L317}
-  ///
-  /// [google.bigtable.admin.v2.GetBackupRequest]:
-  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_table_admin.proto#L889}
-  /// [google.bigtable.admin.v2.Backup]:
-  /// @googleapis_reference_link{google/bigtable/admin/v2/table.proto#L317}
-  ///
-  StatusOr<google::bigtable::admin::v2::Backup> GetBackup(
-      google::bigtable::admin::v2::GetBackupRequest const& request,
-      Options options = {});
-
-  ///
-  /// Updates a pending or completed Cloud Bigtable Backup.
-  ///
-  /// @param request
-  /// @googleapis_link{google::bigtable::admin::v2::UpdateBackupRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L873}
-  /// @param options  Optional. Operation options.
-  /// @return
-  /// @googleapis_link{google::bigtable::admin::v2::Backup,google/bigtable/admin/v2/table.proto#L317}
-  ///
-  /// [google.bigtable.admin.v2.UpdateBackupRequest]:
-  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_table_admin.proto#L873}
-  /// [google.bigtable.admin.v2.Backup]:
-  /// @googleapis_reference_link{google/bigtable/admin/v2/table.proto#L317}
-  ///
-  StatusOr<google::bigtable::admin::v2::Backup> UpdateBackup(
-      google::bigtable::admin::v2::UpdateBackupRequest const& request,
-      Options options = {});
-
-  ///
-  /// Deletes a pending or completed Cloud Bigtable backup.
-  ///
-  /// @param request
-  /// @googleapis_link{google::bigtable::admin::v2::DeleteBackupRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L902}
-  /// @param options  Optional. Operation options.
-  ///
-  /// [google.bigtable.admin.v2.DeleteBackupRequest]:
-  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_table_admin.proto#L902}
-  ///
-  Status DeleteBackup(
-      google::bigtable::admin::v2::DeleteBackupRequest const& request,
-      Options options = {});
-
-  ///
-  /// Lists Cloud Bigtable backups. Returns both completed and pending
-  /// backups.
-  ///
-  /// @param request
-  /// @googleapis_link{google::bigtable::admin::v2::ListBackupsRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L915}
-  /// @param options  Optional. Operation options.
-  /// @return
-  /// @googleapis_link{google::bigtable::admin::v2::Backup,google/bigtable/admin/v2/table.proto#L317}
-  ///
-  /// [google.bigtable.admin.v2.ListBackupsRequest]:
-  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_table_admin.proto#L915}
-  /// [google.bigtable.admin.v2.Backup]:
-  /// @googleapis_reference_link{google/bigtable/admin/v2/table.proto#L317}
-  ///
-  StreamRange<google::bigtable::admin::v2::Backup> ListBackups(
-      google::bigtable::admin::v2::ListBackupsRequest request,
-      Options options = {});
-
-  ///
-  /// Create a new table by restoring from a completed backup. The new table
-  /// must be in the same project as the instance containing the backup.  The
-  /// returned table [long-running operation][google.longrunning.Operation] can
-  /// be used to track the progress of the operation, and to cancel it.  The
-  /// [metadata][google.longrunning.Operation.metadata] field type is
-  /// [RestoreTableMetadata][google.bigtable.admin.RestoreTableMetadata].  The
-  /// [response][google.longrunning.Operation.response] type is
-  /// [Table][google.bigtable.admin.v2.Table], if successful.
-  ///
-  /// @param request
-  /// @googleapis_link{google::bigtable::admin::v2::RestoreTableRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L336}
-  /// @param options  Optional. Operation options.
-  /// @return
-  /// @googleapis_link{google::bigtable::admin::v2::Table,google/bigtable/admin/v2/table.proto#L61}
-  ///
-  /// [google.bigtable.admin.v2.RestoreTableRequest]:
-  /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_table_admin.proto#L336}
-  /// [google.bigtable.admin.v2.Table]:
-  /// @googleapis_reference_link{google/bigtable/admin/v2/table.proto#L61}
-  ///
-  future<StatusOr<google::bigtable::admin::v2::Table>> RestoreTable(
-      google::bigtable::admin::v2::RestoreTableRequest const& request,
-      Options options = {});
-
-  ///
-  /// Gets the access control policy for a Table or Backup resource.
-  /// Returns an empty policy if the resource exists but does not have a policy
-  /// set.
-  ///
-  /// @param request
-  /// @googleapis_link{google::iam::v1::GetIamPolicyRequest,google/iam/v1/iam_policy.proto#L113}
-  /// @param options  Optional. Operation options.
-  /// @return
-  /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
-  ///
-  /// [google.iam.v1.GetIamPolicyRequest]:
-  /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L113}
-  /// [google.iam.v1.Policy]:
-  /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
-  ///
-  StatusOr<google::iam::v1::Policy> GetIamPolicy(
-      google::iam::v1::GetIamPolicyRequest const& request,
-      Options options = {});
-
-  ///
-  /// Sets the access control policy on a Table or Backup resource.
-  /// Replaces any existing policy.
-  ///
-  /// @param request
-  /// @googleapis_link{google::iam::v1::SetIamPolicyRequest,google/iam/v1/iam_policy.proto#L98}
-  /// @param options  Optional. Operation options.
-  /// @return
-  /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
-  ///
-  /// [google.iam.v1.SetIamPolicyRequest]:
-  /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L98}
-  /// [google.iam.v1.Policy]:
-  /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
-  ///
-  StatusOr<google::iam::v1::Policy> SetIamPolicy(
-      google::iam::v1::SetIamPolicyRequest const& request,
-      Options options = {});
-
-  ///
-  /// Returns permissions that the caller has on the specified Table or Backup
-  /// resource.
-  ///
-  /// @param request
-  /// @googleapis_link{google::iam::v1::TestIamPermissionsRequest,google/iam/v1/iam_policy.proto#L126}
-  /// @param options  Optional. Operation options.
-  /// @return
-  /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
-  ///
-  /// [google.iam.v1.TestIamPermissionsRequest]:
-  /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L126}
-  /// [google.iam.v1.TestIamPermissionsResponse]:
-  /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L141}
-  ///
-  StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
-      google::iam::v1::TestIamPermissionsRequest const& request,
-      Options options = {});
 
   ///
   /// Checks replication consistency based on a consistency token, that is, if

--- a/google/cloud/iam/iam_client.cc
+++ b/google/cloud/iam/iam_client.cc
@@ -41,12 +41,29 @@ IAMClient::ListServiceAccounts(std::string const& name, Options options) {
   return connection_->ListServiceAccounts(request);
 }
 
+StreamRange<google::iam::admin::v1::ServiceAccount>
+IAMClient::ListServiceAccounts(
+    google::iam::admin::v1::ListServiceAccountsRequest request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
+  return connection_->ListServiceAccounts(std::move(request));
+}
+
 StatusOr<google::iam::admin::v1::ServiceAccount> IAMClient::GetServiceAccount(
     std::string const& name, Options options) {
   internal::OptionsSpan span(
       internal::MergeOptions(std::move(options), options_));
   google::iam::admin::v1::GetServiceAccountRequest request;
   request.set_name(name);
+  return connection_->GetServiceAccount(request);
+}
+
+StatusOr<google::iam::admin::v1::ServiceAccount> IAMClient::GetServiceAccount(
+    google::iam::admin::v1::GetServiceAccountRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->GetServiceAccount(request);
 }
 
@@ -64,6 +81,23 @@ IAMClient::CreateServiceAccount(
   return connection_->CreateServiceAccount(request);
 }
 
+StatusOr<google::iam::admin::v1::ServiceAccount>
+IAMClient::CreateServiceAccount(
+    google::iam::admin::v1::CreateServiceAccountRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
+  return connection_->CreateServiceAccount(request);
+}
+
+StatusOr<google::iam::admin::v1::ServiceAccount> IAMClient::PatchServiceAccount(
+    google::iam::admin::v1::PatchServiceAccountRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
+  return connection_->PatchServiceAccount(request);
+}
+
 Status IAMClient::DeleteServiceAccount(std::string const& name,
                                        Options options) {
   internal::OptionsSpan span(
@@ -71,6 +105,39 @@ Status IAMClient::DeleteServiceAccount(std::string const& name,
   google::iam::admin::v1::DeleteServiceAccountRequest request;
   request.set_name(name);
   return connection_->DeleteServiceAccount(request);
+}
+
+Status IAMClient::DeleteServiceAccount(
+    google::iam::admin::v1::DeleteServiceAccountRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
+  return connection_->DeleteServiceAccount(request);
+}
+
+StatusOr<google::iam::admin::v1::UndeleteServiceAccountResponse>
+IAMClient::UndeleteServiceAccount(
+    google::iam::admin::v1::UndeleteServiceAccountRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
+  return connection_->UndeleteServiceAccount(request);
+}
+
+Status IAMClient::EnableServiceAccount(
+    google::iam::admin::v1::EnableServiceAccountRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
+  return connection_->EnableServiceAccount(request);
+}
+
+Status IAMClient::DisableServiceAccount(
+    google::iam::admin::v1::DisableServiceAccountRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
+  return connection_->DisableServiceAccount(request);
 }
 
 StatusOr<google::iam::admin::v1::ListServiceAccountKeysResponse>
@@ -88,6 +155,15 @@ IAMClient::ListServiceAccountKeys(
   return connection_->ListServiceAccountKeys(request);
 }
 
+StatusOr<google::iam::admin::v1::ListServiceAccountKeysResponse>
+IAMClient::ListServiceAccountKeys(
+    google::iam::admin::v1::ListServiceAccountKeysRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
+  return connection_->ListServiceAccountKeys(request);
+}
+
 StatusOr<google::iam::admin::v1::ServiceAccountKey>
 IAMClient::GetServiceAccountKey(
     std::string const& name,
@@ -98,6 +174,15 @@ IAMClient::GetServiceAccountKey(
   google::iam::admin::v1::GetServiceAccountKeyRequest request;
   request.set_name(name);
   request.set_public_key_type(public_key_type);
+  return connection_->GetServiceAccountKey(request);
+}
+
+StatusOr<google::iam::admin::v1::ServiceAccountKey>
+IAMClient::GetServiceAccountKey(
+    google::iam::admin::v1::GetServiceAccountKeyRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->GetServiceAccountKey(request);
 }
 
@@ -116,6 +201,24 @@ IAMClient::CreateServiceAccountKey(
   return connection_->CreateServiceAccountKey(request);
 }
 
+StatusOr<google::iam::admin::v1::ServiceAccountKey>
+IAMClient::CreateServiceAccountKey(
+    google::iam::admin::v1::CreateServiceAccountKeyRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
+  return connection_->CreateServiceAccountKey(request);
+}
+
+StatusOr<google::iam::admin::v1::ServiceAccountKey>
+IAMClient::UploadServiceAccountKey(
+    google::iam::admin::v1::UploadServiceAccountKeyRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
+  return connection_->UploadServiceAccountKey(request);
+}
+
 Status IAMClient::DeleteServiceAccountKey(std::string const& name,
                                           Options options) {
   internal::OptionsSpan span(
@@ -125,12 +228,27 @@ Status IAMClient::DeleteServiceAccountKey(std::string const& name,
   return connection_->DeleteServiceAccountKey(request);
 }
 
+Status IAMClient::DeleteServiceAccountKey(
+    google::iam::admin::v1::DeleteServiceAccountKeyRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
+  return connection_->DeleteServiceAccountKey(request);
+}
+
 StatusOr<google::iam::v1::Policy> IAMClient::GetIamPolicy(
     std::string const& resource, Options options) {
   internal::OptionsSpan span(
       internal::MergeOptions(std::move(options), options_));
   google::iam::v1::GetIamPolicyRequest request;
   request.set_resource(resource);
+  return connection_->GetIamPolicy(request);
+}
+
+StatusOr<google::iam::v1::Policy> IAMClient::GetIamPolicy(
+    google::iam::v1::GetIamPolicyRequest const& request, Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->GetIamPolicy(request);
 }
 
@@ -169,6 +287,13 @@ StatusOr<google::iam::v1::Policy> IAMClient::SetIamPolicy(
   }
 }
 
+StatusOr<google::iam::v1::Policy> IAMClient::SetIamPolicy(
+    google::iam::v1::SetIamPolicyRequest const& request, Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
+  return connection_->SetIamPolicy(request);
+}
+
 StatusOr<google::iam::v1::TestIamPermissionsResponse>
 IAMClient::TestIamPermissions(std::string const& resource,
                               std::vector<std::string> const& permissions,
@@ -181,140 +306,6 @@ IAMClient::TestIamPermissions(std::string const& resource,
   return connection_->TestIamPermissions(request);
 }
 
-StreamRange<google::iam::admin::v1::Role> IAMClient::QueryGrantableRoles(
-    std::string const& full_resource_name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  google::iam::admin::v1::QueryGrantableRolesRequest request;
-  request.set_full_resource_name(full_resource_name);
-  return connection_->QueryGrantableRoles(request);
-}
-
-StreamRange<google::iam::admin::v1::ServiceAccount>
-IAMClient::ListServiceAccounts(
-    google::iam::admin::v1::ListServiceAccountsRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->ListServiceAccounts(std::move(request));
-}
-
-StatusOr<google::iam::admin::v1::ServiceAccount> IAMClient::GetServiceAccount(
-    google::iam::admin::v1::GetServiceAccountRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->GetServiceAccount(request);
-}
-
-StatusOr<google::iam::admin::v1::ServiceAccount>
-IAMClient::CreateServiceAccount(
-    google::iam::admin::v1::CreateServiceAccountRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->CreateServiceAccount(request);
-}
-
-StatusOr<google::iam::admin::v1::ServiceAccount> IAMClient::PatchServiceAccount(
-    google::iam::admin::v1::PatchServiceAccountRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->PatchServiceAccount(request);
-}
-
-Status IAMClient::DeleteServiceAccount(
-    google::iam::admin::v1::DeleteServiceAccountRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->DeleteServiceAccount(request);
-}
-
-StatusOr<google::iam::admin::v1::UndeleteServiceAccountResponse>
-IAMClient::UndeleteServiceAccount(
-    google::iam::admin::v1::UndeleteServiceAccountRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->UndeleteServiceAccount(request);
-}
-
-Status IAMClient::EnableServiceAccount(
-    google::iam::admin::v1::EnableServiceAccountRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->EnableServiceAccount(request);
-}
-
-Status IAMClient::DisableServiceAccount(
-    google::iam::admin::v1::DisableServiceAccountRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->DisableServiceAccount(request);
-}
-
-StatusOr<google::iam::admin::v1::ListServiceAccountKeysResponse>
-IAMClient::ListServiceAccountKeys(
-    google::iam::admin::v1::ListServiceAccountKeysRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->ListServiceAccountKeys(request);
-}
-
-StatusOr<google::iam::admin::v1::ServiceAccountKey>
-IAMClient::GetServiceAccountKey(
-    google::iam::admin::v1::GetServiceAccountKeyRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->GetServiceAccountKey(request);
-}
-
-StatusOr<google::iam::admin::v1::ServiceAccountKey>
-IAMClient::CreateServiceAccountKey(
-    google::iam::admin::v1::CreateServiceAccountKeyRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->CreateServiceAccountKey(request);
-}
-
-StatusOr<google::iam::admin::v1::ServiceAccountKey>
-IAMClient::UploadServiceAccountKey(
-    google::iam::admin::v1::UploadServiceAccountKeyRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->UploadServiceAccountKey(request);
-}
-
-Status IAMClient::DeleteServiceAccountKey(
-    google::iam::admin::v1::DeleteServiceAccountKeyRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->DeleteServiceAccountKey(request);
-}
-
-StatusOr<google::iam::v1::Policy> IAMClient::GetIamPolicy(
-    google::iam::v1::GetIamPolicyRequest const& request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->GetIamPolicy(request);
-}
-
-StatusOr<google::iam::v1::Policy> IAMClient::SetIamPolicy(
-    google::iam::v1::SetIamPolicyRequest const& request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->SetIamPolicy(request);
-}
-
 StatusOr<google::iam::v1::TestIamPermissionsResponse>
 IAMClient::TestIamPermissions(
     google::iam::v1::TestIamPermissionsRequest const& request,
@@ -322,6 +313,15 @@ IAMClient::TestIamPermissions(
   internal::OptionsSpan span(
       internal::MergeOptions(std::move(options), options_));
   return connection_->TestIamPermissions(request);
+}
+
+StreamRange<google::iam::admin::v1::Role> IAMClient::QueryGrantableRoles(
+    std::string const& full_resource_name, Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
+  google::iam::admin::v1::QueryGrantableRolesRequest request;
+  request.set_full_resource_name(full_resource_name);
+  return connection_->QueryGrantableRoles(request);
 }
 
 StreamRange<google::iam::admin::v1::Role> IAMClient::QueryGrantableRoles(

--- a/google/cloud/iam/iam_client.h
+++ b/google/cloud/iam/iam_client.h
@@ -121,6 +121,25 @@ class IAMClient {
       std::string const& name, Options options = {});
 
   ///
+  /// Lists every [ServiceAccount][google.iam.admin.v1.ServiceAccount] that
+  /// belongs to a specific project.
+  ///
+  /// @param request
+  /// @googleapis_link{google::iam::admin::v1::ListServiceAccountsRequest,google/iam/admin/v1/iam.proto#L544}
+  /// @param options  Optional. Operation options.
+  /// @return
+  /// @googleapis_link{google::iam::admin::v1::ServiceAccount,google/iam/admin/v1/iam.proto#L461}
+  ///
+  /// [google.iam.admin.v1.ListServiceAccountsRequest]:
+  /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L544}
+  /// [google.iam.admin.v1.ServiceAccount]:
+  /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L461}
+  ///
+  StreamRange<google::iam::admin::v1::ServiceAccount> ListServiceAccounts(
+      google::iam::admin::v1::ListServiceAccountsRequest request,
+      Options options = {});
+
+  ///
   /// Gets a [ServiceAccount][google.iam.admin.v1.ServiceAccount].
   ///
   /// @param name  Required. The resource name of the service account in the
@@ -140,6 +159,24 @@ class IAMClient {
   ///
   StatusOr<google::iam::admin::v1::ServiceAccount> GetServiceAccount(
       std::string const& name, Options options = {});
+
+  ///
+  /// Gets a [ServiceAccount][google.iam.admin.v1.ServiceAccount].
+  ///
+  /// @param request
+  /// @googleapis_link{google::iam::admin::v1::GetServiceAccountRequest,google/iam/admin/v1/iam.proto#L579}
+  /// @param options  Optional. Operation options.
+  /// @return
+  /// @googleapis_link{google::iam::admin::v1::ServiceAccount,google/iam/admin/v1/iam.proto#L461}
+  ///
+  /// [google.iam.admin.v1.GetServiceAccountRequest]:
+  /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L579}
+  /// [google.iam.admin.v1.ServiceAccount]:
+  /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L461}
+  ///
+  StatusOr<google::iam::admin::v1::ServiceAccount> GetServiceAccount(
+      google::iam::admin::v1::GetServiceAccountRequest const& request,
+      Options options = {});
 
   ///
   /// Creates a [ServiceAccount][google.iam.admin.v1.ServiceAccount].
@@ -168,323 +205,6 @@ class IAMClient {
   StatusOr<google::iam::admin::v1::ServiceAccount> CreateServiceAccount(
       std::string const& name, std::string const& account_id,
       google::iam::admin::v1::ServiceAccount const& service_account,
-      Options options = {});
-
-  ///
-  /// Deletes a [ServiceAccount][google.iam.admin.v1.ServiceAccount].
-  ///
-  /// **Warning:** After you delete a service account, you might not be able to
-  /// undelete it. If you know that you need to re-enable the service account in
-  /// the future, use
-  /// [DisableServiceAccount][google.iam.admin.v1.IAM.DisableServiceAccount]
-  /// instead.
-  ///
-  /// If you delete a service account, IAM permanently removes the service
-  /// account 30 days later. Google Cloud cannot recover the service account
-  /// after it is permanently removed, even if you file a support request.
-  ///
-  /// To help avoid unplanned outages, we recommend that you disable the service
-  /// account before you delete it. Use
-  /// [DisableServiceAccount][google.iam.admin.v1.IAM.DisableServiceAccount] to
-  /// disable the service account, then wait at least 24 hours and watch for
-  /// unintended consequences. If there are no unintended consequences, you can
-  /// delete the service account.
-  ///
-  /// @param name  Required. The resource name of the service account in the
-  /// following format:
-  ///  `projects/{PROJECT_ID}/serviceAccounts/{ACCOUNT}`.
-  ///  Using `-` as a wildcard for the `PROJECT_ID` will infer the project from
-  ///  the account. The `ACCOUNT` value can be the `email` address or the
-  ///  `unique_id` of the service account.
-  /// @param options  Optional. Operation options.
-  ///
-  /// [google.iam.admin.v1.DeleteServiceAccountRequest]:
-  /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L594}
-  ///
-  Status DeleteServiceAccount(std::string const& name, Options options = {});
-
-  ///
-  /// Lists every [ServiceAccountKey][google.iam.admin.v1.ServiceAccountKey] for
-  /// a service account.
-  ///
-  /// @param name  Required. The resource name of the service account in the
-  /// following format:
-  ///  `projects/{PROJECT_ID}/serviceAccounts/{ACCOUNT}`.
-  ///  Using `-` as a wildcard for the `PROJECT_ID`, will infer the project from
-  ///  the account. The `ACCOUNT` value can be the `email` address or the
-  ///  `unique_id` of the service account.
-  /// @param key_types  Filters the types of keys the user wants to include in
-  /// the list
-  ///  response. Duplicate key types are not allowed. If no key type
-  ///  is provided, all keys are returned.
-  /// @param options  Optional. Operation options.
-  /// @return
-  /// @googleapis_link{google::iam::admin::v1::ListServiceAccountKeysResponse,google/iam/admin/v1/iam.proto#L692}
-  ///
-  /// [google.iam.admin.v1.ListServiceAccountKeysRequest]:
-  /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L657}
-  /// [google.iam.admin.v1.ListServiceAccountKeysResponse]:
-  /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L692}
-  ///
-  StatusOr<google::iam::admin::v1::ListServiceAccountKeysResponse>
-  ListServiceAccountKeys(
-      std::string const& name,
-      std::vector<
-          google::iam::admin::v1::ListServiceAccountKeysRequest::KeyType> const&
-          key_types,
-      Options options = {});
-
-  ///
-  /// Gets a [ServiceAccountKey][google.iam.admin.v1.ServiceAccountKey].
-  ///
-  /// @param name  Required. The resource name of the service account key in the
-  /// following format:
-  ///  `projects/{PROJECT_ID}/serviceAccounts/{ACCOUNT}/keys/{key}`.
-  ///  Using `-` as a wildcard for the `PROJECT_ID` will infer the project from
-  ///  the account. The `ACCOUNT` value can be the `email` address or the
-  ///  `unique_id` of the service account.
-  /// @param public_key_type  The output format of the public key requested.
-  ///  X509_PEM is the default output format.
-  /// @param options  Optional. Operation options.
-  /// @return
-  /// @googleapis_link{google::iam::admin::v1::ServiceAccountKey,google/iam/admin/v1/iam.proto#L741}
-  ///
-  /// [google.iam.admin.v1.GetServiceAccountKeyRequest]:
-  /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L698}
-  /// [google.iam.admin.v1.ServiceAccountKey]:
-  /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L741}
-  ///
-  StatusOr<google::iam::admin::v1::ServiceAccountKey> GetServiceAccountKey(
-      std::string const& name,
-      google::iam::admin::v1::ServiceAccountPublicKeyType public_key_type,
-      Options options = {});
-
-  ///
-  /// Creates a [ServiceAccountKey][google.iam.admin.v1.ServiceAccountKey].
-  ///
-  /// @param name  Required. The resource name of the service account in the
-  /// following format:
-  ///  `projects/{PROJECT_ID}/serviceAccounts/{ACCOUNT}`.
-  ///  Using `-` as a wildcard for the `PROJECT_ID` will infer the project from
-  ///  the account. The `ACCOUNT` value can be the `email` address or the
-  ///  `unique_id` of the service account.
-  /// @param private_key_type  The output format of the private key. The default
-  /// value is
-  ///  `TYPE_GOOGLE_CREDENTIALS_FILE`, which is the Google Credentials File
-  ///  format.
-  /// @param key_algorithm  Which type of key and algorithm to use for the key.
-  ///  The default is currently a 2K RSA key.  However this may change in the
-  ///  future.
-  /// @param options  Optional. Operation options.
-  /// @return
-  /// @googleapis_link{google::iam::admin::v1::ServiceAccountKey,google/iam/admin/v1/iam.proto#L741}
-  ///
-  /// [google.iam.admin.v1.CreateServiceAccountKeyRequest]:
-  /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L791}
-  /// [google.iam.admin.v1.ServiceAccountKey]:
-  /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L741}
-  ///
-  StatusOr<google::iam::admin::v1::ServiceAccountKey> CreateServiceAccountKey(
-      std::string const& name,
-      google::iam::admin::v1::ServiceAccountPrivateKeyType private_key_type,
-      google::iam::admin::v1::ServiceAccountKeyAlgorithm key_algorithm,
-      Options options = {});
-
-  ///
-  /// Deletes a [ServiceAccountKey][google.iam.admin.v1.ServiceAccountKey].
-  /// Deleting a service account key does not revoke short-lived credentials
-  /// that have been issued based on the service account key.
-  ///
-  /// @param name  Required. The resource name of the service account key in the
-  /// following format:
-  ///  `projects/{PROJECT_ID}/serviceAccounts/{ACCOUNT}/keys/{key}`.
-  ///  Using `-` as a wildcard for the `PROJECT_ID` will infer the project from
-  ///  the account. The `ACCOUNT` value can be the `email` address or the
-  ///  `unique_id` of the service account.
-  /// @param options  Optional. Operation options.
-  ///
-  /// [google.iam.admin.v1.DeleteServiceAccountKeyRequest]:
-  /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L832}
-  ///
-  Status DeleteServiceAccountKey(std::string const& name, Options options = {});
-
-  ///
-  /// Gets the IAM policy that is attached to a
-  /// [ServiceAccount][google.iam.admin.v1.ServiceAccount]. This IAM policy
-  /// specifies which members have access to the service account.
-  ///
-  /// This method does not tell you whether the service account has been granted
-  /// any roles on other resources. To check whether a service account has role
-  /// grants on a resource, use the `getIamPolicy` method for that resource. For
-  /// example, to view the role grants for a project, call the Resource Manager
-  /// API's
-  /// [`projects.getIamPolicy`](https://cloud.google.com/resource-manager/reference/rest/v1/projects/getIamPolicy)
-  /// method.
-  ///
-  /// @param resource  REQUIRED: The resource for which the policy is being
-  /// requested.
-  ///  See the operation documentation for the appropriate value for this field.
-  /// @param options  Optional. Operation options.
-  /// @return
-  /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
-  ///
-  /// [google.iam.v1.GetIamPolicyRequest]:
-  /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L113}
-  /// [google.iam.v1.Policy]:
-  /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
-  ///
-  StatusOr<google::iam::v1::Policy> GetIamPolicy(std::string const& resource,
-                                                 Options options = {});
-
-  ///
-  /// Sets the IAM policy that is attached to a
-  /// [ServiceAccount][google.iam.admin.v1.ServiceAccount].
-  ///
-  /// Use this method to grant or revoke access to the service account. For
-  /// example, you could grant a member the ability to impersonate the service
-  /// account.
-  ///
-  /// This method does not enable the service account to access other resources.
-  /// To grant roles to a service account on a resource, follow these steps:
-  ///
-  /// 1. Call the resource's `getIamPolicy` method to get its current IAM
-  /// policy.
-  /// 2. Edit the policy so that it binds the service account to an IAM role for
-  /// the resource.
-  /// 3. Call the resource's `setIamPolicy` method to update its IAM policy.
-  ///
-  /// For detailed instructions, see
-  /// [Granting roles to a service account for specific
-  /// resources](https://cloud.google.com/iam/help/service-accounts/granting-access-to-service-accounts).
-  ///
-  /// @param resource  REQUIRED: The resource for which the policy is being
-  /// specified.
-  ///  See the operation documentation for the appropriate value for this field.
-  /// @param policy  REQUIRED: The complete policy to be applied to the
-  /// `resource`. The size of
-  ///  the policy is limited to a few 10s of KB. An empty policy is a
-  ///  valid policy but certain Cloud Platform services (such as Projects)
-  ///  might reject them.
-  /// @param options  Optional. Operation options.
-  /// @return
-  /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
-  ///
-  /// [google.iam.v1.SetIamPolicyRequest]:
-  /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L98}
-  /// [google.iam.v1.Policy]:
-  /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
-  ///
-  StatusOr<google::iam::v1::Policy> SetIamPolicy(
-      std::string const& resource, google::iam::v1::Policy const& policy,
-      Options options = {});
-
-  /**
-   * Updates the IAM policy for @p resource using an optimistic concurrency
-   * control loop.
-   *
-   * The loop fetches the current policy for @p resource, and passes it to @p
-   * updater, which should return the new policy. This new policy should use the
-   * current etag so that the read-modify-write cycle can detect races and rerun
-   * the update when there is a mismatch. If the new policy does not have an
-   * etag, the existing policy will be blindly overwritten. If @p updater does
-   * not yield a policy, the control loop is terminated and kCancelled is
-   * returned.
-   *
-   * @param resource  Required. The resource for which the policy is being
-   * specified. See the operation documentation for the appropriate value for
-   * this field.
-   * @param updater  Required. Functor to map the current policy to a new one.
-   * @param options  Optional. Options to control the loop. Expected options
-   * are:
-   *       - `IAMBackoffPolicyOption`
-   * @return google::iam::v1::Policy
-   */
-  StatusOr<google::iam::v1::Policy> SetIamPolicy(std::string const& resource,
-                                                 IamUpdater const& updater,
-                                                 Options options = {});
-
-  ///
-  /// Tests whether the caller has the specified permissions on a
-  /// [ServiceAccount][google.iam.admin.v1.ServiceAccount].
-  ///
-  /// @param resource  REQUIRED: The resource for which the policy detail is
-  /// being requested.
-  ///  See the operation documentation for the appropriate value for this field.
-  /// @param permissions  The set of permissions to check for the `resource`.
-  /// Permissions with
-  ///  wildcards (such as '*' or 'storage.*') are not allowed. For more
-  ///  information see
-  ///  [IAM Overview](https://cloud.google.com/iam/docs/overview#permissions).
-  /// @param options  Optional. Operation options.
-  /// @return
-  /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
-  ///
-  /// [google.iam.v1.TestIamPermissionsRequest]:
-  /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L126}
-  /// [google.iam.v1.TestIamPermissionsResponse]:
-  /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L141}
-  ///
-  StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
-      std::string const& resource, std::vector<std::string> const& permissions,
-      Options options = {});
-
-  ///
-  /// Lists roles that can be granted on a Google Cloud resource. A role is
-  /// grantable if the IAM policy for the resource can contain bindings to the
-  /// role.
-  ///
-  /// @param full_resource_name  Required. The full resource name to query from
-  /// the list of grantable roles.
-  ///  The name follows the Google Cloud Platform resource format.
-  ///  For example, a Cloud Platform project with id `my-project` will be named
-  ///  `//cloudresourcemanager.googleapis.com/projects/my-project`.
-  /// @param options  Optional. Operation options.
-  /// @return
-  /// @googleapis_link{google::iam::admin::v1::Role,google/iam/admin/v1/iam.proto#L1004}
-  ///
-  /// [google.iam.admin.v1.QueryGrantableRolesRequest]:
-  /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L1062}
-  /// [google.iam.admin.v1.Role]:
-  /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L1004}
-  ///
-  StreamRange<google::iam::admin::v1::Role> QueryGrantableRoles(
-      std::string const& full_resource_name, Options options = {});
-
-  ///
-  /// Lists every [ServiceAccount][google.iam.admin.v1.ServiceAccount] that
-  /// belongs to a specific project.
-  ///
-  /// @param request
-  /// @googleapis_link{google::iam::admin::v1::ListServiceAccountsRequest,google/iam/admin/v1/iam.proto#L544}
-  /// @param options  Optional. Operation options.
-  /// @return
-  /// @googleapis_link{google::iam::admin::v1::ServiceAccount,google/iam/admin/v1/iam.proto#L461}
-  ///
-  /// [google.iam.admin.v1.ListServiceAccountsRequest]:
-  /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L544}
-  /// [google.iam.admin.v1.ServiceAccount]:
-  /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L461}
-  ///
-  StreamRange<google::iam::admin::v1::ServiceAccount> ListServiceAccounts(
-      google::iam::admin::v1::ListServiceAccountsRequest request,
-      Options options = {});
-
-  ///
-  /// Gets a [ServiceAccount][google.iam.admin.v1.ServiceAccount].
-  ///
-  /// @param request
-  /// @googleapis_link{google::iam::admin::v1::GetServiceAccountRequest,google/iam/admin/v1/iam.proto#L579}
-  /// @param options  Optional. Operation options.
-  /// @return
-  /// @googleapis_link{google::iam::admin::v1::ServiceAccount,google/iam/admin/v1/iam.proto#L461}
-  ///
-  /// [google.iam.admin.v1.GetServiceAccountRequest]:
-  /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L579}
-  /// [google.iam.admin.v1.ServiceAccount]:
-  /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L461}
-  ///
-  StatusOr<google::iam::admin::v1::ServiceAccount> GetServiceAccount(
-      google::iam::admin::v1::GetServiceAccountRequest const& request,
       Options options = {});
 
   ///
@@ -522,6 +242,39 @@ class IAMClient {
   StatusOr<google::iam::admin::v1::ServiceAccount> PatchServiceAccount(
       google::iam::admin::v1::PatchServiceAccountRequest const& request,
       Options options = {});
+
+  ///
+  /// Deletes a [ServiceAccount][google.iam.admin.v1.ServiceAccount].
+  ///
+  /// **Warning:** After you delete a service account, you might not be able to
+  /// undelete it. If you know that you need to re-enable the service account in
+  /// the future, use
+  /// [DisableServiceAccount][google.iam.admin.v1.IAM.DisableServiceAccount]
+  /// instead.
+  ///
+  /// If you delete a service account, IAM permanently removes the service
+  /// account 30 days later. Google Cloud cannot recover the service account
+  /// after it is permanently removed, even if you file a support request.
+  ///
+  /// To help avoid unplanned outages, we recommend that you disable the service
+  /// account before you delete it. Use
+  /// [DisableServiceAccount][google.iam.admin.v1.IAM.DisableServiceAccount] to
+  /// disable the service account, then wait at least 24 hours and watch for
+  /// unintended consequences. If there are no unintended consequences, you can
+  /// delete the service account.
+  ///
+  /// @param name  Required. The resource name of the service account in the
+  /// following format:
+  ///  `projects/{PROJECT_ID}/serviceAccounts/{ACCOUNT}`.
+  ///  Using `-` as a wildcard for the `PROJECT_ID` will infer the project from
+  ///  the account. The `ACCOUNT` value can be the `email` address or the
+  ///  `unique_id` of the service account.
+  /// @param options  Optional. Operation options.
+  ///
+  /// [google.iam.admin.v1.DeleteServiceAccountRequest]:
+  /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L594}
+  ///
+  Status DeleteServiceAccount(std::string const& name, Options options = {});
 
   ///
   /// Deletes a [ServiceAccount][google.iam.admin.v1.ServiceAccount].
@@ -638,6 +391,37 @@ class IAMClient {
   /// Lists every [ServiceAccountKey][google.iam.admin.v1.ServiceAccountKey] for
   /// a service account.
   ///
+  /// @param name  Required. The resource name of the service account in the
+  /// following format:
+  ///  `projects/{PROJECT_ID}/serviceAccounts/{ACCOUNT}`.
+  ///  Using `-` as a wildcard for the `PROJECT_ID`, will infer the project from
+  ///  the account. The `ACCOUNT` value can be the `email` address or the
+  ///  `unique_id` of the service account.
+  /// @param key_types  Filters the types of keys the user wants to include in
+  /// the list
+  ///  response. Duplicate key types are not allowed. If no key type
+  ///  is provided, all keys are returned.
+  /// @param options  Optional. Operation options.
+  /// @return
+  /// @googleapis_link{google::iam::admin::v1::ListServiceAccountKeysResponse,google/iam/admin/v1/iam.proto#L692}
+  ///
+  /// [google.iam.admin.v1.ListServiceAccountKeysRequest]:
+  /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L657}
+  /// [google.iam.admin.v1.ListServiceAccountKeysResponse]:
+  /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L692}
+  ///
+  StatusOr<google::iam::admin::v1::ListServiceAccountKeysResponse>
+  ListServiceAccountKeys(
+      std::string const& name,
+      std::vector<
+          google::iam::admin::v1::ListServiceAccountKeysRequest::KeyType> const&
+          key_types,
+      Options options = {});
+
+  ///
+  /// Lists every [ServiceAccountKey][google.iam.admin.v1.ServiceAccountKey] for
+  /// a service account.
+  ///
   /// @param request
   /// @googleapis_link{google::iam::admin::v1::ListServiceAccountKeysRequest,google/iam/admin/v1/iam.proto#L657}
   /// @param options  Optional. Operation options.
@@ -657,6 +441,31 @@ class IAMClient {
   ///
   /// Gets a [ServiceAccountKey][google.iam.admin.v1.ServiceAccountKey].
   ///
+  /// @param name  Required. The resource name of the service account key in the
+  /// following format:
+  ///  `projects/{PROJECT_ID}/serviceAccounts/{ACCOUNT}/keys/{key}`.
+  ///  Using `-` as a wildcard for the `PROJECT_ID` will infer the project from
+  ///  the account. The `ACCOUNT` value can be the `email` address or the
+  ///  `unique_id` of the service account.
+  /// @param public_key_type  The output format of the public key requested.
+  ///  X509_PEM is the default output format.
+  /// @param options  Optional. Operation options.
+  /// @return
+  /// @googleapis_link{google::iam::admin::v1::ServiceAccountKey,google/iam/admin/v1/iam.proto#L741}
+  ///
+  /// [google.iam.admin.v1.GetServiceAccountKeyRequest]:
+  /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L698}
+  /// [google.iam.admin.v1.ServiceAccountKey]:
+  /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L741}
+  ///
+  StatusOr<google::iam::admin::v1::ServiceAccountKey> GetServiceAccountKey(
+      std::string const& name,
+      google::iam::admin::v1::ServiceAccountPublicKeyType public_key_type,
+      Options options = {});
+
+  ///
+  /// Gets a [ServiceAccountKey][google.iam.admin.v1.ServiceAccountKey].
+  ///
   /// @param request
   /// @googleapis_link{google::iam::admin::v1::GetServiceAccountKeyRequest,google/iam/admin/v1/iam.proto#L698}
   /// @param options  Optional. Operation options.
@@ -670,6 +479,37 @@ class IAMClient {
   ///
   StatusOr<google::iam::admin::v1::ServiceAccountKey> GetServiceAccountKey(
       google::iam::admin::v1::GetServiceAccountKeyRequest const& request,
+      Options options = {});
+
+  ///
+  /// Creates a [ServiceAccountKey][google.iam.admin.v1.ServiceAccountKey].
+  ///
+  /// @param name  Required. The resource name of the service account in the
+  /// following format:
+  ///  `projects/{PROJECT_ID}/serviceAccounts/{ACCOUNT}`.
+  ///  Using `-` as a wildcard for the `PROJECT_ID` will infer the project from
+  ///  the account. The `ACCOUNT` value can be the `email` address or the
+  ///  `unique_id` of the service account.
+  /// @param private_key_type  The output format of the private key. The default
+  /// value is
+  ///  `TYPE_GOOGLE_CREDENTIALS_FILE`, which is the Google Credentials File
+  ///  format.
+  /// @param key_algorithm  Which type of key and algorithm to use for the key.
+  ///  The default is currently a 2K RSA key.  However this may change in the
+  ///  future.
+  /// @param options  Optional. Operation options.
+  /// @return
+  /// @googleapis_link{google::iam::admin::v1::ServiceAccountKey,google/iam/admin/v1/iam.proto#L741}
+  ///
+  /// [google.iam.admin.v1.CreateServiceAccountKeyRequest]:
+  /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L791}
+  /// [google.iam.admin.v1.ServiceAccountKey]:
+  /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L741}
+  ///
+  StatusOr<google::iam::admin::v1::ServiceAccountKey> CreateServiceAccountKey(
+      std::string const& name,
+      google::iam::admin::v1::ServiceAccountPrivateKeyType private_key_type,
+      google::iam::admin::v1::ServiceAccountKeyAlgorithm key_algorithm,
       Options options = {});
 
   ///
@@ -714,6 +554,24 @@ class IAMClient {
   /// Deleting a service account key does not revoke short-lived credentials
   /// that have been issued based on the service account key.
   ///
+  /// @param name  Required. The resource name of the service account key in the
+  /// following format:
+  ///  `projects/{PROJECT_ID}/serviceAccounts/{ACCOUNT}/keys/{key}`.
+  ///  Using `-` as a wildcard for the `PROJECT_ID` will infer the project from
+  ///  the account. The `ACCOUNT` value can be the `email` address or the
+  ///  `unique_id` of the service account.
+  /// @param options  Optional. Operation options.
+  ///
+  /// [google.iam.admin.v1.DeleteServiceAccountKeyRequest]:
+  /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L832}
+  ///
+  Status DeleteServiceAccountKey(std::string const& name, Options options = {});
+
+  ///
+  /// Deletes a [ServiceAccountKey][google.iam.admin.v1.ServiceAccountKey].
+  /// Deleting a service account key does not revoke short-lived credentials
+  /// that have been issued based on the service account key.
+  ///
   /// @param request
   /// @googleapis_link{google::iam::admin::v1::DeleteServiceAccountKeyRequest,google/iam/admin/v1/iam.proto#L832}
   /// @param options  Optional. Operation options.
@@ -724,6 +582,34 @@ class IAMClient {
   Status DeleteServiceAccountKey(
       google::iam::admin::v1::DeleteServiceAccountKeyRequest const& request,
       Options options = {});
+
+  ///
+  /// Gets the IAM policy that is attached to a
+  /// [ServiceAccount][google.iam.admin.v1.ServiceAccount]. This IAM policy
+  /// specifies which members have access to the service account.
+  ///
+  /// This method does not tell you whether the service account has been granted
+  /// any roles on other resources. To check whether a service account has role
+  /// grants on a resource, use the `getIamPolicy` method for that resource. For
+  /// example, to view the role grants for a project, call the Resource Manager
+  /// API's
+  /// [`projects.getIamPolicy`](https://cloud.google.com/resource-manager/reference/rest/v1/projects/getIamPolicy)
+  /// method.
+  ///
+  /// @param resource  REQUIRED: The resource for which the policy is being
+  /// requested.
+  ///  See the operation documentation for the appropriate value for this field.
+  /// @param options  Optional. Operation options.
+  /// @return
+  /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
+  ///
+  /// [google.iam.v1.GetIamPolicyRequest]:
+  /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L113}
+  /// [google.iam.v1.Policy]:
+  /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
+  ///
+  StatusOr<google::iam::v1::Policy> GetIamPolicy(std::string const& resource,
+                                                 Options options = {});
 
   ///
   /// Gets the IAM policy that is attached to a
@@ -774,6 +660,73 @@ class IAMClient {
   /// [Granting roles to a service account for specific
   /// resources](https://cloud.google.com/iam/help/service-accounts/granting-access-to-service-accounts).
   ///
+  /// @param resource  REQUIRED: The resource for which the policy is being
+  /// specified.
+  ///  See the operation documentation for the appropriate value for this field.
+  /// @param policy  REQUIRED: The complete policy to be applied to the
+  /// `resource`. The size of
+  ///  the policy is limited to a few 10s of KB. An empty policy is a
+  ///  valid policy but certain Cloud Platform services (such as Projects)
+  ///  might reject them.
+  /// @param options  Optional. Operation options.
+  /// @return
+  /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
+  ///
+  /// [google.iam.v1.SetIamPolicyRequest]:
+  /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L98}
+  /// [google.iam.v1.Policy]:
+  /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
+  ///
+  StatusOr<google::iam::v1::Policy> SetIamPolicy(
+      std::string const& resource, google::iam::v1::Policy const& policy,
+      Options options = {});
+
+  /**
+   * Updates the IAM policy for @p resource using an optimistic concurrency
+   * control loop.
+   *
+   * The loop fetches the current policy for @p resource, and passes it to @p
+   * updater, which should return the new policy. This new policy should use the
+   * current etag so that the read-modify-write cycle can detect races and rerun
+   * the update when there is a mismatch. If the new policy does not have an
+   * etag, the existing policy will be blindly overwritten. If @p updater does
+   * not yield a policy, the control loop is terminated and kCancelled is
+   * returned.
+   *
+   * @param resource  Required. The resource for which the policy is being
+   * specified. See the operation documentation for the appropriate value for
+   * this field.
+   * @param updater  Required. Functor to map the current policy to a new one.
+   * @param options  Optional. Options to control the loop. Expected options
+   * are:
+   *       - `IAMBackoffPolicyOption`
+   * @return google::iam::v1::Policy
+   */
+  StatusOr<google::iam::v1::Policy> SetIamPolicy(std::string const& resource,
+                                                 IamUpdater const& updater,
+                                                 Options options = {});
+
+  ///
+  /// Sets the IAM policy that is attached to a
+  /// [ServiceAccount][google.iam.admin.v1.ServiceAccount].
+  ///
+  /// Use this method to grant or revoke access to the service account. For
+  /// example, you could grant a member the ability to impersonate the service
+  /// account.
+  ///
+  /// This method does not enable the service account to access other resources.
+  /// To grant roles to a service account on a resource, follow these steps:
+  ///
+  /// 1. Call the resource's `getIamPolicy` method to get its current IAM
+  /// policy.
+  /// 2. Edit the policy so that it binds the service account to an IAM role for
+  /// the resource.
+  /// 3. Call the resource's `setIamPolicy` method to update its IAM policy.
+  ///
+  /// For detailed instructions, see
+  /// [Granting roles to a service account for specific
+  /// resources](https://cloud.google.com/iam/help/service-accounts/granting-access-to-service-accounts).
+  ///
   /// @param request
   /// @googleapis_link{google::iam::v1::SetIamPolicyRequest,google/iam/v1/iam_policy.proto#L98}
   /// @param options  Optional. Operation options.
@@ -787,6 +740,31 @@ class IAMClient {
   ///
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
       google::iam::v1::SetIamPolicyRequest const& request,
+      Options options = {});
+
+  ///
+  /// Tests whether the caller has the specified permissions on a
+  /// [ServiceAccount][google.iam.admin.v1.ServiceAccount].
+  ///
+  /// @param resource  REQUIRED: The resource for which the policy detail is
+  /// being requested.
+  ///  See the operation documentation for the appropriate value for this field.
+  /// @param permissions  The set of permissions to check for the `resource`.
+  /// Permissions with
+  ///  wildcards (such as '*' or 'storage.*') are not allowed. For more
+  ///  information see
+  ///  [IAM Overview](https://cloud.google.com/iam/docs/overview#permissions).
+  /// @param options  Optional. Operation options.
+  /// @return
+  /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
+  ///
+  /// [google.iam.v1.TestIamPermissionsRequest]:
+  /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L126}
+  /// [google.iam.v1.TestIamPermissionsResponse]:
+  /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L141}
+  ///
+  StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
+      std::string const& resource, std::vector<std::string> const& permissions,
       Options options = {});
 
   ///
@@ -807,6 +785,28 @@ class IAMClient {
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
       google::iam::v1::TestIamPermissionsRequest const& request,
       Options options = {});
+
+  ///
+  /// Lists roles that can be granted on a Google Cloud resource. A role is
+  /// grantable if the IAM policy for the resource can contain bindings to the
+  /// role.
+  ///
+  /// @param full_resource_name  Required. The full resource name to query from
+  /// the list of grantable roles.
+  ///  The name follows the Google Cloud Platform resource format.
+  ///  For example, a Cloud Platform project with id `my-project` will be named
+  ///  `//cloudresourcemanager.googleapis.com/projects/my-project`.
+  /// @param options  Optional. Operation options.
+  /// @return
+  /// @googleapis_link{google::iam::admin::v1::Role,google/iam/admin/v1/iam.proto#L1004}
+  ///
+  /// [google.iam.admin.v1.QueryGrantableRolesRequest]:
+  /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L1062}
+  /// [google.iam.admin.v1.Role]:
+  /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L1004}
+  ///
+  StreamRange<google::iam::admin::v1::Role> QueryGrantableRoles(
+      std::string const& full_resource_name, Options options = {});
 
   ///
   /// Lists roles that can be granted on a Google Cloud resource. A role is

--- a/google/cloud/iam/iam_credentials_client.cc
+++ b/google/cloud/iam/iam_credentials_client.cc
@@ -47,6 +47,15 @@ IAMCredentialsClient::GenerateAccessToken(
   return connection_->GenerateAccessToken(request);
 }
 
+StatusOr<google::iam::credentials::v1::GenerateAccessTokenResponse>
+IAMCredentialsClient::GenerateAccessToken(
+    google::iam::credentials::v1::GenerateAccessTokenRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
+  return connection_->GenerateAccessToken(request);
+}
+
 StatusOr<google::iam::credentials::v1::GenerateIdTokenResponse>
 IAMCredentialsClient::GenerateIdToken(std::string const& name,
                                       std::vector<std::string> const& delegates,
@@ -59,6 +68,15 @@ IAMCredentialsClient::GenerateIdToken(std::string const& name,
   *request.mutable_delegates() = {delegates.begin(), delegates.end()};
   request.set_audience(audience);
   request.set_include_email(include_email);
+  return connection_->GenerateIdToken(request);
+}
+
+StatusOr<google::iam::credentials::v1::GenerateIdTokenResponse>
+IAMCredentialsClient::GenerateIdToken(
+    google::iam::credentials::v1::GenerateIdTokenRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->GenerateIdToken(request);
 }
 
@@ -75,6 +93,15 @@ IAMCredentialsClient::SignBlob(std::string const& name,
   return connection_->SignBlob(request);
 }
 
+StatusOr<google::iam::credentials::v1::SignBlobResponse>
+IAMCredentialsClient::SignBlob(
+    google::iam::credentials::v1::SignBlobRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
+  return connection_->SignBlob(request);
+}
+
 StatusOr<google::iam::credentials::v1::SignJwtResponse>
 IAMCredentialsClient::SignJwt(std::string const& name,
                               std::vector<std::string> const& delegates,
@@ -86,33 +113,6 @@ IAMCredentialsClient::SignJwt(std::string const& name,
   *request.mutable_delegates() = {delegates.begin(), delegates.end()};
   request.set_payload(payload);
   return connection_->SignJwt(request);
-}
-
-StatusOr<google::iam::credentials::v1::GenerateAccessTokenResponse>
-IAMCredentialsClient::GenerateAccessToken(
-    google::iam::credentials::v1::GenerateAccessTokenRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->GenerateAccessToken(request);
-}
-
-StatusOr<google::iam::credentials::v1::GenerateIdTokenResponse>
-IAMCredentialsClient::GenerateIdToken(
-    google::iam::credentials::v1::GenerateIdTokenRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->GenerateIdToken(request);
-}
-
-StatusOr<google::iam::credentials::v1::SignBlobResponse>
-IAMCredentialsClient::SignBlob(
-    google::iam::credentials::v1::SignBlobRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->SignBlob(request);
 }
 
 StatusOr<google::iam::credentials::v1::SignJwtResponse>

--- a/google/cloud/iam/iam_credentials_client.h
+++ b/google/cloud/iam/iam_credentials_client.h
@@ -140,6 +140,25 @@ class IAMCredentialsClient {
                       Options options = {});
 
   ///
+  /// Generates an OAuth 2.0 access token for a service account.
+  ///
+  /// @param request
+  /// @googleapis_link{google::iam::credentials::v1::GenerateAccessTokenRequest,google/iam/credentials/v1/common.proto#L35}
+  /// @param options  Optional. Operation options.
+  /// @return
+  /// @googleapis_link{google::iam::credentials::v1::GenerateAccessTokenResponse,google/iam/credentials/v1/common.proto#L72}
+  ///
+  /// [google.iam.credentials.v1.GenerateAccessTokenRequest]:
+  /// @googleapis_reference_link{google/iam/credentials/v1/common.proto#L35}
+  /// [google.iam.credentials.v1.GenerateAccessTokenResponse]:
+  /// @googleapis_reference_link{google/iam/credentials/v1/common.proto#L72}
+  ///
+  StatusOr<google::iam::credentials::v1::GenerateAccessTokenResponse>
+  GenerateAccessToken(
+      google::iam::credentials::v1::GenerateAccessTokenRequest const& request,
+      Options options = {});
+
+  ///
   /// Generates an OpenID Connect ID token for a service account.
   ///
   /// @param name  Required. The resource name of the service account for which
@@ -181,6 +200,25 @@ class IAMCredentialsClient {
                   Options options = {});
 
   ///
+  /// Generates an OpenID Connect ID token for a service account.
+  ///
+  /// @param request
+  /// @googleapis_link{google::iam::credentials::v1::GenerateIdTokenRequest,google/iam/credentials/v1/common.proto#L153}
+  /// @param options  Optional. Operation options.
+  /// @return
+  /// @googleapis_link{google::iam::credentials::v1::GenerateIdTokenResponse,google/iam/credentials/v1/common.proto#L186}
+  ///
+  /// [google.iam.credentials.v1.GenerateIdTokenRequest]:
+  /// @googleapis_reference_link{google/iam/credentials/v1/common.proto#L153}
+  /// [google.iam.credentials.v1.GenerateIdTokenResponse]:
+  /// @googleapis_reference_link{google/iam/credentials/v1/common.proto#L186}
+  ///
+  StatusOr<google::iam::credentials::v1::GenerateIdTokenResponse>
+  GenerateIdToken(
+      google::iam::credentials::v1::GenerateIdTokenRequest const& request,
+      Options options = {});
+
+  ///
   /// Signs a blob using a service account's system-managed private key.
   ///
   /// @param name  Required. The resource name of the service account for which
@@ -213,6 +251,24 @@ class IAMCredentialsClient {
   StatusOr<google::iam::credentials::v1::SignBlobResponse> SignBlob(
       std::string const& name, std::vector<std::string> const& delegates,
       std::string const& payload, Options options = {});
+
+  ///
+  /// Signs a blob using a service account's system-managed private key.
+  ///
+  /// @param request
+  /// @googleapis_link{google::iam::credentials::v1::SignBlobRequest,google/iam/credentials/v1/common.proto#L81}
+  /// @param options  Optional. Operation options.
+  /// @return
+  /// @googleapis_link{google::iam::credentials::v1::SignBlobResponse,google/iam/credentials/v1/common.proto#L109}
+  ///
+  /// [google.iam.credentials.v1.SignBlobRequest]:
+  /// @googleapis_reference_link{google/iam/credentials/v1/common.proto#L81}
+  /// [google.iam.credentials.v1.SignBlobResponse]:
+  /// @googleapis_reference_link{google/iam/credentials/v1/common.proto#L109}
+  ///
+  StatusOr<google::iam::credentials::v1::SignBlobResponse> SignBlob(
+      google::iam::credentials::v1::SignBlobRequest const& request,
+      Options options = {});
 
   ///
   /// Signs a JWT using a service account's system-managed private key.
@@ -248,62 +304,6 @@ class IAMCredentialsClient {
   StatusOr<google::iam::credentials::v1::SignJwtResponse> SignJwt(
       std::string const& name, std::vector<std::string> const& delegates,
       std::string const& payload, Options options = {});
-
-  ///
-  /// Generates an OAuth 2.0 access token for a service account.
-  ///
-  /// @param request
-  /// @googleapis_link{google::iam::credentials::v1::GenerateAccessTokenRequest,google/iam/credentials/v1/common.proto#L35}
-  /// @param options  Optional. Operation options.
-  /// @return
-  /// @googleapis_link{google::iam::credentials::v1::GenerateAccessTokenResponse,google/iam/credentials/v1/common.proto#L72}
-  ///
-  /// [google.iam.credentials.v1.GenerateAccessTokenRequest]:
-  /// @googleapis_reference_link{google/iam/credentials/v1/common.proto#L35}
-  /// [google.iam.credentials.v1.GenerateAccessTokenResponse]:
-  /// @googleapis_reference_link{google/iam/credentials/v1/common.proto#L72}
-  ///
-  StatusOr<google::iam::credentials::v1::GenerateAccessTokenResponse>
-  GenerateAccessToken(
-      google::iam::credentials::v1::GenerateAccessTokenRequest const& request,
-      Options options = {});
-
-  ///
-  /// Generates an OpenID Connect ID token for a service account.
-  ///
-  /// @param request
-  /// @googleapis_link{google::iam::credentials::v1::GenerateIdTokenRequest,google/iam/credentials/v1/common.proto#L153}
-  /// @param options  Optional. Operation options.
-  /// @return
-  /// @googleapis_link{google::iam::credentials::v1::GenerateIdTokenResponse,google/iam/credentials/v1/common.proto#L186}
-  ///
-  /// [google.iam.credentials.v1.GenerateIdTokenRequest]:
-  /// @googleapis_reference_link{google/iam/credentials/v1/common.proto#L153}
-  /// [google.iam.credentials.v1.GenerateIdTokenResponse]:
-  /// @googleapis_reference_link{google/iam/credentials/v1/common.proto#L186}
-  ///
-  StatusOr<google::iam::credentials::v1::GenerateIdTokenResponse>
-  GenerateIdToken(
-      google::iam::credentials::v1::GenerateIdTokenRequest const& request,
-      Options options = {});
-
-  ///
-  /// Signs a blob using a service account's system-managed private key.
-  ///
-  /// @param request
-  /// @googleapis_link{google::iam::credentials::v1::SignBlobRequest,google/iam/credentials/v1/common.proto#L81}
-  /// @param options  Optional. Operation options.
-  /// @return
-  /// @googleapis_link{google::iam::credentials::v1::SignBlobResponse,google/iam/credentials/v1/common.proto#L109}
-  ///
-  /// [google.iam.credentials.v1.SignBlobRequest]:
-  /// @googleapis_reference_link{google/iam/credentials/v1/common.proto#L81}
-  /// [google.iam.credentials.v1.SignBlobResponse]:
-  /// @googleapis_reference_link{google/iam/credentials/v1/common.proto#L109}
-  ///
-  StatusOr<google::iam::credentials::v1::SignBlobResponse> SignBlob(
-      google::iam::credentials::v1::SignBlobRequest const& request,
-      Options options = {});
 
   ///
   /// Signs a JWT using a service account's system-managed private key.

--- a/google/cloud/logging/logging_service_v2_client.cc
+++ b/google/cloud/logging/logging_service_v2_client.cc
@@ -41,6 +41,13 @@ Status LoggingServiceV2Client::DeleteLog(std::string const& log_name,
   return connection_->DeleteLog(request);
 }
 
+Status LoggingServiceV2Client::DeleteLog(
+    google::logging::v2::DeleteLogRequest const& request, Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
+  return connection_->DeleteLog(request);
+}
+
 StatusOr<google::logging::v2::WriteLogEntriesResponse>
 LoggingServiceV2Client::WriteLogEntries(
     std::string const& log_name, google::api::MonitoredResource const& resource,
@@ -54,6 +61,15 @@ LoggingServiceV2Client::WriteLogEntries(
   *request.mutable_resource() = resource;
   *request.mutable_labels() = {labels.begin(), labels.end()};
   *request.mutable_entries() = {entries.begin(), entries.end()};
+  return connection_->WriteLogEntries(request);
+}
+
+StatusOr<google::logging::v2::WriteLogEntriesResponse>
+LoggingServiceV2Client::WriteLogEntries(
+    google::logging::v2::WriteLogEntriesRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->WriteLogEntries(request);
 }
 
@@ -71,31 +87,6 @@ LoggingServiceV2Client::ListLogEntries(
   return connection_->ListLogEntries(request);
 }
 
-StreamRange<std::string> LoggingServiceV2Client::ListLogs(
-    std::string const& parent, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  google::logging::v2::ListLogsRequest request;
-  request.set_parent(parent);
-  return connection_->ListLogs(request);
-}
-
-Status LoggingServiceV2Client::DeleteLog(
-    google::logging::v2::DeleteLogRequest const& request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->DeleteLog(request);
-}
-
-StatusOr<google::logging::v2::WriteLogEntriesResponse>
-LoggingServiceV2Client::WriteLogEntries(
-    google::logging::v2::WriteLogEntriesRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->WriteLogEntries(request);
-}
-
 StreamRange<google::logging::v2::LogEntry>
 LoggingServiceV2Client::ListLogEntries(
     google::logging::v2::ListLogEntriesRequest request, Options options) {
@@ -111,6 +102,15 @@ LoggingServiceV2Client::ListMonitoredResourceDescriptors(
   internal::OptionsSpan span(
       internal::MergeOptions(std::move(options), options_));
   return connection_->ListMonitoredResourceDescriptors(std::move(request));
+}
+
+StreamRange<std::string> LoggingServiceV2Client::ListLogs(
+    std::string const& parent, Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
+  google::logging::v2::ListLogsRequest request;
+  request.set_parent(parent);
+  return connection_->ListLogs(request);
 }
 
 StreamRange<std::string> LoggingServiceV2Client::ListLogs(

--- a/google/cloud/logging/logging_service_v2_client.h
+++ b/google/cloud/logging/logging_service_v2_client.h
@@ -110,6 +110,22 @@ class LoggingServiceV2Client {
   Status DeleteLog(std::string const& log_name, Options options = {});
 
   ///
+  /// Deletes all the log entries in a log. The log reappears if it receives new
+  /// entries. Log entries written shortly before the delete operation might not
+  /// be deleted. Entries received after the delete operation with a timestamp
+  /// before the operation will be deleted.
+  ///
+  /// @param request
+  /// @googleapis_link{google::logging::v2::DeleteLogRequest,google/logging/v2/logging.proto#L140}
+  /// @param options  Optional. Operation options.
+  ///
+  /// [google.logging.v2.DeleteLogRequest]:
+  /// @googleapis_reference_link{google/logging/v2/logging.proto#L140}
+  ///
+  Status DeleteLog(google::logging::v2::DeleteLogRequest const& request,
+                   Options options = {});
+
+  ///
   /// Writes log entries to Logging. This API method is the
   /// only way to send log entries to Logging. This method
   /// is used, directly or indirectly, by the Logging agent
@@ -183,6 +199,30 @@ class LoggingServiceV2Client {
       Options options = {});
 
   ///
+  /// Writes log entries to Logging. This API method is the
+  /// only way to send log entries to Logging. This method
+  /// is used, directly or indirectly, by the Logging agent
+  /// (fluentd) and all logging libraries configured to use Logging.
+  /// A single request may contain log entries for a maximum of 1000
+  /// different resources (projects, organizations, billing accounts or
+  /// folders)
+  ///
+  /// @param request
+  /// @googleapis_link{google::logging::v2::WriteLogEntriesRequest,google/logging/v2/logging.proto#L162}
+  /// @param options  Optional. Operation options.
+  /// @return
+  /// @googleapis_link{google::logging::v2::WriteLogEntriesResponse,google/logging/v2/logging.proto#L243}
+  ///
+  /// [google.logging.v2.WriteLogEntriesRequest]:
+  /// @googleapis_reference_link{google/logging/v2/logging.proto#L162}
+  /// [google.logging.v2.WriteLogEntriesResponse]:
+  /// @googleapis_reference_link{google/logging/v2/logging.proto#L243}
+  ///
+  StatusOr<google::logging::v2::WriteLogEntriesResponse> WriteLogEntries(
+      google::logging::v2::WriteLogEntriesRequest const& request,
+      Options options = {});
+
+  ///
   /// Lists log entries.  Use this method to retrieve log entries that
   /// originated from a project/folder/organization/billing account.  For ways
   /// to export log entries, see [Exporting
@@ -231,64 +271,6 @@ class LoggingServiceV2Client {
       std::string const& order_by, Options options = {});
 
   ///
-  /// Lists the logs in projects, organizations, folders, or billing accounts.
-  /// Only logs that have entries are listed.
-  ///
-  /// @param parent  Required. The resource name that owns the logs:
-  ///      "projects/[PROJECT_ID]"
-  ///      "organizations/[ORGANIZATION_ID]"
-  ///      "billingAccounts/[BILLING_ACCOUNT_ID]"
-  ///      "folders/[FOLDER_ID]"
-  /// @param options  Optional. Operation options.
-  /// @return std::string
-  ///
-  /// [google.logging.v2.ListLogsRequest]:
-  /// @googleapis_reference_link{google/logging/v2/logging.proto#L356}
-  ///
-  StreamRange<std::string> ListLogs(std::string const& parent,
-                                    Options options = {});
-
-  ///
-  /// Deletes all the log entries in a log. The log reappears if it receives new
-  /// entries. Log entries written shortly before the delete operation might not
-  /// be deleted. Entries received after the delete operation with a timestamp
-  /// before the operation will be deleted.
-  ///
-  /// @param request
-  /// @googleapis_link{google::logging::v2::DeleteLogRequest,google/logging/v2/logging.proto#L140}
-  /// @param options  Optional. Operation options.
-  ///
-  /// [google.logging.v2.DeleteLogRequest]:
-  /// @googleapis_reference_link{google/logging/v2/logging.proto#L140}
-  ///
-  Status DeleteLog(google::logging::v2::DeleteLogRequest const& request,
-                   Options options = {});
-
-  ///
-  /// Writes log entries to Logging. This API method is the
-  /// only way to send log entries to Logging. This method
-  /// is used, directly or indirectly, by the Logging agent
-  /// (fluentd) and all logging libraries configured to use Logging.
-  /// A single request may contain log entries for a maximum of 1000
-  /// different resources (projects, organizations, billing accounts or
-  /// folders)
-  ///
-  /// @param request
-  /// @googleapis_link{google::logging::v2::WriteLogEntriesRequest,google/logging/v2/logging.proto#L162}
-  /// @param options  Optional. Operation options.
-  /// @return
-  /// @googleapis_link{google::logging::v2::WriteLogEntriesResponse,google/logging/v2/logging.proto#L243}
-  ///
-  /// [google.logging.v2.WriteLogEntriesRequest]:
-  /// @googleapis_reference_link{google/logging/v2/logging.proto#L162}
-  /// [google.logging.v2.WriteLogEntriesResponse]:
-  /// @googleapis_reference_link{google/logging/v2/logging.proto#L243}
-  ///
-  StatusOr<google::logging::v2::WriteLogEntriesResponse> WriteLogEntries(
-      google::logging::v2::WriteLogEntriesRequest const& request,
-      Options options = {});
-
-  ///
   /// Lists log entries.  Use this method to retrieve log entries that
   /// originated from a project/folder/organization/billing account.  For ways
   /// to export log entries, see [Exporting
@@ -326,6 +308,24 @@ class LoggingServiceV2Client {
   ListMonitoredResourceDescriptors(
       google::logging::v2::ListMonitoredResourceDescriptorsRequest request,
       Options options = {});
+
+  ///
+  /// Lists the logs in projects, organizations, folders, or billing accounts.
+  /// Only logs that have entries are listed.
+  ///
+  /// @param parent  Required. The resource name that owns the logs:
+  ///      "projects/[PROJECT_ID]"
+  ///      "organizations/[ORGANIZATION_ID]"
+  ///      "billingAccounts/[BILLING_ACCOUNT_ID]"
+  ///      "folders/[FOLDER_ID]"
+  /// @param options  Optional. Operation options.
+  /// @return std::string
+  ///
+  /// [google.logging.v2.ListLogsRequest]:
+  /// @googleapis_reference_link{google/logging/v2/logging.proto#L356}
+  ///
+  StreamRange<std::string> ListLogs(std::string const& parent,
+                                    Options options = {});
 
   ///
   /// Lists the logs in projects, organizations, folders, or billing accounts.

--- a/google/cloud/pubsublite/admin_client.cc
+++ b/google/cloud/pubsublite/admin_client.cc
@@ -46,12 +46,28 @@ StatusOr<google::cloud::pubsublite::v1::Topic> AdminServiceClient::CreateTopic(
   return connection_->CreateTopic(request);
 }
 
+StatusOr<google::cloud::pubsublite::v1::Topic> AdminServiceClient::CreateTopic(
+    google::cloud::pubsublite::v1::CreateTopicRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
+  return connection_->CreateTopic(request);
+}
+
 StatusOr<google::cloud::pubsublite::v1::Topic> AdminServiceClient::GetTopic(
     std::string const& name, Options options) {
   internal::OptionsSpan span(
       internal::MergeOptions(std::move(options), options_));
   google::cloud::pubsublite::v1::GetTopicRequest request;
   request.set_name(name);
+  return connection_->GetTopic(request);
+}
+
+StatusOr<google::cloud::pubsublite::v1::Topic> AdminServiceClient::GetTopic(
+    google::cloud::pubsublite::v1::GetTopicRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->GetTopic(request);
 }
 
@@ -65,6 +81,15 @@ AdminServiceClient::GetTopicPartitions(std::string const& name,
   return connection_->GetTopicPartitions(request);
 }
 
+StatusOr<google::cloud::pubsublite::v1::TopicPartitions>
+AdminServiceClient::GetTopicPartitions(
+    google::cloud::pubsublite::v1::GetTopicPartitionsRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
+  return connection_->GetTopicPartitions(request);
+}
+
 StreamRange<google::cloud::pubsublite::v1::Topic>
 AdminServiceClient::ListTopics(std::string const& parent, Options options) {
   internal::OptionsSpan span(
@@ -72,6 +97,14 @@ AdminServiceClient::ListTopics(std::string const& parent, Options options) {
   google::cloud::pubsublite::v1::ListTopicsRequest request;
   request.set_parent(parent);
   return connection_->ListTopics(request);
+}
+
+StreamRange<google::cloud::pubsublite::v1::Topic>
+AdminServiceClient::ListTopics(
+    google::cloud::pubsublite::v1::ListTopicsRequest request, Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
+  return connection_->ListTopics(std::move(request));
 }
 
 StatusOr<google::cloud::pubsublite::v1::Topic> AdminServiceClient::UpdateTopic(
@@ -85,12 +118,28 @@ StatusOr<google::cloud::pubsublite::v1::Topic> AdminServiceClient::UpdateTopic(
   return connection_->UpdateTopic(request);
 }
 
+StatusOr<google::cloud::pubsublite::v1::Topic> AdminServiceClient::UpdateTopic(
+    google::cloud::pubsublite::v1::UpdateTopicRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
+  return connection_->UpdateTopic(request);
+}
+
 Status AdminServiceClient::DeleteTopic(std::string const& name,
                                        Options options) {
   internal::OptionsSpan span(
       internal::MergeOptions(std::move(options), options_));
   google::cloud::pubsublite::v1::DeleteTopicRequest request;
   request.set_name(name);
+  return connection_->DeleteTopic(request);
+}
+
+Status AdminServiceClient::DeleteTopic(
+    google::cloud::pubsublite::v1::DeleteTopicRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->DeleteTopic(request);
 }
 
@@ -101,6 +150,14 @@ StreamRange<std::string> AdminServiceClient::ListTopicSubscriptions(
   google::cloud::pubsublite::v1::ListTopicSubscriptionsRequest request;
   request.set_name(name);
   return connection_->ListTopicSubscriptions(request);
+}
+
+StreamRange<std::string> AdminServiceClient::ListTopicSubscriptions(
+    google::cloud::pubsublite::v1::ListTopicSubscriptionsRequest request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
+  return connection_->ListTopicSubscriptions(std::move(request));
 }
 
 StatusOr<google::cloud::pubsublite::v1::Subscription>
@@ -118,11 +175,29 @@ AdminServiceClient::CreateSubscription(
 }
 
 StatusOr<google::cloud::pubsublite::v1::Subscription>
+AdminServiceClient::CreateSubscription(
+    google::cloud::pubsublite::v1::CreateSubscriptionRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
+  return connection_->CreateSubscription(request);
+}
+
+StatusOr<google::cloud::pubsublite::v1::Subscription>
 AdminServiceClient::GetSubscription(std::string const& name, Options options) {
   internal::OptionsSpan span(
       internal::MergeOptions(std::move(options), options_));
   google::cloud::pubsublite::v1::GetSubscriptionRequest request;
   request.set_name(name);
+  return connection_->GetSubscription(request);
+}
+
+StatusOr<google::cloud::pubsublite::v1::Subscription>
+AdminServiceClient::GetSubscription(
+    google::cloud::pubsublite::v1::GetSubscriptionRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->GetSubscription(request);
 }
 
@@ -134,6 +209,15 @@ AdminServiceClient::ListSubscriptions(std::string const& parent,
   google::cloud::pubsublite::v1::ListSubscriptionsRequest request;
   request.set_parent(parent);
   return connection_->ListSubscriptions(request);
+}
+
+StreamRange<google::cloud::pubsublite::v1::Subscription>
+AdminServiceClient::ListSubscriptions(
+    google::cloud::pubsublite::v1::ListSubscriptionsRequest request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
+  return connection_->ListSubscriptions(std::move(request));
 }
 
 StatusOr<google::cloud::pubsublite::v1::Subscription>
@@ -148,162 +232,6 @@ AdminServiceClient::UpdateSubscription(
   return connection_->UpdateSubscription(request);
 }
 
-Status AdminServiceClient::DeleteSubscription(std::string const& name,
-                                              Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  google::cloud::pubsublite::v1::DeleteSubscriptionRequest request;
-  request.set_name(name);
-  return connection_->DeleteSubscription(request);
-}
-
-StatusOr<google::cloud::pubsublite::v1::Reservation>
-AdminServiceClient::CreateReservation(
-    std::string const& parent,
-    google::cloud::pubsublite::v1::Reservation const& reservation,
-    std::string const& reservation_id, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  google::cloud::pubsublite::v1::CreateReservationRequest request;
-  request.set_parent(parent);
-  *request.mutable_reservation() = reservation;
-  request.set_reservation_id(reservation_id);
-  return connection_->CreateReservation(request);
-}
-
-StatusOr<google::cloud::pubsublite::v1::Reservation>
-AdminServiceClient::GetReservation(std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  google::cloud::pubsublite::v1::GetReservationRequest request;
-  request.set_name(name);
-  return connection_->GetReservation(request);
-}
-
-StreamRange<google::cloud::pubsublite::v1::Reservation>
-AdminServiceClient::ListReservations(std::string const& parent,
-                                     Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  google::cloud::pubsublite::v1::ListReservationsRequest request;
-  request.set_parent(parent);
-  return connection_->ListReservations(request);
-}
-
-StatusOr<google::cloud::pubsublite::v1::Reservation>
-AdminServiceClient::UpdateReservation(
-    google::cloud::pubsublite::v1::Reservation const& reservation,
-    google::protobuf::FieldMask const& update_mask, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  google::cloud::pubsublite::v1::UpdateReservationRequest request;
-  *request.mutable_reservation() = reservation;
-  *request.mutable_update_mask() = update_mask;
-  return connection_->UpdateReservation(request);
-}
-
-Status AdminServiceClient::DeleteReservation(std::string const& name,
-                                             Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  google::cloud::pubsublite::v1::DeleteReservationRequest request;
-  request.set_name(name);
-  return connection_->DeleteReservation(request);
-}
-
-StreamRange<std::string> AdminServiceClient::ListReservationTopics(
-    std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  google::cloud::pubsublite::v1::ListReservationTopicsRequest request;
-  request.set_name(name);
-  return connection_->ListReservationTopics(request);
-}
-
-StatusOr<google::cloud::pubsublite::v1::Topic> AdminServiceClient::CreateTopic(
-    google::cloud::pubsublite::v1::CreateTopicRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->CreateTopic(request);
-}
-
-StatusOr<google::cloud::pubsublite::v1::Topic> AdminServiceClient::GetTopic(
-    google::cloud::pubsublite::v1::GetTopicRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->GetTopic(request);
-}
-
-StatusOr<google::cloud::pubsublite::v1::TopicPartitions>
-AdminServiceClient::GetTopicPartitions(
-    google::cloud::pubsublite::v1::GetTopicPartitionsRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->GetTopicPartitions(request);
-}
-
-StreamRange<google::cloud::pubsublite::v1::Topic>
-AdminServiceClient::ListTopics(
-    google::cloud::pubsublite::v1::ListTopicsRequest request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->ListTopics(std::move(request));
-}
-
-StatusOr<google::cloud::pubsublite::v1::Topic> AdminServiceClient::UpdateTopic(
-    google::cloud::pubsublite::v1::UpdateTopicRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->UpdateTopic(request);
-}
-
-Status AdminServiceClient::DeleteTopic(
-    google::cloud::pubsublite::v1::DeleteTopicRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->DeleteTopic(request);
-}
-
-StreamRange<std::string> AdminServiceClient::ListTopicSubscriptions(
-    google::cloud::pubsublite::v1::ListTopicSubscriptionsRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->ListTopicSubscriptions(std::move(request));
-}
-
-StatusOr<google::cloud::pubsublite::v1::Subscription>
-AdminServiceClient::CreateSubscription(
-    google::cloud::pubsublite::v1::CreateSubscriptionRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->CreateSubscription(request);
-}
-
-StatusOr<google::cloud::pubsublite::v1::Subscription>
-AdminServiceClient::GetSubscription(
-    google::cloud::pubsublite::v1::GetSubscriptionRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->GetSubscription(request);
-}
-
-StreamRange<google::cloud::pubsublite::v1::Subscription>
-AdminServiceClient::ListSubscriptions(
-    google::cloud::pubsublite::v1::ListSubscriptionsRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->ListSubscriptions(std::move(request));
-}
-
 StatusOr<google::cloud::pubsublite::v1::Subscription>
 AdminServiceClient::UpdateSubscription(
     google::cloud::pubsublite::v1::UpdateSubscriptionRequest const& request,
@@ -311,6 +239,15 @@ AdminServiceClient::UpdateSubscription(
   internal::OptionsSpan span(
       internal::MergeOptions(std::move(options), options_));
   return connection_->UpdateSubscription(request);
+}
+
+Status AdminServiceClient::DeleteSubscription(std::string const& name,
+                                              Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
+  google::cloud::pubsublite::v1::DeleteSubscriptionRequest request;
+  request.set_name(name);
+  return connection_->DeleteSubscription(request);
 }
 
 Status AdminServiceClient::DeleteSubscription(
@@ -332,11 +269,34 @@ AdminServiceClient::SeekSubscription(
 
 StatusOr<google::cloud::pubsublite::v1::Reservation>
 AdminServiceClient::CreateReservation(
+    std::string const& parent,
+    google::cloud::pubsublite::v1::Reservation const& reservation,
+    std::string const& reservation_id, Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
+  google::cloud::pubsublite::v1::CreateReservationRequest request;
+  request.set_parent(parent);
+  *request.mutable_reservation() = reservation;
+  request.set_reservation_id(reservation_id);
+  return connection_->CreateReservation(request);
+}
+
+StatusOr<google::cloud::pubsublite::v1::Reservation>
+AdminServiceClient::CreateReservation(
     google::cloud::pubsublite::v1::CreateReservationRequest const& request,
     Options options) {
   internal::OptionsSpan span(
       internal::MergeOptions(std::move(options), options_));
   return connection_->CreateReservation(request);
+}
+
+StatusOr<google::cloud::pubsublite::v1::Reservation>
+AdminServiceClient::GetReservation(std::string const& name, Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
+  google::cloud::pubsublite::v1::GetReservationRequest request;
+  request.set_name(name);
+  return connection_->GetReservation(request);
 }
 
 StatusOr<google::cloud::pubsublite::v1::Reservation>
@@ -346,6 +306,16 @@ AdminServiceClient::GetReservation(
   internal::OptionsSpan span(
       internal::MergeOptions(std::move(options), options_));
   return connection_->GetReservation(request);
+}
+
+StreamRange<google::cloud::pubsublite::v1::Reservation>
+AdminServiceClient::ListReservations(std::string const& parent,
+                                     Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
+  google::cloud::pubsublite::v1::ListReservationsRequest request;
+  request.set_parent(parent);
+  return connection_->ListReservations(request);
 }
 
 StreamRange<google::cloud::pubsublite::v1::Reservation>
@@ -359,11 +329,32 @@ AdminServiceClient::ListReservations(
 
 StatusOr<google::cloud::pubsublite::v1::Reservation>
 AdminServiceClient::UpdateReservation(
+    google::cloud::pubsublite::v1::Reservation const& reservation,
+    google::protobuf::FieldMask const& update_mask, Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
+  google::cloud::pubsublite::v1::UpdateReservationRequest request;
+  *request.mutable_reservation() = reservation;
+  *request.mutable_update_mask() = update_mask;
+  return connection_->UpdateReservation(request);
+}
+
+StatusOr<google::cloud::pubsublite::v1::Reservation>
+AdminServiceClient::UpdateReservation(
     google::cloud::pubsublite::v1::UpdateReservationRequest const& request,
     Options options) {
   internal::OptionsSpan span(
       internal::MergeOptions(std::move(options), options_));
   return connection_->UpdateReservation(request);
+}
+
+Status AdminServiceClient::DeleteReservation(std::string const& name,
+                                             Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
+  google::cloud::pubsublite::v1::DeleteReservationRequest request;
+  request.set_name(name);
+  return connection_->DeleteReservation(request);
 }
 
 Status AdminServiceClient::DeleteReservation(
@@ -372,6 +363,15 @@ Status AdminServiceClient::DeleteReservation(
   internal::OptionsSpan span(
       internal::MergeOptions(std::move(options), options_));
   return connection_->DeleteReservation(request);
+}
+
+StreamRange<std::string> AdminServiceClient::ListReservationTopics(
+    std::string const& name, Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
+  google::cloud::pubsublite::v1::ListReservationTopicsRequest request;
+  request.set_name(name);
+  return connection_->ListReservationTopics(request);
 }
 
 StreamRange<std::string> AdminServiceClient::ListReservationTopics(

--- a/google/cloud/pubsublite/admin_client.h
+++ b/google/cloud/pubsublite/admin_client.h
@@ -113,6 +113,24 @@ class AdminServiceClient {
       std::string const& topic_id, Options options = {});
 
   ///
+  /// Creates a new topic.
+  ///
+  /// @param request
+  /// @googleapis_link{google::cloud::pubsublite::v1::CreateTopicRequest,google/cloud/pubsublite/v1/admin.proto#L227}
+  /// @param options  Optional. Operation options.
+  /// @return
+  /// @googleapis_link{google::cloud::pubsublite::v1::Topic,google/cloud/pubsublite/v1/common.proto#L102}
+  ///
+  /// [google.cloud.pubsublite.v1.CreateTopicRequest]:
+  /// @googleapis_reference_link{google/cloud/pubsublite/v1/admin.proto#L227}
+  /// [google.cloud.pubsublite.v1.Topic]:
+  /// @googleapis_reference_link{google/cloud/pubsublite/v1/common.proto#L102}
+  ///
+  StatusOr<google::cloud::pubsublite::v1::Topic> CreateTopic(
+      google::cloud::pubsublite::v1::CreateTopicRequest const& request,
+      Options options = {});
+
+  ///
   /// Returns the topic configuration.
   ///
   /// @param name  Required. The name of the topic whose configuration to
@@ -128,6 +146,24 @@ class AdminServiceClient {
   ///
   StatusOr<google::cloud::pubsublite::v1::Topic> GetTopic(
       std::string const& name, Options options = {});
+
+  ///
+  /// Returns the topic configuration.
+  ///
+  /// @param request
+  /// @googleapis_link{google::cloud::pubsublite::v1::GetTopicRequest,google/cloud/pubsublite/v1/admin.proto#L248}
+  /// @param options  Optional. Operation options.
+  /// @return
+  /// @googleapis_link{google::cloud::pubsublite::v1::Topic,google/cloud/pubsublite/v1/common.proto#L102}
+  ///
+  /// [google.cloud.pubsublite.v1.GetTopicRequest]:
+  /// @googleapis_reference_link{google/cloud/pubsublite/v1/admin.proto#L248}
+  /// [google.cloud.pubsublite.v1.Topic]:
+  /// @googleapis_reference_link{google/cloud/pubsublite/v1/common.proto#L102}
+  ///
+  StatusOr<google::cloud::pubsublite::v1::Topic> GetTopic(
+      google::cloud::pubsublite::v1::GetTopicRequest const& request,
+      Options options = {});
 
   ///
   /// Returns the partition information for the requested topic.
@@ -146,6 +182,24 @@ class AdminServiceClient {
       std::string const& name, Options options = {});
 
   ///
+  /// Returns the partition information for the requested topic.
+  ///
+  /// @param request
+  /// @googleapis_link{google::cloud::pubsublite::v1::GetTopicPartitionsRequest,google/cloud/pubsublite/v1/admin.proto#L259}
+  /// @param options  Optional. Operation options.
+  /// @return
+  /// @googleapis_link{google::cloud::pubsublite::v1::TopicPartitions,google/cloud/pubsublite/v1/admin.proto#L270}
+  ///
+  /// [google.cloud.pubsublite.v1.GetTopicPartitionsRequest]:
+  /// @googleapis_reference_link{google/cloud/pubsublite/v1/admin.proto#L259}
+  /// [google.cloud.pubsublite.v1.TopicPartitions]:
+  /// @googleapis_reference_link{google/cloud/pubsublite/v1/admin.proto#L270}
+  ///
+  StatusOr<google::cloud::pubsublite::v1::TopicPartitions> GetTopicPartitions(
+      google::cloud::pubsublite::v1::GetTopicPartitionsRequest const& request,
+      Options options = {});
+
+  ///
   /// Returns the list of topics for the given project.
   ///
   /// @param parent  Required. The parent whose topics are to be listed.
@@ -161,6 +215,24 @@ class AdminServiceClient {
   ///
   StreamRange<google::cloud::pubsublite::v1::Topic> ListTopics(
       std::string const& parent, Options options = {});
+
+  ///
+  /// Returns the list of topics for the given project.
+  ///
+  /// @param request
+  /// @googleapis_link{google::cloud::pubsublite::v1::ListTopicsRequest,google/cloud/pubsublite/v1/admin.proto#L276}
+  /// @param options  Optional. Operation options.
+  /// @return
+  /// @googleapis_link{google::cloud::pubsublite::v1::Topic,google/cloud/pubsublite/v1/common.proto#L102}
+  ///
+  /// [google.cloud.pubsublite.v1.ListTopicsRequest]:
+  /// @googleapis_reference_link{google/cloud/pubsublite/v1/admin.proto#L276}
+  /// [google.cloud.pubsublite.v1.Topic]:
+  /// @googleapis_reference_link{google/cloud/pubsublite/v1/common.proto#L102}
+  ///
+  StreamRange<google::cloud::pubsublite::v1::Topic> ListTopics(
+      google::cloud::pubsublite::v1::ListTopicsRequest request,
+      Options options = {});
 
   ///
   /// Updates properties of the specified topic.
@@ -183,6 +255,24 @@ class AdminServiceClient {
       google::protobuf::FieldMask const& update_mask, Options options = {});
 
   ///
+  /// Updates properties of the specified topic.
+  ///
+  /// @param request
+  /// @googleapis_link{google::cloud::pubsublite::v1::UpdateTopicRequest,google/cloud/pubsublite/v1/admin.proto#L311}
+  /// @param options  Optional. Operation options.
+  /// @return
+  /// @googleapis_link{google::cloud::pubsublite::v1::Topic,google/cloud/pubsublite/v1/common.proto#L102}
+  ///
+  /// [google.cloud.pubsublite.v1.UpdateTopicRequest]:
+  /// @googleapis_reference_link{google/cloud/pubsublite/v1/admin.proto#L311}
+  /// [google.cloud.pubsublite.v1.Topic]:
+  /// @googleapis_reference_link{google/cloud/pubsublite/v1/common.proto#L102}
+  ///
+  StatusOr<google::cloud::pubsublite::v1::Topic> UpdateTopic(
+      google::cloud::pubsublite::v1::UpdateTopicRequest const& request,
+      Options options = {});
+
+  ///
   /// Deletes the specified topic.
   ///
   /// @param name  Required. The name of the topic to delete.
@@ -192,6 +282,20 @@ class AdminServiceClient {
   /// @googleapis_reference_link{google/cloud/pubsublite/v1/admin.proto#L320}
   ///
   Status DeleteTopic(std::string const& name, Options options = {});
+
+  ///
+  /// Deletes the specified topic.
+  ///
+  /// @param request
+  /// @googleapis_link{google::cloud::pubsublite::v1::DeleteTopicRequest,google/cloud/pubsublite/v1/admin.proto#L320}
+  /// @param options  Optional. Operation options.
+  ///
+  /// [google.cloud.pubsublite.v1.DeleteTopicRequest]:
+  /// @googleapis_reference_link{google/cloud/pubsublite/v1/admin.proto#L320}
+  ///
+  Status DeleteTopic(
+      google::cloud::pubsublite::v1::DeleteTopicRequest const& request,
+      Options options = {});
 
   ///
   /// Lists the subscriptions attached to the specified topic.
@@ -205,6 +309,21 @@ class AdminServiceClient {
   ///
   StreamRange<std::string> ListTopicSubscriptions(std::string const& name,
                                                   Options options = {});
+
+  ///
+  /// Lists the subscriptions attached to the specified topic.
+  ///
+  /// @param request
+  /// @googleapis_link{google::cloud::pubsublite::v1::ListTopicSubscriptionsRequest,google/cloud/pubsublite/v1/admin.proto#L331}
+  /// @param options  Optional. Operation options.
+  /// @return std::string
+  ///
+  /// [google.cloud.pubsublite.v1.ListTopicSubscriptionsRequest]:
+  /// @googleapis_reference_link{google/cloud/pubsublite/v1/admin.proto#L331}
+  ///
+  StreamRange<std::string> ListTopicSubscriptions(
+      google::cloud::pubsublite::v1::ListTopicSubscriptionsRequest request,
+      Options options = {});
 
   ///
   /// Creates a new subscription.
@@ -233,6 +352,24 @@ class AdminServiceClient {
       std::string const& subscription_id, Options options = {});
 
   ///
+  /// Creates a new subscription.
+  ///
+  /// @param request
+  /// @googleapis_link{google::cloud::pubsublite::v1::CreateSubscriptionRequest,google/cloud/pubsublite/v1/admin.proto#L365}
+  /// @param options  Optional. Operation options.
+  /// @return
+  /// @googleapis_link{google::cloud::pubsublite::v1::Subscription,google/cloud/pubsublite/v1/common.proto#L186}
+  ///
+  /// [google.cloud.pubsublite.v1.CreateSubscriptionRequest]:
+  /// @googleapis_reference_link{google/cloud/pubsublite/v1/admin.proto#L365}
+  /// [google.cloud.pubsublite.v1.Subscription]:
+  /// @googleapis_reference_link{google/cloud/pubsublite/v1/common.proto#L186}
+  ///
+  StatusOr<google::cloud::pubsublite::v1::Subscription> CreateSubscription(
+      google::cloud::pubsublite::v1::CreateSubscriptionRequest const& request,
+      Options options = {});
+
+  ///
   /// Returns the subscription configuration.
   ///
   /// @param name  Required. The name of the subscription whose configuration to
@@ -250,6 +387,24 @@ class AdminServiceClient {
       std::string const& name, Options options = {});
 
   ///
+  /// Returns the subscription configuration.
+  ///
+  /// @param request
+  /// @googleapis_link{google::cloud::pubsublite::v1::GetSubscriptionRequest,google/cloud/pubsublite/v1/admin.proto#L391}
+  /// @param options  Optional. Operation options.
+  /// @return
+  /// @googleapis_link{google::cloud::pubsublite::v1::Subscription,google/cloud/pubsublite/v1/common.proto#L186}
+  ///
+  /// [google.cloud.pubsublite.v1.GetSubscriptionRequest]:
+  /// @googleapis_reference_link{google/cloud/pubsublite/v1/admin.proto#L391}
+  /// [google.cloud.pubsublite.v1.Subscription]:
+  /// @googleapis_reference_link{google/cloud/pubsublite/v1/common.proto#L186}
+  ///
+  StatusOr<google::cloud::pubsublite::v1::Subscription> GetSubscription(
+      google::cloud::pubsublite::v1::GetSubscriptionRequest const& request,
+      Options options = {});
+
+  ///
   /// Returns the list of subscriptions for the given project.
   ///
   /// @param parent  Required. The parent whose subscriptions are to be listed.
@@ -265,6 +420,24 @@ class AdminServiceClient {
   ///
   StreamRange<google::cloud::pubsublite::v1::Subscription> ListSubscriptions(
       std::string const& parent, Options options = {});
+
+  ///
+  /// Returns the list of subscriptions for the given project.
+  ///
+  /// @param request
+  /// @googleapis_link{google::cloud::pubsublite::v1::ListSubscriptionsRequest,google/cloud/pubsublite/v1/admin.proto#L402}
+  /// @param options  Optional. Operation options.
+  /// @return
+  /// @googleapis_link{google::cloud::pubsublite::v1::Subscription,google/cloud/pubsublite/v1/common.proto#L186}
+  ///
+  /// [google.cloud.pubsublite.v1.ListSubscriptionsRequest]:
+  /// @googleapis_reference_link{google/cloud/pubsublite/v1/admin.proto#L402}
+  /// [google.cloud.pubsublite.v1.Subscription]:
+  /// @googleapis_reference_link{google/cloud/pubsublite/v1/common.proto#L186}
+  ///
+  StreamRange<google::cloud::pubsublite::v1::Subscription> ListSubscriptions(
+      google::cloud::pubsublite::v1::ListSubscriptionsRequest request,
+      Options options = {});
 
   ///
   /// Updates properties of the specified subscription.
@@ -288,300 +461,6 @@ class AdminServiceClient {
       google::protobuf::FieldMask const& update_mask, Options options = {});
 
   ///
-  /// Deletes the specified subscription.
-  ///
-  /// @param name  Required. The name of the subscription to delete.
-  /// @param options  Optional. Operation options.
-  ///
-  /// [google.cloud.pubsublite.v1.DeleteSubscriptionRequest]:
-  /// @googleapis_reference_link{google/cloud/pubsublite/v1/admin.proto#L447}
-  ///
-  Status DeleteSubscription(std::string const& name, Options options = {});
-
-  ///
-  /// Creates a new reservation.
-  ///
-  /// @param parent  Required. The parent location in which to create the
-  /// reservation.
-  ///  Structured like `projects/{project_number}/locations/{location}`.
-  /// @param reservation  Required. Configuration of the reservation to create.
-  /// Its `name` field is ignored.
-  /// @param reservation_id  Required. The ID to use for the reservation, which
-  /// will become the final component of
-  ///  the reservation's name.
-  ///  This value is structured like: `my-reservation-name`.
-  /// @param options  Optional. Operation options.
-  /// @return
-  /// @googleapis_link{google::cloud::pubsublite::v1::Reservation,google/cloud/pubsublite/v1/common.proto#L80}
-  ///
-  /// [google.cloud.pubsublite.v1.CreateReservationRequest]:
-  /// @googleapis_reference_link{google/cloud/pubsublite/v1/admin.proto#L516}
-  /// [google.cloud.pubsublite.v1.Reservation]:
-  /// @googleapis_reference_link{google/cloud/pubsublite/v1/common.proto#L80}
-  ///
-  StatusOr<google::cloud::pubsublite::v1::Reservation> CreateReservation(
-      std::string const& parent,
-      google::cloud::pubsublite::v1::Reservation const& reservation,
-      std::string const& reservation_id, Options options = {});
-
-  ///
-  /// Returns the reservation configuration.
-  ///
-  /// @param name  Required. The name of the reservation whose configuration to
-  /// return.
-  ///  Structured like:
-  ///  projects/{project_number}/locations/{location}/reservations/{reservation_id}
-  /// @param options  Optional. Operation options.
-  /// @return
-  /// @googleapis_link{google::cloud::pubsublite::v1::Reservation,google/cloud/pubsublite/v1/common.proto#L80}
-  ///
-  /// [google.cloud.pubsublite.v1.GetReservationRequest]:
-  /// @googleapis_reference_link{google/cloud/pubsublite/v1/admin.proto#L537}
-  /// [google.cloud.pubsublite.v1.Reservation]:
-  /// @googleapis_reference_link{google/cloud/pubsublite/v1/common.proto#L80}
-  ///
-  StatusOr<google::cloud::pubsublite::v1::Reservation> GetReservation(
-      std::string const& name, Options options = {});
-
-  ///
-  /// Returns the list of reservations for the given project.
-  ///
-  /// @param parent  Required. The parent whose reservations are to be listed.
-  ///  Structured like `projects/{project_number}/locations/{location}`.
-  /// @param options  Optional. Operation options.
-  /// @return
-  /// @googleapis_link{google::cloud::pubsublite::v1::Reservation,google/cloud/pubsublite/v1/common.proto#L80}
-  ///
-  /// [google.cloud.pubsublite.v1.ListReservationsRequest]:
-  /// @googleapis_reference_link{google/cloud/pubsublite/v1/admin.proto#L550}
-  /// [google.cloud.pubsublite.v1.Reservation]:
-  /// @googleapis_reference_link{google/cloud/pubsublite/v1/common.proto#L80}
-  ///
-  StreamRange<google::cloud::pubsublite::v1::Reservation> ListReservations(
-      std::string const& parent, Options options = {});
-
-  ///
-  /// Updates properties of the specified reservation.
-  ///
-  /// @param reservation  Required. The reservation to update. Its `name` field
-  /// must be populated.
-  /// @param update_mask  Required. A mask specifying the reservation fields to
-  /// change.
-  /// @param options  Optional. Operation options.
-  /// @return
-  /// @googleapis_link{google::cloud::pubsublite::v1::Reservation,google/cloud/pubsublite/v1/common.proto#L80}
-  ///
-  /// [google.cloud.pubsublite.v1.UpdateReservationRequest]:
-  /// @googleapis_reference_link{google/cloud/pubsublite/v1/admin.proto#L585}
-  /// [google.cloud.pubsublite.v1.Reservation]:
-  /// @googleapis_reference_link{google/cloud/pubsublite/v1/common.proto#L80}
-  ///
-  StatusOr<google::cloud::pubsublite::v1::Reservation> UpdateReservation(
-      google::cloud::pubsublite::v1::Reservation const& reservation,
-      google::protobuf::FieldMask const& update_mask, Options options = {});
-
-  ///
-  /// Deletes the specified reservation.
-  ///
-  /// @param name  Required. The name of the reservation to delete.
-  ///  Structured like:
-  ///  projects/{project_number}/locations/{location}/reservations/{reservation_id}
-  /// @param options  Optional. Operation options.
-  ///
-  /// [google.cloud.pubsublite.v1.DeleteReservationRequest]:
-  /// @googleapis_reference_link{google/cloud/pubsublite/v1/admin.proto#L594}
-  ///
-  Status DeleteReservation(std::string const& name, Options options = {});
-
-  ///
-  /// Lists the topics attached to the specified reservation.
-  ///
-  /// @param name  Required. The name of the reservation whose topics to list.
-  ///  Structured like:
-  ///  projects/{project_number}/locations/{location}/reservations/{reservation_id}
-  /// @param options  Optional. Operation options.
-  /// @return std::string
-  ///
-  /// [google.cloud.pubsublite.v1.ListReservationTopicsRequest]:
-  /// @googleapis_reference_link{google/cloud/pubsublite/v1/admin.proto#L607}
-  ///
-  StreamRange<std::string> ListReservationTopics(std::string const& name,
-                                                 Options options = {});
-
-  ///
-  /// Creates a new topic.
-  ///
-  /// @param request
-  /// @googleapis_link{google::cloud::pubsublite::v1::CreateTopicRequest,google/cloud/pubsublite/v1/admin.proto#L227}
-  /// @param options  Optional. Operation options.
-  /// @return
-  /// @googleapis_link{google::cloud::pubsublite::v1::Topic,google/cloud/pubsublite/v1/common.proto#L102}
-  ///
-  /// [google.cloud.pubsublite.v1.CreateTopicRequest]:
-  /// @googleapis_reference_link{google/cloud/pubsublite/v1/admin.proto#L227}
-  /// [google.cloud.pubsublite.v1.Topic]:
-  /// @googleapis_reference_link{google/cloud/pubsublite/v1/common.proto#L102}
-  ///
-  StatusOr<google::cloud::pubsublite::v1::Topic> CreateTopic(
-      google::cloud::pubsublite::v1::CreateTopicRequest const& request,
-      Options options = {});
-
-  ///
-  /// Returns the topic configuration.
-  ///
-  /// @param request
-  /// @googleapis_link{google::cloud::pubsublite::v1::GetTopicRequest,google/cloud/pubsublite/v1/admin.proto#L248}
-  /// @param options  Optional. Operation options.
-  /// @return
-  /// @googleapis_link{google::cloud::pubsublite::v1::Topic,google/cloud/pubsublite/v1/common.proto#L102}
-  ///
-  /// [google.cloud.pubsublite.v1.GetTopicRequest]:
-  /// @googleapis_reference_link{google/cloud/pubsublite/v1/admin.proto#L248}
-  /// [google.cloud.pubsublite.v1.Topic]:
-  /// @googleapis_reference_link{google/cloud/pubsublite/v1/common.proto#L102}
-  ///
-  StatusOr<google::cloud::pubsublite::v1::Topic> GetTopic(
-      google::cloud::pubsublite::v1::GetTopicRequest const& request,
-      Options options = {});
-
-  ///
-  /// Returns the partition information for the requested topic.
-  ///
-  /// @param request
-  /// @googleapis_link{google::cloud::pubsublite::v1::GetTopicPartitionsRequest,google/cloud/pubsublite/v1/admin.proto#L259}
-  /// @param options  Optional. Operation options.
-  /// @return
-  /// @googleapis_link{google::cloud::pubsublite::v1::TopicPartitions,google/cloud/pubsublite/v1/admin.proto#L270}
-  ///
-  /// [google.cloud.pubsublite.v1.GetTopicPartitionsRequest]:
-  /// @googleapis_reference_link{google/cloud/pubsublite/v1/admin.proto#L259}
-  /// [google.cloud.pubsublite.v1.TopicPartitions]:
-  /// @googleapis_reference_link{google/cloud/pubsublite/v1/admin.proto#L270}
-  ///
-  StatusOr<google::cloud::pubsublite::v1::TopicPartitions> GetTopicPartitions(
-      google::cloud::pubsublite::v1::GetTopicPartitionsRequest const& request,
-      Options options = {});
-
-  ///
-  /// Returns the list of topics for the given project.
-  ///
-  /// @param request
-  /// @googleapis_link{google::cloud::pubsublite::v1::ListTopicsRequest,google/cloud/pubsublite/v1/admin.proto#L276}
-  /// @param options  Optional. Operation options.
-  /// @return
-  /// @googleapis_link{google::cloud::pubsublite::v1::Topic,google/cloud/pubsublite/v1/common.proto#L102}
-  ///
-  /// [google.cloud.pubsublite.v1.ListTopicsRequest]:
-  /// @googleapis_reference_link{google/cloud/pubsublite/v1/admin.proto#L276}
-  /// [google.cloud.pubsublite.v1.Topic]:
-  /// @googleapis_reference_link{google/cloud/pubsublite/v1/common.proto#L102}
-  ///
-  StreamRange<google::cloud::pubsublite::v1::Topic> ListTopics(
-      google::cloud::pubsublite::v1::ListTopicsRequest request,
-      Options options = {});
-
-  ///
-  /// Updates properties of the specified topic.
-  ///
-  /// @param request
-  /// @googleapis_link{google::cloud::pubsublite::v1::UpdateTopicRequest,google/cloud/pubsublite/v1/admin.proto#L311}
-  /// @param options  Optional. Operation options.
-  /// @return
-  /// @googleapis_link{google::cloud::pubsublite::v1::Topic,google/cloud/pubsublite/v1/common.proto#L102}
-  ///
-  /// [google.cloud.pubsublite.v1.UpdateTopicRequest]:
-  /// @googleapis_reference_link{google/cloud/pubsublite/v1/admin.proto#L311}
-  /// [google.cloud.pubsublite.v1.Topic]:
-  /// @googleapis_reference_link{google/cloud/pubsublite/v1/common.proto#L102}
-  ///
-  StatusOr<google::cloud::pubsublite::v1::Topic> UpdateTopic(
-      google::cloud::pubsublite::v1::UpdateTopicRequest const& request,
-      Options options = {});
-
-  ///
-  /// Deletes the specified topic.
-  ///
-  /// @param request
-  /// @googleapis_link{google::cloud::pubsublite::v1::DeleteTopicRequest,google/cloud/pubsublite/v1/admin.proto#L320}
-  /// @param options  Optional. Operation options.
-  ///
-  /// [google.cloud.pubsublite.v1.DeleteTopicRequest]:
-  /// @googleapis_reference_link{google/cloud/pubsublite/v1/admin.proto#L320}
-  ///
-  Status DeleteTopic(
-      google::cloud::pubsublite::v1::DeleteTopicRequest const& request,
-      Options options = {});
-
-  ///
-  /// Lists the subscriptions attached to the specified topic.
-  ///
-  /// @param request
-  /// @googleapis_link{google::cloud::pubsublite::v1::ListTopicSubscriptionsRequest,google/cloud/pubsublite/v1/admin.proto#L331}
-  /// @param options  Optional. Operation options.
-  /// @return std::string
-  ///
-  /// [google.cloud.pubsublite.v1.ListTopicSubscriptionsRequest]:
-  /// @googleapis_reference_link{google/cloud/pubsublite/v1/admin.proto#L331}
-  ///
-  StreamRange<std::string> ListTopicSubscriptions(
-      google::cloud::pubsublite::v1::ListTopicSubscriptionsRequest request,
-      Options options = {});
-
-  ///
-  /// Creates a new subscription.
-  ///
-  /// @param request
-  /// @googleapis_link{google::cloud::pubsublite::v1::CreateSubscriptionRequest,google/cloud/pubsublite/v1/admin.proto#L365}
-  /// @param options  Optional. Operation options.
-  /// @return
-  /// @googleapis_link{google::cloud::pubsublite::v1::Subscription,google/cloud/pubsublite/v1/common.proto#L186}
-  ///
-  /// [google.cloud.pubsublite.v1.CreateSubscriptionRequest]:
-  /// @googleapis_reference_link{google/cloud/pubsublite/v1/admin.proto#L365}
-  /// [google.cloud.pubsublite.v1.Subscription]:
-  /// @googleapis_reference_link{google/cloud/pubsublite/v1/common.proto#L186}
-  ///
-  StatusOr<google::cloud::pubsublite::v1::Subscription> CreateSubscription(
-      google::cloud::pubsublite::v1::CreateSubscriptionRequest const& request,
-      Options options = {});
-
-  ///
-  /// Returns the subscription configuration.
-  ///
-  /// @param request
-  /// @googleapis_link{google::cloud::pubsublite::v1::GetSubscriptionRequest,google/cloud/pubsublite/v1/admin.proto#L391}
-  /// @param options  Optional. Operation options.
-  /// @return
-  /// @googleapis_link{google::cloud::pubsublite::v1::Subscription,google/cloud/pubsublite/v1/common.proto#L186}
-  ///
-  /// [google.cloud.pubsublite.v1.GetSubscriptionRequest]:
-  /// @googleapis_reference_link{google/cloud/pubsublite/v1/admin.proto#L391}
-  /// [google.cloud.pubsublite.v1.Subscription]:
-  /// @googleapis_reference_link{google/cloud/pubsublite/v1/common.proto#L186}
-  ///
-  StatusOr<google::cloud::pubsublite::v1::Subscription> GetSubscription(
-      google::cloud::pubsublite::v1::GetSubscriptionRequest const& request,
-      Options options = {});
-
-  ///
-  /// Returns the list of subscriptions for the given project.
-  ///
-  /// @param request
-  /// @googleapis_link{google::cloud::pubsublite::v1::ListSubscriptionsRequest,google/cloud/pubsublite/v1/admin.proto#L402}
-  /// @param options  Optional. Operation options.
-  /// @return
-  /// @googleapis_link{google::cloud::pubsublite::v1::Subscription,google/cloud/pubsublite/v1/common.proto#L186}
-  ///
-  /// [google.cloud.pubsublite.v1.ListSubscriptionsRequest]:
-  /// @googleapis_reference_link{google/cloud/pubsublite/v1/admin.proto#L402}
-  /// [google.cloud.pubsublite.v1.Subscription]:
-  /// @googleapis_reference_link{google/cloud/pubsublite/v1/common.proto#L186}
-  ///
-  StreamRange<google::cloud::pubsublite::v1::Subscription> ListSubscriptions(
-      google::cloud::pubsublite::v1::ListSubscriptionsRequest request,
-      Options options = {});
-
-  ///
   /// Updates properties of the specified subscription.
   ///
   /// @param request
@@ -598,6 +477,17 @@ class AdminServiceClient {
   StatusOr<google::cloud::pubsublite::v1::Subscription> UpdateSubscription(
       google::cloud::pubsublite::v1::UpdateSubscriptionRequest const& request,
       Options options = {});
+
+  ///
+  /// Deletes the specified subscription.
+  ///
+  /// @param name  Required. The name of the subscription to delete.
+  /// @param options  Optional. Operation options.
+  ///
+  /// [google.cloud.pubsublite.v1.DeleteSubscriptionRequest]:
+  /// @googleapis_reference_link{google/cloud/pubsublite/v1/admin.proto#L447}
+  ///
+  Status DeleteSubscription(std::string const& name, Options options = {});
 
   ///
   /// Deletes the specified subscription.
@@ -655,6 +545,32 @@ class AdminServiceClient {
   ///
   /// Creates a new reservation.
   ///
+  /// @param parent  Required. The parent location in which to create the
+  /// reservation.
+  ///  Structured like `projects/{project_number}/locations/{location}`.
+  /// @param reservation  Required. Configuration of the reservation to create.
+  /// Its `name` field is ignored.
+  /// @param reservation_id  Required. The ID to use for the reservation, which
+  /// will become the final component of
+  ///  the reservation's name.
+  ///  This value is structured like: `my-reservation-name`.
+  /// @param options  Optional. Operation options.
+  /// @return
+  /// @googleapis_link{google::cloud::pubsublite::v1::Reservation,google/cloud/pubsublite/v1/common.proto#L80}
+  ///
+  /// [google.cloud.pubsublite.v1.CreateReservationRequest]:
+  /// @googleapis_reference_link{google/cloud/pubsublite/v1/admin.proto#L516}
+  /// [google.cloud.pubsublite.v1.Reservation]:
+  /// @googleapis_reference_link{google/cloud/pubsublite/v1/common.proto#L80}
+  ///
+  StatusOr<google::cloud::pubsublite::v1::Reservation> CreateReservation(
+      std::string const& parent,
+      google::cloud::pubsublite::v1::Reservation const& reservation,
+      std::string const& reservation_id, Options options = {});
+
+  ///
+  /// Creates a new reservation.
+  ///
   /// @param request
   /// @googleapis_link{google::cloud::pubsublite::v1::CreateReservationRequest,google/cloud/pubsublite/v1/admin.proto#L516}
   /// @param options  Optional. Operation options.
@@ -669,6 +585,25 @@ class AdminServiceClient {
   StatusOr<google::cloud::pubsublite::v1::Reservation> CreateReservation(
       google::cloud::pubsublite::v1::CreateReservationRequest const& request,
       Options options = {});
+
+  ///
+  /// Returns the reservation configuration.
+  ///
+  /// @param name  Required. The name of the reservation whose configuration to
+  /// return.
+  ///  Structured like:
+  ///  projects/{project_number}/locations/{location}/reservations/{reservation_id}
+  /// @param options  Optional. Operation options.
+  /// @return
+  /// @googleapis_link{google::cloud::pubsublite::v1::Reservation,google/cloud/pubsublite/v1/common.proto#L80}
+  ///
+  /// [google.cloud.pubsublite.v1.GetReservationRequest]:
+  /// @googleapis_reference_link{google/cloud/pubsublite/v1/admin.proto#L537}
+  /// [google.cloud.pubsublite.v1.Reservation]:
+  /// @googleapis_reference_link{google/cloud/pubsublite/v1/common.proto#L80}
+  ///
+  StatusOr<google::cloud::pubsublite::v1::Reservation> GetReservation(
+      std::string const& name, Options options = {});
 
   ///
   /// Returns the reservation configuration.
@@ -691,6 +626,23 @@ class AdminServiceClient {
   ///
   /// Returns the list of reservations for the given project.
   ///
+  /// @param parent  Required. The parent whose reservations are to be listed.
+  ///  Structured like `projects/{project_number}/locations/{location}`.
+  /// @param options  Optional. Operation options.
+  /// @return
+  /// @googleapis_link{google::cloud::pubsublite::v1::Reservation,google/cloud/pubsublite/v1/common.proto#L80}
+  ///
+  /// [google.cloud.pubsublite.v1.ListReservationsRequest]:
+  /// @googleapis_reference_link{google/cloud/pubsublite/v1/admin.proto#L550}
+  /// [google.cloud.pubsublite.v1.Reservation]:
+  /// @googleapis_reference_link{google/cloud/pubsublite/v1/common.proto#L80}
+  ///
+  StreamRange<google::cloud::pubsublite::v1::Reservation> ListReservations(
+      std::string const& parent, Options options = {});
+
+  ///
+  /// Returns the list of reservations for the given project.
+  ///
   /// @param request
   /// @googleapis_link{google::cloud::pubsublite::v1::ListReservationsRequest,google/cloud/pubsublite/v1/admin.proto#L550}
   /// @param options  Optional. Operation options.
@@ -705,6 +657,26 @@ class AdminServiceClient {
   StreamRange<google::cloud::pubsublite::v1::Reservation> ListReservations(
       google::cloud::pubsublite::v1::ListReservationsRequest request,
       Options options = {});
+
+  ///
+  /// Updates properties of the specified reservation.
+  ///
+  /// @param reservation  Required. The reservation to update. Its `name` field
+  /// must be populated.
+  /// @param update_mask  Required. A mask specifying the reservation fields to
+  /// change.
+  /// @param options  Optional. Operation options.
+  /// @return
+  /// @googleapis_link{google::cloud::pubsublite::v1::Reservation,google/cloud/pubsublite/v1/common.proto#L80}
+  ///
+  /// [google.cloud.pubsublite.v1.UpdateReservationRequest]:
+  /// @googleapis_reference_link{google/cloud/pubsublite/v1/admin.proto#L585}
+  /// [google.cloud.pubsublite.v1.Reservation]:
+  /// @googleapis_reference_link{google/cloud/pubsublite/v1/common.proto#L80}
+  ///
+  StatusOr<google::cloud::pubsublite::v1::Reservation> UpdateReservation(
+      google::cloud::pubsublite::v1::Reservation const& reservation,
+      google::protobuf::FieldMask const& update_mask, Options options = {});
 
   ///
   /// Updates properties of the specified reservation.
@@ -727,6 +699,19 @@ class AdminServiceClient {
   ///
   /// Deletes the specified reservation.
   ///
+  /// @param name  Required. The name of the reservation to delete.
+  ///  Structured like:
+  ///  projects/{project_number}/locations/{location}/reservations/{reservation_id}
+  /// @param options  Optional. Operation options.
+  ///
+  /// [google.cloud.pubsublite.v1.DeleteReservationRequest]:
+  /// @googleapis_reference_link{google/cloud/pubsublite/v1/admin.proto#L594}
+  ///
+  Status DeleteReservation(std::string const& name, Options options = {});
+
+  ///
+  /// Deletes the specified reservation.
+  ///
   /// @param request
   /// @googleapis_link{google::cloud::pubsublite::v1::DeleteReservationRequest,google/cloud/pubsublite/v1/admin.proto#L594}
   /// @param options  Optional. Operation options.
@@ -737,6 +722,21 @@ class AdminServiceClient {
   Status DeleteReservation(
       google::cloud::pubsublite::v1::DeleteReservationRequest const& request,
       Options options = {});
+
+  ///
+  /// Lists the topics attached to the specified reservation.
+  ///
+  /// @param name  Required. The name of the reservation whose topics to list.
+  ///  Structured like:
+  ///  projects/{project_number}/locations/{location}/reservations/{reservation_id}
+  /// @param options  Optional. Operation options.
+  /// @return std::string
+  ///
+  /// [google.cloud.pubsublite.v1.ListReservationTopicsRequest]:
+  /// @googleapis_reference_link{google/cloud/pubsublite/v1/admin.proto#L607}
+  ///
+  StreamRange<std::string> ListReservationTopics(std::string const& name,
+                                                 Options options = {});
 
   ///
   /// Lists the topics attached to the specified reservation.

--- a/google/cloud/secretmanager/secret_manager_client.cc
+++ b/google/cloud/secretmanager/secret_manager_client.cc
@@ -42,6 +42,15 @@ SecretManagerServiceClient::ListSecrets(std::string const& parent,
   return connection_->ListSecrets(request);
 }
 
+StreamRange<google::cloud::secretmanager::v1::Secret>
+SecretManagerServiceClient::ListSecrets(
+    google::cloud::secretmanager::v1::ListSecretsRequest request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
+  return connection_->ListSecrets(std::move(request));
+}
+
 StatusOr<google::cloud::secretmanager::v1::Secret>
 SecretManagerServiceClient::CreateSecret(
     std::string const& parent, std::string const& secret_id,
@@ -52,6 +61,15 @@ SecretManagerServiceClient::CreateSecret(
   request.set_parent(parent);
   request.set_secret_id(secret_id);
   *request.mutable_secret() = secret;
+  return connection_->CreateSecret(request);
+}
+
+StatusOr<google::cloud::secretmanager::v1::Secret>
+SecretManagerServiceClient::CreateSecret(
+    google::cloud::secretmanager::v1::CreateSecretRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->CreateSecret(request);
 }
 
@@ -68,6 +86,15 @@ SecretManagerServiceClient::AddSecretVersion(
   return connection_->AddSecretVersion(request);
 }
 
+StatusOr<google::cloud::secretmanager::v1::SecretVersion>
+SecretManagerServiceClient::AddSecretVersion(
+    google::cloud::secretmanager::v1::AddSecretVersionRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
+  return connection_->AddSecretVersion(request);
+}
+
 StatusOr<google::cloud::secretmanager::v1::Secret>
 SecretManagerServiceClient::GetSecret(std::string const& name,
                                       Options options) {
@@ -75,6 +102,15 @@ SecretManagerServiceClient::GetSecret(std::string const& name,
       internal::MergeOptions(std::move(options), options_));
   google::cloud::secretmanager::v1::GetSecretRequest request;
   request.set_name(name);
+  return connection_->GetSecret(request);
+}
+
+StatusOr<google::cloud::secretmanager::v1::Secret>
+SecretManagerServiceClient::GetSecret(
+    google::cloud::secretmanager::v1::GetSecretRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->GetSecret(request);
 }
 
@@ -90,12 +126,29 @@ SecretManagerServiceClient::UpdateSecret(
   return connection_->UpdateSecret(request);
 }
 
+StatusOr<google::cloud::secretmanager::v1::Secret>
+SecretManagerServiceClient::UpdateSecret(
+    google::cloud::secretmanager::v1::UpdateSecretRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
+  return connection_->UpdateSecret(request);
+}
+
 Status SecretManagerServiceClient::DeleteSecret(std::string const& name,
                                                 Options options) {
   internal::OptionsSpan span(
       internal::MergeOptions(std::move(options), options_));
   google::cloud::secretmanager::v1::DeleteSecretRequest request;
   request.set_name(name);
+  return connection_->DeleteSecret(request);
+}
+
+Status SecretManagerServiceClient::DeleteSecret(
+    google::cloud::secretmanager::v1::DeleteSecretRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->DeleteSecret(request);
 }
 
@@ -109,6 +162,15 @@ SecretManagerServiceClient::ListSecretVersions(std::string const& parent,
   return connection_->ListSecretVersions(request);
 }
 
+StreamRange<google::cloud::secretmanager::v1::SecretVersion>
+SecretManagerServiceClient::ListSecretVersions(
+    google::cloud::secretmanager::v1::ListSecretVersionsRequest request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
+  return connection_->ListSecretVersions(std::move(request));
+}
+
 StatusOr<google::cloud::secretmanager::v1::SecretVersion>
 SecretManagerServiceClient::GetSecretVersion(std::string const& name,
                                              Options options) {
@@ -119,6 +181,15 @@ SecretManagerServiceClient::GetSecretVersion(std::string const& name,
   return connection_->GetSecretVersion(request);
 }
 
+StatusOr<google::cloud::secretmanager::v1::SecretVersion>
+SecretManagerServiceClient::GetSecretVersion(
+    google::cloud::secretmanager::v1::GetSecretVersionRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
+  return connection_->GetSecretVersion(request);
+}
+
 StatusOr<google::cloud::secretmanager::v1::AccessSecretVersionResponse>
 SecretManagerServiceClient::AccessSecretVersion(std::string const& name,
                                                 Options options) {
@@ -126,6 +197,15 @@ SecretManagerServiceClient::AccessSecretVersion(std::string const& name,
       internal::MergeOptions(std::move(options), options_));
   google::cloud::secretmanager::v1::AccessSecretVersionRequest request;
   request.set_name(name);
+  return connection_->AccessSecretVersion(request);
+}
+
+StatusOr<google::cloud::secretmanager::v1::AccessSecretVersionResponse>
+SecretManagerServiceClient::AccessSecretVersion(
+    google::cloud::secretmanager::v1::AccessSecretVersionRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->AccessSecretVersion(request);
 }
 
@@ -140,12 +220,31 @@ SecretManagerServiceClient::DisableSecretVersion(std::string const& name,
 }
 
 StatusOr<google::cloud::secretmanager::v1::SecretVersion>
+SecretManagerServiceClient::DisableSecretVersion(
+    google::cloud::secretmanager::v1::DisableSecretVersionRequest const&
+        request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
+  return connection_->DisableSecretVersion(request);
+}
+
+StatusOr<google::cloud::secretmanager::v1::SecretVersion>
 SecretManagerServiceClient::EnableSecretVersion(std::string const& name,
                                                 Options options) {
   internal::OptionsSpan span(
       internal::MergeOptions(std::move(options), options_));
   google::cloud::secretmanager::v1::EnableSecretVersionRequest request;
   request.set_name(name);
+  return connection_->EnableSecretVersion(request);
+}
+
+StatusOr<google::cloud::secretmanager::v1::SecretVersion>
+SecretManagerServiceClient::EnableSecretVersion(
+    google::cloud::secretmanager::v1::EnableSecretVersionRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->EnableSecretVersion(request);
 }
 
@@ -157,105 +256,6 @@ SecretManagerServiceClient::DestroySecretVersion(std::string const& name,
   google::cloud::secretmanager::v1::DestroySecretVersionRequest request;
   request.set_name(name);
   return connection_->DestroySecretVersion(request);
-}
-
-StreamRange<google::cloud::secretmanager::v1::Secret>
-SecretManagerServiceClient::ListSecrets(
-    google::cloud::secretmanager::v1::ListSecretsRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->ListSecrets(std::move(request));
-}
-
-StatusOr<google::cloud::secretmanager::v1::Secret>
-SecretManagerServiceClient::CreateSecret(
-    google::cloud::secretmanager::v1::CreateSecretRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->CreateSecret(request);
-}
-
-StatusOr<google::cloud::secretmanager::v1::SecretVersion>
-SecretManagerServiceClient::AddSecretVersion(
-    google::cloud::secretmanager::v1::AddSecretVersionRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->AddSecretVersion(request);
-}
-
-StatusOr<google::cloud::secretmanager::v1::Secret>
-SecretManagerServiceClient::GetSecret(
-    google::cloud::secretmanager::v1::GetSecretRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->GetSecret(request);
-}
-
-StatusOr<google::cloud::secretmanager::v1::Secret>
-SecretManagerServiceClient::UpdateSecret(
-    google::cloud::secretmanager::v1::UpdateSecretRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->UpdateSecret(request);
-}
-
-Status SecretManagerServiceClient::DeleteSecret(
-    google::cloud::secretmanager::v1::DeleteSecretRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->DeleteSecret(request);
-}
-
-StreamRange<google::cloud::secretmanager::v1::SecretVersion>
-SecretManagerServiceClient::ListSecretVersions(
-    google::cloud::secretmanager::v1::ListSecretVersionsRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->ListSecretVersions(std::move(request));
-}
-
-StatusOr<google::cloud::secretmanager::v1::SecretVersion>
-SecretManagerServiceClient::GetSecretVersion(
-    google::cloud::secretmanager::v1::GetSecretVersionRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->GetSecretVersion(request);
-}
-
-StatusOr<google::cloud::secretmanager::v1::AccessSecretVersionResponse>
-SecretManagerServiceClient::AccessSecretVersion(
-    google::cloud::secretmanager::v1::AccessSecretVersionRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->AccessSecretVersion(request);
-}
-
-StatusOr<google::cloud::secretmanager::v1::SecretVersion>
-SecretManagerServiceClient::DisableSecretVersion(
-    google::cloud::secretmanager::v1::DisableSecretVersionRequest const&
-        request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->DisableSecretVersion(request);
-}
-
-StatusOr<google::cloud::secretmanager::v1::SecretVersion>
-SecretManagerServiceClient::EnableSecretVersion(
-    google::cloud::secretmanager::v1::EnableSecretVersionRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->EnableSecretVersion(request);
 }
 
 StatusOr<google::cloud::secretmanager::v1::SecretVersion>

--- a/google/cloud/secretmanager/secret_manager_client.h
+++ b/google/cloud/secretmanager/secret_manager_client.h
@@ -113,6 +113,24 @@ class SecretManagerServiceClient {
       std::string const& parent, Options options = {});
 
   ///
+  /// Lists [Secrets][google.cloud.secretmanager.v1.Secret].
+  ///
+  /// @param request
+  /// @googleapis_link{google::cloud::secretmanager::v1::ListSecretsRequest,google/cloud/secretmanager/v1/service.proto#L206}
+  /// @param options  Optional. Operation options.
+  /// @return
+  /// @googleapis_link{google::cloud::secretmanager::v1::Secret,google/cloud/secretmanager/v1/resources.proto#L40}
+  ///
+  /// [google.cloud.secretmanager.v1.ListSecretsRequest]:
+  /// @googleapis_reference_link{google/cloud/secretmanager/v1/service.proto#L206}
+  /// [google.cloud.secretmanager.v1.Secret]:
+  /// @googleapis_reference_link{google/cloud/secretmanager/v1/resources.proto#L40}
+  ///
+  StreamRange<google::cloud::secretmanager::v1::Secret> ListSecrets(
+      google::cloud::secretmanager::v1::ListSecretsRequest request,
+      Options options = {});
+
+  ///
   /// Creates a new [Secret][google.cloud.secretmanager.v1.Secret] containing no
   /// [SecretVersions][google.cloud.secretmanager.v1.SecretVersion].
   ///
@@ -141,6 +159,25 @@ class SecretManagerServiceClient {
       Options options = {});
 
   ///
+  /// Creates a new [Secret][google.cloud.secretmanager.v1.Secret] containing no
+  /// [SecretVersions][google.cloud.secretmanager.v1.SecretVersion].
+  ///
+  /// @param request
+  /// @googleapis_link{google::cloud::secretmanager::v1::CreateSecretRequest,google/cloud/secretmanager/v1/service.proto#L248}
+  /// @param options  Optional. Operation options.
+  /// @return
+  /// @googleapis_link{google::cloud::secretmanager::v1::Secret,google/cloud/secretmanager/v1/resources.proto#L40}
+  ///
+  /// [google.cloud.secretmanager.v1.CreateSecretRequest]:
+  /// @googleapis_reference_link{google/cloud/secretmanager/v1/service.proto#L248}
+  /// [google.cloud.secretmanager.v1.Secret]:
+  /// @googleapis_reference_link{google/cloud/secretmanager/v1/resources.proto#L40}
+  ///
+  StatusOr<google::cloud::secretmanager::v1::Secret> CreateSecret(
+      google::cloud::secretmanager::v1::CreateSecretRequest const& request,
+      Options options = {});
+
+  ///
   /// Creates a new [SecretVersion][google.cloud.secretmanager.v1.SecretVersion]
   /// containing secret data and attaches it to an existing
   /// [Secret][google.cloud.secretmanager.v1.Secret].
@@ -166,232 +203,6 @@ class SecretManagerServiceClient {
       Options options = {});
 
   ///
-  /// Gets metadata for a given [Secret][google.cloud.secretmanager.v1.Secret].
-  ///
-  /// @param name  Required. The resource name of the
-  /// [Secret][google.cloud.secretmanager.v1.Secret], in the format
-  /// `projects/*/secrets/*`.
-  /// @param options  Optional. Operation options.
-  /// @return
-  /// @googleapis_link{google::cloud::secretmanager::v1::Secret,google/cloud/secretmanager/v1/resources.proto#L40}
-  ///
-  /// [google.cloud.secretmanager.v1.GetSecretRequest]:
-  /// @googleapis_reference_link{google/cloud/secretmanager/v1/service.proto#L285}
-  /// [google.cloud.secretmanager.v1.Secret]:
-  /// @googleapis_reference_link{google/cloud/secretmanager/v1/resources.proto#L40}
-  ///
-  StatusOr<google::cloud::secretmanager::v1::Secret> GetSecret(
-      std::string const& name, Options options = {});
-
-  ///
-  /// Updates metadata of an existing
-  /// [Secret][google.cloud.secretmanager.v1.Secret].
-  ///
-  /// @param secret  Required. [Secret][google.cloud.secretmanager.v1.Secret]
-  /// with updated field values.
-  /// @param update_mask  Required. Specifies the fields to be updated.
-  /// @param options  Optional. Operation options.
-  /// @return
-  /// @googleapis_link{google::cloud::secretmanager::v1::Secret,google/cloud/secretmanager/v1/resources.proto#L40}
-  ///
-  /// [google.cloud.secretmanager.v1.UpdateSecretRequest]:
-  /// @googleapis_reference_link{google/cloud/secretmanager/v1/service.proto#L354}
-  /// [google.cloud.secretmanager.v1.Secret]:
-  /// @googleapis_reference_link{google/cloud/secretmanager/v1/resources.proto#L40}
-  ///
-  StatusOr<google::cloud::secretmanager::v1::Secret> UpdateSecret(
-      google::cloud::secretmanager::v1::Secret const& secret,
-      google::protobuf::FieldMask const& update_mask, Options options = {});
-
-  ///
-  /// Deletes a [Secret][google.cloud.secretmanager.v1.Secret].
-  ///
-  /// @param name  Required. The resource name of the
-  /// [Secret][google.cloud.secretmanager.v1.Secret] to delete in the format
-  ///  `projects/*/secrets/*`.
-  /// @param options  Optional. Operation options.
-  ///
-  /// [google.cloud.secretmanager.v1.DeleteSecretRequest]:
-  /// @googleapis_reference_link{google/cloud/secretmanager/v1/service.proto#L390}
-  ///
-  Status DeleteSecret(std::string const& name, Options options = {});
-
-  ///
-  /// Lists [SecretVersions][google.cloud.secretmanager.v1.SecretVersion]. This
-  /// call does not return secret data.
-  ///
-  /// @param parent  Required. The resource name of the
-  /// [Secret][google.cloud.secretmanager.v1.Secret] associated with the
-  ///  [SecretVersions][google.cloud.secretmanager.v1.SecretVersion] to list, in
-  ///  the format `projects/*/secrets/*`.
-  /// @param options  Optional. Operation options.
-  /// @return
-  /// @googleapis_link{google::cloud::secretmanager::v1::SecretVersion,google/cloud/secretmanager/v1/resources.proto#L103}
-  ///
-  /// [google.cloud.secretmanager.v1.ListSecretVersionsRequest]:
-  /// @googleapis_reference_link{google/cloud/secretmanager/v1/service.proto#L296}
-  /// [google.cloud.secretmanager.v1.SecretVersion]:
-  /// @googleapis_reference_link{google/cloud/secretmanager/v1/resources.proto#L103}
-  ///
-  StreamRange<google::cloud::secretmanager::v1::SecretVersion>
-  ListSecretVersions(std::string const& parent, Options options = {});
-
-  ///
-  /// Gets metadata for a
-  /// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
-  ///
-  /// `projects/*/secrets/*/versions/latest` is an alias to the most recently
-  /// created [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
-  ///
-  /// @param name  Required. The resource name of the
-  /// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] in the format
-  ///  `projects/*/secrets/*/versions/*`.
-  ///  `projects/*/secrets/*/versions/latest` is an alias to the most recently
-  ///  created [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
-  /// @param options  Optional. Operation options.
-  /// @return
-  /// @googleapis_link{google::cloud::secretmanager::v1::SecretVersion,google/cloud/secretmanager/v1/resources.proto#L103}
-  ///
-  /// [google.cloud.secretmanager.v1.GetSecretVersionRequest]:
-  /// @googleapis_reference_link{google/cloud/secretmanager/v1/service.proto#L339}
-  /// [google.cloud.secretmanager.v1.SecretVersion]:
-  /// @googleapis_reference_link{google/cloud/secretmanager/v1/resources.proto#L103}
-  ///
-  StatusOr<google::cloud::secretmanager::v1::SecretVersion> GetSecretVersion(
-      std::string const& name, Options options = {});
-
-  ///
-  /// Accesses a [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
-  /// This call returns the secret data.
-  ///
-  /// `projects/*/secrets/*/versions/latest` is an alias to the most recently
-  /// created [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
-  ///
-  /// @param name  Required. The resource name of the
-  /// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] in the format
-  ///  `projects/*/secrets/*/versions/*`.
-  ///  `projects/*/secrets/*/versions/latest` is an alias to the most recently
-  ///  created [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
-  /// @param options  Optional. Operation options.
-  /// @return
-  /// @googleapis_link{google::cloud::secretmanager::v1::AccessSecretVersionResponse,google/cloud/secretmanager/v1/service.proto#L378}
-  ///
-  /// [google.cloud.secretmanager.v1.AccessSecretVersionRequest]:
-  /// @googleapis_reference_link{google/cloud/secretmanager/v1/service.proto#L363}
-  /// [google.cloud.secretmanager.v1.AccessSecretVersionResponse]:
-  /// @googleapis_reference_link{google/cloud/secretmanager/v1/service.proto#L378}
-  ///
-  StatusOr<google::cloud::secretmanager::v1::AccessSecretVersionResponse>
-  AccessSecretVersion(std::string const& name, Options options = {});
-
-  ///
-  /// Disables a [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
-  ///
-  /// Sets the [state][google.cloud.secretmanager.v1.SecretVersion.state] of the
-  /// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] to
-  /// [DISABLED][google.cloud.secretmanager.v1.SecretVersion.State.DISABLED].
-  ///
-  /// @param name  Required. The resource name of the
-  /// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] to disable in
-  /// the format
-  ///  `projects/*/secrets/*/versions/*`.
-  /// @param options  Optional. Operation options.
-  /// @return
-  /// @googleapis_link{google::cloud::secretmanager::v1::SecretVersion,google/cloud/secretmanager/v1/resources.proto#L103}
-  ///
-  /// [google.cloud.secretmanager.v1.DisableSecretVersionRequest]:
-  /// @googleapis_reference_link{google/cloud/secretmanager/v1/service.proto#L407}
-  /// [google.cloud.secretmanager.v1.SecretVersion]:
-  /// @googleapis_reference_link{google/cloud/secretmanager/v1/resources.proto#L103}
-  ///
-  StatusOr<google::cloud::secretmanager::v1::SecretVersion>
-  DisableSecretVersion(std::string const& name, Options options = {});
-
-  ///
-  /// Enables a [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
-  ///
-  /// Sets the [state][google.cloud.secretmanager.v1.SecretVersion.state] of the
-  /// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] to
-  /// [ENABLED][google.cloud.secretmanager.v1.SecretVersion.State.ENABLED].
-  ///
-  /// @param name  Required. The resource name of the
-  /// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] to enable in
-  /// the format
-  ///  `projects/*/secrets/*/versions/*`.
-  /// @param options  Optional. Operation options.
-  /// @return
-  /// @googleapis_link{google::cloud::secretmanager::v1::SecretVersion,google/cloud/secretmanager/v1/resources.proto#L103}
-  ///
-  /// [google.cloud.secretmanager.v1.EnableSecretVersionRequest]:
-  /// @googleapis_reference_link{google/cloud/secretmanager/v1/service.proto#L424}
-  /// [google.cloud.secretmanager.v1.SecretVersion]:
-  /// @googleapis_reference_link{google/cloud/secretmanager/v1/resources.proto#L103}
-  ///
-  StatusOr<google::cloud::secretmanager::v1::SecretVersion> EnableSecretVersion(
-      std::string const& name, Options options = {});
-
-  ///
-  /// Destroys a [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
-  ///
-  /// Sets the [state][google.cloud.secretmanager.v1.SecretVersion.state] of the
-  /// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] to
-  /// [DESTROYED][google.cloud.secretmanager.v1.SecretVersion.State.DESTROYED]
-  /// and irrevocably destroys the secret data.
-  ///
-  /// @param name  Required. The resource name of the
-  /// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] to destroy in
-  /// the format
-  ///  `projects/*/secrets/*/versions/*`.
-  /// @param options  Optional. Operation options.
-  /// @return
-  /// @googleapis_link{google::cloud::secretmanager::v1::SecretVersion,google/cloud/secretmanager/v1/resources.proto#L103}
-  ///
-  /// [google.cloud.secretmanager.v1.DestroySecretVersionRequest]:
-  /// @googleapis_reference_link{google/cloud/secretmanager/v1/service.proto#L441}
-  /// [google.cloud.secretmanager.v1.SecretVersion]:
-  /// @googleapis_reference_link{google/cloud/secretmanager/v1/resources.proto#L103}
-  ///
-  StatusOr<google::cloud::secretmanager::v1::SecretVersion>
-  DestroySecretVersion(std::string const& name, Options options = {});
-
-  ///
-  /// Lists [Secrets][google.cloud.secretmanager.v1.Secret].
-  ///
-  /// @param request
-  /// @googleapis_link{google::cloud::secretmanager::v1::ListSecretsRequest,google/cloud/secretmanager/v1/service.proto#L206}
-  /// @param options  Optional. Operation options.
-  /// @return
-  /// @googleapis_link{google::cloud::secretmanager::v1::Secret,google/cloud/secretmanager/v1/resources.proto#L40}
-  ///
-  /// [google.cloud.secretmanager.v1.ListSecretsRequest]:
-  /// @googleapis_reference_link{google/cloud/secretmanager/v1/service.proto#L206}
-  /// [google.cloud.secretmanager.v1.Secret]:
-  /// @googleapis_reference_link{google/cloud/secretmanager/v1/resources.proto#L40}
-  ///
-  StreamRange<google::cloud::secretmanager::v1::Secret> ListSecrets(
-      google::cloud::secretmanager::v1::ListSecretsRequest request,
-      Options options = {});
-
-  ///
-  /// Creates a new [Secret][google.cloud.secretmanager.v1.Secret] containing no
-  /// [SecretVersions][google.cloud.secretmanager.v1.SecretVersion].
-  ///
-  /// @param request
-  /// @googleapis_link{google::cloud::secretmanager::v1::CreateSecretRequest,google/cloud/secretmanager/v1/service.proto#L248}
-  /// @param options  Optional. Operation options.
-  /// @return
-  /// @googleapis_link{google::cloud::secretmanager::v1::Secret,google/cloud/secretmanager/v1/resources.proto#L40}
-  ///
-  /// [google.cloud.secretmanager.v1.CreateSecretRequest]:
-  /// @googleapis_reference_link{google/cloud/secretmanager/v1/service.proto#L248}
-  /// [google.cloud.secretmanager.v1.Secret]:
-  /// @googleapis_reference_link{google/cloud/secretmanager/v1/resources.proto#L40}
-  ///
-  StatusOr<google::cloud::secretmanager::v1::Secret> CreateSecret(
-      google::cloud::secretmanager::v1::CreateSecretRequest const& request,
-      Options options = {});
-
-  ///
   /// Creates a new [SecretVersion][google.cloud.secretmanager.v1.SecretVersion]
   /// containing secret data and attaches it to an existing
   /// [Secret][google.cloud.secretmanager.v1.Secret].
@@ -410,6 +221,24 @@ class SecretManagerServiceClient {
   StatusOr<google::cloud::secretmanager::v1::SecretVersion> AddSecretVersion(
       google::cloud::secretmanager::v1::AddSecretVersionRequest const& request,
       Options options = {});
+
+  ///
+  /// Gets metadata for a given [Secret][google.cloud.secretmanager.v1.Secret].
+  ///
+  /// @param name  Required. The resource name of the
+  /// [Secret][google.cloud.secretmanager.v1.Secret], in the format
+  /// `projects/*/secrets/*`.
+  /// @param options  Optional. Operation options.
+  /// @return
+  /// @googleapis_link{google::cloud::secretmanager::v1::Secret,google/cloud/secretmanager/v1/resources.proto#L40}
+  ///
+  /// [google.cloud.secretmanager.v1.GetSecretRequest]:
+  /// @googleapis_reference_link{google/cloud/secretmanager/v1/service.proto#L285}
+  /// [google.cloud.secretmanager.v1.Secret]:
+  /// @googleapis_reference_link{google/cloud/secretmanager/v1/resources.proto#L40}
+  ///
+  StatusOr<google::cloud::secretmanager::v1::Secret> GetSecret(
+      std::string const& name, Options options = {});
 
   ///
   /// Gets metadata for a given [Secret][google.cloud.secretmanager.v1.Secret].
@@ -433,6 +262,26 @@ class SecretManagerServiceClient {
   /// Updates metadata of an existing
   /// [Secret][google.cloud.secretmanager.v1.Secret].
   ///
+  /// @param secret  Required. [Secret][google.cloud.secretmanager.v1.Secret]
+  /// with updated field values.
+  /// @param update_mask  Required. Specifies the fields to be updated.
+  /// @param options  Optional. Operation options.
+  /// @return
+  /// @googleapis_link{google::cloud::secretmanager::v1::Secret,google/cloud/secretmanager/v1/resources.proto#L40}
+  ///
+  /// [google.cloud.secretmanager.v1.UpdateSecretRequest]:
+  /// @googleapis_reference_link{google/cloud/secretmanager/v1/service.proto#L354}
+  /// [google.cloud.secretmanager.v1.Secret]:
+  /// @googleapis_reference_link{google/cloud/secretmanager/v1/resources.proto#L40}
+  ///
+  StatusOr<google::cloud::secretmanager::v1::Secret> UpdateSecret(
+      google::cloud::secretmanager::v1::Secret const& secret,
+      google::protobuf::FieldMask const& update_mask, Options options = {});
+
+  ///
+  /// Updates metadata of an existing
+  /// [Secret][google.cloud.secretmanager.v1.Secret].
+  ///
   /// @param request
   /// @googleapis_link{google::cloud::secretmanager::v1::UpdateSecretRequest,google/cloud/secretmanager/v1/service.proto#L354}
   /// @param options  Optional. Operation options.
@@ -451,6 +300,19 @@ class SecretManagerServiceClient {
   ///
   /// Deletes a [Secret][google.cloud.secretmanager.v1.Secret].
   ///
+  /// @param name  Required. The resource name of the
+  /// [Secret][google.cloud.secretmanager.v1.Secret] to delete in the format
+  ///  `projects/*/secrets/*`.
+  /// @param options  Optional. Operation options.
+  ///
+  /// [google.cloud.secretmanager.v1.DeleteSecretRequest]:
+  /// @googleapis_reference_link{google/cloud/secretmanager/v1/service.proto#L390}
+  ///
+  Status DeleteSecret(std::string const& name, Options options = {});
+
+  ///
+  /// Deletes a [Secret][google.cloud.secretmanager.v1.Secret].
+  ///
   /// @param request
   /// @googleapis_link{google::cloud::secretmanager::v1::DeleteSecretRequest,google/cloud/secretmanager/v1/service.proto#L390}
   /// @param options  Optional. Operation options.
@@ -461,6 +323,26 @@ class SecretManagerServiceClient {
   Status DeleteSecret(
       google::cloud::secretmanager::v1::DeleteSecretRequest const& request,
       Options options = {});
+
+  ///
+  /// Lists [SecretVersions][google.cloud.secretmanager.v1.SecretVersion]. This
+  /// call does not return secret data.
+  ///
+  /// @param parent  Required. The resource name of the
+  /// [Secret][google.cloud.secretmanager.v1.Secret] associated with the
+  ///  [SecretVersions][google.cloud.secretmanager.v1.SecretVersion] to list, in
+  ///  the format `projects/*/secrets/*`.
+  /// @param options  Optional. Operation options.
+  /// @return
+  /// @googleapis_link{google::cloud::secretmanager::v1::SecretVersion,google/cloud/secretmanager/v1/resources.proto#L103}
+  ///
+  /// [google.cloud.secretmanager.v1.ListSecretVersionsRequest]:
+  /// @googleapis_reference_link{google/cloud/secretmanager/v1/service.proto#L296}
+  /// [google.cloud.secretmanager.v1.SecretVersion]:
+  /// @googleapis_reference_link{google/cloud/secretmanager/v1/resources.proto#L103}
+  ///
+  StreamRange<google::cloud::secretmanager::v1::SecretVersion>
+  ListSecretVersions(std::string const& parent, Options options = {});
 
   ///
   /// Lists [SecretVersions][google.cloud.secretmanager.v1.SecretVersion]. This
@@ -489,6 +371,30 @@ class SecretManagerServiceClient {
   /// `projects/*/secrets/*/versions/latest` is an alias to the most recently
   /// created [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
   ///
+  /// @param name  Required. The resource name of the
+  /// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] in the format
+  ///  `projects/*/secrets/*/versions/*`.
+  ///  `projects/*/secrets/*/versions/latest` is an alias to the most recently
+  ///  created [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
+  /// @param options  Optional. Operation options.
+  /// @return
+  /// @googleapis_link{google::cloud::secretmanager::v1::SecretVersion,google/cloud/secretmanager/v1/resources.proto#L103}
+  ///
+  /// [google.cloud.secretmanager.v1.GetSecretVersionRequest]:
+  /// @googleapis_reference_link{google/cloud/secretmanager/v1/service.proto#L339}
+  /// [google.cloud.secretmanager.v1.SecretVersion]:
+  /// @googleapis_reference_link{google/cloud/secretmanager/v1/resources.proto#L103}
+  ///
+  StatusOr<google::cloud::secretmanager::v1::SecretVersion> GetSecretVersion(
+      std::string const& name, Options options = {});
+
+  ///
+  /// Gets metadata for a
+  /// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
+  ///
+  /// `projects/*/secrets/*/versions/latest` is an alias to the most recently
+  /// created [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
+  ///
   /// @param request
   /// @googleapis_link{google::cloud::secretmanager::v1::GetSecretVersionRequest,google/cloud/secretmanager/v1/service.proto#L339}
   /// @param options  Optional. Operation options.
@@ -503,6 +409,30 @@ class SecretManagerServiceClient {
   StatusOr<google::cloud::secretmanager::v1::SecretVersion> GetSecretVersion(
       google::cloud::secretmanager::v1::GetSecretVersionRequest const& request,
       Options options = {});
+
+  ///
+  /// Accesses a [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
+  /// This call returns the secret data.
+  ///
+  /// `projects/*/secrets/*/versions/latest` is an alias to the most recently
+  /// created [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
+  ///
+  /// @param name  Required. The resource name of the
+  /// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] in the format
+  ///  `projects/*/secrets/*/versions/*`.
+  ///  `projects/*/secrets/*/versions/latest` is an alias to the most recently
+  ///  created [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
+  /// @param options  Optional. Operation options.
+  /// @return
+  /// @googleapis_link{google::cloud::secretmanager::v1::AccessSecretVersionResponse,google/cloud/secretmanager/v1/service.proto#L378}
+  ///
+  /// [google.cloud.secretmanager.v1.AccessSecretVersionRequest]:
+  /// @googleapis_reference_link{google/cloud/secretmanager/v1/service.proto#L363}
+  /// [google.cloud.secretmanager.v1.AccessSecretVersionResponse]:
+  /// @googleapis_reference_link{google/cloud/secretmanager/v1/service.proto#L378}
+  ///
+  StatusOr<google::cloud::secretmanager::v1::AccessSecretVersionResponse>
+  AccessSecretVersion(std::string const& name, Options options = {});
 
   ///
   /// Accesses a [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
@@ -535,6 +465,29 @@ class SecretManagerServiceClient {
   /// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] to
   /// [DISABLED][google.cloud.secretmanager.v1.SecretVersion.State.DISABLED].
   ///
+  /// @param name  Required. The resource name of the
+  /// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] to disable in
+  /// the format
+  ///  `projects/*/secrets/*/versions/*`.
+  /// @param options  Optional. Operation options.
+  /// @return
+  /// @googleapis_link{google::cloud::secretmanager::v1::SecretVersion,google/cloud/secretmanager/v1/resources.proto#L103}
+  ///
+  /// [google.cloud.secretmanager.v1.DisableSecretVersionRequest]:
+  /// @googleapis_reference_link{google/cloud/secretmanager/v1/service.proto#L407}
+  /// [google.cloud.secretmanager.v1.SecretVersion]:
+  /// @googleapis_reference_link{google/cloud/secretmanager/v1/resources.proto#L103}
+  ///
+  StatusOr<google::cloud::secretmanager::v1::SecretVersion>
+  DisableSecretVersion(std::string const& name, Options options = {});
+
+  ///
+  /// Disables a [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
+  ///
+  /// Sets the [state][google.cloud.secretmanager.v1.SecretVersion.state] of the
+  /// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] to
+  /// [DISABLED][google.cloud.secretmanager.v1.SecretVersion.State.DISABLED].
+  ///
   /// @param request
   /// @googleapis_link{google::cloud::secretmanager::v1::DisableSecretVersionRequest,google/cloud/secretmanager/v1/service.proto#L407}
   /// @param options  Optional. Operation options.
@@ -559,6 +512,29 @@ class SecretManagerServiceClient {
   /// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] to
   /// [ENABLED][google.cloud.secretmanager.v1.SecretVersion.State.ENABLED].
   ///
+  /// @param name  Required. The resource name of the
+  /// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] to enable in
+  /// the format
+  ///  `projects/*/secrets/*/versions/*`.
+  /// @param options  Optional. Operation options.
+  /// @return
+  /// @googleapis_link{google::cloud::secretmanager::v1::SecretVersion,google/cloud/secretmanager/v1/resources.proto#L103}
+  ///
+  /// [google.cloud.secretmanager.v1.EnableSecretVersionRequest]:
+  /// @googleapis_reference_link{google/cloud/secretmanager/v1/service.proto#L424}
+  /// [google.cloud.secretmanager.v1.SecretVersion]:
+  /// @googleapis_reference_link{google/cloud/secretmanager/v1/resources.proto#L103}
+  ///
+  StatusOr<google::cloud::secretmanager::v1::SecretVersion> EnableSecretVersion(
+      std::string const& name, Options options = {});
+
+  ///
+  /// Enables a [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
+  ///
+  /// Sets the [state][google.cloud.secretmanager.v1.SecretVersion.state] of the
+  /// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] to
+  /// [ENABLED][google.cloud.secretmanager.v1.SecretVersion.State.ENABLED].
+  ///
   /// @param request
   /// @googleapis_link{google::cloud::secretmanager::v1::EnableSecretVersionRequest,google/cloud/secretmanager/v1/service.proto#L424}
   /// @param options  Optional. Operation options.
@@ -574,6 +550,30 @@ class SecretManagerServiceClient {
       google::cloud::secretmanager::v1::EnableSecretVersionRequest const&
           request,
       Options options = {});
+
+  ///
+  /// Destroys a [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
+  ///
+  /// Sets the [state][google.cloud.secretmanager.v1.SecretVersion.state] of the
+  /// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] to
+  /// [DESTROYED][google.cloud.secretmanager.v1.SecretVersion.State.DESTROYED]
+  /// and irrevocably destroys the secret data.
+  ///
+  /// @param name  Required. The resource name of the
+  /// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] to destroy in
+  /// the format
+  ///  `projects/*/secrets/*/versions/*`.
+  /// @param options  Optional. Operation options.
+  /// @return
+  /// @googleapis_link{google::cloud::secretmanager::v1::SecretVersion,google/cloud/secretmanager/v1/resources.proto#L103}
+  ///
+  /// [google.cloud.secretmanager.v1.DestroySecretVersionRequest]:
+  /// @googleapis_reference_link{google/cloud/secretmanager/v1/service.proto#L441}
+  /// [google.cloud.secretmanager.v1.SecretVersion]:
+  /// @googleapis_reference_link{google/cloud/secretmanager/v1/resources.proto#L103}
+  ///
+  StatusOr<google::cloud::secretmanager::v1::SecretVersion>
+  DestroySecretVersion(std::string const& name, Options options = {});
 
   ///
   /// Destroys a [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].

--- a/google/cloud/spanner/admin/database_admin_client.cc
+++ b/google/cloud/spanner/admin/database_admin_client.cc
@@ -43,6 +43,15 @@ DatabaseAdminClient::ListDatabases(std::string const& parent, Options options) {
   return connection_->ListDatabases(request);
 }
 
+StreamRange<google::spanner::admin::database::v1::Database>
+DatabaseAdminClient::ListDatabases(
+    google::spanner::admin::database::v1::ListDatabasesRequest request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
+  return connection_->ListDatabases(std::move(request));
+}
+
 future<StatusOr<google::spanner::admin::database::v1::Database>>
 DatabaseAdminClient::CreateDatabase(std::string const& parent,
                                     std::string const& create_statement,
@@ -55,12 +64,30 @@ DatabaseAdminClient::CreateDatabase(std::string const& parent,
   return connection_->CreateDatabase(request);
 }
 
+future<StatusOr<google::spanner::admin::database::v1::Database>>
+DatabaseAdminClient::CreateDatabase(
+    google::spanner::admin::database::v1::CreateDatabaseRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
+  return connection_->CreateDatabase(request);
+}
+
 StatusOr<google::spanner::admin::database::v1::Database>
 DatabaseAdminClient::GetDatabase(std::string const& name, Options options) {
   internal::OptionsSpan span(
       internal::MergeOptions(std::move(options), options_));
   google::spanner::admin::database::v1::GetDatabaseRequest request;
   request.set_name(name);
+  return connection_->GetDatabase(request);
+}
+
+StatusOr<google::spanner::admin::database::v1::Database>
+DatabaseAdminClient::GetDatabase(
+    google::spanner::admin::database::v1::GetDatabaseRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->GetDatabase(request);
 }
 
@@ -77,12 +104,31 @@ DatabaseAdminClient::UpdateDatabaseDdl(
   return connection_->UpdateDatabaseDdl(request);
 }
 
+future<
+    StatusOr<google::spanner::admin::database::v1::UpdateDatabaseDdlMetadata>>
+DatabaseAdminClient::UpdateDatabaseDdl(
+    google::spanner::admin::database::v1::UpdateDatabaseDdlRequest const&
+        request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
+  return connection_->UpdateDatabaseDdl(request);
+}
+
 Status DatabaseAdminClient::DropDatabase(std::string const& database,
                                          Options options) {
   internal::OptionsSpan span(
       internal::MergeOptions(std::move(options), options_));
   google::spanner::admin::database::v1::DropDatabaseRequest request;
   request.set_database(database);
+  return connection_->DropDatabase(request);
+}
+
+Status DatabaseAdminClient::DropDatabase(
+    google::spanner::admin::database::v1::DropDatabaseRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->DropDatabase(request);
 }
 
@@ -93,6 +139,15 @@ DatabaseAdminClient::GetDatabaseDdl(std::string const& database,
       internal::MergeOptions(std::move(options), options_));
   google::spanner::admin::database::v1::GetDatabaseDdlRequest request;
   request.set_database(database);
+  return connection_->GetDatabaseDdl(request);
+}
+
+StatusOr<google::spanner::admin::database::v1::GetDatabaseDdlResponse>
+DatabaseAdminClient::GetDatabaseDdl(
+    google::spanner::admin::database::v1::GetDatabaseDdlRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->GetDatabaseDdl(request);
 }
 
@@ -133,12 +188,26 @@ StatusOr<google::iam::v1::Policy> DatabaseAdminClient::SetIamPolicy(
   }
 }
 
+StatusOr<google::iam::v1::Policy> DatabaseAdminClient::SetIamPolicy(
+    google::iam::v1::SetIamPolicyRequest const& request, Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
+  return connection_->SetIamPolicy(request);
+}
+
 StatusOr<google::iam::v1::Policy> DatabaseAdminClient::GetIamPolicy(
     std::string const& resource, Options options) {
   internal::OptionsSpan span(
       internal::MergeOptions(std::move(options), options_));
   google::iam::v1::GetIamPolicyRequest request;
   request.set_resource(resource);
+  return connection_->GetIamPolicy(request);
+}
+
+StatusOr<google::iam::v1::Policy> DatabaseAdminClient::GetIamPolicy(
+    google::iam::v1::GetIamPolicyRequest const& request, Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->GetIamPolicy(request);
 }
 
@@ -151,6 +220,15 @@ DatabaseAdminClient::TestIamPermissions(
   google::iam::v1::TestIamPermissionsRequest request;
   request.set_resource(resource);
   *request.mutable_permissions() = {permissions.begin(), permissions.end()};
+  return connection_->TestIamPermissions(request);
+}
+
+StatusOr<google::iam::v1::TestIamPermissionsResponse>
+DatabaseAdminClient::TestIamPermissions(
+    google::iam::v1::TestIamPermissionsRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->TestIamPermissions(request);
 }
 
@@ -168,12 +246,30 @@ DatabaseAdminClient::CreateBackup(
   return connection_->CreateBackup(request);
 }
 
+future<StatusOr<google::spanner::admin::database::v1::Backup>>
+DatabaseAdminClient::CreateBackup(
+    google::spanner::admin::database::v1::CreateBackupRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
+  return connection_->CreateBackup(request);
+}
+
 StatusOr<google::spanner::admin::database::v1::Backup>
 DatabaseAdminClient::GetBackup(std::string const& name, Options options) {
   internal::OptionsSpan span(
       internal::MergeOptions(std::move(options), options_));
   google::spanner::admin::database::v1::GetBackupRequest request;
   request.set_name(name);
+  return connection_->GetBackup(request);
+}
+
+StatusOr<google::spanner::admin::database::v1::Backup>
+DatabaseAdminClient::GetBackup(
+    google::spanner::admin::database::v1::GetBackupRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->GetBackup(request);
 }
 
@@ -189,12 +285,29 @@ DatabaseAdminClient::UpdateBackup(
   return connection_->UpdateBackup(request);
 }
 
+StatusOr<google::spanner::admin::database::v1::Backup>
+DatabaseAdminClient::UpdateBackup(
+    google::spanner::admin::database::v1::UpdateBackupRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
+  return connection_->UpdateBackup(request);
+}
+
 Status DatabaseAdminClient::DeleteBackup(std::string const& name,
                                          Options options) {
   internal::OptionsSpan span(
       internal::MergeOptions(std::move(options), options_));
   google::spanner::admin::database::v1::DeleteBackupRequest request;
   request.set_name(name);
+  return connection_->DeleteBackup(request);
+}
+
+Status DatabaseAdminClient::DeleteBackup(
+    google::spanner::admin::database::v1::DeleteBackupRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->DeleteBackup(request);
 }
 
@@ -205,6 +318,15 @@ DatabaseAdminClient::ListBackups(std::string const& parent, Options options) {
   google::spanner::admin::database::v1::ListBackupsRequest request;
   request.set_parent(parent);
   return connection_->ListBackups(request);
+}
+
+StreamRange<google::spanner::admin::database::v1::Backup>
+DatabaseAdminClient::ListBackups(
+    google::spanner::admin::database::v1::ListBackupsRequest request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
+  return connection_->ListBackups(std::move(request));
 }
 
 future<StatusOr<google::spanner::admin::database::v1::Database>>
@@ -221,6 +343,15 @@ DatabaseAdminClient::RestoreDatabase(std::string const& parent,
   return connection_->RestoreDatabase(request);
 }
 
+future<StatusOr<google::spanner::admin::database::v1::Database>>
+DatabaseAdminClient::RestoreDatabase(
+    google::spanner::admin::database::v1::RestoreDatabaseRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
+  return connection_->RestoreDatabase(request);
+}
+
 StreamRange<google::longrunning::Operation>
 DatabaseAdminClient::ListDatabaseOperations(std::string const& parent,
                                             Options options) {
@@ -232,6 +363,15 @@ DatabaseAdminClient::ListDatabaseOperations(std::string const& parent,
 }
 
 StreamRange<google::longrunning::Operation>
+DatabaseAdminClient::ListDatabaseOperations(
+    google::spanner::admin::database::v1::ListDatabaseOperationsRequest request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
+  return connection_->ListDatabaseOperations(std::move(request));
+}
+
+StreamRange<google::longrunning::Operation>
 DatabaseAdminClient::ListBackupOperations(std::string const& parent,
                                           Options options) {
   internal::OptionsSpan span(
@@ -239,146 +379,6 @@ DatabaseAdminClient::ListBackupOperations(std::string const& parent,
   google::spanner::admin::database::v1::ListBackupOperationsRequest request;
   request.set_parent(parent);
   return connection_->ListBackupOperations(request);
-}
-
-StreamRange<google::spanner::admin::database::v1::Database>
-DatabaseAdminClient::ListDatabases(
-    google::spanner::admin::database::v1::ListDatabasesRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->ListDatabases(std::move(request));
-}
-
-future<StatusOr<google::spanner::admin::database::v1::Database>>
-DatabaseAdminClient::CreateDatabase(
-    google::spanner::admin::database::v1::CreateDatabaseRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->CreateDatabase(request);
-}
-
-StatusOr<google::spanner::admin::database::v1::Database>
-DatabaseAdminClient::GetDatabase(
-    google::spanner::admin::database::v1::GetDatabaseRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->GetDatabase(request);
-}
-
-future<
-    StatusOr<google::spanner::admin::database::v1::UpdateDatabaseDdlMetadata>>
-DatabaseAdminClient::UpdateDatabaseDdl(
-    google::spanner::admin::database::v1::UpdateDatabaseDdlRequest const&
-        request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->UpdateDatabaseDdl(request);
-}
-
-Status DatabaseAdminClient::DropDatabase(
-    google::spanner::admin::database::v1::DropDatabaseRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->DropDatabase(request);
-}
-
-StatusOr<google::spanner::admin::database::v1::GetDatabaseDdlResponse>
-DatabaseAdminClient::GetDatabaseDdl(
-    google::spanner::admin::database::v1::GetDatabaseDdlRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->GetDatabaseDdl(request);
-}
-
-StatusOr<google::iam::v1::Policy> DatabaseAdminClient::SetIamPolicy(
-    google::iam::v1::SetIamPolicyRequest const& request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->SetIamPolicy(request);
-}
-
-StatusOr<google::iam::v1::Policy> DatabaseAdminClient::GetIamPolicy(
-    google::iam::v1::GetIamPolicyRequest const& request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->GetIamPolicy(request);
-}
-
-StatusOr<google::iam::v1::TestIamPermissionsResponse>
-DatabaseAdminClient::TestIamPermissions(
-    google::iam::v1::TestIamPermissionsRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->TestIamPermissions(request);
-}
-
-future<StatusOr<google::spanner::admin::database::v1::Backup>>
-DatabaseAdminClient::CreateBackup(
-    google::spanner::admin::database::v1::CreateBackupRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->CreateBackup(request);
-}
-
-StatusOr<google::spanner::admin::database::v1::Backup>
-DatabaseAdminClient::GetBackup(
-    google::spanner::admin::database::v1::GetBackupRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->GetBackup(request);
-}
-
-StatusOr<google::spanner::admin::database::v1::Backup>
-DatabaseAdminClient::UpdateBackup(
-    google::spanner::admin::database::v1::UpdateBackupRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->UpdateBackup(request);
-}
-
-Status DatabaseAdminClient::DeleteBackup(
-    google::spanner::admin::database::v1::DeleteBackupRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->DeleteBackup(request);
-}
-
-StreamRange<google::spanner::admin::database::v1::Backup>
-DatabaseAdminClient::ListBackups(
-    google::spanner::admin::database::v1::ListBackupsRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->ListBackups(std::move(request));
-}
-
-future<StatusOr<google::spanner::admin::database::v1::Database>>
-DatabaseAdminClient::RestoreDatabase(
-    google::spanner::admin::database::v1::RestoreDatabaseRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->RestoreDatabase(request);
-}
-
-StreamRange<google::longrunning::Operation>
-DatabaseAdminClient::ListDatabaseOperations(
-    google::spanner::admin::database::v1::ListDatabaseOperationsRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->ListDatabaseOperations(std::move(request));
 }
 
 StreamRange<google::longrunning::Operation>

--- a/google/cloud/spanner/admin/database_admin_client.h
+++ b/google/cloud/spanner/admin/database_admin_client.h
@@ -110,6 +110,24 @@ class DatabaseAdminClient {
       std::string const& parent, Options options = {});
 
   ///
+  /// Lists Cloud Spanner databases.
+  ///
+  /// @param request
+  /// @googleapis_link{google::spanner::admin::database::v1::ListDatabasesRequest,google/spanner/admin/database/v1/spanner_database_admin.proto#L413}
+  /// @param options  Optional. Operation options.
+  /// @return
+  /// @googleapis_link{google::spanner::admin::database::v1::Database,google/spanner/admin/database/v1/spanner_database_admin.proto#L326}
+  ///
+  /// [google.spanner.admin.database.v1.ListDatabasesRequest]:
+  /// @googleapis_reference_link{google/spanner/admin/database/v1/spanner_database_admin.proto#L413}
+  /// [google.spanner.admin.database.v1.Database]:
+  /// @googleapis_reference_link{google/spanner/admin/database/v1/spanner_database_admin.proto#L326}
+  ///
+  StreamRange<google::spanner::admin::database::v1::Database> ListDatabases(
+      google::spanner::admin::database::v1::ListDatabasesRequest request,
+      Options options = {});
+
+  ///
   /// Creates a new Cloud Spanner database and starts to prepare it for serving.
   /// The returned [long-running operation][google.longrunning.Operation] will
   /// have a name of the format `<database_name>/operations/<operation_id>` and
@@ -142,6 +160,33 @@ class DatabaseAdminClient {
                  Options options = {});
 
   ///
+  /// Creates a new Cloud Spanner database and starts to prepare it for serving.
+  /// The returned [long-running operation][google.longrunning.Operation] will
+  /// have a name of the format `<database_name>/operations/<operation_id>` and
+  /// can be used to track preparation of the database. The
+  /// [metadata][google.longrunning.Operation.metadata] field type is
+  /// [CreateDatabaseMetadata][google.spanner.admin.database.v1.CreateDatabaseMetadata].
+  /// The [response][google.longrunning.Operation.response] field type is
+  /// [Database][google.spanner.admin.database.v1.Database], if successful.
+  ///
+  /// @param request
+  /// @googleapis_link{google::spanner::admin::database::v1::CreateDatabaseRequest,google/spanner/admin/database/v1/spanner_database_admin.proto#L445}
+  /// @param options  Optional. Operation options.
+  /// @return
+  /// @googleapis_link{google::spanner::admin::database::v1::Database,google/spanner/admin/database/v1/spanner_database_admin.proto#L326}
+  ///
+  /// [google.spanner.admin.database.v1.CreateDatabaseRequest]:
+  /// @googleapis_reference_link{google/spanner/admin/database/v1/spanner_database_admin.proto#L445}
+  /// [google.spanner.admin.database.v1.Database]:
+  /// @googleapis_reference_link{google/spanner/admin/database/v1/spanner_database_admin.proto#L326}
+  ///
+  future<StatusOr<google::spanner::admin::database::v1::Database>>
+  CreateDatabase(
+      google::spanner::admin::database::v1::CreateDatabaseRequest const&
+          request,
+      Options options = {});
+
+  ///
   /// Gets the state of a Cloud Spanner database.
   ///
   /// @param name  Required. The name of the requested database. Values are of
@@ -158,6 +203,24 @@ class DatabaseAdminClient {
   ///
   StatusOr<google::spanner::admin::database::v1::Database> GetDatabase(
       std::string const& name, Options options = {});
+
+  ///
+  /// Gets the state of a Cloud Spanner database.
+  ///
+  /// @param request
+  /// @googleapis_link{google::spanner::admin::database::v1::GetDatabaseRequest,google/spanner/admin/database/v1/spanner_database_admin.proto#L484}
+  /// @param options  Optional. Operation options.
+  /// @return
+  /// @googleapis_link{google::spanner::admin::database::v1::Database,google/spanner/admin/database/v1/spanner_database_admin.proto#L326}
+  ///
+  /// [google.spanner.admin.database.v1.GetDatabaseRequest]:
+  /// @googleapis_reference_link{google/spanner/admin/database/v1/spanner_database_admin.proto#L484}
+  /// [google.spanner.admin.database.v1.Database]:
+  /// @googleapis_reference_link{google/spanner/admin/database/v1/spanner_database_admin.proto#L326}
+  ///
+  StatusOr<google::spanner::admin::database::v1::Database> GetDatabase(
+      google::spanner::admin::database::v1::GetDatabaseRequest const& request,
+      Options options = {});
 
   ///
   /// Updates the schema of a Cloud Spanner database by
@@ -187,6 +250,34 @@ class DatabaseAdminClient {
                     Options options = {});
 
   ///
+  /// Updates the schema of a Cloud Spanner database by
+  /// creating/altering/dropping tables, columns, indexes, etc. The returned
+  /// [long-running operation][google.longrunning.Operation] will have a name of
+  /// the format `<database_name>/operations/<operation_id>` and can be used to
+  /// track execution of the schema change(s). The
+  /// [metadata][google.longrunning.Operation.metadata] field type is
+  /// [UpdateDatabaseDdlMetadata][google.spanner.admin.database.v1.UpdateDatabaseDdlMetadata].
+  /// The operation has no response.
+  ///
+  /// @param request
+  /// @googleapis_link{google::spanner::admin::database::v1::UpdateDatabaseDdlRequest,google/spanner/admin/database/v1/spanner_database_admin.proto#L511}
+  /// @param options  Optional. Operation options.
+  /// @return
+  /// @googleapis_link{google::spanner::admin::database::v1::UpdateDatabaseDdlMetadata,google/spanner/admin/database/v1/spanner_database_admin.proto#L547}
+  ///
+  /// [google.spanner.admin.database.v1.UpdateDatabaseDdlRequest]:
+  /// @googleapis_reference_link{google/spanner/admin/database/v1/spanner_database_admin.proto#L511}
+  /// [google.spanner.admin.database.v1.UpdateDatabaseDdlMetadata]:
+  /// @googleapis_reference_link{google/spanner/admin/database/v1/spanner_database_admin.proto#L547}
+  ///
+  future<
+      StatusOr<google::spanner::admin::database::v1::UpdateDatabaseDdlMetadata>>
+  UpdateDatabaseDdl(
+      google::spanner::admin::database::v1::UpdateDatabaseDdlRequest const&
+          request,
+      Options options = {});
+
+  ///
   /// Drops (aka deletes) a Cloud Spanner database.
   /// Completed backups for the database will be retained according to their
   /// `expire_time`.
@@ -198,6 +289,22 @@ class DatabaseAdminClient {
   /// @googleapis_reference_link{google/spanner/admin/database/v1/spanner_database_admin.proto#L579}
   ///
   Status DropDatabase(std::string const& database, Options options = {});
+
+  ///
+  /// Drops (aka deletes) a Cloud Spanner database.
+  /// Completed backups for the database will be retained according to their
+  /// `expire_time`.
+  ///
+  /// @param request
+  /// @googleapis_link{google::spanner::admin::database::v1::DropDatabaseRequest,google/spanner/admin/database/v1/spanner_database_admin.proto#L579}
+  /// @param options  Optional. Operation options.
+  ///
+  /// [google.spanner.admin.database.v1.DropDatabaseRequest]:
+  /// @googleapis_reference_link{google/spanner/admin/database/v1/spanner_database_admin.proto#L579}
+  ///
+  Status DropDatabase(
+      google::spanner::admin::database::v1::DropDatabaseRequest const& request,
+      Options options = {});
 
   ///
   /// Returns the schema of a Cloud Spanner database as a list of formatted
@@ -218,6 +325,28 @@ class DatabaseAdminClient {
   ///
   StatusOr<google::spanner::admin::database::v1::GetDatabaseDdlResponse>
   GetDatabaseDdl(std::string const& database, Options options = {});
+
+  ///
+  /// Returns the schema of a Cloud Spanner database as a list of formatted
+  /// DDL statements. This method does not show pending schema updates, those
+  /// may be queried using the [Operations][google.longrunning.Operations] API.
+  ///
+  /// @param request
+  /// @googleapis_link{google::spanner::admin::database::v1::GetDatabaseDdlRequest,google/spanner/admin/database/v1/spanner_database_admin.proto#L590}
+  /// @param options  Optional. Operation options.
+  /// @return
+  /// @googleapis_link{google::spanner::admin::database::v1::GetDatabaseDdlResponse,google/spanner/admin/database/v1/spanner_database_admin.proto#L603}
+  ///
+  /// [google.spanner.admin.database.v1.GetDatabaseDdlRequest]:
+  /// @googleapis_reference_link{google/spanner/admin/database/v1/spanner_database_admin.proto#L590}
+  /// [google.spanner.admin.database.v1.GetDatabaseDdlResponse]:
+  /// @googleapis_reference_link{google/spanner/admin/database/v1/spanner_database_admin.proto#L603}
+  ///
+  StatusOr<google::spanner::admin::database::v1::GetDatabaseDdlResponse>
+  GetDatabaseDdl(
+      google::spanner::admin::database::v1::GetDatabaseDdlRequest const&
+          request,
+      Options options = {});
 
   ///
   /// Sets the access control policy on a database or backup resource.
@@ -275,6 +404,30 @@ class DatabaseAdminClient {
                                                  Options options = {});
 
   ///
+  /// Sets the access control policy on a database or backup resource.
+  /// Replaces any existing policy.
+  ///
+  /// Authorization requires `spanner.databases.setIamPolicy`
+  /// permission on [resource][google.iam.v1.SetIamPolicyRequest.resource].
+  /// For backups, authorization requires `spanner.backups.setIamPolicy`
+  /// permission on [resource][google.iam.v1.SetIamPolicyRequest.resource].
+  ///
+  /// @param request
+  /// @googleapis_link{google::iam::v1::SetIamPolicyRequest,google/iam/v1/iam_policy.proto#L98}
+  /// @param options  Optional. Operation options.
+  /// @return
+  /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
+  ///
+  /// [google.iam.v1.SetIamPolicyRequest]:
+  /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L98}
+  /// [google.iam.v1.Policy]:
+  /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
+  ///
+  StatusOr<google::iam::v1::Policy> SetIamPolicy(
+      google::iam::v1::SetIamPolicyRequest const& request,
+      Options options = {});
+
+  ///
   /// Gets the access control policy for a database or backup resource.
   /// Returns an empty policy if a database or backup exists but does not have a
   /// policy set.
@@ -298,6 +451,31 @@ class DatabaseAdminClient {
   ///
   StatusOr<google::iam::v1::Policy> GetIamPolicy(std::string const& resource,
                                                  Options options = {});
+
+  ///
+  /// Gets the access control policy for a database or backup resource.
+  /// Returns an empty policy if a database or backup exists but does not have a
+  /// policy set.
+  ///
+  /// Authorization requires `spanner.databases.getIamPolicy` permission on
+  /// [resource][google.iam.v1.GetIamPolicyRequest.resource].
+  /// For backups, authorization requires `spanner.backups.getIamPolicy`
+  /// permission on [resource][google.iam.v1.GetIamPolicyRequest.resource].
+  ///
+  /// @param request
+  /// @googleapis_link{google::iam::v1::GetIamPolicyRequest,google/iam/v1/iam_policy.proto#L113}
+  /// @param options  Optional. Operation options.
+  /// @return
+  /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
+  ///
+  /// [google.iam.v1.GetIamPolicyRequest]:
+  /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L113}
+  /// [google.iam.v1.Policy]:
+  /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
+  ///
+  StatusOr<google::iam::v1::Policy> GetIamPolicy(
+      google::iam::v1::GetIamPolicyRequest const& request,
+      Options options = {});
 
   ///
   /// Returns permissions that the caller has on the specified database or
@@ -330,6 +508,33 @@ class DatabaseAdminClient {
   ///
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
       std::string const& resource, std::vector<std::string> const& permissions,
+      Options options = {});
+
+  ///
+  /// Returns permissions that the caller has on the specified database or
+  /// backup resource.
+  ///
+  /// Attempting this RPC on a non-existent Cloud Spanner database will
+  /// result in a NOT_FOUND error if the user has
+  /// `spanner.databases.list` permission on the containing Cloud
+  /// Spanner instance. Otherwise returns an empty set of permissions.
+  /// Calling this method on a backup that does not exist will
+  /// result in a NOT_FOUND error if the user has
+  /// `spanner.backups.list` permission on the containing instance.
+  ///
+  /// @param request
+  /// @googleapis_link{google::iam::v1::TestIamPermissionsRequest,google/iam/v1/iam_policy.proto#L126}
+  /// @param options  Optional. Operation options.
+  /// @return
+  /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
+  ///
+  /// [google.iam.v1.TestIamPermissionsRequest]:
+  /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L126}
+  /// [google.iam.v1.TestIamPermissionsResponse]:
+  /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L141}
+  ///
+  StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
+      google::iam::v1::TestIamPermissionsRequest const& request,
       Options options = {});
 
   ///
@@ -373,6 +578,35 @@ class DatabaseAdminClient {
       std::string const& backup_id, Options options = {});
 
   ///
+  /// Starts creating a new Cloud Spanner Backup.
+  /// The returned backup [long-running operation][google.longrunning.Operation]
+  /// will have a name of the format
+  /// `projects/<project>/instances/<instance>/backups/<backup>/operations/<operation_id>`
+  /// and can be used to track creation of the backup. The
+  /// [metadata][google.longrunning.Operation.metadata] field type is
+  /// [CreateBackupMetadata][google.spanner.admin.database.v1.CreateBackupMetadata].
+  /// The [response][google.longrunning.Operation.response] field type is
+  /// [Backup][google.spanner.admin.database.v1.Backup], if successful.
+  /// Cancelling the returned operation will stop the creation and delete the
+  /// backup. There can be only one pending backup creation per database. Backup
+  /// creation of different databases can run concurrently.
+  ///
+  /// @param request
+  /// @googleapis_link{google::spanner::admin::database::v1::CreateBackupRequest,google/spanner/admin/database/v1/backup.proto#L123}
+  /// @param options  Optional. Operation options.
+  /// @return
+  /// @googleapis_link{google::spanner::admin::database::v1::Backup,google/spanner/admin/database/v1/backup.proto#L36}
+  ///
+  /// [google.spanner.admin.database.v1.CreateBackupRequest]:
+  /// @googleapis_reference_link{google/spanner/admin/database/v1/backup.proto#L123}
+  /// [google.spanner.admin.database.v1.Backup]:
+  /// @googleapis_reference_link{google/spanner/admin/database/v1/backup.proto#L36}
+  ///
+  future<StatusOr<google::spanner::admin::database::v1::Backup>> CreateBackup(
+      google::spanner::admin::database::v1::CreateBackupRequest const& request,
+      Options options = {});
+
+  ///
   /// Gets metadata on a pending or completed
   /// [Backup][google.spanner.admin.database.v1.Backup].
   ///
@@ -390,6 +624,25 @@ class DatabaseAdminClient {
   ///
   StatusOr<google::spanner::admin::database::v1::Backup> GetBackup(
       std::string const& name, Options options = {});
+
+  ///
+  /// Gets metadata on a pending or completed
+  /// [Backup][google.spanner.admin.database.v1.Backup].
+  ///
+  /// @param request
+  /// @googleapis_link{google::spanner::admin::database::v1::GetBackupRequest,google/spanner/admin/database/v1/backup.proto#L202}
+  /// @param options  Optional. Operation options.
+  /// @return
+  /// @googleapis_link{google::spanner::admin::database::v1::Backup,google/spanner/admin/database/v1/backup.proto#L36}
+  ///
+  /// [google.spanner.admin.database.v1.GetBackupRequest]:
+  /// @googleapis_reference_link{google/spanner/admin/database/v1/backup.proto#L202}
+  /// [google.spanner.admin.database.v1.Backup]:
+  /// @googleapis_reference_link{google/spanner/admin/database/v1/backup.proto#L36}
+  ///
+  StatusOr<google::spanner::admin::database::v1::Backup> GetBackup(
+      google::spanner::admin::database::v1::GetBackupRequest const& request,
+      Options options = {});
 
   ///
   /// Updates a pending or completed
@@ -420,6 +673,25 @@ class DatabaseAdminClient {
       google::protobuf::FieldMask const& update_mask, Options options = {});
 
   ///
+  /// Updates a pending or completed
+  /// [Backup][google.spanner.admin.database.v1.Backup].
+  ///
+  /// @param request
+  /// @googleapis_link{google::spanner::admin::database::v1::UpdateBackupRequest,google/spanner/admin/database/v1/backup.proto#L186}
+  /// @param options  Optional. Operation options.
+  /// @return
+  /// @googleapis_link{google::spanner::admin::database::v1::Backup,google/spanner/admin/database/v1/backup.proto#L36}
+  ///
+  /// [google.spanner.admin.database.v1.UpdateBackupRequest]:
+  /// @googleapis_reference_link{google/spanner/admin/database/v1/backup.proto#L186}
+  /// [google.spanner.admin.database.v1.Backup]:
+  /// @googleapis_reference_link{google/spanner/admin/database/v1/backup.proto#L36}
+  ///
+  StatusOr<google::spanner::admin::database::v1::Backup> UpdateBackup(
+      google::spanner::admin::database::v1::UpdateBackupRequest const& request,
+      Options options = {});
+
+  ///
   /// Deletes a pending or completed
   /// [Backup][google.spanner.admin.database.v1.Backup].
   ///
@@ -432,6 +704,21 @@ class DatabaseAdminClient {
   /// @googleapis_reference_link{google/spanner/admin/database/v1/backup.proto#L215}
   ///
   Status DeleteBackup(std::string const& name, Options options = {});
+
+  ///
+  /// Deletes a pending or completed
+  /// [Backup][google.spanner.admin.database.v1.Backup].
+  ///
+  /// @param request
+  /// @googleapis_link{google::spanner::admin::database::v1::DeleteBackupRequest,google/spanner/admin/database/v1/backup.proto#L215}
+  /// @param options  Optional. Operation options.
+  ///
+  /// [google.spanner.admin.database.v1.DeleteBackupRequest]:
+  /// @googleapis_reference_link{google/spanner/admin/database/v1/backup.proto#L215}
+  ///
+  Status DeleteBackup(
+      google::spanner::admin::database::v1::DeleteBackupRequest const& request,
+      Options options = {});
 
   ///
   /// Lists completed and pending backups.
@@ -452,6 +739,26 @@ class DatabaseAdminClient {
   ///
   StreamRange<google::spanner::admin::database::v1::Backup> ListBackups(
       std::string const& parent, Options options = {});
+
+  ///
+  /// Lists completed and pending backups.
+  /// Backups returned are ordered by `create_time` in descending order,
+  /// starting from the most recent `create_time`.
+  ///
+  /// @param request
+  /// @googleapis_link{google::spanner::admin::database::v1::ListBackupsRequest,google/spanner/admin/database/v1/backup.proto#L228}
+  /// @param options  Optional. Operation options.
+  /// @return
+  /// @googleapis_link{google::spanner::admin::database::v1::Backup,google/spanner/admin/database/v1/backup.proto#L36}
+  ///
+  /// [google.spanner.admin.database.v1.ListBackupsRequest]:
+  /// @googleapis_reference_link{google/spanner/admin/database/v1/backup.proto#L228}
+  /// [google.spanner.admin.database.v1.Backup]:
+  /// @googleapis_reference_link{google/spanner/admin/database/v1/backup.proto#L36}
+  ///
+  StreamRange<google::spanner::admin::database::v1::Backup> ListBackups(
+      google::spanner::admin::database::v1::ListBackupsRequest request,
+      Options options = {});
 
   ///
   /// Create a new database by restoring from a completed backup. The new
@@ -499,364 +806,6 @@ class DatabaseAdminClient {
                   std::string const& backup, Options options = {});
 
   ///
-  /// Lists database [longrunning-operations][google.longrunning.Operation].
-  /// A database operation has a name of the form
-  /// `projects/<project>/instances/<instance>/databases/<database>/operations/<operation>`.
-  /// The long-running operation
-  /// [metadata][google.longrunning.Operation.metadata] field type
-  /// `metadata.type_url` describes the type of the metadata. Operations
-  /// returned include those that have completed/failed/canceled within the last
-  /// 7 days, and pending operations.
-  ///
-  /// @param parent  Required. The instance of the database operations.
-  ///  Values are of the form `projects/<project>/instances/<instance>`.
-  /// @param options  Optional. Operation options.
-  /// @return
-  /// @googleapis_link{google::longrunning::Operation,google/longrunning/operations.proto#L128}
-  ///
-  /// [google.spanner.admin.database.v1.ListDatabaseOperationsRequest]:
-  /// @googleapis_reference_link{google/spanner/admin/database/v1/spanner_database_admin.proto#L611}
-  /// [google.longrunning.Operation]:
-  /// @googleapis_reference_link{google/longrunning/operations.proto#L128}
-  ///
-  StreamRange<google::longrunning::Operation> ListDatabaseOperations(
-      std::string const& parent, Options options = {});
-
-  ///
-  /// Lists the backup [long-running operations][google.longrunning.Operation]
-  /// in the given instance. A backup operation has a name of the form
-  /// `projects/<project>/instances/<instance>/backups/<backup>/operations/<operation>`.
-  /// The long-running operation
-  /// [metadata][google.longrunning.Operation.metadata] field type
-  /// `metadata.type_url` describes the type of the metadata. Operations
-  /// returned include those that have completed/failed/canceled within the last
-  /// 7 days, and pending operations. Operations returned are ordered by
-  /// `operation.metadata.value.progress.start_time` in descending order
-  /// starting from the most recently started operation.
-  ///
-  /// @param parent  Required. The instance of the backup operations. Values are
-  /// of
-  ///  the form `projects/<project>/instances/<instance>`.
-  /// @param options  Optional. Operation options.
-  /// @return
-  /// @googleapis_link{google::longrunning::Operation,google/longrunning/operations.proto#L128}
-  ///
-  /// [google.spanner.admin.database.v1.ListBackupOperationsRequest]:
-  /// @googleapis_reference_link{google/spanner/admin/database/v1/backup.proto#L300}
-  /// [google.longrunning.Operation]:
-  /// @googleapis_reference_link{google/longrunning/operations.proto#L128}
-  ///
-  StreamRange<google::longrunning::Operation> ListBackupOperations(
-      std::string const& parent, Options options = {});
-
-  ///
-  /// Lists Cloud Spanner databases.
-  ///
-  /// @param request
-  /// @googleapis_link{google::spanner::admin::database::v1::ListDatabasesRequest,google/spanner/admin/database/v1/spanner_database_admin.proto#L413}
-  /// @param options  Optional. Operation options.
-  /// @return
-  /// @googleapis_link{google::spanner::admin::database::v1::Database,google/spanner/admin/database/v1/spanner_database_admin.proto#L326}
-  ///
-  /// [google.spanner.admin.database.v1.ListDatabasesRequest]:
-  /// @googleapis_reference_link{google/spanner/admin/database/v1/spanner_database_admin.proto#L413}
-  /// [google.spanner.admin.database.v1.Database]:
-  /// @googleapis_reference_link{google/spanner/admin/database/v1/spanner_database_admin.proto#L326}
-  ///
-  StreamRange<google::spanner::admin::database::v1::Database> ListDatabases(
-      google::spanner::admin::database::v1::ListDatabasesRequest request,
-      Options options = {});
-
-  ///
-  /// Creates a new Cloud Spanner database and starts to prepare it for serving.
-  /// The returned [long-running operation][google.longrunning.Operation] will
-  /// have a name of the format `<database_name>/operations/<operation_id>` and
-  /// can be used to track preparation of the database. The
-  /// [metadata][google.longrunning.Operation.metadata] field type is
-  /// [CreateDatabaseMetadata][google.spanner.admin.database.v1.CreateDatabaseMetadata].
-  /// The [response][google.longrunning.Operation.response] field type is
-  /// [Database][google.spanner.admin.database.v1.Database], if successful.
-  ///
-  /// @param request
-  /// @googleapis_link{google::spanner::admin::database::v1::CreateDatabaseRequest,google/spanner/admin/database/v1/spanner_database_admin.proto#L445}
-  /// @param options  Optional. Operation options.
-  /// @return
-  /// @googleapis_link{google::spanner::admin::database::v1::Database,google/spanner/admin/database/v1/spanner_database_admin.proto#L326}
-  ///
-  /// [google.spanner.admin.database.v1.CreateDatabaseRequest]:
-  /// @googleapis_reference_link{google/spanner/admin/database/v1/spanner_database_admin.proto#L445}
-  /// [google.spanner.admin.database.v1.Database]:
-  /// @googleapis_reference_link{google/spanner/admin/database/v1/spanner_database_admin.proto#L326}
-  ///
-  future<StatusOr<google::spanner::admin::database::v1::Database>>
-  CreateDatabase(
-      google::spanner::admin::database::v1::CreateDatabaseRequest const&
-          request,
-      Options options = {});
-
-  ///
-  /// Gets the state of a Cloud Spanner database.
-  ///
-  /// @param request
-  /// @googleapis_link{google::spanner::admin::database::v1::GetDatabaseRequest,google/spanner/admin/database/v1/spanner_database_admin.proto#L484}
-  /// @param options  Optional. Operation options.
-  /// @return
-  /// @googleapis_link{google::spanner::admin::database::v1::Database,google/spanner/admin/database/v1/spanner_database_admin.proto#L326}
-  ///
-  /// [google.spanner.admin.database.v1.GetDatabaseRequest]:
-  /// @googleapis_reference_link{google/spanner/admin/database/v1/spanner_database_admin.proto#L484}
-  /// [google.spanner.admin.database.v1.Database]:
-  /// @googleapis_reference_link{google/spanner/admin/database/v1/spanner_database_admin.proto#L326}
-  ///
-  StatusOr<google::spanner::admin::database::v1::Database> GetDatabase(
-      google::spanner::admin::database::v1::GetDatabaseRequest const& request,
-      Options options = {});
-
-  ///
-  /// Updates the schema of a Cloud Spanner database by
-  /// creating/altering/dropping tables, columns, indexes, etc. The returned
-  /// [long-running operation][google.longrunning.Operation] will have a name of
-  /// the format `<database_name>/operations/<operation_id>` and can be used to
-  /// track execution of the schema change(s). The
-  /// [metadata][google.longrunning.Operation.metadata] field type is
-  /// [UpdateDatabaseDdlMetadata][google.spanner.admin.database.v1.UpdateDatabaseDdlMetadata].
-  /// The operation has no response.
-  ///
-  /// @param request
-  /// @googleapis_link{google::spanner::admin::database::v1::UpdateDatabaseDdlRequest,google/spanner/admin/database/v1/spanner_database_admin.proto#L511}
-  /// @param options  Optional. Operation options.
-  /// @return
-  /// @googleapis_link{google::spanner::admin::database::v1::UpdateDatabaseDdlMetadata,google/spanner/admin/database/v1/spanner_database_admin.proto#L547}
-  ///
-  /// [google.spanner.admin.database.v1.UpdateDatabaseDdlRequest]:
-  /// @googleapis_reference_link{google/spanner/admin/database/v1/spanner_database_admin.proto#L511}
-  /// [google.spanner.admin.database.v1.UpdateDatabaseDdlMetadata]:
-  /// @googleapis_reference_link{google/spanner/admin/database/v1/spanner_database_admin.proto#L547}
-  ///
-  future<
-      StatusOr<google::spanner::admin::database::v1::UpdateDatabaseDdlMetadata>>
-  UpdateDatabaseDdl(
-      google::spanner::admin::database::v1::UpdateDatabaseDdlRequest const&
-          request,
-      Options options = {});
-
-  ///
-  /// Drops (aka deletes) a Cloud Spanner database.
-  /// Completed backups for the database will be retained according to their
-  /// `expire_time`.
-  ///
-  /// @param request
-  /// @googleapis_link{google::spanner::admin::database::v1::DropDatabaseRequest,google/spanner/admin/database/v1/spanner_database_admin.proto#L579}
-  /// @param options  Optional. Operation options.
-  ///
-  /// [google.spanner.admin.database.v1.DropDatabaseRequest]:
-  /// @googleapis_reference_link{google/spanner/admin/database/v1/spanner_database_admin.proto#L579}
-  ///
-  Status DropDatabase(
-      google::spanner::admin::database::v1::DropDatabaseRequest const& request,
-      Options options = {});
-
-  ///
-  /// Returns the schema of a Cloud Spanner database as a list of formatted
-  /// DDL statements. This method does not show pending schema updates, those
-  /// may be queried using the [Operations][google.longrunning.Operations] API.
-  ///
-  /// @param request
-  /// @googleapis_link{google::spanner::admin::database::v1::GetDatabaseDdlRequest,google/spanner/admin/database/v1/spanner_database_admin.proto#L590}
-  /// @param options  Optional. Operation options.
-  /// @return
-  /// @googleapis_link{google::spanner::admin::database::v1::GetDatabaseDdlResponse,google/spanner/admin/database/v1/spanner_database_admin.proto#L603}
-  ///
-  /// [google.spanner.admin.database.v1.GetDatabaseDdlRequest]:
-  /// @googleapis_reference_link{google/spanner/admin/database/v1/spanner_database_admin.proto#L590}
-  /// [google.spanner.admin.database.v1.GetDatabaseDdlResponse]:
-  /// @googleapis_reference_link{google/spanner/admin/database/v1/spanner_database_admin.proto#L603}
-  ///
-  StatusOr<google::spanner::admin::database::v1::GetDatabaseDdlResponse>
-  GetDatabaseDdl(
-      google::spanner::admin::database::v1::GetDatabaseDdlRequest const&
-          request,
-      Options options = {});
-
-  ///
-  /// Sets the access control policy on a database or backup resource.
-  /// Replaces any existing policy.
-  ///
-  /// Authorization requires `spanner.databases.setIamPolicy`
-  /// permission on [resource][google.iam.v1.SetIamPolicyRequest.resource].
-  /// For backups, authorization requires `spanner.backups.setIamPolicy`
-  /// permission on [resource][google.iam.v1.SetIamPolicyRequest.resource].
-  ///
-  /// @param request
-  /// @googleapis_link{google::iam::v1::SetIamPolicyRequest,google/iam/v1/iam_policy.proto#L98}
-  /// @param options  Optional. Operation options.
-  /// @return
-  /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
-  ///
-  /// [google.iam.v1.SetIamPolicyRequest]:
-  /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L98}
-  /// [google.iam.v1.Policy]:
-  /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
-  ///
-  StatusOr<google::iam::v1::Policy> SetIamPolicy(
-      google::iam::v1::SetIamPolicyRequest const& request,
-      Options options = {});
-
-  ///
-  /// Gets the access control policy for a database or backup resource.
-  /// Returns an empty policy if a database or backup exists but does not have a
-  /// policy set.
-  ///
-  /// Authorization requires `spanner.databases.getIamPolicy` permission on
-  /// [resource][google.iam.v1.GetIamPolicyRequest.resource].
-  /// For backups, authorization requires `spanner.backups.getIamPolicy`
-  /// permission on [resource][google.iam.v1.GetIamPolicyRequest.resource].
-  ///
-  /// @param request
-  /// @googleapis_link{google::iam::v1::GetIamPolicyRequest,google/iam/v1/iam_policy.proto#L113}
-  /// @param options  Optional. Operation options.
-  /// @return
-  /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
-  ///
-  /// [google.iam.v1.GetIamPolicyRequest]:
-  /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L113}
-  /// [google.iam.v1.Policy]:
-  /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
-  ///
-  StatusOr<google::iam::v1::Policy> GetIamPolicy(
-      google::iam::v1::GetIamPolicyRequest const& request,
-      Options options = {});
-
-  ///
-  /// Returns permissions that the caller has on the specified database or
-  /// backup resource.
-  ///
-  /// Attempting this RPC on a non-existent Cloud Spanner database will
-  /// result in a NOT_FOUND error if the user has
-  /// `spanner.databases.list` permission on the containing Cloud
-  /// Spanner instance. Otherwise returns an empty set of permissions.
-  /// Calling this method on a backup that does not exist will
-  /// result in a NOT_FOUND error if the user has
-  /// `spanner.backups.list` permission on the containing instance.
-  ///
-  /// @param request
-  /// @googleapis_link{google::iam::v1::TestIamPermissionsRequest,google/iam/v1/iam_policy.proto#L126}
-  /// @param options  Optional. Operation options.
-  /// @return
-  /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
-  ///
-  /// [google.iam.v1.TestIamPermissionsRequest]:
-  /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L126}
-  /// [google.iam.v1.TestIamPermissionsResponse]:
-  /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L141}
-  ///
-  StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
-      google::iam::v1::TestIamPermissionsRequest const& request,
-      Options options = {});
-
-  ///
-  /// Starts creating a new Cloud Spanner Backup.
-  /// The returned backup [long-running operation][google.longrunning.Operation]
-  /// will have a name of the format
-  /// `projects/<project>/instances/<instance>/backups/<backup>/operations/<operation_id>`
-  /// and can be used to track creation of the backup. The
-  /// [metadata][google.longrunning.Operation.metadata] field type is
-  /// [CreateBackupMetadata][google.spanner.admin.database.v1.CreateBackupMetadata].
-  /// The [response][google.longrunning.Operation.response] field type is
-  /// [Backup][google.spanner.admin.database.v1.Backup], if successful.
-  /// Cancelling the returned operation will stop the creation and delete the
-  /// backup. There can be only one pending backup creation per database. Backup
-  /// creation of different databases can run concurrently.
-  ///
-  /// @param request
-  /// @googleapis_link{google::spanner::admin::database::v1::CreateBackupRequest,google/spanner/admin/database/v1/backup.proto#L123}
-  /// @param options  Optional. Operation options.
-  /// @return
-  /// @googleapis_link{google::spanner::admin::database::v1::Backup,google/spanner/admin/database/v1/backup.proto#L36}
-  ///
-  /// [google.spanner.admin.database.v1.CreateBackupRequest]:
-  /// @googleapis_reference_link{google/spanner/admin/database/v1/backup.proto#L123}
-  /// [google.spanner.admin.database.v1.Backup]:
-  /// @googleapis_reference_link{google/spanner/admin/database/v1/backup.proto#L36}
-  ///
-  future<StatusOr<google::spanner::admin::database::v1::Backup>> CreateBackup(
-      google::spanner::admin::database::v1::CreateBackupRequest const& request,
-      Options options = {});
-
-  ///
-  /// Gets metadata on a pending or completed
-  /// [Backup][google.spanner.admin.database.v1.Backup].
-  ///
-  /// @param request
-  /// @googleapis_link{google::spanner::admin::database::v1::GetBackupRequest,google/spanner/admin/database/v1/backup.proto#L202}
-  /// @param options  Optional. Operation options.
-  /// @return
-  /// @googleapis_link{google::spanner::admin::database::v1::Backup,google/spanner/admin/database/v1/backup.proto#L36}
-  ///
-  /// [google.spanner.admin.database.v1.GetBackupRequest]:
-  /// @googleapis_reference_link{google/spanner/admin/database/v1/backup.proto#L202}
-  /// [google.spanner.admin.database.v1.Backup]:
-  /// @googleapis_reference_link{google/spanner/admin/database/v1/backup.proto#L36}
-  ///
-  StatusOr<google::spanner::admin::database::v1::Backup> GetBackup(
-      google::spanner::admin::database::v1::GetBackupRequest const& request,
-      Options options = {});
-
-  ///
-  /// Updates a pending or completed
-  /// [Backup][google.spanner.admin.database.v1.Backup].
-  ///
-  /// @param request
-  /// @googleapis_link{google::spanner::admin::database::v1::UpdateBackupRequest,google/spanner/admin/database/v1/backup.proto#L186}
-  /// @param options  Optional. Operation options.
-  /// @return
-  /// @googleapis_link{google::spanner::admin::database::v1::Backup,google/spanner/admin/database/v1/backup.proto#L36}
-  ///
-  /// [google.spanner.admin.database.v1.UpdateBackupRequest]:
-  /// @googleapis_reference_link{google/spanner/admin/database/v1/backup.proto#L186}
-  /// [google.spanner.admin.database.v1.Backup]:
-  /// @googleapis_reference_link{google/spanner/admin/database/v1/backup.proto#L36}
-  ///
-  StatusOr<google::spanner::admin::database::v1::Backup> UpdateBackup(
-      google::spanner::admin::database::v1::UpdateBackupRequest const& request,
-      Options options = {});
-
-  ///
-  /// Deletes a pending or completed
-  /// [Backup][google.spanner.admin.database.v1.Backup].
-  ///
-  /// @param request
-  /// @googleapis_link{google::spanner::admin::database::v1::DeleteBackupRequest,google/spanner/admin/database/v1/backup.proto#L215}
-  /// @param options  Optional. Operation options.
-  ///
-  /// [google.spanner.admin.database.v1.DeleteBackupRequest]:
-  /// @googleapis_reference_link{google/spanner/admin/database/v1/backup.proto#L215}
-  ///
-  Status DeleteBackup(
-      google::spanner::admin::database::v1::DeleteBackupRequest const& request,
-      Options options = {});
-
-  ///
-  /// Lists completed and pending backups.
-  /// Backups returned are ordered by `create_time` in descending order,
-  /// starting from the most recent `create_time`.
-  ///
-  /// @param request
-  /// @googleapis_link{google::spanner::admin::database::v1::ListBackupsRequest,google/spanner/admin/database/v1/backup.proto#L228}
-  /// @param options  Optional. Operation options.
-  /// @return
-  /// @googleapis_link{google::spanner::admin::database::v1::Backup,google/spanner/admin/database/v1/backup.proto#L36}
-  ///
-  /// [google.spanner.admin.database.v1.ListBackupsRequest]:
-  /// @googleapis_reference_link{google/spanner/admin/database/v1/backup.proto#L228}
-  /// [google.spanner.admin.database.v1.Backup]:
-  /// @googleapis_reference_link{google/spanner/admin/database/v1/backup.proto#L36}
-  ///
-  StreamRange<google::spanner::admin::database::v1::Backup> ListBackups(
-      google::spanner::admin::database::v1::ListBackupsRequest request,
-      Options options = {});
-
-  ///
   /// Create a new database by restoring from a completed backup. The new
   /// database must be in the same project and in an instance with the same
   /// instance configuration as the instance containing
@@ -902,6 +851,30 @@ class DatabaseAdminClient {
   /// returned include those that have completed/failed/canceled within the last
   /// 7 days, and pending operations.
   ///
+  /// @param parent  Required. The instance of the database operations.
+  ///  Values are of the form `projects/<project>/instances/<instance>`.
+  /// @param options  Optional. Operation options.
+  /// @return
+  /// @googleapis_link{google::longrunning::Operation,google/longrunning/operations.proto#L128}
+  ///
+  /// [google.spanner.admin.database.v1.ListDatabaseOperationsRequest]:
+  /// @googleapis_reference_link{google/spanner/admin/database/v1/spanner_database_admin.proto#L611}
+  /// [google.longrunning.Operation]:
+  /// @googleapis_reference_link{google/longrunning/operations.proto#L128}
+  ///
+  StreamRange<google::longrunning::Operation> ListDatabaseOperations(
+      std::string const& parent, Options options = {});
+
+  ///
+  /// Lists database [longrunning-operations][google.longrunning.Operation].
+  /// A database operation has a name of the form
+  /// `projects/<project>/instances/<instance>/databases/<database>/operations/<operation>`.
+  /// The long-running operation
+  /// [metadata][google.longrunning.Operation.metadata] field type
+  /// `metadata.type_url` describes the type of the metadata. Operations
+  /// returned include those that have completed/failed/canceled within the last
+  /// 7 days, and pending operations.
+  ///
   /// @param request
   /// @googleapis_link{google::spanner::admin::database::v1::ListDatabaseOperationsRequest,google/spanner/admin/database/v1/spanner_database_admin.proto#L611}
   /// @param options  Optional. Operation options.
@@ -917,6 +890,33 @@ class DatabaseAdminClient {
       google::spanner::admin::database::v1::ListDatabaseOperationsRequest
           request,
       Options options = {});
+
+  ///
+  /// Lists the backup [long-running operations][google.longrunning.Operation]
+  /// in the given instance. A backup operation has a name of the form
+  /// `projects/<project>/instances/<instance>/backups/<backup>/operations/<operation>`.
+  /// The long-running operation
+  /// [metadata][google.longrunning.Operation.metadata] field type
+  /// `metadata.type_url` describes the type of the metadata. Operations
+  /// returned include those that have completed/failed/canceled within the last
+  /// 7 days, and pending operations. Operations returned are ordered by
+  /// `operation.metadata.value.progress.start_time` in descending order
+  /// starting from the most recently started operation.
+  ///
+  /// @param parent  Required. The instance of the backup operations. Values are
+  /// of
+  ///  the form `projects/<project>/instances/<instance>`.
+  /// @param options  Optional. Operation options.
+  /// @return
+  /// @googleapis_link{google::longrunning::Operation,google/longrunning/operations.proto#L128}
+  ///
+  /// [google.spanner.admin.database.v1.ListBackupOperationsRequest]:
+  /// @googleapis_reference_link{google/spanner/admin/database/v1/backup.proto#L300}
+  /// [google.longrunning.Operation]:
+  /// @googleapis_reference_link{google/longrunning/operations.proto#L128}
+  ///
+  StreamRange<google::longrunning::Operation> ListBackupOperations(
+      std::string const& parent, Options options = {});
 
   ///
   /// Lists the backup [long-running operations][google.longrunning.Operation]

--- a/google/cloud/spanner/admin/instance_admin_client.cc
+++ b/google/cloud/spanner/admin/instance_admin_client.cc
@@ -44,6 +44,15 @@ InstanceAdminClient::ListInstanceConfigs(std::string const& parent,
   return connection_->ListInstanceConfigs(request);
 }
 
+StreamRange<google::spanner::admin::instance::v1::InstanceConfig>
+InstanceAdminClient::ListInstanceConfigs(
+    google::spanner::admin::instance::v1::ListInstanceConfigsRequest request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
+  return connection_->ListInstanceConfigs(std::move(request));
+}
+
 StatusOr<google::spanner::admin::instance::v1::InstanceConfig>
 InstanceAdminClient::GetInstanceConfig(std::string const& name,
                                        Options options) {
@@ -51,6 +60,16 @@ InstanceAdminClient::GetInstanceConfig(std::string const& name,
       internal::MergeOptions(std::move(options), options_));
   google::spanner::admin::instance::v1::GetInstanceConfigRequest request;
   request.set_name(name);
+  return connection_->GetInstanceConfig(request);
+}
+
+StatusOr<google::spanner::admin::instance::v1::InstanceConfig>
+InstanceAdminClient::GetInstanceConfig(
+    google::spanner::admin::instance::v1::GetInstanceConfigRequest const&
+        request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->GetInstanceConfig(request);
 }
 
@@ -63,12 +82,30 @@ InstanceAdminClient::ListInstances(std::string const& parent, Options options) {
   return connection_->ListInstances(request);
 }
 
+StreamRange<google::spanner::admin::instance::v1::Instance>
+InstanceAdminClient::ListInstances(
+    google::spanner::admin::instance::v1::ListInstancesRequest request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
+  return connection_->ListInstances(std::move(request));
+}
+
 StatusOr<google::spanner::admin::instance::v1::Instance>
 InstanceAdminClient::GetInstance(std::string const& name, Options options) {
   internal::OptionsSpan span(
       internal::MergeOptions(std::move(options), options_));
   google::spanner::admin::instance::v1::GetInstanceRequest request;
   request.set_name(name);
+  return connection_->GetInstance(request);
+}
+
+StatusOr<google::spanner::admin::instance::v1::Instance>
+InstanceAdminClient::GetInstance(
+    google::spanner::admin::instance::v1::GetInstanceRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->GetInstance(request);
 }
 
@@ -87,6 +124,15 @@ InstanceAdminClient::CreateInstance(
 }
 
 future<StatusOr<google::spanner::admin::instance::v1::Instance>>
+InstanceAdminClient::CreateInstance(
+    google::spanner::admin::instance::v1::CreateInstanceRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
+  return connection_->CreateInstance(request);
+}
+
+future<StatusOr<google::spanner::admin::instance::v1::Instance>>
 InstanceAdminClient::UpdateInstance(
     google::spanner::admin::instance::v1::Instance const& instance,
     google::protobuf::FieldMask const& field_mask, Options options) {
@@ -98,12 +144,29 @@ InstanceAdminClient::UpdateInstance(
   return connection_->UpdateInstance(request);
 }
 
+future<StatusOr<google::spanner::admin::instance::v1::Instance>>
+InstanceAdminClient::UpdateInstance(
+    google::spanner::admin::instance::v1::UpdateInstanceRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
+  return connection_->UpdateInstance(request);
+}
+
 Status InstanceAdminClient::DeleteInstance(std::string const& name,
                                            Options options) {
   internal::OptionsSpan span(
       internal::MergeOptions(std::move(options), options_));
   google::spanner::admin::instance::v1::DeleteInstanceRequest request;
   request.set_name(name);
+  return connection_->DeleteInstance(request);
+}
+
+Status InstanceAdminClient::DeleteInstance(
+    google::spanner::admin::instance::v1::DeleteInstanceRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->DeleteInstance(request);
 }
 
@@ -144,12 +207,26 @@ StatusOr<google::iam::v1::Policy> InstanceAdminClient::SetIamPolicy(
   }
 }
 
+StatusOr<google::iam::v1::Policy> InstanceAdminClient::SetIamPolicy(
+    google::iam::v1::SetIamPolicyRequest const& request, Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
+  return connection_->SetIamPolicy(request);
+}
+
 StatusOr<google::iam::v1::Policy> InstanceAdminClient::GetIamPolicy(
     std::string const& resource, Options options) {
   internal::OptionsSpan span(
       internal::MergeOptions(std::move(options), options_));
   google::iam::v1::GetIamPolicyRequest request;
   request.set_resource(resource);
+  return connection_->GetIamPolicy(request);
+}
+
+StatusOr<google::iam::v1::Policy> InstanceAdminClient::GetIamPolicy(
+    google::iam::v1::GetIamPolicyRequest const& request, Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->GetIamPolicy(request);
 }
 
@@ -163,83 +240,6 @@ InstanceAdminClient::TestIamPermissions(
   request.set_resource(resource);
   *request.mutable_permissions() = {permissions.begin(), permissions.end()};
   return connection_->TestIamPermissions(request);
-}
-
-StreamRange<google::spanner::admin::instance::v1::InstanceConfig>
-InstanceAdminClient::ListInstanceConfigs(
-    google::spanner::admin::instance::v1::ListInstanceConfigsRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->ListInstanceConfigs(std::move(request));
-}
-
-StatusOr<google::spanner::admin::instance::v1::InstanceConfig>
-InstanceAdminClient::GetInstanceConfig(
-    google::spanner::admin::instance::v1::GetInstanceConfigRequest const&
-        request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->GetInstanceConfig(request);
-}
-
-StreamRange<google::spanner::admin::instance::v1::Instance>
-InstanceAdminClient::ListInstances(
-    google::spanner::admin::instance::v1::ListInstancesRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->ListInstances(std::move(request));
-}
-
-StatusOr<google::spanner::admin::instance::v1::Instance>
-InstanceAdminClient::GetInstance(
-    google::spanner::admin::instance::v1::GetInstanceRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->GetInstance(request);
-}
-
-future<StatusOr<google::spanner::admin::instance::v1::Instance>>
-InstanceAdminClient::CreateInstance(
-    google::spanner::admin::instance::v1::CreateInstanceRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->CreateInstance(request);
-}
-
-future<StatusOr<google::spanner::admin::instance::v1::Instance>>
-InstanceAdminClient::UpdateInstance(
-    google::spanner::admin::instance::v1::UpdateInstanceRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->UpdateInstance(request);
-}
-
-Status InstanceAdminClient::DeleteInstance(
-    google::spanner::admin::instance::v1::DeleteInstanceRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->DeleteInstance(request);
-}
-
-StatusOr<google::iam::v1::Policy> InstanceAdminClient::SetIamPolicy(
-    google::iam::v1::SetIamPolicyRequest const& request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->SetIamPolicy(request);
-}
-
-StatusOr<google::iam::v1::Policy> InstanceAdminClient::GetIamPolicy(
-    google::iam::v1::GetIamPolicyRequest const& request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->GetIamPolicy(request);
 }
 
 StatusOr<google::iam::v1::TestIamPermissionsResponse>

--- a/google/cloud/spanner/admin/instance_admin_client.h
+++ b/google/cloud/spanner/admin/instance_admin_client.h
@@ -128,6 +128,25 @@ class InstanceAdminClient {
   ListInstanceConfigs(std::string const& parent, Options options = {});
 
   ///
+  /// Lists the supported instance configurations for a given project.
+  ///
+  /// @param request
+  /// @googleapis_link{google::spanner::admin::instance::v1::ListInstanceConfigsRequest,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L415}
+  /// @param options  Optional. Operation options.
+  /// @return
+  /// @googleapis_link{google::spanner::admin::instance::v1::InstanceConfig,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L304}
+  ///
+  /// [google.spanner.admin.instance.v1.ListInstanceConfigsRequest]:
+  /// @googleapis_reference_link{google/spanner/admin/instance/v1/spanner_instance_admin.proto#L415}
+  /// [google.spanner.admin.instance.v1.InstanceConfig]:
+  /// @googleapis_reference_link{google/spanner/admin/instance/v1/spanner_instance_admin.proto#L304}
+  ///
+  StreamRange<google::spanner::admin::instance::v1::InstanceConfig>
+  ListInstanceConfigs(
+      google::spanner::admin::instance::v1::ListInstanceConfigsRequest request,
+      Options options = {});
+
+  ///
   /// Gets information about a particular instance configuration.
   ///
   /// @param name  Required. The name of the requested instance configuration.
@@ -144,6 +163,26 @@ class InstanceAdminClient {
   ///
   StatusOr<google::spanner::admin::instance::v1::InstanceConfig>
   GetInstanceConfig(std::string const& name, Options options = {});
+
+  ///
+  /// Gets information about a particular instance configuration.
+  ///
+  /// @param request
+  /// @googleapis_link{google::spanner::admin::instance::v1::GetInstanceConfigRequest,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L449}
+  /// @param options  Optional. Operation options.
+  /// @return
+  /// @googleapis_link{google::spanner::admin::instance::v1::InstanceConfig,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L304}
+  ///
+  /// [google.spanner.admin.instance.v1.GetInstanceConfigRequest]:
+  /// @googleapis_reference_link{google/spanner/admin/instance/v1/spanner_instance_admin.proto#L449}
+  /// [google.spanner.admin.instance.v1.InstanceConfig]:
+  /// @googleapis_reference_link{google/spanner/admin/instance/v1/spanner_instance_admin.proto#L304}
+  ///
+  StatusOr<google::spanner::admin::instance::v1::InstanceConfig>
+  GetInstanceConfig(
+      google::spanner::admin::instance::v1::GetInstanceConfigRequest const&
+          request,
+      Options options = {});
 
   ///
   /// Lists all instances in the given project.
@@ -164,6 +203,24 @@ class InstanceAdminClient {
       std::string const& parent, Options options = {});
 
   ///
+  /// Lists all instances in the given project.
+  ///
+  /// @param request
+  /// @googleapis_link{google::spanner::admin::instance::v1::ListInstancesRequest,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L499}
+  /// @param options  Optional. Operation options.
+  /// @return
+  /// @googleapis_link{google::spanner::admin::instance::v1::Instance,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328}
+  ///
+  /// [google.spanner.admin.instance.v1.ListInstancesRequest]:
+  /// @googleapis_reference_link{google/spanner/admin/instance/v1/spanner_instance_admin.proto#L499}
+  /// [google.spanner.admin.instance.v1.Instance]:
+  /// @googleapis_reference_link{google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328}
+  ///
+  StreamRange<google::spanner::admin::instance::v1::Instance> ListInstances(
+      google::spanner::admin::instance::v1::ListInstancesRequest request,
+      Options options = {});
+
+  ///
   /// Gets information about a particular instance.
   ///
   /// @param name  Required. The name of the requested instance. Values are of
@@ -180,6 +237,24 @@ class InstanceAdminClient {
   ///
   StatusOr<google::spanner::admin::instance::v1::Instance> GetInstance(
       std::string const& name, Options options = {});
+
+  ///
+  /// Gets information about a particular instance.
+  ///
+  /// @param request
+  /// @googleapis_link{google::spanner::admin::instance::v1::GetInstanceRequest,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L461}
+  /// @param options  Optional. Operation options.
+  /// @return
+  /// @googleapis_link{google::spanner::admin::instance::v1::Instance,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328}
+  ///
+  /// [google.spanner.admin.instance.v1.GetInstanceRequest]:
+  /// @googleapis_reference_link{google/spanner/admin/instance/v1/spanner_instance_admin.proto#L461}
+  /// [google.spanner.admin.instance.v1.Instance]:
+  /// @googleapis_reference_link{google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328}
+  ///
+  StatusOr<google::spanner::admin::instance::v1::Instance> GetInstance(
+      google::spanner::admin::instance::v1::GetInstanceRequest const& request,
+      Options options = {});
 
   ///
   /// Creates an instance and begins preparing it to begin serving. The
@@ -240,275 +315,6 @@ class InstanceAdminClient {
   CreateInstance(std::string const& parent, std::string const& instance_id,
                  google::spanner::admin::instance::v1::Instance const& instance,
                  Options options = {});
-
-  ///
-  /// Updates an instance, and begins allocating or releasing resources
-  /// as requested. The returned [long-running
-  /// operation][google.longrunning.Operation] can be used to track the
-  /// progress of updating the instance. If the named instance does not
-  /// exist, returns `NOT_FOUND`.
-  ///
-  /// Immediately upon completion of this request:
-  ///
-  ///   * For resource types for which a decrease in the instance's allocation
-  ///     has been requested, billing is based on the newly-requested level.
-  ///
-  /// Until completion of the returned operation:
-  ///
-  ///   * Cancelling the operation sets its metadata's
-  ///     [cancel_time][google.spanner.admin.instance.v1.UpdateInstanceMetadata.cancel_time],
-  ///     and begins restoring resources to their pre-request values. The
-  ///     operation is guaranteed to succeed at undoing all resource changes,
-  ///     after which point it terminates with a `CANCELLED` status.
-  ///   * All other attempts to modify the instance are rejected.
-  ///   * Reading the instance via the API continues to give the pre-request
-  ///     resource levels.
-  ///
-  /// Upon completion of the returned operation:
-  ///
-  ///   * Billing begins for all successfully-allocated resources (some types
-  ///     may have lower than the requested levels).
-  ///   * All newly-reserved resources are available for serving the instance's
-  ///     tables.
-  ///   * The instance's new resource levels are readable via the API.
-  ///
-  /// The returned [long-running operation][google.longrunning.Operation] will
-  /// have a name of the format `<instance_name>/operations/<operation_id>` and
-  /// can be used to track the instance modification.  The
-  /// [metadata][google.longrunning.Operation.metadata] field type is
-  /// [UpdateInstanceMetadata][google.spanner.admin.instance.v1.UpdateInstanceMetadata].
-  /// The [response][google.longrunning.Operation.response] field type is
-  /// [Instance][google.spanner.admin.instance.v1.Instance], if successful.
-  ///
-  /// Authorization requires `spanner.instances.update` permission on
-  /// resource [name][google.spanner.admin.instance.v1.Instance.name].
-  ///
-  /// @param instance  Required. The instance to update, which must always
-  /// include the instance
-  ///  name.  Otherwise, only fields mentioned in
-  ///  [field_mask][google.spanner.admin.instance.v1.UpdateInstanceRequest.field_mask]
-  ///  need be included.
-  /// @param field_mask  Required. A mask specifying which fields in
-  /// [Instance][google.spanner.admin.instance.v1.Instance] should be updated.
-  ///  The field mask must always be specified; this prevents any future fields
-  ///  in [Instance][google.spanner.admin.instance.v1.Instance] from being
-  ///  erased accidentally by clients that do not know about them.
-  /// @param options  Optional. Operation options.
-  /// @return
-  /// @googleapis_link{google::spanner::admin::instance::v1::Instance,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328}
-  ///
-  /// [google.spanner.admin.instance.v1.UpdateInstanceRequest]:
-  /// @googleapis_reference_link{google/spanner/admin/instance/v1/spanner_instance_admin.proto#L552}
-  /// [google.spanner.admin.instance.v1.Instance]:
-  /// @googleapis_reference_link{google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328}
-  ///
-  future<StatusOr<google::spanner::admin::instance::v1::Instance>>
-  UpdateInstance(google::spanner::admin::instance::v1::Instance const& instance,
-                 google::protobuf::FieldMask const& field_mask,
-                 Options options = {});
-
-  ///
-  /// Deletes an instance.
-  ///
-  /// Immediately upon completion of the request:
-  ///
-  ///   * Billing ceases for all of the instance's reserved resources.
-  ///
-  /// Soon afterward:
-  ///
-  ///   * The instance and *all of its databases* immediately and
-  ///     irrevocably disappear from the API. All data in the databases
-  ///     is permanently deleted.
-  ///
-  /// @param name  Required. The name of the instance to be deleted. Values are
-  /// of the form
-  ///  `projects/<project>/instances/<instance>`
-  /// @param options  Optional. Operation options.
-  ///
-  /// [google.spanner.admin.instance.v1.DeleteInstanceRequest]:
-  /// @googleapis_reference_link{google/spanner/admin/instance/v1/spanner_instance_admin.proto#L565}
-  ///
-  Status DeleteInstance(std::string const& name, Options options = {});
-
-  ///
-  /// Sets the access control policy on an instance resource. Replaces any
-  /// existing policy.
-  ///
-  /// Authorization requires `spanner.instances.setIamPolicy` on
-  /// [resource][google.iam.v1.SetIamPolicyRequest.resource].
-  ///
-  /// @param resource  REQUIRED: The resource for which the policy is being
-  /// specified.
-  ///  See the operation documentation for the appropriate value for this field.
-  /// @param policy  REQUIRED: The complete policy to be applied to the
-  /// `resource`. The size of
-  ///  the policy is limited to a few 10s of KB. An empty policy is a
-  ///  valid policy but certain Cloud Platform services (such as Projects)
-  ///  might reject them.
-  /// @param options  Optional. Operation options.
-  /// @return
-  /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
-  ///
-  /// [google.iam.v1.SetIamPolicyRequest]:
-  /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L98}
-  /// [google.iam.v1.Policy]:
-  /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
-  ///
-  StatusOr<google::iam::v1::Policy> SetIamPolicy(
-      std::string const& resource, google::iam::v1::Policy const& policy,
-      Options options = {});
-
-  /**
-   * Updates the IAM policy for @p resource using an optimistic concurrency
-   * control loop.
-   *
-   * The loop fetches the current policy for @p resource, and passes it to @p
-   * updater, which should return the new policy. This new policy should use the
-   * current etag so that the read-modify-write cycle can detect races and rerun
-   * the update when there is a mismatch. If the new policy does not have an
-   * etag, the existing policy will be blindly overwritten. If @p updater does
-   * not yield a policy, the control loop is terminated and kCancelled is
-   * returned.
-   *
-   * @param resource  Required. The resource for which the policy is being
-   * specified. See the operation documentation for the appropriate value for
-   * this field.
-   * @param updater  Required. Functor to map the current policy to a new one.
-   * @param options  Optional. Options to control the loop. Expected options
-   * are:
-   *       - `InstanceAdminBackoffPolicyOption`
-   * @return google::iam::v1::Policy
-   */
-  StatusOr<google::iam::v1::Policy> SetIamPolicy(std::string const& resource,
-                                                 IamUpdater const& updater,
-                                                 Options options = {});
-
-  ///
-  /// Gets the access control policy for an instance resource. Returns an empty
-  /// policy if an instance exists but does not have a policy set.
-  ///
-  /// Authorization requires `spanner.instances.getIamPolicy` on
-  /// [resource][google.iam.v1.GetIamPolicyRequest.resource].
-  ///
-  /// @param resource  REQUIRED: The resource for which the policy is being
-  /// requested.
-  ///  See the operation documentation for the appropriate value for this field.
-  /// @param options  Optional. Operation options.
-  /// @return
-  /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
-  ///
-  /// [google.iam.v1.GetIamPolicyRequest]:
-  /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L113}
-  /// [google.iam.v1.Policy]:
-  /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
-  ///
-  StatusOr<google::iam::v1::Policy> GetIamPolicy(std::string const& resource,
-                                                 Options options = {});
-
-  ///
-  /// Returns permissions that the caller has on the specified instance
-  /// resource.
-  ///
-  /// Attempting this RPC on a non-existent Cloud Spanner instance resource will
-  /// result in a NOT_FOUND error if the user has `spanner.instances.list`
-  /// permission on the containing Google Cloud Project. Otherwise returns an
-  /// empty set of permissions.
-  ///
-  /// @param resource  REQUIRED: The resource for which the policy detail is
-  /// being requested.
-  ///  See the operation documentation for the appropriate value for this field.
-  /// @param permissions  The set of permissions to check for the `resource`.
-  /// Permissions with
-  ///  wildcards (such as '*' or 'storage.*') are not allowed. For more
-  ///  information see
-  ///  [IAM Overview](https://cloud.google.com/iam/docs/overview#permissions).
-  /// @param options  Optional. Operation options.
-  /// @return
-  /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
-  ///
-  /// [google.iam.v1.TestIamPermissionsRequest]:
-  /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L126}
-  /// [google.iam.v1.TestIamPermissionsResponse]:
-  /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L141}
-  ///
-  StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
-      std::string const& resource, std::vector<std::string> const& permissions,
-      Options options = {});
-
-  ///
-  /// Lists the supported instance configurations for a given project.
-  ///
-  /// @param request
-  /// @googleapis_link{google::spanner::admin::instance::v1::ListInstanceConfigsRequest,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L415}
-  /// @param options  Optional. Operation options.
-  /// @return
-  /// @googleapis_link{google::spanner::admin::instance::v1::InstanceConfig,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L304}
-  ///
-  /// [google.spanner.admin.instance.v1.ListInstanceConfigsRequest]:
-  /// @googleapis_reference_link{google/spanner/admin/instance/v1/spanner_instance_admin.proto#L415}
-  /// [google.spanner.admin.instance.v1.InstanceConfig]:
-  /// @googleapis_reference_link{google/spanner/admin/instance/v1/spanner_instance_admin.proto#L304}
-  ///
-  StreamRange<google::spanner::admin::instance::v1::InstanceConfig>
-  ListInstanceConfigs(
-      google::spanner::admin::instance::v1::ListInstanceConfigsRequest request,
-      Options options = {});
-
-  ///
-  /// Gets information about a particular instance configuration.
-  ///
-  /// @param request
-  /// @googleapis_link{google::spanner::admin::instance::v1::GetInstanceConfigRequest,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L449}
-  /// @param options  Optional. Operation options.
-  /// @return
-  /// @googleapis_link{google::spanner::admin::instance::v1::InstanceConfig,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L304}
-  ///
-  /// [google.spanner.admin.instance.v1.GetInstanceConfigRequest]:
-  /// @googleapis_reference_link{google/spanner/admin/instance/v1/spanner_instance_admin.proto#L449}
-  /// [google.spanner.admin.instance.v1.InstanceConfig]:
-  /// @googleapis_reference_link{google/spanner/admin/instance/v1/spanner_instance_admin.proto#L304}
-  ///
-  StatusOr<google::spanner::admin::instance::v1::InstanceConfig>
-  GetInstanceConfig(
-      google::spanner::admin::instance::v1::GetInstanceConfigRequest const&
-          request,
-      Options options = {});
-
-  ///
-  /// Lists all instances in the given project.
-  ///
-  /// @param request
-  /// @googleapis_link{google::spanner::admin::instance::v1::ListInstancesRequest,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L499}
-  /// @param options  Optional. Operation options.
-  /// @return
-  /// @googleapis_link{google::spanner::admin::instance::v1::Instance,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328}
-  ///
-  /// [google.spanner.admin.instance.v1.ListInstancesRequest]:
-  /// @googleapis_reference_link{google/spanner/admin/instance/v1/spanner_instance_admin.proto#L499}
-  /// [google.spanner.admin.instance.v1.Instance]:
-  /// @googleapis_reference_link{google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328}
-  ///
-  StreamRange<google::spanner::admin::instance::v1::Instance> ListInstances(
-      google::spanner::admin::instance::v1::ListInstancesRequest request,
-      Options options = {});
-
-  ///
-  /// Gets information about a particular instance.
-  ///
-  /// @param request
-  /// @googleapis_link{google::spanner::admin::instance::v1::GetInstanceRequest,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L461}
-  /// @param options  Optional. Operation options.
-  /// @return
-  /// @googleapis_link{google::spanner::admin::instance::v1::Instance,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328}
-  ///
-  /// [google.spanner.admin.instance.v1.GetInstanceRequest]:
-  /// @googleapis_reference_link{google/spanner/admin/instance/v1/spanner_instance_admin.proto#L461}
-  /// [google.spanner.admin.instance.v1.Instance]:
-  /// @googleapis_reference_link{google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328}
-  ///
-  StatusOr<google::spanner::admin::instance::v1::Instance> GetInstance(
-      google::spanner::admin::instance::v1::GetInstanceRequest const& request,
-      Options options = {});
 
   ///
   /// Creates an instance and begins preparing it to begin serving. The
@@ -605,6 +411,72 @@ class InstanceAdminClient {
   /// Authorization requires `spanner.instances.update` permission on
   /// resource [name][google.spanner.admin.instance.v1.Instance.name].
   ///
+  /// @param instance  Required. The instance to update, which must always
+  /// include the instance
+  ///  name.  Otherwise, only fields mentioned in
+  ///  [field_mask][google.spanner.admin.instance.v1.UpdateInstanceRequest.field_mask]
+  ///  need be included.
+  /// @param field_mask  Required. A mask specifying which fields in
+  /// [Instance][google.spanner.admin.instance.v1.Instance] should be updated.
+  ///  The field mask must always be specified; this prevents any future fields
+  ///  in [Instance][google.spanner.admin.instance.v1.Instance] from being
+  ///  erased accidentally by clients that do not know about them.
+  /// @param options  Optional. Operation options.
+  /// @return
+  /// @googleapis_link{google::spanner::admin::instance::v1::Instance,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328}
+  ///
+  /// [google.spanner.admin.instance.v1.UpdateInstanceRequest]:
+  /// @googleapis_reference_link{google/spanner/admin/instance/v1/spanner_instance_admin.proto#L552}
+  /// [google.spanner.admin.instance.v1.Instance]:
+  /// @googleapis_reference_link{google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328}
+  ///
+  future<StatusOr<google::spanner::admin::instance::v1::Instance>>
+  UpdateInstance(google::spanner::admin::instance::v1::Instance const& instance,
+                 google::protobuf::FieldMask const& field_mask,
+                 Options options = {});
+
+  ///
+  /// Updates an instance, and begins allocating or releasing resources
+  /// as requested. The returned [long-running
+  /// operation][google.longrunning.Operation] can be used to track the
+  /// progress of updating the instance. If the named instance does not
+  /// exist, returns `NOT_FOUND`.
+  ///
+  /// Immediately upon completion of this request:
+  ///
+  ///   * For resource types for which a decrease in the instance's allocation
+  ///     has been requested, billing is based on the newly-requested level.
+  ///
+  /// Until completion of the returned operation:
+  ///
+  ///   * Cancelling the operation sets its metadata's
+  ///     [cancel_time][google.spanner.admin.instance.v1.UpdateInstanceMetadata.cancel_time],
+  ///     and begins restoring resources to their pre-request values. The
+  ///     operation is guaranteed to succeed at undoing all resource changes,
+  ///     after which point it terminates with a `CANCELLED` status.
+  ///   * All other attempts to modify the instance are rejected.
+  ///   * Reading the instance via the API continues to give the pre-request
+  ///     resource levels.
+  ///
+  /// Upon completion of the returned operation:
+  ///
+  ///   * Billing begins for all successfully-allocated resources (some types
+  ///     may have lower than the requested levels).
+  ///   * All newly-reserved resources are available for serving the instance's
+  ///     tables.
+  ///   * The instance's new resource levels are readable via the API.
+  ///
+  /// The returned [long-running operation][google.longrunning.Operation] will
+  /// have a name of the format `<instance_name>/operations/<operation_id>` and
+  /// can be used to track the instance modification.  The
+  /// [metadata][google.longrunning.Operation.metadata] field type is
+  /// [UpdateInstanceMetadata][google.spanner.admin.instance.v1.UpdateInstanceMetadata].
+  /// The [response][google.longrunning.Operation.response] field type is
+  /// [Instance][google.spanner.admin.instance.v1.Instance], if successful.
+  ///
+  /// Authorization requires `spanner.instances.update` permission on
+  /// resource [name][google.spanner.admin.instance.v1.Instance.name].
+  ///
   /// @param request
   /// @googleapis_link{google::spanner::admin::instance::v1::UpdateInstanceRequest,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L552}
   /// @param options  Optional. Operation options.
@@ -621,6 +493,29 @@ class InstanceAdminClient {
       google::spanner::admin::instance::v1::UpdateInstanceRequest const&
           request,
       Options options = {});
+
+  ///
+  /// Deletes an instance.
+  ///
+  /// Immediately upon completion of the request:
+  ///
+  ///   * Billing ceases for all of the instance's reserved resources.
+  ///
+  /// Soon afterward:
+  ///
+  ///   * The instance and *all of its databases* immediately and
+  ///     irrevocably disappear from the API. All data in the databases
+  ///     is permanently deleted.
+  ///
+  /// @param name  Required. The name of the instance to be deleted. Values are
+  /// of the form
+  ///  `projects/<project>/instances/<instance>`
+  /// @param options  Optional. Operation options.
+  ///
+  /// [google.spanner.admin.instance.v1.DeleteInstanceRequest]:
+  /// @googleapis_reference_link{google/spanner/admin/instance/v1/spanner_instance_admin.proto#L565}
+  ///
+  Status DeleteInstance(std::string const& name, Options options = {});
 
   ///
   /// Deletes an instance.
@@ -654,6 +549,59 @@ class InstanceAdminClient {
   /// Authorization requires `spanner.instances.setIamPolicy` on
   /// [resource][google.iam.v1.SetIamPolicyRequest.resource].
   ///
+  /// @param resource  REQUIRED: The resource for which the policy is being
+  /// specified.
+  ///  See the operation documentation for the appropriate value for this field.
+  /// @param policy  REQUIRED: The complete policy to be applied to the
+  /// `resource`. The size of
+  ///  the policy is limited to a few 10s of KB. An empty policy is a
+  ///  valid policy but certain Cloud Platform services (such as Projects)
+  ///  might reject them.
+  /// @param options  Optional. Operation options.
+  /// @return
+  /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
+  ///
+  /// [google.iam.v1.SetIamPolicyRequest]:
+  /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L98}
+  /// [google.iam.v1.Policy]:
+  /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
+  ///
+  StatusOr<google::iam::v1::Policy> SetIamPolicy(
+      std::string const& resource, google::iam::v1::Policy const& policy,
+      Options options = {});
+
+  /**
+   * Updates the IAM policy for @p resource using an optimistic concurrency
+   * control loop.
+   *
+   * The loop fetches the current policy for @p resource, and passes it to @p
+   * updater, which should return the new policy. This new policy should use the
+   * current etag so that the read-modify-write cycle can detect races and rerun
+   * the update when there is a mismatch. If the new policy does not have an
+   * etag, the existing policy will be blindly overwritten. If @p updater does
+   * not yield a policy, the control loop is terminated and kCancelled is
+   * returned.
+   *
+   * @param resource  Required. The resource for which the policy is being
+   * specified. See the operation documentation for the appropriate value for
+   * this field.
+   * @param updater  Required. Functor to map the current policy to a new one.
+   * @param options  Optional. Options to control the loop. Expected options
+   * are:
+   *       - `InstanceAdminBackoffPolicyOption`
+   * @return google::iam::v1::Policy
+   */
+  StatusOr<google::iam::v1::Policy> SetIamPolicy(std::string const& resource,
+                                                 IamUpdater const& updater,
+                                                 Options options = {});
+
+  ///
+  /// Sets the access control policy on an instance resource. Replaces any
+  /// existing policy.
+  ///
+  /// Authorization requires `spanner.instances.setIamPolicy` on
+  /// [resource][google.iam.v1.SetIamPolicyRequest.resource].
+  ///
   /// @param request
   /// @googleapis_link{google::iam::v1::SetIamPolicyRequest,google/iam/v1/iam_policy.proto#L98}
   /// @param options  Optional. Operation options.
@@ -676,6 +624,28 @@ class InstanceAdminClient {
   /// Authorization requires `spanner.instances.getIamPolicy` on
   /// [resource][google.iam.v1.GetIamPolicyRequest.resource].
   ///
+  /// @param resource  REQUIRED: The resource for which the policy is being
+  /// requested.
+  ///  See the operation documentation for the appropriate value for this field.
+  /// @param options  Optional. Operation options.
+  /// @return
+  /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
+  ///
+  /// [google.iam.v1.GetIamPolicyRequest]:
+  /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L113}
+  /// [google.iam.v1.Policy]:
+  /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
+  ///
+  StatusOr<google::iam::v1::Policy> GetIamPolicy(std::string const& resource,
+                                                 Options options = {});
+
+  ///
+  /// Gets the access control policy for an instance resource. Returns an empty
+  /// policy if an instance exists but does not have a policy set.
+  ///
+  /// Authorization requires `spanner.instances.getIamPolicy` on
+  /// [resource][google.iam.v1.GetIamPolicyRequest.resource].
+  ///
   /// @param request
   /// @googleapis_link{google::iam::v1::GetIamPolicyRequest,google/iam/v1/iam_policy.proto#L113}
   /// @param options  Optional. Operation options.
@@ -689,6 +659,36 @@ class InstanceAdminClient {
   ///
   StatusOr<google::iam::v1::Policy> GetIamPolicy(
       google::iam::v1::GetIamPolicyRequest const& request,
+      Options options = {});
+
+  ///
+  /// Returns permissions that the caller has on the specified instance
+  /// resource.
+  ///
+  /// Attempting this RPC on a non-existent Cloud Spanner instance resource will
+  /// result in a NOT_FOUND error if the user has `spanner.instances.list`
+  /// permission on the containing Google Cloud Project. Otherwise returns an
+  /// empty set of permissions.
+  ///
+  /// @param resource  REQUIRED: The resource for which the policy detail is
+  /// being requested.
+  ///  See the operation documentation for the appropriate value for this field.
+  /// @param permissions  The set of permissions to check for the `resource`.
+  /// Permissions with
+  ///  wildcards (such as '*' or 'storage.*') are not allowed. For more
+  ///  information see
+  ///  [IAM Overview](https://cloud.google.com/iam/docs/overview#permissions).
+  /// @param options  Optional. Operation options.
+  /// @return
+  /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
+  ///
+  /// [google.iam.v1.TestIamPermissionsRequest]:
+  /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L126}
+  /// [google.iam.v1.TestIamPermissionsResponse]:
+  /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L141}
+  ///
+  StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
+      std::string const& resource, std::vector<std::string> const& permissions,
       Options options = {});
 
   ///

--- a/google/cloud/tasks/cloud_tasks_client.cc
+++ b/google/cloud/tasks/cloud_tasks_client.cc
@@ -42,12 +42,26 @@ StreamRange<google::cloud::tasks::v2::Queue> CloudTasksClient::ListQueues(
   return connection_->ListQueues(request);
 }
 
+StreamRange<google::cloud::tasks::v2::Queue> CloudTasksClient::ListQueues(
+    google::cloud::tasks::v2::ListQueuesRequest request, Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
+  return connection_->ListQueues(std::move(request));
+}
+
 StatusOr<google::cloud::tasks::v2::Queue> CloudTasksClient::GetQueue(
     std::string const& name, Options options) {
   internal::OptionsSpan span(
       internal::MergeOptions(std::move(options), options_));
   google::cloud::tasks::v2::GetQueueRequest request;
   request.set_name(name);
+  return connection_->GetQueue(request);
+}
+
+StatusOr<google::cloud::tasks::v2::Queue> CloudTasksClient::GetQueue(
+    google::cloud::tasks::v2::GetQueueRequest const& request, Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->GetQueue(request);
 }
 
@@ -62,6 +76,14 @@ StatusOr<google::cloud::tasks::v2::Queue> CloudTasksClient::CreateQueue(
   return connection_->CreateQueue(request);
 }
 
+StatusOr<google::cloud::tasks::v2::Queue> CloudTasksClient::CreateQueue(
+    google::cloud::tasks::v2::CreateQueueRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
+  return connection_->CreateQueue(request);
+}
+
 StatusOr<google::cloud::tasks::v2::Queue> CloudTasksClient::UpdateQueue(
     google::cloud::tasks::v2::Queue const& queue,
     google::protobuf::FieldMask const& update_mask, Options options) {
@@ -73,11 +95,27 @@ StatusOr<google::cloud::tasks::v2::Queue> CloudTasksClient::UpdateQueue(
   return connection_->UpdateQueue(request);
 }
 
+StatusOr<google::cloud::tasks::v2::Queue> CloudTasksClient::UpdateQueue(
+    google::cloud::tasks::v2::UpdateQueueRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
+  return connection_->UpdateQueue(request);
+}
+
 Status CloudTasksClient::DeleteQueue(std::string const& name, Options options) {
   internal::OptionsSpan span(
       internal::MergeOptions(std::move(options), options_));
   google::cloud::tasks::v2::DeleteQueueRequest request;
   request.set_name(name);
+  return connection_->DeleteQueue(request);
+}
+
+Status CloudTasksClient::DeleteQueue(
+    google::cloud::tasks::v2::DeleteQueueRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->DeleteQueue(request);
 }
 
@@ -90,12 +128,28 @@ StatusOr<google::cloud::tasks::v2::Queue> CloudTasksClient::PurgeQueue(
   return connection_->PurgeQueue(request);
 }
 
+StatusOr<google::cloud::tasks::v2::Queue> CloudTasksClient::PurgeQueue(
+    google::cloud::tasks::v2::PurgeQueueRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
+  return connection_->PurgeQueue(request);
+}
+
 StatusOr<google::cloud::tasks::v2::Queue> CloudTasksClient::PauseQueue(
     std::string const& name, Options options) {
   internal::OptionsSpan span(
       internal::MergeOptions(std::move(options), options_));
   google::cloud::tasks::v2::PauseQueueRequest request;
   request.set_name(name);
+  return connection_->PauseQueue(request);
+}
+
+StatusOr<google::cloud::tasks::v2::Queue> CloudTasksClient::PauseQueue(
+    google::cloud::tasks::v2::PauseQueueRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->PauseQueue(request);
 }
 
@@ -108,12 +162,27 @@ StatusOr<google::cloud::tasks::v2::Queue> CloudTasksClient::ResumeQueue(
   return connection_->ResumeQueue(request);
 }
 
+StatusOr<google::cloud::tasks::v2::Queue> CloudTasksClient::ResumeQueue(
+    google::cloud::tasks::v2::ResumeQueueRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
+  return connection_->ResumeQueue(request);
+}
+
 StatusOr<google::iam::v1::Policy> CloudTasksClient::GetIamPolicy(
     std::string const& resource, Options options) {
   internal::OptionsSpan span(
       internal::MergeOptions(std::move(options), options_));
   google::iam::v1::GetIamPolicyRequest request;
   request.set_resource(resource);
+  return connection_->GetIamPolicy(request);
+}
+
+StatusOr<google::iam::v1::Policy> CloudTasksClient::GetIamPolicy(
+    google::iam::v1::GetIamPolicyRequest const& request, Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->GetIamPolicy(request);
 }
 
@@ -153,6 +222,13 @@ StatusOr<google::iam::v1::Policy> CloudTasksClient::SetIamPolicy(
   }
 }
 
+StatusOr<google::iam::v1::Policy> CloudTasksClient::SetIamPolicy(
+    google::iam::v1::SetIamPolicyRequest const& request, Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
+  return connection_->SetIamPolicy(request);
+}
+
 StatusOr<google::iam::v1::TestIamPermissionsResponse>
 CloudTasksClient::TestIamPermissions(
     std::string const& resource, std::vector<std::string> const& permissions,
@@ -165,6 +241,15 @@ CloudTasksClient::TestIamPermissions(
   return connection_->TestIamPermissions(request);
 }
 
+StatusOr<google::iam::v1::TestIamPermissionsResponse>
+CloudTasksClient::TestIamPermissions(
+    google::iam::v1::TestIamPermissionsRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
+  return connection_->TestIamPermissions(request);
+}
+
 StreamRange<google::cloud::tasks::v2::Task> CloudTasksClient::ListTasks(
     std::string const& parent, Options options) {
   internal::OptionsSpan span(
@@ -174,12 +259,26 @@ StreamRange<google::cloud::tasks::v2::Task> CloudTasksClient::ListTasks(
   return connection_->ListTasks(request);
 }
 
+StreamRange<google::cloud::tasks::v2::Task> CloudTasksClient::ListTasks(
+    google::cloud::tasks::v2::ListTasksRequest request, Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
+  return connection_->ListTasks(std::move(request));
+}
+
 StatusOr<google::cloud::tasks::v2::Task> CloudTasksClient::GetTask(
     std::string const& name, Options options) {
   internal::OptionsSpan span(
       internal::MergeOptions(std::move(options), options_));
   google::cloud::tasks::v2::GetTaskRequest request;
   request.set_name(name);
+  return connection_->GetTask(request);
+}
+
+StatusOr<google::cloud::tasks::v2::Task> CloudTasksClient::GetTask(
+    google::cloud::tasks::v2::GetTaskRequest const& request, Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->GetTask(request);
 }
 
@@ -194,11 +293,27 @@ StatusOr<google::cloud::tasks::v2::Task> CloudTasksClient::CreateTask(
   return connection_->CreateTask(request);
 }
 
+StatusOr<google::cloud::tasks::v2::Task> CloudTasksClient::CreateTask(
+    google::cloud::tasks::v2::CreateTaskRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
+  return connection_->CreateTask(request);
+}
+
 Status CloudTasksClient::DeleteTask(std::string const& name, Options options) {
   internal::OptionsSpan span(
       internal::MergeOptions(std::move(options), options_));
   google::cloud::tasks::v2::DeleteTaskRequest request;
   request.set_name(name);
+  return connection_->DeleteTask(request);
+}
+
+Status CloudTasksClient::DeleteTask(
+    google::cloud::tasks::v2::DeleteTaskRequest const& request,
+    Options options) {
+  internal::OptionsSpan span(
+      internal::MergeOptions(std::move(options), options_));
   return connection_->DeleteTask(request);
 }
 
@@ -209,121 +324,6 @@ StatusOr<google::cloud::tasks::v2::Task> CloudTasksClient::RunTask(
   google::cloud::tasks::v2::RunTaskRequest request;
   request.set_name(name);
   return connection_->RunTask(request);
-}
-
-StreamRange<google::cloud::tasks::v2::Queue> CloudTasksClient::ListQueues(
-    google::cloud::tasks::v2::ListQueuesRequest request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->ListQueues(std::move(request));
-}
-
-StatusOr<google::cloud::tasks::v2::Queue> CloudTasksClient::GetQueue(
-    google::cloud::tasks::v2::GetQueueRequest const& request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->GetQueue(request);
-}
-
-StatusOr<google::cloud::tasks::v2::Queue> CloudTasksClient::CreateQueue(
-    google::cloud::tasks::v2::CreateQueueRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->CreateQueue(request);
-}
-
-StatusOr<google::cloud::tasks::v2::Queue> CloudTasksClient::UpdateQueue(
-    google::cloud::tasks::v2::UpdateQueueRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->UpdateQueue(request);
-}
-
-Status CloudTasksClient::DeleteQueue(
-    google::cloud::tasks::v2::DeleteQueueRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->DeleteQueue(request);
-}
-
-StatusOr<google::cloud::tasks::v2::Queue> CloudTasksClient::PurgeQueue(
-    google::cloud::tasks::v2::PurgeQueueRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->PurgeQueue(request);
-}
-
-StatusOr<google::cloud::tasks::v2::Queue> CloudTasksClient::PauseQueue(
-    google::cloud::tasks::v2::PauseQueueRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->PauseQueue(request);
-}
-
-StatusOr<google::cloud::tasks::v2::Queue> CloudTasksClient::ResumeQueue(
-    google::cloud::tasks::v2::ResumeQueueRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->ResumeQueue(request);
-}
-
-StatusOr<google::iam::v1::Policy> CloudTasksClient::GetIamPolicy(
-    google::iam::v1::GetIamPolicyRequest const& request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->GetIamPolicy(request);
-}
-
-StatusOr<google::iam::v1::Policy> CloudTasksClient::SetIamPolicy(
-    google::iam::v1::SetIamPolicyRequest const& request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->SetIamPolicy(request);
-}
-
-StatusOr<google::iam::v1::TestIamPermissionsResponse>
-CloudTasksClient::TestIamPermissions(
-    google::iam::v1::TestIamPermissionsRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->TestIamPermissions(request);
-}
-
-StreamRange<google::cloud::tasks::v2::Task> CloudTasksClient::ListTasks(
-    google::cloud::tasks::v2::ListTasksRequest request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->ListTasks(std::move(request));
-}
-
-StatusOr<google::cloud::tasks::v2::Task> CloudTasksClient::GetTask(
-    google::cloud::tasks::v2::GetTaskRequest const& request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->GetTask(request);
-}
-
-StatusOr<google::cloud::tasks::v2::Task> CloudTasksClient::CreateTask(
-    google::cloud::tasks::v2::CreateTaskRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->CreateTask(request);
-}
-
-Status CloudTasksClient::DeleteTask(
-    google::cloud::tasks::v2::DeleteTaskRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
-  return connection_->DeleteTask(request);
 }
 
 StatusOr<google::cloud::tasks::v2::Task> CloudTasksClient::RunTask(

--- a/google/cloud/tasks/cloud_tasks_client.h
+++ b/google/cloud/tasks/cloud_tasks_client.h
@@ -104,6 +104,26 @@ class CloudTasksClient {
       std::string const& parent, Options options = {});
 
   ///
+  /// Lists queues.
+  ///
+  /// Queues are returned in lexicographical order.
+  ///
+  /// @param request
+  /// @googleapis_link{google::cloud::tasks::v2::ListQueuesRequest,google/cloud/tasks/v2/cloudtasks.proto#L308}
+  /// @param options  Optional. Operation options.
+  /// @return
+  /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
+  ///
+  /// [google.cloud.tasks.v2.ListQueuesRequest]:
+  /// @googleapis_reference_link{google/cloud/tasks/v2/cloudtasks.proto#L308}
+  /// [google.cloud.tasks.v2.Queue]:
+  /// @googleapis_reference_link{google/cloud/tasks/v2/queue.proto#L34}
+  ///
+  StreamRange<google::cloud::tasks::v2::Queue> ListQueues(
+      google::cloud::tasks::v2::ListQueuesRequest request,
+      Options options = {});
+
+  ///
   /// Gets a queue.
   ///
   /// @param name  Required. The resource name of the queue. For example:
@@ -119,6 +139,24 @@ class CloudTasksClient {
   ///
   StatusOr<google::cloud::tasks::v2::Queue> GetQueue(std::string const& name,
                                                      Options options = {});
+
+  ///
+  /// Gets a queue.
+  ///
+  /// @param request
+  /// @googleapis_link{google::cloud::tasks::v2::GetQueueRequest,google/cloud/tasks/v2/cloudtasks.proto#L369}
+  /// @param options  Optional. Operation options.
+  /// @return
+  /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
+  ///
+  /// [google.cloud.tasks.v2.GetQueueRequest]:
+  /// @googleapis_reference_link{google/cloud/tasks/v2/cloudtasks.proto#L369}
+  /// [google.cloud.tasks.v2.Queue]:
+  /// @googleapis_reference_link{google/cloud/tasks/v2/queue.proto#L34}
+  ///
+  StatusOr<google::cloud::tasks::v2::Queue> GetQueue(
+      google::cloud::tasks::v2::GetQueueRequest const& request,
+      Options options = {});
 
   ///
   /// Creates a queue.
@@ -153,6 +191,34 @@ class CloudTasksClient {
   ///
   StatusOr<google::cloud::tasks::v2::Queue> CreateQueue(
       std::string const& parent, google::cloud::tasks::v2::Queue const& queue,
+      Options options = {});
+
+  ///
+  /// Creates a queue.
+  ///
+  /// Queues created with this method allow tasks to live for a maximum of 31
+  /// days. After a task is 31 days old, the task will be deleted regardless of
+  /// whether it was dispatched or not.
+  ///
+  /// WARNING: Using this method may have unintended side effects if you are
+  /// using an App Engine `queue.yaml` or `queue.xml` file to manage your
+  /// queues. Read [Overview of Queue Management and
+  /// queue.yaml](https://cloud.google.com/tasks/docs/queue-yaml) before using
+  /// this method.
+  ///
+  /// @param request
+  /// @googleapis_link{google::cloud::tasks::v2::CreateQueueRequest,google/cloud/tasks/v2/cloudtasks.proto#L381}
+  /// @param options  Optional. Operation options.
+  /// @return
+  /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
+  ///
+  /// [google.cloud.tasks.v2.CreateQueueRequest]:
+  /// @googleapis_reference_link{google/cloud/tasks/v2/cloudtasks.proto#L381}
+  /// [google.cloud.tasks.v2.Queue]:
+  /// @googleapis_reference_link{google/cloud/tasks/v2/queue.proto#L34}
+  ///
+  StatusOr<google::cloud::tasks::v2::Queue> CreateQueue(
+      google::cloud::tasks::v2::CreateQueueRequest const& request,
       Options options = {});
 
   ///
@@ -193,6 +259,37 @@ class CloudTasksClient {
       google::protobuf::FieldMask const& update_mask, Options options = {});
 
   ///
+  /// Updates a queue.
+  ///
+  /// This method creates the queue if it does not exist and updates
+  /// the queue if it does exist.
+  ///
+  /// Queues created with this method allow tasks to live for a maximum of 31
+  /// days. After a task is 31 days old, the task will be deleted regardless of
+  /// whether it was dispatched or not.
+  ///
+  /// WARNING: Using this method may have unintended side effects if you are
+  /// using an App Engine `queue.yaml` or `queue.xml` file to manage your
+  /// queues. Read [Overview of Queue Management and
+  /// queue.yaml](https://cloud.google.com/tasks/docs/queue-yaml) before using
+  /// this method.
+  ///
+  /// @param request
+  /// @googleapis_link{google::cloud::tasks::v2::UpdateQueueRequest,google/cloud/tasks/v2/cloudtasks.proto#L402}
+  /// @param options  Optional. Operation options.
+  /// @return
+  /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
+  ///
+  /// [google.cloud.tasks.v2.UpdateQueueRequest]:
+  /// @googleapis_reference_link{google/cloud/tasks/v2/cloudtasks.proto#L402}
+  /// [google.cloud.tasks.v2.Queue]:
+  /// @googleapis_reference_link{google/cloud/tasks/v2/queue.proto#L34}
+  ///
+  StatusOr<google::cloud::tasks::v2::Queue> UpdateQueue(
+      google::cloud::tasks::v2::UpdateQueueRequest const& request,
+      Options options = {});
+
+  ///
   /// Deletes a queue.
   ///
   /// This command will delete the queue even if it has tasks in it.
@@ -214,6 +311,31 @@ class CloudTasksClient {
   /// @googleapis_reference_link{google/cloud/tasks/v2/cloudtasks.proto#L419}
   ///
   Status DeleteQueue(std::string const& name, Options options = {});
+
+  ///
+  /// Deletes a queue.
+  ///
+  /// This command will delete the queue even if it has tasks in it.
+  ///
+  /// Note: If you delete a queue, a queue with the same name can't be created
+  /// for 7 days.
+  ///
+  /// WARNING: Using this method may have unintended side effects if you are
+  /// using an App Engine `queue.yaml` or `queue.xml` file to manage your
+  /// queues. Read [Overview of Queue Management and
+  /// queue.yaml](https://cloud.google.com/tasks/docs/queue-yaml) before using
+  /// this method.
+  ///
+  /// @param request
+  /// @googleapis_link{google::cloud::tasks::v2::DeleteQueueRequest,google/cloud/tasks/v2/cloudtasks.proto#L419}
+  /// @param options  Optional. Operation options.
+  ///
+  /// [google.cloud.tasks.v2.DeleteQueueRequest]:
+  /// @googleapis_reference_link{google/cloud/tasks/v2/cloudtasks.proto#L419}
+  ///
+  Status DeleteQueue(
+      google::cloud::tasks::v2::DeleteQueueRequest const& request,
+      Options options = {});
 
   ///
   /// Purges a queue by deleting all of its tasks.
@@ -239,6 +361,30 @@ class CloudTasksClient {
                                                        Options options = {});
 
   ///
+  /// Purges a queue by deleting all of its tasks.
+  ///
+  /// All tasks created before this method is called are permanently deleted.
+  ///
+  /// Purge operations can take up to one minute to take effect. Tasks
+  /// might be dispatched before the purge takes effect. A purge is
+  /// irreversible.
+  ///
+  /// @param request
+  /// @googleapis_link{google::cloud::tasks::v2::PurgeQueueRequest,google/cloud/tasks/v2/cloudtasks.proto#L431}
+  /// @param options  Optional. Operation options.
+  /// @return
+  /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
+  ///
+  /// [google.cloud.tasks.v2.PurgeQueueRequest]:
+  /// @googleapis_reference_link{google/cloud/tasks/v2/cloudtasks.proto#L431}
+  /// [google.cloud.tasks.v2.Queue]:
+  /// @googleapis_reference_link{google/cloud/tasks/v2/queue.proto#L34}
+  ///
+  StatusOr<google::cloud::tasks::v2::Queue> PurgeQueue(
+      google::cloud::tasks::v2::PurgeQueueRequest const& request,
+      Options options = {});
+
+  ///
   /// Pauses the queue.
   ///
   /// If a queue is paused then the system will stop dispatching tasks
@@ -261,6 +407,31 @@ class CloudTasksClient {
   ///
   StatusOr<google::cloud::tasks::v2::Queue> PauseQueue(std::string const& name,
                                                        Options options = {});
+
+  ///
+  /// Pauses the queue.
+  ///
+  /// If a queue is paused then the system will stop dispatching tasks
+  /// until the queue is resumed via
+  /// [ResumeQueue][google.cloud.tasks.v2.CloudTasks.ResumeQueue]. Tasks can
+  /// still be added when the queue is paused. A queue is paused if its
+  /// [state][google.cloud.tasks.v2.Queue.state] is
+  /// [PAUSED][google.cloud.tasks.v2.Queue.State.PAUSED].
+  ///
+  /// @param request
+  /// @googleapis_link{google::cloud::tasks::v2::PauseQueueRequest,google/cloud/tasks/v2/cloudtasks.proto#L443}
+  /// @param options  Optional. Operation options.
+  /// @return
+  /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
+  ///
+  /// [google.cloud.tasks.v2.PauseQueueRequest]:
+  /// @googleapis_reference_link{google/cloud/tasks/v2/cloudtasks.proto#L443}
+  /// [google.cloud.tasks.v2.Queue]:
+  /// @googleapis_reference_link{google/cloud/tasks/v2/queue.proto#L34}
+  ///
+  StatusOr<google::cloud::tasks::v2::Queue> PauseQueue(
+      google::cloud::tasks::v2::PauseQueueRequest const& request,
+      Options options = {});
 
   ///
   /// Resume a queue.
@@ -293,6 +464,37 @@ class CloudTasksClient {
                                                         Options options = {});
 
   ///
+  /// Resume a queue.
+  ///
+  /// This method resumes a queue after it has been
+  /// [PAUSED][google.cloud.tasks.v2.Queue.State.PAUSED] or
+  /// [DISABLED][google.cloud.tasks.v2.Queue.State.DISABLED]. The state of a
+  /// queue is stored in the queue's [state][google.cloud.tasks.v2.Queue.state];
+  /// after calling this method it will be set to
+  /// [RUNNING][google.cloud.tasks.v2.Queue.State.RUNNING].
+  ///
+  /// WARNING: Resuming many high-QPS queues at the same time can
+  /// lead to target overloading. If you are resuming high-QPS
+  /// queues, follow the 500/50/5 pattern described in
+  /// [Managing Cloud Tasks Scaling
+  /// Risks](https://cloud.google.com/tasks/docs/manage-cloud-task-scaling).
+  ///
+  /// @param request
+  /// @googleapis_link{google::cloud::tasks::v2::ResumeQueueRequest,google/cloud/tasks/v2/cloudtasks.proto#L455}
+  /// @param options  Optional. Operation options.
+  /// @return
+  /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
+  ///
+  /// [google.cloud.tasks.v2.ResumeQueueRequest]:
+  /// @googleapis_reference_link{google/cloud/tasks/v2/cloudtasks.proto#L455}
+  /// [google.cloud.tasks.v2.Queue]:
+  /// @googleapis_reference_link{google/cloud/tasks/v2/queue.proto#L34}
+  ///
+  StatusOr<google::cloud::tasks::v2::Queue> ResumeQueue(
+      google::cloud::tasks::v2::ResumeQueueRequest const& request,
+      Options options = {});
+
+  ///
   /// Gets the access control policy for a [Queue][google.cloud.tasks.v2.Queue].
   /// Returns an empty policy if the resource exists and does not have a policy
   /// set.
@@ -317,6 +519,32 @@ class CloudTasksClient {
   ///
   StatusOr<google::iam::v1::Policy> GetIamPolicy(std::string const& resource,
                                                  Options options = {});
+
+  ///
+  /// Gets the access control policy for a [Queue][google.cloud.tasks.v2.Queue].
+  /// Returns an empty policy if the resource exists and does not have a policy
+  /// set.
+  ///
+  /// Authorization requires the following
+  /// [Google IAM](https://cloud.google.com/iam) permission on the specified
+  /// resource parent:
+  ///
+  /// * `cloudtasks.queues.getIamPolicy`
+  ///
+  /// @param request
+  /// @googleapis_link{google::iam::v1::GetIamPolicyRequest,google/iam/v1/iam_policy.proto#L113}
+  /// @param options  Optional. Operation options.
+  /// @return
+  /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
+  ///
+  /// [google.iam.v1.GetIamPolicyRequest]:
+  /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L113}
+  /// [google.iam.v1.Policy]:
+  /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
+  ///
+  StatusOr<google::iam::v1::Policy> GetIamPolicy(
+      google::iam::v1::GetIamPolicyRequest const& request,
+      Options options = {});
 
   ///
   /// Sets the access control policy for a [Queue][google.cloud.tasks.v2.Queue].
@@ -378,6 +606,34 @@ class CloudTasksClient {
                                                  Options options = {});
 
   ///
+  /// Sets the access control policy for a [Queue][google.cloud.tasks.v2.Queue].
+  /// Replaces any existing policy.
+  ///
+  /// Note: The Cloud Console does not check queue-level IAM permissions yet.
+  /// Project-level permissions are required to use the Cloud Console.
+  ///
+  /// Authorization requires the following
+  /// [Google IAM](https://cloud.google.com/iam) permission on the specified
+  /// resource parent:
+  ///
+  /// * `cloudtasks.queues.setIamPolicy`
+  ///
+  /// @param request
+  /// @googleapis_link{google::iam::v1::SetIamPolicyRequest,google/iam/v1/iam_policy.proto#L98}
+  /// @param options  Optional. Operation options.
+  /// @return
+  /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
+  ///
+  /// [google.iam.v1.SetIamPolicyRequest]:
+  /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L98}
+  /// [google.iam.v1.Policy]:
+  /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
+  ///
+  StatusOr<google::iam::v1::Policy> SetIamPolicy(
+      google::iam::v1::SetIamPolicyRequest const& request,
+      Options options = {});
+
+  ///
   /// Returns permissions that a caller has on a
   /// [Queue][google.cloud.tasks.v2.Queue]. If the resource does not exist, this
   /// will return an empty set of permissions, not a
@@ -409,6 +665,31 @@ class CloudTasksClient {
       Options options = {});
 
   ///
+  /// Returns permissions that a caller has on a
+  /// [Queue][google.cloud.tasks.v2.Queue]. If the resource does not exist, this
+  /// will return an empty set of permissions, not a
+  /// [NOT_FOUND][google.rpc.Code.NOT_FOUND] error.
+  ///
+  /// Note: This operation is designed to be used for building permission-aware
+  /// UIs and command-line tools, not for authorization checking. This operation
+  /// may "fail open" without warning.
+  ///
+  /// @param request
+  /// @googleapis_link{google::iam::v1::TestIamPermissionsRequest,google/iam/v1/iam_policy.proto#L126}
+  /// @param options  Optional. Operation options.
+  /// @return
+  /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
+  ///
+  /// [google.iam.v1.TestIamPermissionsRequest]:
+  /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L126}
+  /// [google.iam.v1.TestIamPermissionsResponse]:
+  /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L141}
+  ///
+  StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
+      google::iam::v1::TestIamPermissionsRequest const& request,
+      Options options = {});
+
+  ///
   /// Lists the tasks in a queue.
   ///
   /// By default, only the [BASIC][google.cloud.tasks.v2.Task.View.BASIC] view
@@ -434,6 +715,31 @@ class CloudTasksClient {
       std::string const& parent, Options options = {});
 
   ///
+  /// Lists the tasks in a queue.
+  ///
+  /// By default, only the [BASIC][google.cloud.tasks.v2.Task.View.BASIC] view
+  /// is retrieved due to performance considerations;
+  /// [response_view][google.cloud.tasks.v2.ListTasksRequest.response_view]
+  /// controls the subset of information which is returned.
+  ///
+  /// The tasks may be returned in any order. The ordering may change at any
+  /// time.
+  ///
+  /// @param request
+  /// @googleapis_link{google::cloud::tasks::v2::ListTasksRequest,google/cloud/tasks/v2/cloudtasks.proto#L467}
+  /// @param options  Optional. Operation options.
+  /// @return
+  /// @googleapis_link{google::cloud::tasks::v2::Task,google/cloud/tasks/v2/task.proto#L33}
+  ///
+  /// [google.cloud.tasks.v2.ListTasksRequest]:
+  /// @googleapis_reference_link{google/cloud/tasks/v2/cloudtasks.proto#L467}
+  /// [google.cloud.tasks.v2.Task]:
+  /// @googleapis_reference_link{google/cloud/tasks/v2/task.proto#L33}
+  ///
+  StreamRange<google::cloud::tasks::v2::Task> ListTasks(
+      google::cloud::tasks::v2::ListTasksRequest request, Options options = {});
+
+  ///
   /// Gets a task.
   ///
   /// @param name  Required. The task name. For example:
@@ -449,6 +755,24 @@ class CloudTasksClient {
   ///
   StatusOr<google::cloud::tasks::v2::Task> GetTask(std::string const& name,
                                                    Options options = {});
+
+  ///
+  /// Gets a task.
+  ///
+  /// @param request
+  /// @googleapis_link{google::cloud::tasks::v2::GetTaskRequest,google/cloud/tasks/v2/cloudtasks.proto#L529}
+  /// @param options  Optional. Operation options.
+  /// @return
+  /// @googleapis_link{google::cloud::tasks::v2::Task,google/cloud/tasks/v2/task.proto#L33}
+  ///
+  /// [google.cloud.tasks.v2.GetTaskRequest]:
+  /// @googleapis_reference_link{google/cloud/tasks/v2/cloudtasks.proto#L529}
+  /// [google.cloud.tasks.v2.Task]:
+  /// @googleapis_reference_link{google/cloud/tasks/v2/task.proto#L33}
+  ///
+  StatusOr<google::cloud::tasks::v2::Task> GetTask(
+      google::cloud::tasks::v2::GetTaskRequest const& request,
+      Options options = {});
 
   ///
   /// Creates a task and adds it to a queue.
@@ -501,6 +825,28 @@ class CloudTasksClient {
       Options options = {});
 
   ///
+  /// Creates a task and adds it to a queue.
+  ///
+  /// Tasks cannot be updated after creation; there is no UpdateTask command.
+  ///
+  /// * The maximum task size is 100KB.
+  ///
+  /// @param request
+  /// @googleapis_link{google::cloud::tasks::v2::CreateTaskRequest,google/cloud/tasks/v2/cloudtasks.proto#L555}
+  /// @param options  Optional. Operation options.
+  /// @return
+  /// @googleapis_link{google::cloud::tasks::v2::Task,google/cloud/tasks/v2/task.proto#L33}
+  ///
+  /// [google.cloud.tasks.v2.CreateTaskRequest]:
+  /// @googleapis_reference_link{google/cloud/tasks/v2/cloudtasks.proto#L555}
+  /// [google.cloud.tasks.v2.Task]:
+  /// @googleapis_reference_link{google/cloud/tasks/v2/task.proto#L33}
+  ///
+  StatusOr<google::cloud::tasks::v2::Task> CreateTask(
+      google::cloud::tasks::v2::CreateTaskRequest const& request,
+      Options options = {});
+
+  ///
   /// Deletes a task.
   ///
   /// A task can be deleted if it is scheduled or dispatched. A task
@@ -515,6 +861,23 @@ class CloudTasksClient {
   /// @googleapis_reference_link{google/cloud/tasks/v2/cloudtasks.proto#L619}
   ///
   Status DeleteTask(std::string const& name, Options options = {});
+
+  ///
+  /// Deletes a task.
+  ///
+  /// A task can be deleted if it is scheduled or dispatched. A task
+  /// cannot be deleted if it has executed successfully or permanently
+  /// failed.
+  ///
+  /// @param request
+  /// @googleapis_link{google::cloud::tasks::v2::DeleteTaskRequest,google/cloud/tasks/v2/cloudtasks.proto#L619}
+  /// @param options  Optional. Operation options.
+  ///
+  /// [google.cloud.tasks.v2.DeleteTaskRequest]:
+  /// @googleapis_reference_link{google/cloud/tasks/v2/cloudtasks.proto#L619}
+  ///
+  Status DeleteTask(google::cloud::tasks::v2::DeleteTaskRequest const& request,
+                    Options options = {});
 
   ///
   /// Forces a task to run now.
@@ -557,369 +920,6 @@ class CloudTasksClient {
   ///
   StatusOr<google::cloud::tasks::v2::Task> RunTask(std::string const& name,
                                                    Options options = {});
-
-  ///
-  /// Lists queues.
-  ///
-  /// Queues are returned in lexicographical order.
-  ///
-  /// @param request
-  /// @googleapis_link{google::cloud::tasks::v2::ListQueuesRequest,google/cloud/tasks/v2/cloudtasks.proto#L308}
-  /// @param options  Optional. Operation options.
-  /// @return
-  /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
-  ///
-  /// [google.cloud.tasks.v2.ListQueuesRequest]:
-  /// @googleapis_reference_link{google/cloud/tasks/v2/cloudtasks.proto#L308}
-  /// [google.cloud.tasks.v2.Queue]:
-  /// @googleapis_reference_link{google/cloud/tasks/v2/queue.proto#L34}
-  ///
-  StreamRange<google::cloud::tasks::v2::Queue> ListQueues(
-      google::cloud::tasks::v2::ListQueuesRequest request,
-      Options options = {});
-
-  ///
-  /// Gets a queue.
-  ///
-  /// @param request
-  /// @googleapis_link{google::cloud::tasks::v2::GetQueueRequest,google/cloud/tasks/v2/cloudtasks.proto#L369}
-  /// @param options  Optional. Operation options.
-  /// @return
-  /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
-  ///
-  /// [google.cloud.tasks.v2.GetQueueRequest]:
-  /// @googleapis_reference_link{google/cloud/tasks/v2/cloudtasks.proto#L369}
-  /// [google.cloud.tasks.v2.Queue]:
-  /// @googleapis_reference_link{google/cloud/tasks/v2/queue.proto#L34}
-  ///
-  StatusOr<google::cloud::tasks::v2::Queue> GetQueue(
-      google::cloud::tasks::v2::GetQueueRequest const& request,
-      Options options = {});
-
-  ///
-  /// Creates a queue.
-  ///
-  /// Queues created with this method allow tasks to live for a maximum of 31
-  /// days. After a task is 31 days old, the task will be deleted regardless of
-  /// whether it was dispatched or not.
-  ///
-  /// WARNING: Using this method may have unintended side effects if you are
-  /// using an App Engine `queue.yaml` or `queue.xml` file to manage your
-  /// queues. Read [Overview of Queue Management and
-  /// queue.yaml](https://cloud.google.com/tasks/docs/queue-yaml) before using
-  /// this method.
-  ///
-  /// @param request
-  /// @googleapis_link{google::cloud::tasks::v2::CreateQueueRequest,google/cloud/tasks/v2/cloudtasks.proto#L381}
-  /// @param options  Optional. Operation options.
-  /// @return
-  /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
-  ///
-  /// [google.cloud.tasks.v2.CreateQueueRequest]:
-  /// @googleapis_reference_link{google/cloud/tasks/v2/cloudtasks.proto#L381}
-  /// [google.cloud.tasks.v2.Queue]:
-  /// @googleapis_reference_link{google/cloud/tasks/v2/queue.proto#L34}
-  ///
-  StatusOr<google::cloud::tasks::v2::Queue> CreateQueue(
-      google::cloud::tasks::v2::CreateQueueRequest const& request,
-      Options options = {});
-
-  ///
-  /// Updates a queue.
-  ///
-  /// This method creates the queue if it does not exist and updates
-  /// the queue if it does exist.
-  ///
-  /// Queues created with this method allow tasks to live for a maximum of 31
-  /// days. After a task is 31 days old, the task will be deleted regardless of
-  /// whether it was dispatched or not.
-  ///
-  /// WARNING: Using this method may have unintended side effects if you are
-  /// using an App Engine `queue.yaml` or `queue.xml` file to manage your
-  /// queues. Read [Overview of Queue Management and
-  /// queue.yaml](https://cloud.google.com/tasks/docs/queue-yaml) before using
-  /// this method.
-  ///
-  /// @param request
-  /// @googleapis_link{google::cloud::tasks::v2::UpdateQueueRequest,google/cloud/tasks/v2/cloudtasks.proto#L402}
-  /// @param options  Optional. Operation options.
-  /// @return
-  /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
-  ///
-  /// [google.cloud.tasks.v2.UpdateQueueRequest]:
-  /// @googleapis_reference_link{google/cloud/tasks/v2/cloudtasks.proto#L402}
-  /// [google.cloud.tasks.v2.Queue]:
-  /// @googleapis_reference_link{google/cloud/tasks/v2/queue.proto#L34}
-  ///
-  StatusOr<google::cloud::tasks::v2::Queue> UpdateQueue(
-      google::cloud::tasks::v2::UpdateQueueRequest const& request,
-      Options options = {});
-
-  ///
-  /// Deletes a queue.
-  ///
-  /// This command will delete the queue even if it has tasks in it.
-  ///
-  /// Note: If you delete a queue, a queue with the same name can't be created
-  /// for 7 days.
-  ///
-  /// WARNING: Using this method may have unintended side effects if you are
-  /// using an App Engine `queue.yaml` or `queue.xml` file to manage your
-  /// queues. Read [Overview of Queue Management and
-  /// queue.yaml](https://cloud.google.com/tasks/docs/queue-yaml) before using
-  /// this method.
-  ///
-  /// @param request
-  /// @googleapis_link{google::cloud::tasks::v2::DeleteQueueRequest,google/cloud/tasks/v2/cloudtasks.proto#L419}
-  /// @param options  Optional. Operation options.
-  ///
-  /// [google.cloud.tasks.v2.DeleteQueueRequest]:
-  /// @googleapis_reference_link{google/cloud/tasks/v2/cloudtasks.proto#L419}
-  ///
-  Status DeleteQueue(
-      google::cloud::tasks::v2::DeleteQueueRequest const& request,
-      Options options = {});
-
-  ///
-  /// Purges a queue by deleting all of its tasks.
-  ///
-  /// All tasks created before this method is called are permanently deleted.
-  ///
-  /// Purge operations can take up to one minute to take effect. Tasks
-  /// might be dispatched before the purge takes effect. A purge is
-  /// irreversible.
-  ///
-  /// @param request
-  /// @googleapis_link{google::cloud::tasks::v2::PurgeQueueRequest,google/cloud/tasks/v2/cloudtasks.proto#L431}
-  /// @param options  Optional. Operation options.
-  /// @return
-  /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
-  ///
-  /// [google.cloud.tasks.v2.PurgeQueueRequest]:
-  /// @googleapis_reference_link{google/cloud/tasks/v2/cloudtasks.proto#L431}
-  /// [google.cloud.tasks.v2.Queue]:
-  /// @googleapis_reference_link{google/cloud/tasks/v2/queue.proto#L34}
-  ///
-  StatusOr<google::cloud::tasks::v2::Queue> PurgeQueue(
-      google::cloud::tasks::v2::PurgeQueueRequest const& request,
-      Options options = {});
-
-  ///
-  /// Pauses the queue.
-  ///
-  /// If a queue is paused then the system will stop dispatching tasks
-  /// until the queue is resumed via
-  /// [ResumeQueue][google.cloud.tasks.v2.CloudTasks.ResumeQueue]. Tasks can
-  /// still be added when the queue is paused. A queue is paused if its
-  /// [state][google.cloud.tasks.v2.Queue.state] is
-  /// [PAUSED][google.cloud.tasks.v2.Queue.State.PAUSED].
-  ///
-  /// @param request
-  /// @googleapis_link{google::cloud::tasks::v2::PauseQueueRequest,google/cloud/tasks/v2/cloudtasks.proto#L443}
-  /// @param options  Optional. Operation options.
-  /// @return
-  /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
-  ///
-  /// [google.cloud.tasks.v2.PauseQueueRequest]:
-  /// @googleapis_reference_link{google/cloud/tasks/v2/cloudtasks.proto#L443}
-  /// [google.cloud.tasks.v2.Queue]:
-  /// @googleapis_reference_link{google/cloud/tasks/v2/queue.proto#L34}
-  ///
-  StatusOr<google::cloud::tasks::v2::Queue> PauseQueue(
-      google::cloud::tasks::v2::PauseQueueRequest const& request,
-      Options options = {});
-
-  ///
-  /// Resume a queue.
-  ///
-  /// This method resumes a queue after it has been
-  /// [PAUSED][google.cloud.tasks.v2.Queue.State.PAUSED] or
-  /// [DISABLED][google.cloud.tasks.v2.Queue.State.DISABLED]. The state of a
-  /// queue is stored in the queue's [state][google.cloud.tasks.v2.Queue.state];
-  /// after calling this method it will be set to
-  /// [RUNNING][google.cloud.tasks.v2.Queue.State.RUNNING].
-  ///
-  /// WARNING: Resuming many high-QPS queues at the same time can
-  /// lead to target overloading. If you are resuming high-QPS
-  /// queues, follow the 500/50/5 pattern described in
-  /// [Managing Cloud Tasks Scaling
-  /// Risks](https://cloud.google.com/tasks/docs/manage-cloud-task-scaling).
-  ///
-  /// @param request
-  /// @googleapis_link{google::cloud::tasks::v2::ResumeQueueRequest,google/cloud/tasks/v2/cloudtasks.proto#L455}
-  /// @param options  Optional. Operation options.
-  /// @return
-  /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
-  ///
-  /// [google.cloud.tasks.v2.ResumeQueueRequest]:
-  /// @googleapis_reference_link{google/cloud/tasks/v2/cloudtasks.proto#L455}
-  /// [google.cloud.tasks.v2.Queue]:
-  /// @googleapis_reference_link{google/cloud/tasks/v2/queue.proto#L34}
-  ///
-  StatusOr<google::cloud::tasks::v2::Queue> ResumeQueue(
-      google::cloud::tasks::v2::ResumeQueueRequest const& request,
-      Options options = {});
-
-  ///
-  /// Gets the access control policy for a [Queue][google.cloud.tasks.v2.Queue].
-  /// Returns an empty policy if the resource exists and does not have a policy
-  /// set.
-  ///
-  /// Authorization requires the following
-  /// [Google IAM](https://cloud.google.com/iam) permission on the specified
-  /// resource parent:
-  ///
-  /// * `cloudtasks.queues.getIamPolicy`
-  ///
-  /// @param request
-  /// @googleapis_link{google::iam::v1::GetIamPolicyRequest,google/iam/v1/iam_policy.proto#L113}
-  /// @param options  Optional. Operation options.
-  /// @return
-  /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
-  ///
-  /// [google.iam.v1.GetIamPolicyRequest]:
-  /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L113}
-  /// [google.iam.v1.Policy]:
-  /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
-  ///
-  StatusOr<google::iam::v1::Policy> GetIamPolicy(
-      google::iam::v1::GetIamPolicyRequest const& request,
-      Options options = {});
-
-  ///
-  /// Sets the access control policy for a [Queue][google.cloud.tasks.v2.Queue].
-  /// Replaces any existing policy.
-  ///
-  /// Note: The Cloud Console does not check queue-level IAM permissions yet.
-  /// Project-level permissions are required to use the Cloud Console.
-  ///
-  /// Authorization requires the following
-  /// [Google IAM](https://cloud.google.com/iam) permission on the specified
-  /// resource parent:
-  ///
-  /// * `cloudtasks.queues.setIamPolicy`
-  ///
-  /// @param request
-  /// @googleapis_link{google::iam::v1::SetIamPolicyRequest,google/iam/v1/iam_policy.proto#L98}
-  /// @param options  Optional. Operation options.
-  /// @return
-  /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
-  ///
-  /// [google.iam.v1.SetIamPolicyRequest]:
-  /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L98}
-  /// [google.iam.v1.Policy]:
-  /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
-  ///
-  StatusOr<google::iam::v1::Policy> SetIamPolicy(
-      google::iam::v1::SetIamPolicyRequest const& request,
-      Options options = {});
-
-  ///
-  /// Returns permissions that a caller has on a
-  /// [Queue][google.cloud.tasks.v2.Queue]. If the resource does not exist, this
-  /// will return an empty set of permissions, not a
-  /// [NOT_FOUND][google.rpc.Code.NOT_FOUND] error.
-  ///
-  /// Note: This operation is designed to be used for building permission-aware
-  /// UIs and command-line tools, not for authorization checking. This operation
-  /// may "fail open" without warning.
-  ///
-  /// @param request
-  /// @googleapis_link{google::iam::v1::TestIamPermissionsRequest,google/iam/v1/iam_policy.proto#L126}
-  /// @param options  Optional. Operation options.
-  /// @return
-  /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
-  ///
-  /// [google.iam.v1.TestIamPermissionsRequest]:
-  /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L126}
-  /// [google.iam.v1.TestIamPermissionsResponse]:
-  /// @googleapis_reference_link{google/iam/v1/iam_policy.proto#L141}
-  ///
-  StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
-      google::iam::v1::TestIamPermissionsRequest const& request,
-      Options options = {});
-
-  ///
-  /// Lists the tasks in a queue.
-  ///
-  /// By default, only the [BASIC][google.cloud.tasks.v2.Task.View.BASIC] view
-  /// is retrieved due to performance considerations;
-  /// [response_view][google.cloud.tasks.v2.ListTasksRequest.response_view]
-  /// controls the subset of information which is returned.
-  ///
-  /// The tasks may be returned in any order. The ordering may change at any
-  /// time.
-  ///
-  /// @param request
-  /// @googleapis_link{google::cloud::tasks::v2::ListTasksRequest,google/cloud/tasks/v2/cloudtasks.proto#L467}
-  /// @param options  Optional. Operation options.
-  /// @return
-  /// @googleapis_link{google::cloud::tasks::v2::Task,google/cloud/tasks/v2/task.proto#L33}
-  ///
-  /// [google.cloud.tasks.v2.ListTasksRequest]:
-  /// @googleapis_reference_link{google/cloud/tasks/v2/cloudtasks.proto#L467}
-  /// [google.cloud.tasks.v2.Task]:
-  /// @googleapis_reference_link{google/cloud/tasks/v2/task.proto#L33}
-  ///
-  StreamRange<google::cloud::tasks::v2::Task> ListTasks(
-      google::cloud::tasks::v2::ListTasksRequest request, Options options = {});
-
-  ///
-  /// Gets a task.
-  ///
-  /// @param request
-  /// @googleapis_link{google::cloud::tasks::v2::GetTaskRequest,google/cloud/tasks/v2/cloudtasks.proto#L529}
-  /// @param options  Optional. Operation options.
-  /// @return
-  /// @googleapis_link{google::cloud::tasks::v2::Task,google/cloud/tasks/v2/task.proto#L33}
-  ///
-  /// [google.cloud.tasks.v2.GetTaskRequest]:
-  /// @googleapis_reference_link{google/cloud/tasks/v2/cloudtasks.proto#L529}
-  /// [google.cloud.tasks.v2.Task]:
-  /// @googleapis_reference_link{google/cloud/tasks/v2/task.proto#L33}
-  ///
-  StatusOr<google::cloud::tasks::v2::Task> GetTask(
-      google::cloud::tasks::v2::GetTaskRequest const& request,
-      Options options = {});
-
-  ///
-  /// Creates a task and adds it to a queue.
-  ///
-  /// Tasks cannot be updated after creation; there is no UpdateTask command.
-  ///
-  /// * The maximum task size is 100KB.
-  ///
-  /// @param request
-  /// @googleapis_link{google::cloud::tasks::v2::CreateTaskRequest,google/cloud/tasks/v2/cloudtasks.proto#L555}
-  /// @param options  Optional. Operation options.
-  /// @return
-  /// @googleapis_link{google::cloud::tasks::v2::Task,google/cloud/tasks/v2/task.proto#L33}
-  ///
-  /// [google.cloud.tasks.v2.CreateTaskRequest]:
-  /// @googleapis_reference_link{google/cloud/tasks/v2/cloudtasks.proto#L555}
-  /// [google.cloud.tasks.v2.Task]:
-  /// @googleapis_reference_link{google/cloud/tasks/v2/task.proto#L33}
-  ///
-  StatusOr<google::cloud::tasks::v2::Task> CreateTask(
-      google::cloud::tasks::v2::CreateTaskRequest const& request,
-      Options options = {});
-
-  ///
-  /// Deletes a task.
-  ///
-  /// A task can be deleted if it is scheduled or dispatched. A task
-  /// cannot be deleted if it has executed successfully or permanently
-  /// failed.
-  ///
-  /// @param request
-  /// @googleapis_link{google::cloud::tasks::v2::DeleteTaskRequest,google/cloud/tasks/v2/cloudtasks.proto#L619}
-  /// @param options  Optional. Operation options.
-  ///
-  /// [google.cloud.tasks.v2.DeleteTaskRequest]:
-  /// @googleapis_reference_link{google/cloud/tasks/v2/cloudtasks.proto#L619}
-  ///
-  Status DeleteTask(google::cloud::tasks::v2::DeleteTaskRequest const& request,
-                    Options options = {});
 
   ///
   /// Forces a task to run now.


### PR DESCRIPTION
It is nicer to have the signature-extension operations generated
right next to their request-proto overloads.  This is particularly
true in the client header, which we expect customers to read.

The only true edit is `generator/internal/client_generator.cc`.
The remainder of the PR is updated golden files and regenerated
service interfaces.

Fixes #5997

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7743)
<!-- Reviewable:end -->
