### PR TITLE
fix(generator): handle empty method signatures

### DIFF
--- a/generator/integration_tests/generator_integration_test.cc
+++ b/generator/integration_tests/generator_integration_test.cc
@@ -97,7 +97,7 @@ class GeneratorIntegrationTest : public testing::TestWithParam<std::string> {
                           "Codegen C++ Generator");
 
     product_path_ = "generator/integration_tests/golden/";
-    copyright_year_ = CurrentCopyrightYear();
+    copyright_year_ = "2022";
     omit_rpc1_ = "Omitted1";
     omit_rpc2_ = "GoldenKitchenSink.Omitted2";
     service_endpoint_env_var_ = "GOLDEN_KITCHEN_SINK_ENDPOINT";

--- a/generator/integration_tests/generator_integration_test.cc
+++ b/generator/integration_tests/generator_integration_test.cc
@@ -97,9 +97,7 @@ class GeneratorIntegrationTest : public testing::TestWithParam<std::string> {
                           "Codegen C++ Generator");
 
     product_path_ = "generator/integration_tests/golden/";
-    // The golden files were last generated on 2021, update next time you
-    // re-generate said files.
-    copyright_year_ = "2021";
+    copyright_year_ = CurrentCopyrightYear();
     omit_rpc1_ = "Omitted1";
     omit_rpc2_ = "GoldenKitchenSink.Omitted2";
     service_endpoint_env_var_ = "GOLDEN_KITCHEN_SINK_ENDPOINT";

--- a/generator/integration_tests/golden/golden_kitchen_sink_client.cc
+++ b/generator/integration_tests/golden/golden_kitchen_sink_client.cc
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2022 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/integration_tests/golden/golden_kitchen_sink_client.cc
+++ b/generator/integration_tests/golden/golden_kitchen_sink_client.cc
@@ -120,6 +120,19 @@ GoldenKitchenSinkClient::ListServiceAccountKeys(google::test::admin::database::v
   return connection_->ListServiceAccountKeys(request);
 }
 
+Status
+GoldenKitchenSinkClient::DoNothing(Options options) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
+  google::protobuf::Empty request;
+  return connection_->DoNothing(request);
+}
+
+Status
+GoldenKitchenSinkClient::DoNothing(google::protobuf::Empty const& request, Options options) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
+  return connection_->DoNothing(request);
+}
+
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace golden
 }  // namespace cloud

