### PR TITLE
ci: remove hardcoded branches on windows builds

### DIFF
--- a/ci/kokoro/windows/build.ps1
+++ b/ci/kokoro/windows/build.ps1
@@ -51,7 +51,7 @@ the KOKORO_JOB_NAME environment variable.
 # TODO(#4896): Enable generator integration tests for windows.
 $env:GOOGLE_CLOUD_CPP_GENERATOR_RUN_INTEGRATION_TESTS = "no"
 
-$env:BUILD_CACHE = "gs://cloud-cpp-kokoro-results/build-cache/google-cloud-cpp/main/vcpkg-binary-cache/windows/${BuildName}/"
+$env:BUILD_CACHE = "gs://cloud-cpp-kokoro-results/build-cache/google-cloud-cpp/vcpkg-binary-cache/windows/${BuildName}/"
 $DependencyScriptArgs=@()
 if (($BuildName -eq "cmake") -or ($BuildName -eq "cmake-debug")) {
     $env:CONFIG = "Debug"


### PR DESCRIPTION
The cache for Windows builds just contains vcpkg binary files, these are independent
of the branch being targeted as the cache is a content cache. We can remove the branch
name from the cache path and simplify the script a itty-tiny-little-bit.

Fixes #3517

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7764)
<!-- Reviewable:end -->
