### PR TITLE
fix(generator): bidir streaming RPCs improvements

### DIFF
--- a/generator/integration_tests/golden/golden_kitchen_sink_connection.cc
+++ b/generator/integration_tests/golden/golden_kitchen_sink_connection.cc
@@ -243,8 +243,8 @@ class GoldenKitchenSinkConnectionImpl : public GoldenKitchenSinkConnection {
       google::test::admin::database::v1::AppendRowsRequest,
       google::test::admin::database::v1::AppendRowsResponse>>
   AsyncAppendRows() override {
-    auto cq = background_->cq();
-    return stub_->AsyncAppendRows(cq, absl::make_unique<grpc::ClientContext>());
+    return stub_->AsyncAppendRows(
+        background_->cq(), absl::make_unique<grpc::ClientContext>());
   }
 
  private:

--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_auth_decorator.cc
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_auth_decorator.cc
@@ -90,15 +90,17 @@ Status GoldenKitchenSinkAuth::DoNothing(
   return child_->DoNothing(context, request);
 }
 
-std::unique_ptr<GoldenKitchenSinkStub::AsyncAppendRowsStream>
+std::unique_ptr<::google::cloud::internal::AsyncStreamingReadWriteRpc<
+    google::test::admin::database::v1::AppendRowsRequest,
+    google::test::admin::database::v1::AppendRowsResponse>>
 GoldenKitchenSinkAuth::AsyncAppendRows(
-    google::cloud::CompletionQueue& cq,
+    google::cloud::CompletionQueue const& cq,
     std::unique_ptr<grpc::ClientContext> context) {
   using StreamAuth = google::cloud::internal::AsyncStreamingReadWriteRpcAuth<
     google::test::admin::database::v1::AppendRowsRequest, google::test::admin::database::v1::AppendRowsResponse>;
 
   auto child = child_;
-  auto call = [child, cq](std::unique_ptr<grpc::ClientContext> ctx) mutable {
+  auto call = [child, cq](std::unique_ptr<grpc::ClientContext> ctx) {
     return child->AsyncAppendRows(cq, std::move(ctx));
   };
   return absl::make_unique<StreamAuth>(

--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_auth_decorator.h
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_auth_decorator.h
@@ -67,8 +67,11 @@ class GoldenKitchenSinkAuth : public GoldenKitchenSinkStub {
       grpc::ClientContext& context,
       google::protobuf::Empty const& request) override;
 
-  std::unique_ptr<AsyncAppendRowsStream> AsyncAppendRows(
-      google::cloud::CompletionQueue& cq,
+  std::unique_ptr<::google::cloud::internal::AsyncStreamingReadWriteRpc<
+      google::test::admin::database::v1::AppendRowsRequest,
+      google::test::admin::database::v1::AppendRowsResponse>>
+  AsyncAppendRows(
+      google::cloud::CompletionQueue const& cq,
       std::unique_ptr<grpc::ClientContext> context) override;
 
  private:

--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_logging_decorator.cc
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_logging_decorator.cc
@@ -129,9 +129,11 @@ GoldenKitchenSinkLogging::DoNothing(
       context, request, __func__, tracing_options_);
 }
 
-std::unique_ptr<GoldenKitchenSinkStub::AsyncAppendRowsStream>
+std::unique_ptr<::google::cloud::internal::AsyncStreamingReadWriteRpc<
+    google::test::admin::database::v1::AppendRowsRequest,
+    google::test::admin::database::v1::AppendRowsResponse>>
 GoldenKitchenSinkLogging::AsyncAppendRows(
-    google::cloud::CompletionQueue& cq,
+    google::cloud::CompletionQueue const& cq,
     std::unique_ptr<grpc::ClientContext> context) {
   using LoggingStream =
      ::google::cloud::internal::AsyncStreamingReadWriteRpcLogging<google::test::admin::database::v1::AppendRowsRequest, google::test::admin::database::v1::AppendRowsResponse>;

--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_logging_decorator.h
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_logging_decorator.h
@@ -67,8 +67,11 @@ class GoldenKitchenSinkLogging : public GoldenKitchenSinkStub {
     grpc::ClientContext& context,
     google::protobuf::Empty const& request) override;
 
-  std::unique_ptr<AsyncAppendRowsStream> AsyncAppendRows(
-      google::cloud::CompletionQueue& cq,
+  std::unique_ptr<::google::cloud::internal::AsyncStreamingReadWriteRpc<
+      google::test::admin::database::v1::AppendRowsRequest,
+      google::test::admin::database::v1::AppendRowsResponse>>
+  AsyncAppendRows(
+      google::cloud::CompletionQueue const& cq,
       std::unique_ptr<grpc::ClientContext> context) override;
 
  private:

--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_metadata_decorator.cc
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_metadata_decorator.cc
@@ -88,9 +88,11 @@ GoldenKitchenSinkMetadata::DoNothing(
   return child_->DoNothing(context, request);
 }
 
-std::unique_ptr<GoldenKitchenSinkStub::AsyncAppendRowsStream>
+std::unique_ptr<::google::cloud::internal::AsyncStreamingReadWriteRpc<
+      google::test::admin::database::v1::AppendRowsRequest,
+      google::test::admin::database::v1::AppendRowsResponse>>
 GoldenKitchenSinkMetadata::AsyncAppendRows(
-    google::cloud::CompletionQueue& cq,
+    google::cloud::CompletionQueue const& cq,
     std::unique_ptr<grpc::ClientContext> context) {
   SetMetadata(*context, {});
   return child_->AsyncAppendRows(cq, std::move(context));

--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_metadata_decorator.h
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_metadata_decorator.h
@@ -63,8 +63,11 @@ class GoldenKitchenSinkMetadata : public GoldenKitchenSinkStub {
     grpc::ClientContext& context,
     google::protobuf::Empty const& request) override;
 
-  std::unique_ptr<AsyncAppendRowsStream> AsyncAppendRows(
-      google::cloud::CompletionQueue& cq,
+  std::unique_ptr<::google::cloud::internal::AsyncStreamingReadWriteRpc<
+      google::test::admin::database::v1::AppendRowsRequest,
+      google::test::admin::database::v1::AppendRowsResponse>>
+  AsyncAppendRows(
+      google::cloud::CompletionQueue const& cq,
       std::unique_ptr<grpc::ClientContext> context) override;
 
  private:

--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_stub.cc
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_stub.cc
@@ -118,9 +118,11 @@ DefaultGoldenKitchenSinkStub::DoNothing(
     return google::cloud::Status();
 }
 
-std::unique_ptr<GoldenKitchenSinkStub::AsyncAppendRowsStream>
+std::unique_ptr<::google::cloud::internal::AsyncStreamingReadWriteRpc<
+    google::test::admin::database::v1::AppendRowsRequest,
+    google::test::admin::database::v1::AppendRowsResponse>>
 DefaultGoldenKitchenSinkStub::AsyncAppendRows(
-    google::cloud::CompletionQueue& cq,
+    google::cloud::CompletionQueue const& cq,
     std::unique_ptr<grpc::ClientContext> context) {
   return google::cloud::internal::MakeStreamingReadWriteRpc<google::test::admin::database::v1::AppendRowsRequest, google::test::admin::database::v1::AppendRowsResponse>(
       cq, std::move(context),

--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_stub.h
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_stub.h
@@ -64,9 +64,11 @@ class GoldenKitchenSinkStub {
     grpc::ClientContext& context,
     google::protobuf::Empty const& request) = 0;
 
-  using AsyncAppendRowsStream = ::google::cloud::internal::AsyncStreamingReadWriteRpc<google::test::admin::database::v1::AppendRowsRequest, google::test::admin::database::v1::AppendRowsResponse>;
-  virtual std::unique_ptr<AsyncAppendRowsStream> AsyncAppendRows(
-      google::cloud::CompletionQueue& cq,
+  virtual std::unique_ptr<::google::cloud::internal::AsyncStreamingReadWriteRpc<
+      google::test::admin::database::v1::AppendRowsRequest,
+      google::test::admin::database::v1::AppendRowsResponse>>
+  AsyncAppendRows(
+      google::cloud::CompletionQueue const& cq,
       std::unique_ptr<grpc::ClientContext> context) = 0;
 
 };
@@ -112,8 +114,11 @@ class DefaultGoldenKitchenSinkStub : public GoldenKitchenSinkStub {
     grpc::ClientContext& client_context,
     google::protobuf::Empty const& request) override;
 
-  std::unique_ptr<AsyncAppendRowsStream> AsyncAppendRows(
-      google::cloud::CompletionQueue& cq,
+  std::unique_ptr<::google::cloud::internal::AsyncStreamingReadWriteRpc<
+      google::test::admin::database::v1::AppendRowsRequest,
+      google::test::admin::database::v1::AppendRowsResponse>>
+  AsyncAppendRows(
+      google::cloud::CompletionQueue const& cq,
       std::unique_ptr<grpc::ClientContext> context) override;
 
  private:

--- a/generator/integration_tests/golden/mocks/mock_golden_kitchen_sink_stub.h
+++ b/generator/integration_tests/golden/mocks/mock_golden_kitchen_sink_stub.h
@@ -72,7 +72,14 @@ class MockGoldenKitchenSinkStub : public GoldenKitchenSinkStub {
        ::google::protobuf::Empty const&),
       (override));
 
-  MOCK_METHOD(std::unique_ptr<GoldenKitchenSinkStub::AsyncAppendRowsStream>, AsyncAppendRows, (google::cloud::CompletionQueue& cq, std::unique_ptr<grpc::ClientContext> context), (override));
+  MOCK_METHOD(
+      (std::unique_ptr<::google::cloud::internal::AsyncStreamingReadWriteRpc<
+           ::google::test::admin::database::v1::AppendRowsRequest,
+           ::google::test::admin::database::v1::AppendRowsResponse>>),
+      AsyncAppendRows,
+      (google::cloud::CompletionQueue const& cq,
+           std::unique_ptr<grpc::ClientContext> context),
+      (override));
 };
 
 class MockTailLogEntriesStreamingReadRpc

--- a/generator/internal/connection_generator.cc
+++ b/generator/internal/connection_generator.cc
@@ -395,8 +395,8 @@ $connection_class_name$::Async$method_name$(
       $request_type$,
       $response_type$>>
   Async$method_name$() override {
-    auto cq = background_->cq();
-    return stub_->Async$method_name$(cq, absl::make_unique<grpc::ClientContext>());
+    return stub_->Async$method_name$(
+        background_->cq(), absl::make_unique<grpc::ClientContext>());
   }
 
 )""");

--- a/generator/internal/logging_decorator_generator.cc
+++ b/generator/internal/logging_decorator_generator.cc
@@ -74,8 +74,11 @@ Status LoggingDecoratorGenerator::GenerateHeader() {
     if (IsBidirStreaming(method)) {
       HeaderPrintMethod(
           method, __FILE__, __LINE__,
-          R"""(  std::unique_ptr<Async$method_name$Stream> Async$method_name$(
-      google::cloud::CompletionQueue& cq,
+          R"""(  std::unique_ptr<::google::cloud::internal::AsyncStreamingReadWriteRpc<
+      $request_type$,
+      $response_type$>>
+  Async$method_name$(
+      google::cloud::CompletionQueue const& cq,
       std::unique_ptr<grpc::ClientContext> context) override;
 
 )""");
@@ -201,9 +204,11 @@ Status LoggingDecoratorGenerator::GenerateCc() {
     if (IsBidirStreaming(method)) {
       CcPrintMethod(
           method, __FILE__, __LINE__,
-          R"""(std::unique_ptr<$stub_class_name$::Async$method_name$Stream>
+          R"""(std::unique_ptr<::google::cloud::internal::AsyncStreamingReadWriteRpc<
+    $request_type$,
+    $response_type$>>
 $logging_class_name$::Async$method_name$(
-    google::cloud::CompletionQueue& cq,
+    google::cloud::CompletionQueue const& cq,
     std::unique_ptr<grpc::ClientContext> context) {
   using LoggingStream =
      ::google::cloud::internal::AsyncStreamingReadWriteRpcLogging<$request_type$, $response_type$>;

--- a/generator/internal/metadata_decorator_generator.cc
+++ b/generator/internal/metadata_decorator_generator.cc
@@ -68,8 +68,11 @@ Status MetadataDecoratorGenerator::GenerateHeader() {
     if (IsBidirStreaming(method)) {
       HeaderPrintMethod(
           method, __FILE__, __LINE__,
-          R"""(  std::unique_ptr<Async$method_name$Stream> Async$method_name$(
-      google::cloud::CompletionQueue& cq,
+          R"""(  std::unique_ptr<::google::cloud::internal::AsyncStreamingReadWriteRpc<
+      $request_type$,
+      $response_type$>>
+  Async$method_name$(
+      google::cloud::CompletionQueue const& cq,
       std::unique_ptr<grpc::ClientContext> context) override;
 
 )""");
@@ -188,9 +191,11 @@ Status MetadataDecoratorGenerator::GenerateCc() {
     if (IsBidirStreaming(method)) {
       CcPrintMethod(
           method, __FILE__, __LINE__,
-          R"""(std::unique_ptr<$stub_class_name$::Async$method_name$Stream>
+          R"""(std::unique_ptr<::google::cloud::internal::AsyncStreamingReadWriteRpc<
+      $request_type$,
+      $response_type$>>
 $metadata_class_name$::Async$method_name$(
-    google::cloud::CompletionQueue& cq,
+    google::cloud::CompletionQueue const& cq,
     std::unique_ptr<grpc::ClientContext> context) {
   SetMetadata(*context, {});
   return child_->Async$method_name$(cq, std::move(context));

--- a/generator/internal/stub_generator.cc
+++ b/generator/internal/stub_generator.cc
@@ -79,9 +79,11 @@ Status StubGenerator::GenerateHeader() {
     if (IsBidirStreaming(method)) {
       HeaderPrintMethod(
           method, __FILE__, __LINE__,
-          R"""(  using Async$method_name$Stream = ::google::cloud::internal::AsyncStreamingReadWriteRpc<$request_type$, $response_type$>;
-  virtual std::unique_ptr<Async$method_name$Stream> Async$method_name$(
-      google::cloud::CompletionQueue& cq,
+          R"""(  virtual std::unique_ptr<::google::cloud::internal::AsyncStreamingReadWriteRpc<
+      $request_type$,
+      $response_type$>>
+  Async$method_name$(
+      google::cloud::CompletionQueue const& cq,
       std::unique_ptr<grpc::ClientContext> context) = 0;
 
 )""");
@@ -185,8 +187,11 @@ Status StubGenerator::GenerateHeader() {
     if (IsBidirStreaming(method)) {
       HeaderPrintMethod(
           method, __FILE__, __LINE__,
-          R"""(  std::unique_ptr<Async$method_name$Stream> Async$method_name$(
-      google::cloud::CompletionQueue& cq,
+          R"""(  std::unique_ptr<::google::cloud::internal::AsyncStreamingReadWriteRpc<
+      $request_type$,
+      $response_type$>>
+  Async$method_name$(
+      google::cloud::CompletionQueue const& cq,
       std::unique_ptr<grpc::ClientContext> context) override;
 
 )""");
@@ -313,9 +318,11 @@ Status StubGenerator::GenerateCc() {
     if (IsBidirStreaming(method)) {
       CcPrintMethod(
           method, __FILE__, __LINE__,
-          R"""(std::unique_ptr<$stub_class_name$::Async$method_name$Stream>
+          R"""(std::unique_ptr<::google::cloud::internal::AsyncStreamingReadWriteRpc<
+    $request_type$,
+    $response_type$>>
 Default$stub_class_name$::Async$method_name$(
-    google::cloud::CompletionQueue& cq,
+    google::cloud::CompletionQueue const& cq,
     std::unique_ptr<grpc::ClientContext> context) {
   return google::cloud::internal::MakeStreamingReadWriteRpc<$request_type$, $response_type$>(
       cq, std::move(context),

--- a/google/cloud/logging/internal/logging_service_v2_auth_decorator.cc
+++ b/google/cloud/logging/internal/logging_service_v2_auth_decorator.cc
@@ -75,16 +75,18 @@ StatusOr<google::logging::v2::ListLogsResponse> LoggingServiceV2Auth::ListLogs(
   return child_->ListLogs(context, request);
 }
 
-std::unique_ptr<LoggingServiceV2Stub::AsyncTailLogEntriesStream>
+std::unique_ptr<::google::cloud::internal::AsyncStreamingReadWriteRpc<
+    google::logging::v2::TailLogEntriesRequest,
+    google::logging::v2::TailLogEntriesResponse>>
 LoggingServiceV2Auth::AsyncTailLogEntries(
-    google::cloud::CompletionQueue& cq,
+    google::cloud::CompletionQueue const& cq,
     std::unique_ptr<grpc::ClientContext> context) {
   using StreamAuth = google::cloud::internal::AsyncStreamingReadWriteRpcAuth<
       google::logging::v2::TailLogEntriesRequest,
       google::logging::v2::TailLogEntriesResponse>;
 
   auto child = child_;
-  auto call = [child, cq](std::unique_ptr<grpc::ClientContext> ctx) mutable {
+  auto call = [child, cq](std::unique_ptr<grpc::ClientContext> ctx) {
     return child->AsyncTailLogEntries(cq, std::move(ctx));
   };
   return absl::make_unique<StreamAuth>(

--- a/google/cloud/logging/internal/logging_service_v2_auth_decorator.h
+++ b/google/cloud/logging/internal/logging_service_v2_auth_decorator.h
@@ -60,9 +60,11 @@ class LoggingServiceV2Auth : public LoggingServiceV2Stub {
       grpc::ClientContext& context,
       google::logging::v2::ListLogsRequest const& request) override;
 
-  std::unique_ptr<AsyncTailLogEntriesStream> AsyncTailLogEntries(
-      google::cloud::CompletionQueue& cq,
-      std::unique_ptr<grpc::ClientContext> context) override;
+  std::unique_ptr<::google::cloud::internal::AsyncStreamingReadWriteRpc<
+      google::logging::v2::TailLogEntriesRequest,
+      google::logging::v2::TailLogEntriesResponse>>
+  AsyncTailLogEntries(google::cloud::CompletionQueue const& cq,
+                      std::unique_ptr<grpc::ClientContext> context) override;
 
  private:
   std::shared_ptr<google::cloud::internal::GrpcAuthenticationStrategy> auth_;

--- a/google/cloud/logging/internal/logging_service_v2_logging_decorator.cc
+++ b/google/cloud/logging/internal/logging_service_v2_logging_decorator.cc
@@ -96,9 +96,11 @@ LoggingServiceV2Logging::ListLogs(
       context, request, __func__, tracing_options_);
 }
 
-std::unique_ptr<LoggingServiceV2Stub::AsyncTailLogEntriesStream>
+std::unique_ptr<::google::cloud::internal::AsyncStreamingReadWriteRpc<
+    google::logging::v2::TailLogEntriesRequest,
+    google::logging::v2::TailLogEntriesResponse>>
 LoggingServiceV2Logging::AsyncTailLogEntries(
-    google::cloud::CompletionQueue& cq,
+    google::cloud::CompletionQueue const& cq,
     std::unique_ptr<grpc::ClientContext> context) {
   using LoggingStream =
       ::google::cloud::internal::AsyncStreamingReadWriteRpcLogging<

--- a/google/cloud/logging/internal/logging_service_v2_logging_decorator.h
+++ b/google/cloud/logging/internal/logging_service_v2_logging_decorator.h
@@ -60,9 +60,11 @@ class LoggingServiceV2Logging : public LoggingServiceV2Stub {
       grpc::ClientContext& context,
       google::logging::v2::ListLogsRequest const& request) override;
 
-  std::unique_ptr<AsyncTailLogEntriesStream> AsyncTailLogEntries(
-      google::cloud::CompletionQueue& cq,
-      std::unique_ptr<grpc::ClientContext> context) override;
+  std::unique_ptr<::google::cloud::internal::AsyncStreamingReadWriteRpc<
+      google::logging::v2::TailLogEntriesRequest,
+      google::logging::v2::TailLogEntriesResponse>>
+  AsyncTailLogEntries(google::cloud::CompletionQueue const& cq,
+                      std::unique_ptr<grpc::ClientContext> context) override;
 
  private:
   std::shared_ptr<LoggingServiceV2Stub> child_;

--- a/google/cloud/logging/internal/logging_service_v2_metadata_decorator.cc
+++ b/google/cloud/logging/internal/logging_service_v2_metadata_decorator.cc
@@ -73,9 +73,11 @@ LoggingServiceV2Metadata::ListLogs(
   return child_->ListLogs(context, request);
 }
 
-std::unique_ptr<LoggingServiceV2Stub::AsyncTailLogEntriesStream>
+std::unique_ptr<::google::cloud::internal::AsyncStreamingReadWriteRpc<
+    google::logging::v2::TailLogEntriesRequest,
+    google::logging::v2::TailLogEntriesResponse>>
 LoggingServiceV2Metadata::AsyncTailLogEntries(
-    google::cloud::CompletionQueue& cq,
+    google::cloud::CompletionQueue const& cq,
     std::unique_ptr<grpc::ClientContext> context) {
   SetMetadata(*context, {});
   return child_->AsyncTailLogEntries(cq, std::move(context));

--- a/google/cloud/logging/internal/logging_service_v2_metadata_decorator.h
+++ b/google/cloud/logging/internal/logging_service_v2_metadata_decorator.h
@@ -57,9 +57,11 @@ class LoggingServiceV2Metadata : public LoggingServiceV2Stub {
       grpc::ClientContext& context,
       google::logging::v2::ListLogsRequest const& request) override;
 
-  std::unique_ptr<AsyncTailLogEntriesStream> AsyncTailLogEntries(
-      google::cloud::CompletionQueue& cq,
-      std::unique_ptr<grpc::ClientContext> context) override;
+  std::unique_ptr<::google::cloud::internal::AsyncStreamingReadWriteRpc<
+      google::logging::v2::TailLogEntriesRequest,
+      google::logging::v2::TailLogEntriesResponse>>
+  AsyncTailLogEntries(google::cloud::CompletionQueue const& cq,
+                      std::unique_ptr<grpc::ClientContext> context) override;
 
  private:
   void SetMetadata(grpc::ClientContext& context,

--- a/google/cloud/logging/internal/logging_service_v2_stub.cc
+++ b/google/cloud/logging/internal/logging_service_v2_stub.cc
@@ -91,9 +91,11 @@ DefaultLoggingServiceV2Stub::ListLogs(
   return response;
 }
 
-std::unique_ptr<LoggingServiceV2Stub::AsyncTailLogEntriesStream>
+std::unique_ptr<::google::cloud::internal::AsyncStreamingReadWriteRpc<
+    google::logging::v2::TailLogEntriesRequest,
+    google::logging::v2::TailLogEntriesResponse>>
 DefaultLoggingServiceV2Stub::AsyncTailLogEntries(
-    google::cloud::CompletionQueue& cq,
+    google::cloud::CompletionQueue const& cq,
     std::unique_ptr<grpc::ClientContext> context) {
   return google::cloud::internal::MakeStreamingReadWriteRpc<
       google::logging::v2::TailLogEntriesRequest,

--- a/google/cloud/logging/internal/logging_service_v2_stub.h
+++ b/google/cloud/logging/internal/logging_service_v2_stub.h
@@ -58,13 +58,11 @@ class LoggingServiceV2Stub {
       grpc::ClientContext& context,
       google::logging::v2::ListLogsRequest const& request) = 0;
 
-  using AsyncTailLogEntriesStream =
-      ::google::cloud::internal::AsyncStreamingReadWriteRpc<
-          google::logging::v2::TailLogEntriesRequest,
-          google::logging::v2::TailLogEntriesResponse>;
-  virtual std::unique_ptr<AsyncTailLogEntriesStream> AsyncTailLogEntries(
-      google::cloud::CompletionQueue& cq,
-      std::unique_ptr<grpc::ClientContext> context) = 0;
+  virtual std::unique_ptr<::google::cloud::internal::AsyncStreamingReadWriteRpc<
+      google::logging::v2::TailLogEntriesRequest,
+      google::logging::v2::TailLogEntriesResponse>>
+  AsyncTailLogEntries(google::cloud::CompletionQueue const& cq,
+                      std::unique_ptr<grpc::ClientContext> context) = 0;
 };
 
 class DefaultLoggingServiceV2Stub : public LoggingServiceV2Stub {
@@ -96,9 +94,11 @@ class DefaultLoggingServiceV2Stub : public LoggingServiceV2Stub {
       grpc::ClientContext& client_context,
       google::logging::v2::ListLogsRequest const& request) override;
 
-  std::unique_ptr<AsyncTailLogEntriesStream> AsyncTailLogEntries(
-      google::cloud::CompletionQueue& cq,
-      std::unique_ptr<grpc::ClientContext> context) override;
+  std::unique_ptr<::google::cloud::internal::AsyncStreamingReadWriteRpc<
+      google::logging::v2::TailLogEntriesRequest,
+      google::logging::v2::TailLogEntriesResponse>>
+  AsyncTailLogEntries(google::cloud::CompletionQueue const& cq,
+                      std::unique_ptr<grpc::ClientContext> context) override;
 
  private:
   std::unique_ptr<google::logging::v2::LoggingServiceV2::StubInterface>

--- a/google/cloud/logging/logging_service_v2_connection.cc
+++ b/google/cloud/logging/logging_service_v2_connection.cc
@@ -245,8 +245,7 @@ class LoggingServiceV2ConnectionImpl : public LoggingServiceV2Connection {
       google::logging::v2::TailLogEntriesRequest,
       google::logging::v2::TailLogEntriesResponse>>
   AsyncTailLogEntries() override {
-    auto cq = background_->cq();
-    return stub_->AsyncTailLogEntries(cq,
+    return stub_->AsyncTailLogEntries(background_->cq(),
                                       absl::make_unique<grpc::ClientContext>());
   }
 


### PR DESCRIPTION
Remove the alias for bidir streaming RPC return types. I realized they
could conflict with any other method name defined in the same interface.

I also changed the completion queue parameter in the `Stub` classes from
`CompletionQueue&` to `Completion const&`. There is one place, in the
`*Auth` decorator, where taking by-value would save us one refcount
twiddle. Since this class is optional, and that save would require C++14
(or a helper functor to capture by move), and the classes are in
`internal::` I decided to just go with the reference.

Part of the work for #7795

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7937)
<!-- Reviewable:end -->