--- a/generator/integration_tests/golden/golden_kitchen_sink_client.h
+++ b/generator/integration_tests/golden/golden_kitchen_sink_client.h
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2022 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -116,10 +116,10 @@ class GoldenKitchenSinkClient {
   ///  not specified, the token's lifetime will be set to a default value of one
   ///  hour.
   /// @param options  Optional. Operation options.
-  /// @return @googleapis_link{google::test::admin::database::v1::GenerateAccessTokenResponse,generator/integration_tests/test.proto#L872}
+  /// @return @googleapis_link{google::test::admin::database::v1::GenerateAccessTokenResponse,generator/integration_tests/test.proto#L880}
   ///
-  /// [google.test.admin.database.v1.GenerateAccessTokenRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L835}
-  /// [google.test.admin.database.v1.GenerateAccessTokenResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L872}
+  /// [google.test.admin.database.v1.GenerateAccessTokenRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L843}
+  /// [google.test.admin.database.v1.GenerateAccessTokenResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L880}
   ///
   StatusOr<google::test::admin::database::v1::GenerateAccessTokenResponse>
   GenerateAccessToken(std::string const& name, std::vector<std::string> const& delegates, std::vector<std::string> const& scope, google::protobuf::Duration const& lifetime, Options options = {});
@@ -127,12 +127,12 @@ class GoldenKitchenSinkClient {
   ///
   /// Generates an OAuth 2.0 access token for a service account.
   ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::GenerateAccessTokenRequest,generator/integration_tests/test.proto#L835}
+  /// @param request @googleapis_link{google::test::admin::database::v1::GenerateAccessTokenRequest,generator/integration_tests/test.proto#L843}
   /// @param options  Optional. Operation options.
-  /// @return @googleapis_link{google::test::admin::database::v1::GenerateAccessTokenResponse,generator/integration_tests/test.proto#L872}
+  /// @return @googleapis_link{google::test::admin::database::v1::GenerateAccessTokenResponse,generator/integration_tests/test.proto#L880}
   ///
-  /// [google.test.admin.database.v1.GenerateAccessTokenRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L835}
-  /// [google.test.admin.database.v1.GenerateAccessTokenResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L872}
+  /// [google.test.admin.database.v1.GenerateAccessTokenRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L843}
+  /// [google.test.admin.database.v1.GenerateAccessTokenResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L880}
   ///
   StatusOr<google::test::admin::database::v1::GenerateAccessTokenResponse>
   GenerateAccessToken(google::test::admin::database::v1::GenerateAccessTokenRequest const& request, Options options = {});
@@ -158,10 +158,10 @@ class GoldenKitchenSinkClient {
   /// @param include_email  Include the service account email in the token. If set to `true`, the
   ///  token will contain `email` and `email_verified` claims.
   /// @param options  Optional. Operation options.
-  /// @return @googleapis_link{google::test::admin::database::v1::GenerateIdTokenResponse,generator/integration_tests/test.proto#L914}
+  /// @return @googleapis_link{google::test::admin::database::v1::GenerateIdTokenResponse,generator/integration_tests/test.proto#L922}
   ///
-  /// [google.test.admin.database.v1.GenerateIdTokenRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L881}
-  /// [google.test.admin.database.v1.GenerateIdTokenResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L914}
+  /// [google.test.admin.database.v1.GenerateIdTokenRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L889}
+  /// [google.test.admin.database.v1.GenerateIdTokenResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L922}
   ///
   StatusOr<google::test::admin::database::v1::GenerateIdTokenResponse>
   GenerateIdToken(std::string const& name, std::vector<std::string> const& delegates, std::string const& audience, bool include_email, Options options = {});
@@ -169,12 +169,12 @@ class GoldenKitchenSinkClient {
   ///
   /// Generates an OpenID Connect ID token for a service account.
   ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::GenerateIdTokenRequest,generator/integration_tests/test.proto#L881}
+  /// @param request @googleapis_link{google::test::admin::database::v1::GenerateIdTokenRequest,generator/integration_tests/test.proto#L889}
   /// @param options  Optional. Operation options.
-  /// @return @googleapis_link{google::test::admin::database::v1::GenerateIdTokenResponse,generator/integration_tests/test.proto#L914}
+  /// @return @googleapis_link{google::test::admin::database::v1::GenerateIdTokenResponse,generator/integration_tests/test.proto#L922}
   ///
-  /// [google.test.admin.database.v1.GenerateIdTokenRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L881}
-  /// [google.test.admin.database.v1.GenerateIdTokenResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L914}
+  /// [google.test.admin.database.v1.GenerateIdTokenRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L889}
+  /// [google.test.admin.database.v1.GenerateIdTokenResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L922}
   ///
   StatusOr<google::test::admin::database::v1::GenerateIdTokenResponse>
   GenerateIdToken(google::test::admin::database::v1::GenerateIdTokenRequest const& request, Options options = {});
@@ -206,10 +206,10 @@ class GoldenKitchenSinkClient {
   ///  as a label in this parameter, then the log entry's label is not changed.
   ///  See [LogEntry][google.logging.v2.LogEntry]. Test delimiter$
   /// @param options  Optional. Operation options.
-  /// @return @googleapis_link{google::test::admin::database::v1::WriteLogEntriesResponse,generator/integration_tests/test.proto#L953}
+  /// @return @googleapis_link{google::test::admin::database::v1::WriteLogEntriesResponse,generator/integration_tests/test.proto#L961}
   ///
-  /// [google.test.admin.database.v1.WriteLogEntriesRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L920}
-  /// [google.test.admin.database.v1.WriteLogEntriesResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L953}
+  /// [google.test.admin.database.v1.WriteLogEntriesRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L928}
+  /// [google.test.admin.database.v1.WriteLogEntriesResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L961}
   ///
   StatusOr<google::test::admin::database::v1::WriteLogEntriesResponse>
   WriteLogEntries(std::string const& log_name, std::map<std::string, std::string> const& labels, Options options = {});
@@ -223,12 +223,12 @@ class GoldenKitchenSinkClient {
   /// different resources (projects, organizations, billing accounts or
   /// folders)
   ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::WriteLogEntriesRequest,generator/integration_tests/test.proto#L920}
+  /// @param request @googleapis_link{google::test::admin::database::v1::WriteLogEntriesRequest,generator/integration_tests/test.proto#L928}
   /// @param options  Optional. Operation options.
-  /// @return @googleapis_link{google::test::admin::database::v1::WriteLogEntriesResponse,generator/integration_tests/test.proto#L953}
+  /// @return @googleapis_link{google::test::admin::database::v1::WriteLogEntriesResponse,generator/integration_tests/test.proto#L961}
   ///
-  /// [google.test.admin.database.v1.WriteLogEntriesRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L920}
-  /// [google.test.admin.database.v1.WriteLogEntriesResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L953}
+  /// [google.test.admin.database.v1.WriteLogEntriesRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L928}
+  /// [google.test.admin.database.v1.WriteLogEntriesResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L961}
   ///
   StatusOr<google::test::admin::database::v1::WriteLogEntriesResponse>
   WriteLogEntries(google::test::admin::database::v1::WriteLogEntriesRequest const& request, Options options = {});
@@ -245,7 +245,7 @@ class GoldenKitchenSinkClient {
   /// @param options  Optional. Operation options.
   /// @return std::string
   ///
-  /// [google.test.admin.database.v1.ListLogsRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L956}
+  /// [google.test.admin.database.v1.ListLogsRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L964}
   ///
   StreamRange<std::string>
   ListLogs(std::string const& parent, Options options = {});
@@ -254,11 +254,11 @@ class GoldenKitchenSinkClient {
   /// Lists the logs in projects, organizations, folders, or billing accounts.
   /// Only logs that have entries are listed.
   ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::ListLogsRequest,generator/integration_tests/test.proto#L956}
+  /// @param request @googleapis_link{google::test::admin::database::v1::ListLogsRequest,generator/integration_tests/test.proto#L964}
   /// @param options  Optional. Operation options.
   /// @return std::string
   ///
-  /// [google.test.admin.database.v1.ListLogsRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L956}
+  /// [google.test.admin.database.v1.ListLogsRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L964}
   ///
   StreamRange<std::string>
   ListLogs(google::test::admin::database::v1::ListLogsRequest request, Options options = {});
@@ -278,10 +278,10 @@ class GoldenKitchenSinkClient {
   ///      "billingAccounts/[BILLING_ACCOUNT_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]"
   ///      "folders/[FOLDER_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]"
   /// @param options  Optional. Operation options.
-  /// @return @googleapis_link{google::test::admin::database::v1::TailLogEntriesResponse,generator/integration_tests/test.proto#L1214}
+  /// @return @googleapis_link{google::test::admin::database::v1::TailLogEntriesResponse,generator/integration_tests/test.proto#L1222}
   ///
-  /// [google.test.admin.database.v1.TailLogEntriesRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1182}
-  /// [google.test.admin.database.v1.TailLogEntriesResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1214}
+  /// [google.test.admin.database.v1.TailLogEntriesRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1190}
+  /// [google.test.admin.database.v1.TailLogEntriesResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1222}
   ///
   StreamRange<google::test::admin::database::v1::TailLogEntriesResponse>
   TailLogEntries(std::vector<std::string> const& resource_names, Options options = {});
@@ -290,12 +290,12 @@ class GoldenKitchenSinkClient {
   /// Streaming read of log entries as they are ingested. Until the stream is
   /// terminated, it will continue reading logs.
   ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::TailLogEntriesRequest,generator/integration_tests/test.proto#L1182}
+  /// @param request @googleapis_link{google::test::admin::database::v1::TailLogEntriesRequest,generator/integration_tests/test.proto#L1190}
   /// @param options  Optional. Operation options.
-  /// @return @googleapis_link{google::test::admin::database::v1::TailLogEntriesResponse,generator/integration_tests/test.proto#L1214}
+  /// @return @googleapis_link{google::test::admin::database::v1::TailLogEntriesResponse,generator/integration_tests/test.proto#L1222}
   ///
-  /// [google.test.admin.database.v1.TailLogEntriesRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1182}
-  /// [google.test.admin.database.v1.TailLogEntriesResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1214}
+  /// [google.test.admin.database.v1.TailLogEntriesRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1190}
+  /// [google.test.admin.database.v1.TailLogEntriesResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1222}
   ///
   StreamRange<google::test::admin::database::v1::TailLogEntriesResponse>
   TailLogEntries(google::test::admin::database::v1::TailLogEntriesRequest const& request, Options options = {});
@@ -312,10 +312,10 @@ class GoldenKitchenSinkClient {
   ///  response. Duplicate key types are not allowed. If no key type
   ///  is provided, all keys are returned.
   /// @param options  Optional. Operation options.
-  /// @return @googleapis_link{google::test::admin::database::v1::ListServiceAccountKeysResponse,generator/integration_tests/test.proto#L1286}
+  /// @return @googleapis_link{google::test::admin::database::v1::ListServiceAccountKeysResponse,generator/integration_tests/test.proto#L1294}
   ///
-  /// [google.test.admin.database.v1.ListServiceAccountKeysRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1254}
-  /// [google.test.admin.database.v1.ListServiceAccountKeysResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1286}
+  /// [google.test.admin.database.v1.ListServiceAccountKeysRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1262}
+  /// [google.test.admin.database.v1.ListServiceAccountKeysResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1294}
   ///
   StatusOr<google::test::admin::database::v1::ListServiceAccountKeysResponse>
   ListServiceAccountKeys(std::string const& name, std::vector<google::test::admin::database::v1::ListServiceAccountKeysRequest::KeyType> const& key_types, Options options = {});
@@ -323,12 +323,12 @@ class GoldenKitchenSinkClient {
   ///
   /// Lists every [ServiceAccountKey][google.iam.admin.v1.ServiceAccountKey] for a service account.
   ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::ListServiceAccountKeysRequest,generator/integration_tests/test.proto#L1254}
+  /// @param request @googleapis_link{google::test::admin::database::v1::ListServiceAccountKeysRequest,generator/integration_tests/test.proto#L1262}
   /// @param options  Optional. Operation options.
-  /// @return @googleapis_link{google::test::admin::database::v1::ListServiceAccountKeysResponse,generator/integration_tests/test.proto#L1286}
+  /// @return @googleapis_link{google::test::admin::database::v1::ListServiceAccountKeysResponse,generator/integration_tests/test.proto#L1294}
   ///
-  /// [google.test.admin.database.v1.ListServiceAccountKeysRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1254}
-  /// [google.test.admin.database.v1.ListServiceAccountKeysResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1286}
+  /// [google.test.admin.database.v1.ListServiceAccountKeysRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1262}
+  /// [google.test.admin.database.v1.ListServiceAccountKeysResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1294}
   ///
   StatusOr<google::test::admin::database::v1::ListServiceAccountKeysResponse>
   ListServiceAccountKeys(google::test::admin::database::v1::ListServiceAccountKeysRequest const& request, Options options = {});

--- a/generator/integration_tests/golden/golden_kitchen_sink_client.h
+++ b/generator/integration_tests/golden/golden_kitchen_sink_client.h
@@ -333,6 +333,27 @@ class GoldenKitchenSinkClient {
   StatusOr<google::test::admin::database::v1::ListServiceAccountKeysResponse>
   ListServiceAccountKeys(google::test::admin::database::v1::ListServiceAccountKeysRequest const& request, Options options = {});
 
+  ///
+  /// Does Nothing.
+  ///
+  /// @param options  Optional. Operation options.
+  ///
+  /// [google.protobuf.Empty]: @googleapis_reference_link{google/protobuf/empty.proto#L52}
+  ///
+  Status
+  DoNothing(Options options = {});
+
+  ///
+  /// Does Nothing.
+  ///
+  /// @param request @googleapis_link{google::protobuf::Empty,google/protobuf/empty.proto#L52}
+  /// @param options  Optional. Operation options.
+  ///
+  /// [google.protobuf.Empty]: @googleapis_reference_link{google/protobuf/empty.proto#L52}
+  ///
+  Status
+  DoNothing(google::protobuf::Empty const& request, Options options = {});
+
  private:
   std::shared_ptr<GoldenKitchenSinkConnection> connection_;
   Options options_;

--- a/generator/integration_tests/golden/golden_kitchen_sink_connection.cc
+++ b/generator/integration_tests/golden/golden_kitchen_sink_connection.cc
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2022 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/integration_tests/golden/golden_kitchen_sink_connection.cc
+++ b/generator/integration_tests/golden/golden_kitchen_sink_connection.cc
@@ -83,6 +83,12 @@ GoldenKitchenSinkConnection::ListServiceAccountKeys(
   return Status(StatusCode::kUnimplemented, "not implemented");
 }
 
+Status
+GoldenKitchenSinkConnection::DoNothing(
+    google::protobuf::Empty const&) {
+  return Status(StatusCode::kUnimplemented, "not implemented");
+}
+
 namespace {
 class GoldenKitchenSinkConnectionImpl : public GoldenKitchenSinkConnection {
  public:
@@ -205,6 +211,19 @@ class GoldenKitchenSinkConnectionImpl : public GoldenKitchenSinkConnection {
         [this](grpc::ClientContext& context,
             google::test::admin::database::v1::ListServiceAccountKeysRequest const& request) {
           return stub_->ListServiceAccountKeys(context, request);
+        },
+        request, __func__);
+  }
+
+  Status
+  DoNothing(
+      google::protobuf::Empty const& request) override {
+    return google::cloud::internal::RetryLoop(
+        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
+        idempotency_policy_->DoNothing(request),
+        [this](grpc::ClientContext& context,
+            google::protobuf::Empty const& request) {
+          return stub_->DoNothing(context, request);
         },
         request, __func__);
   }

--- a/generator/integration_tests/golden/golden_kitchen_sink_connection.h
+++ b/generator/integration_tests/golden/golden_kitchen_sink_connection.h
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2022 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/integration_tests/golden/golden_kitchen_sink_connection.h
+++ b/generator/integration_tests/golden/golden_kitchen_sink_connection.h
@@ -70,6 +70,9 @@ class GoldenKitchenSinkConnection {
   virtual StatusOr<google::test::admin::database::v1::ListServiceAccountKeysResponse>
   ListServiceAccountKeys(google::test::admin::database::v1::ListServiceAccountKeysRequest const& request);
 
+  virtual Status
+  DoNothing(google::protobuf::Empty const& request);
+
 };
 
 std::shared_ptr<GoldenKitchenSinkConnection> MakeGoldenKitchenSinkConnection(

--- a/generator/integration_tests/golden/golden_kitchen_sink_connection_idempotency_policy.cc
+++ b/generator/integration_tests/golden/golden_kitchen_sink_connection_idempotency_policy.cc
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2022 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/integration_tests/golden/golden_kitchen_sink_connection_idempotency_policy.cc
+++ b/generator/integration_tests/golden/golden_kitchen_sink_connection_idempotency_policy.cc
@@ -64,6 +64,11 @@ class DefaultGoldenKitchenSinkConnectionIdempotencyPolicy : public GoldenKitchen
     return Idempotency::kIdempotent;
   }
 
+  Idempotency
+  DoNothing(google::protobuf::Empty const&) override {
+    return Idempotency::kIdempotent;
+  }
+
 };
 }  // namespace
 

--- a/generator/integration_tests/golden/golden_kitchen_sink_connection_idempotency_policy.h
+++ b/generator/integration_tests/golden/golden_kitchen_sink_connection_idempotency_policy.h
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2022 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/integration_tests/golden/golden_kitchen_sink_connection_idempotency_policy.h
+++ b/generator/integration_tests/golden/golden_kitchen_sink_connection_idempotency_policy.h
@@ -52,6 +52,9 @@ class GoldenKitchenSinkConnectionIdempotencyPolicy {
   virtual google::cloud::internal::Idempotency
   ListServiceAccountKeys(google::test::admin::database::v1::ListServiceAccountKeysRequest const& request) = 0;
 
+  virtual google::cloud::internal::Idempotency
+  DoNothing(google::protobuf::Empty const& request) = 0;
+
 };
 
 std::unique_ptr<GoldenKitchenSinkConnectionIdempotencyPolicy>

--- a/generator/integration_tests/golden/golden_kitchen_sink_options.h
+++ b/generator/integration_tests/golden/golden_kitchen_sink_options.h
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2022 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/integration_tests/golden/golden_thing_admin_client.cc
+++ b/generator/integration_tests/golden/golden_thing_admin_client.cc
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2022 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -42,6 +42,19 @@ StreamRange<google::test::admin::database::v1::Database>
 GoldenThingAdminClient::ListDatabases(google::test::admin::database::v1::ListDatabasesRequest request, Options options) {
   internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
   return connection_->ListDatabases(std::move(request));
+}
+
+Status
+GoldenThingAdminClient::DoNothing(Options options) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
+  google::protobuf::Empty request;
+  return connection_->DoNothing(request);
+}
+
+Status
+GoldenThingAdminClient::DoNothing(google::protobuf::Empty const& request, Options options) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
+  return connection_->DoNothing(request);
 }
 
 future<StatusOr<google::test::admin::database::v1::Database>>

--- a/generator/integration_tests/golden/golden_thing_admin_client.cc
+++ b/generator/integration_tests/golden/golden_thing_admin_client.cc
@@ -44,19 +44,6 @@ GoldenThingAdminClient::ListDatabases(google::test::admin::database::v1::ListDat
   return connection_->ListDatabases(std::move(request));
 }
 
-Status
-GoldenThingAdminClient::DoNothing(Options options) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
-  google::protobuf::Empty request;
-  return connection_->DoNothing(request);
-}
-
-Status
-GoldenThingAdminClient::DoNothing(google::protobuf::Empty const& request, Options options) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
-  return connection_->DoNothing(request);
-}
-
 future<StatusOr<google::test::admin::database::v1::Database>>
 GoldenThingAdminClient::CreateDatabase(std::string const& parent, std::string const& create_statement, Options options) {
   internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));

--- a/generator/integration_tests/golden/golden_thing_admin_client.h
+++ b/generator/integration_tests/golden/golden_thing_admin_client.h
@@ -94,10 +94,10 @@ class GoldenThingAdminClient {
   /// @param parent  Required. The instance whose databases should be listed.
   ///  Values are of the form `projects/<project>/instances/<instance>`.
   /// @param options  Optional. Operation options.
-  /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L337}
+  /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
   ///
-  /// [google.test.admin.database.v1.ListDatabasesRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L385}
-  /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L337}
+  /// [google.test.admin.database.v1.ListDatabasesRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L377}
+  /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L329}
   ///
   StreamRange<google::test::admin::database::v1::Database>
   ListDatabases(std::string const& parent, Options options = {});
@@ -105,36 +105,15 @@ class GoldenThingAdminClient {
   ///
   /// Lists Cloud Test databases.
   ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::ListDatabasesRequest,generator/integration_tests/test.proto#L385}
+  /// @param request @googleapis_link{google::test::admin::database::v1::ListDatabasesRequest,generator/integration_tests/test.proto#L377}
   /// @param options  Optional. Operation options.
-  /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L337}
+  /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
   ///
-  /// [google.test.admin.database.v1.ListDatabasesRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L385}
-  /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L337}
+  /// [google.test.admin.database.v1.ListDatabasesRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L377}
+  /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L329}
   ///
   StreamRange<google::test::admin::database::v1::Database>
   ListDatabases(google::test::admin::database::v1::ListDatabasesRequest request, Options options = {});
-
-  ///
-  /// Does Nothing.
-  ///
-  /// @param options  Optional. Operation options.
-  ///
-  /// [google.protobuf.Empty]: @googleapis_reference_link{google/protobuf/empty.proto#L52}
-  ///
-  Status
-  DoNothing(Options options = {});
-
-  ///
-  /// Does Nothing.
-  ///
-  /// @param request @googleapis_link{google::protobuf::Empty,google/protobuf/empty.proto#L52}
-  /// @param options  Optional. Operation options.
-  ///
-  /// [google.protobuf.Empty]: @googleapis_reference_link{google/protobuf/empty.proto#L52}
-  ///
-  Status
-  DoNothing(google::protobuf::Empty const& request, Options options = {});
 
   ///
   /// Creates a new Cloud Test database and starts to prepare it for serving.
@@ -154,10 +133,10 @@ class GoldenThingAdminClient {
   ///  If the database ID is a reserved word or if it contains a hyphen, the
   ///  database ID must be enclosed in backticks (`` ` ``).
   /// @param options  Optional. Operation options.
-  /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L337}
+  /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
   ///
-  /// [google.test.admin.database.v1.CreateDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L417}
-  /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L337}
+  /// [google.test.admin.database.v1.CreateDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L409}
+  /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L329}
   ///
   future<StatusOr<google::test::admin::database::v1::Database>>
   CreateDatabase(std::string const& parent, std::string const& create_statement, Options options = {});
@@ -172,12 +151,12 @@ class GoldenThingAdminClient {
   /// [response][google.longrunning.Operation.response] field type is
   /// [Database][google.test.admin.database.v1.Database], if successful.
   ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::CreateDatabaseRequest,generator/integration_tests/test.proto#L417}
+  /// @param request @googleapis_link{google::test::admin::database::v1::CreateDatabaseRequest,generator/integration_tests/test.proto#L409}
   /// @param options  Optional. Operation options.
-  /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L337}
+  /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
   ///
-  /// [google.test.admin.database.v1.CreateDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L417}
-  /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L337}
+  /// [google.test.admin.database.v1.CreateDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L409}
+  /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L329}
   ///
   future<StatusOr<google::test::admin::database::v1::Database>>
   CreateDatabase(google::test::admin::database::v1::CreateDatabaseRequest const& request, Options options = {});
