### PR TITLE
impl(bigtable): convert to common policies

### DIFF
--- a/google/cloud/bigtable/CMakeLists.txt
+++ b/google/cloud/bigtable/CMakeLists.txt
@@ -22,8 +22,8 @@ set(DOXYGEN_PROJECT_BRIEF "A C++ Client Library for Google Cloud Bigtable")
 set(DOXYGEN_PROJECT_NUMBER "${PROJECT_VERSION}")
 set(DOXYGEN_EXAMPLE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/examples"
                          "${CMAKE_CURRENT_SOURCE_DIR}/quickstart")
-set(DOXYGEN_EXCLUDE_SYMBOLS "benchmarks" "bigtable_admin_internal" "internal"
-                            "testing" "examples")
+set(DOXYGEN_EXCLUDE_SYMBOLS "benchmarks" "bigtable_admin_internal"
+                            "bigtable_internal" "internal" "testing" "examples")
 
 include(GoogleCloudCppCommon)
 

--- a/google/cloud/bigtable/polling_policy.cc
+++ b/google/cloud/bigtable/polling_policy.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/bigtable/polling_policy.h"
+#include "absl/memory/memory.h"
 
 namespace google {
 namespace cloud {

--- a/google/cloud/bigtable/polling_policy.cc
+++ b/google/cloud/bigtable/polling_policy.cc
@@ -18,6 +18,7 @@ namespace google {
 namespace cloud {
 namespace bigtable {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+
 std::unique_ptr<PollingPolicy> DefaultPollingPolicy(
     internal::RPCPolicyParameters defaults) {
   return std::unique_ptr<PollingPolicy>(new GenericPollingPolicy<>(defaults));
@@ -25,5 +26,35 @@ std::unique_ptr<PollingPolicy> DefaultPollingPolicy(
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigtable
+namespace bigtable_internal {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+
+std::unique_ptr<PollingPolicy> MakeCommonPollingPolicy(
+    std::unique_ptr<bigtable::PollingPolicy> policy) {
+  class CommonPollingPolicy : public PollingPolicy {
+   public:
+    explicit CommonPollingPolicy(std::unique_ptr<bigtable::PollingPolicy> impl)
+        : impl_(std::move(impl)) {}
+    ~CommonPollingPolicy() override = default;
+
+    std::unique_ptr<PollingPolicy> clone() const override {
+      return absl::make_unique<CommonPollingPolicy>(impl_->clone());
+    }
+    bool OnFailure(google::cloud::Status const& status) override {
+      return impl_->OnFailure(status);
+    }
+    std::chrono::milliseconds WaitPeriod() override {
+      return impl_->WaitPeriod();
+    }
+
+   private:
+    std::unique_ptr<bigtable::PollingPolicy> impl_;
+  };
+
+  return absl::make_unique<CommonPollingPolicy>(std::move(policy));
+}
+
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace bigtable_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/bigtable/polling_policy.h
+++ b/google/cloud/bigtable/polling_policy.h
@@ -19,6 +19,7 @@
 #include "google/cloud/bigtable/rpc_retry_policy.h"
 #include "google/cloud/bigtable/version.h"
 #include "google/cloud/grpc_error_delegate.h"
+#include "google/cloud/polling_policy.h"
 #include <grpcpp/grpcpp.h>
 #include <chrono>
 
@@ -162,6 +163,14 @@ std::unique_ptr<PollingPolicy> DefaultPollingPolicy(
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigtable
+namespace bigtable_internal {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+
+std::unique_ptr<PollingPolicy> MakeCommonPollingPolicy(
+    std::unique_ptr<bigtable::PollingPolicy> policy);
+
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace bigtable_internal
 }  // namespace cloud
 }  // namespace google
 

--- a/google/cloud/bigtable/polling_policy.h
+++ b/google/cloud/bigtable/polling_policy.h
@@ -60,7 +60,7 @@ class PollingPolicy {
    * Return true if `status` represents a permanent error that cannot be
    * retried.
    */
-  virtual bool IsPermanentError(google::cloud::Status const& status) = 0;
+  virtual bool IsPermanentError(Status const& status) = 0;
 
   /**
    * Handle an RPC failure.
@@ -77,7 +77,7 @@ class PollingPolicy {
    *
    * @return true if the RPC operation should be retried.
    */
-  virtual bool OnFailure(google::cloud::Status const& status) = 0;
+  virtual bool OnFailure(Status const& status) = 0;
 
   /**
    * Return true if we cannot try again.
@@ -136,15 +136,15 @@ class GenericPollingPolicy : public PollingPolicy {
     backoff_clone_->Setup(context);
   }
 
-  bool IsPermanentError(google::cloud::Status const& status) override {
+  bool IsPermanentError(Status const& status) override {
     return RPCRetryPolicy::IsPermanentFailure(status);
   }
 
-  bool OnFailure(google::cloud::Status const& status) override {
+  bool OnFailure(Status const& status) override {
     return retry_clone_->OnFailure(status);
   }
 
-  bool Exhausted() override { return !OnFailure(google::cloud::Status()); }
+  bool Exhausted() override { return !OnFailure(Status()); }
 
   std::chrono::milliseconds WaitPeriod() override {
     return backoff_clone_->OnCompletion(grpc::Status::OK);

--- a/google/cloud/bigtable/polling_policy_test.cc
+++ b/google/cloud/bigtable/polling_policy_test.cc
@@ -48,6 +48,15 @@ void CheckLimitedTime(PollingPolicy& tested) {
       },
       std::chrono::system_clock::now() + kLimitedTimeTestPeriod,
       kLimitedTimeTolerance);
+
+  auto common = bigtable_internal::MakeCommonPollingPolicy(tested.clone());
+  testing_util::CheckPredicateBecomesFalse(
+      [&common] {
+        return common->OnFailure(
+            Status(StatusCode::kUnavailable, "please try again"));
+      },
+      std::chrono::system_clock::now() + kLimitedTimeTestPeriod,
+      kLimitedTimeTolerance);
 }
 
 /// @test A simple test for the LimitedTimeRetryPolicy.
@@ -83,6 +92,10 @@ TEST(GenericPollingPolicy, OnNonRetryable) {
       static_cast<PollingPolicy&>(tested).OnFailure(CreatePermanentError()));
   EXPECT_FALSE(
       tested.OnFailure(MakeStatusFromRpcError(CreatePermanentError())));
+
+  auto common = bigtable_internal::MakeCommonPollingPolicy(tested.clone());
+  EXPECT_FALSE(
+      common->OnFailure(MakeStatusFromRpcError(CreatePermanentError())));
 }
 
 /// @test Verify that IsPermanentError works.

--- a/google/cloud/bigtable/polling_policy_test.cc
+++ b/google/cloud/bigtable/polling_policy_test.cc
@@ -30,12 +30,15 @@ namespace {
 Status PermanentError() {
   return Status(StatusCode::kFailedPrecondition, "failed");
 }
+
 grpc::Status GrpcPermanentError() {
   return grpc::Status(grpc::StatusCode::FAILED_PRECONDITION, "failed");
 }
+
 Status TransientError() {
   return Status(StatusCode::kUnavailable, "try again");
 }
+
 grpc::Status GrpcTransientError() {
   return grpc::Status(grpc::StatusCode::UNAVAILABLE, "try again");
 }

--- a/google/cloud/bigtable/polling_policy_test.cc
+++ b/google/cloud/bigtable/polling_policy_test.cc
@@ -27,9 +27,17 @@ namespace cloud {
 namespace bigtable {
 namespace {
 
-/// Create a grpc::Status with a status code for permanent errors.
-grpc::Status CreatePermanentError() {
+Status PermanentError() {
+  return Status(StatusCode::kFailedPrecondition, "failed");
+}
+grpc::Status GrpcPermanentError() {
   return grpc::Status(grpc::StatusCode::FAILED_PRECONDITION, "failed");
+}
+Status TransientError() {
+  return Status(StatusCode::kUnavailable, "try again");
+}
+grpc::Status GrpcTransientError() {
+  return grpc::Status(grpc::StatusCode::UNAVAILABLE, "try again");
 }
 
 using testing_util::chrono_literals::operator"" _ms;
@@ -42,74 +50,84 @@ auto const kLimitedTimeTolerance = 10_ms;
  */
 void CheckLimitedTime(PollingPolicy& tested) {
   testing_util::CheckPredicateBecomesFalse(
-      [&tested] {
-        return tested.OnFailure(
-            grpc::Status(grpc::StatusCode::UNAVAILABLE, "please try again"));
-      },
-      std::chrono::system_clock::now() + kLimitedTimeTestPeriod,
-      kLimitedTimeTolerance);
-
-  auto common = bigtable_internal::MakeCommonPollingPolicy(tested.clone());
-  testing_util::CheckPredicateBecomesFalse(
-      [&common] {
-        return common->OnFailure(
-            Status(StatusCode::kUnavailable, "please try again"));
-      },
+      [&tested] { return tested.OnFailure(GrpcTransientError()); },
       std::chrono::system_clock::now() + kLimitedTimeTestPeriod,
       kLimitedTimeTolerance);
 }
 
-/// @test A simple test for the LimitedTimeRetryPolicy.
+void CheckLimitedTime(std::unique_ptr<google::cloud::PollingPolicy> common) {
+  testing_util::CheckPredicateBecomesFalse(
+      [&common] { return common->OnFailure(TransientError()); },
+      std::chrono::system_clock::now() + kLimitedTimeTestPeriod,
+      kLimitedTimeTolerance);
+}
+
+/// @test A simple test for the GenericPollingPolicy.
 TEST(GenericPollingPolicy, Simple) {
   LimitedTimeRetryPolicy retry(kLimitedTimeTestPeriod);
-  ExponentialBackoffPolicy backoff(internal::kBigtableLimits);
+  ExponentialBackoffPolicy backoff(10_ms, 50_ms);
   GenericPollingPolicy<> tested(retry, backoff);
   CheckLimitedTime(tested);
+
+  auto common = bigtable_internal::MakeCommonPollingPolicy(tested.clone());
+  CheckLimitedTime(std::move(common));
 }
 
-/// @test Test cloning for LimitedTimeRetryPolicy.
+/// @test Test cloning for GenericPollingPolicy.
 TEST(GenericPollingPolicy, Clone) {
-  auto const transient = Status(StatusCode::kUnavailable, "try again");
-
   LimitedErrorCountRetryPolicy retry(1);
-  ExponentialBackoffPolicy backoff(internal::kBigtableLimits);
+  ExponentialBackoffPolicy backoff(10_ms, 50_ms);
   GenericPollingPolicy<LimitedErrorCountRetryPolicy> original(retry, backoff);
-  EXPECT_TRUE(original.OnFailure(transient));
-  EXPECT_FALSE(original.OnFailure(transient));
+  EXPECT_TRUE(original.OnFailure(TransientError()));
+  EXPECT_FALSE(original.OnFailure(TransientError()));
+  EXPECT_GE(10_ms, original.WaitPeriod());
+  EXPECT_LE(10_ms, original.WaitPeriod());
 
   // Ensure the initial state of the policy is cloned, not the current state.
   auto clone = original.clone();
-  EXPECT_TRUE(clone->OnFailure(transient));
-  EXPECT_FALSE(clone->OnFailure(transient));
+  EXPECT_TRUE(clone->OnFailure(TransientError()));
+  EXPECT_FALSE(clone->OnFailure(TransientError()));
+  EXPECT_GE(10_ms, clone->WaitPeriod());
+  EXPECT_LE(10_ms, clone->WaitPeriod());
+
+  auto common = bigtable_internal::MakeCommonPollingPolicy(original.clone());
+  EXPECT_TRUE(common->OnFailure(TransientError()));
+  EXPECT_FALSE(common->OnFailure(TransientError()));
+  EXPECT_GE(10_ms, common->WaitPeriod());
+  EXPECT_LE(10_ms, common->WaitPeriod());
+
+  // Ensure the initial state of the policy is cloned, not the current state.
+  auto common_clone = common->clone();
+  EXPECT_TRUE(common_clone->OnFailure(TransientError()));
+  EXPECT_FALSE(common_clone->OnFailure(TransientError()));
+  EXPECT_GE(10_ms, common_clone->WaitPeriod());
+  EXPECT_LE(10_ms, common_clone->WaitPeriod());
 }
 
 /// @test Verify that non-retryable errors cause an immediate failure.
 TEST(GenericPollingPolicy, OnNonRetryable) {
   LimitedTimeRetryPolicy retry(kLimitedTimeTestPeriod);
-  ExponentialBackoffPolicy backoff(internal::kBigtableLimits);
+  ExponentialBackoffPolicy backoff(10_ms, 50_ms);
   GenericPollingPolicy<> tested(retry, backoff);
   EXPECT_FALSE(
-      static_cast<PollingPolicy&>(tested).OnFailure(CreatePermanentError()));
-  EXPECT_FALSE(
-      tested.OnFailure(MakeStatusFromRpcError(CreatePermanentError())));
+      static_cast<PollingPolicy&>(tested).OnFailure(GrpcPermanentError()));
+  EXPECT_FALSE(tested.OnFailure(PermanentError()));
 
   auto common = bigtable_internal::MakeCommonPollingPolicy(tested.clone());
-  EXPECT_FALSE(
-      common->OnFailure(MakeStatusFromRpcError(CreatePermanentError())));
+  EXPECT_FALSE(common->OnFailure(PermanentError()));
 }
 
 /// @test Verify that IsPermanentError works.
 TEST(GenericPollingPolicy, IsPermanentError) {
   LimitedTimeRetryPolicy retry(kLimitedTimeTestPeriod);
-  ExponentialBackoffPolicy backoff(internal::kBigtableLimits);
+  ExponentialBackoffPolicy backoff(10_ms, 50_ms);
   GenericPollingPolicy<> tested(retry, backoff);
-  EXPECT_TRUE(
-      tested.IsPermanentError(Status(StatusCode::kPermissionDenied, "")));
-  EXPECT_FALSE(tested.IsPermanentError(Status(StatusCode::kUnavailable, "")));
+  EXPECT_TRUE(tested.IsPermanentError(PermanentError()));
+  EXPECT_FALSE(tested.IsPermanentError(TransientError()));
   EXPECT_TRUE(static_cast<PollingPolicy&>(tested).IsPermanentError(
-      grpc::Status(grpc::StatusCode::PERMISSION_DENIED, "")));
+      GrpcPermanentError()));
   EXPECT_FALSE(static_cast<PollingPolicy&>(tested).IsPermanentError(
-      grpc::Status(grpc::StatusCode::UNAVAILABLE, "")));
+      GrpcTransientError()));
 }
 
 /// @test Verify that the backoff policy's wait period is used.
@@ -120,9 +138,9 @@ TEST(GenericPollingPolicy, WaitPeriod) {
   EXPECT_GE(10_ms, tested.WaitPeriod());
   EXPECT_LE(10_ms, tested.WaitPeriod());
 
-  // Ensure the initial state of the policy is cloned, not the current state.
-  auto clone = tested.clone();
-  EXPECT_GE(10_ms, clone->WaitPeriod());
+  auto common = bigtable_internal::MakeCommonPollingPolicy(tested.clone());
+  EXPECT_GE(10_ms, common->WaitPeriod());
+  EXPECT_LE(10_ms, common->WaitPeriod());
 }
 
 }  // anonymous namespace

--- a/google/cloud/bigtable/rpc_backoff_policy.cc
+++ b/google/cloud/bigtable/rpc_backoff_policy.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/bigtable/rpc_backoff_policy.h"
+#include "absl/memory/memory.h"
 
 namespace google {
 namespace cloud {

--- a/google/cloud/bigtable/rpc_backoff_policy.cc
+++ b/google/cloud/bigtable/rpc_backoff_policy.cc
@@ -48,5 +48,33 @@ std::chrono::milliseconds ExponentialBackoffPolicy::OnCompletion(
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigtable
+namespace bigtable_internal {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+
+std::unique_ptr<internal::BackoffPolicy> MakeCommonBackoffPolicy(
+    std::unique_ptr<bigtable::RPCBackoffPolicy> policy) {
+  class CommonBackoffPolicy : public internal::BackoffPolicy {
+   public:
+    explicit CommonBackoffPolicy(
+        std::unique_ptr<bigtable::RPCBackoffPolicy> impl)
+        : impl_(std::move(impl)) {}
+    ~CommonBackoffPolicy() override = default;
+
+    std::unique_ptr<internal::BackoffPolicy> clone() const override {
+      return absl::make_unique<CommonBackoffPolicy>(impl_->clone());
+    }
+    std::chrono::milliseconds OnCompletion() override {
+      return impl_->OnCompletion();
+    }
+
+   private:
+    std::unique_ptr<bigtable::RPCBackoffPolicy> impl_;
+  };
+
+  return absl::make_unique<CommonBackoffPolicy>(std::move(policy));
+}
+
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace bigtable_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/bigtable/rpc_backoff_policy.h
+++ b/google/cloud/bigtable/rpc_backoff_policy.h
@@ -113,6 +113,14 @@ class ExponentialBackoffPolicy : public RPCBackoffPolicy {
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigtable
+namespace bigtable_internal {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+
+std::unique_ptr<internal::BackoffPolicy> MakeCommonBackoffPolicy(
+    std::unique_ptr<bigtable::RPCBackoffPolicy> policy);
+
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace bigtable_internal
 }  // namespace cloud
 }  // namespace google
 

--- a/google/cloud/bigtable/rpc_backoff_policy.h
+++ b/google/cloud/bigtable/rpc_backoff_policy.h
@@ -66,14 +66,11 @@ class RPCBackoffPolicy {
    * @return true the delay before trying the operation again.
    * @param status the status returned by the last RPC operation.
    */
-  virtual std::chrono::milliseconds OnCompletion(
-      google::cloud::Status const& status) = 0;
+  virtual std::chrono::milliseconds OnCompletion(Status const& status) = 0;
   // TODO(#2344) - remove ::grpc::Status version.
   virtual std::chrono::milliseconds OnCompletion(grpc::Status const& s) = 0;
 
-  std::chrono::milliseconds OnCompletion() {
-    return OnCompletion(google::cloud::Status{});
-  }
+  std::chrono::milliseconds OnCompletion() { return OnCompletion(Status{}); }
 };
 
 /// Return an instance of the default RPCBackoffPolicy.
@@ -98,8 +95,7 @@ class ExponentialBackoffPolicy : public RPCBackoffPolicy {
 
   std::unique_ptr<RPCBackoffPolicy> clone() const override;
   void Setup(grpc::ClientContext& context) const override;
-  std::chrono::milliseconds OnCompletion(
-      google::cloud::Status const& status) override;
+  std::chrono::milliseconds OnCompletion(Status const& status) override;
   // TODO(#2344) - remove ::grpc::Status version.
   std::chrono::milliseconds OnCompletion(grpc::Status const& status) override;
 

--- a/google/cloud/bigtable/rpc_backoff_policy_test.cc
+++ b/google/cloud/bigtable/rpc_backoff_policy_test.cc
@@ -34,7 +34,6 @@ grpc::Status CreateTransientError() {
 /// @test A simple test for the ExponentialBackoffRetryPolicy.
 TEST(ExponentialBackoffRetryPolicy, Simple) {
   ExponentialBackoffPolicy tested(10_ms, 500_ms);
-  auto common = bigtable_internal::MakeCommonBackoffPolicy(tested.clone());
 
   EXPECT_GE(10_ms, tested.OnCompletion(CreateTransientError()));
   EXPECT_NE(500_ms, tested.OnCompletion(CreateTransientError()));
@@ -46,6 +45,7 @@ TEST(ExponentialBackoffRetryPolicy, Simple) {
   EXPECT_GE(500_ms, tested.OnCompletion(CreateTransientError()));
 
   // Verify that converting to a common backoff policy preserves behavior.
+  auto common = bigtable_internal::MakeCommonBackoffPolicy(tested.clone());
   EXPECT_GE(10_ms, common->OnCompletion());
   EXPECT_NE(500_ms, common->OnCompletion());
   EXPECT_NE(500_ms, common->OnCompletion());

--- a/google/cloud/bigtable/rpc_backoff_policy_test.cc
+++ b/google/cloud/bigtable/rpc_backoff_policy_test.cc
@@ -67,6 +67,16 @@ TEST(ExponentialBackoffRetryPolicy, Clone) {
   // Ensure the initial state of the policy is cloned, not the current state.
   tested = tested->clone();
   EXPECT_GE(10_ms, tested->OnCompletion(CreateTransientError()));
+
+  // Verify that converting to a common backoff policy preserves behavior.
+  auto common = bigtable_internal::MakeCommonBackoffPolicy(original.clone());
+  auto common_clone = common->clone();
+  EXPECT_GE(10_ms, common_clone->OnCompletion());
+  EXPECT_LE(10_ms, common_clone->OnCompletion());
+
+  // Ensure the initial state of the policy is cloned, not the current state.
+  common_clone = common_clone->clone();
+  EXPECT_GE(10_ms, common_clone->OnCompletion());
 }
 
 /// @test Test for testing randomness for 2 objects of

--- a/google/cloud/bigtable/rpc_retry_policy.cc
+++ b/google/cloud/bigtable/rpc_retry_policy.cc
@@ -43,6 +43,10 @@ bool LimitedErrorCountRetryPolicy::OnFailure(grpc::Status const& status) {
   return impl_.OnFailure(MakeStatusFromRpcError(status));
 }
 
+bool LimitedErrorCountRetryPolicy::IsExhausted() const {
+  return impl_.IsExhausted();
+}
+
 LimitedTimeRetryPolicy::LimitedTimeRetryPolicy(
     internal::RPCPolicyParameters defaults)
     : impl_(defaults.maximum_retry_period) {}
@@ -64,6 +68,8 @@ bool LimitedTimeRetryPolicy::OnFailure(google::cloud::Status const& status) {
 bool LimitedTimeRetryPolicy::OnFailure(grpc::Status const& status) {
   return impl_.OnFailure(MakeStatusFromRpcError(status));
 }
+
+bool LimitedTimeRetryPolicy::IsExhausted() const { return impl_.IsExhausted(); }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigtable


### PR DESCRIPTION
Part of the work for #7529. (This is the same code as #7594)

Add conversion methods for bigtable retry, backoff, polling policies -> common retry, backoff, polling policies. The retry is templated because the Instance and Table Admin options have different types.
https://github.com/googleapis/google-cloud-cpp/blob/4082229488f2099f064954b2f317221fe3bb6442/google/cloud/bigtable/admin/bigtable_instance_admin_options.h#L36
https://github.com/googleapis/google-cloud-cpp/blob/4082229488f2099f064954b2f317221fe3bb6442/google/cloud/bigtable/admin/bigtable_table_admin_options.h#L36

The conversion to `Options`, as described in the issue, will be added in a subsequent PR. The `Setup(grpc::ClientContext&)` functionality will be captured then.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7849)
<!-- Reviewable:end -->
