### PR TITLE
cleanup(generator): fully qualify some helpers

### DIFF
--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_auth_decorator.cc
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_auth_decorator.cc
@@ -63,7 +63,7 @@ StatusOr<google::test::admin::database::v1::ListLogsResponse> GoldenKitchenSinkA
   return child_->ListLogs(context, request);
 }
 
-std::unique_ptr<internal::StreamingReadRpc<google::test::admin::database::v1::TailLogEntriesResponse>>
+std::unique_ptr<google::cloud::internal::StreamingReadRpc<google::test::admin::database::v1::TailLogEntriesResponse>>
 GoldenKitchenSinkAuth::TailLogEntries(
    std::unique_ptr<grpc::ClientContext> context,
    google::test::admin::database::v1::TailLogEntriesRequest const& request) {

--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_auth_decorator.h
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_auth_decorator.h
@@ -54,7 +54,7 @@ class GoldenKitchenSinkAuth : public GoldenKitchenSinkStub {
       grpc::ClientContext& context,
       google::test::admin::database::v1::ListLogsRequest const& request) override;
 
-  std::unique_ptr<internal::StreamingReadRpc<google::test::admin::database::v1::TailLogEntriesResponse>>
+  std::unique_ptr<google::cloud::internal::StreamingReadRpc<google::test::admin::database::v1::TailLogEntriesResponse>>
   TailLogEntries(
       std::unique_ptr<grpc::ClientContext> context,
       google::test::admin::database::v1::TailLogEntriesRequest const& request) override;

--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_logging_decorator.cc
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_logging_decorator.cc
@@ -85,21 +85,21 @@ GoldenKitchenSinkLogging::ListLogs(
       context, request, __func__, tracing_options_);
 }
 