@@ -188,10 +167,10 @@ class GoldenThingAdminClient {
   /// @param name  Required. The name of the requested database. Values are of the form
   ///  `projects/<project>/instances/<instance>/databases/<database>`.
   /// @param options  Optional. Operation options.
-  /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L337}
+  /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
   ///
-  /// [google.test.admin.database.v1.GetDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L451}
-  /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L337}
+  /// [google.test.admin.database.v1.GetDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L443}
+  /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L329}
   ///
   StatusOr<google::test::admin::database::v1::Database>
   GetDatabase(std::string const& name, Options options = {});
@@ -199,12 +178,12 @@ class GoldenThingAdminClient {
   ///
   /// Gets the state of a Cloud Test database.
   ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::GetDatabaseRequest,generator/integration_tests/test.proto#L451}
+  /// @param request @googleapis_link{google::test::admin::database::v1::GetDatabaseRequest,generator/integration_tests/test.proto#L443}
   /// @param options  Optional. Operation options.
-  /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L337}
+  /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
   ///
-  /// [google.test.admin.database.v1.GetDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L451}
-  /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L337}
+  /// [google.test.admin.database.v1.GetDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L443}
+  /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L329}
   ///
   StatusOr<google::test::admin::database::v1::Database>
   GetDatabase(google::test::admin::database::v1::GetDatabaseRequest const& request, Options options = {});
@@ -221,10 +200,10 @@ class GoldenThingAdminClient {
   /// @param database  Required. The database to update.
   /// @param statements  Required. DDL statements to be applied to the database.
   /// @param options  Optional. Operation options.
-  /// @return @googleapis_link{google::test::admin::database::v1::UpdateDatabaseDdlMetadata,generator/integration_tests/test.proto#L514}
+  /// @return @googleapis_link{google::test::admin::database::v1::UpdateDatabaseDdlMetadata,generator/integration_tests/test.proto#L506}
   ///
-  /// [google.test.admin.database.v1.UpdateDatabaseDdlRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L478}
-  /// [google.test.admin.database.v1.UpdateDatabaseDdlMetadata]: @googleapis_reference_link{generator/integration_tests/test.proto#L514}
+  /// [google.test.admin.database.v1.UpdateDatabaseDdlRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L470}
+  /// [google.test.admin.database.v1.UpdateDatabaseDdlMetadata]: @googleapis_reference_link{generator/integration_tests/test.proto#L506}
   ///
   future<StatusOr<google::test::admin::database::v1::UpdateDatabaseDdlMetadata>>
   UpdateDatabaseDdl(std::string const& database, std::vector<std::string> const& statements, Options options = {});
@@ -238,12 +217,12 @@ class GoldenThingAdminClient {
   /// [metadata][google.longrunning.Operation.metadata] field type is
   /// [UpdateDatabaseDdlMetadata][google.test.admin.database.v1.UpdateDatabaseDdlMetadata].  The operation has no response.
   ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::UpdateDatabaseDdlRequest,generator/integration_tests/test.proto#L478}
+  /// @param request @googleapis_link{google::test::admin::database::v1::UpdateDatabaseDdlRequest,generator/integration_tests/test.proto#L470}
   /// @param options  Optional. Operation options.
-  /// @return @googleapis_link{google::test::admin::database::v1::UpdateDatabaseDdlMetadata,generator/integration_tests/test.proto#L514}
+  /// @return @googleapis_link{google::test::admin::database::v1::UpdateDatabaseDdlMetadata,generator/integration_tests/test.proto#L506}
   ///
-  /// [google.test.admin.database.v1.UpdateDatabaseDdlRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L478}
-  /// [google.test.admin.database.v1.UpdateDatabaseDdlMetadata]: @googleapis_reference_link{generator/integration_tests/test.proto#L514}
+  /// [google.test.admin.database.v1.UpdateDatabaseDdlRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L470}
+  /// [google.test.admin.database.v1.UpdateDatabaseDdlMetadata]: @googleapis_reference_link{generator/integration_tests/test.proto#L506}
   ///
   future<StatusOr<google::test::admin::database::v1::UpdateDatabaseDdlMetadata>>
   UpdateDatabaseDdl(google::test::admin::database::v1::UpdateDatabaseDdlRequest const& request, Options options = {});
@@ -256,7 +235,7 @@ class GoldenThingAdminClient {
   /// @param database  Required. The database to be dropped.
   /// @param options  Optional. Operation options.
   ///
-  /// [google.test.admin.database.v1.DropDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L531}
+  /// [google.test.admin.database.v1.DropDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L523}
   ///
   Status
   DropDatabase(std::string const& database, Options options = {});
@@ -266,10 +245,10 @@ class GoldenThingAdminClient {
   /// Completed backups for the database will be retained according to their
   /// `expire_time`.
   ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::DropDatabaseRequest,generator/integration_tests/test.proto#L531}
+  /// @param request @googleapis_link{google::test::admin::database::v1::DropDatabaseRequest,generator/integration_tests/test.proto#L523}
   /// @param options  Optional. Operation options.
   ///
-  /// [google.test.admin.database.v1.DropDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L531}
+  /// [google.test.admin.database.v1.DropDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L523}
   ///
   Status
   DropDatabase(google::test::admin::database::v1::DropDatabaseRequest const& request, Options options = {});
@@ -281,10 +260,10 @@ class GoldenThingAdminClient {
   ///
   /// @param database  Required. The database whose schema we wish to get.
   /// @param options  Optional. Operation options.
-  /// @return @googleapis_link{google::test::admin::database::v1::GetDatabaseDdlResponse,generator/integration_tests/test.proto#L553}
+  /// @return @googleapis_link{google::test::admin::database::v1::GetDatabaseDdlResponse,generator/integration_tests/test.proto#L545}
   ///
-  /// [google.test.admin.database.v1.GetDatabaseDdlRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L542}
-  /// [google.test.admin.database.v1.GetDatabaseDdlResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L553}
+  /// [google.test.admin.database.v1.GetDatabaseDdlRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L534}
+  /// [google.test.admin.database.v1.GetDatabaseDdlResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L545}
   ///
   StatusOr<google::test::admin::database::v1::GetDatabaseDdlResponse>
   GetDatabaseDdl(std::string const& database, Options options = {});
@@ -294,12 +273,12 @@ class GoldenThingAdminClient {
   /// DDL statements. This method does not show pending schema updates, those may
   /// be queried using the [Operations][google.longrunning.Operations] API.
   ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::GetDatabaseDdlRequest,generator/integration_tests/test.proto#L542}
+  /// @param request @googleapis_link{google::test::admin::database::v1::GetDatabaseDdlRequest,generator/integration_tests/test.proto#L534}
   /// @param options  Optional. Operation options.
-  /// @return @googleapis_link{google::test::admin::database::v1::GetDatabaseDdlResponse,generator/integration_tests/test.proto#L553}
+  /// @return @googleapis_link{google::test::admin::database::v1::GetDatabaseDdlResponse,generator/integration_tests/test.proto#L545}
   ///
-  /// [google.test.admin.database.v1.GetDatabaseDdlRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L542}
-  /// [google.test.admin.database.v1.GetDatabaseDdlResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L553}
+  /// [google.test.admin.database.v1.GetDatabaseDdlRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L534}
+  /// [google.test.admin.database.v1.GetDatabaseDdlResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L545}
   ///
   StatusOr<google::test::admin::database::v1::GetDatabaseDdlResponse>
   GetDatabaseDdl(google::test::admin::database::v1::GetDatabaseDdlRequest const& request, Options options = {});
@@ -666,10 +645,10 @@ class GoldenThingAdminClient {
   /// @param backup  Name of the backup from which to restore.  Values are of the form
   ///  `projects/<project>/instances/<instance>/backups/<backup>`.
   /// @param options  Optional. Operation options.
-  /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L337}
+  /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
   ///
-  /// [google.test.admin.database.v1.RestoreDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L642}
-  /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L337}
+  /// [google.test.admin.database.v1.RestoreDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L634}
+  /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L329}
   ///
   future<StatusOr<google::test::admin::database::v1::Database>>
   RestoreDatabase(std::string const& parent, std::string const& database_id, std::string const& backup, Options options = {});
@@ -693,12 +672,12 @@ class GoldenThingAdminClient {
   /// initiated, without waiting for the optimize operation associated with the
   /// first restore to complete.
   ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::RestoreDatabaseRequest,generator/integration_tests/test.proto#L642}
+  /// @param request @googleapis_link{google::test::admin::database::v1::RestoreDatabaseRequest,generator/integration_tests/test.proto#L634}
   /// @param options  Optional. Operation options.
-  /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L337}
+  /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
   ///
-  /// [google.test.admin.database.v1.RestoreDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L642}
-  /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L337}
+  /// [google.test.admin.database.v1.RestoreDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L634}
+  /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L329}
   ///
   future<StatusOr<google::test::admin::database::v1::Database>>
   RestoreDatabase(google::test::admin::database::v1::RestoreDatabaseRequest const& request, Options options = {});
@@ -718,7 +697,7 @@ class GoldenThingAdminClient {
   /// @param options  Optional. Operation options.
   /// @return @googleapis_link{google::longrunning::Operation,google/longrunning/operations.proto#L128}
   ///
-  /// [google.test.admin.database.v1.ListDatabaseOperationsRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L561}
+  /// [google.test.admin.database.v1.ListDatabaseOperationsRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L553}
   /// [google.longrunning.Operation]: @googleapis_reference_link{google/longrunning/operations.proto#L128}
   ///
   StreamRange<google::longrunning::Operation>
@@ -734,11 +713,11 @@ class GoldenThingAdminClient {
   /// include those that have completed/failed/canceled within the last 7 days,
   /// and pending operations.
   ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::ListDatabaseOperationsRequest,generator/integration_tests/test.proto#L561}
+  /// @param request @googleapis_link{google::test::admin::database::v1::ListDatabaseOperationsRequest,generator/integration_tests/test.proto#L553}
   /// @param options  Optional. Operation options.
   /// @return @googleapis_link{google::longrunning::Operation,google/longrunning/operations.proto#L128}
   ///
-  /// [google.test.admin.database.v1.ListDatabaseOperationsRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L561}
+  /// [google.test.admin.database.v1.ListDatabaseOperationsRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L553}
   /// [google.longrunning.Operation]: @googleapis_reference_link{google/longrunning/operations.proto#L128}
   ///
   StreamRange<google::longrunning::Operation>
@@ -795,10 +774,10 @@ class GoldenThingAdminClient {
   /// @param name  Required. The name of the requested database. Values are of the form
   ///  `projects/<project>/instances/<instance>/databases/<database>`.
   /// @param options  Optional. Operation options.
-  /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L337}
+  /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
   ///
-  /// [google.test.admin.database.v1.GetDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L451}
-  /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L337}
+  /// [google.test.admin.database.v1.GetDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L443}
+  /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L329}
   ///
   future<StatusOr<google::test::admin::database::v1::Database>>
   AsyncGetDatabase(std::string const& name, Options options = {});
@@ -806,12 +785,12 @@ class GoldenThingAdminClient {
   ///
   /// Gets the state of a Cloud Test database.
   ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::GetDatabaseRequest,generator/integration_tests/test.proto#L451}
+  /// @param request @googleapis_link{google::test::admin::database::v1::GetDatabaseRequest,generator/integration_tests/test.proto#L443}
   /// @param options  Optional. Operation options.
-  /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L337}
+  /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
   ///
-  /// [google.test.admin.database.v1.GetDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L451}
-  /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L337}
+  /// [google.test.admin.database.v1.GetDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L443}
+  /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L329}
   ///
   future<StatusOr<google::test::admin::database::v1::Database>>
   AsyncGetDatabase(google::test::admin::database::v1::GetDatabaseRequest const& request, Options options = {});
