### PR TITLE
impl(common): add an (internal) option to setup grpc::ClientContext

### DIFF
--- a/google/cloud/grpc_options.cc
+++ b/google/cloud/grpc_options.cc
@@ -22,6 +22,18 @@ namespace cloud {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace internal {
 
+void ConfigureContext(grpc::ClientContext& context, Options const& opts) {
+  if (opts.has<GrpcSetupOption>()) {
+    opts.get<GrpcSetupOption>()(context);
+  }
+}
+
+void ConfigurePollContext(grpc::ClientContext& context, Options const& opts) {
+  if (opts.has<GrpcSetupPollOption>()) {
+    opts.get<GrpcSetupPollOption>()(context);
+  }
+}
+
 grpc::ChannelArguments MakeChannelArguments(Options const& opts) {
   auto channel_arguments = opts.get<GrpcChannelArgumentsNativeOption>();
   for (auto const& p : opts.get<GrpcChannelArgumentsOption>()) {

--- a/google/cloud/grpc_options.h
+++ b/google/cloud/grpc_options.h
@@ -157,6 +157,42 @@ using GrpcOptionList =
 
 namespace internal {
 
+/**
+ * A generic function to directly configure a gRPC context.
+ *
+ * This function takes effect before the context is used to make any requests.
+ *
+ * @warning It is NOT recommended to call `set_auth_context()` or
+ *     `set_credentials()` directly on the context. Instead, use the Google
+ *     Unified Auth Credentials library, via
+ *     #google::cloud::UnifiedCredentialsOption.
+ */
+struct GrpcSetupOption {
+  using Type = std::function<void(grpc::ClientContext&)>;
+};
+
+/**
+ * A generic function to directly configure a gRPC context for polling
+ * long-running operations.
+ *
+ * This function takes effect before the context is used to make any poll or
+ * cancel requests for long-running operations.
+ *
+ * @warning It is NOT recommended to call `set_auth_context()` or
+ *     `set_credentials()` directly on the context. Instead, use the Google
+ *     Unified Auth Credentials library, via
+ *     #google::cloud::UnifiedCredentialsOption.
+ */
+struct GrpcSetupPollOption {
+  using Type = std::function<void(grpc::ClientContext&)>;
+};
+
+/// Configure the ClientContext using options.
+void ConfigureContext(grpc::ClientContext& context, Options const& opts);
+
+/// Configure the ClientContext for polling operations using options.
+void ConfigurePollContext(grpc::ClientContext& context, Options const& opts);
+
 /// Creates a new `grpc::ChannelArguments` configured with @p opts.
 grpc::ChannelArguments MakeChannelArguments(Options const& opts);
 

--- a/google/cloud/grpc_options_test.cc
+++ b/google/cloud/grpc_options_test.cc
@@ -250,6 +250,36 @@ TEST(GrpcOptionList, Unexpected) {
       Contains(ContainsRegex("caller: Unexpected option.+UnexpectedOption")));
 }
 
+TEST(GrpcClientContext, Configure) {
+  auto setup = [](grpc::ClientContext& context) {
+    // This might not be the most useful setting, but it is the most easily
+    // tested setting.
+    context.set_compression_algorithm(GRPC_COMPRESS_DEFLATE);
+  };
+  auto opts = Options{}.set<internal::GrpcSetupOption>(setup);
+
+  grpc::ClientContext context;
+  EXPECT_EQ(GRPC_COMPRESS_NONE, context.compression_algorithm());
+  internal::ConfigureContext(context, std::move(opts));
+  EXPECT_EQ(GRPC_COMPRESS_DEFLATE, context.compression_algorithm());
+}
+
+TEST(GrpcClientContext, ConfigurePoll) {
+  auto setup_poll = [](grpc::ClientContext& context) {
+    // This might not be the most useful setting, but it is the most easily
+    // tested setting.
+    context.set_compression_algorithm(GRPC_COMPRESS_DEFLATE);
+  };
+  auto opts = Options{}.set<internal::GrpcSetupPollOption>(setup_poll);
+
+  grpc::ClientContext context;
+  EXPECT_EQ(GRPC_COMPRESS_NONE, context.compression_algorithm());
+  internal::ConfigureContext(context, opts);
+  EXPECT_EQ(GRPC_COMPRESS_NONE, context.compression_algorithm());
+  internal::ConfigurePollContext(context, std::move(opts));
+  EXPECT_EQ(GRPC_COMPRESS_DEFLATE, context.compression_algorithm());
+}
+
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/internal/async_retry_loop.h
+++ b/google/cloud/internal/async_retry_loop.h
@@ -18,6 +18,7 @@
 #include "google/cloud/backoff_policy.h"
 #include "google/cloud/completion_queue.h"
 #include "google/cloud/future.h"
+#include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/invoke_result.h"
 #include "google/cloud/internal/retry_loop_helpers.h"
 #include "google/cloud/internal/retry_policy.h"
@@ -225,6 +226,7 @@ class AsyncRetryLoopImpl
     auto state = StartOperation();
     if (state.cancelled) return;
     auto context = absl::make_unique<grpc::ClientContext>();
+    ConfigureContext(*context, CurrentOptions());
     SetupContext<RetryPolicyType>::Setup(*retry_policy_, *context);
     SetPending(
         state.operation,

--- a/google/cloud/internal/retry_loop.h
+++ b/google/cloud/internal/retry_loop.h
@@ -16,6 +16,7 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_RETRY_LOOP_H
 
 #include "google/cloud/backoff_policy.h"
+#include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/invoke_result.h"
 #include "google/cloud/internal/retry_loop_helpers.h"
 #include "google/cloud/internal/retry_policy.h"
@@ -69,6 +70,7 @@ auto RetryLoopImpl(std::unique_ptr<RetryPolicy> retry_policy,
   while (!retry_policy->IsExhausted()) {
     // Need to create a new context for each retry.
     grpc::ClientContext context;
+    ConfigureContext(context, CurrentOptions());
     auto result = functor(context, request);
     if (result.ok()) {
       return result;


### PR DESCRIPTION
Add ability to configure the `grpc::ClientContext` before each RPC call. For now, this has been developed in an `internal` namespace. The options may never be made public, but I figured it wouldn't hurt to document them anyway.
 
Part of the work for #7529. [This comment](https://github.com/googleapis/google-cloud-cpp/issues/7529#issuecomment-1006772608) is worth reading to understand the context of this change. Especially the **Downside** section, which could invalidate the entire PR.

Some Notes/Choices:
* `GrpcSetupPollOption` takes effect on cancel requests. (Even though there is no equivalent function in Bigtable). I could use a second opinion on whether the option should apply to both cancels and polls, or just polls.
* There is no configuration done on the context used when we [generate access tokens](https://github.com/googleapis/google-cloud-cpp/blob/be1bc0a9de3df833ecce0602f86f364ae8d1e384/google/cloud/internal/grpc_impersonate_service_account.cc#L46).
* [`AsyncRetryUnaryRpc`](https://github.com/googleapis/google-cloud-cpp/blob/be1bc0a9de3df833ecce0602f86f364ae8d1e384/google/cloud/internal/async_retry_unary_rpc.h#L150) does not configure the context. All calls to this class will be replaced by `AsyncRetryLoop`, which does configure the context. (So such a change is unnecessary)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7839)
<!-- Reviewable:end -->
