### PR TITLE
cleanup(storage)!: uploads track committed_size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,51 @@
 
 ## v1.36.0 - TBD
 
+### [Storage](https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/storage/README.md)
+
+**BREAKING CHANGE:** with this release any use of the
+`storage::internal::ResumableUploadResponse` type require changes. Applications
+should have little need for this type, outside mocks, so the changes should not
+affect production code.
+
+Nevertheless, we apologize for the inconvenience, and while we would have
+preferred to avoid breaking changes, it was inevitable to introduce some
+breaking changes to fix a data loss bug.
+
+If you are affected by this change, you will need to change your tests following
+this guide. Any place where you return a `ResumableUploadResponse` needs to
+change from:
+
+```cc
+storage::internal::ResumableUploadResource{
+  /*upload_session_url=*/std::string{"typically-unused"},
+  /*last_committed_byte=*/std::uint64_t{value},
+  /*payload=*/absl::nullopt, // or some gcs::ObjectMetadata value
+  /*upload_state=*/ResumableUploadResponse::kInProgress, // or kDone
+  /*annotations=*/std::string{"typically-unused"}
+}
+```
+
+to:
+
+```cc
+storage::internal::ResumableUploadResource{
+  /*upload_session_url=*/std::string{"typically-unused"},
+  /*upload_state=*/ResumableUploadResponse::kInProgress, // or kDone
+  /*committed_size=*/value + 1, // or absl::nullopt
+  /*payload=*/absl::nullopt, // or some gcs::ObjectMetadata value
+  /*annotations=*/std::string{"typically-unused"}
+}
+```
+
+That is, you need to re-order the fields **and** change increase the
+`value` to reflect the number of committed bytes vs. the index in the
+last committed byte.
+
+Changing the order of the fields was intentional. It will create a build
+failure, which is easier to detect and repair than a run-time error in
+your tests.
+
 ## v1.35.0 - 2022-01
 
 ### New GA Libraries

--- a/google/cloud/storage/client_write_object_test.cc
+++ b/google/cloud/storage/client_write_object_test.cc
@@ -62,15 +62,15 @@ TEST_F(WriteObjectTest, WriteObject) {
         EXPECT_CALL(*mock, next_expected_byte()).WillRepeatedly(Return(0));
         EXPECT_CALL(*mock, UploadChunk)
             .WillRepeatedly(Return(make_status_or(ResumableUploadResponse{
-                "fake-url", 0, {}, ResumableUploadResponse::kInProgress, {}})));
+                "fake-url", ResumableUploadResponse::kInProgress, 0, {}, {}})));
         EXPECT_CALL(*mock, ResetSession())
             .WillOnce(Return(make_status_or(ResumableUploadResponse{
-                "fake-url", 0, {}, ResumableUploadResponse::kInProgress, {}})));
+                "fake-url", ResumableUploadResponse::kInProgress, 0, {}, {}})));
         EXPECT_CALL(*mock, UploadFinalChunk)
             .WillOnce(
                 Return(StatusOr<ResumableUploadResponse>(TransientError())))
             .WillOnce(Return(make_status_or(ResumableUploadResponse{
-                "fake-url", 0, expected, ResumableUploadResponse::kDone, {}})));
+                "fake-url", ResumableUploadResponse::kDone, 0, expected, {}})));
 
         return make_status_or(
             std::unique_ptr<internal::ResumableUploadSession>(std::move(mock)));