@@ -824,7 +803,7 @@ class GoldenThingAdminClient {
   /// @param database  Required. The database to be dropped.
   /// @param options  Optional. Operation options.
   ///
-  /// [google.test.admin.database.v1.DropDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L531}
+  /// [google.test.admin.database.v1.DropDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L523}
   ///
   future<Status>
   AsyncDropDatabase(std::string const& database, Options options = {});
@@ -834,10 +813,10 @@ class GoldenThingAdminClient {
   /// Completed backups for the database will be retained according to their
   /// `expire_time`.
   ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::DropDatabaseRequest,generator/integration_tests/test.proto#L531}
+  /// @param request @googleapis_link{google::test::admin::database::v1::DropDatabaseRequest,generator/integration_tests/test.proto#L523}
   /// @param options  Optional. Operation options.
   ///
-  /// [google.test.admin.database.v1.DropDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L531}
+  /// [google.test.admin.database.v1.DropDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L523}
   ///
   future<Status>
   AsyncDropDatabase(google::test::admin::database::v1::DropDatabaseRequest const& request, Options options = {});

--- a/generator/integration_tests/golden/golden_thing_admin_client.h
+++ b/generator/integration_tests/golden/golden_thing_admin_client.h
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2022 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -94,10 +94,10 @@ class GoldenThingAdminClient {
   /// @param parent  Required. The instance whose databases should be listed.
   ///  Values are of the form `projects/<project>/instances/<instance>`.
   /// @param options  Optional. Operation options.
-  /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
+  /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L337}
   ///
-  /// [google.test.admin.database.v1.ListDatabasesRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L377}
-  /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L329}
+  /// [google.test.admin.database.v1.ListDatabasesRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L385}
+  /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L337}
   ///
   StreamRange<google::test::admin::database::v1::Database>
   ListDatabases(std::string const& parent, Options options = {});
@@ -105,15 +105,36 @@ class GoldenThingAdminClient {
   ///
   /// Lists Cloud Test databases.
   ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::ListDatabasesRequest,generator/integration_tests/test.proto#L377}
+  /// @param request @googleapis_link{google::test::admin::database::v1::ListDatabasesRequest,generator/integration_tests/test.proto#L385}
   /// @param options  Optional. Operation options.
-  /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
+  /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L337}
   ///
-  /// [google.test.admin.database.v1.ListDatabasesRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L377}
-  /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L329}
+  /// [google.test.admin.database.v1.ListDatabasesRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L385}
+  /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L337}
   ///
   StreamRange<google::test::admin::database::v1::Database>
   ListDatabases(google::test::admin::database::v1::ListDatabasesRequest request, Options options = {});
+
+  ///
+  /// Does Nothing.
+  ///
+  /// @param options  Optional. Operation options.
+  ///
+  /// [google.protobuf.Empty]: @googleapis_reference_link{google/protobuf/empty.proto#L52}
+  ///
+  Status
+  DoNothing(Options options = {});
+
+  ///
+  /// Does Nothing.
+  ///
+  /// @param request @googleapis_link{google::protobuf::Empty,google/protobuf/empty.proto#L52}
+  /// @param options  Optional. Operation options.
+  ///
+  /// [google.protobuf.Empty]: @googleapis_reference_link{google/protobuf/empty.proto#L52}
+  ///
+  Status
+  DoNothing(google::protobuf::Empty const& request, Options options = {});
 
   ///
   /// Creates a new Cloud Test database and starts to prepare it for serving.
@@ -133,10 +154,10 @@ class GoldenThingAdminClient {
   ///  If the database ID is a reserved word or if it contains a hyphen, the
   ///  database ID must be enclosed in backticks (`` ` ``).
   /// @param options  Optional. Operation options.
-  /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
+  /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L337}
   ///
-  /// [google.test.admin.database.v1.CreateDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L409}
-  /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L329}
+  /// [google.test.admin.database.v1.CreateDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L417}
+  /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L337}
   ///
   future<StatusOr<google::test::admin::database::v1::Database>>
   CreateDatabase(std::string const& parent, std::string const& create_statement, Options options = {});
@@ -151,12 +172,12 @@ class GoldenThingAdminClient {
   /// [response][google.longrunning.Operation.response] field type is
   /// [Database][google.test.admin.database.v1.Database], if successful.
   ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::CreateDatabaseRequest,generator/integration_tests/test.proto#L409}
+  /// @param request @googleapis_link{google::test::admin::database::v1::CreateDatabaseRequest,generator/integration_tests/test.proto#L417}
   /// @param options  Optional. Operation options.
-  /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
+  /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L337}
   ///
-  /// [google.test.admin.database.v1.CreateDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L409}
-  /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L329}
+  /// [google.test.admin.database.v1.CreateDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L417}
+  /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L337}
   ///
   future<StatusOr<google::test::admin::database::v1::Database>>
   CreateDatabase(google::test::admin::database::v1::CreateDatabaseRequest const& request, Options options = {});
@@ -167,10 +188,10 @@ class GoldenThingAdminClient {
   /// @param name  Required. The name of the requested database. Values are of the form
   ///  `projects/<project>/instances/<instance>/databases/<database>`.
   /// @param options  Optional. Operation options.
-  /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
+  /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L337}
   ///
-  /// [google.test.admin.database.v1.GetDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L443}
-  /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L329}
+  /// [google.test.admin.database.v1.GetDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L451}
+  /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L337}
   ///
   StatusOr<google::test::admin::database::v1::Database>
   GetDatabase(std::string const& name, Options options = {});
@@ -178,12 +199,12 @@ class GoldenThingAdminClient {
   ///
   /// Gets the state of a Cloud Test database.
   ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::GetDatabaseRequest,generator/integration_tests/test.proto#L443}
+  /// @param request @googleapis_link{google::test::admin::database::v1::GetDatabaseRequest,generator/integration_tests/test.proto#L451}
   /// @param options  Optional. Operation options.
-  /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
+  /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L337}
   ///
-  /// [google.test.admin.database.v1.GetDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L443}
-  /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L329}
+  /// [google.test.admin.database.v1.GetDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L451}
+  /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L337}
   ///
   StatusOr<google::test::admin::database::v1::Database>
   GetDatabase(google::test::admin::database::v1::GetDatabaseRequest const& request, Options options = {});
@@ -200,10 +221,10 @@ class GoldenThingAdminClient {
   /// @param database  Required. The database to update.
   /// @param statements  Required. DDL statements to be applied to the database.
   /// @param options  Optional. Operation options.
-  /// @return @googleapis_link{google::test::admin::database::v1::UpdateDatabaseDdlMetadata,generator/integration_tests/test.proto#L506}
+  /// @return @googleapis_link{google::test::admin::database::v1::UpdateDatabaseDdlMetadata,generator/integration_tests/test.proto#L514}
   ///
-  /// [google.test.admin.database.v1.UpdateDatabaseDdlRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L470}
-  /// [google.test.admin.database.v1.UpdateDatabaseDdlMetadata]: @googleapis_reference_link{generator/integration_tests/test.proto#L506}
+  /// [google.test.admin.database.v1.UpdateDatabaseDdlRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L478}
+  /// [google.test.admin.database.v1.UpdateDatabaseDdlMetadata]: @googleapis_reference_link{generator/integration_tests/test.proto#L514}
   ///
   future<StatusOr<google::test::admin::database::v1::UpdateDatabaseDdlMetadata>>
   UpdateDatabaseDdl(std::string const& database, std::vector<std::string> const& statements, Options options = {});
@@ -217,12 +238,12 @@ class GoldenThingAdminClient {
   /// [metadata][google.longrunning.Operation.metadata] field type is
   /// [UpdateDatabaseDdlMetadata][google.test.admin.database.v1.UpdateDatabaseDdlMetadata].  The operation has no response.
   ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::UpdateDatabaseDdlRequest,generator/integration_tests/test.proto#L470}
+  /// @param request @googleapis_link{google::test::admin::database::v1::UpdateDatabaseDdlRequest,generator/integration_tests/test.proto#L478}
   /// @param options  Optional. Operation options.
-  /// @return @googleapis_link{google::test::admin::database::v1::UpdateDatabaseDdlMetadata,generator/integration_tests/test.proto#L506}
+  /// @return @googleapis_link{google::test::admin::database::v1::UpdateDatabaseDdlMetadata,generator/integration_tests/test.proto#L514}
   ///
-  /// [google.test.admin.database.v1.UpdateDatabaseDdlRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L470}
-  /// [google.test.admin.database.v1.UpdateDatabaseDdlMetadata]: @googleapis_reference_link{generator/integration_tests/test.proto#L506}
+  /// [google.test.admin.database.v1.UpdateDatabaseDdlRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L478}
+  /// [google.test.admin.database.v1.UpdateDatabaseDdlMetadata]: @googleapis_reference_link{generator/integration_tests/test.proto#L514}
   ///
   future<StatusOr<google::test::admin::database::v1::UpdateDatabaseDdlMetadata>>
   UpdateDatabaseDdl(google::test::admin::database::v1::UpdateDatabaseDdlRequest const& request, Options options = {});
@@ -235,7 +256,7 @@ class GoldenThingAdminClient {
   /// @param database  Required. The database to be dropped.
   /// @param options  Optional. Operation options.
   ///
-  /// [google.test.admin.database.v1.DropDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L523}
+  /// [google.test.admin.database.v1.DropDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L531}
   ///
   Status
   DropDatabase(std::string const& database, Options options = {});
@@ -245,10 +266,10 @@ class GoldenThingAdminClient {
   /// Completed backups for the database will be retained according to their
   /// `expire_time`.
   ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::DropDatabaseRequest,generator/integration_tests/test.proto#L523}
+  /// @param request @googleapis_link{google::test::admin::database::v1::DropDatabaseRequest,generator/integration_tests/test.proto#L531}
   /// @param options  Optional. Operation options.
   ///
-  /// [google.test.admin.database.v1.DropDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L523}
+  /// [google.test.admin.database.v1.DropDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L531}
   ///
   Status
   DropDatabase(google::test::admin::database::v1::DropDatabaseRequest const& request, Options options = {});
@@ -260,10 +281,10 @@ class GoldenThingAdminClient {
   ///
   /// @param database  Required. The database whose schema we wish to get.
   /// @param options  Optional. Operation options.
-  /// @return @googleapis_link{google::test::admin::database::v1::GetDatabaseDdlResponse,generator/integration_tests/test.proto#L545}
+  /// @return @googleapis_link{google::test::admin::database::v1::GetDatabaseDdlResponse,generator/integration_tests/test.proto#L553}
   ///
-  /// [google.test.admin.database.v1.GetDatabaseDdlRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L534}
-  /// [google.test.admin.database.v1.GetDatabaseDdlResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L545}
+  /// [google.test.admin.database.v1.GetDatabaseDdlRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L542}
+  /// [google.test.admin.database.v1.GetDatabaseDdlResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L553}
   ///
   StatusOr<google::test::admin::database::v1::GetDatabaseDdlResponse>
   GetDatabaseDdl(std::string const& database, Options options = {});
@@ -273,12 +294,12 @@ class GoldenThingAdminClient {
   /// DDL statements. This method does not show pending schema updates, those may
   /// be queried using the [Operations][google.longrunning.Operations] API.
   ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::GetDatabaseDdlRequest,generator/integration_tests/test.proto#L534}
+  /// @param request @googleapis_link{google::test::admin::database::v1::GetDatabaseDdlRequest,generator/integration_tests/test.proto#L542}
   /// @param options  Optional. Operation options.
-  /// @return @googleapis_link{google::test::admin::database::v1::GetDatabaseDdlResponse,generator/integration_tests/test.proto#L545}
+  /// @return @googleapis_link{google::test::admin::database::v1::GetDatabaseDdlResponse,generator/integration_tests/test.proto#L553}
   ///
-  /// [google.test.admin.database.v1.GetDatabaseDdlRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L534}
-  /// [google.test.admin.database.v1.GetDatabaseDdlResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L545}
+  /// [google.test.admin.database.v1.GetDatabaseDdlRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L542}
+  /// [google.test.admin.database.v1.GetDatabaseDdlResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L553}
   ///
   StatusOr<google::test::admin::database::v1::GetDatabaseDdlResponse>
   GetDatabaseDdl(google::test::admin::database::v1::GetDatabaseDdlRequest const& request, Options options = {});
@@ -645,10 +666,10 @@ class GoldenThingAdminClient {
   /// @param backup  Name of the backup from which to restore.  Values are of the form
   ///  `projects/<project>/instances/<instance>/backups/<backup>`.
   /// @param options  Optional. Operation options.
-  /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
+  /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L337}
   ///
-  /// [google.test.admin.database.v1.RestoreDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L634}
-  /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L329}
+  /// [google.test.admin.database.v1.RestoreDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L642}
+  /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L337}
   ///
   future<StatusOr<google::test::admin::database::v1::Database>>
   RestoreDatabase(std::string const& parent, std::string const& database_id, std::string const& backup, Options options = {});
@@ -672,12 +693,12 @@ class GoldenThingAdminClient {
   /// initiated, without waiting for the optimize operation associated with the
   /// first restore to complete.
   ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::RestoreDatabaseRequest,generator/integration_tests/test.proto#L634}
+  /// @param request @googleapis_link{google::test::admin::database::v1::RestoreDatabaseRequest,generator/integration_tests/test.proto#L642}
   /// @param options  Optional. Operation options.
-  /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
+  /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L337}
   ///
-  /// [google.test.admin.database.v1.RestoreDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L634}
-  /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L329}
+  /// [google.test.admin.database.v1.RestoreDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L642}
+  /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L337}
   ///
   future<StatusOr<google::test::admin::database::v1::Database>>
   RestoreDatabase(google::test::admin::database::v1::RestoreDatabaseRequest const& request, Options options = {});
@@ -697,7 +718,7 @@ class GoldenThingAdminClient {
   /// @param options  Optional. Operation options.
   /// @return @googleapis_link{google::longrunning::Operation,google/longrunning/operations.proto#L128}
   ///
-  /// [google.test.admin.database.v1.ListDatabaseOperationsRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L553}
+  /// [google.test.admin.database.v1.ListDatabaseOperationsRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L561}
   /// [google.longrunning.Operation]: @googleapis_reference_link{google/longrunning/operations.proto#L128}
   ///
   StreamRange<google::longrunning::Operation>
@@ -713,11 +734,11 @@ class GoldenThingAdminClient {
   /// include those that have completed/failed/canceled within the last 7 days,
   /// and pending operations.
   ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::ListDatabaseOperationsRequest,generator/integration_tests/test.proto#L553}
+  /// @param request @googleapis_link{google::test::admin::database::v1::ListDatabaseOperationsRequest,generator/integration_tests/test.proto#L561}
   /// @param options  Optional. Operation options.
   /// @return @googleapis_link{google::longrunning::Operation,google/longrunning/operations.proto#L128}
   ///
-  /// [google.test.admin.database.v1.ListDatabaseOperationsRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L553}
+  /// [google.test.admin.database.v1.ListDatabaseOperationsRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L561}
   /// [google.longrunning.Operation]: @googleapis_reference_link{google/longrunning/operations.proto#L128}
   ///
   StreamRange<google::longrunning::Operation>
@@ -774,10 +795,10 @@ class GoldenThingAdminClient {
   /// @param name  Required. The name of the requested database. Values are of the form
   ///  `projects/<project>/instances/<instance>/databases/<database>`.
   /// @param options  Optional. Operation options.
-  /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
+  /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L337}
   ///
-  /// [google.test.admin.database.v1.GetDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L443}
-  /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L329}
+  /// [google.test.admin.database.v1.GetDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L451}
+  /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L337}
   ///
   future<StatusOr<google::test::admin::database::v1::Database>>
   AsyncGetDatabase(std::string const& name, Options options = {});
@@ -785,12 +806,12 @@ class GoldenThingAdminClient {
   ///
   /// Gets the state of a Cloud Test database.
   ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::GetDatabaseRequest,generator/integration_tests/test.proto#L443}
+  /// @param request @googleapis_link{google::test::admin::database::v1::GetDatabaseRequest,generator/integration_tests/test.proto#L451}
   /// @param options  Optional. Operation options.
-  /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L329}
+  /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L337}
   ///
-  /// [google.test.admin.database.v1.GetDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L443}
-  /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L329}
+  /// [google.test.admin.database.v1.GetDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L451}
+  /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L337}
   ///
   future<StatusOr<google::test::admin::database::v1::Database>>
   AsyncGetDatabase(google::test::admin::database::v1::GetDatabaseRequest const& request, Options options = {});
