### PR TITLE
ci: enable Pub/Sub Lite in CMake builds

### DIFF
--- a/ci/cloudbuild/builds/check-api.sh
+++ b/ci/cloudbuild/builds/check-api.sh
@@ -21,18 +21,18 @@ source module ci/cloudbuild/builds/lib/cmake.sh
 
 export CC=gcc
 export CXX=g++
+mapfile -t cmake_args < <(cmake::common_args)
 
 INSTALL_PREFIX=/var/tmp/google-cloud-cpp
 # abi-dumper wants us to use -Og, but that causes bogus warnings about
 # uninitialized values with GCC, so we disable that warning with
 # -Wno-maybe-uninitialized. See also:
 # https://github.com/googleapis/google-cloud-cpp/issues/6313
-cmake -GNinja \
+cmake "${cmake_args[@]}" \
   -DCMAKE_INSTALL_PREFIX="${INSTALL_PREFIX}" \
   -DBUILD_SHARED_LIBS=ON \
   -DCMAKE_BUILD_TYPE=Debug \
-  -DCMAKE_CXX_FLAGS="-Og -Wno-maybe-uninitialized" \
-  -S . -B cmake-out
+  -DCMAKE_CXX_FLAGS="-Og -Wno-maybe-uninitialized"
 cmake --build cmake-out
 cmake --build cmake-out --target install
 

--- a/ci/cloudbuild/builds/clang-60.sh
+++ b/ci/cloudbuild/builds/clang-60.sh
@@ -18,13 +18,15 @@ set -euo pipefail
 
 source "$(dirname "$0")/../../lib/init.sh"
 source module ci/cloudbuild/builds/lib/cmake.sh
+source module ci/cloudbuild/builds/lib/features.sh
 
 # We run this test in a Docker image that includes the oldest Clang that we
 # support, which happens to be 6.0 currently.
 export CC=clang
 export CXX=clang++
 
-cmake -GNinja -DBUILD_SHARED_LIBS=yes -DGOOGLE_CLOUD_CPP_ENABLE_CCACHE=ON \
-  -H. -Bcmake-out
+cmake -GNinja -H. -Bcmake-out \
+  -DGOOGLE_CLOUD_CPP_ENABLE="$(features::always_build_cmake)" \
+  -DBUILD_SHARED_LIBS=yes -DGOOGLE_CLOUD_CPP_ENABLE_CCACHE=ON
 cmake --build cmake-out
 env -C cmake-out ctest --output-on-failure -LE "integration-test" -j "$(nproc)"

--- a/ci/cloudbuild/builds/clang-tidy.sh
+++ b/ci/cloudbuild/builds/clang-tidy.sh
@@ -23,12 +23,13 @@ source module ci/cloudbuild/builds/lib/integration.sh
 export CC=clang
 export CXX=clang++
 export CTCACHE_DIR=~/.cache/ctcache
+mapfile -t cmake_args < <(cmake::common_args)
 
 # See https://github.com/matus-chochlik/ctcache for docs about the clang-tidy-cache
-cmake -GNinja -DCMAKE_CXX_CLANG_TIDY=/usr/local/bin/clang-tidy-wrapper \
+cmake "${cmake_args[@]}" \
+  -DCMAKE_CXX_CLANG_TIDY=/usr/local/bin/clang-tidy-wrapper \
   -DGOOGLE_CLOUD_CPP_ENABLE_GENERATOR=ON \
-  -DGOOGLE_CLOUD_CPP_STORAGE_ENABLE_GRPC=ON \
-  -S . -B cmake-out
+  -DGOOGLE_CLOUD_CPP_STORAGE_ENABLE_GRPC=ON
 cmake --build cmake-out
 env -C cmake-out ctest -LE "integration-test" --parallel "$(nproc)"
 

--- a/ci/cloudbuild/builds/cmake-install.sh
+++ b/ci/cloudbuild/builds/cmake-install.sh
@@ -28,15 +28,15 @@ export CXX=clang++
 INSTALL_PREFIX="$(mktemp -d)"
 readonly INSTALL_PREFIX
 