-std::unique_ptr<internal::StreamingReadRpc<google::test::admin::database::v1::TailLogEntriesResponse>>
+std::unique_ptr<google::cloud::internal::StreamingReadRpc<google::test::admin::database::v1::TailLogEntriesResponse>>
 GoldenKitchenSinkLogging::TailLogEntries(
     std::unique_ptr<grpc::ClientContext> context,
     google::test::admin::database::v1::TailLogEntriesRequest const& request) {
   return google::cloud::internal::LogWrapper(
       [this](std::unique_ptr<grpc::ClientContext> context,
              google::test::admin::database::v1::TailLogEntriesRequest const& request) ->
-      std::unique_ptr<internal::StreamingReadRpc<
+      std::unique_ptr<google::cloud::internal::StreamingReadRpc<
           google::test::admin::database::v1::TailLogEntriesResponse>> {
         auto stream = child_->TailLogEntries(std::move(context), request);
         if (components_.count("rpc-streams") > 0) {
-          stream = absl::make_unique<internal::StreamingReadRpcLogging<
+          stream = absl::make_unique<google::cloud::internal::StreamingReadRpcLogging<
              google::test::admin::database::v1::TailLogEntriesResponse>>(
                std::move(stream), tracing_options_,
-               internal::RequestIdForLogging());
+               google::cloud::internal::RequestIdForLogging());
         }
         return stream;
       },
@@ -139,7 +139,7 @@ GoldenKitchenSinkLogging::AsyncAppendRows(
   using LoggingStream =
      ::google::cloud::internal::AsyncStreamingReadWriteRpcLogging<google::test::admin::database::v1::AppendRowsRequest, google::test::admin::database::v1::AppendRowsResponse>;
 
-  auto request_id = internal::RequestIdForLogging();
+  auto request_id = google::cloud::internal::RequestIdForLogging();
   GCP_LOG(DEBUG) << __func__ << "(" << request_id << ")";
   auto stream = child_->AsyncAppendRows(cq, std::move(context));
   if (components_.count("rpc-streams") > 0) {
@@ -157,7 +157,7 @@ GoldenKitchenSinkLogging::WriteObject(
   using LoggingStream = ::google::cloud::internal::StreamingWriteRpcLogging<
       google::test::admin::database::v1::WriteObjectRequest, google::test::admin::database::v1::WriteObjectResponse>;
 
-  auto request_id = internal::RequestIdForLogging();
+  auto request_id = google::cloud::internal::RequestIdForLogging();
   GCP_LOG(DEBUG) << __func__ << "(" << request_id << ")";
   auto stream = child_->WriteObject(std::move(context));
   if (components_.count("rpc-streams") > 0) {

--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_logging_decorator.h
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_logging_decorator.h
@@ -54,7 +54,7 @@ class GoldenKitchenSinkLogging : public GoldenKitchenSinkStub {
     grpc::ClientContext& context,
     google::test::admin::database::v1::ListLogsRequest const& request) override;
 
-  std::unique_ptr<internal::StreamingReadRpc<google::test::admin::database::v1::TailLogEntriesResponse>>
+  std::unique_ptr<google::cloud::internal::StreamingReadRpc<google::test::admin::database::v1::TailLogEntriesResponse>>
   TailLogEntries(
     std::unique_ptr<grpc::ClientContext> context,
     google::test::admin::database::v1::TailLogEntriesRequest const& request) override;

--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_metadata_decorator.cc
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_metadata_decorator.cc
@@ -64,7 +64,7 @@ GoldenKitchenSinkMetadata::ListLogs(
   return child_->ListLogs(context, request);
 }
 
-std::unique_ptr<internal::StreamingReadRpc<google::test::admin::database::v1::TailLogEntriesResponse>>
+std::unique_ptr<google::cloud::internal::StreamingReadRpc<google::test::admin::database::v1::TailLogEntriesResponse>>
 GoldenKitchenSinkMetadata::TailLogEntries(
     std::unique_ptr<grpc::ClientContext> context,
     google::test::admin::database::v1::TailLogEntriesRequest const& request) {

--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_metadata_decorator.h
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_metadata_decorator.h
@@ -50,7 +50,7 @@ class GoldenKitchenSinkMetadata : public GoldenKitchenSinkStub {
     grpc::ClientContext& context,
     google::test::admin::database::v1::ListLogsRequest const& request) override;
 
-  std::unique_ptr<internal::StreamingReadRpc<google::test::admin::database::v1::TailLogEntriesResponse>>
+  std::unique_ptr<google::cloud::internal::StreamingReadRpc<google::test::admin::database::v1::TailLogEntriesResponse>>
     TailLogEntries(
     std::unique_ptr<grpc::ClientContext> context,
     google::test::admin::database::v1::TailLogEntriesRequest const& request) override;

--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_stub.cc
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_stub.cc
@@ -82,12 +82,12 @@ DefaultGoldenKitchenSinkStub::ListLogs(
     return response;
 }
 
-std::unique_ptr<internal::StreamingReadRpc<google::test::admin::database::v1::TailLogEntriesResponse>>
+std::unique_ptr<google::cloud::internal::StreamingReadRpc<google::test::admin::database::v1::TailLogEntriesResponse>>
 DefaultGoldenKitchenSinkStub::TailLogEntries(
     std::unique_ptr<grpc::ClientContext> client_context,
     google::test::admin::database::v1::TailLogEntriesRequest const& request) {
   auto stream = grpc_stub_->TailLogEntries(client_context.get(), request);
-  return absl::make_unique<internal::StreamingReadRpcImpl<
+  return absl::make_unique<google::cloud::internal::StreamingReadRpcImpl<
       google::test::admin::database::v1::TailLogEntriesResponse>>(
       std::move(client_context), std::move(stream));
 }

--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_stub.h
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_stub.h
@@ -53,7 +53,7 @@ class GoldenKitchenSinkStub {
     grpc::ClientContext& context,
     google::test::admin::database::v1::ListLogsRequest const& request) = 0;
 
-  virtual std::unique_ptr<internal::StreamingReadRpc<google::test::admin::database::v1::TailLogEntriesResponse>>
+  virtual std::unique_ptr<google::cloud::internal::StreamingReadRpc<google::test::admin::database::v1::TailLogEntriesResponse>>
   TailLogEntries(
     std::unique_ptr<grpc::ClientContext> context,
     google::test::admin::database::v1::TailLogEntriesRequest const& request) = 0;
@@ -107,7 +107,7 @@ class DefaultGoldenKitchenSinkStub : public GoldenKitchenSinkStub {
     grpc::ClientContext& client_context,
     google::test::admin::database::v1::ListLogsRequest const& request) override;
 
-  std::unique_ptr<internal::StreamingReadRpc<google::test::admin::database::v1::TailLogEntriesResponse>>
+  std::unique_ptr<google::cloud::internal::StreamingReadRpc<google::test::admin::database::v1::TailLogEntriesResponse>>
   TailLogEntries(
     std::unique_ptr<grpc::ClientContext> client_context,
     google::test::admin::database::v1::TailLogEntriesRequest const& request) override;

--- a/generator/integration_tests/golden/mocks/mock_golden_kitchen_sink_stub.h
+++ b/generator/integration_tests/golden/mocks/mock_golden_kitchen_sink_stub.h
@@ -91,7 +91,7 @@ class MockGoldenKitchenSinkStub : public GoldenKitchenSinkStub {
 };
 
 class MockTailLogEntriesStreamingReadRpc
-    : public internal::StreamingReadRpc<::google::test::admin::database::v1::TailLogEntriesResponse> {
+    : public google::cloud::internal::StreamingReadRpc<::google::test::admin::database::v1::TailLogEntriesResponse> {
 public:
   MOCK_METHOD(void, Cancel, (), (override));
   MOCK_METHOD((absl::variant<Status, ::google::test::admin::database::v1::TailLogEntriesResponse>), Read, (),

--- a/generator/integration_tests/golden/tests/golden_kitchen_sink_logging_decorator_test.cc
+++ b/generator/integration_tests/golden/tests/golden_kitchen_sink_logging_decorator_test.cc
@@ -160,7 +160,7 @@ TEST_F(LoggingDecoratorTest, TailLogEntriesRpcNoRpcStreams) {
   EXPECT_CALL(*mock_response, Read).WillOnce(Return(Status()));
   EXPECT_CALL(*mock_, TailLogEntries)
       .WillOnce(Return(ByMove(
-          std::unique_ptr<internal::StreamingReadRpc<
+          std::unique_ptr<google::cloud::internal::StreamingReadRpc<
               google::test::admin::database::v1::TailLogEntriesResponse>>(
               mock_response.release()))));
   GoldenKitchenSinkLogging stub(mock_, TracingOptions{}, {});
@@ -180,7 +180,7 @@ TEST_F(LoggingDecoratorTest, TailLogEntriesRpcWithRpcStreams) {
   EXPECT_CALL(*mock_response, Read).WillOnce(Return(Status()));
   EXPECT_CALL(*mock_, TailLogEntries)
       .WillOnce(Return(ByMove(
-          std::unique_ptr<internal::StreamingReadRpc<
+          std::unique_ptr<google::cloud::internal::StreamingReadRpc<
               google::test::admin::database::v1::TailLogEntriesResponse>>(
               mock_response.release()))));
   GoldenKitchenSinkLogging stub(mock_, TracingOptions{}, {"rpc-streams"});

--- a/generator/internal/auth_decorator_generator.cc
+++ b/generator/internal/auth_decorator_generator.cc
@@ -111,7 +111,7 @@ Status AuthDecoratorGenerator::GenerateHeader() {
 )"""}},
                        IsLongrunningOperation),
          MethodPattern({{R"""(
-  std::unique_ptr<internal::StreamingReadRpc<$response_type$>>
+  std::unique_ptr<google::cloud::internal::StreamingReadRpc<$response_type$>>
   $method_name$(
       std::unique_ptr<grpc::ClientContext> context,
       $request_type$ const& request) override;
@@ -274,7 +274,7 @@ $auth_class_name$::Async$method_name$(
 )"""}},
                        IsLongrunningOperation),
          MethodPattern({{R"""(
-std::unique_ptr<internal::StreamingReadRpc<$response_type$>>
+std::unique_ptr<google::cloud::internal::StreamingReadRpc<$response_type$>>
 $auth_class_name$::$method_name$(
    std::unique_ptr<grpc::ClientContext> context,
    $request_type$ const& request) {

--- a/generator/internal/logging_decorator_generator.cc
+++ b/generator/internal/logging_decorator_generator.cc
@@ -117,7 +117,7 @@ Status LoggingDecoratorGenerator::GenerateHeader() {
              IsLongrunningOperation),
          MethodPattern(
              {// clang-format off
-   {"  std::unique_ptr<internal::StreamingReadRpc<$response_type$>>\n"
+   {"  std::unique_ptr<google::cloud::internal::StreamingReadRpc<$response_type$>>\n"
     "  $method_name$(\n"
     "    std::unique_ptr<grpc::ClientContext> context,\n"
     "    $request_type$ const& request) override;\n"
@@ -227,7 +227,7 @@ $logging_class_name$::$method_name$(
   using LoggingStream = ::google::cloud::internal::StreamingWriteRpcLogging<
       $request_type$, $response_type$>;
 
-  auto request_id = internal::RequestIdForLogging();
+  auto request_id = google::cloud::internal::RequestIdForLogging();
   GCP_LOG(DEBUG) << __func__ << "(" << request_id << ")";
   auto stream = child_->$method_name$(std::move(context));
   if (components_.count("rpc-streams") > 0) {
@@ -252,7 +252,7 @@ $logging_class_name$::Async$method_name$(
   using LoggingStream =
      ::google::cloud::internal::AsyncStreamingReadWriteRpcLogging<$request_type$, $response_type$>;
 
-  auto request_id = internal::RequestIdForLogging();
+  auto request_id = google::cloud::internal::RequestIdForLogging();
   GCP_LOG(DEBUG) << __func__ << "(" << request_id << ")";
   auto stream = child_->Async$method_name$(cq, std::move(context));
   if (components_.count("rpc-streams") > 0) {
@@ -304,23 +304,27 @@ $logging_class_name$::Async$method_name$(
                        IsLongrunningOperation),
          MethodPattern(
              {// clang-format off}
-              {"std::unique_ptr<internal::StreamingReadRpc<$response_type$>>\n"
+              {"std::unique_ptr<google::cloud::internal::StreamingReadRpc<$"
+               "response_type$>>\n"
                "$logging_class_name$::$method_name$(\n"
                "    std::unique_ptr<grpc::ClientContext> context,\n"
                "    $request_type$ const& request) {\n"
                "  return google::cloud::internal::LogWrapper(\n"
                "      [this](std::unique_ptr<grpc::ClientContext> context,\n"
                "             $request_type$ const& request) ->\n"
-               "      std::unique_ptr<internal::StreamingReadRpc<\n"
+               "      "
+               "std::unique_ptr<google::cloud::internal::StreamingReadRpc<\n"
                "          $response_type$>> {\n"
                "        auto stream = "
                "child_->$method_name$(std::move(context), request);\n"
                "        if (components_.count(\"rpc-streams\") > 0) {\n"
                "          stream = "
-               "absl::make_unique<internal::StreamingReadRpcLogging<\n"
+               "absl::make_unique<google::cloud::internal::"
+               "StreamingReadRpcLogging<\n"
                "             $response_type$>>(\n"
                "               std::move(stream), tracing_options_,\n"
-               "               internal::RequestIdForLogging());\n"
+               "               "
+               "google::cloud::internal::RequestIdForLogging());\n"
                "        }\n"
                "        return stream;\n"
                "      },\n"

--- a/generator/internal/metadata_decorator_generator.cc
+++ b/generator/internal/metadata_decorator_generator.cc
@@ -111,7 +111,7 @@ Status MetadataDecoratorGenerator::GenerateHeader() {
              IsLongrunningOperation),
          MethodPattern(
              {// clang-format off
-   {"  std::unique_ptr<internal::StreamingReadRpc<$response_type$>>\n"
+   {"  std::unique_ptr<google::cloud::internal::StreamingReadRpc<$response_type$>>\n"
     "    $method_name$(\n"
     "    std::unique_ptr<grpc::ClientContext> context,\n"
     "    $request_type$ const& request) override;\n"
@@ -276,7 +276,7 @@ $metadata_class_name$::Async$method_name$(
          MethodPattern(
              {
                  // clang-format off
-   {"std::unique_ptr<internal::StreamingReadRpc<$response_type$>>\n"
+   {"std::unique_ptr<google::cloud::internal::StreamingReadRpc<$response_type$>>\n"
     "$metadata_class_name$::$method_name$(\n"
     "    std::unique_ptr<grpc::ClientContext> context,\n"
     "    $request_type$ const& request) {\n"},

--- a/generator/internal/stub_generator.cc
+++ b/generator/internal/stub_generator.cc
@@ -128,7 +128,7 @@ Status StubGenerator::GenerateHeader() {
              IsLongrunningOperation),
          MethodPattern(
              {// clang-format off
-   {"  virtual std::unique_ptr<internal::StreamingReadRpc<$response_type$>>\n"
+   {"  virtual std::unique_ptr<google::cloud::internal::StreamingReadRpc<$response_type$>>\n"
     "  $method_name$(\n"
     "    std::unique_ptr<grpc::ClientContext> context,\n"
     "    $request_type$ const& request) = 0;\n"
@@ -248,7 +248,7 @@ Status StubGenerator::GenerateHeader() {
              IsLongrunningOperation),
          MethodPattern(
              {// clang-format off
-   {"  std::unique_ptr<internal::StreamingReadRpc<$response_type$>>\n"
+   {"  std::unique_ptr<google::cloud::internal::StreamingReadRpc<$response_type$>>\n"
     "  $method_name$(\n"
     "    std::unique_ptr<grpc::ClientContext> client_context,\n"
     "    $request_type$ const& request) override;\n"
@@ -422,12 +422,12 @@ Default$stub_class_name$::Async$method_name$(
                        IsLongrunningOperation),
          MethodPattern(
              {// clang-format off
-   {"std::unique_ptr<internal::StreamingReadRpc<$response_type$>>\n"
+   {"std::unique_ptr<google::cloud::internal::StreamingReadRpc<$response_type$>>\n"
     "Default$stub_class_name$::$method_name$(\n"
     "    std::unique_ptr<grpc::ClientContext> client_context,\n"
     "    $request_type$ const& request) {\n"
     "  auto stream = grpc_stub_->$method_name$(client_context.get(), request);\n"
-    "  return absl::make_unique<internal::StreamingReadRpcImpl<\n"
+    "  return absl::make_unique<google::cloud::internal::StreamingReadRpcImpl<\n"
     "      $response_type$>>(\n"
     "      std::move(client_context), std::move(stream));\n"
     "}\n\n"}},

--- a/google/cloud/bigquery/internal/bigquery_read_auth_decorator.cc
+++ b/google/cloud/bigquery/internal/bigquery_read_auth_decorator.cc
@@ -40,7 +40,7 @@ BigQueryReadAuth::CreateReadSession(
   return child_->CreateReadSession(context, request);
 }
 
-std::unique_ptr<internal::StreamingReadRpc<
+std::unique_ptr<google::cloud::internal::StreamingReadRpc<
     google::cloud::bigquery::storage::v1::ReadRowsResponse>>
 BigQueryReadAuth::ReadRows(
     std::unique_ptr<grpc::ClientContext> context,

--- a/google/cloud/bigquery/internal/bigquery_read_auth_decorator.h
+++ b/google/cloud/bigquery/internal/bigquery_read_auth_decorator.h
@@ -43,7 +43,7 @@ class BigQueryReadAuth : public BigQueryReadStub {
       google::cloud::bigquery::storage::v1::CreateReadSessionRequest const&
           request) override;
 
-  std::unique_ptr<internal::StreamingReadRpc<
+  std::unique_ptr<google::cloud::internal::StreamingReadRpc<
       google::cloud::bigquery::storage::v1::ReadRowsResponse>>
   ReadRows(std::unique_ptr<grpc::ClientContext> context,
            google::cloud::bigquery::storage::v1::ReadRowsRequest const& request)

--- a/google/cloud/bigquery/internal/bigquery_read_logging_decorator.cc
+++ b/google/cloud/bigquery/internal/bigquery_read_logging_decorator.cc
@@ -48,7 +48,7 @@ BigQueryReadLogging::CreateReadSession(
       context, request, __func__, tracing_options_);
 }
 
-std::unique_ptr<internal::StreamingReadRpc<
+std::unique_ptr<google::cloud::internal::StreamingReadRpc<
     google::cloud::bigquery::storage::v1::ReadRowsResponse>>
 BigQueryReadLogging::ReadRows(
     std::unique_ptr<grpc::ClientContext> context,
@@ -57,14 +57,15 @@ BigQueryReadLogging::ReadRows(
       [this](
           std::unique_ptr<grpc::ClientContext> context,
           google::cloud::bigquery::storage::v1::ReadRowsRequest const& request)
-          -> std::unique_ptr<internal::StreamingReadRpc<
+          -> std::unique_ptr<google::cloud::internal::StreamingReadRpc<
               google::cloud::bigquery::storage::v1::ReadRowsResponse>> {
         auto stream = child_->ReadRows(std::move(context), request);
         if (components_.count("rpc-streams") > 0) {
-          stream = absl::make_unique<internal::StreamingReadRpcLogging<
-              google::cloud::bigquery::storage::v1::ReadRowsResponse>>(
+          stream = absl::make_unique<
+              google::cloud::internal::StreamingReadRpcLogging<
+                  google::cloud::bigquery::storage::v1::ReadRowsResponse>>(
               std::move(stream), tracing_options_,
-              internal::RequestIdForLogging());
+              google::cloud::internal::RequestIdForLogging());
         }
         return stream;
       },

--- a/google/cloud/bigquery/internal/bigquery_read_logging_decorator.h
+++ b/google/cloud/bigquery/internal/bigquery_read_logging_decorator.h
@@ -43,7 +43,7 @@ class BigQueryReadLogging : public BigQueryReadStub {
       google::cloud::bigquery::storage::v1::CreateReadSessionRequest const&
           request) override;
 
-  std::unique_ptr<internal::StreamingReadRpc<
+  std::unique_ptr<google::cloud::internal::StreamingReadRpc<
       google::cloud::bigquery::storage::v1::ReadRowsResponse>>
   ReadRows(std::unique_ptr<grpc::ClientContext> context,
            google::cloud::bigquery::storage::v1::ReadRowsRequest const& request)

--- a/google/cloud/bigquery/internal/bigquery_read_metadata_decorator.cc
+++ b/google/cloud/bigquery/internal/bigquery_read_metadata_decorator.cc
@@ -42,7 +42,7 @@ BigQueryReadMetadata::CreateReadSession(
   return child_->CreateReadSession(context, request);
 }
 
-std::unique_ptr<internal::StreamingReadRpc<
+std::unique_ptr<google::cloud::internal::StreamingReadRpc<
     google::cloud::bigquery::storage::v1::ReadRowsResponse>>
 BigQueryReadMetadata::ReadRows(
     std::unique_ptr<grpc::ClientContext> context,

--- a/google/cloud/bigquery/internal/bigquery_read_metadata_decorator.h
+++ b/google/cloud/bigquery/internal/bigquery_read_metadata_decorator.h
@@ -39,7 +39,7 @@ class BigQueryReadMetadata : public BigQueryReadStub {
       google::cloud::bigquery::storage::v1::CreateReadSessionRequest const&
           request) override;
 
-  std::unique_ptr<internal::StreamingReadRpc<
+  std::unique_ptr<google::cloud::internal::StreamingReadRpc<
       google::cloud::bigquery::storage::v1::ReadRowsResponse>>
   ReadRows(std::unique_ptr<grpc::ClientContext> context,
            google::cloud::bigquery::storage::v1::ReadRowsRequest const& request)

--- a/google/cloud/bigquery/internal/bigquery_read_stub.cc
+++ b/google/cloud/bigquery/internal/bigquery_read_stub.cc
@@ -44,13 +44,13 @@ DefaultBigQueryReadStub::CreateReadSession(
   return response;
 }
 
-std::unique_ptr<internal::StreamingReadRpc<
+std::unique_ptr<google::cloud::internal::StreamingReadRpc<
     google::cloud::bigquery::storage::v1::ReadRowsResponse>>
 DefaultBigQueryReadStub::ReadRows(
     std::unique_ptr<grpc::ClientContext> client_context,
     google::cloud::bigquery::storage::v1::ReadRowsRequest const& request) {
   auto stream = grpc_stub_->ReadRows(client_context.get(), request);
-  return absl::make_unique<internal::StreamingReadRpcImpl<
+  return absl::make_unique<google::cloud::internal::StreamingReadRpcImpl<
       google::cloud::bigquery::storage::v1::ReadRowsResponse>>(
       std::move(client_context), std::move(stream));
 }

--- a/google/cloud/bigquery/internal/bigquery_read_stub.h
+++ b/google/cloud/bigquery/internal/bigquery_read_stub.h
@@ -40,7 +40,7 @@ class BigQueryReadStub {
       google::cloud::bigquery::storage::v1::CreateReadSessionRequest const&
           request) = 0;
 
-  virtual std::unique_ptr<internal::StreamingReadRpc<
+  virtual std::unique_ptr<google::cloud::internal::StreamingReadRpc<
       google::cloud::bigquery::storage::v1::ReadRowsResponse>>
   ReadRows(
       std::unique_ptr<grpc::ClientContext> context,
@@ -67,7 +67,7 @@ class DefaultBigQueryReadStub : public BigQueryReadStub {
       google::cloud::bigquery::storage::v1::CreateReadSessionRequest const&
           request) override;
 
-  std::unique_ptr<internal::StreamingReadRpc<
+  std::unique_ptr<google::cloud::internal::StreamingReadRpc<
       google::cloud::bigquery::storage::v1::ReadRowsResponse>>
   ReadRows(std::unique_ptr<grpc::ClientContext> client_context,
            google::cloud::bigquery::storage::v1::ReadRowsRequest const& request)

--- a/google/cloud/logging/internal/logging_service_v2_logging_decorator.cc
+++ b/google/cloud/logging/internal/logging_service_v2_logging_decorator.cc
@@ -107,7 +107,7 @@ LoggingServiceV2Logging::AsyncTailLogEntries(
           google::logging::v2::TailLogEntriesRequest,
           google::logging::v2::TailLogEntriesResponse>;
 
-  auto request_id = internal::RequestIdForLogging();
+  auto request_id = google::cloud::internal::RequestIdForLogging();
   GCP_LOG(DEBUG) << __func__ << "(" << request_id << ")";
   auto stream = child_->AsyncTailLogEntries(cq, std::move(context));
   if (components_.count("rpc-streams") > 0) {


### PR DESCRIPTION
The generator was emitting `internal::Foo` for some helpers in
`google::cloud::internal`. This works perfectly fine for generated
libraries, but I want to use some of the generated code in
`google::cloud::storage::internal` where the names become ambiguous.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7948)
<!-- Reviewable:end -->