@@ -803,7 +824,7 @@ class GoldenThingAdminClient {
   /// @param database  Required. The database to be dropped.
   /// @param options  Optional. Operation options.
   ///
-  /// [google.test.admin.database.v1.DropDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L523}
+  /// [google.test.admin.database.v1.DropDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L531}
   ///
   future<Status>
   AsyncDropDatabase(std::string const& database, Options options = {});
@@ -813,10 +834,10 @@ class GoldenThingAdminClient {
   /// Completed backups for the database will be retained according to their
   /// `expire_time`.
   ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::DropDatabaseRequest,generator/integration_tests/test.proto#L523}
+  /// @param request @googleapis_link{google::test::admin::database::v1::DropDatabaseRequest,generator/integration_tests/test.proto#L531}
   /// @param options  Optional. Operation options.
   ///
-  /// [google.test.admin.database.v1.DropDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L523}
+  /// [google.test.admin.database.v1.DropDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L531}
   ///
   future<Status>
   AsyncDropDatabase(google::test::admin::database::v1::DropDatabaseRequest const& request, Options options = {});

--- a/generator/integration_tests/golden/golden_thing_admin_connection.cc
+++ b/generator/integration_tests/golden/golden_thing_admin_connection.cc
@@ -48,12 +48,6 @@ StreamRange<google::test::admin::database::v1::Database> GoldenThingAdminConnect
     });
 }
 
-Status
-GoldenThingAdminConnection::DoNothing(
-    google::protobuf::Empty const&) {
-  return Status(StatusCode::kUnimplemented, "not implemented");
-}
-
 future<StatusOr<google::test::admin::database::v1::Database>>
 GoldenThingAdminConnection::CreateDatabase(
     google::test::admin::database::v1::CreateDatabaseRequest const&) {
@@ -238,19 +232,6 @@ class GoldenThingAdminConnectionImpl : public GoldenThingAdminConnection {
           std::move(messages.begin(), messages.end(), result.begin());
           return result;
         });
-  }
-
-  Status
-  DoNothing(
-      google::protobuf::Empty const& request) override {
-    return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->DoNothing(request),
-        [this](grpc::ClientContext& context,
-            google::protobuf::Empty const& request) {
-          return stub_->DoNothing(context, request);
-        },
-        request, __func__);
   }
 
   future<StatusOr<google::test::admin::database::v1::Database>>

--- a/generator/integration_tests/golden/golden_thing_admin_connection.h
+++ b/generator/integration_tests/golden/golden_thing_admin_connection.h
@@ -54,9 +54,6 @@ class GoldenThingAdminConnection {
   virtual StreamRange<google::test::admin::database::v1::Database>
   ListDatabases(google::test::admin::database::v1::ListDatabasesRequest request);
 
-  virtual Status
-  DoNothing(google::protobuf::Empty const& request);
-
   virtual future<StatusOr<google::test::admin::database::v1::Database>>
   CreateDatabase(google::test::admin::database::v1::CreateDatabaseRequest const& request);
 

--- a/generator/integration_tests/golden/golden_thing_admin_connection.h
+++ b/generator/integration_tests/golden/golden_thing_admin_connection.h
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2022 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -53,6 +53,9 @@ class GoldenThingAdminConnection {
 
   virtual StreamRange<google::test::admin::database::v1::Database>
   ListDatabases(google::test::admin::database::v1::ListDatabasesRequest request);
+
+  virtual Status
+  DoNothing(google::protobuf::Empty const& request);
 
   virtual future<StatusOr<google::test::admin::database::v1::Database>>
   CreateDatabase(google::test::admin::database::v1::CreateDatabaseRequest const& request);

--- a/generator/integration_tests/golden/golden_thing_admin_connection_idempotency_policy.cc
+++ b/generator/integration_tests/golden/golden_thing_admin_connection_idempotency_policy.cc
@@ -45,11 +45,6 @@ class DefaultGoldenThingAdminConnectionIdempotencyPolicy : public GoldenThingAdm
   }
 
   Idempotency
-  DoNothing(google::protobuf::Empty const&) override {
-    return Idempotency::kIdempotent;
-  }
-
-  Idempotency
   CreateDatabase(google::test::admin::database::v1::CreateDatabaseRequest const&) override {
     return Idempotency::kNonIdempotent;
   }

--- a/generator/integration_tests/golden/golden_thing_admin_connection_idempotency_policy.cc
+++ b/generator/integration_tests/golden/golden_thing_admin_connection_idempotency_policy.cc
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2022 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -41,6 +41,11 @@ class DefaultGoldenThingAdminConnectionIdempotencyPolicy : public GoldenThingAdm
 
   Idempotency
   ListDatabases(google::test::admin::database::v1::ListDatabasesRequest) override {
+    return Idempotency::kIdempotent;
+  }
+
+  Idempotency
+  DoNothing(google::protobuf::Empty const&) override {
     return Idempotency::kIdempotent;
   }
 

--- a/generator/integration_tests/golden/golden_thing_admin_connection_idempotency_policy.h
+++ b/generator/integration_tests/golden/golden_thing_admin_connection_idempotency_policy.h
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2022 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -40,6 +40,9 @@ class GoldenThingAdminConnectionIdempotencyPolicy {
 
   virtual google::cloud::internal::Idempotency
   ListDatabases(google::test::admin::database::v1::ListDatabasesRequest request) = 0;
+
+  virtual google::cloud::internal::Idempotency
+  DoNothing(google::protobuf::Empty const& request) = 0;
 
   virtual google::cloud::internal::Idempotency
   CreateDatabase(google::test::admin::database::v1::CreateDatabaseRequest const& request) = 0;

--- a/generator/integration_tests/golden/golden_thing_admin_connection_idempotency_policy.h
+++ b/generator/integration_tests/golden/golden_thing_admin_connection_idempotency_policy.h
@@ -42,9 +42,6 @@ class GoldenThingAdminConnectionIdempotencyPolicy {
   ListDatabases(google::test::admin::database::v1::ListDatabasesRequest request) = 0;
 
   virtual google::cloud::internal::Idempotency
-  DoNothing(google::protobuf::Empty const& request) = 0;
-
-  virtual google::cloud::internal::Idempotency
   CreateDatabase(google::test::admin::database::v1::CreateDatabaseRequest const& request) = 0;
 
   virtual google::cloud::internal::Idempotency

--- a/generator/integration_tests/golden/golden_thing_admin_options.h
+++ b/generator/integration_tests/golden/golden_thing_admin_options.h
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2022 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_auth_decorator.cc
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_auth_decorator.cc
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2022 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_auth_decorator.cc
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_auth_decorator.cc
@@ -81,6 +81,14 @@ StatusOr<google::test::admin::database::v1::ListServiceAccountKeysResponse> Gold
   return child_->ListServiceAccountKeys(context, request);
 }
 
+Status GoldenKitchenSinkAuth::DoNothing(
+    grpc::ClientContext& context,
+    google::protobuf::Empty const& request) {
+  auto status = auth_->ConfigureContext(context);
+  if (!status.ok()) return status;
+  return child_->DoNothing(context, request);
+}
+
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace golden_internal
 }  // namespace cloud

--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_auth_decorator.h
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_auth_decorator.h
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2022 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_auth_decorator.h
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_auth_decorator.h
@@ -63,6 +63,10 @@ class GoldenKitchenSinkAuth : public GoldenKitchenSinkStub {
       grpc::ClientContext& context,
       google::test::admin::database::v1::ListServiceAccountKeysRequest const& request) override;
 
+  Status DoNothing(
+      grpc::ClientContext& context,
+      google::protobuf::Empty const& request) override;
+
  private:
   std::shared_ptr<google::cloud::internal::GrpcAuthenticationStrategy> auth_;
   std::shared_ptr<GoldenKitchenSinkStub> child_;

--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_logging_decorator.cc
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_logging_decorator.cc
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2022 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_logging_decorator.cc
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_logging_decorator.cc
@@ -116,6 +116,18 @@ GoldenKitchenSinkLogging::ListServiceAccountKeys(
       context, request, __func__, tracing_options_);
 }
 
+Status
+GoldenKitchenSinkLogging::DoNothing(
+    grpc::ClientContext& context,
+    google::protobuf::Empty const& request) {
+  return google::cloud::internal::LogWrapper(
+      [this](grpc::ClientContext& context,
+             google::protobuf::Empty const& request) {
+        return child_->DoNothing(context, request);
+      },
+      context, request, __func__, tracing_options_);
+}
+
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace golden_internal
 }  // namespace cloud

--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_logging_decorator.h
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_logging_decorator.h
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2022 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_logging_decorator.h
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_logging_decorator.h
@@ -63,6 +63,10 @@ class GoldenKitchenSinkLogging : public GoldenKitchenSinkStub {
     grpc::ClientContext& context,
     google::test::admin::database::v1::ListServiceAccountKeysRequest const& request) override;
 
+  Status DoNothing(
+    grpc::ClientContext& context,
+    google::protobuf::Empty const& request) override;
+
  private:
   std::shared_ptr<GoldenKitchenSinkStub> child_;
   TracingOptions tracing_options_;

--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_metadata_decorator.cc
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_metadata_decorator.cc
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2022 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_metadata_decorator.cc
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_metadata_decorator.cc
@@ -80,6 +80,14 @@ GoldenKitchenSinkMetadata::ListServiceAccountKeys(
   return child_->ListServiceAccountKeys(context, request);
 }
 
