### PR TITLE
cleanup: CMake changes to declare libraries GA

### DIFF
--- a/google/cloud/secretmanager/CMakeLists.txt
+++ b/google/cloud/secretmanager/CMakeLists.txt
@@ -17,7 +17,7 @@
 include(GoogleapisConfig)
 set(DOXYGEN_PROJECT_NAME "Secret Manager API C++ Client")
 set(DOXYGEN_PROJECT_BRIEF "A C++ Client Library for the Secret Manager API")
-set(DOXYGEN_PROJECT_NUMBER "${PROJECT_VERSION} (Experimental)")
+set(DOXYGEN_PROJECT_NUMBER "${PROJECT_VERSION}")
 set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "secretmanager_internal"
                             "secretmanager_testing" "examples")
 set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
@@ -80,13 +80,13 @@ target_link_libraries(
 google_cloud_cpp_add_common_options(google_cloud_cpp_secretmanager)
 set_target_properties(
     google_cloud_cpp_secretmanager
-    PROPERTIES EXPORT_NAME google-cloud-cpp::experimental-secretmanager
-               VERSION "${PROJECT_VERSION}" SOVERSION
-                                            "${PROJECT_VERSION_MAJOR}")
+    PROPERTIES EXPORT_NAME google-cloud-cpp::secretmanager VERSION
+                                                           "${PROJECT_VERSION}"
+               SOVERSION "${PROJECT_VERSION_MAJOR}")
 target_compile_options(google_cloud_cpp_secretmanager
                        PUBLIC ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
-add_library(google-cloud-cpp::experimental-secretmanager ALIAS
+add_library(google-cloud-cpp::secretmanager ALIAS
             google_cloud_cpp_secretmanager)
 
 # To avoid maintaining the list of files for the library, export them to a .bzl
@@ -111,8 +111,11 @@ add_library(google_cloud_cpp_secretmanager_mocks INTERFACE)
 target_sources(google_cloud_cpp_secretmanager_mocks INTERFACE ${mock_files})
 target_link_libraries(
     google_cloud_cpp_secretmanager_mocks
-    INTERFACE google-cloud-cpp::experimental-secretmanager GTest::gmock_main
-              GTest::gmock GTest::gtest)
+    INTERFACE google-cloud-cpp::secretmanager GTest::gmock_main GTest::gmock
+              GTest::gtest)
+set_target_properties(
+    google_cloud_cpp_secretmanager_mocks
+    PROPERTIES EXPORT_NAME google-cloud-cpp::secretmanager_mocks)
 create_bazel_config(google_cloud_cpp_secretmanager_mocks YEAR "2021")
 target_include_directories(
     google_cloud_cpp_secretmanager_mocks

--- a/google/cloud/secretmanager/config.cmake.in
+++ b/google/cloud/secretmanager/config.cmake.in
@@ -20,3 +20,8 @@ find_dependency(google_cloud_cpp_grpc_utils)
 find_dependency(absl)
 
 include("${CMAKE_CURRENT_LIST_DIR}/google_cloud_cpp_secretmanager-targets.cmake")
+
+if (NOT TARGET google-cloud-cpp::experimental-secretmanager)
+    add_library(google-cloud-cpp::experimental-secretmanager ALIAS
+                google-cloud-cpp::secretmanager)
+endif ()

--- a/google/cloud/tasks/CMakeLists.txt
+++ b/google/cloud/tasks/CMakeLists.txt
@@ -17,7 +17,7 @@
 include(GoogleapisConfig)
 set(DOXYGEN_PROJECT_NAME "Cloud Tasks API C++ Client")
 set(DOXYGEN_PROJECT_BRIEF "A C++ Client Library for the Cloud Tasks API")
-set(DOXYGEN_PROJECT_NUMBER "${PROJECT_VERSION} (Experimental)")
+set(DOXYGEN_PROJECT_NUMBER "${PROJECT_VERSION}")
 set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "tasks_internal" "tasks_testing"
                             "examples")
 set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
@@ -82,13 +82,12 @@ target_link_libraries(
 google_cloud_cpp_add_common_options(google_cloud_cpp_tasks)
 set_target_properties(
     google_cloud_cpp_tasks
-    PROPERTIES EXPORT_NAME google-cloud-cpp::experimental-tasks
-               VERSION "${PROJECT_VERSION}" SOVERSION
-                                            "${PROJECT_VERSION_MAJOR}")
+    PROPERTIES EXPORT_NAME google-cloud-cpp::tasks VERSION "${PROJECT_VERSION}"
+               SOVERSION "${PROJECT_VERSION_MAJOR}")
 target_compile_options(google_cloud_cpp_tasks
                        PUBLIC ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
-add_library(google-cloud-cpp::experimental-tasks ALIAS google_cloud_cpp_tasks)
+add_library(google-cloud-cpp::tasks ALIAS google_cloud_cpp_tasks)
 
 # To avoid maintaining the list of files for the library, export them to a .bzl
 # file.
@@ -114,6 +113,8 @@ target_link_libraries(
     google_cloud_cpp_tasks_mocks
     INTERFACE google-cloud-cpp::experimental-tasks GTest::gmock_main
               GTest::gmock GTest::gtest)
+set_target_properties(google_cloud_cpp_tasks_mocks
+                      PROPERTIES EXPORT_NAME google-cloud-cpp::tasks_mocks)
 create_bazel_config(google_cloud_cpp_tasks_mocks YEAR "2021")
 target_include_directories(
     google_cloud_cpp_tasks_mocks

--- a/google/cloud/tasks/config.cmake.in
+++ b/google/cloud/tasks/config.cmake.in
@@ -20,3 +20,8 @@ find_dependency(google_cloud_cpp_grpc_utils)
 find_dependency(absl)
 
 include("${CMAKE_CURRENT_LIST_DIR}/google_cloud_cpp_tasks-targets.cmake")
+
+if (NOT TARGET google-cloud-cpp::experimental-tasks)
+    add_library(google-cloud-cpp::experimental-tasks ALIAS
+                google-cloud-cpp::tasks)
+endif ()


### PR DESCRIPTION
I missed these when declaring the libraries GA.

I will be writing a document to describe all the steps.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7841)
<!-- Reviewable:end -->