-read -r ENABLED_FEATURES < <(features::cmake_definition)
+read -r ENABLED_FEATURES < <(features::list_full_cmake)
+mapfile -t cmake_args < <(cmake::common_args)
 
 # Compiles and installs all libraries and headers.
-cmake -GNinja \
+cmake "${cmake_args[@]}" \
   -DBUILD_TESTING=OFF \
   -DGOOGLE_CLOUD_CPP_ENABLE_EXAMPLES=OFF \
   -DCMAKE_INSTALL_PREFIX="${INSTALL_PREFIX}" \
-  -DGOOGLE_CLOUD_CPP_ENABLE="${ENABLED_FEATURES}" \
-  -S . -B cmake-out
+  -DGOOGLE_CLOUD_CPP_ENABLE="${ENABLED_FEATURES}"
 cmake --build cmake-out
 cmake --install cmake-out --component google_cloud_cpp_development
 
@@ -170,7 +170,7 @@ done
 
 # Tests the installed artifacts by building and running the quickstarts.
 # shellcheck disable=SC2046
-libraries="$(printf ";%s" $(features::list | grep -v experimental-))"
+libraries="$(printf ";%s" $(features::list_full | grep -v experimental-))"
 libraries="${libraries:1}"
 cmake -G Ninja \
   -S "${PROJECT_ROOT}/ci/verify_quickstart" \

--- a/ci/cloudbuild/builds/cxx11.sh
+++ b/ci/cloudbuild/builds/cxx11.sh
@@ -22,8 +22,9 @@ source module ci/cloudbuild/builds/lib/integration.sh
 
 export CC=gcc
 export CXX=g++
+mapfile -t cmake_args < <(cmake::common_args)
 
-cmake -GNinja -DCMAKE_CXX_STANDARD=11 -S . -B cmake-out
+cmake "${cmake_args[@]}" -DCMAKE_CXX_STANDARD=11
 cmake --build cmake-out
 env -C cmake-out ctest -LE "integration-test" --parallel "$(nproc)"
 

--- a/ci/cloudbuild/builds/cxx20.sh
+++ b/ci/cloudbuild/builds/cxx20.sh
@@ -22,8 +22,9 @@ source module ci/cloudbuild/builds/lib/integration.sh
 
 export CC=gcc
 export CXX=g++
+mapfile -t cmake_args < <(cmake::common_args)
 
-cmake -GNinja -DCMAKE_CXX_STANDARD=20 -S . -B cmake-out
+cmake "${cmake_args[@]}" -DCMAKE_CXX_STANDARD=20
 cmake --build cmake-out
 env -C cmake-out ctest -LE "integration-test" --parallel "$(nproc)"
 

--- a/ci/cloudbuild/builds/gcc-54.sh
+++ b/ci/cloudbuild/builds/gcc-54.sh
@@ -24,8 +24,9 @@ source module ci/cloudbuild/builds/lib/cmake.sh
 export CC=gcc
 export CXX=g++
 