+Status
+GoldenKitchenSinkMetadata::DoNothing(
+    grpc::ClientContext& context,
+    google::protobuf::Empty const& request) {
+  SetMetadata(context, {});
+  return child_->DoNothing(context, request);
+}
+
 void GoldenKitchenSinkMetadata::SetMetadata(grpc::ClientContext& context,
                                         std::string const& request_params) {
   context.AddMetadata("x-goog-request-params", request_params);

--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_metadata_decorator.h
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_metadata_decorator.h
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2022 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_metadata_decorator.h
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_metadata_decorator.h
@@ -59,6 +59,10 @@ class GoldenKitchenSinkMetadata : public GoldenKitchenSinkStub {
     grpc::ClientContext& context,
     google::test::admin::database::v1::ListServiceAccountKeysRequest const& request) override;
 
+  Status DoNothing(
+    grpc::ClientContext& context,
+    google::protobuf::Empty const& request) override;
+
  private:
   void SetMetadata(grpc::ClientContext& context,
                    std::string const& request_params);

--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_option_defaults.cc
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_option_defaults.cc
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2022 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_option_defaults.h
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_option_defaults.h
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2022 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_retry_traits.h
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_retry_traits.h
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2022 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_stub.cc
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_stub.cc
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2022 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_stub.cc
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_stub.cc
@@ -105,6 +105,19 @@ DefaultGoldenKitchenSinkStub::ListServiceAccountKeys(
     return response;
 }
 
+Status
+DefaultGoldenKitchenSinkStub::DoNothing(
+  grpc::ClientContext& client_context,
+  google::protobuf::Empty const& request) {
+    google::protobuf::Empty response;
+    auto status =
+        grpc_stub_->DoNothing(&client_context, request, &response);
+    if (!status.ok()) {
+      return google::cloud::MakeStatusFromRpcError(status);
+    }
+    return google::cloud::Status();
+}
+
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace golden_internal
 }  // namespace cloud

--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_stub.h
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_stub.h
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2022 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_stub.h
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_stub.h
@@ -59,6 +59,10 @@ class GoldenKitchenSinkStub {
     grpc::ClientContext& context,
     google::test::admin::database::v1::ListServiceAccountKeysRequest const& request) = 0;
 
