### PR TITLE
feat(generator): streaming-write RPCs for Stubs

### DIFF
--- a/generator/integration_tests/golden/golden_kitchen_sink_client.h
+++ b/generator/integration_tests/golden/golden_kitchen_sink_client.h
@@ -116,10 +116,10 @@ class GoldenKitchenSinkClient {
   ///  not specified, the token's lifetime will be set to a default value of one
   ///  hour.
   /// @param options  Optional. Operation options.
-  /// @return @googleapis_link{google::test::admin::database::v1::GenerateAccessTokenResponse,generator/integration_tests/test.proto#L899}
+  /// @return @googleapis_link{google::test::admin::database::v1::GenerateAccessTokenResponse,generator/integration_tests/test.proto#L910}
   ///
-  /// [google.test.admin.database.v1.GenerateAccessTokenRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L862}
-  /// [google.test.admin.database.v1.GenerateAccessTokenResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L899}
+  /// [google.test.admin.database.v1.GenerateAccessTokenRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L873}
+  /// [google.test.admin.database.v1.GenerateAccessTokenResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L910}
   ///
   StatusOr<google::test::admin::database::v1::GenerateAccessTokenResponse>
   GenerateAccessToken(std::string const& name, std::vector<std::string> const& delegates, std::vector<std::string> const& scope, google::protobuf::Duration const& lifetime, Options options = {});
@@ -127,12 +127,12 @@ class GoldenKitchenSinkClient {
   ///
   /// Generates an OAuth 2.0 access token for a service account.
   ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::GenerateAccessTokenRequest,generator/integration_tests/test.proto#L862}
+  /// @param request @googleapis_link{google::test::admin::database::v1::GenerateAccessTokenRequest,generator/integration_tests/test.proto#L873}
   /// @param options  Optional. Operation options.
-  /// @return @googleapis_link{google::test::admin::database::v1::GenerateAccessTokenResponse,generator/integration_tests/test.proto#L899}
+  /// @return @googleapis_link{google::test::admin::database::v1::GenerateAccessTokenResponse,generator/integration_tests/test.proto#L910}
   ///
-  /// [google.test.admin.database.v1.GenerateAccessTokenRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L862}
-  /// [google.test.admin.database.v1.GenerateAccessTokenResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L899}
+  /// [google.test.admin.database.v1.GenerateAccessTokenRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L873}
+  /// [google.test.admin.database.v1.GenerateAccessTokenResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L910}
   ///
   StatusOr<google::test::admin::database::v1::GenerateAccessTokenResponse>
   GenerateAccessToken(google::test::admin::database::v1::GenerateAccessTokenRequest const& request, Options options = {});
@@ -158,10 +158,10 @@ class GoldenKitchenSinkClient {
   /// @param include_email  Include the service account email in the token. If set to `true`, the
   ///  token will contain `email` and `email_verified` claims.
   /// @param options  Optional. Operation options.
-  /// @return @googleapis_link{google::test::admin::database::v1::GenerateIdTokenResponse,generator/integration_tests/test.proto#L941}
+  /// @return @googleapis_link{google::test::admin::database::v1::GenerateIdTokenResponse,generator/integration_tests/test.proto#L952}
   ///
-  /// [google.test.admin.database.v1.GenerateIdTokenRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L908}
-  /// [google.test.admin.database.v1.GenerateIdTokenResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L941}
+  /// [google.test.admin.database.v1.GenerateIdTokenRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L919}
+  /// [google.test.admin.database.v1.GenerateIdTokenResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L952}
   ///
   StatusOr<google::test::admin::database::v1::GenerateIdTokenResponse>
   GenerateIdToken(std::string const& name, std::vector<std::string> const& delegates, std::string const& audience, bool include_email, Options options = {});
@@ -169,12 +169,12 @@ class GoldenKitchenSinkClient {
   ///
   /// Generates an OpenID Connect ID token for a service account.
   ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::GenerateIdTokenRequest,generator/integration_tests/test.proto#L908}
+  /// @param request @googleapis_link{google::test::admin::database::v1::GenerateIdTokenRequest,generator/integration_tests/test.proto#L919}
   /// @param options  Optional. Operation options.
-  /// @return @googleapis_link{google::test::admin::database::v1::GenerateIdTokenResponse,generator/integration_tests/test.proto#L941}
+  /// @return @googleapis_link{google::test::admin::database::v1::GenerateIdTokenResponse,generator/integration_tests/test.proto#L952}
   ///
-  /// [google.test.admin.database.v1.GenerateIdTokenRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L908}
-  /// [google.test.admin.database.v1.GenerateIdTokenResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L941}
+  /// [google.test.admin.database.v1.GenerateIdTokenRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L919}
+  /// [google.test.admin.database.v1.GenerateIdTokenResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L952}
   ///
   StatusOr<google::test::admin::database::v1::GenerateIdTokenResponse>
   GenerateIdToken(google::test::admin::database::v1::GenerateIdTokenRequest const& request, Options options = {});
@@ -206,10 +206,10 @@ class GoldenKitchenSinkClient {
   ///  as a label in this parameter, then the log entry's label is not changed.
   ///  See [LogEntry][google.logging.v2.LogEntry]. Test delimiter$
   /// @param options  Optional. Operation options.
-  /// @return @googleapis_link{google::test::admin::database::v1::WriteLogEntriesResponse,generator/integration_tests/test.proto#L980}
+  /// @return @googleapis_link{google::test::admin::database::v1::WriteLogEntriesResponse,generator/integration_tests/test.proto#L991}
   ///
-  /// [google.test.admin.database.v1.WriteLogEntriesRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L947}
-  /// [google.test.admin.database.v1.WriteLogEntriesResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L980}
+  /// [google.test.admin.database.v1.WriteLogEntriesRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L958}
+  /// [google.test.admin.database.v1.WriteLogEntriesResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L991}
   ///
   StatusOr<google::test::admin::database::v1::WriteLogEntriesResponse>
   WriteLogEntries(std::string const& log_name, std::map<std::string, std::string> const& labels, Options options = {});
@@ -223,12 +223,12 @@ class GoldenKitchenSinkClient {
   /// different resources (projects, organizations, billing accounts or
   /// folders)
   ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::WriteLogEntriesRequest,generator/integration_tests/test.proto#L947}
+  /// @param request @googleapis_link{google::test::admin::database::v1::WriteLogEntriesRequest,generator/integration_tests/test.proto#L958}
   /// @param options  Optional. Operation options.
-  /// @return @googleapis_link{google::test::admin::database::v1::WriteLogEntriesResponse,generator/integration_tests/test.proto#L980}
+  /// @return @googleapis_link{google::test::admin::database::v1::WriteLogEntriesResponse,generator/integration_tests/test.proto#L991}
   ///
-  /// [google.test.admin.database.v1.WriteLogEntriesRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L947}
-  /// [google.test.admin.database.v1.WriteLogEntriesResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L980}
+  /// [google.test.admin.database.v1.WriteLogEntriesRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L958}
+  /// [google.test.admin.database.v1.WriteLogEntriesResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L991}
   ///
   StatusOr<google::test::admin::database::v1::WriteLogEntriesResponse>
   WriteLogEntries(google::test::admin::database::v1::WriteLogEntriesRequest const& request, Options options = {});
@@ -245,7 +245,7 @@ class GoldenKitchenSinkClient {
   /// @param options  Optional. Operation options.
   /// @return std::string
   ///
-  /// [google.test.admin.database.v1.ListLogsRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L983}
+  /// [google.test.admin.database.v1.ListLogsRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L994}
   ///
   StreamRange<std::string>
   ListLogs(std::string const& parent, Options options = {});
@@ -254,11 +254,11 @@ class GoldenKitchenSinkClient {
   /// Lists the logs in projects, organizations, folders, or billing accounts.
   /// Only logs that have entries are listed.
   ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::ListLogsRequest,generator/integration_tests/test.proto#L983}
+  /// @param request @googleapis_link{google::test::admin::database::v1::ListLogsRequest,generator/integration_tests/test.proto#L994}
   /// @param options  Optional. Operation options.
   /// @return std::string
   ///
-  /// [google.test.admin.database.v1.ListLogsRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L983}
+  /// [google.test.admin.database.v1.ListLogsRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L994}
   ///
   StreamRange<std::string>
   ListLogs(google::test::admin::database::v1::ListLogsRequest request, Options options = {});
@@ -278,10 +278,10 @@ class GoldenKitchenSinkClient {
   ///      "billingAccounts/[BILLING_ACCOUNT_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]"
   ///      "folders/[FOLDER_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]"
   /// @param options  Optional. Operation options.
-  /// @return @googleapis_link{google::test::admin::database::v1::TailLogEntriesResponse,generator/integration_tests/test.proto#L1241}
+  /// @return @googleapis_link{google::test::admin::database::v1::TailLogEntriesResponse,generator/integration_tests/test.proto#L1252}
   ///
-  /// [google.test.admin.database.v1.TailLogEntriesRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1209}
-  /// [google.test.admin.database.v1.TailLogEntriesResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1241}
+  /// [google.test.admin.database.v1.TailLogEntriesRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1220}
+  /// [google.test.admin.database.v1.TailLogEntriesResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1252}
   ///
   StreamRange<google::test::admin::database::v1::TailLogEntriesResponse>
   TailLogEntries(std::vector<std::string> const& resource_names, Options options = {});
@@ -290,12 +290,12 @@ class GoldenKitchenSinkClient {
   /// Streaming read of log entries as they are ingested. Until the stream is
   /// terminated, it will continue reading logs.
   ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::TailLogEntriesRequest,generator/integration_tests/test.proto#L1209}
+  /// @param request @googleapis_link{google::test::admin::database::v1::TailLogEntriesRequest,generator/integration_tests/test.proto#L1220}
   /// @param options  Optional. Operation options.
-  /// @return @googleapis_link{google::test::admin::database::v1::TailLogEntriesResponse,generator/integration_tests/test.proto#L1241}
+  /// @return @googleapis_link{google::test::admin::database::v1::TailLogEntriesResponse,generator/integration_tests/test.proto#L1252}
   ///
-  /// [google.test.admin.database.v1.TailLogEntriesRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1209}
-  /// [google.test.admin.database.v1.TailLogEntriesResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1241}
+  /// [google.test.admin.database.v1.TailLogEntriesRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1220}
+  /// [google.test.admin.database.v1.TailLogEntriesResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1252}
   ///
   StreamRange<google::test::admin::database::v1::TailLogEntriesResponse>
   TailLogEntries(google::test::admin::database::v1::TailLogEntriesRequest const& request, Options options = {});
@@ -312,10 +312,10 @@ class GoldenKitchenSinkClient {
   ///  response. Duplicate key types are not allowed. If no key type
   ///  is provided, all keys are returned.
   /// @param options  Optional. Operation options.
-  /// @return @googleapis_link{google::test::admin::database::v1::ListServiceAccountKeysResponse,generator/integration_tests/test.proto#L1313}
+  /// @return @googleapis_link{google::test::admin::database::v1::ListServiceAccountKeysResponse,generator/integration_tests/test.proto#L1324}
   ///
-  /// [google.test.admin.database.v1.ListServiceAccountKeysRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1281}
-  /// [google.test.admin.database.v1.ListServiceAccountKeysResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1313}
+  /// [google.test.admin.database.v1.ListServiceAccountKeysRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1292}
+  /// [google.test.admin.database.v1.ListServiceAccountKeysResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1324}
   ///
   StatusOr<google::test::admin::database::v1::ListServiceAccountKeysResponse>
   ListServiceAccountKeys(std::string const& name, std::vector<google::test::admin::database::v1::ListServiceAccountKeysRequest::KeyType> const& key_types, Options options = {});
@@ -323,12 +323,12 @@ class GoldenKitchenSinkClient {
   ///
   /// Lists every [ServiceAccountKey][google.iam.admin.v1.ServiceAccountKey] for a service account.
   ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::ListServiceAccountKeysRequest,generator/integration_tests/test.proto#L1281}
+  /// @param request @googleapis_link{google::test::admin::database::v1::ListServiceAccountKeysRequest,generator/integration_tests/test.proto#L1292}
   /// @param options  Optional. Operation options.
-  /// @return @googleapis_link{google::test::admin::database::v1::ListServiceAccountKeysResponse,generator/integration_tests/test.proto#L1313}
+  /// @return @googleapis_link{google::test::admin::database::v1::ListServiceAccountKeysResponse,generator/integration_tests/test.proto#L1324}
   ///
-  /// [google.test.admin.database.v1.ListServiceAccountKeysRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1281}
-  /// [google.test.admin.database.v1.ListServiceAccountKeysResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1313}
+  /// [google.test.admin.database.v1.ListServiceAccountKeysRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1292}
+  /// [google.test.admin.database.v1.ListServiceAccountKeysResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1324}
   ///
   StatusOr<google::test::admin::database::v1::ListServiceAccountKeysResponse>
   ListServiceAccountKeys(google::test::admin::database::v1::ListServiceAccountKeysRequest const& request, Options options = {});

--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_auth_decorator.cc
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_auth_decorator.cc
@@ -107,6 +107,18 @@ GoldenKitchenSinkAuth::AsyncAppendRows(
     std::move(context), auth_, StreamAuth::StreamFactory(std::move(call)));
 }
 
+std::unique_ptr<::google::cloud::internal::StreamingWriteRpc<
+    google::test::admin::database::v1::WriteObjectRequest,
+    google::test::admin::database::v1::WriteObjectResponse>>
+GoldenKitchenSinkAuth::WriteObject(
+    std::unique_ptr<grpc::ClientContext> context) {
+  using ErrorStream = ::google::cloud::internal::StreamingWriteRpcError<
+      google::test::admin::database::v1::WriteObjectRequest, google::test::admin::database::v1::WriteObjectResponse>;
+  auto status = auth_->ConfigureContext(*context);
+  if (!status.ok()) return absl::make_unique<ErrorStream>(std::move(status));
+  return child_->WriteObject(std::move(context));
+}
+
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace golden_internal
 }  // namespace cloud

--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_auth_decorator.h
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_auth_decorator.h
@@ -74,6 +74,11 @@ class GoldenKitchenSinkAuth : public GoldenKitchenSinkStub {
       google::cloud::CompletionQueue const& cq,
       std::unique_ptr<grpc::ClientContext> context) override;
 
+  std::unique_ptr<::google::cloud::internal::StreamingWriteRpc<
+      google::test::admin::database::v1::WriteObjectRequest,
+      google::test::admin::database::v1::WriteObjectResponse>> WriteObject(
+      std::unique_ptr<grpc::ClientContext> context) override;
+
  private:
   std::shared_ptr<google::cloud::internal::GrpcAuthenticationStrategy> auth_;
   std::shared_ptr<GoldenKitchenSinkStub> child_;

--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_logging_decorator.h
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_logging_decorator.h
@@ -74,6 +74,12 @@ class GoldenKitchenSinkLogging : public GoldenKitchenSinkStub {
       google::cloud::CompletionQueue const& cq,
       std::unique_ptr<grpc::ClientContext> context) override;
 
+  std::unique_ptr<::google::cloud::internal::StreamingWriteRpc<
+      google::test::admin::database::v1::WriteObjectRequest,
+      google::test::admin::database::v1::WriteObjectResponse>>
+   WriteObject(
+      std::unique_ptr<grpc::ClientContext> context) override;
+
  private:
   std::shared_ptr<GoldenKitchenSinkStub> child_;
   TracingOptions tracing_options_;

--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_metadata_decorator.cc
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_metadata_decorator.cc
@@ -98,6 +98,15 @@ GoldenKitchenSinkMetadata::AsyncAppendRows(
   return child_->AsyncAppendRows(cq, std::move(context));
 }
 
+std::unique_ptr<::google::cloud::internal::StreamingWriteRpc<
+    google::test::admin::database::v1::WriteObjectRequest,
+    google::test::admin::database::v1::WriteObjectResponse>>
+GoldenKitchenSinkMetadata::WriteObject(
+    std::unique_ptr<grpc::ClientContext> context) {
+  SetMetadata(*context, {});
+  return child_->WriteObject(std::move(context));
+}
+
 void GoldenKitchenSinkMetadata::SetMetadata(grpc::ClientContext& context,
                                         std::string const& request_params) {
   context.AddMetadata("x-goog-request-params", request_params);

--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_metadata_decorator.h
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_metadata_decorator.h
@@ -70,6 +70,12 @@ class GoldenKitchenSinkMetadata : public GoldenKitchenSinkStub {
       google::cloud::CompletionQueue const& cq,
       std::unique_ptr<grpc::ClientContext> context) override;
 
+  std::unique_ptr<::google::cloud::internal::StreamingWriteRpc<
+      google::test::admin::database::v1::WriteObjectRequest,
+      google::test::admin::database::v1::WriteObjectResponse>>
+  WriteObject(
+      std::unique_ptr<grpc::ClientContext> context) override;
+
  private:
   void SetMetadata(grpc::ClientContext& context,
                    std::string const& request_params);

--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_stub.cc
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_stub.cc
@@ -131,6 +131,18 @@ DefaultGoldenKitchenSinkStub::AsyncAppendRows(
       });
 }
 
+std::unique_ptr<::google::cloud::internal::StreamingWriteRpc<
+    google::test::admin::database::v1::WriteObjectRequest,
+    google::test::admin::database::v1::WriteObjectResponse>>
+DefaultGoldenKitchenSinkStub::WriteObject(
+    std::unique_ptr<grpc::ClientContext> context) {
+  auto response = absl::make_unique<google::test::admin::database::v1::WriteObjectResponse>();
+  auto stream = grpc_stub_->WriteObject(context.get(), response.get());
+  return absl::make_unique<::google::cloud::internal::StreamingWriteRpcImpl<
+      google::test::admin::database::v1::WriteObjectRequest, google::test::admin::database::v1::WriteObjectResponse>>(
+    std::move(context), std::move(response), std::move(stream));
+}
+
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace golden_internal
 }  // namespace cloud

--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_stub.h
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_stub.h
@@ -21,6 +21,7 @@
 
 #include "google/cloud/internal/async_read_write_stream_impl.h"
 #include "google/cloud/internal/streaming_read_rpc.h"
+#include "google/cloud/internal/streaming_write_rpc.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include <generator/integration_tests/test.grpc.pb.h>
@@ -71,6 +72,12 @@ class GoldenKitchenSinkStub {
       google::cloud::CompletionQueue const& cq,
       std::unique_ptr<grpc::ClientContext> context) = 0;
 
+ virtual std::unique_ptr<::google::cloud::internal::StreamingWriteRpc<
+      google::test::admin::database::v1::WriteObjectRequest,
+      google::test::admin::database::v1::WriteObjectResponse>>
+  WriteObject(
+      std::unique_ptr<grpc::ClientContext> context) = 0;
+
 };
 
 class DefaultGoldenKitchenSinkStub : public GoldenKitchenSinkStub {
@@ -119,6 +126,12 @@ class DefaultGoldenKitchenSinkStub : public GoldenKitchenSinkStub {
       google::test::admin::database::v1::AppendRowsResponse>>
   AsyncAppendRows(
       google::cloud::CompletionQueue const& cq,
+      std::unique_ptr<grpc::ClientContext> context) override;
+
+  std::unique_ptr<::google::cloud::internal::StreamingWriteRpc<
+      google::test::admin::database::v1::WriteObjectRequest,
+      google::test::admin::database::v1::WriteObjectResponse>>
+  WriteObject(
       std::unique_ptr<grpc::ClientContext> context) override;
 
  private:

--- a/generator/integration_tests/golden/mocks/mock_golden_kitchen_sink_stub.h
+++ b/generator/integration_tests/golden/mocks/mock_golden_kitchen_sink_stub.h
@@ -80,6 +80,14 @@ class MockGoldenKitchenSinkStub : public GoldenKitchenSinkStub {
       (google::cloud::CompletionQueue const& cq,
            std::unique_ptr<grpc::ClientContext> context),
       (override));
+
+  MOCK_METHOD(
+      (std::unique_ptr<::google::cloud::internal::StreamingWriteRpc<
+           ::google::test::admin::database::v1::WriteObjectRequest,
+           ::google::test::admin::database::v1::WriteObjectResponse>>),
+      WriteObject,
+      (std::unique_ptr<grpc::ClientContext> context),
+      (override));
 };
 
 class MockTailLogEntriesStreamingReadRpc
@@ -90,6 +98,14 @@ public:
   (override));
   MOCK_METHOD(internal::StreamingRpcMetadata, GetRequestMetadata, (),
   (const, override));
+};
+
+class MockWriteObjectStreamingWriteRpc
+    : public internal::StreamingWriteRpc<::google::test::admin::database::v1::WriteObjectRequest, ::google::test::admin::database::v1::WriteObjectResponse> {
+public:
+  MOCK_METHOD(void, Cancel, (), (override));
+  MOCK_METHOD(bool, Write, (::google::test::admin::database::v1::WriteObjectRequest const&, grpc::WriteOptions), (override));
+  MOCK_METHOD(StatusOr<::google::test::admin::database::v1::WriteObjectResponse>, Close, (), (override));
 };
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/generator/integration_tests/test.proto
+++ b/generator/integration_tests/test.proto
@@ -849,6 +849,9 @@ service GoldenKitchenSink {
   // A much simplified version of the AppendRows in google.cloud.bigquery.storage.v1.BigQueryWrite
   rpc AppendRows(stream AppendRowsRequest) returns (stream AppendRowsResponse) {
   }
+
+  // A much simplified version of the WriteObject method in google.storage.v2.Storage
+  rpc WriteObject(stream WriteObjectRequest) returns (WriteObjectResponse) {}
 }
 
 message AppendRowsRequest {
@@ -856,6 +859,14 @@ message AppendRowsRequest {
 }
 
 message AppendRowsResponse {
+  string response = 1;
+}
+
+message WriteObjectRequest {
+  string stream = 1;
+}
+
+message WriteObjectResponse {
   string response = 1;
 }
 

--- a/generator/internal/predicate_utils.cc
+++ b/generator/internal/predicate_utils.cc
@@ -101,6 +101,10 @@ bool IsStreamingRead(google::protobuf::MethodDescriptor const& method) {
   return !method.client_streaming() && method.server_streaming();
 }
 
+bool IsStreamingWrite(google::protobuf::MethodDescriptor const& method) {
+  return method.client_streaming() && !method.server_streaming();
+}
+
 bool IsBidirStreaming(google::protobuf::MethodDescriptor const& method) {
   return method.client_streaming() && method.server_streaming();
 }

--- a/generator/internal/predicate_utils.h
+++ b/generator/internal/predicate_utils.h
@@ -44,6 +44,12 @@ bool IsNonStreaming(google::protobuf::MethodDescriptor const& method);
 bool IsStreamingRead(google::protobuf::MethodDescriptor const& method);
 
 /**
+ * Determines if the given method has a stream request and a non-stream
+ * response.
+ */
+bool IsStreamingWrite(google::protobuf::MethodDescriptor const& method);
+
+/**
  * In a bidir streaming method both requests and responses are streamable.
  */
 bool IsBidirStreaming(google::protobuf::MethodDescriptor const& method);

--- a/generator/internal/service_code_generator.cc
+++ b/generator/internal/service_code_generator.cc
@@ -128,6 +128,13 @@ bool ServiceCodeGenerator::HasStreamingReadMethod() const {
                      });
 }
 
+bool ServiceCodeGenerator::HasStreamingWriteMethod() const {
+  return std::any_of(methods_.begin(), methods_.end(),
+                     [](google::protobuf::MethodDescriptor const& m) {
+                       return IsStreamingWrite(m);
+                     });
+}
+
 bool ServiceCodeGenerator::HasBidirStreamingMethod() const {
   return std::any_of(methods_.begin(), methods_.end(),
                      [](google::protobuf::MethodDescriptor const& m) {

--- a/generator/internal/service_code_generator.h
+++ b/generator/internal/service_code_generator.h
@@ -122,6 +122,12 @@ class ServiceCodeGenerator : public GeneratorInterface {
   bool HasStreamingReadMethod() const;
 
   /**
+   * Determines if the service contains at least once rpc with a stream
+   * request.
+   */
+  bool HasStreamingWriteMethod() const;
+
+  /**
    * Determines if the service contains at least one bidir streaming RPC
    */
   bool HasBidirStreamingMethod() const;

--- a/generator/internal/service_code_generator_test.cc
+++ b/generator/internal/service_code_generator_test.cc
@@ -81,6 +81,7 @@ class TestGenerator : public ServiceCodeGenerator {
   using ServiceCodeGenerator::HasMessageWithMapField;
   using ServiceCodeGenerator::HasPaginatedMethod;
   using ServiceCodeGenerator::HasStreamingReadMethod;
+  using ServiceCodeGenerator::HasStreamingWriteMethod;
   using ServiceCodeGenerator::MethodSignatureWellKnownProtobufTypeIncludes;
 
   Status GenerateHeader() override { return {}; }
@@ -590,6 +591,84 @@ TEST_F(StreamingReadTest, HasStreamingReadFalse) {
       .WillOnce(Return(output.release()));
   TestGenerator g(service_file_descriptor->service(1), generator_context.get());
   EXPECT_FALSE(g.HasStreamingReadMethod());
+}
+
+TEST(ServiceCodeGeneratorTest, HasWriteStreaming) {
+  auto constexpr kBidirStreamingServiceProto = R"""(
+syntax = "proto3";
+package google.protobuf;
+// Leading comments about message Foo.
+message Foo {
+  string baz = 1;
+  map<string, string> labels = 2;
+}
+// Leading comments about message Empty.
+message Bar {
+  int32 x = 1;
+}
+
+// This service has a streaming write RPC.
+service Service0 {
+  // Leading comments about rpc Method0.
+  rpc Method0(Foo) returns (stream Bar) {
+  }
+  // Leading comments about rpc Method1.
+  rpc Method1(stream Foo) returns (Bar) {
+  }
+  // Leading comments about rpc Method2.
+  rpc Method2(stream Foo) returns (stream Bar) {
+  }
+  // Leading comments about rpc Method3.
+  rpc Method3(Foo) returns (Bar) {
+  }
+}
+
+// This service has client-streaming (aka streaming-reads) and bidir-streaming
+// (aka streaming-read-write) RPCs, but does not have streaming write RPCs.
+service Service1 {
+  // Leading comments about rpc Method0.
+  rpc Method0(Foo) returns (stream Bar) {
+  }
+  // Leading comments about rpc Method1.
+  rpc Method1(stream Foo) returns (stream Bar) {
+  }
+  // Leading comments about rpc Method2.
+  rpc Method2(Foo) returns (Bar) {
+  }
+}
+)""";
+
+  StringSourceTree source_tree(std::map<std::string, std::string>{
+      {"google/cloud/foo/streaming.proto", kBidirStreamingServiceProto}});
+  google::protobuf::compiler::SourceTreeDescriptorDatabase source_tree_db(
+      &source_tree);
+  google::protobuf::SimpleDescriptorDatabase simple_db;
+  FileDescriptorProto file_proto;
+  // we need descriptor.proto to be accessible by the pool
+  // since our test file imports it
+  FileDescriptorProto::descriptor()->file()->CopyTo(&file_proto);
+  simple_db.Add(file_proto);
+  google::protobuf::MergedDescriptorDatabase merged_db(&simple_db,
+                                                       &source_tree_db);
+  AbortingErrorCollector collector;
+  DescriptorPool pool(&merged_db, &collector);
+
+  FileDescriptor const* service_file_descriptor =
+      pool.FindFileByName("google/cloud/foo/streaming.proto");
+
+  auto generator_context = absl::make_unique<MockGeneratorContext>();
+  EXPECT_CALL(*generator_context, Open("header_path"))
+      .Times(2)
+      .WillRepeatedly(
+          [](std::string const&) { return new MockZeroCopyOutputStream(); });
+
+  TestGenerator g_service_0(service_file_descriptor->service(0),
+                            generator_context.get());
+  EXPECT_TRUE(g_service_0.HasStreamingWriteMethod());
+
+  TestGenerator g_service_1(service_file_descriptor->service(1),
+                            generator_context.get());
+  EXPECT_FALSE(g_service_1.HasStreamingWriteMethod());
 }
 
 TEST(ServiceCodeGeneratorTest, HasBidirStreaming) {

--- a/generator/internal/stub_generator.cc
+++ b/generator/internal/stub_generator.cc
@@ -54,6 +54,8 @@ Status StubGenerator::GenerateHeader() {
        "google/cloud/status_or.h",
        HasStreamingReadMethod() ? "google/cloud/internal/streaming_read_rpc.h"
                                 : "",
+       HasStreamingWriteMethod() ? "google/cloud/internal/streaming_write_rpc.h"
+                                 : "",
        HasBidirStreamingMethod()
            ? "google/cloud/internal/async_read_write_stream_impl.h"
            : "",
@@ -76,6 +78,18 @@ Status StubGenerator::GenerateHeader() {
   // clang-format on
 
   for (auto const& method : methods()) {
+    if (IsStreamingWrite(method)) {
+      HeaderPrintMethod(
+          method, __FILE__, __LINE__,
+          R"""( virtual std::unique_ptr<::google::cloud::internal::StreamingWriteRpc<
+      $request_type$,
+      $response_type$>>
+  $method_name$(
+      std::unique_ptr<grpc::ClientContext> context) = 0;
+
+)""");
+      continue;
+    }
     if (IsBidirStreaming(method)) {
       HeaderPrintMethod(
           method, __FILE__, __LINE__,
@@ -184,6 +198,18 @@ Status StubGenerator::GenerateHeader() {
 
   for (auto const& method : methods()) {
     // emit methods
+    if (IsStreamingWrite(method)) {
+      HeaderPrintMethod(
+          method, __FILE__, __LINE__,
+          R"""(  std::unique_ptr<::google::cloud::internal::StreamingWriteRpc<
+      $request_type$,
+      $response_type$>>
+  $method_name$(
+      std::unique_ptr<grpc::ClientContext> context) override;
+
+)""");
+      continue;
+    }
     if (IsBidirStreaming(method)) {
       HeaderPrintMethod(
           method, __FILE__, __LINE__,
@@ -315,6 +341,24 @@ Status StubGenerator::GenerateCc() {
 
   // default stub class member methods
   for (auto const& method : methods()) {
+    if (IsStreamingWrite(method)) {
+      CcPrintMethod(
+          method, __FILE__, __LINE__,
+          R"""(std::unique_ptr<::google::cloud::internal::StreamingWriteRpc<
+    $request_type$,
+    $response_type$>>
+Default$stub_class_name$::$method_name$(
+    std::unique_ptr<grpc::ClientContext> context) {
+  auto response = absl::make_unique<$response_type$>();
+  auto stream = grpc_stub_->$method_name$(context.get(), response.get());
+  return absl::make_unique<::google::cloud::internal::StreamingWriteRpcImpl<
+      $request_type$, $response_type$>>(
+    std::move(context), std::move(response), std::move(stream));
+}
+
+)""");
+      continue;
+    }
     if (IsBidirStreaming(method)) {
       CcPrintMethod(
           method, __FILE__, __LINE__,


### PR DESCRIPTION
Change the generator to support streaming write (aka client-side
streaming) RPCs in the `*Stub` class and its decorators. Changed the
golden files to include one such method. Change the unit tests for the
golden files to test the generated code.

The generated libraries are unaffected by this change, as none of the
libraries we have uses streaming write RPCs.

Part of the work for #7929

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7941)
<!-- Reviewable:end -->
