### PR TITLE
cleanup: prefer *_mocks for top-level Bazel rules

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -42,7 +42,7 @@ cc_library(
 )
 
 cc_library(
-    name = "experimental-assuredworkloads-mocks",
+    name = "experimental-assuredworkloads_mocks",
     deps = [
         "//google/cloud/assuredworkloads:google_cloud_cpp_assuredworkloads_mocks",
     ],
@@ -199,6 +199,15 @@ cc_library(
 
 cc_library(
     name = "iam-mocks",
+    deprecation = "please use //:iam_mocks instead.",
+    tags = ["manual"],
+    deps = [
+        "//google/cloud/iam:google_cloud_cpp_iam_mocks",
+    ],
+)
+
+cc_library(
+    name = "iam_mocks",
     deps = [
         "//google/cloud/iam:google_cloud_cpp_iam_mocks",
     ],
@@ -212,7 +221,7 @@ cc_library(
 )
 
 cc_library(
-    name = "experimental-kms-mocks",
+    name = "experimental-kms_mocks",
     deps = [
         "//google/cloud/kms:google_cloud_cpp_kms_mocks",
     ],
@@ -226,7 +235,7 @@ cc_library(
 )
 
 cc_library(
-    name = "experimental-logging-mocks",
+    name = "experimental-logging_mocks",
     deps = [
         "//google/cloud/logging:google_cloud_cpp_logging_mocks",
     ],
@@ -241,6 +250,15 @@ cc_library(
 
 cc_library(
     name = "bigquery-mocks",
+    deprecation = "please use //:bigquery_mocks instead.",
+    tags = ["manual"],
+    deps = [
+        "//google/cloud/bigquery:google_cloud_cpp_bigquery_mocks",
+    ],
+)
+
+cc_library(
+    name = "bigquery_mocks",
     deps = [
         "//google/cloud/bigquery:google_cloud_cpp_bigquery_mocks",
     ],

--- a/ci/verify_current_targets/BUILD.bazel
+++ b/ci/verify_current_targets/BUILD.bazel
@@ -21,7 +21,7 @@ CURRENT_TARGETS = [
     ":bigtable",
     ":iam",
     ":experimental-logging",
-    ":experimental-logging-mocks",
+    ":experimental-logging_mocks",
     ":pubsub",
     ":spanner",
     ":storage",


### PR DESCRIPTION
For experimental targets I just removed any `*-mocks` targets. For GA
targets I created a `*_mocks` and deprecated the `*-mocks` rule.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7831)
<!-- Reviewable:end -->
