### PR TITLE
cleanup: simplify logic

### DIFF
--- a/google/cloud/internal/async_retry_loop.h
+++ b/google/cloud/internal/async_retry_loop.h
@@ -152,20 +152,13 @@ class AsyncRetryLoopImpl
 
   void OnBackoffTimer(StatusOr<std::chrono::system_clock::time_point> tp) {
     SetIdle();
+    if (Cancelled()) return;
     if (!tp) {
-      if (Cancelled()) {
-        // The retry loop has been canceled and that cancelled the timer.
-        SetDone(
-            RetryLoopError("Retry loop cancelled", location_, last_status_));
-
-      } else {
-        // Some kind of error in the CompletionQueue, probably shutting down.
-        SetDone(RetryLoopError("Timer failure in", location_,
-                               std::move(tp).status()));
-      }
+      // Some kind of error in the CompletionQueue, probably shutting down.
+      SetDone(RetryLoopError("Timer failure in", location_,
+                             std::move(tp).status()));
       return;
     }
-    if (Cancelled()) return;
     StartAttempt();
   }
 


### PR DESCRIPTION
if `Cancelled() == true`, we have already set the state to Done and filled the promise. https://github.com/googleapis/google-cloud-cpp/blob/508e008ffd7c7a0fbdb092660378464d185f7c8b/google/cloud/internal/async_retry_loop.h#L212-L216

and the call to `SetDone()` does nothing https://github.com/googleapis/google-cloud-cpp/blob/508e008ffd7c7a0fbdb092660378464d185f7c8b/google/cloud/internal/async_retry_loop.h#L193

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7767)
<!-- Reviewable:end -->