-cmake -GNinja -DBUILD_SHARED_LIBS=yes -DGOOGLE_CLOUD_CPP_ENABLE_CCACHE=ON \
-  -H. -Bcmake-out
+cmake -GNinja -H. -Bcmake-out \
+  -DGOOGLE_CLOUD_CPP_ENABLE="$(features::always_build_cmake)" \
+  -DBUILD_SHARED_LIBS=yes -DGOOGLE_CLOUD_CPP_ENABLE_CCACHE=ON
 cmake --build cmake-out
 (
   cd cmake-out

--- a/ci/cloudbuild/builds/gcc-63.sh
+++ b/ci/cloudbuild/builds/gcc-63.sh
@@ -24,8 +24,9 @@ source module ci/cloudbuild/builds/lib/cmake.sh
 export CC=gcc
 export CXX=g++
 
-cmake -GNinja -DBUILD_SHARED_LIBS=yes -DGOOGLE_CLOUD_CPP_ENABLE_CCACHE=ON \
-  -H. -Bcmake-out
+cmake -GNinja -H. -Bcmake-out \
+  -DGOOGLE_CLOUD_CPP_ENABLE="$(features::always_build_cmake)" \
+  -DBUILD_SHARED_LIBS=yes -DGOOGLE_CLOUD_CPP_ENABLE_CCACHE=ON
 cmake --build cmake-out
 (
   cd cmake-out

--- a/ci/cloudbuild/builds/install-gcs-grpc.sh
+++ b/ci/cloudbuild/builds/install-gcs-grpc.sh
@@ -22,13 +22,13 @@ source module ci/cloudbuild/builds/lib/quickstart.sh
 
 export CC=gcc
 export CXX=g++
+mapfile -t cmake_args < <(cmake::common_args)
 
 INSTALL_PREFIX="/var/tmp/google-cloud-cpp"
-cmake -GNinja \
+cmake "${cmake_args[@]}" \
   -DGOOGLE_CLOUD_CPP_STORAGE_ENABLE_GRPC=ON \
   -DBUILD_SHARED_LIBS=ON \
-  -DCMAKE_INSTALL_PREFIX="${INSTALL_PREFIX}" \
-  -S . -B cmake-out
+  -DCMAKE_INSTALL_PREFIX="${INSTALL_PREFIX}"
 cmake --build cmake-out
 env -C cmake-out ctest -LE "integration-test" --parallel "$(nproc)"
 cmake --build cmake-out --target install

--- a/ci/cloudbuild/builds/lib/cmake.sh
+++ b/ci/cloudbuild/builds/lib/cmake.sh
@@ -23,6 +23,7 @@ if ((CI_CLOUDBUILD_BUILDS_LIB_CMAKE_SH__++ != 0)); then
 fi # include guard
 
 source module ci/lib/io.sh
+source module ci/cloudbuild/builds/lib/features.sh
 
 io::log "Using CMake version"
 cmake --version
@@ -47,3 +48,12 @@ if command -v ccache >/dev/null 2>&1; then
   }
   trap show_stats_handler EXIT
 fi
+
+function cmake::common_args() {
+  local args
+  args=(
+    -DGOOGLE_CLOUD_CPP_ENABLE="$(features::always_build_cmake)"
+  )
+  args+=(-GNinja -S . -B cmake-out)
+  printf "%s\n" "${args[@]}"
+}

--- a/ci/cloudbuild/builds/lib/features.sh
+++ b/ci/cloudbuild/builds/lib/features.sh
@@ -22,30 +22,45 @@ if ((CI_CLOUDBUILD_BUILDS_LIB_FEATURES_SH__++ != 0)); then
   return 0
 fi # include guard
 
+function features::always_build() {
+  local list
+  list=(
+    # These have hand-crafted code, therefore we always want to build them.
+    bigtable
+    spanner
+    storage
+    pubsub
+    pubsublite
+    # While these libraries are automatically generated, they contain
+    # hand-crafted tests
+    bigquery
+    iam
+    logging
+  )
+  printf "%s\n" "${list[@]}" | sort -u
+}
+
+function features::always_build_cmake() {
+  local features
+  mapfile -t feature_list < <(features::always_build)
+  features="$(printf ",%s" "${feature_list[@]}")"
+  echo "${features:1}"
+}
+
 function features::libraries() {
   local feature_list
   mapfile -t feature_list <ci/etc/full_feature_list
-  # Add the hand-crafted libraries
-  feature_list+=(
-    bigtable
-    pubsub
-    spanner
-    storage
-  )
-  printf "%s\n" "${feature_list[@]}"
+  mapfile -t always < <(features::always_build)
+  printf "%s\n" "${feature_list[@]}" "${always[@]}" | sort -u
 }
 
-function features::list() {
+function features::list_full() {
   local feature_list
   mapfile -t feature_list < <(features::libraries)
-  # Add any custom features to the full list of libraries
-  feature_list+=(
-    experimental-storage-grpc
-  )
-  printf "%s\n" "${feature_list[@]}"
+  printf "%s\n" "${feature_list[@]}" experimental-storage-grpc | sort -u
 }
 
-function features::cmake_definition() {
+function features::list_full_cmake() {
   local features
   mapfile -t feature_list < <(features::list)
   features="$(printf ",%s" "${feature_list[@]}")"

--- a/ci/cloudbuild/builds/lib/features.sh
+++ b/ci/cloudbuild/builds/lib/features.sh
@@ -62,7 +62,7 @@ function features::list_full() {
 
 function features::list_full_cmake() {
   local features
-  mapfile -t feature_list < <(features::list)
+  mapfile -t feature_list < <(features::list_full)
   features="$(printf ",%s" "${feature_list[@]}")"
   echo "${features:1}"
 }

--- a/ci/cloudbuild/builds/noex.sh
+++ b/ci/cloudbuild/builds/noex.sh
@@ -22,8 +22,9 @@ source module ci/cloudbuild/builds/lib/integration.sh
 
 export CC=gcc
 export CXX=g++
+mapfile -t cmake_args < <(cmake::common_args)
 
-cmake -GNinja -DGOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS=NO -S . -B cmake-out
+cmake "${cmake_args[@]}" -DGOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS=NO
 cmake --build cmake-out
 env -C cmake-out ctest -LE "integration-test" --parallel "$(nproc)"
 

--- a/ci/cloudbuild/builds/publish-docs.sh
+++ b/ci/cloudbuild/builds/publish-docs.sh
@@ -20,8 +20,8 @@ source "$(dirname "$0")/../../lib/init.sh"
 source module ci/cloudbuild/builds/lib/cmake.sh
 source module ci/cloudbuild/builds/lib/features.sh
 
-mapfile -t FEATURE_LIST < <(features::list)
-read -r ENABLED_FEATURES < <(features::cmake_definition)
+mapfile -t FEATURE_LIST < <(features::list_full)
+read -r ENABLED_FEATURES < <(features::list_full_cmake)
 
 version=""
 doc_args=(

--- a/ci/cloudbuild/builds/scan-build.sh
+++ b/ci/cloudbuild/builds/scan-build.sh
@@ -25,11 +25,12 @@ source module ci/cloudbuild/builds/lib/cmake.sh
 
 export CC=clang
 export CXX=clang++
+mapfile -t cmake_args < <(cmake::common_args)
 
 scan_build=(
   "scan-build"
   "-o"
   "${HOME}/scan-build"
 )
-"${scan_build[@]}" cmake -GNinja -S . -B cmake-out
+"${scan_build[@]}" cmake "${cmake_args[@]}"
 "${scan_build[@]}" cmake --build cmake-out

--- a/ci/cloudbuild/builds/shared.sh
+++ b/ci/cloudbuild/builds/shared.sh
@@ -22,12 +22,12 @@ source module ci/cloudbuild/builds/lib/quickstart.sh
 
 export CC=gcc
 export CXX=g++
+mapfile -t cmake_args < <(cmake::common_args)
 
 INSTALL_PREFIX="/var/tmp/google-cloud-cpp"
-cmake -GNinja \
+cmake "${cmake_args[@]}" \
   -DBUILD_SHARED_LIBS=ON \
-  -DCMAKE_INSTALL_PREFIX="${INSTALL_PREFIX}" \
-  -S . -B cmake-out
+  -DCMAKE_INSTALL_PREFIX="${INSTALL_PREFIX}"
 cmake --build cmake-out
 env -C cmake-out ctest -LE "integration-test" --parallel "$(nproc)"
 cmake --build cmake-out --target install


### PR DESCRIPTION
The `pubsublite` library now contains hand-crafted as well as
automatically generated code. We need to build this library in most
cases.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7772)
<!-- Reviewable:end -->
