### PR TITLE
cleanup(docs): fix some scaffolding

### DIFF
--- a/generator/internal/scaffold_generator.cc
+++ b/generator/internal/scaffold_generator.cc
@@ -577,9 +577,9 @@ An idiomatic C++ client library for
 [$title$](https://cloud.google.com/$site_root$/), a service that
 $description$
 
-This library is **experimental**. Its APIS are subject to change without notice.
+This library is **experimental**. Its APIs are subject to change without notice.
 
-This library requires a C++11 compiler, it is supported (and tested) on multiple
+This library requires a C++11 compiler. It is supported (and tested) on multiple
 Linux distributions, as well as Windows and macOS. The
 [README][github-readme] on [GitHub][github-link] provides detailed
 instructions to install the necessary dependencies, as well as how to compile
@@ -592,7 +592,7 @@ you'll need to configure your build system to discover and compile the Cloud
 C++ client libraries. In some cases your build system or package manager may
 need to download the libraries too. The Cloud C++ client libraries natively
 support [Bazel](https://bazel.build/) and [CMake](https://cmake.org/) as build
-systems. We've created a minimal, "Hello World", [quickstart][quickstart-link]
+systems. We've created a minimal, "Hello World", [quickstart][github-quickstart]
 that includes detailed instructions on how to compile the library for use in
 your application. You can fetch the source from [GitHub][github-link] as normal:
 
@@ -666,6 +666,7 @@ can override the default policies.
 <!-- The ugly %2E disables auto-linking in Doxygen -->
 [github-readme]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/$library$/README%2Emd
 [github-install]: https://github.com/googleapis/google-cloud-cpp/blob/main/doc/packaging%2Emd
+[github-quickstart]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/$library$/quickstart/README%2Emd
 
 */
 )""";
@@ -702,14 +703,12 @@ some experience as a C++ developer and that you have a working C++ toolchain
 ## Before you begin
 
 To run the quickstart examples you will need a working Google Cloud Platform
-(GCP) project, as well as a Cloud Spanner instance and database.
-The [quickstart][quickstart-link] covers the necessary
-steps in detail. Make a note of the GCP project id, the instance id, and the
-database id as you will need them below.
+(GCP) project. The [quickstart][quickstart-link] covers the necessary
+steps in detail.
 
 ## Configuring authentication for the C++ Client Library
 
-Like most Google Cloud Platform (GCP) services, Cloud Spanner requires that
+Like most Google Cloud Platform (GCP) services, $title$ requires that
 your application authenticates with the service before accessing any data. If
 you are not familiar with GCP authentication please take this opportunity to
 review the [Authentication Overview][authentication-quickstart]. This library
@@ -838,7 +837,7 @@ set GRPC_DEFAULT_SSL_ROOTS_FILE_PATH=%cd%\roots.pem
 ```
 
 [bazel-install]: https://docs.bazel.build/versions/main/install.html
-[quickstart-link]: https://cloud.google.com/$site_root$/docs
+[quickstart-link]: https://cloud.google.com/$site_root$/docs/quickstart
 [grpc-roots-pem-bug]: https://github.com/grpc/grpc/issues/16571
 [choco-cmake-link]: https://chocolatey.org/packages/cmake
 [homebrew-cmake-link]: https://formulae.brew.sh/formula/cmake

--- a/google/cloud/accessapproval/README.md
+++ b/google/cloud/accessapproval/README.md
@@ -6,7 +6,7 @@ This directory contains an idiomatic C++ client library for the
 [Access Approval API][cloud-service-docs], a service for controlling access to
 data by Google personnel.
 
-This library is **experimental**. Its APIS are subject to change without notice.
+This library is **experimental**. Its APIs are subject to change without notice.
 
 Please note that the Google Cloud C++ client libraries do **not** follow
 [Semantic Versioning](https://semver.org/).

--- a/google/cloud/accessapproval/doc/main.dox
+++ b/google/cloud/accessapproval/doc/main.dox
@@ -6,9 +6,9 @@ An idiomatic C++ client library for the
 [Access Approval API](https://cloud.google.com/access-approval/),
 a service for controlling access to data by Google personnel.
 
-This library is **experimental**. Its APIS are subject to change without notice.
+This library is **experimental**. Its APIs are subject to change without notice.
 
-This library requires a C++11 compiler, it is supported (and tested) on multiple
+This library requires a C++11 compiler. It is supported (and tested) on multiple
 Linux distributions, as well as Windows and macOS. The
 [README][github-readme] on [GitHub][github-link] provides detailed
 instructions to install the necessary dependencies, as well as how to compile
@@ -21,7 +21,7 @@ you'll need to configure your build system to discover and compile the Cloud
 C++ client libraries. In some cases your build system or package manager may
 need to download the libraries too. The Cloud C++ client libraries natively
 support [Bazel](https://bazel.build/) and [CMake](https://cmake.org/) as build
-systems. We've created a minimal, "Hello World", [quickstart][quickstart-link]
+systems. We've created a minimal, "Hello World", [quickstart][github-quickstart]
 that includes detailed instructions on how to compile the library for use in
 your application. You can fetch the source from [GitHub][github-link] as normal:
 
@@ -95,5 +95,6 @@ can override the default policies.
 <!-- The ugly %2E disables auto-linking in Doxygen -->
 [github-readme]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/accessapproval/README%2Emd
 [github-install]: https://github.com/googleapis/google-cloud-cpp/blob/main/doc/packaging%2Emd
+[github-quickstart]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/accessapproval/quickstart/README%2Emd
 
 */

--- a/google/cloud/accessapproval/quickstart/README.md
+++ b/google/cloud/accessapproval/quickstart/README.md
@@ -23,14 +23,12 @@ some experience as a C++ developer and that you have a working C++ toolchain
 ## Before you begin
 
 To run the quickstart examples you will need a working Google Cloud Platform
-(GCP) project, as well as a Cloud Spanner instance and database.
-The [quickstart][quickstart-link] covers the necessary
-steps in detail. Make a note of the GCP project id, the instance id, and the
-database id as you will need them below.
+(GCP) project. The [quickstart][quickstart-link] covers the necessary
+steps in detail.
 
 ## Configuring authentication for the C++ Client Library
 
-Like most Google Cloud Platform (GCP) services, Cloud Spanner requires that
+Like most Google Cloud Platform (GCP) services, Access Approval requires that
 your application authenticates with the service before accessing any data. If
 you are not familiar with GCP authentication please take this opportunity to
 review the [Authentication Overview][authentication-quickstart]. This library
@@ -159,7 +157,7 @@ set GRPC_DEFAULT_SSL_ROOTS_FILE_PATH=%cd%\roots.pem
 ```
 
 [bazel-install]: https://docs.bazel.build/versions/main/install.html
-[quickstart-link]: https://cloud.google.com/access-approval/docs
+[quickstart-link]: https://cloud.google.com/access-approval/docs/quickstart
 [grpc-roots-pem-bug]: https://github.com/grpc/grpc/issues/16571
 [choco-cmake-link]: https://chocolatey.org/packages/cmake
 [homebrew-cmake-link]: https://formulae.brew.sh/formula/cmake

--- a/google/cloud/assuredworkloads/README.md
+++ b/google/cloud/assuredworkloads/README.md
@@ -6,7 +6,7 @@ This directory contains an idiomatic C++ client library for
 [Assured Workloads API][cloud-service-docs], a service to accelerate your path
 to running more secure and compliant workloads on Google Cloud.
 
-This library is **experimental**. Its APIS are subject to change without notice.
+This library is **experimental**. Its APIs are subject to change without notice.
 
 Please note that the Google Cloud C++ client libraries do **not** follow
 [Semantic Versioning](https://semver.org/).

--- a/google/cloud/assuredworkloads/doc/main.dox
+++ b/google/cloud/assuredworkloads/doc/main.dox
@@ -7,9 +7,9 @@ An idiomatic C++ client library for
 to accelerate your path to running more secure and compliant workloads on Google
 Cloud.
 
-This library is **experimental**. Its APIS are subject to change without notice.
+This library is **experimental**. Its APIs are subject to change without notice.
 
-This library requires a C++11 compiler, it is supported (and tested) on multiple
+This library requires a C++11 compiler. It is supported (and tested) on multiple
 Linux distributions, as well as Windows and macOS. The
 [README][github-readme] on [GitHub][github-link] provides detailed
 instructions to install the necessary dependencies, as well as how to compile
@@ -22,7 +22,7 @@ you'll need to configure your build system to discover and compile the Cloud
 C++ client libraries. In some cases your build system or package manager may
 need to download the libraries too. The Cloud C++ client libraries natively
 support [Bazel](https://bazel.build/) and [CMake](https://cmake.org/) as build
-systems. We've created a minimal, "Hello World", [quickstart][quickstart-link]
+systems. We've created a minimal, "Hello World", [quickstart][github-quickstart]
 that includes detailed instructions on how to compile the library for use in
 your application. You can fetch the source from [GitHub][github-link] as normal:
 
@@ -96,5 +96,6 @@ can override the default policies.
 <!-- The ugly %2E disables auto-linking in Doxygen -->
 [github-readme]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/assuredworkloads/README%2Emd
 [github-install]: https://github.com/googleapis/google-cloud-cpp/blob/main/doc/packaging%2Emd
+[github-quickstart]: https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/assuredworkloads/quickstart/README%2Emd
 
 */

--- a/google/cloud/assuredworkloads/quickstart/README.md
+++ b/google/cloud/assuredworkloads/quickstart/README.md
@@ -23,14 +23,12 @@ some experience as a C++ developer and that you have a working C++ toolchain
 ## Before you begin
 
 To run the quickstart examples you will need a working Google Cloud Platform
-(GCP) project, as well as a Cloud Spanner instance and database.
-The [quickstart][quickstart-link] covers the necessary
-steps in detail. Make a note of the GCP project id, the instance id, and the
-database id as you will need them below.
+(GCP) project. The [quickstart][quickstart-link] covers the necessary
+steps in detail.
 
 ## Configuring authentication for the C++ Client Library
 
-Like most Google Cloud Platform (GCP) services, Cloud Spanner requires that
+Like most Google Cloud Platform (GCP) services, Assured Workloads requires that
 your application authenticates with the service before accessing any data. If
 you are not familiar with GCP authentication please take this opportunity to
 review the [Authentication Overview][authentication-quickstart]. This library
@@ -159,7 +157,7 @@ set GRPC_DEFAULT_SSL_ROOTS_FILE_PATH=%cd%\roots.pem
 ```
 
 [bazel-install]: https://docs.bazel.build/versions/main/install.html
-[quickstart-link]: https://cloud.google.com/assuredworkloads/docs
+[quickstart-link]: https://cloud.google.com/assuredworkloads/docs/how-to-get-started
 [grpc-roots-pem-bug]: https://github.com/grpc/grpc/issues/16571
 [choco-cmake-link]: https://chocolatey.org/packages/cmake
 [homebrew-cmake-link]: https://formulae.brew.sh/formula/cmake

--- a/google/cloud/kms/README.md
+++ b/google/cloud/kms/README.md
@@ -7,7 +7,7 @@ This directory contains an idiomatic C++ client library for
 keys and performs cryptographic operations in a central cloud service, for
 direct use by other cloud resources and applications.
 
-This library is **experimental**. Its APIS are subject to change without notice.
+This library is **experimental**. Its APIs are subject to change without notice.
 
 Please note that the Google Cloud C++ client libraries do **not** follow
 [Semantic Versioning](https://semver.org/).

--- a/google/cloud/kms/doc/main.dox
+++ b/google/cloud/kms/doc/main.dox
@@ -7,9 +7,9 @@ An idiomatic C++ client library for
 that manages keys and performs cryptographic operations in a central cloud
 service, for direct use by other cloud resources and applications.
 
-This library is **experimental**. Its APIS are subject to change without notice.
+This library is **experimental**. Its APIs are subject to change without notice.
 
-This library requires a C++11 compiler, it is supported (and tested) on multiple
+This library requires a C++11 compiler. It is supported (and tested) on multiple
 Linux distributions, as well as Windows and macOS. The
 [README][github-readme] on [GitHub][github-link] provides detailed
 instructions to install the necessary dependencies, as well as how to compile
@@ -22,7 +22,7 @@ you'll need to configure your build system to discover and compile the Cloud
 C++ client libraries. In some cases your build system or package manager may
 need to download the libraries too. The Cloud C++ client libraries natively
 support [Bazel](https://bazel.build/) and [CMake](https://cmake.org/) as build
-systems. We've created a minimal, "Hello World", [quickstart][quickstart-link]
+systems. We've created a minimal, "Hello World", [quickstart][github-quickstart]
 that includes detailed instructions on how to compile the library for use in
 your application. You can fetch the source from [GitHub][github-link] as normal:
 
@@ -96,5 +96,6 @@ can override the default policies.
 <!-- The ugly %2E disables auto-linking in Doxygen -->
 [github-readme]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/kms/README%2Emd
 [github-install]: https://github.com/googleapis/google-cloud-cpp/blob/main/doc/packaging%2Emd
+[github-quickstart]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/kms/quickstart/README%2Emd
 
 */

--- a/google/cloud/kms/quickstart/README.md
+++ b/google/cloud/kms/quickstart/README.md
@@ -23,14 +23,12 @@ some experience as a C++ developer and that you have a working C++ toolchain
 ## Before you begin
 
 To run the quickstart examples you will need a working Google Cloud Platform
-(GCP) project, as well as a Cloud Spanner instance and database.
-The [quickstart][quickstart-link] covers the necessary
-steps in detail. Make a note of the GCP project id, the instance id, and the
-database id as you will need them below.
+(GCP) project. The [quickstart][quickstart-link] covers the necessary
+steps in detail.
 
 ## Configuring authentication for the C++ Client Library
 
-Like most Google Cloud Platform (GCP) services, Cloud Spanner requires that
+Like most Google Cloud Platform (GCP) services, Cloud KMS requires that
 your application authenticates with the service before accessing any data. If
 you are not familiar with GCP authentication please take this opportunity to
 review the [Authentication Overview][authentication-quickstart]. This library
@@ -159,7 +157,7 @@ set GRPC_DEFAULT_SSL_ROOTS_FILE_PATH=%cd%\roots.pem
 ```
 
 [bazel-install]: https://docs.bazel.build/versions/main/install.html
-[quickstart-link]: https://cloud.google.com/kms/docs
+[quickstart-link]: https://cloud.google.com/kms/docs/quickstart
 [grpc-roots-pem-bug]: https://github.com/grpc/grpc/issues/16571
 [choco-cmake-link]: https://chocolatey.org/packages/cmake
 [homebrew-cmake-link]: https://formulae.brew.sh/formula/cmake

--- a/google/cloud/logging/README.md
+++ b/google/cloud/logging/README.md
@@ -6,7 +6,7 @@ This directory contains an idiomatic C++ client library for interacting with
 [Cloud Logging](https://cloud.google.com/logging/),
 a service for real-time log management and analysis at scale.
 
-This library is **experimental**. Its APIS are subject to change without notice.
+This library is **experimental**. Its APIs are subject to change without notice.
 
 Please note that the Google Cloud C++ client libraries do **not** follow
 [Semantic Versioning](https://semver.org/).

--- a/google/cloud/logging/doc/main.dox
+++ b/google/cloud/logging/doc/main.dox
@@ -6,9 +6,9 @@ An idiomatic C++ client library for
 [Cloud Logging API](https://cloud.google.com/logging/), a service that writes
 log entries and manages your Cloud Logging configuration.
 
-This library is **experimental**. Its APIS are subject to change without notice.
+This library is **experimental**. Its APIs are subject to change without notice.
 
-This library requires a C++11 compiler, it is supported (and tested) on multiple
+This library requires a C++11 compiler. It is supported (and tested) on multiple
 Linux distributions, as well as Windows and macOS. The
 [README][github-readme] on [GitHub][github-link] provides detailed
 instructions to install the necessary dependencies, as well as how to compile
@@ -21,7 +21,7 @@ you'll need to configure your build system to discover and compile the Cloud
 C++ client libraries. In some cases your build system or package manager may
 need to download the libraries too. The Cloud C++ client libraries natively
 support [Bazel](https://bazel.build/) and [CMake](https://cmake.org/) as build
-systems. We've created a minimal, "Hello World", [quickstart][quickstart-link]
+systems. We've created a minimal, "Hello World", [quickstart][github-quickstart]
 that includes detailed instructions on how to compile the library for use in
 your application. You can fetch the source from [GitHub][github-link] as normal:
 
@@ -95,5 +95,6 @@ can override the default policies.
 <!-- The ugly %2E disables auto-linking in Doxygen -->
 [github-readme]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/logging/README%2Emd
 [github-install]: https://github.com/googleapis/google-cloud-cpp/blob/main/doc/packaging%2Emd
+[github-quickstart]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/logging/quickstart/README%2Emd
 
 */

--- a/google/cloud/logging/quickstart/README.md
+++ b/google/cloud/logging/quickstart/README.md
@@ -23,14 +23,12 @@ some experience as a C++ developer and that you have a working C++ toolchain
 ## Before you begin
 
 To run the quickstart examples you will need a working Google Cloud Platform
-(GCP) project, as well as a Cloud Spanner instance and database.
-The [quickstart][quickstart-link] covers the necessary
-steps in detail. Make a note of the GCP project id, the instance id, and the
-database id as you will need them below.
+(GCP) project. The [quickstart][quickstart-link] covers the necessary
+steps in detail.
 
 ## Configuring authentication for the C++ Client Library
 
-Like most Google Cloud Platform (GCP) services, Cloud Spanner requires that
+Like most Google Cloud Platform (GCP) services, Cloud Logging requires that
 your application authenticates with the service before accessing any data. If
 you are not familiar with GCP authentication please take this opportunity to
 review the [Authentication Overview][authentication-quickstart]. This library
@@ -159,7 +157,7 @@ set GRPC_DEFAULT_SSL_ROOTS_FILE_PATH=%cd%\roots.pem
 ```
 
 [bazel-install]: https://docs.bazel.build/versions/main/install.html
-[quickstart-link]: https://cloud.google.com/logging/docs
+[quickstart-link]: https://cloud.google.com/logging/docs/quickstart
 [grpc-roots-pem-bug]: https://github.com/grpc/grpc/issues/16571
 [choco-cmake-link]: https://chocolatey.org/packages/cmake
 [homebrew-cmake-link]: https://formulae.brew.sh/formula/cmake

--- a/google/cloud/pubsublite/README.md
+++ b/google/cloud/pubsublite/README.md
@@ -7,7 +7,7 @@ This directory contains an idiomatic C++ client library for
 messaging service built for very low cost of operation by offering zonal storage
 and pre-provisioned capacity.
 
-This library is **experimental**. Its APIS are subject to change without notice.
+This library is **experimental**. Its APIs are subject to change without notice.
 
 Please note that the Google Cloud C++ client libraries do **not** follow
 [Semantic Versioning](https://semver.org/).

--- a/google/cloud/pubsublite/doc/main.dox
+++ b/google/cloud/pubsublite/doc/main.dox
@@ -7,9 +7,9 @@ An idiomatic C++ client library for
 messaging service built for very low cost of operation by offering zonal storage
 and pre-provisioned capacity.
 
-This library is **experimental**. Its APIS are subject to change without notice.
+This library is **experimental**. Its APIs are subject to change without notice.
 
-This library requires a C++11 compiler, it is supported (and tested) on multiple
+This library requires a C++11 compiler. It is supported (and tested) on multiple
 Linux distributions, as well as Windows and macOS. The
 [README][github-readme] on [GitHub][github-link] provides detailed
 instructions to install the necessary dependencies, as well as how to compile
@@ -22,7 +22,7 @@ you'll need to configure your build system to discover and compile the Cloud
 C++ client libraries. In some cases your build system or package manager may
 need to download the libraries too. The Cloud C++ client libraries natively
 support [Bazel](https://bazel.build/) and [CMake](https://cmake.org/) as build
-systems. We've created a minimal, "Hello World", [quickstart][quickstart-link]
+systems. We've created a minimal, "Hello World", [quickstart][github-quickstart]
 that includes detailed instructions on how to compile the library for use in
 your application. You can fetch the source from [GitHub][github-link] as normal:
 
@@ -96,5 +96,6 @@ can override the default policies.
 <!-- The ugly %2E disables auto-linking in Doxygen -->
 [github-readme]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/pubsublite/README%2Emd
 [github-install]: https://github.com/googleapis/google-cloud-cpp/blob/main/doc/packaging%2Emd
+[github-quickstart]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/pubsublite/quickstart/README%2Emd
 
 */

--- a/google/cloud/pubsublite/quickstart/README.md
+++ b/google/cloud/pubsublite/quickstart/README.md
@@ -23,14 +23,12 @@ some experience as a C++ developer and that you have a working C++ toolchain
 ## Before you begin
 
 To run the quickstart examples you will need a working Google Cloud Platform
-(GCP) project, as well as a Cloud Spanner instance and database.
-The [quickstart][quickstart-link] covers the necessary
-steps in detail. Make a note of the GCP project id, the instance id, and the
-database id as you will need them below.
+(GCP) project. The [quickstart][quickstart-link] covers the necessary
+steps in detail.
 
 ## Configuring authentication for the C++ Client Library
 
-Like most Google Cloud Platform (GCP) services, Cloud Spanner requires that
+Like most Google Cloud Platform (GCP) services, Pub/Sub Lite requires that
 your application authenticates with the service before accessing any data. If
 you are not familiar with GCP authentication please take this opportunity to
 review the [Authentication Overview][authentication-quickstart]. This library
@@ -159,7 +157,7 @@ set GRPC_DEFAULT_SSL_ROOTS_FILE_PATH=%cd%\roots.pem
 ```
 
 [bazel-install]: https://docs.bazel.build/versions/main/install.html
-[quickstart-link]: https://cloud.google.com/pubsublite/docs
+[quickstart-link]: https://cloud.google.com/pubsub/lite/docs/quickstart
 [grpc-roots-pem-bug]: https://github.com/grpc/grpc/issues/16571
 [choco-cmake-link]: https://chocolatey.org/packages/cmake
 [homebrew-cmake-link]: https://formulae.brew.sh/formula/cmake

--- a/google/cloud/scheduler/README.md
+++ b/google/cloud/scheduler/README.md
@@ -6,7 +6,7 @@ This directory contains an idiomatic C++ client library for
 [Cloud Scheduler][cloud-service-docs], a service that creates and manages jobs
 run on a regular recurring schedule.
 
-This library is **experimental**. Its APIS are subject to change without notice.
+This library is **experimental**. Its APIs are subject to change without notice.
 
 Please note that the Google Cloud C++ client libraries do **not** follow
 [Semantic Versioning](https://semver.org/).

--- a/google/cloud/scheduler/doc/main.dox
+++ b/google/cloud/scheduler/doc/main.dox
@@ -6,9 +6,9 @@ An idiomatic C++ client library for
 [Cloud Scheduler](https://cloud.google.com/scheduler/), a service that
 creates and manages jobs run on a regular recurring schedule.
 
-This library is **experimental**. Its APIS are subject to change without notice.
+This library is **experimental**. Its APIs are subject to change without notice.
 
-This library requires a C++11 compiler, it is supported (and tested) on multiple
+This library requires a C++11 compiler. It is supported (and tested) on multiple
 Linux distributions, as well as Windows and macOS. The
 [README][github-readme] on [GitHub][github-link] provides detailed
 instructions to install the necessary dependencies, as well as how to compile
@@ -21,7 +21,7 @@ you'll need to configure your build system to discover and compile the Cloud
 C++ client libraries. In some cases your build system or package manager may
 need to download the libraries too. The Cloud C++ client libraries natively
 support [Bazel](https://bazel.build/) and [CMake](https://cmake.org/) as build
-systems. We've created a minimal, "Hello World", [quickstart][quickstart-link]
+systems. We've created a minimal, "Hello World", [quickstart][github-quickstart]
 that includes detailed instructions on how to compile the library for use in
 your application. You can fetch the source from [GitHub][github-link] as normal:
 
@@ -95,5 +95,6 @@ can override the default policies.
 <!-- The ugly %2E disables auto-linking in Doxygen -->
 [github-readme]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/scheduler/README%2Emd
 [github-install]: https://github.com/googleapis/google-cloud-cpp/blob/main/doc/packaging%2Emd
+[github-quickstart]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/scheduler/quickstart/README%2Emd
 
 */

--- a/google/cloud/scheduler/quickstart/README.md
+++ b/google/cloud/scheduler/quickstart/README.md
@@ -23,14 +23,12 @@ some experience as a C++ developer and that you have a working C++ toolchain
 ## Before you begin
 
 To run the quickstart examples you will need a working Google Cloud Platform
-(GCP) project, as well as a Cloud Spanner instance and database.
-The [quickstart][quickstart-link] covers the necessary
-steps in detail. Make a note of the GCP project id, the instance id, and the
-database id as you will need them below.
+(GCP) project. The [quickstart][quickstart-link] covers the necessary
+steps in detail.
 
 ## Configuring authentication for the C++ Client Library
 
-Like most Google Cloud Platform (GCP) services, Cloud Spanner requires that
+Like most Google Cloud Platform (GCP) services, Cloud Scheduler requires that
 your application authenticates with the service before accessing any data. If
 you are not familiar with GCP authentication please take this opportunity to
 review the [Authentication Overview][authentication-quickstart]. This library
@@ -159,7 +157,7 @@ set GRPC_DEFAULT_SSL_ROOTS_FILE_PATH=%cd%\roots.pem
 ```
 
 [bazel-install]: https://docs.bazel.build/versions/main/install.html
-[quickstart-link]: https://cloud.google.com/scheduler/docs
+[quickstart-link]: https://cloud.google.com/scheduler/docs/quickstart
 [grpc-roots-pem-bug]: https://github.com/grpc/grpc/issues/16571
 [choco-cmake-link]: https://chocolatey.org/packages/cmake
 [homebrew-cmake-link]: https://formulae.brew.sh/formula/cmake

--- a/google/cloud/secretmanager/doc/main.dox
+++ b/google/cloud/secretmanager/doc/main.dox
@@ -6,9 +6,9 @@ An idiomatic C++ client library for
 [Secret Manager API](https://cloud.google.com/secretmanager/), a service that
 stores sensitive data such as API keys, passwords, and certificates.
 
-This library is **experimental**. Its APIS are subject to change without notice.
+This library is **experimental**. Its APIs are subject to change without notice.
 
-This library requires a C++11 compiler, it is supported (and tested) on multiple
+This library requires a C++11 compiler. It is supported (and tested) on multiple
 Linux distributions, as well as Windows and macOS. The
 [README][github-readme] on [GitHub][github-link] provides detailed
 instructions to install the necessary dependencies, as well as how to compile
@@ -21,7 +21,7 @@ you'll need to configure your build system to discover and compile the Cloud
 C++ client libraries. In some cases your build system or package manager may
 need to download the libraries too. The Cloud C++ client libraries natively
 support [Bazel](https://bazel.build/) and [CMake](https://cmake.org/) as build
-systems. We've created a minimal, "Hello World", [quickstart][quickstart-link]
+systems. We've created a minimal, "Hello World", [quickstart][github-quickstart]
 that includes detailed instructions on how to compile the library for use in
 your application. You can fetch the source from [GitHub][github-link] as normal:
 
@@ -95,5 +95,6 @@ can override the default policies.
 <!-- The ugly %2E disables auto-linking in Doxygen -->
 [github-readme]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/secretmanager/README%2Emd
 [github-install]: https://github.com/googleapis/google-cloud-cpp/blob/main/doc/packaging%2Emd
+[github-quickstart]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/secretmanager/quickstart/README%2Emd
 
 */

--- a/google/cloud/secretmanager/quickstart/README.md
+++ b/google/cloud/secretmanager/quickstart/README.md
@@ -23,14 +23,12 @@ some experience as a C++ developer and that you have a working C++ toolchain
 ## Before you begin
 
 To run the quickstart examples you will need a working Google Cloud Platform
-(GCP) project, as well as a Cloud Spanner instance and database.
-The [quickstart][quickstart-link] covers the necessary
-steps in detail. Make a note of the GCP project id, the instance id, and the
-database id as you will need them below.
+(GCP) project. The [quickstart][quickstart-link] covers the necessary
+steps in detail.
 
 ## Configuring authentication for the C++ Client Library
 
-Like most Google Cloud Platform (GCP) services, Cloud Spanner requires that
+Like most Google Cloud Platform (GCP) services, Secret Manager requires that
 your application authenticates with the service before accessing any data. If
 you are not familiar with GCP authentication please take this opportunity to
 review the [Authentication Overview][authentication-quickstart]. This library
@@ -159,7 +157,7 @@ set GRPC_DEFAULT_SSL_ROOTS_FILE_PATH=%cd%\roots.pem
 ```
 
 [bazel-install]: https://docs.bazel.build/versions/main/install.html
-[quickstart-link]: https://cloud.google.com/secretmanager/docs
+[quickstart-link]: https://cloud.google.com/secret-manager/docs/quickstart
 [grpc-roots-pem-bug]: https://github.com/grpc/grpc/issues/16571
 [choco-cmake-link]: https://chocolatey.org/packages/cmake
 [homebrew-cmake-link]: https://formulae.brew.sh/formula/cmake

--- a/google/cloud/spanner/doc/spanner-main.dox
+++ b/google/cloud/spanner/doc/spanner-main.dox
@@ -5,7 +5,7 @@
 The Cloud Spanner C++ Client library offers types and functions to use Cloud
 Spanner from C++11 applications.
 
-This library requires a C++11 compiler, it is supported (and tested) on multiple
+This library requires a C++11 compiler. It is supported (and tested) on multiple
 Linux distributions.
 
 ## Quickstart

--- a/google/cloud/storage/doc/storage-main.dox
+++ b/google/cloud/storage/doc/storage-main.dox
@@ -11,7 +11,7 @@ read and modify the metadata associated with objects and buckets, configure
 encryption keys, configure notifications via Cloud Pub/Sub, and change the
 access control list of object or buckets.
 
-This library requires a C++11 compiler, it is supported (and tested) on multiple
+This library requires a C++11 compiler. It is supported (and tested) on multiple
 Linux distributions, as well as Windows and macOS. The
 [README][github-readme] on [GitHub][github-link] provides detailed
 instructions to install the necessary dependencies, as well as how to compile

--- a/google/cloud/tasks/doc/main.dox
+++ b/google/cloud/tasks/doc/main.dox
@@ -6,9 +6,9 @@ An idiomatic C++ client library for
 [Cloud Tasks API](https://cloud.google.com/tasks/), a service that
 manages the execution of large numbers of distributed requests.
 
-This library is **experimental**. Its APIS are subject to change without notice.
+This library is **experimental**. Its APIs are subject to change without notice.
 
-This library requires a C++11 compiler, it is supported (and tested) on multiple
+This library requires a C++11 compiler. It is supported (and tested) on multiple
 Linux distributions, as well as Windows and macOS. The
 [README][github-readme] on [GitHub][github-link] provides detailed
 instructions to install the necessary dependencies, as well as how to compile
@@ -21,7 +21,7 @@ you'll need to configure your build system to discover and compile the Cloud
 C++ client libraries. In some cases your build system or package manager may
 need to download the libraries too. The Cloud C++ client libraries natively
 support [Bazel](https://bazel.build/) and [CMake](https://cmake.org/) as build
-systems. We've created a minimal, "Hello World", [quickstart][quickstart-link]
+systems. We've created a minimal, "Hello World", [quickstart][github-quickstart]
 that includes detailed instructions on how to compile the library for use in
 your application. You can fetch the source from [GitHub][github-link] as normal:
 
@@ -95,5 +95,6 @@ can override the default policies.
 <!-- The ugly %2E disables auto-linking in Doxygen -->
 [github-readme]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/tasks/README%2Emd
 [github-install]: https://github.com/googleapis/google-cloud-cpp/blob/main/doc/packaging%2Emd
+[github-quickstart]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/tasks/quickstart/README%2Emd
 
 */

--- a/google/cloud/tasks/quickstart/README.md
+++ b/google/cloud/tasks/quickstart/README.md
@@ -23,14 +23,12 @@ some experience as a C++ developer and that you have a working C++ toolchain
 ## Before you begin
 
 To run the quickstart examples you will need a working Google Cloud Platform
-(GCP) project, as well as a Cloud Spanner instance and database.
-The [quickstart][quickstart-link] covers the necessary
-steps in detail. Make a note of the GCP project id, the instance id, and the
-database id as you will need them below.
+(GCP) project. The [quickstart][quickstart-link] covers the necessary
+steps in detail.
 
 ## Configuring authentication for the C++ Client Library
 
-Like most Google Cloud Platform (GCP) services, Cloud Spanner requires that
+Like most Google Cloud Platform (GCP) services, Cloud Tasks requires that
 your application authenticates with the service before accessing any data. If
 you are not familiar with GCP authentication please take this opportunity to
 review the [Authentication Overview][authentication-quickstart]. This library
@@ -159,7 +157,7 @@ set GRPC_DEFAULT_SSL_ROOTS_FILE_PATH=%cd%\roots.pem
 ```
 
 [bazel-install]: https://docs.bazel.build/versions/main/install.html
-[quickstart-link]: https://cloud.google.com/tasks/docs
+[quickstart-link]: https://cloud.google.com/tasks/docs/quickstart
 [grpc-roots-pem-bug]: https://github.com/grpc/grpc/issues/16571
 [choco-cmake-link]: https://chocolatey.org/packages/cmake
 [homebrew-cmake-link]: https://formulae.brew.sh/formula/cmake

--- a/google/cloud/websecurityscanner/README.md
+++ b/google/cloud/websecurityscanner/README.md
@@ -6,7 +6,7 @@ This directory contains an idiomatic C++ client library for
 [Web Security Scanner][cloud-service-docs], a service that scans your
 Compute and App Engine apps for common web vulnerabilities.
 
-This library is **experimental**. Its APIS are subject to change without notice.
+This library is **experimental**. Its APIs are subject to change without notice.
 
 Please note that the Google Cloud C++ client libraries do **not** follow
 [Semantic Versioning](https://semver.org/).

--- a/google/cloud/websecurityscanner/doc/main.dox
+++ b/google/cloud/websecurityscanner/doc/main.dox
@@ -7,9 +7,9 @@ An idiomatic C++ client library for
 service that scans your Compute and App Engine apps for common web
 vulnerabilities.
 
-This library is **experimental**. Its APIS are subject to change without notice.
+This library is **experimental**. Its APIs are subject to change without notice.
 
-This library requires a C++11 compiler, it is supported (and tested) on multiple
+This library requires a C++11 compiler. It is supported (and tested) on multiple
 Linux distributions, as well as Windows and macOS. The
 [README][github-readme] on [GitHub][github-link] provides detailed
 instructions to install the necessary dependencies, as well as how to compile
@@ -22,7 +22,7 @@ you'll need to configure your build system to discover and compile the Cloud
 C++ client libraries. In some cases your build system or package manager may
 need to download the libraries too. The Cloud C++ client libraries natively
 support [Bazel](https://bazel.build/) and [CMake](https://cmake.org/) as build
-systems. We've created a minimal, "Hello World", [quickstart][quickstart-link]
+systems. We've created a minimal, "Hello World", [quickstart][github-quickstart]
 that includes detailed instructions on how to compile the library for use in
 your application. You can fetch the source from [GitHub][github-link] as normal:
 
@@ -96,5 +96,6 @@ can override the default policies.
 <!-- The ugly %2E disables auto-linking in Doxygen -->
 [github-readme]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/websecurityscanner/README%2Emd
 [github-install]: https://github.com/googleapis/google-cloud-cpp/blob/main/doc/packaging%2Emd
+[github-quickstart]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/websecurityscanner/quickstart/README%2Emd
 
 */

--- a/google/cloud/websecurityscanner/quickstart/README.md
+++ b/google/cloud/websecurityscanner/quickstart/README.md
@@ -23,14 +23,12 @@ some experience as a C++ developer and that you have a working C++ toolchain
 ## Before you begin
 
 To run the quickstart examples you will need a working Google Cloud Platform
-(GCP) project, as well as a Cloud Spanner instance and database.
-The [quickstart][quickstart-link] covers the necessary
-steps in detail. Make a note of the GCP project id, the instance id, and the
-database id as you will need them below.
+(GCP) project. The [quickstart][quickstart-link] covers the necessary
+steps in detail.
 
 ## Configuring authentication for the C++ Client Library
 
-Like most Google Cloud Platform (GCP) services, Cloud Spanner requires that
+Like most Google Cloud Platform (GCP) services, Web Security Scanner requires that
 your application authenticates with the service before accessing any data. If
 you are not familiar with GCP authentication please take this opportunity to
 review the [Authentication Overview][authentication-quickstart]. This library
@@ -159,7 +157,7 @@ set GRPC_DEFAULT_SSL_ROOTS_FILE_PATH=%cd%\roots.pem
 ```
 
 [bazel-install]: https://docs.bazel.build/versions/main/install.html
-[quickstart-link]: https://cloud.google.com/security-command-center``/docs
+[quickstart-link]: https://cloud.google.com/security-command-center/docs/quickstart
 [grpc-roots-pem-bug]: https://github.com/grpc/grpc/issues/16571
 [choco-cmake-link]: https://chocolatey.org/packages/cmake
 [homebrew-cmake-link]: https://formulae.brew.sh/formula/cmake

--- a/google/cloud/workflows/README.md
+++ b/google/cloud/workflows/README.md
@@ -6,7 +6,7 @@ This directory contains an idiomatic C++ client library for the
 [Workflows API][cloud-service-docs], a service to orchestrate and automate
 Google Cloud and HTTP-based API services with serverless workflows.
 
-This library is **experimental**. Its APIS are subject to change without notice.
+This library is **experimental**. Its APIs are subject to change without notice.
 
 Please note that the Google Cloud C++ client libraries do **not** follow
 [Semantic Versioning](https://semver.org/).

--- a/google/cloud/workflows/doc/main.dox
+++ b/google/cloud/workflows/doc/main.dox
@@ -6,9 +6,9 @@ An idiomatic C++ client library for
 [Workflows API](https://cloud.google.com/workflows/), a service to orchestrate
 and automate Google Cloud and HTTP-based API services with serverless workflows.
 
-This library is **experimental**. Its APIS are subject to change without notice.
+This library is **experimental**. Its APIs are subject to change without notice.
 
-This library requires a C++11 compiler, it is supported (and tested) on multiple
+This library requires a C++11 compiler. It is supported (and tested) on multiple
 Linux distributions, as well as Windows and macOS. The
 [README][github-readme] on [GitHub][github-link] provides detailed
 instructions to install the necessary dependencies, as well as how to compile
@@ -21,7 +21,7 @@ you'll need to configure your build system to discover and compile the Cloud
 C++ client libraries. In some cases your build system or package manager may
 need to download the libraries too. The Cloud C++ client libraries natively
 support [Bazel](https://bazel.build/) and [CMake](https://cmake.org/) as build
-systems. We've created a minimal, "Hello World", [quickstart][quickstart-link]
+systems. We've created a minimal, "Hello World", [quickstart][github-quickstart]
 that includes detailed instructions on how to compile the library for use in
 your application. You can fetch the source from [GitHub][github-link] as normal:
 
@@ -95,5 +95,6 @@ can override the default policies.
 <!-- The ugly %2E disables auto-linking in Doxygen -->
 [github-readme]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/workflows/README%2Emd
 [github-install]: https://github.com/googleapis/google-cloud-cpp/blob/main/doc/packaging%2Emd
+[github-quickstart]:  https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/workflows/quickstart/README%2Emd
 
 */

--- a/google/cloud/workflows/quickstart/README.md
+++ b/google/cloud/workflows/quickstart/README.md
@@ -23,14 +23,12 @@ some experience as a C++ developer and that you have a working C++ toolchain
 ## Before you begin
 
 To run the quickstart examples you will need a working Google Cloud Platform
-(GCP) project, as well as a Cloud Spanner instance and database.
-The [quickstart][quickstart-link] covers the necessary
-steps in detail. Make a note of the GCP project id, the instance id, and the
-database id as you will need them below.
+(GCP) project. The [quickstart][quickstart-link] covers the necessary
+steps in detail.
 
 ## Configuring authentication for the C++ Client Library
 
-Like most Google Cloud Platform (GCP) services, Cloud Spanner requires that
+Like most Google Cloud Platform (GCP) services, Workflows requires that
 your application authenticates with the service before accessing any data. If
 you are not familiar with GCP authentication please take this opportunity to
 review the [Authentication Overview][authentication-quickstart]. This library
@@ -159,7 +157,7 @@ set GRPC_DEFAULT_SSL_ROOTS_FILE_PATH=%cd%\roots.pem
 ```
 
 [bazel-install]: https://docs.bazel.build/versions/main/install.html
-[quickstart-link]: https://cloud.google.com/workflows/docs
+[quickstart-link]: https://cloud.google.com/workflows/docs/quickstarts
 [grpc-roots-pem-bug]: https://github.com/grpc/grpc/issues/16571
 [choco-cmake-link]: https://chocolatey.org/packages/cmake
 [homebrew-cmake-link]: https://formulae.brew.sh/formula/cmake


### PR DESCRIPTION
Some references to Spanner had been copied a bunch in our generated READMEs.

The quickstart linked from the `main.dox` files, was missing. I set it to point to the library's `quickstart/README.md` on github.

The GCP quickstarts linked from our quickstart's READMEs were checked manually.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7834)
<!-- Reviewable:end -->
