### PR TITLE
test(bigtable): run a few more tests against emulator

### DIFF
--- a/google/cloud/bigtable/tests/data_integration_test.cc
+++ b/google/cloud/bigtable/tests/data_integration_test.cc
@@ -191,11 +191,8 @@ TEST_F(DataIntegrationTest, TableReadRowsAllRows) {
                      RowReader::NO_ROWS_LIMIT, Filter::PassAllFilter());
   CheckEqualUnordered(created, MoveCellsFromReader(read3));
 
-  if (!UsingCloudBigtableEmulator()) {
-    // TODO(#151) - remove workarounds for emulator bug(s).
-    auto read4 = table.ReadRows(RowSet(), Filter::PassAllFilter());
-    CheckEqualUnordered(created, MoveCellsFromReader(read4));
-  }
+  auto read4 = table.ReadRows(RowSet(), Filter::PassAllFilter());
+  CheckEqualUnordered(created, MoveCellsFromReader(read4));
 }
 
 TEST_F(DataIntegrationTest, TableReadRowsPartialRows) {
@@ -460,11 +457,6 @@ TEST_F(DataIntegrationTest, TableCellValueInt64Test) {
 }
 
 TEST_F(DataIntegrationTest, TableReadMultipleCellsBigValue) {
-  if (UsingCloudBigtableEmulator()) {
-    // TODO(#151) - remove workarounds for emulator bug(s).
-    return;
-  }
-
   auto table = GetTable();
 
   std::string const row_key = "row-key-1";

--- a/google/cloud/bigtable/tests/filters_integration_test.cc
+++ b/google/cloud/bigtable/tests/filters_integration_test.cc
@@ -354,10 +354,6 @@ TEST_F(FilterIntegrationTest, CellsRowOffset) {
 
 TEST_F(FilterIntegrationTest, RowSample) {
   using ::google::cloud::testing_util::chrono_literals::operator"" _ms;
-  // TODO(#151) - remove workarounds for emulator bug(s).
-  if (UsingCloudBigtableEmulator()) {
-    return;
-  }
 
   auto table = GetTable();
   std::string const prefix = "row-sample-prefix";
@@ -439,11 +435,6 @@ TEST_F(FilterIntegrationTest, StripValueTransformer) {
 }
 
 TEST_F(FilterIntegrationTest, ApplyLabelTransformer) {
-  // TODO(#151) - remove workarounds for emulator bug(s).
-  if (UsingCloudBigtableEmulator()) {
-    return;
-  }
-
   auto table = GetTable();
   std::string const prefix = "apply-label-transformer-prefix";
   std::vector<Cell> created{

--- a/google/cloud/bigtable/tests/mutations_integration_test.cc
+++ b/google/cloud/bigtable/tests/mutations_integration_test.cc
@@ -210,10 +210,6 @@ TEST_F(MutationIntegrationTest, DeleteFromColumnForTimestampRangeTest) {
  * We expect the server (and not the client library) to reject invalid ranges.
  */
 TEST_F(MutationIntegrationTest, DeleteFromColumnForReversedTimestampRangeTest) {
-  // TODO(#151) - remove workarounds for emulator bug(s).
-  if (UsingCloudBigtableEmulator()) {
-    return;
-  }
   auto table = GetTable();
   // Create a vector of cell which will be inserted into bigtable
   std::string const key = "row";
@@ -246,10 +242,6 @@ TEST_F(MutationIntegrationTest, DeleteFromColumnForReversedTimestampRangeTest) {
  * We expect the server (and not the client library) to reject invalid ranges.
  */
 TEST_F(MutationIntegrationTest, DeleteFromColumnForEmptyTimestampRangeTest) {
-  // TODO(#151) - remove workarounds for emulator bug(s).
-  if (UsingCloudBigtableEmulator()) {
-    return;
-  }
   auto table = GetTable();
   // Create a vector of cell which will be inserted into bigtable
   std::string const key = "row";


### PR DESCRIPTION
Part of #151 

The bigtable emulator can now handle these tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7758)
<!-- Reviewable:end -->