+  virtual Status DoNothing(
+    grpc::ClientContext& context,
+    google::protobuf::Empty const& request) = 0;
+
 };
 
 class DefaultGoldenKitchenSinkStub : public GoldenKitchenSinkStub {
@@ -96,6 +100,11 @@ class DefaultGoldenKitchenSinkStub : public GoldenKitchenSinkStub {
   ListServiceAccountKeys(
     grpc::ClientContext& client_context,
     google::test::admin::database::v1::ListServiceAccountKeysRequest const& request) override;
+
+  Status
+  DoNothing(
+    grpc::ClientContext& client_context,
+    google::protobuf::Empty const& request) override;
 
  private:
   std::unique_ptr<google::test::admin::database::v1::GoldenKitchenSink::StubInterface> grpc_stub_;

--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_stub_factory.cc
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_stub_factory.cc
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2022 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_stub_factory.h
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_stub_factory.h
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2022 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/integration_tests/golden/internal/golden_thing_admin_auth_decorator.cc
+++ b/generator/integration_tests/golden/internal/golden_thing_admin_auth_decorator.cc
@@ -38,14 +38,6 @@ StatusOr<google::test::admin::database::v1::ListDatabasesResponse> GoldenThingAd
   return child_->ListDatabases(context, request);
 }
 
-Status GoldenThingAdminAuth::DoNothing(
-    grpc::ClientContext& context,
-    google::protobuf::Empty const& request) {
-  auto status = auth_->ConfigureContext(context);
-  if (!status.ok()) return status;
-  return child_->DoNothing(context, request);
-}
-
 future<StatusOr<google::longrunning::Operation>>
 GoldenThingAdminAuth::AsyncCreateDatabase(
       google::cloud::CompletionQueue& cq,

--- a/generator/integration_tests/golden/internal/golden_thing_admin_auth_decorator.cc
+++ b/generator/integration_tests/golden/internal/golden_thing_admin_auth_decorator.cc
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2022 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -36,6 +36,14 @@ StatusOr<google::test::admin::database::v1::ListDatabasesResponse> GoldenThingAd
   auto status = auth_->ConfigureContext(context);
   if (!status.ok()) return status;
   return child_->ListDatabases(context, request);
+}
+
+Status GoldenThingAdminAuth::DoNothing(
+    grpc::ClientContext& context,
+    google::protobuf::Empty const& request) {
+  auto status = auth_->ConfigureContext(context);
+  if (!status.ok()) return status;
+  return child_->DoNothing(context, request);
 }
 
 future<StatusOr<google::longrunning::Operation>>

--- a/generator/integration_tests/golden/internal/golden_thing_admin_auth_decorator.h
+++ b/generator/integration_tests/golden/internal/golden_thing_admin_auth_decorator.h
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2022 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -42,6 +42,10 @@ class GoldenThingAdminAuth : public GoldenThingAdminStub {
   StatusOr<google::test::admin::database::v1::ListDatabasesResponse> ListDatabases(
       grpc::ClientContext& context,
       google::test::admin::database::v1::ListDatabasesRequest const& request) override;
+
+  Status DoNothing(
+      grpc::ClientContext& context,
+      google::protobuf::Empty const& request) override;
 
   future<StatusOr<google::longrunning::Operation>> AsyncCreateDatabase(
       google::cloud::CompletionQueue& cq,

--- a/generator/integration_tests/golden/internal/golden_thing_admin_auth_decorator.h
+++ b/generator/integration_tests/golden/internal/golden_thing_admin_auth_decorator.h
@@ -43,10 +43,6 @@ class GoldenThingAdminAuth : public GoldenThingAdminStub {
       grpc::ClientContext& context,
       google::test::admin::database::v1::ListDatabasesRequest const& request) override;
 
-  Status DoNothing(
-      grpc::ClientContext& context,
-      google::protobuf::Empty const& request) override;
-
   future<StatusOr<google::longrunning::Operation>> AsyncCreateDatabase(
       google::cloud::CompletionQueue& cq,
       std::unique_ptr<grpc::ClientContext> context,

--- a/generator/integration_tests/golden/internal/golden_thing_admin_logging_decorator.cc
+++ b/generator/integration_tests/golden/internal/golden_thing_admin_logging_decorator.cc
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2022 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -42,6 +42,18 @@ GoldenThingAdminLogging::ListDatabases(
       [this](grpc::ClientContext& context,
              google::test::admin::database::v1::ListDatabasesRequest const& request) {
         return child_->ListDatabases(context, request);
+      },
+      context, request, __func__, tracing_options_);
+}
+
+Status
+GoldenThingAdminLogging::DoNothing(
+    grpc::ClientContext& context,
+    google::protobuf::Empty const& request) {
+  return google::cloud::internal::LogWrapper(
+      [this](grpc::ClientContext& context,
+             google::protobuf::Empty const& request) {
+        return child_->DoNothing(context, request);
       },
       context, request, __func__, tracing_options_);
 }

--- a/generator/integration_tests/golden/internal/golden_thing_admin_logging_decorator.cc
+++ b/generator/integration_tests/golden/internal/golden_thing_admin_logging_decorator.cc
@@ -46,18 +46,6 @@ GoldenThingAdminLogging::ListDatabases(
       context, request, __func__, tracing_options_);
 }
 
-Status
-GoldenThingAdminLogging::DoNothing(
-    grpc::ClientContext& context,
-    google::protobuf::Empty const& request) {
-  return google::cloud::internal::LogWrapper(
-      [this](grpc::ClientContext& context,
-             google::protobuf::Empty const& request) {
-        return child_->DoNothing(context, request);
-      },
-      context, request, __func__, tracing_options_);
-}
-
 future<StatusOr<google::longrunning::Operation>>
 GoldenThingAdminLogging::AsyncCreateDatabase(
       google::cloud::CompletionQueue& cq,

--- a/generator/integration_tests/golden/internal/golden_thing_admin_logging_decorator.h
+++ b/generator/integration_tests/golden/internal/golden_thing_admin_logging_decorator.h
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2022 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -42,6 +42,10 @@ class GoldenThingAdminLogging : public GoldenThingAdminStub {
   StatusOr<google::test::admin::database::v1::ListDatabasesResponse> ListDatabases(
     grpc::ClientContext& context,
     google::test::admin::database::v1::ListDatabasesRequest const& request) override;
+
+  Status DoNothing(
+    grpc::ClientContext& context,
+    google::protobuf::Empty const& request) override;
 
   future<StatusOr<google::longrunning::Operation>> AsyncCreateDatabase(
       google::cloud::CompletionQueue& cq,

--- a/generator/integration_tests/golden/internal/golden_thing_admin_logging_decorator.h
+++ b/generator/integration_tests/golden/internal/golden_thing_admin_logging_decorator.h
@@ -43,10 +43,6 @@ class GoldenThingAdminLogging : public GoldenThingAdminStub {
     grpc::ClientContext& context,
     google::test::admin::database::v1::ListDatabasesRequest const& request) override;
 
-  Status DoNothing(
-    grpc::ClientContext& context,
-    google::protobuf::Empty const& request) override;
-
   future<StatusOr<google::longrunning::Operation>> AsyncCreateDatabase(
       google::cloud::CompletionQueue& cq,
       std::unique_ptr<grpc::ClientContext> context,

--- a/generator/integration_tests/golden/internal/golden_thing_admin_metadata_decorator.cc
+++ b/generator/integration_tests/golden/internal/golden_thing_admin_metadata_decorator.cc
@@ -40,14 +40,6 @@ GoldenThingAdminMetadata::ListDatabases(
   return child_->ListDatabases(context, request);
 }
 
-Status
-GoldenThingAdminMetadata::DoNothing(
-    grpc::ClientContext& context,
-    google::protobuf::Empty const& request) {
-  SetMetadata(context, {});
-  return child_->DoNothing(context, request);
-}
-
 future<StatusOr<google::longrunning::Operation>>
 GoldenThingAdminMetadata::AsyncCreateDatabase(
     google::cloud::CompletionQueue& cq,

--- a/generator/integration_tests/golden/internal/golden_thing_admin_metadata_decorator.cc
+++ b/generator/integration_tests/golden/internal/golden_thing_admin_metadata_decorator.cc
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2022 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -38,6 +38,14 @@ GoldenThingAdminMetadata::ListDatabases(
     google::test::admin::database::v1::ListDatabasesRequest const& request) {
   SetMetadata(context, "parent=" + request.parent());
   return child_->ListDatabases(context, request);
+}
+
+Status
+GoldenThingAdminMetadata::DoNothing(
+    grpc::ClientContext& context,
+    google::protobuf::Empty const& request) {
+  SetMetadata(context, {});
+  return child_->DoNothing(context, request);
 }
 
 future<StatusOr<google::longrunning::Operation>>

--- a/generator/integration_tests/golden/internal/golden_thing_admin_metadata_decorator.h
+++ b/generator/integration_tests/golden/internal/golden_thing_admin_metadata_decorator.h
@@ -39,10 +39,6 @@ class GoldenThingAdminMetadata : public GoldenThingAdminStub {
     grpc::ClientContext& context,
     google::test::admin::database::v1::ListDatabasesRequest const& request) override;
 
-  Status DoNothing(
-    grpc::ClientContext& context,
-    google::protobuf::Empty const& request) override;
-
   future<StatusOr<google::longrunning::Operation>> AsyncCreateDatabase(
       google::cloud::CompletionQueue& cq,
       std::unique_ptr<grpc::ClientContext> context,

--- a/generator/integration_tests/golden/internal/golden_thing_admin_metadata_decorator.h
+++ b/generator/integration_tests/golden/internal/golden_thing_admin_metadata_decorator.h
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2022 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -38,6 +38,10 @@ class GoldenThingAdminMetadata : public GoldenThingAdminStub {
   StatusOr<google::test::admin::database::v1::ListDatabasesResponse> ListDatabases(
     grpc::ClientContext& context,
     google::test::admin::database::v1::ListDatabasesRequest const& request) override;
+
+  Status DoNothing(
+    grpc::ClientContext& context,
+    google::protobuf::Empty const& request) override;
 
   future<StatusOr<google::longrunning::Operation>> AsyncCreateDatabase(
       google::cloud::CompletionQueue& cq,

--- a/generator/integration_tests/golden/internal/golden_thing_admin_option_defaults.cc
+++ b/generator/integration_tests/golden/internal/golden_thing_admin_option_defaults.cc
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2022 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/integration_tests/golden/internal/golden_thing_admin_option_defaults.h
+++ b/generator/integration_tests/golden/internal/golden_thing_admin_option_defaults.h
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2022 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/integration_tests/golden/internal/golden_thing_admin_retry_traits.h
+++ b/generator/integration_tests/golden/internal/golden_thing_admin_retry_traits.h
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2022 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/integration_tests/golden/internal/golden_thing_admin_stub.cc
+++ b/generator/integration_tests/golden/internal/golden_thing_admin_stub.cc
@@ -43,19 +43,6 @@ DefaultGoldenThingAdminStub::ListDatabases(
     return response;
 }
 
-Status
-DefaultGoldenThingAdminStub::DoNothing(
-  grpc::ClientContext& client_context,
-  google::protobuf::Empty const& request) {
-    google::protobuf::Empty response;
-    auto status =
-        grpc_stub_->DoNothing(&client_context, request, &response);
-    if (!status.ok()) {
-      return google::cloud::MakeStatusFromRpcError(status);
-    }
-    return google::cloud::Status();
-}
-
 future<StatusOr<google::longrunning::Operation>>
 DefaultGoldenThingAdminStub::AsyncCreateDatabase(
       google::cloud::CompletionQueue& cq,

--- a/generator/integration_tests/golden/internal/golden_thing_admin_stub.cc
+++ b/generator/integration_tests/golden/internal/golden_thing_admin_stub.cc
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2022 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -41,6 +41,19 @@ DefaultGoldenThingAdminStub::ListDatabases(
       return google::cloud::MakeStatusFromRpcError(status);
     }
     return response;
+}
+
+Status
+DefaultGoldenThingAdminStub::DoNothing(
+  grpc::ClientContext& client_context,
+  google::protobuf::Empty const& request) {
+    google::protobuf::Empty response;
+    auto status =
+        grpc_stub_->DoNothing(&client_context, request, &response);
+    if (!status.ok()) {
+      return google::cloud::MakeStatusFromRpcError(status);
+    }
+    return google::cloud::Status();
 }
 
 future<StatusOr<google::longrunning::Operation>>

--- a/generator/integration_tests/golden/internal/golden_thing_admin_stub.h
+++ b/generator/integration_tests/golden/internal/golden_thing_admin_stub.h
@@ -40,10 +40,6 @@ class GoldenThingAdminStub {
     grpc::ClientContext& context,
     google::test::admin::database::v1::ListDatabasesRequest const& request) = 0;
 
-  virtual Status DoNothing(
-    grpc::ClientContext& context,
-    google::protobuf::Empty const& request) = 0;
-
   virtual future<StatusOr<google::longrunning::Operation>> AsyncCreateDatabase(
       google::cloud::CompletionQueue& cq,
       std::unique_ptr<grpc::ClientContext> context,
@@ -147,11 +143,6 @@ class DefaultGoldenThingAdminStub : public GoldenThingAdminStub {
   ListDatabases(
     grpc::ClientContext& client_context,
     google::test::admin::database::v1::ListDatabasesRequest const& request) override;
-
-  Status
-  DoNothing(
-    grpc::ClientContext& client_context,
-    google::protobuf::Empty const& request) override;
 
   future<StatusOr<google::longrunning::Operation>> AsyncCreateDatabase(
       google::cloud::CompletionQueue& cq,

--- a/generator/integration_tests/golden/internal/golden_thing_admin_stub.h
+++ b/generator/integration_tests/golden/internal/golden_thing_admin_stub.h
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2022 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -39,6 +39,10 @@ class GoldenThingAdminStub {
   virtual StatusOr<google::test::admin::database::v1::ListDatabasesResponse> ListDatabases(
     grpc::ClientContext& context,
     google::test::admin::database::v1::ListDatabasesRequest const& request) = 0;
+
+  virtual Status DoNothing(
+    grpc::ClientContext& context,
+    google::protobuf::Empty const& request) = 0;
 
   virtual future<StatusOr<google::longrunning::Operation>> AsyncCreateDatabase(
       google::cloud::CompletionQueue& cq,
@@ -143,6 +147,11 @@ class DefaultGoldenThingAdminStub : public GoldenThingAdminStub {
   ListDatabases(
     grpc::ClientContext& client_context,
     google::test::admin::database::v1::ListDatabasesRequest const& request) override;
+
+  Status
+  DoNothing(
+    grpc::ClientContext& client_context,
+    google::protobuf::Empty const& request) override;
 
   future<StatusOr<google::longrunning::Operation>> AsyncCreateDatabase(
       google::cloud::CompletionQueue& cq,

--- a/generator/integration_tests/golden/internal/golden_thing_admin_stub_factory.cc
+++ b/generator/integration_tests/golden/internal/golden_thing_admin_stub_factory.cc
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2022 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/integration_tests/golden/internal/golden_thing_admin_stub_factory.h
+++ b/generator/integration_tests/golden/internal/golden_thing_admin_stub_factory.h
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2022 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/integration_tests/golden/mocks/mock_golden_kitchen_sink_connection.h
+++ b/generator/integration_tests/golden/mocks/mock_golden_kitchen_sink_connection.h
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2022 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/integration_tests/golden/mocks/mock_golden_kitchen_sink_connection.h
+++ b/generator/integration_tests/golden/mocks/mock_golden_kitchen_sink_connection.h
@@ -53,6 +53,10 @@ class MockGoldenKitchenSinkConnection : public golden::GoldenKitchenSinkConnecti
   ListServiceAccountKeys,
   (google::test::admin::database::v1::ListServiceAccountKeysRequest const& request), (override));
 
+  MOCK_METHOD(Status,
+  DoNothing,
+  (google::protobuf::Empty const& request), (override));
+
 };
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/generator/integration_tests/golden/mocks/mock_golden_kitchen_sink_stub.h
+++ b/generator/integration_tests/golden/mocks/mock_golden_kitchen_sink_stub.h
@@ -65,6 +65,12 @@ class MockGoldenKitchenSinkStub : public GoldenKitchenSinkStub {
       (grpc::ClientContext&, ::google::test::admin::database::v1::
                                  ListServiceAccountKeysRequest const&),
       (override));
+  MOCK_METHOD(
+      Status,
+      DoNothing,
+      (grpc::ClientContext&,
+       ::google::protobuf::Empty const&),
+      (override));
 };
 
 class MockTailLogEntriesStreamingReadRpc

--- a/generator/integration_tests/golden/mocks/mock_golden_thing_admin_connection.h
+++ b/generator/integration_tests/golden/mocks/mock_golden_thing_admin_connection.h
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2022 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -32,6 +32,10 @@ class MockGoldenThingAdminConnection : public golden::GoldenThingAdminConnection
   MOCK_METHOD(StreamRange<google::test::admin::database::v1::Database>,
   ListDatabases,
   (google::test::admin::database::v1::ListDatabasesRequest request), (override));
+
+  MOCK_METHOD(Status,
+  DoNothing,
+  (google::protobuf::Empty const& request), (override));
 
   MOCK_METHOD(future<StatusOr<google::test::admin::database::v1::Database>>,
   CreateDatabase,

--- a/generator/integration_tests/golden/mocks/mock_golden_thing_admin_connection.h
+++ b/generator/integration_tests/golden/mocks/mock_golden_thing_admin_connection.h
@@ -33,10 +33,6 @@ class MockGoldenThingAdminConnection : public golden::GoldenThingAdminConnection
   ListDatabases,
   (google::test::admin::database::v1::ListDatabasesRequest request), (override));
 
-  MOCK_METHOD(Status,
-  DoNothing,
-  (google::protobuf::Empty const& request), (override));
-
   MOCK_METHOD(future<StatusOr<google::test::admin::database::v1::Database>>,
   CreateDatabase,
   (google::test::admin::database::v1::CreateDatabaseRequest const& request), (override));

--- a/generator/integration_tests/golden/mocks/mock_golden_thing_admin_stub.h
+++ b/generator/integration_tests/golden/mocks/mock_golden_thing_admin_stub.h
@@ -35,6 +35,12 @@ class MockGoldenThingAdminStub
        ::google::test::admin::database::v1::ListDatabasesRequest const&),
       (override));
   MOCK_METHOD(
+      Status,
+      DoNothing,
+      (grpc::ClientContext&,
+       ::google::protobuf::Empty const&),
+      (override));
+  MOCK_METHOD(
       future<StatusOr<::google::longrunning::Operation>>, AsyncCreateDatabase,
       (google::cloud::CompletionQueue&,
        std::unique_ptr<grpc::ClientContext>,

--- a/generator/integration_tests/golden/mocks/mock_golden_thing_admin_stub.h
+++ b/generator/integration_tests/golden/mocks/mock_golden_thing_admin_stub.h
@@ -35,12 +35,6 @@ class MockGoldenThingAdminStub
        ::google::test::admin::database::v1::ListDatabasesRequest const&),
       (override));
   MOCK_METHOD(
-      Status,
-      DoNothing,
-      (grpc::ClientContext&,
-       ::google::protobuf::Empty const&),
-      (override));
-  MOCK_METHOD(
       future<StatusOr<::google::longrunning::Operation>>, AsyncCreateDatabase,
       (google::cloud::CompletionQueue&,
        std::unique_ptr<grpc::ClientContext>,

--- a/generator/integration_tests/golden/tests/golden_kitchen_sink_stub_test.cc
+++ b/generator/integration_tests/golden/tests/golden_kitchen_sink_stub_test.cc
@@ -161,13 +161,13 @@ class MockGrpcGoldenKitchenSinkStub : public ::google::test::admin::database::
                ::google::protobuf::Empty* response),
               (override));
   MOCK_METHOD(
-      ::grpc::ClientAsyncResponseReaderInterface< ::google::protobuf::Empty>*,
+      ::grpc::ClientAsyncResponseReaderInterface<::google::protobuf::Empty>*,
       AsyncOmitted1Raw,
       (::grpc::ClientContext * context,
        ::google::protobuf::Empty const& request, ::grpc::CompletionQueue* cq),
       (override));
   MOCK_METHOD(
-      ::grpc::ClientAsyncResponseReaderInterface< ::google::protobuf::Empty>*,
+      ::grpc::ClientAsyncResponseReaderInterface<::google::protobuf::Empty>*,
       PrepareAsyncOmitted1Raw,
       (::grpc::ClientContext * context,
        ::google::protobuf::Empty const& request, ::grpc::CompletionQueue* cq),
@@ -178,13 +178,13 @@ class MockGrpcGoldenKitchenSinkStub : public ::google::test::admin::database::
                ::google::protobuf::Empty* response),
               (override));
   MOCK_METHOD(
-      ::grpc::ClientAsyncResponseReaderInterface< ::google::protobuf::Empty>*,
+      ::grpc::ClientAsyncResponseReaderInterface<::google::protobuf::Empty>*,
       AsyncOmitted2Raw,
       (::grpc::ClientContext * context,
        ::google::protobuf::Empty const& request, ::grpc::CompletionQueue* cq),
       (override));
   MOCK_METHOD(
-      ::grpc::ClientAsyncResponseReaderInterface< ::google::protobuf::Empty>*,
+      ::grpc::ClientAsyncResponseReaderInterface<::google::protobuf::Empty>*,
       PrepareAsyncOmitted2Raw,
       (::grpc::ClientContext * context,
        ::google::protobuf::Empty const& request, ::grpc::CompletionQueue* cq),
@@ -197,7 +197,6 @@ class MockGrpcGoldenKitchenSinkStub : public ::google::test::admin::database::
        ::google::test::admin::database::v1::ListServiceAccountKeysResponse*
            response),
       (override));
-
   MOCK_METHOD(
       ::grpc::ClientAsyncResponseReaderInterface<
           ::google::test::admin::database::v1::ListServiceAccountKeysResponse>*,
@@ -215,6 +214,23 @@ class MockGrpcGoldenKitchenSinkStub : public ::google::test::admin::database::
        ::google::test::admin::database::v1::ListServiceAccountKeysRequest const&
            request,
        ::grpc::CompletionQueue* cq),
+      (override));
+  MOCK_METHOD(::grpc::Status, DoNothing,
+              (::grpc::ClientContext * context,
+               ::google::protobuf::Empty const& request,
+               ::google::protobuf::Empty* response),
+              (override));
+  MOCK_METHOD(
+      ::grpc::ClientAsyncResponseReaderInterface<::google::protobuf::Empty>*,
+      AsyncDoNothingRaw,
+      (::grpc::ClientContext * context,
+       ::google::protobuf::Empty const& request, ::grpc::CompletionQueue* cq),
+      (override));
+  MOCK_METHOD(
+      ::grpc::ClientAsyncResponseReaderInterface<::google::protobuf::Empty>*,
+      PrepareAsyncDoNothingRaw,
+      (::grpc::ClientContext * context,
+       ::google::protobuf::Empty const& request, ::grpc::CompletionQueue* cq),
       (override));
 };
 

--- a/generator/integration_tests/golden/tests/golden_thing_admin_stub_test.cc
+++ b/generator/integration_tests/golden/tests/golden_thing_admin_stub_test.cc
@@ -44,6 +44,11 @@ class MockGrpcGoldenThingAdminStub : public ::google::test::admin::database::
        ::google::test::admin::database::v1::ListDatabasesRequest const& request,
        ::google::test::admin::database::v1::ListDatabasesResponse* response),
       (override));
+  MOCK_METHOD(::grpc::Status, DoNothing,
+              (::grpc::ClientContext * context,
+               ::google::protobuf::Empty const& request,
+               ::google::protobuf::Empty* response),
+              (override));
   MOCK_METHOD(::grpc::Status, CreateDatabase,
               (::grpc::ClientContext * context,
                ::google::test::admin::database::v1::CreateDatabaseRequest const&
@@ -160,6 +165,18 @@ class MockGrpcGoldenThingAdminStub : public ::google::test::admin::database::
       (::grpc::ClientContext * context,
        ::google::test::admin::database::v1::ListDatabasesRequest const& request,
        ::grpc::CompletionQueue* cq),
+      (override));
+  MOCK_METHOD(
+      ::grpc::ClientAsyncResponseReaderInterface<::google::protobuf::Empty>*,
+      AsyncDoNothingRaw,
+      (::grpc::ClientContext * context,
+       ::google::protobuf::Empty const& request, ::grpc::CompletionQueue* cq),
+      (override));
+  MOCK_METHOD(
+      ::grpc::ClientAsyncResponseReaderInterface<::google::protobuf::Empty>*,
+      PrepareAsyncDoNothingRaw,
+      (::grpc::ClientContext * context,
+       ::google::protobuf::Empty const& request, ::grpc::CompletionQueue* cq),
       (override));
   MOCK_METHOD(::grpc::ClientAsyncResponseReaderInterface<
                   ::google::longrunning::Operation>*,

--- a/generator/integration_tests/golden/tests/golden_thing_admin_stub_test.cc
+++ b/generator/integration_tests/golden/tests/golden_thing_admin_stub_test.cc
@@ -44,12 +44,11 @@ class MockGrpcGoldenThingAdminStub : public ::google::test::admin::database::
        ::google::test::admin::database::v1::ListDatabasesRequest const& request,
        ::google::test::admin::database::v1::ListDatabasesResponse* response),
       (override));
-  MOCK_METHOD(
-      ::grpc::Status, DoNothing,
-      (::grpc::ClientContext * context,
-       ::google::protobuf::Empty const& request,
-       ::google::protobuf::Empty* response),
-      (override));
+  MOCK_METHOD(::grpc::Status, DoNothing,
+              (::grpc::ClientContext * context,
+               ::google::protobuf::Empty const& request,
+               ::google::protobuf::Empty* response),
+              (override));
   MOCK_METHOD(::grpc::Status, CreateDatabase,
               (::grpc::ClientContext * context,
                ::google::test::admin::database::v1::CreateDatabaseRequest const&

--- a/generator/integration_tests/golden/tests/golden_thing_admin_stub_test.cc
+++ b/generator/integration_tests/golden/tests/golden_thing_admin_stub_test.cc
@@ -44,11 +44,6 @@ class MockGrpcGoldenThingAdminStub : public ::google::test::admin::database::
        ::google::test::admin::database::v1::ListDatabasesRequest const& request,
        ::google::test::admin::database::v1::ListDatabasesResponse* response),
       (override));
-  MOCK_METHOD(::grpc::Status, DoNothing,
-              (::grpc::ClientContext * context,
-               ::google::protobuf::Empty const& request,
-               ::google::protobuf::Empty* response),
-              (override));
   MOCK_METHOD(::grpc::Status, CreateDatabase,
               (::grpc::ClientContext * context,
                ::google::test::admin::database::v1::CreateDatabaseRequest const&
@@ -165,18 +160,6 @@ class MockGrpcGoldenThingAdminStub : public ::google::test::admin::database::
       (::grpc::ClientContext * context,
        ::google::test::admin::database::v1::ListDatabasesRequest const& request,
        ::grpc::CompletionQueue* cq),
-      (override));
-  MOCK_METHOD(
-      ::grpc::ClientAsyncResponseReaderInterface<::google::protobuf::Empty>*,
-      AsyncDoNothingRaw,
-      (::grpc::ClientContext * context,
-       ::google::protobuf::Empty const& request, ::grpc::CompletionQueue* cq),
-      (override));
-  MOCK_METHOD(
-      ::grpc::ClientAsyncResponseReaderInterface<::google::protobuf::Empty>*,
-      PrepareAsyncDoNothingRaw,
-      (::grpc::ClientContext * context,
-       ::google::protobuf::Empty const& request, ::grpc::CompletionQueue* cq),
       (override));
   MOCK_METHOD(::grpc::ClientAsyncResponseReaderInterface<
                   ::google::longrunning::Operation>*,

--- a/generator/integration_tests/golden/tests/golden_thing_admin_stub_test.cc
+++ b/generator/integration_tests/golden/tests/golden_thing_admin_stub_test.cc
@@ -44,11 +44,12 @@ class MockGrpcGoldenThingAdminStub : public ::google::test::admin::database::
        ::google::test::admin::database::v1::ListDatabasesRequest const& request,
        ::google::test::admin::database::v1::ListDatabasesResponse* response),
       (override));
-  MOCK_METHOD(::grpc::Status, DoNothing,
-              (::grpc::ClientContext * context,
-               ::google::protobuf::Empty const& request,
-               ::google::protobuf::Empty* response),
-              (override));
+  MOCK_METHOD(
+      ::grpc::Status, DoNothing,
+      (::grpc::ClientContext * context,
+       ::google::protobuf::Empty const& request,
+       ::google::protobuf::Empty* response),
+      (override));
   MOCK_METHOD(::grpc::Status, CreateDatabase,
               (::grpc::ClientContext * context,
                ::google::test::admin::database::v1::CreateDatabaseRequest const&

--- a/generator/integration_tests/test.proto
+++ b/generator/integration_tests/test.proto
@@ -63,14 +63,6 @@ service GoldenThingAdmin {
     option (google.api.method_signature) = "parent";
   }
 
-  // Does Nothing.
-  rpc DoNothing(google.protobuf.Empty) returns (google.protobuf.Empty) {
-    option (google.api.http) = {
-      get: "/v1/doNothing"
-    };
-    option (google.api.method_signature) = "";
-  }
-
   // Creates a new Cloud Test database and starts to prepare it for serving.
   // The returned [long-running operation][google.longrunning.Operation] will
   // have a name of the format `<database_name>/operations/<operation_id>` and
@@ -836,6 +828,14 @@ service GoldenKitchenSink {
       get: "/v1/{name=projects/*/serviceAccounts/*}/keys"
     };
     option (google.api.method_signature) = "name,key_types";
+  }
+
+  // Does Nothing.
+  rpc DoNothing(google.protobuf.Empty) returns (google.protobuf.Empty) {
+    option (google.api.http) = {
+      get: "/v1/doNothing"
+    };
+    option (google.api.method_signature) = "";
   }
 
 }

--- a/generator/integration_tests/test.proto
+++ b/generator/integration_tests/test.proto
@@ -63,6 +63,14 @@ service GoldenThingAdmin {
     option (google.api.method_signature) = "parent";
   }
 
+  // Does Nothing.
+  rpc DoNothing(google.protobuf.Empty) returns (google.protobuf.Empty) {
+    option (google.api.http) = {
+      get: "/v1/doNothing"
+    };
+    option (google.api.method_signature) = "";
+  }
+
   // Creates a new Cloud Test database and starts to prepare it for serving.
   // The returned [long-running operation][google.longrunning.Operation] will
   // have a name of the format `<database_name>/operations/<operation_id>` and

--- a/generator/internal/client_generator.cc
+++ b/generator/internal/client_generator.cc
@@ -120,7 +120,7 @@ Status ClientGenerator::GenerateHeader() {
     for (int i = 0; i < method_signature_extension.size(); ++i) {
       std::string method_string =
           absl::StrCat("  $method_name$($method_signature", i,
-                       "$, Options options = {});\n\n");
+                       "$Options options = {});\n\n");
       HeaderPrintMethod(
           method,
           {MethodPattern(
@@ -265,7 +265,7 @@ Status ClientGenerator::GenerateHeader() {
     for (int i = 0; i < method_signature_extension.size(); ++i) {
       std::string method_string =
           absl::StrCat("  Async$method_name$($method_signature", i,
-                       "$, Options options = {});\n\n");
+                       "$Options options = {});\n\n");
       HeaderPrintMethod(
           method,
           {MethodPattern(
@@ -358,7 +358,7 @@ Status ClientGenerator::GenerateCc() {
     for (int i = 0; i < method_signature_extension.size(); ++i) {
       std::string method_string =
           absl::StrCat("$client_class_name$::$method_name$($method_signature",
-                       i, "$, Options options) {\n");
+                       i, "$Options options) {\n");
       std::string method_request_string =
           absl::StrCat("$method_request_setters", i, "$");
       CcPrintMethod(
@@ -535,7 +535,7 @@ Status ClientGenerator::GenerateCc() {
     for (int i = 0; i < method_signature_extension.size(); ++i) {
       std::string method_string = absl::StrCat(
           "$client_class_name$::Async$method_name$($method_signature", i,
-          "$, Options options) {\n");
+          "$Options options) {\n");
       std::string method_request_string =
           absl::StrCat("$method_request_setters", i, "$");
       CcPrintMethod(

--- a/generator/internal/descriptor_utils_test.cc
+++ b/generator/internal/descriptor_utils_test.cc
@@ -415,6 +415,7 @@ char const* const kServiceProto =
     "    option (google.api.method_signature) = \"toggle\";\n"
     "    option (google.api.method_signature) = \"name,title\";\n"
     "    option (google.api.method_signature) = \"name,swallow_types\";\n"
+    "    option (google.api.method_signature) = \"\";\n"
     "  }\n"
     "  // Leading comments about rpc $Method6.\n"
     "  rpc Method6(Foo) returns (Empty) {\n"
@@ -640,22 +641,24 @@ INSTANTIATE_TEST_SUITE_P(
                              "default_idempotency", "kNonIdempotent"),
         // Method5
         MethodVarsTestValues("google.protobuf.Service.Method5",
-                             "method_signature0", "std::string const& name"),
+                             "method_signature0", "std::string const& name, "),
         MethodVarsTestValues("google.protobuf.Service.Method5",
                              "method_signature1",
                              "std::int32_t number, "
-                             "google::protobuf::Foo const& widget"),
+                             "google::protobuf::Foo const& widget, "),
         MethodVarsTestValues("google.protobuf.Service.Method5",
-                             "method_signature2", "bool toggle"),
+                             "method_signature2", "bool toggle, "),
         MethodVarsTestValues("google.protobuf.Service.Method5",
                              "method_signature3",
                              "std::string const& name, "
-                             "std::string const& title"),
+                             "std::string const& title, "),
         MethodVarsTestValues("google.protobuf.Service.Method5",
                              "method_signature4",
                              "std::string const& name, "
                              "std::vector<google::protobuf::Bar::SwallowType>"
-                             " const& swallow_types"),
+                             " const& swallow_types, "),
+        MethodVarsTestValues("google.protobuf.Service.Method5",
+                             "method_signature5", ""),
         MethodVarsTestValues("google.protobuf.Service.Method5",
                              "method_request_setters0",
                              "  request.set_name(name);\n"),
@@ -692,7 +695,7 @@ INSTANTIATE_TEST_SUITE_P(
                              "default_idempotency", "kIdempotent"),
         MethodVarsTestValues(
             "google.protobuf.Service.Method6", "method_signature0",
-            "std::map<std::string, std::string> const& labels"),
+            "std::map<std::string, std::string> const& labels, "),
         MethodVarsTestValues(
             "google.protobuf.Service.Method6", "method_request_setters0",
             "  *request.mutable_labels() = {labels.begin(), labels.end()};\n"),

--- a/generator/internal/service_code_generator.cc
+++ b/generator/internal/service_code_generator.cc
@@ -139,6 +139,7 @@ ServiceCodeGenerator::MethodSignatureWellKnownProtobufTypeIncludes() const {
     for (auto const& extension : method_signature_extension) {
       std::vector<std::string> parameters = absl::StrSplit(extension, ',');
       for (auto const& parameter : parameters) {
+        if (parameter.empty()) continue;
         auto path = IncludePathForWellKnownProtobufType(
             *input_type->FindFieldByName(parameter));
         if (path) include_paths.push_back(*path);


### PR DESCRIPTION
Fixes #7814 

If we are given an empty parameter list, generate a client method that only takes `Options`.

I tried to break the change up into useful commits for the reviewer. They are:
1. logic changes
2. output for the generated client code
3. all other generated code (noise)
4. update a mock, which I forgot to do in the first commit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7825)
<!-- Reviewable:end -->
