### PR TITLE
impl(generator): support additional proto files for lro return types

### DIFF
--- a/generator/generator_config.proto
+++ b/generator/generator_config.proto
@@ -53,6 +53,11 @@ message ServiceConfiguration {
   // does not provide good application-level concepts (consider chunking for
   // rows or values).
   bool omit_client = 11;
+
+  // If additional proto files are needed that aren't imported by the service
+  // file, add them using this field. This typically happens when an annotation
+  // lists a type that is not defined in any of the imported proto files.
+  repeated string additional_proto_files = 12;
 }
 
 message GeneratorConfiguration {

--- a/generator/integration_tests/generator_integration_test.cc
+++ b/generator/integration_tests/generator_integration_test.cc
@@ -107,6 +107,7 @@ class GeneratorIntegrationTest : public testing::TestWithParam<std::string> {
     retry_code1_ = "GoldenKitchenSink.kInternal";
     retry_code2_ = "kUnavailable";
     retry_code3_ = "GoldenThingAdmin.kDeadlineExceeded";
+    additional_proto_file_ = "generator/integration_tests/backup.proto";
 
     std::vector<std::string> args;
     // empty arg keeps first real arg from being ignored.
@@ -128,7 +129,12 @@ class GeneratorIntegrationTest : public testing::TestWithParam<std::string> {
     args.emplace_back("--cpp_codegen_opt=retry_status_code=" + retry_code1_);
     args.emplace_back("--cpp_codegen_opt=retry_status_code=" + retry_code2_);
     args.emplace_back("--cpp_codegen_opt=retry_status_code=" + retry_code3_);
+    args.emplace_back("--cpp_codegen_opt=additional_proto_file=" +
+                      additional_proto_file_);
     args.emplace_back("generator/integration_tests/test.proto");
+    // It's redundant to add backup.proto as it's imported by test.proto, but
+    // it lets us test the additional_proto_file flag.
+    args.emplace_back("generator/integration_tests/backup.proto");
 
     std::vector<char const*> c_args;
     c_args.reserve(args.size());
@@ -156,6 +162,7 @@ class GeneratorIntegrationTest : public testing::TestWithParam<std::string> {
   std::string retry_code1_;
   std::string retry_code2_;
   std::string retry_code3_;
+  std::string additional_proto_file_;
 };
 
 TEST_P(GeneratorIntegrationTest, CompareGeneratedToGolden) {

--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_stub.h
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_stub.h
@@ -23,6 +23,7 @@
 #include "google/cloud/internal/streaming_read_rpc.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
+#include <generator/integration_tests/backup.pb.h>
 #include <generator/integration_tests/test.grpc.pb.h>
 #include <memory>
 

--- a/generator/integration_tests/golden/internal/golden_thing_admin_stub.h
+++ b/generator/integration_tests/golden/internal/golden_thing_admin_stub.h
@@ -23,6 +23,7 @@
 #include "google/cloud/future.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
+#include <generator/integration_tests/backup.pb.h>
 #include <generator/integration_tests/test.grpc.pb.h>
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>

--- a/generator/internal/codegen_utils.cc
+++ b/generator/internal/codegen_utils.cc
@@ -134,6 +134,12 @@ void ProcessArgRetryGrpcStatusCode(
                   command_line_args);
 }
 
+void ProcessArgAdditionalProtoFiles(
+    std::vector<std::pair<std::string, std::string>>& command_line_args) {
+  ProcessRepeated("additional_proto_file", "additional_proto_files",
+                  command_line_args);
+}
+
 }  // namespace
 
 std::string CurrentCopyrightYear() {
@@ -226,6 +232,7 @@ ProcessCommandLineArgs(std::string const& parameters) {
   ProcessArgEmulatorEndpointEnvVar(command_line_args);
   ProcessArgGenerateAsyncRpc(command_line_args);
   ProcessArgRetryGrpcStatusCode(command_line_args);
+  ProcessArgAdditionalProtoFiles(command_line_args);
   return command_line_args;
 }
 

--- a/generator/internal/descriptor_utils.cc
+++ b/generator/internal/descriptor_utils.cc
@@ -364,6 +364,21 @@ void SetRetryStatusCodeExpression(VarsDictionary& vars) {
   vars["retry_status_code_expression"] = retry_status_code_expression;
 }
 
+std::string FormatAdditionalPbHeaderPaths(VarsDictionary& vars) {
+  std::vector<std::string> additional_pb_header_paths;
+  auto iter = vars.find("additional_proto_files");
+  if (iter != vars.end()) {
+    std::vector<std::string> additional_proto_files =
+        absl::StrSplit(iter->second, absl::ByChar(','));
+    for (auto& file : additional_proto_files) {
+      absl::StripAsciiWhitespace(&file);
+      additional_pb_header_paths.push_back(
+          absl::StrCat(absl::StripSuffix(file, ".proto"), ".pb.h"));
+    }
+  }
+  return absl::StrJoin(additional_pb_header_paths, ",");
+}
+
 }  // namespace
 
 absl::optional<ResourceRoutingInfo> ParseResourceRoutingHeader(
@@ -483,6 +498,7 @@ VarsDictionary CreateServiceVars(
     google::protobuf::ServiceDescriptor const& descriptor,
     std::vector<std::pair<std::string, std::string>> const& initial_values) {
   VarsDictionary vars(initial_values.begin(), initial_values.end());
+  vars["additional_pb_header_paths"] = FormatAdditionalPbHeaderPaths(vars);
   vars["class_comment_block"] =
       FormatClassCommentsFromServiceComments(descriptor);
   vars["client_class_name"] = absl::StrCat(descriptor.name(), "Client");

--- a/generator/internal/stub_generator.cc
+++ b/generator/internal/stub_generator.cc
@@ -58,6 +58,9 @@ Status StubGenerator::GenerateHeader() {
            ? "google/cloud/internal/async_read_write_stream_impl.h"
            : "",
        "google/cloud/version.h"});
+  std::vector<std::string> additional_pb_header_paths =
+      absl::StrSplit(vars("additional_pb_header_paths"), absl::ByChar(','));
+  HeaderSystemIncludes(additional_pb_header_paths);
   HeaderSystemIncludes(
       {vars("proto_grpc_header_path"),
        HasLongrunningMethod() ? "google/longrunning/operations.grpc.pb.h" : "",

--- a/generator/standalone_main.cc
+++ b/generator/standalone_main.cc
@@ -219,7 +219,15 @@ int main(int argc, char** argv) {
     for (auto const& gen_async_rpc : service.gen_async_rpcs()) {
       args.emplace_back("--cpp_codegen_opt=gen_async_rpc=" + gen_async_rpc);
     }
+    for (auto const& additional_proto_file : service.additional_proto_files()) {
+      args.emplace_back("--cpp_codegen_opt=additional_proto_file=" +
+                        additional_proto_file);
+    }
     args.emplace_back(service.service_proto_path());
+    for (auto const& additional_proto_file : service.additional_proto_files()) {
+      args.emplace_back(additional_proto_file);
+    }
+
     GCP_LOG(INFO) << "Generating service code using: "
                   << absl::StrJoin(args, ";") << "\n";
 


### PR DESCRIPTION
Allows additional proto files to be specified in the config. The files are used for type lookups during code generation and to format include statements in the <service_name>_stub.h files. The proto files are also run through protoc in order to produce the accompanying pb.h and pb.cc files.

fixes #7922

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7940)
<!-- Reviewable:end -->