@@ -227,7 +227,7 @@ TEST_F(WriteObjectTest, UploadStreamResumable) {
               bytes_written += internal::TotalBytes(data);
               EXPECT_EQ(bytes_written, size);
               return make_status_or(ResumableUploadResponse{
-                  "fake-url", 0, expected, ResumableUploadResponse::kDone, {}});
+                  "fake-url", ResumableUploadResponse::kDone, 0, expected, {}});
             });
 
         return make_status_or(
@@ -285,7 +285,7 @@ TEST_F(WriteObjectTest, UploadFile) {
               bytes_written += internal::TotalBytes(data);
               EXPECT_EQ(bytes_written, size);
               return make_status_or(ResumableUploadResponse{
-                  "fake-url", 0, expected, ResumableUploadResponse::kDone, {}});
+                  "fake-url", ResumableUploadResponse::kDone, 0, expected, {}});
             });
 
         return make_status_or(

--- a/google/cloud/storage/examples/storage_client_mock_samples.cc
+++ b/google/cloud/storage/examples/storage_client_mock_samples.cc
@@ -89,16 +89,16 @@ TEST(StorageMockingSamples, MockWriteObject) {
         EXPECT_CALL(*mock_result, UploadChunk)
             .WillRepeatedly(Return(google::cloud::make_status_or(
                 ResumableUploadResponse{"fake-url",
-                                        0,
-                                        {},
                                         ResumableUploadResponse::kInProgress,
+                                        /*committed_size=*/absl::nullopt,
+                                        /*object_metadata=*/absl::nullopt,
                                         {}})));
         EXPECT_CALL(*mock_result, UploadFinalChunk)
             .WillRepeatedly(Return(google::cloud::make_status_or(
                 ResumableUploadResponse{"fake-url",
-                                        0,
-                                        expected_metadata,
                                         ResumableUploadResponse::kDone,
+                                        /*committed_size=*/absl::nullopt,
+                                        /*object_metadata=*/expected_metadata,
                                         {}})));
 
         std::unique_ptr<gcs::internal::ResumableUploadSession> result(

--- a/google/cloud/storage/internal/curl_resumable_upload_session.cc
+++ b/google/cloud/storage/internal/curl_resumable_upload_session.cc
@@ -73,11 +73,9 @@ void CurlResumableUploadSession::Update(
     // value. In this case we update the next expected byte using the chunk
     // size, as we know the upload was successful.
     next_expected_ += chunk_size;
-  } else if (result->last_committed_byte != 0) {
-    next_expected_ = result->last_committed_byte + 1;
   } else {
     // Nothing has been committed on the server side yet, keep resending.
-    next_expected_ = 0;
+    next_expected_ = result->committed_size.value_or(0);
   }
   if (session_id_.empty() && !result->upload_session_url.empty()) {
     session_id_ = result->upload_session_url;

--- a/google/cloud/storage/internal/grpc_client.cc
+++ b/google/cloud/storage/internal/grpc_client.cc
@@ -188,12 +188,9 @@ StatusOr<ResumableUploadResponse> GrpcClient::QueryResumableUpload(
 
   ResumableUploadResponse response;
   response.upload_state = ResumableUploadResponse::kInProgress;
-  // TODO(#6880) - cleanup the committed_byte vs. size thing
-  if (status->has_persisted_size() && status->persisted_size()) {
-    response.last_committed_byte =
+  if (status->has_persisted_size()) {
+    response.committed_size =
         static_cast<std::uint64_t>(status->persisted_size());
-  } else {
-    response.last_committed_byte = 0;
   }
   if (status->has_resource()) {
     response.payload =

--- a/google/cloud/storage/internal/grpc_object_request_parser.cc
+++ b/google/cloud/storage/internal/grpc_object_request_parser.cc
@@ -256,12 +256,8 @@ ResumableUploadResponse GrpcObjectRequestParser::FromProto(
     google::storage::v2::WriteObjectResponse const& p, Options const& options) {
   ResumableUploadResponse response;
   response.upload_state = ResumableUploadResponse::kInProgress;
-  if (p.has_persisted_size() && p.persisted_size() > 0) {
-    // TODO(#6880) - cleanup the committed_byte vs. size thing
-    response.last_committed_byte =
-        static_cast<std::uint64_t>(p.persisted_size()) - 1;
-  } else {
-    response.last_committed_byte = 0;
+  if (p.has_persisted_size()) {
+    response.committed_size = static_cast<std::uint64_t>(p.persisted_size());
   }
   if (p.has_resource()) {
     response.payload =

--- a/google/cloud/storage/internal/grpc_resumable_upload_session.cc
+++ b/google/cloud/storage/internal/grpc_resumable_upload_session.cc
@@ -61,7 +61,7 @@ StatusOr<ResumableUploadResponse> GrpcResumableUploadSession::ResetSession() {
   if (!last_response_) return last_response_;
 
   done_ = (last_response_->upload_state == ResumableUploadResponse::kDone);
-  next_expected_ = last_response_->last_committed_byte;
+  next_expected_ = last_response_->committed_size.value_or(0);
   return last_response_;
 }
 

--- a/google/cloud/storage/internal/logging_resumable_upload_session_test.cc
+++ b/google/cloud/storage/internal/logging_resumable_upload_session_test.cc
@@ -119,7 +119,7 @@ TEST_F(LoggingResumableUploadSessionTest, LastResponseOk) {
   auto mock = absl::make_unique<testing::MockResumableUploadSession>();
 
   const StatusOr<ResumableUploadResponse> last_response(ResumableUploadResponse{
-      "upload url", 1, {}, ResumableUploadResponse::kInProgress, {}});
+      "upload url", ResumableUploadResponse::kInProgress, 1, {}, {}});
   EXPECT_CALL(*mock, last_response()).WillOnce(ReturnRef(last_response));
 
   LoggingResumableUploadSession session(std::move(mock));

--- a/google/cloud/storage/internal/object_write_streambuf.cc
+++ b/google/cloud/storage/internal/object_write_streambuf.cc
@@ -36,7 +36,7 @@ ObjectWriteStreambuf::ObjectWriteStreambuf(
       hash_validator_(std::move(hash_validator)),
       auto_finalize_(auto_finalize),
       last_response_(ResumableUploadResponse{
-          {}, 0, {}, ResumableUploadResponse::kInProgress, {}}) {
+          {}, ResumableUploadResponse::kInProgress, 0, absl::nullopt, {}}) {
   current_ios_buffer_.resize(max_buffer_size_);
   auto* pbeg = current_ios_buffer_.data();
   auto* pend = pbeg + current_ios_buffer_.size();

--- a/google/cloud/storage/internal/resumable_upload_session.cc
+++ b/google/cloud/storage/internal/resumable_upload_session.cc
@@ -24,6 +24,33 @@ namespace cloud {
 namespace storage {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace internal {
+namespace {
+StatusOr<std::uint64_t> ParseRangeHeader(std::string const& range) {
+  // We expect a `Range:` header in the format described here:
+  //    https://cloud.google.com/storage/docs/json_api/v1/how-tos/resumable-upload
+  // that is the value should match `bytes=0-[0-9]+`:
+
+  char const prefix[] = "bytes=0-";
+  auto constexpr kPrefixLen = sizeof(prefix) - 1;
+  if (range.rfind(prefix, 0) != 0) {
+    return Status(
+        StatusCode::kInternal,
+        "cannot parse Range header in resumable upload response, value=" +
+            range);
+  }
+  char const* buffer = range.data() + kPrefixLen;
+  char* endptr;
+  auto constexpr kBytesBase = 10;
+  auto last = std::strtoll(buffer, &endptr, kBytesBase);
+  if (buffer != endptr && *endptr == '\0' && 0 <= last) {
+    return last;
+  }
+  return Status(
+      StatusCode::kInternal,
+      "cannot parse Range header in resumable upload response, value=" + range);
+}
+}  // namespace
+
 StatusOr<ResumableUploadResponse> ResumableUploadResponse::FromHttpResponse(
     HttpResponse response) {
   ResumableUploadResponse result;
@@ -33,55 +60,24 @@ StatusOr<ResumableUploadResponse> ResumableUploadResponse::FromHttpResponse(
   } else {
     result.upload_state = kInProgress;
   }
-  result.last_committed_byte = 0;
   result.annotations += "code=" + std::to_string(response.status_code);
   // For the JSON API, the payload contains the object resource when the upload
   // is finished. In that case, we try to parse it.
   if (result.upload_state == kDone && !response.payload.empty()) {
     auto contents = ObjectMetadataParser::FromString(response.payload);
-    if (!contents) {
-      return std::move(contents).status();
-    }
+    if (!contents) return std::move(contents).status();
     result.payload = *std::move(contents);
   }
   if (response.headers.find("location") != response.headers.end()) {
     result.upload_session_url = response.headers.find("location")->second;
   }
   auto r = response.headers.find("range");
-  if (r == response.headers.end()) {
-    std::ostringstream os;
-    os << __func__ << "() missing range header in resumable upload response"
-       << ", response=" << response;
-    result.annotations += " " + std::move(os).str();
-    return result;
-  }
-  // We expect a `Range:` header in the format described here:
-  //    https://cloud.google.com/storage/docs/json_api/v1/how-tos/resumable-upload
-  // that is the value should match `bytes=0-[0-9]+`:
-  std::string const& range = r->second;
-  result.annotations += " range=" + range;
+  if (r == response.headers.end()) return result;
 
-  char const prefix[] = "bytes=0-";
-  auto constexpr kPrefixLen = sizeof(prefix) - 1;
-  if (range.rfind(prefix, 0) != 0) {
-    std::ostringstream os;
-    os << __func__ << "() cannot parse range: header in resumable upload"
-       << " response, header=" << range << ", response=" << response;
-    result.annotations += " " + std::move(os).str();
-    return result;
-  }
-  char const* buffer = range.data() + kPrefixLen;
-  char* endptr;
-  auto constexpr kBytesBase = 10;
-  auto last = std::strtoll(buffer, &endptr, kBytesBase);
-  if (buffer != endptr && *endptr == '\0' && 0 <= last) {
-    result.last_committed_byte = static_cast<std::uint64_t>(last);
-  } else {
-    std::ostringstream os;
-    os << __func__ << "() cannot parse range: header in resumable upload"
-       << " response, header=" << range << ", response=" << response;
-    result.annotations += " " + std::move(os).str();
-  }
+  result.annotations += " range=" + r->second;
+  auto last_committed_byte = ParseRangeHeader(r->second);
+  if (!last_committed_byte) return std::move(last_committed_byte).status();
+  result.committed_size = *last_committed_byte + 1;
 
   return result;
 }
@@ -89,7 +85,7 @@ StatusOr<ResumableUploadResponse> ResumableUploadResponse::FromHttpResponse(
 bool operator==(ResumableUploadResponse const& lhs,
                 ResumableUploadResponse const& rhs) {
   return lhs.upload_session_url == rhs.upload_session_url &&
-         lhs.last_committed_byte == rhs.last_committed_byte &&
+         lhs.committed_size == rhs.committed_size &&
          lhs.payload == rhs.payload && lhs.upload_state == rhs.upload_state;
 }
 
@@ -99,18 +95,23 @@ bool operator!=(ResumableUploadResponse const& lhs,
 }
 
 std::ostream& operator<<(std::ostream& os, ResumableUploadResponse const& r) {
+  char const* state = r.upload_state == ResumableUploadResponse::kDone
+                          ? "kDone"
+                          : "kInProgress";
   os << "ResumableUploadResponse={upload_session_url=" << r.upload_session_url
-     << ", last_committed_byte=" << r.last_committed_byte << ", payload=";
+     << ", upload_state=" << state << ", committed_size=";
+  if (r.committed_size.has_value()) {
+    os << *r.committed_size;
+  } else {
+    os << "{}";
+  }
+  os << ", payload=";
   if (r.payload.has_value()) {
     os << *r.payload;
   } else {
     os << "{}";
   }
-  return os << ", upload_state="
-            << (r.upload_state == ResumableUploadResponse::kDone
-                    ? "kDone"
-                    : "kInProgress")
-            << ", annotations=" << r.annotations << "}";
+  return os << ", annotations=" << r.annotations << "}";
 }
 
 }  // namespace internal

--- a/google/cloud/storage/internal/resumable_upload_session.h
+++ b/google/cloud/storage/internal/resumable_upload_session.h
@@ -89,13 +89,14 @@ class ResumableUploadSession {
 
 struct ResumableUploadResponse {
   enum UploadState { kInProgress, kDone };
+
   static StatusOr<ResumableUploadResponse> FromHttpResponse(
       HttpResponse response);
 
   std::string upload_session_url;
-  std::uint64_t last_committed_byte;
-  absl::optional<google::cloud::storage::ObjectMetadata> payload;
   UploadState upload_state;
+  absl::optional<std::uint64_t> committed_size;
+  absl::optional<google::cloud::storage::ObjectMetadata> payload;
   std::string annotations;
 };
 

--- a/google/cloud/storage/parallel_uploads_test.cc
+++ b/google/cloud/storage/parallel_uploads_test.cc
@@ -172,7 +172,7 @@ class ParallelUploadTest
     EXPECT_CALL(res, next_expected_byte()).WillRepeatedly(Return(0));
     EXPECT_CALL(res, UploadChunk)
         .WillRepeatedly(Return(make_status_or(ResumableUploadResponse{
-            "fake-url", 0, {}, ResumableUploadResponse::kInProgress, {}})));
+            "fake-url", ResumableUploadResponse::kInProgress, 0, {}, {}})));
     EXPECT_CALL(res, UploadFinalChunk)
         .WillRepeatedly(Return(std::move(status)));
     AddNewExpectation(object_name, resumable_session_id);
@@ -204,18 +204,18 @@ class ParallelUploadTest
             EXPECT_THAT(content, ElementsAre(ConstBuffer(*expected_content)));
             return make_status_or(
                 ResumableUploadResponse{"fake-url",
+                                        ResumableUploadResponse::kDone,
                                         0,
                                         MockObject(object_name, generation),
-                                        ResumableUploadResponse::kDone,
                                         {}});
           });
     } else {
       EXPECT_CALL(res, UploadFinalChunk)
           .WillOnce(Return(make_status_or(
               ResumableUploadResponse{"fake-url",
+                                      ResumableUploadResponse::kDone,
                                       0,
                                       MockObject(object_name, generation),
-                                      ResumableUploadResponse::kDone,
                                       {}})));
     }
     AddNewExpectation(object_name, resumable_session_id);


### PR DESCRIPTION
Fixing how the `storage` client library deals with reponses lacking a
`Range` header will break any existing unit tests that mock a
`ResumableUploadSession`. This creates an opportunity to cleanup the
semantics of `ResumableUploadResponse`. This change performs that
cleanup.

**BREAKING CHANGE:** with this PR any use of the
`storage::internal::ResumableUploadResponse` type require changes.
Applications should have little need for this type, outside mocks, so
the changes should not affect production code.

Nevertheless, we apologize for the inconvenience, and while we would have
preferred to avoid breaking changes, it was inevitable to introduce some
breaking changes to fix a data loss bug.

If you are affected by this change, we expect that any existing tests
will fail to compile. This was an intentional choice, the semantics of
some values are changing, we think it is better to have these issues
detected at compile-time rather than during test execution.

We have updated the examples to use the new mocks, and the release notes
include more details on how to change any affected tests.

Fixes #6880, part of the work for #7835