### PR TITLE
impl(generator): bidir streaming RPCs in Stubs

### DIFF
--- a/generator/integration_tests/golden/golden_kitchen_sink_client.h
+++ b/generator/integration_tests/golden/golden_kitchen_sink_client.h
@@ -116,10 +116,10 @@ class GoldenKitchenSinkClient {
   ///  not specified, the token's lifetime will be set to a default value of one
   ///  hour.
   /// @param options  Optional. Operation options.
-  /// @return @googleapis_link{google::test::admin::database::v1::GenerateAccessTokenResponse,generator/integration_tests/test.proto#L888}
+  /// @return @googleapis_link{google::test::admin::database::v1::GenerateAccessTokenResponse,generator/integration_tests/test.proto#L899}
   ///
-  /// [google.test.admin.database.v1.GenerateAccessTokenRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L851}
-  /// [google.test.admin.database.v1.GenerateAccessTokenResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L888}
+  /// [google.test.admin.database.v1.GenerateAccessTokenRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L862}
+  /// [google.test.admin.database.v1.GenerateAccessTokenResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L899}
   ///
   StatusOr<google::test::admin::database::v1::GenerateAccessTokenResponse>
   GenerateAccessToken(std::string const& name, std::vector<std::string> const& delegates, std::vector<std::string> const& scope, google::protobuf::Duration const& lifetime, Options options = {});
@@ -127,12 +127,12 @@ class GoldenKitchenSinkClient {
   ///
   /// Generates an OAuth 2.0 access token for a service account.
   ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::GenerateAccessTokenRequest,generator/integration_tests/test.proto#L851}
+  /// @param request @googleapis_link{google::test::admin::database::v1::GenerateAccessTokenRequest,generator/integration_tests/test.proto#L862}
   /// @param options  Optional. Operation options.
-  /// @return @googleapis_link{google::test::admin::database::v1::GenerateAccessTokenResponse,generator/integration_tests/test.proto#L888}
+  /// @return @googleapis_link{google::test::admin::database::v1::GenerateAccessTokenResponse,generator/integration_tests/test.proto#L899}
   ///
-  /// [google.test.admin.database.v1.GenerateAccessTokenRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L851}
-  /// [google.test.admin.database.v1.GenerateAccessTokenResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L888}
+  /// [google.test.admin.database.v1.GenerateAccessTokenRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L862}
+  /// [google.test.admin.database.v1.GenerateAccessTokenResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L899}
   ///
   StatusOr<google::test::admin::database::v1::GenerateAccessTokenResponse>
   GenerateAccessToken(google::test::admin::database::v1::GenerateAccessTokenRequest const& request, Options options = {});
@@ -158,10 +158,10 @@ class GoldenKitchenSinkClient {
   /// @param include_email  Include the service account email in the token. If set to `true`, the
   ///  token will contain `email` and `email_verified` claims.
   /// @param options  Optional. Operation options.
-  /// @return @googleapis_link{google::test::admin::database::v1::GenerateIdTokenResponse,generator/integration_tests/test.proto#L930}
+  /// @return @googleapis_link{google::test::admin::database::v1::GenerateIdTokenResponse,generator/integration_tests/test.proto#L941}
   ///
-  /// [google.test.admin.database.v1.GenerateIdTokenRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L897}
-  /// [google.test.admin.database.v1.GenerateIdTokenResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L930}
+  /// [google.test.admin.database.v1.GenerateIdTokenRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L908}
+  /// [google.test.admin.database.v1.GenerateIdTokenResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L941}
   ///
   StatusOr<google::test::admin::database::v1::GenerateIdTokenResponse>
   GenerateIdToken(std::string const& name, std::vector<std::string> const& delegates, std::string const& audience, bool include_email, Options options = {});
@@ -169,12 +169,12 @@ class GoldenKitchenSinkClient {
   ///
   /// Generates an OpenID Connect ID token for a service account.
   ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::GenerateIdTokenRequest,generator/integration_tests/test.proto#L897}
+  /// @param request @googleapis_link{google::test::admin::database::v1::GenerateIdTokenRequest,generator/integration_tests/test.proto#L908}
   /// @param options  Optional. Operation options.
-  /// @return @googleapis_link{google::test::admin::database::v1::GenerateIdTokenResponse,generator/integration_tests/test.proto#L930}
+  /// @return @googleapis_link{google::test::admin::database::v1::GenerateIdTokenResponse,generator/integration_tests/test.proto#L941}
   ///
-  /// [google.test.admin.database.v1.GenerateIdTokenRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L897}
-  /// [google.test.admin.database.v1.GenerateIdTokenResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L930}
+  /// [google.test.admin.database.v1.GenerateIdTokenRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L908}
+  /// [google.test.admin.database.v1.GenerateIdTokenResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L941}
   ///
   StatusOr<google::test::admin::database::v1::GenerateIdTokenResponse>
   GenerateIdToken(google::test::admin::database::v1::GenerateIdTokenRequest const& request, Options options = {});
@@ -206,10 +206,10 @@ class GoldenKitchenSinkClient {
   ///  as a label in this parameter, then the log entry's label is not changed.
   ///  See [LogEntry][google.logging.v2.LogEntry]. Test delimiter$
   /// @param options  Optional. Operation options.
-  /// @return @googleapis_link{google::test::admin::database::v1::WriteLogEntriesResponse,generator/integration_tests/test.proto#L969}
+  /// @return @googleapis_link{google::test::admin::database::v1::WriteLogEntriesResponse,generator/integration_tests/test.proto#L980}
   ///
-  /// [google.test.admin.database.v1.WriteLogEntriesRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L936}
-  /// [google.test.admin.database.v1.WriteLogEntriesResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L969}
+  /// [google.test.admin.database.v1.WriteLogEntriesRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L947}
+  /// [google.test.admin.database.v1.WriteLogEntriesResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L980}
   ///
   StatusOr<google::test::admin::database::v1::WriteLogEntriesResponse>
   WriteLogEntries(std::string const& log_name, std::map<std::string, std::string> const& labels, Options options = {});
@@ -223,12 +223,12 @@ class GoldenKitchenSinkClient {
   /// different resources (projects, organizations, billing accounts or
   /// folders)
   ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::WriteLogEntriesRequest,generator/integration_tests/test.proto#L936}
+  /// @param request @googleapis_link{google::test::admin::database::v1::WriteLogEntriesRequest,generator/integration_tests/test.proto#L947}
   /// @param options  Optional. Operation options.
-  /// @return @googleapis_link{google::test::admin::database::v1::WriteLogEntriesResponse,generator/integration_tests/test.proto#L969}
+  /// @return @googleapis_link{google::test::admin::database::v1::WriteLogEntriesResponse,generator/integration_tests/test.proto#L980}
   ///
-  /// [google.test.admin.database.v1.WriteLogEntriesRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L936}
-  /// [google.test.admin.database.v1.WriteLogEntriesResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L969}
+  /// [google.test.admin.database.v1.WriteLogEntriesRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L947}
+  /// [google.test.admin.database.v1.WriteLogEntriesResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L980}
   ///
   StatusOr<google::test::admin::database::v1::WriteLogEntriesResponse>
   WriteLogEntries(google::test::admin::database::v1::WriteLogEntriesRequest const& request, Options options = {});
@@ -245,7 +245,7 @@ class GoldenKitchenSinkClient {
   /// @param options  Optional. Operation options.
   /// @return std::string
   ///
-  /// [google.test.admin.database.v1.ListLogsRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L972}
+  /// [google.test.admin.database.v1.ListLogsRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L983}
   ///
   StreamRange<std::string>
   ListLogs(std::string const& parent, Options options = {});
@@ -254,11 +254,11 @@ class GoldenKitchenSinkClient {
   /// Lists the logs in projects, organizations, folders, or billing accounts.
   /// Only logs that have entries are listed.
   ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::ListLogsRequest,generator/integration_tests/test.proto#L972}
+  /// @param request @googleapis_link{google::test::admin::database::v1::ListLogsRequest,generator/integration_tests/test.proto#L983}
   /// @param options  Optional. Operation options.
   /// @return std::string
   ///
-  /// [google.test.admin.database.v1.ListLogsRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L972}
+  /// [google.test.admin.database.v1.ListLogsRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L983}
   ///
   StreamRange<std::string>
   ListLogs(google::test::admin::database::v1::ListLogsRequest request, Options options = {});
@@ -278,10 +278,10 @@ class GoldenKitchenSinkClient {
   ///      "billingAccounts/[BILLING_ACCOUNT_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]"
   ///      "folders/[FOLDER_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]"
   /// @param options  Optional. Operation options.
-  /// @return @googleapis_link{google::test::admin::database::v1::TailLogEntriesResponse,generator/integration_tests/test.proto#L1230}
+  /// @return @googleapis_link{google::test::admin::database::v1::TailLogEntriesResponse,generator/integration_tests/test.proto#L1241}
   ///
-  /// [google.test.admin.database.v1.TailLogEntriesRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1198}
-  /// [google.test.admin.database.v1.TailLogEntriesResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1230}
+  /// [google.test.admin.database.v1.TailLogEntriesRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1209}
+  /// [google.test.admin.database.v1.TailLogEntriesResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1241}
   ///
   StreamRange<google::test::admin::database::v1::TailLogEntriesResponse>
   TailLogEntries(std::vector<std::string> const& resource_names, Options options = {});
@@ -290,12 +290,12 @@ class GoldenKitchenSinkClient {
   /// Streaming read of log entries as they are ingested. Until the stream is
   /// terminated, it will continue reading logs.
   ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::TailLogEntriesRequest,generator/integration_tests/test.proto#L1198}
+  /// @param request @googleapis_link{google::test::admin::database::v1::TailLogEntriesRequest,generator/integration_tests/test.proto#L1209}
   /// @param options  Optional. Operation options.
-  /// @return @googleapis_link{google::test::admin::database::v1::TailLogEntriesResponse,generator/integration_tests/test.proto#L1230}
+  /// @return @googleapis_link{google::test::admin::database::v1::TailLogEntriesResponse,generator/integration_tests/test.proto#L1241}
   ///
-  /// [google.test.admin.database.v1.TailLogEntriesRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1198}
-  /// [google.test.admin.database.v1.TailLogEntriesResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1230}
+  /// [google.test.admin.database.v1.TailLogEntriesRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1209}
+  /// [google.test.admin.database.v1.TailLogEntriesResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1241}
   ///
   StreamRange<google::test::admin::database::v1::TailLogEntriesResponse>
   TailLogEntries(google::test::admin::database::v1::TailLogEntriesRequest const& request, Options options = {});
@@ -312,10 +312,10 @@ class GoldenKitchenSinkClient {
   ///  response. Duplicate key types are not allowed. If no key type
   ///  is provided, all keys are returned.
   /// @param options  Optional. Operation options.
-  /// @return @googleapis_link{google::test::admin::database::v1::ListServiceAccountKeysResponse,generator/integration_tests/test.proto#L1302}
+  /// @return @googleapis_link{google::test::admin::database::v1::ListServiceAccountKeysResponse,generator/integration_tests/test.proto#L1313}
   ///
-  /// [google.test.admin.database.v1.ListServiceAccountKeysRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1270}
-  /// [google.test.admin.database.v1.ListServiceAccountKeysResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1302}
+  /// [google.test.admin.database.v1.ListServiceAccountKeysRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1281}
+  /// [google.test.admin.database.v1.ListServiceAccountKeysResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1313}
   ///
   StatusOr<google::test::admin::database::v1::ListServiceAccountKeysResponse>
   ListServiceAccountKeys(std::string const& name, std::vector<google::test::admin::database::v1::ListServiceAccountKeysRequest::KeyType> const& key_types, Options options = {});
@@ -323,12 +323,12 @@ class GoldenKitchenSinkClient {
   ///
   /// Lists every [ServiceAccountKey][google.iam.admin.v1.ServiceAccountKey] for a service account.
   ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::ListServiceAccountKeysRequest,generator/integration_tests/test.proto#L1270}
+  /// @param request @googleapis_link{google::test::admin::database::v1::ListServiceAccountKeysRequest,generator/integration_tests/test.proto#L1281}
   /// @param options  Optional. Operation options.
-  /// @return @googleapis_link{google::test::admin::database::v1::ListServiceAccountKeysResponse,generator/integration_tests/test.proto#L1302}
+  /// @return @googleapis_link{google::test::admin::database::v1::ListServiceAccountKeysResponse,generator/integration_tests/test.proto#L1313}
   ///
-  /// [google.test.admin.database.v1.ListServiceAccountKeysRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1270}
-  /// [google.test.admin.database.v1.ListServiceAccountKeysResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1302}
+  /// [google.test.admin.database.v1.ListServiceAccountKeysRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1281}
+  /// [google.test.admin.database.v1.ListServiceAccountKeysResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1313}
   ///
   StatusOr<google::test::admin::database::v1::ListServiceAccountKeysResponse>
   ListServiceAccountKeys(google::test::admin::database::v1::ListServiceAccountKeysRequest const& request, Options options = {});

--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_auth_decorator.h
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_auth_decorator.h
@@ -67,6 +67,10 @@ class GoldenKitchenSinkAuth : public GoldenKitchenSinkStub {
       grpc::ClientContext& context,
       google::protobuf::Empty const& request) override;
 
+  std::unique_ptr<AsyncAppendRowsStream> AsyncAppendRows(
+      google::cloud::CompletionQueue& cq,
+      std::unique_ptr<grpc::ClientContext> context) override;
+
  private:
   std::shared_ptr<google::cloud::internal::GrpcAuthenticationStrategy> auth_;
   std::shared_ptr<GoldenKitchenSinkStub> child_;

--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_logging_decorator.h
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_logging_decorator.h
@@ -67,6 +67,10 @@ class GoldenKitchenSinkLogging : public GoldenKitchenSinkStub {
     grpc::ClientContext& context,
     google::protobuf::Empty const& request) override;
 
+  std::unique_ptr<AsyncAppendRowsStream> AsyncAppendRows(
+      google::cloud::CompletionQueue& cq,
+      std::unique_ptr<grpc::ClientContext> context) override;
+
  private:
   std::shared_ptr<GoldenKitchenSinkStub> child_;
   TracingOptions tracing_options_;

--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_metadata_decorator.cc
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_metadata_decorator.cc
@@ -88,6 +88,14 @@ GoldenKitchenSinkMetadata::DoNothing(
   return child_->DoNothing(context, request);
 }
 
+std::unique_ptr<GoldenKitchenSinkStub::AsyncAppendRowsStream>
+GoldenKitchenSinkMetadata::AsyncAppendRows(
+    google::cloud::CompletionQueue& cq,
+    std::unique_ptr<grpc::ClientContext> context) {
+  SetMetadata(*context, {});
+  return child_->AsyncAppendRows(cq, std::move(context));
+}
+
 void GoldenKitchenSinkMetadata::SetMetadata(grpc::ClientContext& context,
                                         std::string const& request_params) {
   context.AddMetadata("x-goog-request-params", request_params);

--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_metadata_decorator.h
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_metadata_decorator.h
@@ -63,6 +63,10 @@ class GoldenKitchenSinkMetadata : public GoldenKitchenSinkStub {
     grpc::ClientContext& context,
     google::protobuf::Empty const& request) override;
 
+  std::unique_ptr<AsyncAppendRowsStream> AsyncAppendRows(
+      google::cloud::CompletionQueue& cq,
+      std::unique_ptr<grpc::ClientContext> context) override;
+
  private:
   void SetMetadata(grpc::ClientContext& context,
                    std::string const& request_params);

--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_stub.cc
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_stub.cc
@@ -118,6 +118,17 @@ DefaultGoldenKitchenSinkStub::DoNothing(
     return google::cloud::Status();
 }
 
+std::unique_ptr<GoldenKitchenSinkStub::AsyncAppendRowsStream>
+DefaultGoldenKitchenSinkStub::AsyncAppendRows(
+    google::cloud::CompletionQueue& cq,
+    std::unique_ptr<grpc::ClientContext> context) {
+  return google::cloud::internal::MakeStreamingReadWriteRpc<google::test::admin::database::v1::AppendRowsRequest, google::test::admin::database::v1::AppendRowsResponse>(
+      cq, std::move(context),
+      [this](grpc::ClientContext* context, grpc::CompletionQueue* cq) {
+        return grpc_stub_->PrepareAsyncAppendRows(context, cq);
+      });
+}
+
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace golden_internal
 }  // namespace cloud

--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_stub.h
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_stub.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_INTERNAL_GOLDEN_KITCHEN_SINK_STUB_H
 #define GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_INTERNAL_GOLDEN_KITCHEN_SINK_STUB_H
 
+#include "google/cloud/internal/async_read_write_stream_impl.h"
 #include "google/cloud/internal/streaming_read_rpc.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
@@ -63,6 +64,11 @@ class GoldenKitchenSinkStub {
     grpc::ClientContext& context,
     google::protobuf::Empty const& request) = 0;
 
+  using AsyncAppendRowsStream = ::google::cloud::internal::AsyncStreamingReadWriteRpc<google::test::admin::database::v1::AppendRowsRequest, google::test::admin::database::v1::AppendRowsResponse>;
+  virtual std::unique_ptr<AsyncAppendRowsStream> AsyncAppendRows(
+      google::cloud::CompletionQueue& cq,
+      std::unique_ptr<grpc::ClientContext> context) = 0;
+
 };
 
 class DefaultGoldenKitchenSinkStub : public GoldenKitchenSinkStub {
@@ -105,6 +111,10 @@ class DefaultGoldenKitchenSinkStub : public GoldenKitchenSinkStub {
   DoNothing(
     grpc::ClientContext& client_context,
     google::protobuf::Empty const& request) override;
+
+  std::unique_ptr<AsyncAppendRowsStream> AsyncAppendRows(
+      google::cloud::CompletionQueue& cq,
+      std::unique_ptr<grpc::ClientContext> context) override;
 
  private:
   std::unique_ptr<google::test::admin::database::v1::GoldenKitchenSink::StubInterface> grpc_stub_;

--- a/generator/integration_tests/golden/mocks/mock_golden_kitchen_sink_stub.h
+++ b/generator/integration_tests/golden/mocks/mock_golden_kitchen_sink_stub.h
@@ -71,6 +71,8 @@ class MockGoldenKitchenSinkStub : public GoldenKitchenSinkStub {
       (grpc::ClientContext&,
        ::google::protobuf::Empty const&),
       (override));
+
+  MOCK_METHOD(std::unique_ptr<GoldenKitchenSinkStub::AsyncAppendRowsStream>, AsyncAppendRows, (google::cloud::CompletionQueue& cq, std::unique_ptr<grpc::ClientContext> context), (override));
 };
 
 class MockTailLogEntriesStreamingReadRpc

--- a/generator/integration_tests/golden/tests/golden_kitchen_sink_stub_test.cc
+++ b/generator/integration_tests/golden/tests/golden_kitchen_sink_stub_test.cc
@@ -232,6 +232,20 @@ class MockGrpcGoldenKitchenSinkStub : public ::google::test::admin::database::
       (::grpc::ClientContext * context,
        ::google::protobuf::Empty const& request, ::grpc::CompletionQueue* cq),
       (override));
+
+  using AppendRowsInterface = ::grpc::ClientReaderWriterInterface<
+      ::google::test::admin::database::v1::AppendRowsRequest,
+      ::google::test::admin::database::v1::AppendRowsResponse>;
+  using AppendRowsAsyncInterface = ::grpc::ClientAsyncReaderWriterInterface<
+      ::google::test::admin::database::v1::AppendRowsRequest,
+      ::google::test::admin::database::v1::AppendRowsResponse>;
+  MOCK_METHOD(AppendRowsInterface*, AppendRowsRaw,
+              (::grpc::ClientContext * context), (override));
+  MOCK_METHOD(AppendRowsAsyncInterface*, AsyncAppendRowsRaw,
+              (::grpc::ClientContext*, ::grpc::CompletionQueue*, void*),
+              (override));
+  MOCK_METHOD(AppendRowsAsyncInterface*, PrepareAsyncAppendRowsRaw,
+              (::grpc::ClientContext*, ::grpc::CompletionQueue*), (override));
 };
 
 class GoldenKitchenSinkStubTest : public ::testing::Test {

--- a/generator/integration_tests/test.proto
+++ b/generator/integration_tests/test.proto
@@ -846,6 +846,17 @@ service GoldenKitchenSink {
     option (google.api.method_signature) = "";
   }
 
+  // A much simplified version of the AppendRows in google.cloud.bigquery.storage.v1.BigQueryWrite
+  rpc AppendRows(stream AppendRowsRequest) returns (stream AppendRowsResponse) {
+  }
+}
+
+message AppendRowsRequest {
+  string stream = 1;
+}
+
+message AppendRowsResponse {
+  string response = 1;
 }
 
 message GenerateAccessTokenRequest {

--- a/generator/internal/predicate_utils.cc
+++ b/generator/internal/predicate_utils.cc
@@ -101,6 +101,10 @@ bool IsStreamingRead(google::protobuf::MethodDescriptor const& method) {
   return !method.client_streaming() && method.server_streaming();
 }
 
+bool IsBidirStreaming(google::protobuf::MethodDescriptor const& method) {
+  return method.client_streaming() && method.server_streaming();
+}
+
 bool IsLongrunningOperation(google::protobuf::MethodDescriptor const& method) {
   return method.output_type()->full_name() == "google.longrunning.Operation";
 }

--- a/generator/internal/predicate_utils.h
+++ b/generator/internal/predicate_utils.h
@@ -44,6 +44,11 @@ bool IsNonStreaming(google::protobuf::MethodDescriptor const& method);
 bool IsStreamingRead(google::protobuf::MethodDescriptor const& method);
 
 /**
+ * In a bidir streaming method both requests and responses are streamable.
+ */
+bool IsBidirStreaming(google::protobuf::MethodDescriptor const& method);
+
+/**
  * Determines if the given method is a long running operation.
  */
 bool IsLongrunningOperation(google::protobuf::MethodDescriptor const& method);

--- a/generator/internal/predicate_utils_test.cc
+++ b/generator/internal/predicate_utils_test.cc
@@ -215,6 +215,65 @@ TEST(PredicateUtilsTest, IsNonStreaming) {
       IsNonStreaming(*service_file_descriptor_lro->service(0)->method(3)));
 }
 
+TEST(PredicateUtilsTest, IsBidirStreaming) {
+  FileDescriptorProto service_file;
+  /// @cond
+  auto constexpr kServiceText = R"pb(
+    name: "google/foo/v1/service.proto"
+    package: "google.protobuf"
+    message_type { name: "Input" }
+    message_type { name: "Output" }
+    service {
+      name: "Service"
+      method {
+        name: "NonStreaming"
+        input_type: "google.protobuf.Input"
+        output_type: "google.protobuf.Output"
+      }
+      method {
+        name: "ClientStreaming"
+        input_type: "google.protobuf.Input"
+        output_type: "google.protobuf.Output"
+        client_streaming: true
+      }
+      method {
+        name: "ServerStreaming"
+        input_type: "google.protobuf.Input"
+        output_type: "google.protobuf.Output"
+        server_streaming: true
+      }
+      method {
+        name: "BidirectionalStreaming"
+        input_type: "google.protobuf.Input"
+        output_type: "google.protobuf.Output"
+        client_streaming: true
+        server_streaming: true
+      }
+    }
+  )pb";
+  /// @endcond
+  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(kServiceText,
+                                                            &service_file));
+  DescriptorPool pool;
+  auto const* file_descriptor = pool.BuildFile(service_file);
+  auto const* service = file_descriptor->service(0);
+  struct Expected {
+    std::string name;
+    bool is_bir;
+  } methods[] = {
+      {"NonStreaming", false},
+      {"ClientStreaming", false},
+      {"ServerStreaming", false},
+      {"BidirectionalStreaming", true},
+  };
+  ASSERT_EQ(service->method_count(), sizeof(methods) / sizeof(methods[0]));
+  for (int i = 0; i != service->method_count(); ++i) {
+    ASSERT_EQ(service->method(i)->name(), methods[i].name);
+    ASSERT_EQ(IsBidirStreaming(*service->method(i)), methods[i].is_bir)
+        << "name=" << methods[i].name;
+  }
+}
+
 TEST(PredicateUtilsTest, IsLongrunningMetadataTypeUsedAsResponseEmptyResponse) {
   FileDescriptorProto longrunning_file;
   auto constexpr kLongrunningText = R"pb(

--- a/generator/internal/service_code_generator.cc
+++ b/generator/internal/service_code_generator.cc
@@ -128,6 +128,13 @@ bool ServiceCodeGenerator::HasStreamingReadMethod() const {
                      });
 }
 
+bool ServiceCodeGenerator::HasBidirStreamingMethod() const {
+  return std::any_of(methods_.begin(), methods_.end(),
+                     [](google::protobuf::MethodDescriptor const& m) {
+                       return IsBidirStreaming(m);
+                     });
+}
+
 std::vector<std::string>
 ServiceCodeGenerator::MethodSignatureWellKnownProtobufTypeIncludes() const {
   std::vector<std::string> include_paths;
@@ -222,6 +229,12 @@ Status ServiceCodeGenerator::HeaderPrintMethod(
                      patterns, file, line);
 }
 
+void ServiceCodeGenerator::HeaderPrintMethod(
+    google::protobuf::MethodDescriptor const& method, char const* file,
+    int line, std::string const& text) {
+  header_.Print(line, file, MergeServiceAndMethodVars(method), text);
+}
+
 void ServiceCodeGenerator::CcPrint(std::string const& text) {
   cc_.Print(service_vars_, text);
 }
@@ -238,6 +251,12 @@ Status ServiceCodeGenerator::CcPrintMethod(
     std::vector<MethodPattern> const& patterns, char const* file, int line) {
   return PrintMethod(method, cc_, MergeServiceAndMethodVars(method), patterns,
                      file, line);
+}
+
+void ServiceCodeGenerator::CcPrintMethod(
+    google::protobuf::MethodDescriptor const& method, char const* file,
+    int line, std::string const& text) {
+  cc_.Print(line, file, MergeServiceAndMethodVars(method), text);
 }
 
 void ServiceCodeGenerator::GenerateLocalIncludes(

--- a/generator/internal/service_code_generator.h
+++ b/generator/internal/service_code_generator.h
@@ -81,12 +81,16 @@ class ServiceCodeGenerator : public GeneratorInterface {
   Status HeaderPrintMethod(google::protobuf::MethodDescriptor const& method,
                            std::vector<MethodPattern> const& patterns,
                            char const* file, int line);
+  void HeaderPrintMethod(google::protobuf::MethodDescriptor const& method,
+                         char const* file, int line, std::string const& text);
 
   void CcPrint(std::string const& text);
   void CcPrint(std::vector<PredicatedFragment<void>> const& text);
   Status CcPrintMethod(google::protobuf::MethodDescriptor const& method,
                        std::vector<MethodPattern> const& patterns,
                        char const* file, int line);
+  void CcPrintMethod(google::protobuf::MethodDescriptor const& method,
+                     char const* file, int line, std::string const& text);
 
   /**
    * Determines if the service contains at least one method that returns a
@@ -116,6 +120,11 @@ class ServiceCodeGenerator : public GeneratorInterface {
    * response.
    */
   bool HasStreamingReadMethod() const;
+
+  /**
+   * Determines if the service contains at least one bidir streaming RPC
+   */
+  bool HasBidirStreamingMethod() const;
 
   /**
    * Determines if any of the method signatures has any Protocol Buffer

--- a/generator/internal/service_code_generator_test.cc
+++ b/generator/internal/service_code_generator_test.cc
@@ -76,6 +76,7 @@ class TestGenerator : public ServiceCodeGenerator {
                              {{"header_path_key", "header_path"}}, {},
                              context) {}
 
+  using ServiceCodeGenerator::HasBidirStreamingMethod;
   using ServiceCodeGenerator::HasLongrunningMethod;
   using ServiceCodeGenerator::HasMessageWithMapField;
   using ServiceCodeGenerator::HasPaginatedMethod;
@@ -589,6 +590,84 @@ TEST_F(StreamingReadTest, HasStreamingReadFalse) {
       .WillOnce(Return(output.release()));
   TestGenerator g(service_file_descriptor->service(1), generator_context.get());
   EXPECT_FALSE(g.HasStreamingReadMethod());
+}
+
+TEST(ServiceCodeGeneratorTest, HasBidirStreaming) {
+  auto constexpr kBidirStreamingServiceProto = R"""(
+syntax = "proto3";
+package google.protobuf;
+// Leading comments about message Foo.
+message Foo {
+  string baz = 1;
+  map<string, string> labels = 2;
+}
+// Leading comments about message Empty.
+message Bar {
+  int32 x = 1;
+}
+
+// This service has a bidir streaming RPC.
+service Service0 {
+  // Leading comments about rpc Method0.
+  rpc Method0(Foo) returns (stream Bar) {
+  }
+  // Leading comments about rpc Method1.
+  rpc Method1(stream Foo) returns (Bar) {
+  }
+  // Leading comments about rpc Method2.
+  rpc Method2(stream Foo) returns (stream Bar) {
+  }
+  // Leading comments about rpc Method3.
+  rpc Method3(Foo) returns (Bar) {
+  }
+}
+
+// This service has client-streaming (aka streaming-writes) and server-streaming
+// (aka streaming-write) RPCs, but does not have bidir-streaming RPCs.
+service Service1 {
+  // Leading comments about rpc Method0.
+  rpc Method0(stream Foo) returns (Bar) {
+  }
+  // Leading comments about rpc Method1.
+  rpc Method1(Foo) returns (stream Bar) {
+  }
+  // Leading comments about rpc Method2.
+  rpc Method2(Foo) returns (Bar) {
+  }
+}
+)""";
+
+  StringSourceTree source_tree(std::map<std::string, std::string>{
+      {"google/cloud/foo/streaming.proto", kBidirStreamingServiceProto}});
+  google::protobuf::compiler::SourceTreeDescriptorDatabase source_tree_db(
+      &source_tree);
+  google::protobuf::SimpleDescriptorDatabase simple_db;
+  FileDescriptorProto file_proto;
+  // we need descriptor.proto to be accessible by the pool
+  // since our test file imports it
+  FileDescriptorProto::descriptor()->file()->CopyTo(&file_proto);
+  simple_db.Add(file_proto);
+  google::protobuf::MergedDescriptorDatabase merged_db(&simple_db,
+                                                       &source_tree_db);
+  AbortingErrorCollector collector;
+  DescriptorPool pool(&merged_db, &collector);
+
+  FileDescriptor const* service_file_descriptor =
+      pool.FindFileByName("google/cloud/foo/streaming.proto");
+
+  auto generator_context = absl::make_unique<MockGeneratorContext>();
+  EXPECT_CALL(*generator_context, Open("header_path"))
+      .Times(2)
+      .WillRepeatedly(
+          [](std::string const&) { return new MockZeroCopyOutputStream(); });
+
+  TestGenerator g_service_0(service_file_descriptor->service(0),
+                            generator_context.get());
+  EXPECT_TRUE(g_service_0.HasBidirStreamingMethod());
+
+  TestGenerator g_service_1(service_file_descriptor->service(1),
+                            generator_context.get());
+  EXPECT_FALSE(g_service_1.HasBidirStreamingMethod());
 }
 
 }  // namespace

--- a/google/cloud/logging/internal/logging_service_v2_auth_decorator.cc
+++ b/google/cloud/logging/internal/logging_service_v2_auth_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/logging/v2/logging.proto
 
 #include "google/cloud/logging/internal/logging_service_v2_auth_decorator.h"
+#include "google/cloud/internal/async_read_write_stream_auth.h"
 #include <google/logging/v2/logging.grpc.pb.h>
 #include <memory>
 
@@ -72,6 +73,22 @@ StatusOr<google::logging::v2::ListLogsResponse> LoggingServiceV2Auth::ListLogs(
   auto status = auth_->ConfigureContext(context);
   if (!status.ok()) return status;
   return child_->ListLogs(context, request);
+}
+
+std::unique_ptr<LoggingServiceV2Stub::AsyncTailLogEntriesStream>
+LoggingServiceV2Auth::AsyncTailLogEntries(
+    google::cloud::CompletionQueue& cq,
+    std::unique_ptr<grpc::ClientContext> context) {
+  using StreamAuth = google::cloud::internal::AsyncStreamingReadWriteRpcAuth<
+      google::logging::v2::TailLogEntriesRequest,
+      google::logging::v2::TailLogEntriesResponse>;
+
+  auto child = child_;
+  auto call = [child, cq](std::unique_ptr<grpc::ClientContext> ctx) mutable {
+    return child->AsyncTailLogEntries(cq, std::move(ctx));
+  };
+  return absl::make_unique<StreamAuth>(
+      std::move(context), auth_, StreamAuth::StreamFactory(std::move(call)));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/logging/internal/logging_service_v2_auth_decorator.h
+++ b/google/cloud/logging/internal/logging_service_v2_auth_decorator.h
@@ -60,6 +60,10 @@ class LoggingServiceV2Auth : public LoggingServiceV2Stub {
       grpc::ClientContext& context,
       google::logging::v2::ListLogsRequest const& request) override;
 
+  std::unique_ptr<AsyncTailLogEntriesStream> AsyncTailLogEntries(
+      google::cloud::CompletionQueue& cq,
+      std::unique_ptr<grpc::ClientContext> context) override;
+
  private:
   std::shared_ptr<google::cloud::internal::GrpcAuthenticationStrategy> auth_;
   std::shared_ptr<LoggingServiceV2Stub> child_;

--- a/google/cloud/logging/internal/logging_service_v2_logging_decorator.h
+++ b/google/cloud/logging/internal/logging_service_v2_logging_decorator.h
@@ -60,6 +60,10 @@ class LoggingServiceV2Logging : public LoggingServiceV2Stub {
       grpc::ClientContext& context,
       google::logging::v2::ListLogsRequest const& request) override;
 
+  std::unique_ptr<AsyncTailLogEntriesStream> AsyncTailLogEntries(
+      google::cloud::CompletionQueue& cq,
+      std::unique_ptr<grpc::ClientContext> context) override;
+
  private:
   std::shared_ptr<LoggingServiceV2Stub> child_;
   TracingOptions tracing_options_;

--- a/google/cloud/logging/internal/logging_service_v2_metadata_decorator.cc
+++ b/google/cloud/logging/internal/logging_service_v2_metadata_decorator.cc
@@ -73,6 +73,14 @@ LoggingServiceV2Metadata::ListLogs(
   return child_->ListLogs(context, request);
 }
 
+std::unique_ptr<LoggingServiceV2Stub::AsyncTailLogEntriesStream>
+LoggingServiceV2Metadata::AsyncTailLogEntries(
+    google::cloud::CompletionQueue& cq,
+    std::unique_ptr<grpc::ClientContext> context) {
+  SetMetadata(*context, {});
+  return child_->AsyncTailLogEntries(cq, std::move(context));
+}
+
 void LoggingServiceV2Metadata::SetMetadata(grpc::ClientContext& context,
                                            std::string const& request_params) {
   context.AddMetadata("x-goog-request-params", request_params);

--- a/google/cloud/logging/internal/logging_service_v2_metadata_decorator.h
+++ b/google/cloud/logging/internal/logging_service_v2_metadata_decorator.h
@@ -57,6 +57,10 @@ class LoggingServiceV2Metadata : public LoggingServiceV2Stub {
       grpc::ClientContext& context,
       google::logging::v2::ListLogsRequest const& request) override;
 
+  std::unique_ptr<AsyncTailLogEntriesStream> AsyncTailLogEntries(
+      google::cloud::CompletionQueue& cq,
+      std::unique_ptr<grpc::ClientContext> context) override;
+
  private:
   void SetMetadata(grpc::ClientContext& context,
                    std::string const& request_params);

--- a/google/cloud/logging/internal/logging_service_v2_stub.cc
+++ b/google/cloud/logging/internal/logging_service_v2_stub.cc
@@ -91,6 +91,19 @@ DefaultLoggingServiceV2Stub::ListLogs(
   return response;
 }
 
+std::unique_ptr<LoggingServiceV2Stub::AsyncTailLogEntriesStream>
+DefaultLoggingServiceV2Stub::AsyncTailLogEntries(
+    google::cloud::CompletionQueue& cq,
+    std::unique_ptr<grpc::ClientContext> context) {
+  return google::cloud::internal::MakeStreamingReadWriteRpc<
+      google::logging::v2::TailLogEntriesRequest,
+      google::logging::v2::TailLogEntriesResponse>(
+      cq, std::move(context),
+      [this](grpc::ClientContext* context, grpc::CompletionQueue* cq) {
+        return grpc_stub_->PrepareAsyncTailLogEntries(context, cq);
+      });
+}
+
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace logging_internal
 }  // namespace cloud

--- a/google/cloud/logging/internal/logging_service_v2_stub.h
+++ b/google/cloud/logging/internal/logging_service_v2_stub.h
@@ -19,6 +19,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_LOGGING_INTERNAL_LOGGING_SERVICE_V2_STUB_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_LOGGING_INTERNAL_LOGGING_SERVICE_V2_STUB_H
 
+#include "google/cloud/internal/async_read_write_stream_impl.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include <google/logging/v2/logging.grpc.pb.h>
@@ -56,6 +57,14 @@ class LoggingServiceV2Stub {
   virtual StatusOr<google::logging::v2::ListLogsResponse> ListLogs(
       grpc::ClientContext& context,
       google::logging::v2::ListLogsRequest const& request) = 0;
+
+  using AsyncTailLogEntriesStream =
+      ::google::cloud::internal::AsyncStreamingReadWriteRpc<
+          google::logging::v2::TailLogEntriesRequest,
+          google::logging::v2::TailLogEntriesResponse>;
+  virtual std::unique_ptr<AsyncTailLogEntriesStream> AsyncTailLogEntries(
+      google::cloud::CompletionQueue& cq,
+      std::unique_ptr<grpc::ClientContext> context) = 0;
 };
 
 class DefaultLoggingServiceV2Stub : public LoggingServiceV2Stub {
@@ -86,6 +95,10 @@ class DefaultLoggingServiceV2Stub : public LoggingServiceV2Stub {
   StatusOr<google::logging::v2::ListLogsResponse> ListLogs(
       grpc::ClientContext& client_context,
       google::logging::v2::ListLogsRequest const& request) override;
+
+  std::unique_ptr<AsyncTailLogEntriesStream> AsyncTailLogEntries(
+      google::cloud::CompletionQueue& cq,
+      std::unique_ptr<grpc::ClientContext> context) override;
 
  private:
   std::unique_ptr<google::logging::v2::LoggingServiceV2::StubInterface>


### PR DESCRIPTION
Start support for bidir streaming RPCS in the generator. In this change
only the `*Stub` classes and its decorators get the stubs.

Part of the work for #7795

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7885)
<!-- Reviewable:end -->
