### PR TITLE
fix(common): revamp the async polling loop

### DIFF
--- a/generator/integration_tests/golden/tests/golden_thing_admin_connection_test.cc
+++ b/generator/integration_tests/golden/tests/golden_thing_admin_connection_test.cc
@@ -222,7 +222,7 @@ TEST(GoldenThingAdminConnectionTest, CreateDatabaseCancel) {
   get.PopFront().set_value(op);
   auto g = get.PopFront();
   fut.cancel();
-  g.set_value(op);
+  g.set_value(Status{StatusCode::kCancelled, "cancelled"});
   auto db = fut.get();
   EXPECT_THAT(db, StatusIs(StatusCode::kCancelled));
 }
@@ -355,7 +355,7 @@ TEST(GoldenThingAdminConnectionTest, UpdateDatabaseDdlCancel) {
   get.PopFront().set_value(op);
   auto g = get.PopFront();
   fut.cancel();
-  g.set_value(op);
+  g.set_value(Status{StatusCode::kCancelled, "cancelled"});
   auto db = fut.get();
   EXPECT_THAT(db, StatusIs(StatusCode::kCancelled));
 }
@@ -696,7 +696,7 @@ TEST(GoldenThingAdminConnectionTest, CreateBackupCancel) {
   get.PopFront().set_value(op);
   auto g = get.PopFront();
   fut.cancel();
-  g.set_value(op);
+  g.set_value(Status{StatusCode::kCancelled, "cancelled"});
   auto db = fut.get();
   EXPECT_THAT(db, StatusIs(StatusCode::kCancelled));
 }
@@ -1006,7 +1006,7 @@ TEST(GoldenThingAdminConnectionTest, RestoreBackupCancel) {
   get.PopFront().set_value(op);
   auto g = get.PopFront();
   fut.cancel();
-  g.set_value(op);
+  g.set_value(Status{StatusCode::kCancelled, "cancelled"});
   auto db = fut.get();
   EXPECT_THAT(db, StatusIs(StatusCode::kCancelled));
 }


### PR DESCRIPTION
* Do not drop a cancellation request made before we receive
  the `longrunning::Operation`.

  Instead, remember that a cancellation request was made,
  and then cancel the operation once we know it has started.

  This (probabilistically) saves a significant chunk of time
  in the `spanner_cancel_backup_create` sample, as we now
  always cancel the `CreateBackup()`.

* Do not fabricate a cancelled `Status`.

  The only way we really know an operation has been cancelled
  is by examining the `GetOperation()` response.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7762)
<!-- Reviewable:end -->
