### PR TITLE
fix(generator): multiple method signatures doxygen

### DIFF
--- a/generator/internal/client_generator.cc
+++ b/generator/internal/client_generator.cc
@@ -118,54 +118,43 @@ Status ClientGenerator::GenerateHeader() {
     auto method_signature_extension =
         method.options().GetRepeatedExtension(google::api::method_signature);
     for (int i = 0; i < method_signature_extension.size(); ++i) {
-      std::string method_string =
+      std::string const method_string =
           absl::StrCat("  $method_name$($method_signature", i,
                        "$Options options = {});\n\n");
+      std::string const signature = method_signature_extension[i];
       HeaderPrintMethod(
           method,
           {MethodPattern(
-               {
-                   {FormatMethodCommentsFromRpcComments(
-                       method, MethodParameterStyle::kApiMethodSignature)},
-                   {IsResponseTypeEmpty,
-                    // clang-format off
+               {{FormatMethodCommentsMethodSignature(method, signature)},
+                {IsResponseTypeEmpty,
+                 // clang-format off
                    "  Status\n",
                    "  StatusOr<$response_type$>\n"},
-                  {method_string}
-                   // clang-format on
-               },
+                // clang-format on
+                {method_string}},
                All(IsNonStreaming, Not(IsLongrunningOperation),
                    Not(IsPaginated))),
            MethodPattern(
-               {
-                   {FormatMethodCommentsFromRpcComments(
-                       method, MethodParameterStyle::kApiMethodSignature)},
-                   {IsResponseTypeEmpty,
-                    // clang-format off
+               {{FormatMethodCommentsMethodSignature(method, signature)},
+                {IsResponseTypeEmpty,
+                 // clang-format off
                     "  future<Status>\n",
                     "  future<StatusOr<$longrunning_deduced_response_type$>>\n"},
-                   {method_string}
-                   // clang-format on
-               },
+                // clang-format on
+                {method_string}},
                All(IsNonStreaming, IsLongrunningOperation, Not(IsPaginated))),
            MethodPattern(
                {
-                   // clang-format off
-                   {FormatMethodCommentsFromRpcComments(
-                     method, MethodParameterStyle::kApiMethodSignature)},
+                   {FormatMethodCommentsMethodSignature(method, signature)},
                    {"  StreamRange<$range_output_type$>\n"},
                    {method_string},
-                   // clang-format on
                },
                All(IsNonStreaming, Not(IsLongrunningOperation), IsPaginated)),
            MethodPattern(
                {
-                   // clang-format off
-                   {FormatMethodCommentsFromRpcComments(
-                     method, MethodParameterStyle::kApiMethodSignature)},
+                   {FormatMethodCommentsMethodSignature(method, signature)},
                    {"  StreamRange<$response_type$>\n"},
                    {method_string},
-                   // clang-format on
                },
                IsStreamingRead)},
           __FILE__, __LINE__);
@@ -211,8 +200,7 @@ Status ClientGenerator::GenerateHeader() {
         method,
         {MethodPattern(
              {
-                 {FormatMethodCommentsFromRpcComments(
-                     method, MethodParameterStyle::kProtobufRequest)},
+                 {FormatMethodCommentsProtobufRequest(method)},
                  {IsResponseTypeEmpty,
                   // clang-format off
     "  Status\n",
@@ -225,8 +213,7 @@ Status ClientGenerator::GenerateHeader() {
                  Not(IsPaginated))),
          MethodPattern(
              {
-                 {FormatMethodCommentsFromRpcComments(
-                     method, MethodParameterStyle::kProtobufRequest)},
+                 {FormatMethodCommentsProtobufRequest(method)},
                  {IsResponseTypeEmpty,
                   // clang-format off
     "  future<Status>\n",
@@ -238,9 +225,8 @@ Status ClientGenerator::GenerateHeader() {
              All(IsNonStreaming, IsLongrunningOperation, Not(IsPaginated))),
          MethodPattern(
              {
+                 {FormatMethodCommentsProtobufRequest(method)},
                  // clang-format off
-                 {FormatMethodCommentsFromRpcComments(
-        method, MethodParameterStyle::kProtobufRequest)},
    {"  StreamRange<$range_output_type$>\n"
     "  $method_name$($request_type$ request, Options options = {});\n\n"},
                  // clang-format on
@@ -248,9 +234,8 @@ Status ClientGenerator::GenerateHeader() {
              All(IsNonStreaming, Not(IsLongrunningOperation), IsPaginated)),
          MethodPattern(
              {
+                 {FormatMethodCommentsProtobufRequest(method)},
                  // clang-format off
-                 {FormatMethodCommentsFromRpcComments(
-        method, MethodParameterStyle::kProtobufRequest)},
    {"  StreamRange<$response_type$>\n"
     "  $method_name$($request_type$ const& request, Options options = {});\n\n"},
                  // clang-format on
@@ -263,22 +248,20 @@ Status ClientGenerator::GenerateHeader() {
     auto method_signature_extension =
         method.options().GetRepeatedExtension(google::api::method_signature);
     for (int i = 0; i < method_signature_extension.size(); ++i) {
-      std::string method_string =
+      std::string const method_string =
           absl::StrCat("  Async$method_name$($method_signature", i,
                        "$Options options = {});\n\n");
+      std::string const signature = method_signature_extension[i];
       HeaderPrintMethod(
           method,
           {MethodPattern(
-              {
-                  {FormatMethodCommentsFromRpcComments(
-                      method, MethodParameterStyle::kApiMethodSignature)},
-                  {IsResponseTypeEmpty,
-                   // clang-format off
+              {{FormatMethodCommentsMethodSignature(method, signature)},
+               {IsResponseTypeEmpty,
+                // clang-format off
                    "  future<Status>\n",
                    "  future<StatusOr<$response_type$>>\n"},
-                  {method_string}
-                  // clang-format on
-              },
+               // clang-format on
+               {method_string}},
               All(IsNonStreaming, Not(IsLongrunningOperation),
                   Not(IsPaginated)))},
           __FILE__, __LINE__);
@@ -287,8 +270,7 @@ Status ClientGenerator::GenerateHeader() {
         method,
         {MethodPattern(
             {
-                {FormatMethodCommentsFromRpcComments(
-                    method, MethodParameterStyle::kProtobufRequest)},
+                {FormatMethodCommentsProtobufRequest(method)},
                 {IsResponseTypeEmpty,
                  // clang-format off
     "  future<Status>\n",

--- a/generator/internal/descriptor_utils.h
+++ b/generator/internal/descriptor_utils.h
@@ -71,14 +71,20 @@ Status PrintMethod(google::protobuf::MethodDescriptor const& method,
                    std::vector<MethodPattern> const& patterns, char const* file,
                    int line);
 
-enum class MethodParameterStyle { kApiMethodSignature, kProtobufRequest };
 /**
  * Formats comments from the source .proto file into Doxygen compatible
  * function headers, including param and return lines as necessary.
  */
-std::string FormatMethodCommentsFromRpcComments(
+std::string FormatMethodCommentsMethodSignature(
     google::protobuf::MethodDescriptor const& method,
-    MethodParameterStyle parameter_style);
+    std::string const& signature);
+
+/**
+ * Formats comments from the source .proto file into Doxygen compatible
+ * function headers, including param and return lines as necessary.
+ */
+std::string FormatMethodCommentsProtobufRequest(
+    google::protobuf::MethodDescriptor const& method);
 
 struct ResourceRoutingInfo {
   std::string url_path;


### PR DESCRIPTION
Fixes #7923 

Fix the generator so that the doxygen parameter comments are limited to the method signature in question (instead of all of them). I could have added an extra paremeter that was -1 for a protobuf request or N for the Nth method signature. But that seemed like bad code. So I took the opportunity to refactor the logic a bit, and clean up some things.

The diff is not great here. The old `FormatProtobufRequestParameters` was actually only two lines of code, so I inlined it. The other method was simplified a bit. Also, there is one less `enum` in the world.

In order to update the unit test so that it would have previously failed, I added a comment and method signature to the unit test proto. This explains why some of the line numbers in unrelated tests had to change.

I did not add an RPC with multiple method signatures to `generator/integration_tests/test.proto`. I think the unit test is sufficient.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7926)
<!-- Reviewable:end -->
