### PR TITLE
fix: add GA targets for secretmanager and tasks

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -74,6 +74,20 @@ cc_library(
 )
 
 cc_library(
+    name = "secretmanager",
+    deps = [
+        "//google/cloud/secretmanager:google_cloud_cpp_secretmanager",
+    ],
+)
+
+cc_library(
+    name = "secretmanager_mocks",
+    deps = [
+        "//google/cloud/secretmanager:google_cloud_cpp_secretmanager_mocks",
+    ],
+)
+
+cc_library(
     name = "experimental-secretmanager",
     deps = [
         "//google/cloud/secretmanager:google_cloud_cpp_secretmanager",
@@ -173,6 +187,20 @@ cc_library(
     name = "bigquery-mocks",
     deps = [
         "//google/cloud/bigquery:google_cloud_cpp_bigquery_mocks",
+    ],
+)
+
+cc_library(
+    name = "tasks",
+    deps = [
+        "//google/cloud/tasks:google_cloud_cpp_tasks",
+    ],
+)
+
+cc_library(
+    name = "tasks_mocks",
+    deps = [
+        "//google/cloud/tasks:google_cloud_cpp_tasks_mocks",
     ],
 )
 


### PR DESCRIPTION
I should have done this at the same time as we declared these libraries GA.

I think we can wait until the 1.36.0 release to remove the experimental targets.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7806)
<!-- Reviewable:end -->
