### PR TITLE
feat(common): include the request/response type name in the RPC log

### DIFF
--- a/google/cloud/internal/log_wrapper.cc
+++ b/google/cloud/internal/log_wrapper.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/internal/log_wrapper.h"
+#include "google/cloud/internal/absl_str_cat_quiet.h"
 #include <google/protobuf/text_format.h>
 #include <atomic>
 
@@ -26,11 +27,13 @@ std::string DebugString(google::protobuf::Message const& m,
   std::string str;
   google::protobuf::TextFormat::Printer p;
   p.SetSingleLineMode(options.single_line_mode());
+  if (!options.single_line_mode()) p.SetInitialIndentLevel(1);
   p.SetUseShortRepeatedPrimitives(options.use_short_repeated_primitives());
   p.SetTruncateStringFieldLongerThan(
       options.truncate_string_field_longer_than());
   p.PrintToString(m, &str);
-  return str;
+  return absl::StrCat(m.GetTypeName(), " {",
+                      (options.single_line_mode() ? " " : "\n"), str, "}");
 }
 
 std::string RequestIdForLogging() {

--- a/google/cloud/internal/log_wrapper_test.cc
+++ b/google/cloud/internal/log_wrapper_test.cc
@@ -60,6 +60,7 @@ TEST(LogWrapper, DefaultOptions) {
   TracingOptions tracing_options;
   // clang-format off
   std::string const text =
+      R"pb(google.spanner.v1.Mutation { )pb"
       R"pb(insert { )pb"
       R"pb(table: "Singers" )pb"
       R"pb(columns: "SingerId" )pb"
@@ -72,7 +73,8 @@ TEST(LogWrapper, DefaultOptions) {
       R"pb(values { string_value: "test-fname-2" } )pb"
       R"pb(values { string_value: "test-lname-2" } )pb"
       R"pb(} )pb"
-      R"pb(} )pb";
+      R"pb(} )pb"
+      R"pb(})pb";
   // clang-format on
   EXPECT_EQ(text, internal::DebugString(MakeMutation(), tracing_options));
 }
@@ -81,35 +83,36 @@ TEST(LogWrapper, MultiLine) {
   TracingOptions tracing_options;
   tracing_options.SetOptions("single_line_mode=off");
   // clang-format off
-  std::string const text = R"pb(insert {
-  table: "Singers"
-  columns: "SingerId"
-  columns: "FirstName"
-  columns: "LastName"
-  values {
+  std::string const text = R"pb(google.spanner.v1.Mutation {
+  insert {
+    table: "Singers"
+    columns: "SingerId"
+    columns: "FirstName"
+    columns: "LastName"
     values {
-      string_value: "1"
+      values {
+        string_value: "1"
+      }
+      values {
+        string_value: "test-fname-1"
+      }
+      values {
+        string_value: "test-lname-1"
+      }
     }
     values {
-      string_value: "test-fname-1"
-    }
-    values {
-      string_value: "test-lname-1"
+      values {
+        string_value: "2"
+      }
+      values {
+        string_value: "test-fname-2"
+      }
+      values {
+        string_value: "test-lname-2"
+      }
     }
   }
-  values {
-    values {
-      string_value: "2"
-    }
-    values {
-      string_value: "test-fname-2"
-    }
-    values {
-      string_value: "test-lname-2"
-    }
-  }
-}
-)pb";
+})pb";
   // clang-format on
   EXPECT_EQ(text, internal::DebugString(MakeMutation(), tracing_options));
 }
@@ -118,7 +121,9 @@ TEST(LogWrapper, Truncate) {
   TracingOptions tracing_options;
   tracing_options.SetOptions("truncate_string_field_longer_than=8");
   // clang-format off
-  std::string const text =R"pb(insert { )pb"
+  std::string const text =
+            R"pb(google.spanner.v1.Mutation { )pb"
+            R"pb(insert { )pb"
             R"pb(table: "Singers" )pb"
             R"pb(columns: "SingerId" )pb"
             R"pb(columns: "FirstNam...<truncated>..." )pb"
@@ -130,7 +135,8 @@ TEST(LogWrapper, Truncate) {
             R"pb(values { string_value: "test-fna...<truncated>..." } )pb"
             R"pb(values { string_value: "test-lna...<truncated>..." } )pb"
             R"pb(} )pb"
-            R"pb(} )pb";
+            R"pb(} )pb"
+            R"pb(})pb";
   // clang-format on
   EXPECT_EQ(text, internal::DebugString(MakeMutation(), tracing_options));
 }


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7782)
<!-- Reviewable:end -->
