### PR TITLE
doc: declare Secret Manager and Task as GA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,13 @@
 
 ## v1.35.0 - TBD
 
+### New GA Libraries
+
+The following libraries are now considered stable and complete:
+
+* [Secret Manager API](google/cloud/secretmanager/README.md) [[quickstart]](google/cloud/secretmanager/README.md)
+* [Cloud Tasks API](google/cloud/tasks/README.md) [[quickstart]](google/cloud/tasks/README.md)
+
 ### [Common Libraries](https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/README.md)
 
 * Backoff policies are now cloned from their initial state, instead of their

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ This repository contains idiomatic C++ client libraries for the following
 * [Google Cloud Spanner](google/cloud/spanner/README.md) [[quickstart]](google/cloud/spanner/quickstart/README.md)
 * [Google Cloud Pub/Sub](google/cloud/pubsub/README.md) [[quickstart]](google/cloud/pubsub/quickstart/README.md)
 * [Google Cloud Storage](google/cloud/storage/README.md) [[quickstart]](google/cloud/storage/quickstart/README.md)
+* [Secret Manager API](google/cloud/secretmanager/README.md) [[quickstart]](google/cloud/secretmanager/README.md)
+* [Cloud Tasks API](google/cloud/tasks/README.md) [[quickstart]](google/cloud/tasks/README.md)
 
 See each library's `README.md` file for more information about:
 

--- a/ci/generate-markdown/generate-readme.sh
+++ b/ci/generate-markdown/generate-readme.sh
@@ -60,6 +60,8 @@ This repository contains idiomatic C++ client libraries for the following
 * [Google Cloud Spanner](google/cloud/spanner/README.md) [[quickstart]](google/cloud/spanner/quickstart/README.md)
 * [Google Cloud Pub/Sub](google/cloud/pubsub/README.md) [[quickstart]](google/cloud/pubsub/quickstart/README.md)
 * [Google Cloud Storage](google/cloud/storage/README.md) [[quickstart]](google/cloud/storage/quickstart/README.md)
+* [Secret Manager API](google/cloud/secretmanager/README.md) [[quickstart]](google/cloud/secretmanager/README.md)
+* [Cloud Tasks API](google/cloud/tasks/README.md) [[quickstart]](google/cloud/tasks/README.md)
 
 See each library's `README.md` file for more information about:
 

--- a/google/cloud/secretmanager/README.md
+++ b/google/cloud/secretmanager/README.md
@@ -7,10 +7,8 @@ This directory contains an idiomatic C++ client library for
 stores sensitive data such as API keys, passwords, and certificates.
 Provides convenience while improving security.
 
-This library is **experimental**. Its APIS are subject to change without notice.
-
-Please note that the Google Cloud C++ client libraries do **not** follow
-[Semantic Versioning](https://semver.org/).
+While this library is **GA**, please note that the Google Cloud C++
+client libraries do **not** follow [Semantic Versioning](https://semver.org/).
 
 ## Supported Platforms
 

--- a/google/cloud/tasks/README.md
+++ b/google/cloud/tasks/README.md
@@ -6,10 +6,8 @@ This directory contains an idiomatic C++ client library for
 [Cloud Tasks API][cloud-service-root], a service that manages the
 execution of large numbers of distributed requests.
 
-This library is **experimental**. Its APIS are subject to change without notice.
-
-Please note that the Google Cloud C++ client libraries do **not** follow
-[Semantic Versioning](https://semver.org/).
+While this library is **GA**, please note that the Google Cloud C++
+client libraries do **not** follow [Semantic Versioning](https://semver.org/).
 
 ## Supported Platforms
 


### PR DESCRIPTION
Loggin is missing a bidir streaming API, Pub/Sub Lite is missing the data APIs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7792)
<!-- Reviewable:end -->
