### PR TITLE
refactor(GCS+gRPC): move stub factory function

### DIFF
--- a/google/cloud/storage/CMakeLists.txt
+++ b/google/cloud/storage/CMakeLists.txt
@@ -342,7 +342,9 @@ if (GOOGLE_CLOUD_CPP_STORAGE_ENABLE_GRPC)
         internal/storage_round_robin.cc
         internal/storage_round_robin.h
         internal/storage_stub.cc
-        internal/storage_stub.h)
+        internal/storage_stub.h
+        internal/storage_stub_factory.cc
+        internal/storage_stub_factory.h)
     target_link_libraries(
         google_cloud_cpp_storage_grpc
         PUBLIC google-cloud-cpp::storage
@@ -600,7 +602,8 @@ if (GOOGLE_CLOUD_CPP_STORAGE_ENABLE_GRPC)
             internal/grpc_resumable_upload_session_test.cc
             internal/grpc_resumable_upload_session_url_test.cc
             internal/storage_auth_test.cc
-            internal/storage_round_robin_test.cc)
+            internal/storage_round_robin_test.cc
+            internal/storage_stub_factory_test.cc)
 
         foreach (fname ${storage_client_grpc_unit_tests})
             google_cloud_cpp_add_executable(target "storage" "${fname}")

--- a/google/cloud/storage/google_cloud_cpp_storage_grpc.bzl
+++ b/google/cloud/storage/google_cloud_cpp_storage_grpc.bzl
@@ -33,6 +33,7 @@ google_cloud_cpp_storage_grpc_hdrs = [
     "internal/storage_auth.h",
     "internal/storage_round_robin.h",
     "internal/storage_stub.h",
+    "internal/storage_stub_factory.h",
 ]
 
 google_cloud_cpp_storage_grpc_srcs = [
@@ -51,4 +52,5 @@ google_cloud_cpp_storage_grpc_srcs = [
     "internal/storage_auth.cc",
     "internal/storage_round_robin.cc",
     "internal/storage_stub.cc",
+    "internal/storage_stub_factory.cc",
 ]

--- a/google/cloud/storage/internal/grpc_client.cc
+++ b/google/cloud/storage/internal/grpc_client.cc
@@ -21,18 +21,13 @@
 #include "google/cloud/storage/internal/grpc_object_request_parser.h"
 #include "google/cloud/storage/internal/grpc_resumable_upload_session.h"
 #include "google/cloud/storage/internal/resumable_upload_session.h"
-#include "google/cloud/storage/internal/sha256_hash.h"
-#include "google/cloud/storage/internal/storage_auth.h"
-#include "google/cloud/storage/internal/storage_round_robin.h"
-#include "google/cloud/storage/internal/storage_stub.h"
+#include "google/cloud/storage/internal/storage_stub_factory.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/big_endian.h"
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/internal/invoke_result.h"
 #include "google/cloud/internal/unified_grpc_credentials.h"
 #include "google/cloud/log.h"
-#include "absl/strings/str_split.h"
-#include "absl/time/time.h"
 #include <crc32c/crc32c.h>
 #include <grpcpp/grpcpp.h>
 #include <algorithm>
@@ -44,18 +39,7 @@ namespace storage {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace internal {
 
-using ::google::cloud::internal::GrpcAuthenticationStrategy;
 using ::google::cloud::internal::MakeBackgroundThreadsFactory;
-
-auto constexpr kDirectPathConfig = R"json({
-    "loadBalancingConfig": [{
-      "grpclb": {
-        "childPolicy": [{
-          "pick_first": {}
-        }]
-      }
-    }]
-  })json";
 
 int DefaultGrpcNumChannels() {
   auto constexpr kMinimumChannels = 4;
@@ -85,59 +69,6 @@ Options DefaultOptionsGrpc(Options options) {
     options.set<GrpcNumChannelsOption>(DefaultGrpcNumChannels());
   }
   return options;
-}
-
-std::shared_ptr<grpc::Channel> CreateGrpcChannel(
-    GrpcAuthenticationStrategy& auth, Options const& options, int channel_id) {
-  grpc::ChannelArguments args;
-  auto const& config = options.get<storage_experimental::GrpcPluginOption>();
-  if (config.empty() || config == "default" || config == "none") {
-    // Just configure for the regular path.
-    args.SetInt("grpc.channel_id", channel_id);
-    return auth.CreateChannel(options.get<EndpointOption>(), std::move(args));
-  }
-  std::set<absl::string_view> settings = absl::StrSplit(config, ',');
-  auto const dp = settings.count("dp") != 0 || settings.count("alts") != 0;
-  if (dp || settings.count("pick-first-lb") != 0) {
-    args.SetServiceConfigJSON(kDirectPathConfig);
-  }
-  if (dp || settings.count("enable-dns-srv-queries") != 0) {
-    args.SetInt("grpc.dns_enable_srv_queries", 1);
-  }
-  if (settings.count("disable-dns-srv-queries") != 0) {
-    args.SetInt("grpc.dns_enable_srv_queries", 0);
-  }
-  if (settings.count("exclusive") != 0) {
-    args.SetInt("grpc.channel_id", channel_id);
-  }
-  if (settings.count("alts") != 0) {
-    grpc::experimental::AltsCredentialsOptions alts_opts;
-    return grpc::CreateCustomChannel(
-        options.get<EndpointOption>(),
-        grpc::CompositeChannelCredentials(
-            grpc::experimental::AltsCredentials(alts_opts),
-            grpc::GoogleComputeEngineCredentials()),
-        std::move(args));
-  }
-  return auth.CreateChannel(options.get<EndpointOption>(), std::move(args));
-}
-
-std::shared_ptr<StorageStub> CreateStorageStub(CompletionQueue cq,
-                                               Options const& opts) {
-  auto auth = google::cloud::internal::CreateAuthenticationStrategy(
-      std::move(cq), opts);
-  std::vector<std::shared_ptr<StorageStub>> children(
-      (std::max)(1, opts.get<GrpcNumChannelsOption>()));
-  int id = 0;
-  std::generate(children.begin(), children.end(), [&id, &auth, opts] {
-    return MakeDefaultStorageStub(CreateGrpcChannel(*auth, opts, id++));
-  });
-  std::shared_ptr<StorageStub> stub =
-      std::make_shared<StorageRoundRobin>(std::move(children));
-  if (auth->RequiresConfigureContext()) {
-    stub = std::make_shared<StorageAuth>(std::move(auth), std::move(stub));
-  }
-  return stub;
 }
 
 std::shared_ptr<GrpcClient> GrpcClient::Create(Options opts) {

--- a/google/cloud/storage/internal/storage_stub_factory.cc
+++ b/google/cloud/storage/internal/storage_stub_factory.cc
@@ -1,0 +1,106 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/storage/internal/storage_stub_factory.h"
+#include "google/cloud/storage/grpc_plugin.h"
+#include "google/cloud/storage/internal/storage_auth.h"
+#include "google/cloud/storage/internal/storage_round_robin.h"
+#include "google/cloud/grpc_options.h"
+#include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/unified_grpc_credentials.h"
+#include "google/cloud/log.h"
+#include "absl/strings/str_split.h"
+#include <grpcpp/grpcpp.h>
+
+namespace google {
+namespace cloud {
+namespace storage {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+namespace internal {
+namespace {
+auto constexpr kDirectPathConfig = R"json({
+    "loadBalancingConfig": [{
+      "grpclb": {
+        "childPolicy": [{
+          "pick_first": {}
+        }]
+      }
+    }]
+  })json";
+
+std::shared_ptr<grpc::Channel> CreateGrpcChannel(
+    google::cloud::internal::GrpcAuthenticationStrategy& auth,
+    Options const& options, int channel_id) {
+  grpc::ChannelArguments args;
+  auto const& config = options.get<storage_experimental::GrpcPluginOption>();
+  if (config.empty() || config == "default" || config == "none") {
+    // Just configure for the regular path.
+    args.SetInt("grpc.channel_id", channel_id);
+    return auth.CreateChannel(options.get<EndpointOption>(), std::move(args));
+  }
+  std::set<absl::string_view> settings = absl::StrSplit(config, ',');
+  auto const dp = settings.count("dp") != 0 || settings.count("alts") != 0;
+  if (dp || settings.count("pick-first-lb") != 0) {
+    args.SetServiceConfigJSON(kDirectPathConfig);
+  }
+  if (dp || settings.count("enable-dns-srv-queries") != 0) {
+    args.SetInt("grpc.dns_enable_srv_queries", 1);
+  }
+  if (settings.count("disable-dns-srv-queries") != 0) {
+    args.SetInt("grpc.dns_enable_srv_queries", 0);
+  }
+  if (settings.count("exclusive") != 0) {
+    args.SetInt("grpc.channel_id", channel_id);
+  }
+  if (settings.count("alts") != 0) {
+    grpc::experimental::AltsCredentialsOptions alts_opts;
+    return grpc::CreateCustomChannel(
+        options.get<EndpointOption>(),
+        grpc::CompositeChannelCredentials(
+            grpc::experimental::AltsCredentials(alts_opts),
+            grpc::GoogleComputeEngineCredentials()),
+        std::move(args));
+  }
+  return auth.CreateChannel(options.get<EndpointOption>(), std::move(args));
+}
+
+}  // namespace
+
+std::shared_ptr<StorageStub> CreateStorageStub(
+    google::cloud::CompletionQueue cq, Options const& options) {
+  auto auth = google::cloud::internal::CreateAuthenticationStrategy(
+      std::move(cq), options);
+
+  std::vector<std::shared_ptr<StorageStub>> children(
+      (std::max)(1, options.get<GrpcNumChannelsOption>()));
+  int id = 0;
+  std::generate(children.begin(), children.end(), [&id, &auth, options] {
+    auto channel = CreateGrpcChannel(*auth, options, id++);
+    return MakeDefaultStorageStub(std::move(channel));
+  });
+
+  std::shared_ptr<StorageStub> stub =
+      std::make_shared<StorageRoundRobin>(std::move(children));
+
+  if (auth->RequiresConfigureContext()) {
+    stub = std::make_shared<StorageAuth>(std::move(auth), std::move(stub));
+  }
+  return stub;
+}
+
+}  // namespace internal
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace storage
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/storage/internal/storage_stub_factory.h
+++ b/google/cloud/storage/internal/storage_stub_factory.h
@@ -1,0 +1,39 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_STORAGE_STUB_FACTORY_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_STORAGE_STUB_FACTORY_H
+
+#include "google/cloud/storage/internal/storage_stub.h"
+#include "google/cloud/completion_queue.h"
+#include "google/cloud/options.h"
+#include "google/cloud/version.h"
+#include <memory>
+
+namespace google {
+namespace cloud {
+namespace storage {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+namespace internal {
+
+std::shared_ptr<StorageStub> CreateStorageStub(
+    google::cloud::CompletionQueue cq, Options const& options);
+
+}  // namespace internal
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace storage
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_STORAGE_STUB_FACTORY_H

--- a/google/cloud/storage/internal/storage_stub_factory_test.cc
+++ b/google/cloud/storage/internal/storage_stub_factory_test.cc
@@ -1,0 +1,87 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/storage/internal/storage_stub_factory.h"
+#include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
+#include "google/cloud/grpc_options.h"
+#include "google/cloud/testing_util/status_matchers.h"
+#include "absl/memory/memory.h"
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+namespace storage {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+namespace internal {
+namespace {
+
+using ::google::cloud::testing_util::StatusIs;
+
+// All the tests have nearly identical structure. They create a stub pointing to
+// an invalid endpoint. Getting a kUnavailable error is the expected result.
+
+std::shared_ptr<StorageStub> CreateTestStub(CompletionQueue cq) {
+  auto credentials = google::cloud::MakeAccessTokenCredentials(
+      "test-only-invalid",
+      std::chrono::system_clock::now() + std::chrono::minutes(5));
+  return CreateStorageStub(std::move(cq),
+                           google::cloud::Options{}
+                               .set<EndpointOption>("localhost:1")
+                               .set<TracingComponentsOption>({"rpc"})
+                               .set<UnifiedCredentialsOption>(credentials));
+}
+
+TEST(StorageStubFactory, ReadObject) {
+  CompletionQueue cq;
+  auto stub = CreateTestStub(cq);
+  auto stream = stub->ReadObject(absl::make_unique<grpc::ClientContext>(),
+                                 google::storage::v2::ReadObjectRequest{});
+  auto read = stream->Read();
+  ASSERT_TRUE(absl::holds_alternative<Status>(read));
+  EXPECT_THAT(absl::get<Status>(read), StatusIs(StatusCode::kUnavailable));
+}
+
+TEST(StorageStubFactory, WriteObject) {
+  CompletionQueue cq;
+  auto stub = CreateTestStub(cq);
+  auto stream = stub->WriteObject(absl::make_unique<grpc::ClientContext>());
+  auto close = stream->Close();
+  EXPECT_THAT(close, StatusIs(StatusCode::kUnavailable));
+}
+
+TEST(StorageStubFactory, StartResumableWrite) {
+  CompletionQueue cq;
+  auto stub = CreateTestStub(cq);
+  grpc::ClientContext context;
+  auto response = stub->StartResumableWrite(
+      context, google::storage::v2::StartResumableWriteRequest{});
+  EXPECT_THAT(response, StatusIs(StatusCode::kUnavailable));
+}
+
+TEST(StorageStubFactory, QueryWriteStatus) {
+  CompletionQueue cq;
+  auto stub = CreateTestStub(cq);
+  grpc::ClientContext context;
+  auto response = stub->QueryWriteStatus(
+      context, google::storage::v2::QueryWriteStatusRequest{});
+  EXPECT_THAT(response, StatusIs(StatusCode::kUnavailable));
+}
+
+}  // namespace
+}  // namespace internal
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace storage
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/storage/storage_client_grpc_unit_tests.bzl
+++ b/google/cloud/storage/storage_client_grpc_unit_tests.bzl
@@ -32,4 +32,5 @@ storage_client_grpc_unit_tests = [
     "internal/grpc_resumable_upload_session_url_test.cc",
     "internal/storage_auth_test.cc",
     "internal/storage_round_robin_test.cc",
+    "internal/storage_stub_factory_test.cc",
 ]


### PR DESCRIPTION
Split the factory function for `StorageStub` (with decorators) to its
own `.h` and `.cc` files. This will help as I add additional decorators
and member functions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7952)
<!-- Reviewable:end -->
