### PR TITLE
cleanup: strip API from title in scaffolding

### DIFF
--- a/generator/internal/scaffold_generator.cc
+++ b/generator/internal/scaffold_generator.cc
@@ -98,7 +98,11 @@ std::map<std::string, std::string> ScaffoldVars(
     if (!api.contains("directory")) continue;
     auto const directory = api["directory"].get<std::string>() + "/";
     if (service.service_proto_path().rfind(directory, 0) != 0) continue;
-    vars.emplace("title", api.value("title", ""));
+    // If the title ends in " API", strip the ending.
+    auto title = api.value("title", "");
+    auto pos = title.size() - std::strlen(" API");
+    if (pos > 0 && title.substr(pos) == " API") title = title.substr(0, pos);
+    vars.emplace("title", std::move(title));
     vars.emplace("description", api.value("description", ""));
     vars.emplace("directory", api.value("directory", ""));
   }
@@ -260,8 +264,8 @@ void GenerateReadme(std::ostream& os,
 
 :construction:
 
-This directory contains an idiomatic C++ client library for the
-[$title$][cloud-service-docs], a service to $description$
+This directory contains an idiomatic C++ client library for
+[$title$][cloud-service], a service to $description$
 
 This library is **experimental**. Its APIs are subject to change without notice.
 
@@ -283,7 +287,8 @@ Please note that the Google Cloud C++ client libraries do **not** follow
   client library
 * Detailed header comments in our [public `.h`][source-link] files
 
-[cloud-service-docs]: https://cloud.google.com/$site_root$
+[cloud-service]: https://cloud.google.com/$site_root$
+[cloud-service-docs]: https://cloud.google.com/$site_root$/docs
 [doxygen-link]: https://googleapis.dev/cpp/google-cloud-$library$/latest/
 [source-link]: https://github.com/googleapis/google-cloud-cpp/tree/main/google/cloud/$library$
 
@@ -412,7 +417,7 @@ void GenerateCMakeLists(std::ostream& os,
 
 include(GoogleapisConfig)
 set(DOXYGEN_PROJECT_NAME "$title$ C++ Client")
-set(DOXYGEN_PROJECT_BRIEF "A C++ Client Library for the $title$")
+set(DOXYGEN_PROJECT_BRIEF "A C++ Client Library for the $title$ service")
 set(DOXYGEN_PROJECT_NUMBER "$${PROJECT_VERSION} (Experimental)")
 set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "$library$_internal" "$library$_testing"
                             "examples")
@@ -542,7 +547,7 @@ set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR $${PROJECT_VERSION_MAJOR})
 set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR $${PROJECT_VERSION_MINOR})
 set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH $${PROJECT_VERSION_PATCH})
 set(GOOGLE_CLOUD_PC_NAME "The $title$ C++ Client Library")
-set(GOOGLE_CLOUD_PC_DESCRIPTION "Provides C++ APIs to use the $title$.")
+set(GOOGLE_CLOUD_PC_DESCRIPTION "Provides C++ APIs to use the $title$ service.")
 set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_$library$")
 string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common" " google_cloud_cpp_$library$_protos")
@@ -584,7 +589,7 @@ void GenerateDoxygenMainPage(
 
 @mainpage $title$ C++ Client Library
 
-An idiomatic C++ client library for the [$title$][cloud-service-docs], a service
+An idiomatic C++ client library for [$title$][cloud-service], a service
 to $description$
 
 This library is **experimental**. Its APIs are subject to change without notice.
@@ -663,7 +668,7 @@ The library automatically retries requests that fail with transient errors, and
 uses [exponential backoff] to backoff between retries. Application developers
 can override the default policies.
 
-[cloud-service-docs]: https://cloud.google.com/$site_root$
+[cloud-service]: https://cloud.google.com/$site_root$
 [exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff
 [github-link]: https://github.com/googleapis/google-cloud-cpp 'GitHub Repository'
 <!-- The ugly %2E disables auto-linking in Doxygen -->

--- a/generator/internal/scaffold_generator_test.cc
+++ b/generator/internal/scaffold_generator_test.cc
@@ -121,7 +121,7 @@ TEST_F(ScaffoldGenerator, LibraryName) {
 TEST_F(ScaffoldGenerator, Vars) {
   auto const vars = ScaffoldVars(path(), path(), service());
   EXPECT_THAT(
-      vars, AllOf(Contains(Pair("title", "Test Only API")),
+      vars, AllOf(Contains(Pair("title", "Test Only")),
                   Contains(Pair("description",
                                 "Provides a placeholder to write this test.")),
                   Contains(Pair("library", "test")),
@@ -157,7 +157,8 @@ TEST_F(ScaffoldGenerator, Readme) {
   GenerateReadme(os, vars);
   auto const actual = std::move(os).str();
   EXPECT_THAT(actual, HasSubstr(R"""(
-[cloud-service-docs]: https://cloud.google.com/test
+[cloud-service]: https://cloud.google.com/test
+[cloud-service-docs]: https://cloud.google.com/test/docs
 [doxygen-link]: https://googleapis.dev/cpp/google-cloud-test/latest/
 [source-link]: https://github.com/googleapis/google-cloud-cpp/tree/main/google/cloud/test
 )"""));
@@ -209,11 +210,11 @@ TEST_F(ScaffoldGenerator, DoxygenMainPage) {
   GenerateDoxygenMainPage(os, vars);
   auto const actual = std::move(os).str();
   EXPECT_THAT(actual, HasSubstr(R"""(
-An idiomatic C++ client library for the [Test Only API][cloud-service-docs], a service
+An idiomatic C++ client library for [Test Only][cloud-service], a service
 to Provides a placeholder to write this test.
 )"""));
   EXPECT_THAT(actual, HasSubstr(R"""(
-[cloud-service-docs]: https://cloud.google.com/test
+[cloud-service]: https://cloud.google.com/test
 )"""));
 }
 
@@ -224,7 +225,7 @@ TEST_F(ScaffoldGenerator, QuickstartReadme) {
   auto const actual = std::move(os).str();
   EXPECT_THAT(
       actual,
-      HasSubstr(R"""(# HOWTO: using the Test Only API C++ client in your project
+      HasSubstr(R"""(# HOWTO: using the Test Only C++ client in your project
 )"""));
 }
 

--- a/google/cloud/accessapproval/CMakeLists.txt
+++ b/google/cloud/accessapproval/CMakeLists.txt
@@ -15,8 +15,9 @@
 # ~~~
 
 include(GoogleapisConfig)
-set(DOXYGEN_PROJECT_NAME "Access Approval API C++ Client")
-set(DOXYGEN_PROJECT_BRIEF "A C++ Client Library for the Access Approval API")
+set(DOXYGEN_PROJECT_NAME "Access Approval C++ Client")
+set(DOXYGEN_PROJECT_BRIEF
+    "A C++ Client Library for the Access Approval service")
 set(DOXYGEN_PROJECT_NUMBER "${PROJECT_VERSION} (Experimental)")
 set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "accessapproval_internal"
                             "accessapproval_testing" "examples")
@@ -164,9 +165,9 @@ google_cloud_cpp_install_headers("google_cloud_cpp_accessapproval_mocks"
 set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
 set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
 set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
-set(GOOGLE_CLOUD_PC_NAME "The Access Approval API C++ Client Library")
+set(GOOGLE_CLOUD_PC_NAME "The Access Approval C++ Client Library")
 set(GOOGLE_CLOUD_PC_DESCRIPTION
-    "Provides C++ APIs to access Access Approval API.")
+    "Provides C++ APIs to access the Access Approval service.")
 set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_accessapproval")
 string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common"

--- a/google/cloud/accessapproval/README.md
+++ b/google/cloud/accessapproval/README.md
@@ -1,9 +1,9 @@
-# Access Approval API C++ Client Library
+# Access Approval C++ Client Library
 
 :construction:
 
-This directory contains an idiomatic C++ client library for the
-[Access Approval API][cloud-service-docs], a service for controlling access to
+This directory contains an idiomatic C++ client library for
+[Access Approval][cloud-service], a service for controlling access to
 data by Google personnel.
 
 This library is **experimental**. Its APIs are subject to change without notice.
@@ -21,12 +21,13 @@ Please note that the Google Cloud C++ client libraries do **not** follow
 
 ## Documentation
 
-* Official documentation about the [Access Approval API][cloud-service-docs] service
+* Official documentation about the [Access Approval][cloud-service-docs] service
 * [Reference doxygen documentation][doxygen-link] for each release of this
   client library
 * Detailed header comments in our [public `.h`][source-link] files
 
-[cloud-service-docs]: https://cloud.google.com/access-approval
+[cloud-service]: https://cloud.google.com/access-approval
+[cloud-service-docs]: https://cloud.google.com/access-approval/docs
 [doxygen-link]: https://googleapis.dev/cpp/google-cloud-accessapproval/latest/
 [source-link]: https://github.com/googleapis/google-cloud-cpp/tree/main/google/cloud/accessapproval
 

--- a/google/cloud/accessapproval/doc/main.dox
+++ b/google/cloud/accessapproval/doc/main.dox
@@ -1,9 +1,9 @@
 /*!
 
-@mainpage Access Approval API C++ Client Library
+@mainpage Access Approval C++ Client Library
 
-An idiomatic C++ client library for the
-[Access Approval API](https://cloud.google.com/access-approval/),
+An idiomatic C++ client library for
+[Access Approval](https://cloud.google.com/access-approval/),
 a service for controlling access to data by Google personnel.
 
 This library is **experimental**. Its APIs are subject to change without notice.
@@ -16,7 +16,7 @@ the client library.
 
 ### Setting up your repo
 
-In order to use the Access Approval API C++ client library from your own code,
+In order to use the Access Approval C++ client library from your own code,
 you'll need to configure your build system to discover and compile the Cloud
 C++ client libraries. In some cases your build system or package manager may
 need to download the libraries too. The Cloud C++ client libraries natively
@@ -34,7 +34,7 @@ cd google-cloud-cpp/google/cloud/accessapproval/quickstart
 
 The following shows the code that you'll run in the
 `google/cloud/accessapproval/quickstart/` directory,
-which should give you a taste of the Access Approval API C++ client library API.
+which should give you a taste of the Access Approval C++ client library API.
 
 @include quickstart.cc
 

--- a/google/cloud/accessapproval/quickstart/CMakeLists.txt
+++ b/google/cloud/accessapproval/quickstart/CMakeLists.txt
@@ -12,7 +12,7 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-# This file shows how to use the Access Approval API C++ client library from a
+# This file shows how to use the Access Approval C++ client library from a
 # larger CMake project.
 
 cmake_minimum_required(VERSION 3.5)

--- a/google/cloud/accessapproval/quickstart/README.md
+++ b/google/cloud/accessapproval/quickstart/README.md
@@ -1,6 +1,6 @@
-# HOWTO: using the Access Approval API C++ client in your project
+# HOWTO: using the Access Approval C++ client in your project
 
-This directory contains small examples showing how to use the Access Approval API C++
+This directory contains small examples showing how to use the Access Approval C++
 client library in your own project. These instructions assume that you have
 some experience as a C++ developer and that you have a working C++ toolchain
 (compiler, linker, etc.) installed on your platform.

--- a/google/cloud/accesscontextmanager/CMakeLists.txt
+++ b/google/cloud/accesscontextmanager/CMakeLists.txt
@@ -15,9 +15,9 @@
 # ~~~
 
 include(GoogleapisConfig)
-set(DOXYGEN_PROJECT_NAME "Access Context Manager API C++ Client")
+set(DOXYGEN_PROJECT_NAME "Access Context Manager C++ Client")
 set(DOXYGEN_PROJECT_BRIEF
-    "A C++ Client Library for the Access Context Manager API")
+    "A C++ Client Library for the Access Context Manager service")
 set(DOXYGEN_PROJECT_NUMBER "${PROJECT_VERSION} (Experimental)")
 set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "accesscontextmanager_internal"
                             "accesscontextmanager_testing" "examples")
@@ -172,9 +172,9 @@ google_cloud_cpp_install_headers("google_cloud_cpp_accesscontextmanager_mocks"
 set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
 set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
 set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
-set(GOOGLE_CLOUD_PC_NAME "The Access Context Manager API C++ Client Library")
+set(GOOGLE_CLOUD_PC_NAME "The Access Context Manager C++ Client Library")
 set(GOOGLE_CLOUD_PC_DESCRIPTION
-    "Provides C++ APIs to use the Access Context Manager API.")
+    "Provides C++ APIs to use the Access Context Manager service.")
 set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_accesscontextmanager")
 string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common"

--- a/google/cloud/accesscontextmanager/README.md
+++ b/google/cloud/accesscontextmanager/README.md
@@ -1,9 +1,9 @@
-# Access Context Manager API C++ Client Library
+# Access Context Manager C++ Client Library
 
 :construction:
 
-This directory contains an idiomatic C++ client library for the
-[Access Context Manager API][cloud-service-docs], a service for setting
+This directory contains an idiomatic C++ client library for
+[Access Context Manager][cloud-service], a service for setting
 attribute based access control on requests to GCP services.
 
 This library is **experimental**. Its APIs are subject to change without notice.
@@ -21,12 +21,13 @@ Please note that the Google Cloud C++ client libraries do **not** follow
 
 ## Documentation
 
-* Official documentation about the [Access Context Manager API][cloud-service-docs] service
+* Official documentation about the [Access Context Manager][cloud-service-docs] service
 * [Reference doxygen documentation][doxygen-link] for each release of this
   client library
 * Detailed header comments in our [public `.h`][source-link] files
 
-[cloud-service-docs]: https://cloud.google.com/access-context-manager
+[cloud-service]: https://cloud.google.com/access-context-manager
+[cloud-service-docs]: https://cloud.google.com/access-context-manager/docs
 [doxygen-link]: https://googleapis.dev/cpp/google-cloud-accesscontextmanager/latest/
 [source-link]: https://github.com/googleapis/google-cloud-cpp/tree/main/google/cloud/accesscontextmanager
 

--- a/google/cloud/accesscontextmanager/doc/main.dox
+++ b/google/cloud/accesscontextmanager/doc/main.dox
@@ -1,8 +1,8 @@
 /*!
 
-@mainpage Access Context Manager API C++ Client Library
+@mainpage Access Context Manager C++ Client Library
 
-An idiomatic C++ client library for the [Access Context Manager API][cloud-service-docs], a service
+An idiomatic C++ client library for [Access Context Manager][cloud-service-docs], a service
 for setting attribute based access control on requests to GCP services.
 
 This library is **experimental**. Its APIs are subject to change without notice.
@@ -15,7 +15,7 @@ the client library.
 
 ### Setting up your repo
 
-In order to use the Access Context Manager API C++ client library from your own code,
+In order to use the Access Context Manager C++ client library from your own code,
 you'll need to configure your build system to discover and compile the Cloud
 C++ client libraries. In some cases your build system or package manager may
 need to download the libraries too. The Cloud C++ client libraries natively
@@ -33,7 +33,7 @@ cd google-cloud-cpp/google/cloud/accesscontextmanager/quickstart
 
 The following shows the code that you'll run in the
 `google/cloud/accesscontextmanager/quickstart/` directory,
-which should give you a taste of the Access Context Manager API C++ client library API.
+which should give you a taste of the Access Context Manager C++ client library API.
 
 @include quickstart.cc
 

--- a/google/cloud/accesscontextmanager/quickstart/CMakeLists.txt
+++ b/google/cloud/accesscontextmanager/quickstart/CMakeLists.txt
@@ -12,8 +12,8 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-# This file shows how to use the Access Context Manager API C++ client library
-# from a larger CMake project.
+# This file shows how to use the Access Context Manager C++ client library from
+# a larger CMake project.
 
 cmake_minimum_required(VERSION 3.5)
 project(google-cloud-cpp-accesscontextmanager-quickstart CXX)

--- a/google/cloud/accesscontextmanager/quickstart/README.md
+++ b/google/cloud/accesscontextmanager/quickstart/README.md
@@ -1,6 +1,6 @@
-# HOWTO: using the Access Context Manager API C++ client in your project
+# HOWTO: using the Access Context Manager C++ client in your project
 
-This directory contains small examples showing how to use the Access Context Manager API C++
+This directory contains small examples showing how to use the Access Context Manager C++
 client library in your own project. These instructions assume that you have
 some experience as a C++ developer and that you have a working C++ toolchain
 (compiler, linker, etc.) installed on your platform.
@@ -28,7 +28,7 @@ steps in detail.
 
 ## Configuring authentication for the C++ Client Library
 
-Like most Google Cloud Platform (GCP) services, Access Context Manager API requires that
+Like most Google Cloud Platform (GCP) services, Access Context Manager requires that
 your application authenticates with the service before accessing any data. If
 you are not familiar with GCP authentication please take this opportunity to
 review the [Authentication Overview][authentication-quickstart]. This library

--- a/google/cloud/apigateway/CMakeLists.txt
+++ b/google/cloud/apigateway/CMakeLists.txt
@@ -15,8 +15,8 @@
 # ~~~
 
 include(GoogleapisConfig)
-set(DOXYGEN_PROJECT_NAME "API Gateway API C++ Client")
-set(DOXYGEN_PROJECT_BRIEF "A C++ Client Library for the API Gateway API")
+set(DOXYGEN_PROJECT_NAME "API Gateway C++ Client")
+set(DOXYGEN_PROJECT_BRIEF "A C++ Client Library for the API Gateway service")
 set(DOXYGEN_PROJECT_NUMBER "${PROJECT_VERSION} (Experimental)")
 set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "apigateway_internal"
                             "apigateway_testing" "examples")
@@ -160,8 +160,9 @@ google_cloud_cpp_install_headers("google_cloud_cpp_apigateway_mocks"
 set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
 set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
 set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
-set(GOOGLE_CLOUD_PC_NAME "The API Gateway API C++ Client Library")
-set(GOOGLE_CLOUD_PC_DESCRIPTION "Provides C++ APIs to use the API Gateway API.")
+set(GOOGLE_CLOUD_PC_NAME "The API Gateway C++ Client Library")
+set(GOOGLE_CLOUD_PC_DESCRIPTION
+    "Provides C++ APIs to use the API Gateway service.")
 set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_apigateway")
 string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common" " google_cloud_cpp_apigateway_protos")

--- a/google/cloud/apigateway/README.md
+++ b/google/cloud/apigateway/README.md
@@ -1,9 +1,9 @@
-# API Gateway API C++ Client Library
+# API Gateway C++ Client Library
 
 :construction:
 
-This directory contains an idiomatic C++ client library for the
-[API Gateway API][cloud-service-docs], a service to develop, deploy, secure, and
+This directory contains an idiomatic C++ client library for
+[API Gateway][cloud-service], a service to develop, deploy, secure, and
 manage APIs with a fully managed gateway.
 
 This library is **experimental**. Its APIS are subject to change without notice.
@@ -21,12 +21,13 @@ Please note that the Google Cloud C++ client libraries do **not** follow
 
 ## Documentation
 
-* Official documentation about the [API Gateway API][cloud-service-docs] service
+* Official documentation about the [API Gateway][cloud-service-docs] service
 * [Reference doxygen documentation][doxygen-link] for each release of this
   client library
 * Detailed header comments in our [public `.h`][source-link] files
 
-[cloud-service-docs]: https://cloud.google.com/api-gateway
+[cloud-service]: https://cloud.google.com/api-gateway
+[cloud-service-docs]: https://cloud.google.com/api-gateway/docs
 [doxygen-link]: https://googleapis.dev/cpp/google-cloud-apigateway/latest/
 [source-link]: https://github.com/googleapis/google-cloud-cpp/tree/main/google/cloud/apigateway
 

--- a/google/cloud/apigateway/doc/main.dox
+++ b/google/cloud/apigateway/doc/main.dox
@@ -1,8 +1,8 @@
 /*!
 
-@mainpage API Gateway API C++ Client Library
+@mainpage API Gateway C++ Client Library
 
-An idiomatic C++ client library for the [API Gateway API][cloud-service-docs], a service
+An idiomatic C++ client library for the [API Gateway][cloud-service-docs], a service
 to  develop, deploy, secure, and manage APIs with a fully managed gateway.
 
 This library is **experimental**. Its APIs are subject to change without notice.
@@ -14,7 +14,7 @@ dependencies, as well as how to compile the client library.
 
 ### Setting up your repo
 
-In order to use the API Gateway API C++ client library from your own code,
+In order to use the API Gateway C++ client library from your own code,
 you'll need to configure your build system to discover and compile the Cloud
 C++ client libraries. In some cases your build system or package manager may
 need to download the libraries too. The Cloud C++ client libraries natively
@@ -32,7 +32,7 @@ cd google-cloud-cpp/google/cloud/apigateway/quickstart
 
 The following shows the code that you'll run in the
 `google/cloud/apigateway/quickstart/` directory,
-which should give you a taste of the API Gateway API C++ client library API.
+which should give you a taste of the API Gateway C++ client library API.
 
 @include quickstart.cc
 

--- a/google/cloud/apigateway/quickstart/CMakeLists.txt
+++ b/google/cloud/apigateway/quickstart/CMakeLists.txt
@@ -12,8 +12,8 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-# This file shows how to use the API Gateway API C++ client library from a
-# larger CMake project.
+# This file shows how to use the API Gateway C++ client library from a larger
+# CMake project.
 
 cmake_minimum_required(VERSION 3.5)
 project(google-cloud-cpp-apigateway-quickstart CXX)

--- a/google/cloud/apigateway/quickstart/README.md
+++ b/google/cloud/apigateway/quickstart/README.md
@@ -1,6 +1,6 @@
-# HOWTO: using the API Gateway API C++ client in your project
+# HOWTO: using the API Gateway C++ client in your project
 
-This directory contains small examples showing how to use the API Gateway API C++
+This directory contains small examples showing how to use the API Gateway C++
 client library in your own project. These instructions assume that you have
 some experience as a C++ developer and that you have a working C++ toolchain
 (compiler, linker, etc.) installed on your platform.
@@ -28,7 +28,7 @@ steps in detail.
 
 ## Configuring authentication for the C++ Client Library
 
-Like most Google Cloud Platform (GCP) services, API Gateway API requires that
+Like most Google Cloud Platform (GCP) services, API Gateway requires that
 your application authenticates with the service before accessing any data. If
 you are not familiar with GCP authentication please take this opportunity to
 review the [Authentication Overview][authentication-quickstart]. This library

--- a/google/cloud/appengine/CMakeLists.txt
+++ b/google/cloud/appengine/CMakeLists.txt
@@ -15,8 +15,9 @@
 # ~~~
 
 include(GoogleapisConfig)
-set(DOXYGEN_PROJECT_NAME "App Engine Admin API C++ Client")
-set(DOXYGEN_PROJECT_BRIEF "A C++ Client Library for the App Engine Admin API")
+set(DOXYGEN_PROJECT_NAME "App Engine Admin C++ Client")
+set(DOXYGEN_PROJECT_BRIEF
+    "A C++ Client Library for the App Engine Admin service")
 set(DOXYGEN_PROJECT_NUMBER "${PROJECT_VERSION} (Experimental)")
 set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "appengine_internal" "appengine_testing"
                             "examples")
@@ -177,9 +178,9 @@ google_cloud_cpp_install_headers("google_cloud_cpp_appengine_mocks"
 set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
 set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
 set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
-set(GOOGLE_CLOUD_PC_NAME "The App Engine Admin API C++ Client Library")
+set(GOOGLE_CLOUD_PC_NAME "The App Engine Admin C++ Client Library")
 set(GOOGLE_CLOUD_PC_DESCRIPTION
-    "Provides C++ APIs to use the App Engine Admin API.")
+    "Provides C++ APIs to use the App Engine Admin service.")
 set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_appengine")
 string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common" " google_cloud_cpp_appengine_protos")

--- a/google/cloud/appengine/README.md
+++ b/google/cloud/appengine/README.md
@@ -21,7 +21,7 @@ Please note that the Google Cloud C++ client libraries do **not** follow
 
 ## Documentation
 
-* Official documentation about the [App Engine Admin API][cloud-service-docs] service
+* Official documentation about the [App Engine Admin API][cloud-service-docs]
 * [Reference doxygen documentation][doxygen-link] for each release of this
   client library
 * Detailed header comments in our [public `.h`][source-link] files

--- a/google/cloud/appengine/quickstart/README.md
+++ b/google/cloud/appengine/quickstart/README.md
@@ -28,7 +28,7 @@ steps in detail.
 
 ## Configuring authentication for the C++ Client Library
 
-Like most Google Cloud Platform (GCP) services, App Engine Admin API requires that
+Like most Google Cloud Platform (GCP) services, the App Engine Admin API requires that
 your application authenticates with the service before accessing any data. If
 you are not familiar with GCP authentication please take this opportunity to
 review the [Authentication Overview][authentication-quickstart]. This library

--- a/google/cloud/assuredworkloads/CMakeLists.txt
+++ b/google/cloud/assuredworkloads/CMakeLists.txt
@@ -15,8 +15,9 @@
 # ~~~
 
 include(GoogleapisConfig)
-set(DOXYGEN_PROJECT_NAME "Assured Workloads API C++ Client")
-set(DOXYGEN_PROJECT_BRIEF "A C++ Client Library for the Assured Workloads API")
+set(DOXYGEN_PROJECT_NAME "Assured Workloads C++ Client")
+set(DOXYGEN_PROJECT_BRIEF
+    "A C++ Client Library for the Assured Workloads service")
 set(DOXYGEN_PROJECT_NUMBER "${PROJECT_VERSION} (Experimental)")
 set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "assuredworkloads_internal"
                             "assuredworkloads_testing" "examples")
@@ -169,9 +170,9 @@ google_cloud_cpp_install_headers("google_cloud_cpp_assuredworkloads_mocks"
 set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
 set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
 set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
-set(GOOGLE_CLOUD_PC_NAME "The Assured Workloads API C++ Client Library")
+set(GOOGLE_CLOUD_PC_NAME "The Assured Workloads C++ Client Library")
 set(GOOGLE_CLOUD_PC_DESCRIPTION
-    "Provides C++ APIs to access Assured Workloads API.")
+    "Provides C++ APIs to access the Assured Workloads service.")
 set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_assuredworkloads")
 string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common"

--- a/google/cloud/assuredworkloads/README.md
+++ b/google/cloud/assuredworkloads/README.md
@@ -1,9 +1,9 @@
-# Assured Workloads API C++ Client Library
+# Assured Workloads C++ Client Library
 
 :construction:
 
 This directory contains an idiomatic C++ client library for
-[Assured Workloads API][cloud-service-docs], a service to accelerate your path
+[Assured Workloads][cloud-service], a service to accelerate your path
 to running more secure and compliant workloads on Google Cloud.
 
 This library is **experimental**. Its APIs are subject to change without notice.
@@ -21,12 +21,13 @@ Please note that the Google Cloud C++ client libraries do **not** follow
 
 ## Documentation
 
-* Official documentation about the [Assured Workloads API][cloud-service-docs] service
+* Official documentation about the [Assured Workloads][cloud-service-docs] service
 * [Reference doxygen documentation][doxygen-link] for each release of this
   client library
 * Detailed header comments in our [public `.h`][source-link] files
 
-[cloud-service-docs]: https://cloud.google.com/assured-workloads
+[cloud-service]: https://cloud.google.com/assured-workloads
+[cloud-service-docs]: https://cloud.google.com/assured-workloads/docs
 [doxygen-link]: https://googleapis.dev/cpp/google-cloud-assuredworkloads/latest/
 [source-link]: https://github.com/googleapis/google-cloud-cpp/tree/main/google/cloud/assuredworkloads
 

--- a/google/cloud/assuredworkloads/doc/main.dox
+++ b/google/cloud/assuredworkloads/doc/main.dox
@@ -1,9 +1,9 @@
 /*!
 
-@mainpage Assured Workloads API C++ Client Library
+@mainpage Assured Workloads C++ Client Library
 
 An idiomatic C++ client library for
-[Assured Workloads API](https://cloud.google.com/assured-workloads/), a service
+[Assured Workloads](https://cloud.google.com/assured-workloads/), a service
 to accelerate your path to running more secure and compliant workloads on Google
 Cloud.
 
@@ -17,7 +17,7 @@ the client library.
 
 ### Setting up your repo
 
-In order to use the Assured Workloads API C++ client library from your own code,
+In order to use the Assured Workloads C++ client library from your own code,
 you'll need to configure your build system to discover and compile the Cloud
 C++ client libraries. In some cases your build system or package manager may
 need to download the libraries too. The Cloud C++ client libraries natively
@@ -35,7 +35,7 @@ cd google-cloud-cpp/google/cloud/assuredworkloads/quickstart
 
 The following shows the code that you'll run in the
 `google/cloud/assuredworkloads/quickstart/` directory,
-which should give you a taste of the Assured Workloads API C++ client library API.
+which should give you a taste of the Assured Workloads C++ client library API.
 
 @include quickstart.cc
 

--- a/google/cloud/assuredworkloads/quickstart/CMakeLists.txt
+++ b/google/cloud/assuredworkloads/quickstart/CMakeLists.txt
@@ -12,7 +12,7 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-# This file shows how to use the Assured Workloads API C++ client library from a
+# This file shows how to use the Assured Workloads C++ client library from a
 # larger CMake project.
 
 cmake_minimum_required(VERSION 3.5)

--- a/google/cloud/assuredworkloads/quickstart/README.md
+++ b/google/cloud/assuredworkloads/quickstart/README.md
@@ -1,6 +1,6 @@
-# HOWTO: using the Assured Workloads API C++ client in your project
+# HOWTO: using the Assured Workloads C++ client in your project
 
-This directory contains small examples showing how to use the Assured Workloads API C++
+This directory contains small examples showing how to use the Assured Workloads C++
 client library in your own project. These instructions assume that you have
 some experience as a C++ developer and that you have a working C++ toolchain
 (compiler, linker, etc.) installed on your platform.

--- a/google/cloud/billing/CMakeLists.txt
+++ b/google/cloud/billing/CMakeLists.txt
@@ -15,9 +15,8 @@
 # ~~~
 
 include(GoogleapisConfig)
-set(DOXYGEN_PROJECT_NAME "Cloud Billing Budget API C++ Client")
-set(DOXYGEN_PROJECT_BRIEF
-    "A C++ Client Library for the Cloud Billing Budget API")
+set(DOXYGEN_PROJECT_NAME "Cloud Billing C++ Client")
+set(DOXYGEN_PROJECT_BRIEF "A C++ Client Library for the Cloud Billing service")
 set(DOXYGEN_PROJECT_NUMBER "${PROJECT_VERSION} (Experimental)")
 set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "billing_internal" "billing_testing"
                             "examples")
@@ -173,9 +172,9 @@ google_cloud_cpp_install_headers("google_cloud_cpp_billing_mocks"
 set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
 set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
 set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
-set(GOOGLE_CLOUD_PC_NAME "The Cloud Billing Budget API C++ Client Library")
+set(GOOGLE_CLOUD_PC_NAME "The Cloud Billing C++ Client Library")
 set(GOOGLE_CLOUD_PC_DESCRIPTION
-    "Provides C++ APIs to access Cloud Billing Budget API.")
+    "Provides C++ APIs to access the Cloud Billing service.")
 set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_billing")
 string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common" " google_cloud_cpp_billing_protos")

--- a/google/cloud/billing/README.md
+++ b/google/cloud/billing/README.md
@@ -1,9 +1,9 @@
-# Cloud Billing Budget API C++ Client Library
+# Cloud Billing C++ Client Library
 
 :construction:
 
-This directory contains an idiomatic C++ client library for the
-[Cloud Billing API][cloud-service-docs], a service that interacts with billing
+This directory contains an idiomatic C++ client library for
+[Cloud Billing][cloud-service], a service that interacts with billing
 accounts, billing budgets, and billing catalogs.
 
 This library is **experimental**. Its APIs are subject to change without notice.
@@ -21,12 +21,13 @@ Please note that the Google Cloud C++ client libraries do **not** follow
 
 ## Documentation
 
-* Official documentation about the [Cloud Billing Budget API][cloud-service-docs] service
+* Official documentation about the [Cloud Billing][cloud-service-docs] service
 * [Reference doxygen documentation][doxygen-link] for each release of this
   client library
 * Detailed header comments in our [public `.h`][source-link] files
 
-[cloud-service-docs]: https://cloud.google.com/billing
+[cloud-service]: https://cloud.google.com/billing
+[cloud-service-docs]: https://cloud.google.com/billing/docs
 [doxygen-link]: https://googleapis.dev/cpp/google-cloud-billing/latest/
 [source-link]: https://github.com/googleapis/google-cloud-cpp/tree/main/google/cloud/billing
 

--- a/google/cloud/billing/doc/main.dox
+++ b/google/cloud/billing/doc/main.dox
@@ -1,9 +1,9 @@
 /*!
 
-@mainpage Cloud Billing API C++ Client Library
+@mainpage Cloud Billing C++ Client Library
 
 An idiomatic C++ client library for
-[Cloud Billing API](https://cloud.google.com/billing/), a service that interacts
+[Cloud Billing](https://cloud.google.com/billing/), a service that interacts
 with billing accounts, billing budgets, and billing catalogs.
 
 This library is **experimental**. Its APIs are subject to change without notice.
@@ -16,7 +16,7 @@ the client library.
 
 ### Setting up your repo
 
-In order to use the Cloud Billing Budget API C++ client library from your own code,
+In order to use the Cloud Billing C++ client library from your own code,
 you'll need to configure your build system to discover and compile the Cloud
 C++ client libraries. In some cases your build system or package manager may
 need to download the libraries too. The Cloud C++ client libraries natively
@@ -34,7 +34,7 @@ cd google-cloud-cpp/google/cloud/billing/quickstart
 
 The following shows the code that you'll run in the
 `google/cloud/billing/quickstart/` directory,
-which should give you a taste of the Cloud Billing Budget API C++ client library API.
+which should give you a taste of the Cloud Billing C++ client library API.
 
 @include quickstart.cc
 

--- a/google/cloud/billing/quickstart/CMakeLists.txt
+++ b/google/cloud/billing/quickstart/CMakeLists.txt
@@ -12,8 +12,8 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-# This file shows how to use the Cloud Billing Budget API C++ client library
-# from a larger CMake project.
+# This file shows how to use the Cloud Billing C++ client library from a larger
+# CMake project.
 
 cmake_minimum_required(VERSION 3.5)
 project(google-cloud-cpp-billing-quickstart CXX)

--- a/google/cloud/billing/quickstart/README.md
+++ b/google/cloud/billing/quickstart/README.md
@@ -1,6 +1,6 @@
-# HOWTO: using the Cloud Billing API C++ client in your project
+# HOWTO: using the Cloud Billing C++ client in your project
 
-This directory contains small examples showing how to use the Cloud Billing API C++
+This directory contains small examples showing how to use the Cloud Billing C++
 client library in your own project. These instructions assume that you have
 some experience as a C++ developer and that you have a working C++ toolchain
 (compiler, linker, etc.) installed on your platform.

--- a/google/cloud/datamigration/CMakeLists.txt
+++ b/google/cloud/datamigration/CMakeLists.txt
@@ -15,8 +15,9 @@
 # ~~~
 
 include(GoogleapisConfig)
-set(DOXYGEN_PROJECT_NAME "Database Migration API C++ Client")
-set(DOXYGEN_PROJECT_BRIEF "A C++ Client Library for the Database Migration API")
+set(DOXYGEN_PROJECT_NAME "Database Migration C++ Client")
+set(DOXYGEN_PROJECT_BRIEF
+    "A C++ Client Library for the Database Migration service")
 set(DOXYGEN_PROJECT_NUMBER "${PROJECT_VERSION} (Experimental)")
 set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "datamigration_internal"
                             "datamigration_testing" "examples")
@@ -161,9 +162,9 @@ google_cloud_cpp_install_headers("google_cloud_cpp_datamigration_mocks"
 set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
 set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
 set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
-set(GOOGLE_CLOUD_PC_NAME "The Database Migration API C++ Client Library")
+set(GOOGLE_CLOUD_PC_NAME "The Database Migration C++ Client Library")
 set(GOOGLE_CLOUD_PC_DESCRIPTION
-    "Provides C++ APIs to use the Database Migration API.")
+    "Provides C++ APIs to use the Database Migration service.")
 set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_datamigration")
 string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common"

--- a/google/cloud/datamigration/README.md
+++ b/google/cloud/datamigration/README.md
@@ -1,9 +1,9 @@
-# Database Migration API C++ Client Library
+# Database Migration C++ Client Library
 
 :construction:
 
-This directory contains an idiomatic C++ client library for the
-[Database Migration API][cloud-service-docs], a service to simplify migrations
+This directory contains an idiomatic C++ client library for
+[Database Migration][cloud-service], a service to simplify migrations
 to Cloud SQL.
 
 This library is **experimental**. Its APIS are subject to change without notice.
@@ -21,12 +21,13 @@ Please note that the Google Cloud C++ client libraries do **not** follow
 
 ## Documentation
 
-* Official documentation about the [Database Migration API][cloud-service-docs] service
+* Official documentation about the [Database Migration][cloud-service-docs] service
 * [Reference doxygen documentation][doxygen-link] for each release of this
   client library
 * Detailed header comments in our [public `.h`][source-link] files
 
-[cloud-service-docs]: https://cloud.google.com/database-migration
+[cloud-service]: https://cloud.google.com/database-migration
+[cloud-service-docs]: https://cloud.google.com/database-migration/docs
 [doxygen-link]: https://googleapis.dev/cpp/google-cloud-datamigration/latest/
 [source-link]: https://github.com/googleapis/google-cloud-cpp/tree/main/google/cloud/datamigration
 

--- a/google/cloud/datamigration/doc/main.dox
+++ b/google/cloud/datamigration/doc/main.dox
@@ -1,8 +1,8 @@
 /*!
 
-@mainpage Database Migration API C++ Client Library
+@mainpage Database Migration C++ Client Library
 
-An idiomatic C++ client library for the [Database Migration API][cloud-service-docs], a service
+An idiomatic C++ client library for [Database Migration][cloud-service-docs], a service
 to Manage Cloud Database Migration Service resources on Google Cloud Platform.
 
 This library is **experimental**. Its APIs are subject to change without notice.
@@ -14,7 +14,7 @@ dependencies, as well as how to compile the client library.
 
 ### Setting up your repo
 
-In order to use the Database Migration API C++ client library from your own code,
+In order to use the Database Migration C++ client library from your own code,
 you'll need to configure your build system to discover and compile the Cloud
 C++ client libraries. In some cases your build system or package manager may
 need to download the libraries too. The Cloud C++ client libraries natively
@@ -32,7 +32,7 @@ cd google-cloud-cpp/google/cloud/datamigration/quickstart
 
 The following shows the code that you'll run in the
 `google/cloud/datamigration/quickstart/` directory,
-which should give you a taste of the Database Migration API C++ client library API.
+which should give you a taste of the Database Migration C++ client library API.
 
 @include quickstart.cc
 

--- a/google/cloud/datamigration/quickstart/CMakeLists.txt
+++ b/google/cloud/datamigration/quickstart/CMakeLists.txt
@@ -12,8 +12,8 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-# This file shows how to use the Database Migration API C++ client library from
-# a larger CMake project.
+# This file shows how to use the Database Migration C++ client library from a
+# larger CMake project.
 
 cmake_minimum_required(VERSION 3.5)
 project(google-cloud-cpp-datamigration-quickstart CXX)

--- a/google/cloud/datamigration/quickstart/README.md
+++ b/google/cloud/datamigration/quickstart/README.md
@@ -1,6 +1,6 @@
-# HOWTO: using the Database Migration API C++ client in your project
+# HOWTO: using the Database Migration C++ client in your project
 
-This directory contains small examples showing how to use the Database Migration API C++
+This directory contains small examples showing how to use the Database Migration C++
 client library in your own project. These instructions assume that you have
 some experience as a C++ developer and that you have a working C++ toolchain
 (compiler, linker, etc.) installed on your platform.
@@ -28,7 +28,7 @@ steps in detail.
 
 ## Configuring authentication for the C++ Client Library
 
-Like most Google Cloud Platform (GCP) services, Database Migration API requires that
+Like most Google Cloud Platform (GCP) services, Database Migration requires that
 your application authenticates with the service before accessing any data. If
 you are not familiar with GCP authentication please take this opportunity to
 review the [Authentication Overview][authentication-quickstart]. This library

--- a/google/cloud/eventarc/CMakeLists.txt
+++ b/google/cloud/eventarc/CMakeLists.txt
@@ -15,8 +15,8 @@
 # ~~~
 
 include(GoogleapisConfig)
-set(DOXYGEN_PROJECT_NAME "Eventarc API C++ Client")
-set(DOXYGEN_PROJECT_BRIEF "A C++ Client Library for the Eventarc API")
+set(DOXYGEN_PROJECT_NAME "Eventarc C++ Client")
+set(DOXYGEN_PROJECT_BRIEF "A C++ Client Library for the Eventarc service")
 set(DOXYGEN_PROJECT_NUMBER "${PROJECT_VERSION} (Experimental)")
 set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "eventarc_internal" "eventarc_testing"
                             "examples")
@@ -161,8 +161,9 @@ google_cloud_cpp_install_headers("google_cloud_cpp_eventarc_mocks"
 set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
 set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
 set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
-set(GOOGLE_CLOUD_PC_NAME "The Eventarc API C++ Client Library")
-set(GOOGLE_CLOUD_PC_DESCRIPTION "Provides C++ APIs to use the Eventarc API.")
+set(GOOGLE_CLOUD_PC_NAME "The Eventarc C++ Client Library")
+set(GOOGLE_CLOUD_PC_DESCRIPTION
+    "Provides C++ APIs to use the Eventarc service.")
 set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_eventarc")
 string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common" " google_cloud_cpp_eventarc_protos")

--- a/google/cloud/eventarc/README.md
+++ b/google/cloud/eventarc/README.md
@@ -1,9 +1,9 @@
-# Eventarc API C++ Client Library
+# Eventarc C++ Client Library
 
 :construction:
 
-This directory contains an idiomatic C++ client library for the
-[Eventarc API][cloud-service-docs], a service to asynchronously deliver events.
+This directory contains an idiomatic C++ client library for
+[Eventarc][cloud-service], a service to asynchronously deliver events.
 
 This library is **experimental**. Its APIs are subject to change without notice.
 
@@ -20,12 +20,13 @@ Please note that the Google Cloud C++ client libraries do **not** follow
 
 ## Documentation
 
-* Official documentation about the [Eventarc API][cloud-service-docs] service
+* Official documentation about the [Eventarc][cloud-service-docs] service
 * [Reference doxygen documentation][doxygen-link] for each release of this
   client library
 * Detailed header comments in our [public `.h`][source-link] files
 
-[cloud-service-docs]: https://cloud.google.com/eventarc
+[cloud-service]: https://cloud.google.com/eventarc
+[cloud-service-docs]: https://cloud.google.com/eventarc/docs
 [doxygen-link]: https://googleapis.dev/cpp/google-cloud-eventarc/latest/
 [source-link]: https://github.com/googleapis/google-cloud-cpp/tree/main/google/cloud/eventarc
 

--- a/google/cloud/eventarc/doc/main.dox
+++ b/google/cloud/eventarc/doc/main.dox
@@ -1,8 +1,8 @@
 /*!
 
-@mainpage Eventarc API C++ Client Library
+@mainpage Eventarc C++ Client Library
 
-An idiomatic C++ client library for the [Eventarc API][cloud-service-docs], a
+An idiomatic C++ client library for [Eventarc][cloud-service-docs], a
 service to asynchronously deliver events.
 
 This library is **experimental**. Its APIs are subject to change without notice.
@@ -14,7 +14,7 @@ dependencies, as well as how to compile the client library.
 
 ### Setting up your repo
 
-In order to use the Eventarc API C++ client library from your own code,
+In order to use the Eventarc C++ client library from your own code,
 you'll need to configure your build system to discover and compile the Cloud
 C++ client libraries. In some cases your build system or package manager may
 need to download the libraries too. The Cloud C++ client libraries natively
@@ -32,7 +32,7 @@ cd google-cloud-cpp/google/cloud/eventarc/quickstart
 
 The following shows the code that you'll run in the
 `google/cloud/eventarc/quickstart/` directory,
-which should give you a taste of the Eventarc API C++ client library API.
+which should give you a taste of the Eventarc C++ client library API.
 
 @include quickstart.cc
 

--- a/google/cloud/eventarc/quickstart/CMakeLists.txt
+++ b/google/cloud/eventarc/quickstart/CMakeLists.txt
@@ -12,8 +12,8 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-# This file shows how to use the Eventarc API C++ client library from a larger
-# CMake project.
+# This file shows how to use the Eventarc C++ client library from a larger CMake
+# project.
 
 cmake_minimum_required(VERSION 3.5)
 project(google-cloud-cpp-eventarc-quickstart CXX)

--- a/google/cloud/eventarc/quickstart/README.md
+++ b/google/cloud/eventarc/quickstart/README.md
@@ -1,6 +1,6 @@
-# HOWTO: using the Eventarc API C++ client in your project
+# HOWTO: using the Eventarc C++ client in your project
 
-This directory contains small examples showing how to use the Eventarc API C++
+This directory contains small examples showing how to use the Eventarc C++
 client library in your own project. These instructions assume that you have
 some experience as a C++ developer and that you have a working C++ toolchain
 (compiler, linker, etc.) installed on your platform.
@@ -28,7 +28,7 @@ steps in detail.
 
 ## Configuring authentication for the C++ Client Library
 
-Like most Google Cloud Platform (GCP) services, Eventarc API requires that
+Like most Google Cloud Platform (GCP) services, Eventarc requires that
 your application authenticates with the service before accessing any data. If
 you are not familiar with GCP authentication please take this opportunity to
 review the [Authentication Overview][authentication-quickstart]. This library

--- a/google/cloud/ids/CMakeLists.txt
+++ b/google/cloud/ids/CMakeLists.txt
@@ -15,8 +15,8 @@
 # ~~~
 
 include(GoogleapisConfig)
-set(DOXYGEN_PROJECT_NAME "Cloud IDS API C++ Client")
-set(DOXYGEN_PROJECT_BRIEF "A C++ Client Library for the Cloud IDS API")
+set(DOXYGEN_PROJECT_NAME "Cloud IDS C++ Client")
+set(DOXYGEN_PROJECT_BRIEF "A C++ Client Library for the Cloud IDS service")
 set(DOXYGEN_PROJECT_NUMBER "${PROJECT_VERSION} (Experimental)")
 set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "ids_internal" "ids_testing" "examples")
 set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
@@ -156,8 +156,9 @@ google_cloud_cpp_install_headers("google_cloud_cpp_ids_mocks"
 set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
 set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
 set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
-set(GOOGLE_CLOUD_PC_NAME "The Cloud IDS API C++ Client Library")
-set(GOOGLE_CLOUD_PC_DESCRIPTION "Provides C++ APIs to use the Cloud IDS API.")
+set(GOOGLE_CLOUD_PC_NAME "The Cloud IDS C++ Client Library")
+set(GOOGLE_CLOUD_PC_DESCRIPTION
+    "Provides C++ APIs to use the Cloud IDS service.")
 set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_ids")
 string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common" " google_cloud_cpp_ids_protos")

--- a/google/cloud/ids/README.md
+++ b/google/cloud/ids/README.md
@@ -1,9 +1,9 @@
-# Cloud IDS API C++ Client Library
+# Cloud IDS C++ Client Library
 
 :construction:
 
-This directory contains an idiomatic C++ client library for the
-[Cloud Intrusion Detection System (IDS) API][cloud-service-docs], a
+This directory contains an idiomatic C++ client library for
+[Cloud Intrusion Detection System (IDS)][cloud-service], a
 service to detect malware, spyware, command-and-control attacks, and
 other network-based threats. Its security efficacy is industry leading,
 built with Palo Alto Networks technologies. When you use this product,
@@ -25,12 +25,13 @@ Please note that the Google Cloud C++ client libraries do **not** follow
 
 ## Documentation
 
-* Official documentation about the [Cloud IDS API][cloud-service-docs] service
+* Official documentation about the [Cloud IDS][cloud-service-docs] service
 * [Reference doxygen documentation][doxygen-link] for each release of this
   client library
 * Detailed header comments in our [public `.h`][source-link] files
 
-[cloud-service-docs]: https://cloud.google.com/ids
+[cloud-service]: https://cloud.google.com/ids
+[cloud-service-docs]: https://cloud.google.com/ids/docs
 [doxygen-link]: https://googleapis.dev/cpp/google-cloud-ids/latest/
 [source-link]: https://github.com/googleapis/google-cloud-cpp/tree/main/google/cloud/ids
 

--- a/google/cloud/ids/doc/main.dox
+++ b/google/cloud/ids/doc/main.dox
@@ -1,9 +1,9 @@
 /*!
 
-@mainpage Cloud IDS API C++ Client Library
+@mainpage Cloud IDS C++ Client Library
 
-An idiomatic C++ client library for the
-[Cloud Intrusion Detection System (IDS) API][cloud-service-docs], a
+An idiomatic C++ client library for
+[Cloud Intrusion Detection System (IDS)][cloud-service-docs], a
 service to detect malware, spyware, command-and-control attacks, and
 other network-based threats. Its security efficacy is industry leading,
 built with Palo Alto Networks technologies. When you use this product,
@@ -19,7 +19,7 @@ dependencies, as well as how to compile the client library.
 
 ### Setting up your repo
 
-In order to use the Cloud IDS API C++ client library from your own code,
+In order to use the Cloud IDS C++ client library from your own code,
 you'll need to configure your build system to discover and compile the Cloud
 C++ client libraries. In some cases your build system or package manager may
 need to download the libraries too. The Cloud C++ client libraries natively
@@ -37,7 +37,7 @@ cd google-cloud-cpp/google/cloud/ids/quickstart
 
 The following shows the code that you'll run in the
 `google/cloud/ids/quickstart/` directory,
-which should give you a taste of the Cloud IDS API C++ client library API.
+which should give you a taste of the Cloud IDS C++ client library API.
 
 @include quickstart.cc
 

--- a/google/cloud/ids/quickstart/CMakeLists.txt
+++ b/google/cloud/ids/quickstart/CMakeLists.txt
@@ -12,7 +12,7 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-# This file shows how to use the Cloud IDS API C++ client library from a larger
+# This file shows how to use the Cloud IDS C++ client library from a larger
 # CMake project.
 
 cmake_minimum_required(VERSION 3.5)

--- a/google/cloud/ids/quickstart/README.md
+++ b/google/cloud/ids/quickstart/README.md
@@ -1,6 +1,6 @@
-# HOWTO: using the Cloud IDS API C++ client in your project
+# HOWTO: using the Cloud IDS C++ client in your project
 
-This directory contains small examples showing how to use the Cloud IDS API C++
+This directory contains small examples showing how to use the Cloud IDS C++
 client library in your own project. These instructions assume that you have
 some experience as a C++ developer and that you have a working C++ toolchain
 (compiler, linker, etc.) installed on your platform.
@@ -28,7 +28,7 @@ necessary steps in detail.
 
 ## Configuring authentication for the C++ Client Library
 
-Like most Google Cloud Platform (GCP) services, Cloud IDS API requires that
+Like most Google Cloud Platform (GCP) services, Cloud IDS requires that
 your application authenticates with the service before accessing any data. If
 you are not familiar with GCP authentication please take this opportunity to
 review the [Authentication Overview][authentication-quickstart]. This library

--- a/google/cloud/iot/CMakeLists.txt
+++ b/google/cloud/iot/CMakeLists.txt
@@ -15,8 +15,8 @@
 # ~~~
 
 include(GoogleapisConfig)
-set(DOXYGEN_PROJECT_NAME "Cloud IoT API C++ Client")
-set(DOXYGEN_PROJECT_BRIEF "A C++ Client Library for the Cloud IoT API")
+set(DOXYGEN_PROJECT_NAME "Cloud IoT C++ Client")
+set(DOXYGEN_PROJECT_BRIEF "A C++ Client Library for the Cloud IoT service")
 set(DOXYGEN_PROJECT_NUMBER "${PROJECT_VERSION} (Experimental)")
 set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "iot_internal" "iot_testing" "examples")
 set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
@@ -160,8 +160,9 @@ google_cloud_cpp_install_headers("google_cloud_cpp_iot_mocks"
 set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
 set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
 set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
-set(GOOGLE_CLOUD_PC_NAME "The Cloud IoT API C++ Client Library")
-set(GOOGLE_CLOUD_PC_DESCRIPTION "Provides C++ APIs to use the Cloud IoT API.")
+set(GOOGLE_CLOUD_PC_NAME "The Cloud IoT C++ Client Library")
+set(GOOGLE_CLOUD_PC_DESCRIPTION
+    "Provides C++ APIs to use the Cloud IoT service.")
 set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_iot")
 string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common" " google_cloud_cpp_iot_protos")

--- a/google/cloud/iot/README.md
+++ b/google/cloud/iot/README.md
@@ -1,9 +1,9 @@
-# Cloud IoT API C++ Client Library
+# Cloud IoT C++ Client Library
 
 :construction:
 
 This directory contains an idiomatic C++ client library for the
-[Cloud IoT API][cloud-service-docs], a service to register and manage IoT
+[Cloud IoT][cloud-service], a service to register and manage IoT
 (Internet of Things) devices that connect to the Google Cloud Platform.
 
 This library is **experimental**. Its APIs are subject to change without notice.
@@ -21,12 +21,13 @@ Please note that the Google Cloud C++ client libraries do **not** follow
 
 ## Documentation
 
-* Official documentation about the [Cloud IoT API][cloud-service-docs] service
+* Official documentation about the [Cloud IoT][cloud-service-docs] service
 * [Reference doxygen documentation][doxygen-link] for each release of this
   client library
 * Detailed header comments in our [public `.h`][source-link] files
 
-[cloud-service-docs]: https://cloud.google.com/iot
+[cloud-service]: https://cloud.google.com/solutions/iot
+[cloud-service-docs]: https://cloud.google.com/iot/docs
 [doxygen-link]: https://googleapis.dev/cpp/google-cloud-iot/latest/
 [source-link]: https://github.com/googleapis/google-cloud-cpp/tree/main/google/cloud/iot
 

--- a/google/cloud/iot/doc/main.dox
+++ b/google/cloud/iot/doc/main.dox
@@ -1,9 +1,9 @@
 /*!
 
-@mainpage Cloud IoT API C++ Client Library
+@mainpage Cloud IoT C++ Client Library
 
-An idiomatic C++ client library for the
-[Cloud IoT API][cloud-service-docs], a service to register and manage IoT
+An idiomatic C++ client library for
+[Cloud IoT][cloud-service-docs], a service to register and manage IoT
 (Internet of Things) devices that connect to the Google Cloud Platform.
 
 This library is **experimental**. Its APIs are subject to change without notice.
@@ -15,7 +15,7 @@ dependencies, as well as how to compile the client library.
 
 ### Setting up your repo
 
-In order to use the Cloud IoT API C++ client library from your own code,
+In order to use the Cloud IoT C++ client library from your own code,
 you'll need to configure your build system to discover and compile the Cloud
 C++ client libraries. In some cases your build system or package manager may
 need to download the libraries too. The Cloud C++ client libraries natively
@@ -33,7 +33,7 @@ cd google-cloud-cpp/google/cloud/iot/quickstart
 
 The following shows the code that you'll run in the
 `google/cloud/iot/quickstart/` directory,
-which should give you a taste of the Cloud IoT API C++ client library API.
+which should give you a taste of the Cloud IoT C++ client library API.
 
 @include quickstart.cc
 

--- a/google/cloud/iot/quickstart/CMakeLists.txt
+++ b/google/cloud/iot/quickstart/CMakeLists.txt
@@ -12,7 +12,7 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-# This file shows how to use the Cloud IoT API C++ client library from a larger
+# This file shows how to use the Cloud IoT C++ client library from a larger
 # CMake project.
 
 cmake_minimum_required(VERSION 3.5)

--- a/google/cloud/iot/quickstart/README.md
+++ b/google/cloud/iot/quickstart/README.md
@@ -1,6 +1,6 @@
-# HOWTO: using the Cloud IoT API C++ client in your project
+# HOWTO: using the Cloud IoT C++ client in your project
 
-This directory contains small examples showing how to use the Cloud IoT API C++
+This directory contains small examples showing how to use the Cloud IoT C++
 client library in your own project. These instructions assume that you have
 some experience as a C++ developer and that you have a working C++ toolchain
 (compiler, linker, etc.) installed on your platform.
@@ -28,7 +28,7 @@ necessary background.
 
 ## Configuring authentication for the C++ Client Library
 
-Like most Google Cloud Platform (GCP) services, Cloud IoT API requires that
+Like most Google Cloud Platform (GCP) services, Cloud IoT requires that
 your application authenticates with the service before accessing any data. If
 you are not familiar with GCP authentication please take this opportunity to
 review the [Authentication Overview][authentication-quickstart]. This library

--- a/google/cloud/kms/CMakeLists.txt
+++ b/google/cloud/kms/CMakeLists.txt
@@ -15,9 +15,8 @@
 # ~~~
 
 include(GoogleapisConfig)
-set(DOXYGEN_PROJECT_NAME "Cloud Key Management Service (KMS) API C++ Client")
-set(DOXYGEN_PROJECT_BRIEF
-    "A C++ Client Library for the Cloud Key Management Service (KMS) API")
+set(DOXYGEN_PROJECT_NAME "Cloud KMS C++ Client")
+set(DOXYGEN_PROJECT_BRIEF "A C++ Client Library for Cloud KMS")
 set(DOXYGEN_PROJECT_NUMBER "${PROJECT_VERSION} (Experimental)")
 set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "kms_internal" "kms_testing" "examples")
 set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
@@ -162,10 +161,8 @@ google_cloud_cpp_install_headers("google_cloud_cpp_kms_mocks"
 set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
 set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
 set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
-set(GOOGLE_CLOUD_PC_NAME
-    "The Cloud Key Management Service (KMS) API C++ Client Library")
-set(GOOGLE_CLOUD_PC_DESCRIPTION
-    "Provides C++ APIs to access Cloud Key Management Service (KMS) API.")
+set(GOOGLE_CLOUD_PC_NAME "The Cloud KMS C++ Client Library")
+set(GOOGLE_CLOUD_PC_DESCRIPTION "Provides C++ APIs to access Cloud KMS.")
 set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_kms")
 string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common" " google_cloud_cpp_kms_protos")

--- a/google/cloud/kms/README.md
+++ b/google/cloud/kms/README.md
@@ -1,9 +1,9 @@
-# Cloud Key Management Service (KMS) API C++ Client Library
+# Cloud Key Management Service (KMS) C++ Client Library
 
 :construction:
 
 This directory contains an idiomatic C++ client library for
-[Cloud Key Management Service (KMS)][cloud-service-docs], a service that manages
+[Cloud Key Management Service (KMS)][cloud-service], a service that manages
 keys and performs cryptographic operations in a central cloud service, for
 direct use by other cloud resources and applications.
 
@@ -22,12 +22,13 @@ Please note that the Google Cloud C++ client libraries do **not** follow
 
 ## Documentation
 
-* Official documentation about the [Cloud Key Management Service (KMS) API][cloud-service-docs] service
+* Official documentation about the [Cloud Key Management Service (KMS)][cloud-service-docs] service
 * [Reference doxygen documentation][doxygen-link] for each release of this
   client library
 * Detailed header comments in our [public `.h`][source-link] files
 
-[cloud-service-docs]: https://cloud.google.com/kms
+[cloud-service]: https://cloud.google.com/kms
+[cloud-service-docs]: https://cloud.google.com/kms/docs
 [doxygen-link]: https://googleapis.dev/cpp/google-cloud-kms/latest/
 [source-link]: https://github.com/googleapis/google-cloud-cpp/tree/main/google/cloud/kms
 

--- a/google/cloud/kms/quickstart/CMakeLists.txt
+++ b/google/cloud/kms/quickstart/CMakeLists.txt
@@ -12,8 +12,8 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-# This file shows how to use the Cloud Key Management Service (KMS) API C++
-# client library from a larger CMake project.
+# This file shows how to use the Cloud Key Management Service (KMS) C++ client
+# library from a larger CMake project.
 
 cmake_minimum_required(VERSION 3.5)
 project(google-cloud-cpp-kms-quickstart CXX)

--- a/google/cloud/logging/README.md
+++ b/google/cloud/logging/README.md
@@ -3,8 +3,8 @@
 :construction:
 
 This directory contains an idiomatic C++ client library for interacting with
-[Cloud Logging](https://cloud.google.com/logging/),
-a service for real-time log management and analysis at scale.
+[Cloud Logging][cloud-service], a service for real-time log management and
+analysis at scale.
 
 This library is **experimental**. Its APIs are subject to change without notice.
 
@@ -26,7 +26,7 @@ Please note that the Google Cloud C++ client libraries do **not** follow
   client library
 * Detailed header comments in our [public `.h`][source-link] files
 
-[cloud-service-root]: https://cloud.google.com/logging
+[cloud-service]: https://cloud.google.com/logging
 [cloud-service-docs]: https://cloud.google.com/logging/docs
 [doxygen-link]: https://googleapis.dev/cpp/google-cloud-logging/latest/
 [source-link]: https://github.com/googleapis/google-cloud-cpp/tree/main/google/cloud/logging

--- a/google/cloud/logging/doc/main.dox
+++ b/google/cloud/logging/doc/main.dox
@@ -1,9 +1,9 @@
 /*!
 
-@mainpage Cloud Logging API C++ Client Library
+@mainpage Cloud Logging C++ Client Library
 
 An idiomatic C++ client library for
-[Cloud Logging API](https://cloud.google.com/logging/), a service that writes
+[Cloud Logging](https://cloud.google.com/logging/), a service that writes
 log entries and manages your Cloud Logging configuration.
 
 This library is **experimental**. Its APIs are subject to change without notice.
@@ -16,7 +16,7 @@ the client library.
 
 ### Setting up your repo
 
-In order to use the Cloud Logging API C++ client library from your own code,
+In order to use the Cloud Logging C++ client library from your own code,
 you'll need to configure your build system to discover and compile the Cloud
 C++ client libraries. In some cases your build system or package manager may
 need to download the libraries too. The Cloud C++ client libraries natively
@@ -34,7 +34,7 @@ cd google-cloud-cpp/google/cloud/logging/quickstart
 
 The following shows the code that you'll run in the
 `google/cloud/logging/quickstart/` directory,
-which should give you a taste of the Cloud Logging API C++ client library API.
+which should give you a taste of the Cloud Logging C++ client library API.
 
 @include quickstart.cc
 

--- a/google/cloud/logging/quickstart/CMakeLists.txt
+++ b/google/cloud/logging/quickstart/CMakeLists.txt
@@ -12,8 +12,8 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-# This file shows how to use the Cloud Logging API C++ client library from a
-# larger CMake project.
+# This file shows how to use the Cloud Logging C++ client library from a larger
+# CMake project.
 
 cmake_minimum_required(VERSION 3.5)
 project(google-cloud-cpp-logging-quickstart CXX)

--- a/google/cloud/logging/quickstart/README.md
+++ b/google/cloud/logging/quickstart/README.md
@@ -1,6 +1,6 @@
-# HOWTO: using the Cloud Logging API C++ client in your project
+# HOWTO: using the Cloud Logging C++ client in your project
 
-This directory contains small examples showing how to use the Cloud Logging API C++
+This directory contains small examples showing how to use the Cloud Logging C++
 client library in your own project. These instructions assume that you have
 some experience as a C++ developer and that you have a working C++ toolchain
 (compiler, linker, etc.) installed on your platform.

--- a/google/cloud/oslogin/CMakeLists.txt
+++ b/google/cloud/oslogin/CMakeLists.txt
@@ -15,8 +15,8 @@
 # ~~~
 
 include(GoogleapisConfig)
-set(DOXYGEN_PROJECT_NAME "Cloud OS Login API C++ Client")
-set(DOXYGEN_PROJECT_BRIEF "A C++ Client Library for the Cloud OS Login API")
+set(DOXYGEN_PROJECT_NAME "Cloud OS Login C++ Client")
+set(DOXYGEN_PROJECT_BRIEF "A C++ Client Library for the Cloud OS Login service")
 set(DOXYGEN_PROJECT_NUMBER "${PROJECT_VERSION} (Experimental)")
 set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "oslogin_internal" "oslogin_testing"
                             "examples")
@@ -158,9 +158,9 @@ google_cloud_cpp_install_headers("google_cloud_cpp_oslogin_mocks"
 set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
 set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
 set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
-set(GOOGLE_CLOUD_PC_NAME "The Cloud OS Login API C++ Client Library")
+set(GOOGLE_CLOUD_PC_NAME "The Cloud OS Login C++ Client Library")
 set(GOOGLE_CLOUD_PC_DESCRIPTION
-    "Provides C++ APIs to use the Cloud OS Login API.")
+    "Provides C++ APIs to use the Cloud OS Login service.")
 set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_oslogin")
 string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common" " google_cloud_cpp_oslogin_protos")

--- a/google/cloud/oslogin/README.md
+++ b/google/cloud/oslogin/README.md
@@ -1,9 +1,9 @@
-# Cloud OS Login API C++ Client Library
+# Cloud OS Login C++ Client Library
 
 :construction:
 
-This directory contains an idiomatic C++ client library for the
-[Cloud OS Login API][cloud-service-docs], a service you can use to manage
+This directory contains an idiomatic C++ client library for
+[Cloud OS Login][cloud-service], a service you can use to manage
 access to your VM instances using IAM roles.
 
 This library is **experimental**. Its APIs are subject to change without notice.
@@ -21,12 +21,13 @@ Please note that the Google Cloud C++ client libraries do **not** follow
 
 ## Documentation
 
-* Official documentation about the [Cloud OS Login API][cloud-service-docs] service
+* Official documentation about the [Cloud OS Login][cloud-service-docs] service
 * [Reference doxygen documentation][doxygen-link] for each release of this
   client library
 * Detailed header comments in our [public `.h`][source-link] files
 
-[cloud-service-docs]: https://cloud.google.com/oslogin
+[cloud-service]: https://cloud.google.com/oslogin
+[cloud-service-docs]: https://cloud.google.com/oslogin/docs
 [doxygen-link]: https://googleapis.dev/cpp/google-cloud-oslogin/latest/
 [source-link]: https://github.com/googleapis/google-cloud-cpp/tree/main/google/cloud/oslogin
 

--- a/google/cloud/oslogin/doc/main.dox
+++ b/google/cloud/oslogin/doc/main.dox
@@ -1,9 +1,9 @@
 /*!
 
-@mainpage Cloud OS Login API C++ Client Library
+@mainpage Cloud OS Login C++ Client Library
 
-An idiomatic C++ client library for the
-[Cloud OS Login API][cloud-service-docs], a service you can use to manage
+An idiomatic C++ client library for
+[Cloud OS Login][cloud-service-docs], a service you can use to manage
 access to your VM instances using IAM roles.
 
 This library is **experimental**. Its APIs are subject to change without notice.
@@ -15,7 +15,7 @@ dependencies, as well as how to compile the client library.
 
 ### Setting up your repo
 
-In order to use the Cloud OS Login API C++ client library from your own code,
+In order to use the Cloud OS Login C++ client library from your own code,
 you'll need to configure your build system to discover and compile the Cloud
 C++ client libraries. In some cases your build system or package manager may
 need to download the libraries too. The Cloud C++ client libraries natively
@@ -33,7 +33,7 @@ cd google-cloud-cpp/google/cloud/oslogin/quickstart
 
 The following shows the code that you'll run in the
 `google/cloud/oslogin/quickstart/` directory,
-which should give you a taste of the Cloud OS Login API C++ client library API.
+which should give you a taste of the Cloud OS Login C++ client library API.
 
 @include quickstart.cc
 

--- a/google/cloud/oslogin/quickstart/CMakeLists.txt
+++ b/google/cloud/oslogin/quickstart/CMakeLists.txt
@@ -12,8 +12,8 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-# This file shows how to use the Cloud OS Login API C++ client library from a
-# larger CMake project.
+# This file shows how to use the Cloud OS Login C++ client library from a larger
+# CMake project.
 
 cmake_minimum_required(VERSION 3.5)
 project(google-cloud-cpp-oslogin-quickstart CXX)

--- a/google/cloud/oslogin/quickstart/README.md
+++ b/google/cloud/oslogin/quickstart/README.md
@@ -1,6 +1,6 @@
-# HOWTO: using the Cloud OS Login API C++ client in your project
+# HOWTO: using the Cloud OS Login C++ client in your project
 
-This directory contains small examples showing how to use the Cloud OS Login API C++
+This directory contains small examples showing how to use the Cloud OS Login C++
 client library in your own project. These instructions assume that you have
 some experience as a C++ developer and that you have a working C++ toolchain
 (compiler, linker, etc.) installed on your platform.
@@ -28,7 +28,7 @@ up OS Login.
 
 ## Configuring authentication for the C++ Client Library
 
-Like most Google Cloud Platform (GCP) services, Cloud OS Login API requires that
+Like most Google Cloud Platform (GCP) services, Cloud OS Login requires that
 your application authenticates with the service before accessing any data. If
 you are not familiar with GCP authentication please take this opportunity to
 review the [Authentication Overview][authentication-quickstart]. This library

--- a/google/cloud/pubsublite/CMakeLists.txt
+++ b/google/cloud/pubsublite/CMakeLists.txt
@@ -15,7 +15,7 @@
 # ~~~
 
 include(GoogleapisConfig)
-set(DOXYGEN_PROJECT_NAME "Pub/Sub Lite API C++ Client")
+set(DOXYGEN_PROJECT_NAME "Pub/Sub Lite C++ Client")
 set(DOXYGEN_PROJECT_BRIEF "A C++ Client Library for the Pub/Sub Lite API")
 set(DOXYGEN_PROJECT_NUMBER "${PROJECT_VERSION} (Experimental)")
 set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "pubsublite_internal"
@@ -226,8 +226,9 @@ google_cloud_cpp_install_headers("google_cloud_cpp_pubsublite_mocks"
 set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
 set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
 set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
-set(GOOGLE_CLOUD_PC_NAME "The Pub/Sub Lite API C++ Client Library")
-set(GOOGLE_CLOUD_PC_DESCRIPTION "Provides C++ APIs to access Pub/Sub Lite API.")
+set(GOOGLE_CLOUD_PC_NAME "The Pub/Sub Lite C++ Client Library")
+set(GOOGLE_CLOUD_PC_DESCRIPTION
+    "Provides C++ APIs to access the Pub/Sub Lite service.")
 set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_pubsublite")
 string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common" " google_cloud_cpp_pubsublite_protos")

--- a/google/cloud/pubsublite/README.md
+++ b/google/cloud/pubsublite/README.md
@@ -3,7 +3,7 @@
 :construction:
 
 This directory contains an idiomatic C++ client library for
-[Cloud Pub/Sub Lite][cloud-service-root], a high-volume
+[Cloud Pub/Sub Lite][cloud-service], a high-volume
 messaging service built for very low cost of operation by offering zonal storage
 and pre-provisioned capacity.
 
@@ -27,7 +27,7 @@ Please note that the Google Cloud C++ client libraries do **not** follow
   client library
 * Detailed header comments in our [public `.h`][source-link] files
 
-[cloud-service-root]: https://cloud.google.com/pubsub/lite
+[cloud-service]: https://cloud.google.com/pubsub/lite
 [cloud-service-docs]: https://cloud.google.com/pubsub/lite/docs
 [doxygen-link]: https://googleapis.dev/cpp/google-cloud-pubsublite/latest/
 [source-link]: https://github.com/googleapis/google-cloud-cpp/tree/main/google/cloud/pubsublite

--- a/google/cloud/pubsublite/doc/main.dox
+++ b/google/cloud/pubsublite/doc/main.dox
@@ -1,9 +1,9 @@
 /*!
 
-@mainpage Pub/Sub Lite API C++ Client Library
+@mainpage Pub/Sub Lite C++ Client Library
 
 An idiomatic C++ client library for
-[Pub/Sub Lite API](https://cloud.google.com/pubsublite/),  a high-volume
+[Pub/Sub Lite](https://cloud.google.com/pubsublite/),  a high-volume
 messaging service built for very low cost of operation by offering zonal storage
 and pre-provisioned capacity.
 
@@ -17,7 +17,7 @@ the client library.
 
 ### Setting up your repo
 
-In order to use the Pub/Sub Lite API C++ client library from your own code,
+In order to use the Pub/Sub Lite C++ client library from your own code,
 you'll need to configure your build system to discover and compile the Cloud
 C++ client libraries. In some cases your build system or package manager may
 need to download the libraries too. The Cloud C++ client libraries natively
@@ -35,7 +35,7 @@ cd google-cloud-cpp/google/cloud/pubsublite/quickstart
 
 The following shows the code that you'll run in the
 `google/cloud/pubsublite/quickstart/` directory,
-which should give you a taste of the Pub/Sub Lite API C++ client library API.
+which should give you a taste of the Pub/Sub Lite C++ client library API.
 
 @include quickstart.cc
 

--- a/google/cloud/pubsublite/quickstart/CMakeLists.txt
+++ b/google/cloud/pubsublite/quickstart/CMakeLists.txt
@@ -12,8 +12,8 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-# This file shows how to use the Pub/Sub Lite API C++ client library from a
-# larger CMake project.
+# This file shows how to use the Pub/Sub Lite C++ client library from a larger
+# CMake project.
 
 cmake_minimum_required(VERSION 3.5)
 project(google-cloud-cpp-pubsublite-quickstart CXX)

--- a/google/cloud/pubsublite/quickstart/README.md
+++ b/google/cloud/pubsublite/quickstart/README.md
@@ -1,6 +1,6 @@
-# HOWTO: using the Pub/Sub Lite API C++ client in your project
+# HOWTO: using the Pub/Sub Lite C++ client in your project
 
-This directory contains small examples showing how to use the Pub/Sub Lite API C++
+This directory contains small examples showing how to use the Pub/Sub Lite C++
 client library in your own project. These instructions assume that you have
 some experience as a C++ developer and that you have a working C++ toolchain
 (compiler, linker, etc.) installed on your platform.

--- a/google/cloud/recommender/CMakeLists.txt
+++ b/google/cloud/recommender/CMakeLists.txt
@@ -15,8 +15,8 @@
 # ~~~
 
 include(GoogleapisConfig)
-set(DOXYGEN_PROJECT_NAME "Recommender API C++ Client")
-set(DOXYGEN_PROJECT_BRIEF "A C++ Client Library for the Recommender API")
+set(DOXYGEN_PROJECT_NAME "The Recommender C++ Client")
+set(DOXYGEN_PROJECT_BRIEF "A C++ Client Library for the Recommender service")
 set(DOXYGEN_PROJECT_NUMBER "${PROJECT_VERSION} (Experimental)")
 set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "recommender_internal"
                             "recommender_testing" "examples")
@@ -161,8 +161,9 @@ google_cloud_cpp_install_headers("google_cloud_cpp_recommender_mocks"
 set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
 set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
 set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
-set(GOOGLE_CLOUD_PC_NAME "The Recommender API C++ Client Library")
-set(GOOGLE_CLOUD_PC_DESCRIPTION "Provides C++ APIs to use the Recommender API.")
+set(GOOGLE_CLOUD_PC_NAME "The Recommender C++ Client Library")
+set(GOOGLE_CLOUD_PC_DESCRIPTION
+    "Provides C++ APIs to use the Recommender service.")
 set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_recommender")
 string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common" " google_cloud_cpp_recommender_protos")

--- a/google/cloud/recommender/quickstart/CMakeLists.txt
+++ b/google/cloud/recommender/quickstart/CMakeLists.txt
@@ -12,8 +12,8 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-# This file shows how to use the Recommender API C++ client library from a
-# larger CMake project.
+# This file shows how to use the Recommender C++ client library from a larger
+# CMake project.
 
 cmake_minimum_required(VERSION 3.5)
 project(google-cloud-cpp-recommender-quickstart CXX)

--- a/google/cloud/resourcemanager/CMakeLists.txt
+++ b/google/cloud/resourcemanager/CMakeLists.txt
@@ -15,9 +15,9 @@
 # ~~~
 
 include(GoogleapisConfig)
-set(DOXYGEN_PROJECT_NAME "Cloud Resource Manager API C++ Client")
+set(DOXYGEN_PROJECT_NAME "Cloud Resource Manager C++ Client")
 set(DOXYGEN_PROJECT_BRIEF
-    "A C++ Client Library for the Cloud Resource Manager API")
+    "A C++ Client Library for the Cloud Resource Manager service")
 set(DOXYGEN_PROJECT_NUMBER "${PROJECT_VERSION} (Experimental)")
 set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "resourcemanager_internal"
                             "resourcemanager_testing" "examples")
@@ -173,9 +173,9 @@ google_cloud_cpp_install_headers("google_cloud_cpp_resourcemanager_mocks"
 set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
 set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
 set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
-set(GOOGLE_CLOUD_PC_NAME "The Cloud Resource Manager API C++ Client Library")
+set(GOOGLE_CLOUD_PC_NAME "The Cloud Resource Manager C++ Client Library")
 set(GOOGLE_CLOUD_PC_DESCRIPTION
-    "Provides C++ APIs to use the Cloud Resource Manager API.")
+    "Provides C++ APIs to use the Cloud Resource Manager service.")
 set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_resourcemanager")
 string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common"

--- a/google/cloud/resourcemanager/README.md
+++ b/google/cloud/resourcemanager/README.md
@@ -1,12 +1,12 @@
-# Cloud Resource Manager API C++ Client Library
+# Cloud Resource Manager C++ Client Library
 
 :construction:
 
 This directory contains an idiomatic C++ client library for
-[Resource Manager][cloud-product], a GCP product to hierarchically manage
+[Resource Manager][cloud-service], a GCP product to hierarchically manage
 resources by project, folder, and organization.
 
-This library is **experimental**. Its APIS are subject to change without notice.
+This library is **experimental**. Its APIs are subject to change without notice.
 
 Please note that the Google Cloud C++ client libraries do **not** follow
 [Semantic Versioning](https://semver.org/).
@@ -26,7 +26,7 @@ Please note that the Google Cloud C++ client libraries do **not** follow
   client library
 * Detailed header comments in our [public `.h`][source-link] files
 
-[cloud-product]: https://cloud.google.com/resource-manager
+[cloud-service]: https://cloud.google.com/resource-manager
 [cloud-service-docs]: https://cloud.google.com/resource-manager/docs
 [doxygen-link]: https://googleapis.dev/cpp/google-cloud-resourcemanager/latest/
 [source-link]: https://github.com/googleapis/google-cloud-cpp/tree/main/google/cloud/resourcemanager

--- a/google/cloud/resourcemanager/doc/main.dox
+++ b/google/cloud/resourcemanager/doc/main.dox
@@ -1,12 +1,12 @@
 /*!
 
-@mainpage Cloud Resource Manager API C++ Client Library
+@mainpage Cloud Resource Manager C++ Client Library
 
 An idiomatic C++ client library for
 [Resource Manager][cloud-product], a GCP product to hierarchically manage
 resources by project, folder, and organization.
 
-This library is **experimental**. Its APIs are subject to change without notice.
+This library is **experimental**. Itss are subject to change without notice.
 
 This library requires a C++11 compiler. It is supported (and tested) on multiple
 Linux distributions, as well as Windows and macOS. The [README][github-readme]
@@ -33,7 +33,7 @@ cd google-cloud-cpp/google/cloud/resourcemanager/quickstart
 
 The following shows the code that you'll run in the
 `google/cloud/resourcemanager/quickstart/` directory,
-which should give you a taste of the Cloud Resource Manager API C++ client library API.
+which should give you a taste of the Cloud Resource Manager C++ client library.
 
 @include quickstart.cc
 

--- a/google/cloud/resourcemanager/quickstart/CMakeLists.txt
+++ b/google/cloud/resourcemanager/quickstart/CMakeLists.txt
@@ -12,8 +12,8 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-# This file shows how to use the Cloud Resource Manager API C++ client library
-# from a larger CMake project.
+# This file shows how to use the Cloud Resource Manager C++ client library from
+# a larger CMake project.
 
 cmake_minimum_required(VERSION 3.5)
 project(google-cloud-cpp-resourcemanager-quickstart CXX)

--- a/google/cloud/resourcemanager/quickstart/README.md
+++ b/google/cloud/resourcemanager/quickstart/README.md
@@ -1,7 +1,7 @@
-# HOWTO: using the Cloud Resource Manager API C++ client in your project
+# HOWTO: using the Cloud Resource Manager C++ client in your project
 
 This directory contains small examples showing how to use the Cloud Resource
-Manager API C++ client library in your own project. These instructions assume
+Manager C++ client library in your own project. These instructions assume
 that you have some experience as a C++ developer and that you have a working C++
 toolchain (compiler, linker, etc.) installed on your platform.
 
@@ -28,7 +28,7 @@ steps in detail.
 
 ## Configuring authentication for the C++ Client Library
 
-Like most Google Cloud Platform (GCP) services, Cloud Resource Manager API requires that
+Like most Google Cloud Platform (GCP) services, Cloud Resource Manager requires that
 your application authenticates with the service before accessing any data. If
 you are not familiar with GCP authentication please take this opportunity to
 review the [Authentication Overview][authentication-quickstart]. This library

--- a/google/cloud/scheduler/CMakeLists.txt
+++ b/google/cloud/scheduler/CMakeLists.txt
@@ -15,8 +15,9 @@
 # ~~~
 
 include(GoogleapisConfig)
-set(DOXYGEN_PROJECT_NAME "Cloud Scheduler API C++ Client")
-set(DOXYGEN_PROJECT_BRIEF "A C++ Client Library for the Cloud Scheduler API")
+set(DOXYGEN_PROJECT_NAME "Cloud Scheduler C++ Client")
+set(DOXYGEN_PROJECT_BRIEF
+    "A C++ Client Library for the Cloud Scheduler service")
 set(DOXYGEN_PROJECT_NUMBER "${PROJECT_VERSION} (Experimental)")
 set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "scheduler_internal" "scheduler_testing"
                             "examples")
@@ -166,9 +167,9 @@ google_cloud_cpp_install_headers("google_cloud_cpp_scheduler_mocks"
 set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
 set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
 set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
-set(GOOGLE_CLOUD_PC_NAME "The Cloud Scheduler API C++ Client Library")
+set(GOOGLE_CLOUD_PC_NAME "The Cloud Scheduler C++ Client Library")
 set(GOOGLE_CLOUD_PC_DESCRIPTION
-    "Provides C++ APIs to access Cloud Scheduler API.")
+    "Provides C++ APIs to access the Cloud Scheduler service.")
 set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_scheduler")
 string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common" " google_cloud_cpp_scheduler_protos")

--- a/google/cloud/scheduler/README.md
+++ b/google/cloud/scheduler/README.md
@@ -1,9 +1,9 @@
-# Cloud Scheduler API C++ Client Library
+# Cloud Scheduler C++ Client Library
 
 :construction:
 
 This directory contains an idiomatic C++ client library for
-[Cloud Scheduler][cloud-service-docs], a service that creates and manages jobs
+[Cloud Scheduler][cloud-service], a service that creates and manages jobs
 run on a regular recurring schedule.
 
 This library is **experimental**. Its APIs are subject to change without notice.
@@ -21,12 +21,13 @@ Please note that the Google Cloud C++ client libraries do **not** follow
 
 ## Documentation
 
-* Official documentation about the [Cloud Scheduler API][cloud-service-docs] service
+* Official documentation about the [Cloud Scheduler][cloud-service-docs] service
 * [Reference doxygen documentation][doxygen-link] for each release of this
   client library
 * Detailed header comments in our [public `.h`][source-link] files
 
-[cloud-service-docs]: https://cloud.google.com/scheduler
+[cloud-service]: https://cloud.google.com/scheduler
+[cloud-service-docs]: https://cloud.google.com/scheduler/docs
 [doxygen-link]: https://googleapis.dev/cpp/google-cloud-scheduler/latest/
 [source-link]: https://github.com/googleapis/google-cloud-cpp/tree/main/google/cloud/scheduler
 

--- a/google/cloud/scheduler/doc/main.dox
+++ b/google/cloud/scheduler/doc/main.dox
@@ -1,6 +1,6 @@
 /*!
 
-@mainpage Cloud Scheduler API C++ Client Library
+@mainpage Cloud Scheduler C++ Client Library
 
 An idiomatic C++ client library for
 [Cloud Scheduler](https://cloud.google.com/scheduler/), a service that
@@ -16,7 +16,7 @@ the client library.
 
 ### Setting up your repo
 
-In order to use the Cloud Scheduler API C++ client library from your own code,
+In order to use the Cloud Scheduler C++ client library from your own code,
 you'll need to configure your build system to discover and compile the Cloud
 C++ client libraries. In some cases your build system or package manager may
 need to download the libraries too. The Cloud C++ client libraries natively
@@ -34,7 +34,7 @@ cd google-cloud-cpp/google/cloud/scheduler/quickstart
 
 The following shows the code that you'll run in the
 `google/cloud/scheduler/quickstart/` directory,
-which should give you a taste of the Cloud Scheduler API C++ client library API.
+which should give you a taste of the Cloud Scheduler C++ client library API.
 
 @include quickstart.cc
 

--- a/google/cloud/scheduler/quickstart/CMakeLists.txt
+++ b/google/cloud/scheduler/quickstart/CMakeLists.txt
@@ -12,7 +12,7 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-# This file shows how to use the Cloud Scheduler API C++ client library from a
+# This file shows how to use the Cloud Scheduler C++ client library from a
 # larger CMake project.
 
 cmake_minimum_required(VERSION 3.5)

--- a/google/cloud/scheduler/quickstart/README.md
+++ b/google/cloud/scheduler/quickstart/README.md
@@ -1,6 +1,6 @@
-# HOWTO: using the Cloud Scheduler API C++ client in your project
+# HOWTO: using the Cloud Scheduler C++ client in your project
 
-This directory contains small examples showing how to use the Cloud Scheduler API C++
+This directory contains small examples showing how to use the Cloud Scheduler C++
 client library in your own project. These instructions assume that you have
 some experience as a C++ developer and that you have a working C++ toolchain
 (compiler, linker, etc.) installed on your platform.

--- a/google/cloud/secretmanager/CMakeLists.txt
+++ b/google/cloud/secretmanager/CMakeLists.txt
@@ -15,8 +15,8 @@
 # ~~~
 
 include(GoogleapisConfig)
-set(DOXYGEN_PROJECT_NAME "Secret Manager API C++ Client")
-set(DOXYGEN_PROJECT_BRIEF "A C++ Client Library for the Secret Manager API")
+set(DOXYGEN_PROJECT_NAME "Secret Manager C++ Client")
+set(DOXYGEN_PROJECT_BRIEF "A C++ Client Library for the Secret Manager service")
 set(DOXYGEN_PROJECT_NUMBER "${PROJECT_VERSION}")
 set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "secretmanager_internal"
                             "secretmanager_testing" "examples")
@@ -169,9 +169,9 @@ google_cloud_cpp_install_headers("google_cloud_cpp_secretmanager_mocks"
 set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
 set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
 set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
-set(GOOGLE_CLOUD_PC_NAME "The Secret Manager API C++ Client Library")
+set(GOOGLE_CLOUD_PC_NAME "The Secret Manager C++ Client Library")
 set(GOOGLE_CLOUD_PC_DESCRIPTION
-    "Provides C++ APIs to access Secret Manager API.")
+    "Provides C++ APIs to access the Secret Manager service.")
 set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_secretmanager")
 string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common"

--- a/google/cloud/secretmanager/README.md
+++ b/google/cloud/secretmanager/README.md
@@ -1,7 +1,7 @@
-# Secret Manager API C++ Client Library
+# Secret Manager C++ Client Library
 
 This directory contains an idiomatic C++ client library for
-[Secret Manager API][cloud-service-root], a service that
+[Secret Manager][cloud-service], a service that
 stores sensitive data such as API keys, passwords, and certificates.
 Provides convenience while improving security.
 
@@ -18,12 +18,12 @@ client libraries do **not** follow [Semantic Versioning](https://semver.org/).
 
 ## Documentation
 
-* Official documentation about the [Secret Manager API][cloud-service-docs] service
+* Official documentation about the [Secret Manager][cloud-service-docs] service
 * [Reference doxygen documentation][doxygen-link] for each release of this
   client library
 * Detailed header comments in our [public `.h`][source-link] files
 
-[cloud-service-root]: https://cloud.google.com/secret-manager
+[cloud-service]: https://cloud.google.com/secret-manager
 [cloud-service-docs]: https://cloud.google.com/secret-manager/docs
 [doxygen-link]: https://googleapis.dev/cpp/google-cloud-secretmanager/latest/
 [source-link]: https://github.com/googleapis/google-cloud-cpp/tree/main/google/cloud/secretmanager

--- a/google/cloud/secretmanager/doc/main.dox
+++ b/google/cloud/secretmanager/doc/main.dox
@@ -1,9 +1,9 @@
 /*!
 
-@mainpage Secret Manager API C++ Client Library
+@mainpage Secret Manager C++ Client Library
 
 An idiomatic C++ client library for
-[Secret Manager API](https://cloud.google.com/secretmanager/), a service that
+[Secret Manager](https://cloud.google.com/secretmanager/), a service that
 stores sensitive data such as API keys, passwords, and certificates.
 
 While this library is **GA**, please note that the Google Cloud C++
@@ -17,7 +17,7 @@ the client library.
 
 ### Setting up your repo
 
-In order to use the Secret Manager API C++ client library from your own code,
+In order to use the Secret Manager C++ client library from your own code,
 you'll need to configure your build system to discover and compile the Cloud
 C++ client libraries. In some cases your build system or package manager may
 need to download the libraries too. The Cloud C++ client libraries natively
@@ -35,7 +35,7 @@ cd google-cloud-cpp/google/cloud/secretmanager/quickstart
 
 The following shows the code that you'll run in the
 `google/cloud/secretmanager/quickstart/` directory,
-which should give you a taste of the Secret Manager API C++ client library API.
+which should give you a taste of the Secret Manager C++ client library API.
 
 @include quickstart.cc
 

--- a/google/cloud/secretmanager/quickstart/CMakeLists.txt
+++ b/google/cloud/secretmanager/quickstart/CMakeLists.txt
@@ -12,8 +12,8 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-# This file shows how to use the Secret Manager API C++ client library from a
-# larger CMake project.
+# This file shows how to use the Secret Manager C++ client library from a larger
+# CMake project.
 
 cmake_minimum_required(VERSION 3.5)
 project(google-cloud-cpp-secretmanager-quickstart CXX)

--- a/google/cloud/secretmanager/quickstart/README.md
+++ b/google/cloud/secretmanager/quickstart/README.md
@@ -1,6 +1,6 @@
-# HOWTO: using the Secret Manager API C++ client in your project
+# HOWTO: using the Secret Manager C++ client in your project
 
-This directory contains small examples showing how to use the Secret Manager API C++
+This directory contains small examples showing how to use the Secret Manager C++
 client library in your own project. These instructions assume that you have
 some experience as a C++ developer and that you have a working C++ toolchain
 (compiler, linker, etc.) installed on your platform.

--- a/google/cloud/shell/CMakeLists.txt
+++ b/google/cloud/shell/CMakeLists.txt
@@ -15,8 +15,8 @@
 # ~~~
 
 include(GoogleapisConfig)
-set(DOXYGEN_PROJECT_NAME "Cloud Shell API C++ Client")
-set(DOXYGEN_PROJECT_BRIEF "A C++ Client Library for the Cloud Shell API")
+set(DOXYGEN_PROJECT_NAME "Cloud Shell C++ Client")
+set(DOXYGEN_PROJECT_BRIEF "A C++ Client Library for the Cloud Shell service")
 set(DOXYGEN_PROJECT_NUMBER "${PROJECT_VERSION} (Experimental)")
 set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "shell_internal" "shell_testing"
                             "examples")
@@ -157,8 +157,9 @@ google_cloud_cpp_install_headers("google_cloud_cpp_shell_mocks"
 set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
 set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
 set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
-set(GOOGLE_CLOUD_PC_NAME "The Cloud Shell API C++ Client Library")
-set(GOOGLE_CLOUD_PC_DESCRIPTION "Provides C++ APIs to use the Cloud Shell API.")
+set(GOOGLE_CLOUD_PC_NAME "The Cloud Shell C++ Client Library")
+set(GOOGLE_CLOUD_PC_DESCRIPTION
+    "Provides C++ APIs to use the Cloud Shell service.")
 set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_shell")
 string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common" " google_cloud_cpp_shell_protos")

--- a/google/cloud/shell/README.md
+++ b/google/cloud/shell/README.md
@@ -1,9 +1,9 @@
-# Cloud Shell API C++ Client Library
+# Cloud Shell C++ Client Library
 
 :construction:
 
 This directory contains an idiomatic C++ client library for the
-[Cloud Shell API][cloud-service-docs], a service to allow users to start,
+[Cloud Shell][cloud-service], a service to allow users to start,
 configure, and connect to interactive shell sessions running in the cloud.
 
 This library is **experimental**. Its APIs are subject to change without notice.
@@ -21,12 +21,13 @@ Please note that the Google Cloud C++ client libraries do **not** follow
 
 ## Documentation
 
-* Official documentation about the [Cloud Shell API][cloud-service-docs] service
+* Official documentation about the [Cloud Shell][cloud-service-docs] service
 * [Reference doxygen documentation][doxygen-link] for each release of this
   client library
 * Detailed header comments in our [public `.h`][source-link] files
 
-[cloud-service-docs]: https://cloud.google.com/shell
+[cloud-service]: https://cloud.google.com/shell
+[cloud-service-docs]: https://cloud.google.com/shell/docs
 [doxygen-link]: https://googleapis.dev/cpp/google-cloud-shell/latest/
 [source-link]: https://github.com/googleapis/google-cloud-cpp/tree/main/google/cloud/shell
 

--- a/google/cloud/shell/doc/main.dox
+++ b/google/cloud/shell/doc/main.dox
@@ -1,8 +1,8 @@
 /*!
 
-@mainpage Cloud Shell API C++ Client Library
+@mainpage Cloud Shell C++ Client Library
 
-An idiomatic C++ client library for the [Cloud Shell API][cloud-service-docs],
+An idiomatic C++ client library for [Cloud Shell][cloud-service-docs],
 a service to allow users to start, configure, and connect to interactive shell
 sessions running in the cloud.
 
@@ -15,7 +15,7 @@ dependencies, as well as how to compile the client library.
 
 ### Setting up your repo
 
-In order to use the Cloud Shell API C++ client library from your own code,
+In order to use the Cloud Shell C++ client library from your own code,
 you'll need to configure your build system to discover and compile the Cloud
 C++ client libraries. In some cases your build system or package manager may
 need to download the libraries too. The Cloud C++ client libraries natively
@@ -33,7 +33,7 @@ cd google-cloud-cpp/google/cloud/shell/quickstart
 
 The following shows the code that you'll run in the
 `google/cloud/shell/quickstart/` directory,
-which should give you a taste of the Cloud Shell API C++ client library API.
+which should give you a taste of the Cloud Shell C++ client library API.
 
 @include quickstart.cc
 

--- a/google/cloud/shell/quickstart/CMakeLists.txt
+++ b/google/cloud/shell/quickstart/CMakeLists.txt
@@ -12,8 +12,8 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-# This file shows how to use the Cloud Shell API C++ client library from a
-# larger CMake project.
+# This file shows how to use the Cloud Shell C++ client library from a larger
+# CMake project.
 
 cmake_minimum_required(VERSION 3.5)
 project(google-cloud-cpp-shell-quickstart CXX)

--- a/google/cloud/shell/quickstart/README.md
+++ b/google/cloud/shell/quickstart/README.md
@@ -1,6 +1,6 @@
-# HOWTO: using the Cloud Shell API C++ client in your project
+# HOWTO: using the Cloud Shell C++ client in your project
 
-This directory contains small examples showing how to use the Cloud Shell API C++
+This directory contains small examples showing how to use the Cloud Shell C++
 client library in your own project. These instructions assume that you have
 some experience as a C++ developer and that you have a working C++ toolchain
 (compiler, linker, etc.) installed on your platform.
@@ -28,7 +28,7 @@ steps in detail.
 
 ## Configuring authentication for the C++ Client Library
 
-Like most Google Cloud Platform (GCP) services, Cloud Shell API requires that
+Like most Google Cloud Platform (GCP) services, Cloud Shell requires that
 your application authenticates with the service before accessing any data. If
 you are not familiar with GCP authentication please take this opportunity to
 review the [Authentication Overview][authentication-quickstart]. This library

--- a/google/cloud/storagetransfer/CMakeLists.txt
+++ b/google/cloud/storagetransfer/CMakeLists.txt
@@ -15,8 +15,9 @@
 # ~~~
 
 include(GoogleapisConfig)
-set(DOXYGEN_PROJECT_NAME "Storage Transfer API C++ Client")
-set(DOXYGEN_PROJECT_BRIEF "A C++ Client Library for the Storage Transfer API")
+set(DOXYGEN_PROJECT_NAME "Storage Transfer C++ Client")
+set(DOXYGEN_PROJECT_BRIEF
+    "A C++ Client Library for the Storage Transfer service")
 set(DOXYGEN_PROJECT_NUMBER "${PROJECT_VERSION} (Experimental)")
 set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "storagetransfer_internal"
                             "storagetransfer_testing" "examples")
@@ -164,9 +165,9 @@ google_cloud_cpp_install_headers("google_cloud_cpp_storagetransfer_mocks"
 set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
 set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
 set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
-set(GOOGLE_CLOUD_PC_NAME "The Storage Transfer API C++ Client Library")
+set(GOOGLE_CLOUD_PC_NAME "The Storage Transfer C++ Client Library")
 set(GOOGLE_CLOUD_PC_DESCRIPTION
-    "Provides C++ APIs to use the Storage Transfer API.")
+    "Provides C++ APIs to use the Storage Transfer service.")
 set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_storagetransfer")
 string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common"

--- a/google/cloud/storagetransfer/README.md
+++ b/google/cloud/storagetransfer/README.md
@@ -1,9 +1,9 @@
-# Storage Transfer API C++ Client Library
+# Storage Transfer C++ Client Library
 
 :construction:
 
 This directory contains an idiomatic C++ client library for the
-[Storage Transfer API][cloud-service-docs], a service to transfer data from
+[Storage Transfer Service][cloud-service], a service to transfer data from
 external data sources to a Google Cloud Storage bucket or between Google Cloud
 Storage buckets.
 
@@ -22,12 +22,13 @@ Please note that the Google Cloud C++ client libraries do **not** follow
 
 ## Documentation
 
-* Official documentation about the [Storage Transfer API][cloud-service-docs] service
+* Official documentation about the [Storage Transfer Service][cloud-service-docs]
 * [Reference doxygen documentation][doxygen-link] for each release of this
   client library
 * Detailed header comments in our [public `.h`][source-link] files
 
-[cloud-service-docs]: https://cloud.google.com/storage-transfer
+[cloud-service]: https://cloud.google.com/storage-transfer
+[cloud-service-docs]: https://cloud.google.com/storage-transfer/docs
 [doxygen-link]: https://googleapis.dev/cpp/google-cloud-storagetransfer/latest/
 [source-link]: https://github.com/googleapis/google-cloud-cpp/tree/main/google/cloud/storagetransfer
 

--- a/google/cloud/storagetransfer/doc/main.dox
+++ b/google/cloud/storagetransfer/doc/main.dox
@@ -1,8 +1,8 @@
 /*!
 
-@mainpage Storage Transfer API C++ Client Library
+@mainpage Storage Transfer C++ Client Library
 
-An idiomatic C++ client library for the [Storage Transfer API][cloud-service-docs],
+An idiomatic C++ client library for [Storage Transfer][cloud-service-docs],
 a service to transfers data from external data sources to a Google Cloud Storage
 bucket or between Google Cloud Storage buckets.
 
@@ -15,7 +15,7 @@ dependencies, as well as how to compile the client library.
 
 ### Setting up your repo
 
-In order to use the Storage Transfer API C++ client library from your own code,
+In order to use the Storage Transfer C++ client library from your own code,
 you'll need to configure your build system to discover and compile the Cloud
 C++ client libraries. In some cases your build system or package manager may
 need to download the libraries too. The Cloud C++ client libraries natively
@@ -33,7 +33,7 @@ cd google-cloud-cpp/google/cloud/storagetransfer/quickstart
 
 The following shows the code that you'll run in the
 `google/cloud/storagetransfer/quickstart/` directory,
-which should give you a taste of the Storage Transfer API C++ client library API.
+which should give you a taste of the Storage Transfer C++ client library API.
 
 @include quickstart.cc
 

--- a/google/cloud/storagetransfer/quickstart/CMakeLists.txt
+++ b/google/cloud/storagetransfer/quickstart/CMakeLists.txt
@@ -12,7 +12,7 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-# This file shows how to use the Storage Transfer API C++ client library from a
+# This file shows how to use the Storage Transfer C++ client library from a
 # larger CMake project.
 
 cmake_minimum_required(VERSION 3.5)

--- a/google/cloud/storagetransfer/quickstart/README.md
+++ b/google/cloud/storagetransfer/quickstart/README.md
@@ -1,6 +1,6 @@
-# HOWTO: using the Storage Transfer API C++ client in your project
+# HOWTO: using the Storage Transfer C++ client in your project
 
-This directory contains small examples showing how to use the Storage Transfer API C++
+This directory contains small examples showing how to use the Storage Transfer C++
 client library in your own project. These instructions assume that you have
 some experience as a C++ developer and that you have a working C++ toolchain
 (compiler, linker, etc.) installed on your platform.
@@ -28,7 +28,7 @@ steps in detail.
 
 ## Configuring authentication for the C++ Client Library
 
-Like most Google Cloud Platform (GCP) services, Storage Transfer API requires that
+Like most Google Cloud Platform (GCP) services, Storage Transfer requires that
 your application authenticates with the service before accessing any data. If
 you are not familiar with GCP authentication please take this opportunity to
 review the [Authentication Overview][authentication-quickstart]. This library

--- a/google/cloud/talent/CMakeLists.txt
+++ b/google/cloud/talent/CMakeLists.txt
@@ -15,9 +15,9 @@
 # ~~~
 
 include(GoogleapisConfig)
-set(DOXYGEN_PROJECT_NAME "Cloud Talent Solution API C++ Client")
+set(DOXYGEN_PROJECT_NAME "Cloud Talent Solution C++ Client")
 set(DOXYGEN_PROJECT_BRIEF
-    "A C++ Client Library for the Cloud Talent Solution API")
+    "A C++ Client Library for the Cloud Talent Solution service")
 set(DOXYGEN_PROJECT_NUMBER "${PROJECT_VERSION} (Experimental)")
 set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "talent_internal" "talent_testing"
                             "examples")
@@ -173,9 +173,9 @@ google_cloud_cpp_install_headers("google_cloud_cpp_talent_mocks"
 set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
 set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
 set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
-set(GOOGLE_CLOUD_PC_NAME "The Cloud Talent Solution API C++ Client Library")
+set(GOOGLE_CLOUD_PC_NAME "The Cloud Talent Solution C++ Client Library")
 set(GOOGLE_CLOUD_PC_DESCRIPTION
-    "Provides C++ APIs to use the Cloud Talent Solution API.")
+    "Provides C++ APIs to use the Cloud Talent Solution service.")
 set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_talent")
 string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common" " google_cloud_cpp_talent_protos")

--- a/google/cloud/talent/README.md
+++ b/google/cloud/talent/README.md
@@ -1,9 +1,9 @@
-# Cloud Talent Solution API C++ Client Library
+# Cloud Talent Solution C++ Client Library
 
 :construction:
 
 This directory contains an idiomatic C++ client library for
-[Cloud Talent Solution][cloud-service-docs], a suite of APIs that allow you to
+[Cloud Talent Solution][cloud-service], a suite of APIs that allow you to
 create and manage jobs and profiles in the talent industry.
 
 This library is **experimental**. Its APIs are subject to change without notice.
@@ -21,12 +21,13 @@ Please note that the Google Cloud C++ client libraries do **not** follow
 
 ## Documentation
 
-* Official documentation about the [Cloud Talent Solution API][cloud-service-docs] service
+* Official documentation about the [Cloud Talent Solution][cloud-service-docs] service
 * [Reference doxygen documentation][doxygen-link] for each release of this
   client library
 * Detailed header comments in our [public `.h`][source-link] files
 
-[cloud-service-docs]: https://cloud.google.com/solutions/talent-solution
+[cloud-service]: https://cloud.google.com/solutions/talent-solution
+[cloud-service-docs]: https://cloud.google.com/solutions/talent-solution/docs
 [doxygen-link]: https://googleapis.dev/cpp/google-cloud-talent/latest/
 [source-link]: https://github.com/googleapis/google-cloud-cpp/tree/main/google/cloud/talent
 

--- a/google/cloud/talent/quickstart/CMakeLists.txt
+++ b/google/cloud/talent/quickstart/CMakeLists.txt
@@ -12,8 +12,8 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-# This file shows how to use the Cloud Talent Solution API C++ client library
-# from a larger CMake project.
+# This file shows how to use the Cloud Talent Solution C++ client library from a
+# larger CMake project.
 
 cmake_minimum_required(VERSION 3.5)
 project(google-cloud-cpp-talent-quickstart CXX)

--- a/google/cloud/tasks/CMakeLists.txt
+++ b/google/cloud/tasks/CMakeLists.txt
@@ -15,8 +15,8 @@
 # ~~~
 
 include(GoogleapisConfig)
-set(DOXYGEN_PROJECT_NAME "Cloud Tasks API C++ Client")
-set(DOXYGEN_PROJECT_BRIEF "A C++ Client Library for the Cloud Tasks API")
+set(DOXYGEN_PROJECT_NAME "Cloud Tasks C++ Client")
+set(DOXYGEN_PROJECT_BRIEF "A C++ Client Library for the Cloud Tasks service")
 set(DOXYGEN_PROJECT_NUMBER "${PROJECT_VERSION}")
 set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "tasks_internal" "tasks_testing"
                             "examples")
@@ -167,8 +167,9 @@ google_cloud_cpp_install_headers("google_cloud_cpp_tasks_mocks"
 set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
 set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
 set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
-set(GOOGLE_CLOUD_PC_NAME "The Cloud Tasks API C++ Client Library")
-set(GOOGLE_CLOUD_PC_DESCRIPTION "Provides C++ APIs to access Cloud Tasks API.")
+set(GOOGLE_CLOUD_PC_NAME "The Cloud Tasks C++ Client Library")
+set(GOOGLE_CLOUD_PC_DESCRIPTION
+    "Provides C++ APIs to access the Cloud Tasks service.")
 set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_tasks")
 string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common" " google_cloud_cpp_tasks_protos")

--- a/google/cloud/tasks/README.md
+++ b/google/cloud/tasks/README.md
@@ -1,7 +1,7 @@
-# Cloud Tasks API C++ Client Library
+# Cloud Tasks C++ Client Library
 
 This directory contains an idiomatic C++ client library for
-[Cloud Tasks API][cloud-service-root], a service that manages the
+[Cloud Tasks][cloud-service], a service that manages the
 execution of large numbers of distributed requests.
 
 While this library is **GA**, please note that the Google Cloud C++
@@ -17,12 +17,12 @@ client libraries do **not** follow [Semantic Versioning](https://semver.org/).
 
 ## Documentation
 
-* Official documentation about the [Cloud Tasks API][cloud-service-docs] service
+* Official documentation about the [Cloud Tasks][cloud-service-docs] service
 * [Reference doxygen documentation][doxygen-link] for each release of this
   client library
 * Detailed header comments in our [public `.h`][source-link] files
 
-[cloud-service-root]: https://cloud.google.com/tasks
+[cloud-service]: https://cloud.google.com/tasks
 [cloud-service-docs]: https://cloud.google.com/tasks/docs
 [doxygen-link]: https://googleapis.dev/cpp/google-cloud-tasks/latest/
 [source-link]: https://github.com/googleapis/google-cloud-cpp/tree/main/google/cloud/tasks

--- a/google/cloud/tasks/doc/main.dox
+++ b/google/cloud/tasks/doc/main.dox
@@ -1,9 +1,9 @@
 /*!
 
-@mainpage Cloud Tasks API C++ Client Library
+@mainpage Cloud Tasks C++ Client Library
 
 An idiomatic C++ client library for
-[Cloud Tasks API](https://cloud.google.com/tasks/), a service that
+[Cloud Tasks](https://cloud.google.com/tasks/), a service that
 manages the execution of large numbers of distributed requests.
 
 While this library is **GA**, please note that the Google Cloud C++
@@ -17,7 +17,7 @@ the client library.
 
 ### Setting up your repo
 
-In order to use the Cloud Tasks API C++ client library from your own code,
+In order to use the Cloud Tasks C++ client library from your own code,
 you'll need to configure your build system to discover and compile the Cloud
 C++ client libraries. In some cases your build system or package manager may
 need to download the libraries too. The Cloud C++ client libraries natively
@@ -35,7 +35,7 @@ cd google-cloud-cpp/google/cloud/tasks/quickstart
 
 The following shows the code that you'll run in the
 `google/cloud/tasks/quickstart/` directory,
-which should give you a taste of the Cloud Tasks API C++ client library API.
+which should give you a taste of the Cloud Tasks C++ client library API.
 
 @include quickstart.cc
 

--- a/google/cloud/tasks/quickstart/CMakeLists.txt
+++ b/google/cloud/tasks/quickstart/CMakeLists.txt
@@ -12,8 +12,8 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-# This file shows how to use the Cloud Tasks API C++ client library from a
-# larger CMake project.
+# This file shows how to use the Cloud Tasks C++ client library from a larger
+# CMake project.
 
 cmake_minimum_required(VERSION 3.5)
 project(google-cloud-cpp-tasks-quickstart CXX)

--- a/google/cloud/tasks/quickstart/README.md
+++ b/google/cloud/tasks/quickstart/README.md
@@ -1,6 +1,6 @@
-# HOWTO: using the Cloud Tasks API C++ client in your project
+# HOWTO: using the Cloud Tasks C++ client in your project
 
-This directory contains small examples showing how to use the Cloud Tasks API C++
+This directory contains small examples showing how to use the Cloud Tasks C++
 client library in your own project. These instructions assume that you have
 some experience as a C++ developer and that you have a working C++ toolchain
 (compiler, linker, etc.) installed on your platform.

--- a/google/cloud/vision/CMakeLists.txt
+++ b/google/cloud/vision/CMakeLists.txt
@@ -15,8 +15,8 @@
 # ~~~
 
 include(GoogleapisConfig)
-set(DOXYGEN_PROJECT_NAME "Cloud Vision API C++ Client")
-set(DOXYGEN_PROJECT_BRIEF "A C++ Client Library for the Cloud Vision API")
+set(DOXYGEN_PROJECT_NAME "Cloud Vision C++ Client")
+set(DOXYGEN_PROJECT_BRIEF "A C++ Client Library for the Cloud Vision service")
 set(DOXYGEN_PROJECT_NUMBER "${PROJECT_VERSION} (Experimental)")
 set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "vision_internal" "vision_testing"
                             "examples")
@@ -164,9 +164,9 @@ google_cloud_cpp_install_headers("google_cloud_cpp_vision_mocks"
 set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
 set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
 set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
-set(GOOGLE_CLOUD_PC_NAME "The Cloud Vision API C++ Client Library")
+set(GOOGLE_CLOUD_PC_NAME "The Cloud Vision C++ Client Library")
 set(GOOGLE_CLOUD_PC_DESCRIPTION
-    "Provides C++ APIs to use the Cloud Vision API.")
+    "Provides C++ APIs to use the Cloud Vision service.")
 set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_vision")
 string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common" " google_cloud_cpp_vision_protos")

--- a/google/cloud/vision/README.md
+++ b/google/cloud/vision/README.md
@@ -1,9 +1,9 @@
-# Cloud Vision API C++ Client Library
+# Cloud Vision C++ Client Library
 
 :construction:
 
 This directory contains an idiomatic C++ client library for the
-[Cloud Vision API][cloud-service-docs]. Integrate Google Vision
+[Cloud Vision][cloud-service]. Integrate Google Vision
 features, including image labeling, face, logo, and landmark detection, optical
 character recognition (OCR), and detection of explicit content, into
 applications.
@@ -23,12 +23,13 @@ Please note that the Google Cloud C++ client libraries do **not** follow
 
 ## Documentation
 
-* Official documentation about the [Cloud Vision API][cloud-service-docs] service
+* Official documentation about the [Cloud Vision][cloud-service-docs] service
 * [Reference doxygen documentation][doxygen-link] for each release of this
   client library
 * Detailed header comments in our [public `.h`][source-link] files
 
-[cloud-service-docs]: https://cloud.google.com/vision
+[cloud-service]: https://cloud.google.com/vision
+[cloud-service-docs]: https://cloud.google.com/vision/docs
 [doxygen-link]: https://googleapis.dev/cpp/google-cloud-vision/latest/
 [source-link]: https://github.com/googleapis/google-cloud-cpp/tree/main/google/cloud/vision
 

--- a/google/cloud/vision/doc/main.dox
+++ b/google/cloud/vision/doc/main.dox
@@ -1,8 +1,8 @@
 /*!
 
-@mainpage Cloud Vision API C++ Client Library
+@mainpage Cloud Vision C++ Client Library
 
-An idiomatic C++ client library for the [Cloud Vision API][cloud-service-docs].
+An idiomatic C++ client library for [Cloud Vision][cloud-service-docs].
 Integrate Google Vision features, including image labeling, face, logo, and
 landmark detection, optical character recognition (OCR), and detection of
 explicit content, into applications.
@@ -16,7 +16,7 @@ dependencies, as well as how to compile the client library.
 
 ### Setting up your repo
 
-In order to use the Cloud Vision API C++ client library from your own code,
+In order to use the Cloud Vision C++ client library from your own code,
 you'll need to configure your build system to discover and compile the Cloud
 C++ client libraries. In some cases your build system or package manager may
 need to download the libraries too. The Cloud C++ client libraries natively
@@ -34,7 +34,7 @@ cd google-cloud-cpp/google/cloud/vision/quickstart
 
 The following shows the code that you'll run in the
 `google/cloud/vision/quickstart/` directory,
-which should give you a taste of the Cloud Vision API C++ client library API.
+which should give you a taste of the Cloud Vision C++ client library API.
 
 @include quickstart.cc
 

--- a/google/cloud/vision/quickstart/CMakeLists.txt
+++ b/google/cloud/vision/quickstart/CMakeLists.txt
@@ -12,8 +12,8 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-# This file shows how to use the Cloud Vision API C++ client library from a
-# larger CMake project.
+# This file shows how to use the Cloud Vision C++ client library from a larger
+# CMake project.
 
 cmake_minimum_required(VERSION 3.5)
 project(google-cloud-cpp-vision-quickstart CXX)

--- a/google/cloud/vision/quickstart/README.md
+++ b/google/cloud/vision/quickstart/README.md
@@ -1,6 +1,6 @@
-# HOWTO: using the Cloud Vision API C++ client in your project
+# HOWTO: using the Cloud Vision C++ client in your project
 
-This directory contains small examples showing how to use the Cloud Vision API C++
+This directory contains small examples showing how to use the Cloud Vision C++
 client library in your own project. These instructions assume that you have
 some experience as a C++ developer and that you have a working C++ toolchain
 (compiler, linker, etc.) installed on your platform.
@@ -28,7 +28,7 @@ steps in detail.
 
 ## Configuring authentication for the C++ Client Library
 
-Like most Google Cloud Platform (GCP) services, Cloud Vision API requires that
+Like most Google Cloud Platform (GCP) services, Cloud Vision requires that
 your application authenticates with the service before accessing any data. If
 you are not familiar with GCP authentication please take this opportunity to
 review the [Authentication Overview][authentication-quickstart]. This library

--- a/google/cloud/vmmigration/CMakeLists.txt
+++ b/google/cloud/vmmigration/CMakeLists.txt
@@ -15,8 +15,8 @@
 # ~~~
 
 include(GoogleapisConfig)
-set(DOXYGEN_PROJECT_NAME "VM Migration API C++ Client")
-set(DOXYGEN_PROJECT_BRIEF "A C++ Client Library for the VM Migration API")
+set(DOXYGEN_PROJECT_NAME "VM Migration C++ Client")
+set(DOXYGEN_PROJECT_BRIEF "A C++ Client Library for the VM Migration service")
 set(DOXYGEN_PROJECT_NUMBER "${PROJECT_VERSION} (Experimental)")
 set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "vmmigration_internal"
                             "vmmigration_testing" "examples")
@@ -160,9 +160,9 @@ google_cloud_cpp_install_headers("google_cloud_cpp_vmmigration_mocks"
 set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
 set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
 set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
-set(GOOGLE_CLOUD_PC_NAME "The VM Migration API C++ Client Library")
+set(GOOGLE_CLOUD_PC_NAME "The VM Migration C++ Client Library")
 set(GOOGLE_CLOUD_PC_DESCRIPTION
-    "Provides C++ APIs to use the VM Migration API.")
+    "Provides C++ APIs to use the VM Migration service.")
 set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_vmmigration")
 string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common" " google_cloud_cpp_vmmigration_protos")

--- a/google/cloud/vmmigration/README.md
+++ b/google/cloud/vmmigration/README.md
@@ -1,9 +1,9 @@
-# VM Migration API C++ Client Library
+# VM Migration C++ Client Library
 
 :construction:
 
-This directory contains an idiomatic C++ client library for the
-[VM Migration API][cloud-service-docs], a service to programmatically migrate
+This directory contains an idiomatic C++ client library for
+[VM Migration][cloud-service], a service to programmatically migrate
 workloads to Google Compute Engine.
 
 This library is **experimental**. Its APIs are subject to change without notice.
@@ -21,12 +21,13 @@ Please note that the Google Cloud C++ client libraries do **not** follow
 
 ## Documentation
 
-* Official documentation about the [VM Migration API][cloud-service-docs] service
+* Official documentation about the [VM Migration][cloud-service-docs] service
 * [Reference doxygen documentation][doxygen-link] for each release of this
   client library
 * Detailed header comments in our [public `.h`][source-link] files
 
-[cloud-service-docs]: https://cloud.google.com/migrate/compute-engine
+[cloud-service]: https://cloud.google.com/migrate/compute-engine
+[cloud-service-docs]: https://cloud.google.com/migrate/compute-engine/docs
 [doxygen-link]: https://googleapis.dev/cpp/google-cloud-vmmigration/latest/
 [source-link]: https://github.com/googleapis/google-cloud-cpp/tree/main/google/cloud/vmmigration
 

--- a/google/cloud/vmmigration/doc/main.dox
+++ b/google/cloud/vmmigration/doc/main.dox
@@ -1,8 +1,8 @@
 /*!
 
-@mainpage VM Migration API C++ Client Library
+@mainpage VM Migration C++ Client Library
 
-An idiomatic C++ client library for the [VM Migration API][cloud-service-docs], a service
+An idiomatic C++ client library for [VM Migration][cloud-service-docs], a service
 to programmatically migrate workloads to Google Compute Engine.
 
 This library is **experimental**. Its APIs are subject to change without notice.
@@ -14,7 +14,7 @@ dependencies, as well as how to compile the client library.
 
 ### Setting up your repo
 
-In order to use the VM Migration API C++ client library from your own code,
+In order to use the VM Migration C++ client library from your own code,
 you'll need to configure your build system to discover and compile the Cloud
 C++ client libraries. In some cases your build system or package manager may
 need to download the libraries too. The Cloud C++ client libraries natively
@@ -32,7 +32,7 @@ cd google-cloud-cpp/google/cloud/vmmigration/quickstart
 
 The following shows the code that you'll run in the
 `google/cloud/vmmigration/quickstart/` directory,
-which should give you a taste of the VM Migration API C++ client library API.
+which should give you a taste of the VM Migration C++ client library API.
 
 @include quickstart.cc
 

--- a/google/cloud/vmmigration/quickstart/CMakeLists.txt
+++ b/google/cloud/vmmigration/quickstart/CMakeLists.txt
@@ -12,8 +12,8 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-# This file shows how to use the VM Migration API C++ client library from a
-# larger CMake project.
+# This file shows how to use the VM Migration C++ client library from a larger
+# CMake project.
 
 cmake_minimum_required(VERSION 3.5)
 project(google-cloud-cpp-vmmigration-quickstart CXX)

--- a/google/cloud/vmmigration/quickstart/README.md
+++ b/google/cloud/vmmigration/quickstart/README.md
@@ -1,6 +1,6 @@
-# HOWTO: using the VM Migration API C++ client in your project
+# HOWTO: using the VM Migration C++ client in your project
 
-This directory contains small examples showing how to use the VM Migration API C++
+This directory contains small examples showing how to use the VM Migration C++
 client library in your own project. These instructions assume that you have
 some experience as a C++ developer and that you have a working C++ toolchain
 (compiler, linker, etc.) installed on your platform.
@@ -28,7 +28,7 @@ steps in detail.
 
 ## Configuring authentication for the C++ Client Library
 
-Like most Google Cloud Platform (GCP) services, VM Migration API requires that
+Like most Google Cloud Platform (GCP) services, VM Migration requires that
 your application authenticates with the service before accessing any data. If
 you are not familiar with GCP authentication please take this opportunity to
 review the [Authentication Overview][authentication-quickstart]. This library

--- a/google/cloud/vpcaccess/CMakeLists.txt
+++ b/google/cloud/vpcaccess/CMakeLists.txt
@@ -15,9 +15,9 @@
 # ~~~
 
 include(GoogleapisConfig)
-set(DOXYGEN_PROJECT_NAME "Serverless VPC Access API C++ Client")
+set(DOXYGEN_PROJECT_NAME "Serverless VPC Access C++ Client")
 set(DOXYGEN_PROJECT_BRIEF
-    "A C++ Client Library for the Serverless VPC Access API")
+    "A C++ Client Library for the Serverless VPC Access service")
 set(DOXYGEN_PROJECT_NUMBER "${PROJECT_VERSION} (Experimental)")
 set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "vpcaccess_internal" "vpcaccess_testing"
                             "examples")
@@ -160,9 +160,9 @@ google_cloud_cpp_install_headers("google_cloud_cpp_vpcaccess_mocks"
 set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
 set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
 set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
-set(GOOGLE_CLOUD_PC_NAME "The Serverless VPC Access API C++ Client Library")
+set(GOOGLE_CLOUD_PC_NAME "The Serverless VPC Access C++ Client Library")
 set(GOOGLE_CLOUD_PC_DESCRIPTION
-    "Provides C++ APIs to use the Serverless VPC Access API.")
+    "Provides C++ APIs to use the Serverless VPC Access service.")
 set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_vpcaccess")
 string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common" " google_cloud_cpp_vpcaccess_protos")

--- a/google/cloud/vpcaccess/README.md
+++ b/google/cloud/vpcaccess/README.md
@@ -1,9 +1,9 @@
-# Serverless VPC Access API C++ Client Library
+# Serverless VPC Access C++ Client Library
 
 :construction:
 
-This directory contains an idiomatic C++ client library for the
-[Serverless VPC Access API][cloud-service-docs], a service to manage VPC access
+This directory contains an idiomatic C++ client library for
+[Serverless VPC Access][cloud-service-docs], a service to manage VPC access
 connectors.
 
 This library is **experimental**. Its APIS are subject to change without notice.
@@ -21,12 +21,12 @@ Please note that the Google Cloud C++ client libraries do **not** follow
 
 ## Documentation
 
-* Official documentation about the [Serverless VPC Access API][cloud-service-docs] service
+* Official documentation about the [Serverless VPC Access][cloud-service-docs] service
 * [Reference doxygen documentation][doxygen-link] for each release of this
   client library
 * Detailed header comments in our [public `.h`][source-link] files
 
-[cloud-service-docs]: https://cloud.google.com/vpc/docs/serverless-vpc-access
+[cloud-service-docs]: https://cloud.google.com/vpc/docs/serverless-vpc-access/docs
 [doxygen-link]: https://googleapis.dev/cpp/google-cloud-vpcaccess/latest/
 [source-link]: https://github.com/googleapis/google-cloud-cpp/tree/main/google/cloud/vpcaccess
 

--- a/google/cloud/vpcaccess/doc/main.dox
+++ b/google/cloud/vpcaccess/doc/main.dox
@@ -1,9 +1,9 @@
 /*!
 
-@mainpage Serverless VPC Access API C++ Client Library
+@mainpage Serverless VPC Access C++ Client Library
 
-An idiomatic C++ client library for the [Serverless VPC Access API][cloud-service-docs], a service
-to API for managing VPC access connectors.
+An idiomatic C++ client library for the [Serverless VPC Access][cloud-service-docs], a service
+for managing VPC access connectors.
 
 This library is **experimental**. Its APIs are subject to change without notice.
 
@@ -14,7 +14,7 @@ dependencies, as well as how to compile the client library.
 
 ### Setting up your repo
 
-In order to use the Serverless VPC Access API C++ client library from your own code,
+In order to use the Serverless VPC Access C++ client library from your own code,
 you'll need to configure your build system to discover and compile the Cloud
 C++ client libraries. In some cases your build system or package manager may
 need to download the libraries too. The Cloud C++ client libraries natively
@@ -32,7 +32,7 @@ cd google-cloud-cpp/google/cloud/vpcaccess/quickstart
 
 The following shows the code that you'll run in the
 `google/cloud/vpcaccess/quickstart/` directory,
-which should give you a taste of the Serverless VPC Access API C++ client library API.
+which should give you a taste of the Serverless VPC Access C++ client library API.
 
 @include quickstart.cc
 

--- a/google/cloud/vpcaccess/quickstart/CMakeLists.txt
+++ b/google/cloud/vpcaccess/quickstart/CMakeLists.txt
@@ -12,8 +12,8 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-# This file shows how to use the Serverless VPC Access API C++ client library
-# from a larger CMake project.
+# This file shows how to use the Serverless VPC Access C++ client library from a
+# larger CMake project.
 
 cmake_minimum_required(VERSION 3.5)
 project(google-cloud-cpp-vpcaccess-quickstart CXX)

--- a/google/cloud/vpcaccess/quickstart/README.md
+++ b/google/cloud/vpcaccess/quickstart/README.md
@@ -1,6 +1,6 @@
-# HOWTO: using the Serverless VPC Access API C++ client in your project
+# HOWTO: using the Serverless VPC Access C++ client in your project
 
-This directory contains small examples showing how to use the Serverless VPC Access API C++
+This directory contains small examples showing how to use the Serverless VPC Access C++
 client library in your own project. These instructions assume that you have
 some experience as a C++ developer and that you have a working C++ toolchain
 (compiler, linker, etc.) installed on your platform.
@@ -28,7 +28,7 @@ steps in detail.
 
 ## Configuring authentication for the C++ Client Library
 
-Like most Google Cloud Platform (GCP) services, Serverless VPC Access API requires that
+Like most Google Cloud Platform (GCP) services, Serverless VPC Access requires that
 your application authenticates with the service before accessing any data. If
 you are not familiar with GCP authentication please take this opportunity to
 review the [Authentication Overview][authentication-quickstart]. This library

--- a/google/cloud/webrisk/CMakeLists.txt
+++ b/google/cloud/webrisk/CMakeLists.txt
@@ -15,8 +15,8 @@
 # ~~~
 
 include(GoogleapisConfig)
-set(DOXYGEN_PROJECT_NAME "Web Risk API C++ Client")
-set(DOXYGEN_PROJECT_BRIEF "A C++ Client Library for the Web Risk API")
+set(DOXYGEN_PROJECT_NAME "Web Risk C++ Client")
+set(DOXYGEN_PROJECT_BRIEF "A C++ Client Library for the Web Risk service")
 set(DOXYGEN_PROJECT_NUMBER "${PROJECT_VERSION} (Experimental)")
 set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "webrisk_internal" "webrisk_testing"
                             "examples")
@@ -163,8 +163,9 @@ google_cloud_cpp_install_headers("google_cloud_cpp_webrisk_mocks"
 set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
 set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
 set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
-set(GOOGLE_CLOUD_PC_NAME "The Web Risk API C++ Client Library")
-set(GOOGLE_CLOUD_PC_DESCRIPTION "Provides C++ APIs to access Web Risk API.")
+set(GOOGLE_CLOUD_PC_NAME "The Web Risk C++ Client Library")
+set(GOOGLE_CLOUD_PC_DESCRIPTION
+    "Provides C++ APIs to access the Web Risk service.")
 set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_webrisk")
 string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common" " google_cloud_cpp_webrisk_protos")

--- a/google/cloud/webrisk/README.md
+++ b/google/cloud/webrisk/README.md
@@ -3,7 +3,7 @@
 :construction:
 
 This directory contains an idiomatic C++ client library for
-[Web Risk][cloud-service-docs], a service to detect malicious URLs on your
+[Web Risk][cloud-service], a service to detect malicious URLs on your
 website and in client applications.
 
 This library is **experimental**. Its APIs are subject to change without notice.
@@ -26,7 +26,8 @@ Please note that the Google Cloud C++ client libraries do **not** follow
   client library
 * Detailed header comments in our [public `.h`][source-link] files
 
-[cloud-service-docs]: https://cloud.google.com/web-risk
+[cloud-service]: https://cloud.google.com/web-risk
+[cloud-service-docs]: https://cloud.google.com/web-risk/docs
 [doxygen-link]: https://googleapis.dev/cpp/google-cloud-webrisk/latest/
 [source-link]: https://github.com/googleapis/google-cloud-cpp/tree/main/google/cloud/webrisk
 

--- a/google/cloud/webrisk/doc/main.dox
+++ b/google/cloud/webrisk/doc/main.dox
@@ -1,6 +1,6 @@
 /*!
 
-@mainpage Web Risk API C++ Client Library
+@mainpage Web Risk C++ Client Library
 
 An idiomatic C++ client library for
 [Web Risk](https://cloud.google.com/web-risk/), a service to detect malicious
@@ -16,7 +16,7 @@ the client library.
 
 ### Setting up your repo
 
-In order to use the Web Risk API C++ client library from your own code,
+In order to use the Web Risk C++ client library from your own code,
 you'll need to configure your build system to discover and compile the Cloud
 C++ client libraries. In some cases your build system or package manager may
 need to download the libraries too. The Cloud C++ client libraries natively
@@ -34,7 +34,7 @@ cd google-cloud-cpp/google/cloud/webrisk/quickstart
 
 The following shows the code that you'll run in the
 `google/cloud/webrisk/quickstart/` directory,
-which should give you a taste of the Web Risk API C++ client library API.
+which should give you a taste of the Web Risk C++ client library API.
 
 @include quickstart.cc
 

--- a/google/cloud/webrisk/quickstart/CMakeLists.txt
+++ b/google/cloud/webrisk/quickstart/CMakeLists.txt
@@ -12,8 +12,8 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-# This file shows how to use the Web Risk API C++ client library from a larger
-# CMake project.
+# This file shows how to use the Web Risk C++ client library from a larger CMake
+# project.
 
 cmake_minimum_required(VERSION 3.5)
 project(google-cloud-cpp-webrisk-quickstart CXX)

--- a/google/cloud/webrisk/quickstart/README.md
+++ b/google/cloud/webrisk/quickstart/README.md
@@ -1,6 +1,6 @@
-# HOWTO: using the Web Risk API C++ client in your project
+# HOWTO: using the Web Risk C++ client in your project
 
-This directory contains small examples showing how to use the Web Risk API C++
+This directory contains small examples showing how to use the Web Risk C++
 client library in your own project. These instructions assume that you have
 some experience as a C++ developer and that you have a working C++ toolchain
 (compiler, linker, etc.) installed on your platform.
@@ -28,7 +28,7 @@ steps in detail.
 
 ## Configuring authentication for the C++ Client Library
 
-Like most Google Cloud Platform (GCP) services, Web Risk API requires that
+Like most Google Cloud Platform (GCP) services, Web Risk requires that
 your application authenticates with the service before accessing any data. If
 you are not familiar with GCP authentication please take this opportunity to
 review the [Authentication Overview][authentication-quickstart]. This library

--- a/google/cloud/websecurityscanner/CMakeLists.txt
+++ b/google/cloud/websecurityscanner/CMakeLists.txt
@@ -15,9 +15,9 @@
 # ~~~
 
 include(GoogleapisConfig)
-set(DOXYGEN_PROJECT_NAME "Web Security Scanner API C++ Client")
+set(DOXYGEN_PROJECT_NAME "Web Security Scanner C++ Client")
 set(DOXYGEN_PROJECT_BRIEF
-    "A C++ Client Library for the Web Security Scanner API")
+    "A C++ Client Library for the Web Security Scanner service")
 set(DOXYGEN_PROJECT_NUMBER "${PROJECT_VERSION} (Experimental)")
 set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "websecurityscanner_internal"
                             "websecurityscanner_testing" "examples")
@@ -179,9 +179,9 @@ google_cloud_cpp_install_headers("google_cloud_cpp_websecurityscanner_mocks"
 set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
 set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
 set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
-set(GOOGLE_CLOUD_PC_NAME "The Web Security Scanner API C++ Client Library")
+set(GOOGLE_CLOUD_PC_NAME "The Web Security Scanner C++ Client Library")
 set(GOOGLE_CLOUD_PC_DESCRIPTION
-    "Provides C++ APIs to access Web Security Scanner API.")
+    "Provides C++ APIs to access the Web Security Scanner service.")
 set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_websecurityscanner")
 string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common"

--- a/google/cloud/websecurityscanner/README.md
+++ b/google/cloud/websecurityscanner/README.md
@@ -1,9 +1,9 @@
-# Web Security Scanner API C++ Client Library
+# Web Security Scanner C++ Client Library
 
 :construction:
 
 This directory contains an idiomatic C++ client library for
-[Web Security Scanner][cloud-service-docs], a service that scans your
+[Web Security Scanner][cloud-service], a service that scans your
 Compute and App Engine apps for common web vulnerabilities.
 
 This library is **experimental**. Its APIs are subject to change without notice.
@@ -21,12 +21,13 @@ Please note that the Google Cloud C++ client libraries do **not** follow
 
 ## Documentation
 
-* Official documentation about the [Web Security Scanner API][cloud-service-docs] service
+* Official documentation about the [Web Security Scanner][cloud-service-docs] service
 * [Reference doxygen documentation][doxygen-link] for each release of this
   client library
 * Detailed header comments in our [public `.h`][source-link] files
 
-[cloud-service-docs]: https://cloud.google.com/security-command-center
+[cloud-service]: https://cloud.google.com/security-command-center
+[cloud-service-docs]: https://cloud.google.com/security-command-center/docs
 [doxygen-link]: https://googleapis.dev/cpp/google-cloud-websecurityscanner/latest/
 [source-link]: https://github.com/googleapis/google-cloud-cpp/tree/main/google/cloud/websecurityscanner
 

--- a/google/cloud/websecurityscanner/doc/main.dox
+++ b/google/cloud/websecurityscanner/doc/main.dox
@@ -1,6 +1,6 @@
 /*!
 
-@mainpage Web Security Scanner API C++ Client Library
+@mainpage Web Security Scanner C++ Client Library
 
 An idiomatic C++ client library for
 [Web Security Scanner](https://cloud.google.com/security-command-center/), a
@@ -17,7 +17,7 @@ the client library.
 
 ### Setting up your repo
 
-In order to use the Web Security Scanner API C++ client library from your own code,
+In order to use the Web Security Scanner C++ client library from your own code,
 you'll need to configure your build system to discover and compile the Cloud
 C++ client libraries. In some cases your build system or package manager may
 need to download the libraries too. The Cloud C++ client libraries natively
@@ -35,7 +35,7 @@ cd google-cloud-cpp/google/cloud/websecurityscanner/quickstart
 
 The following shows the code that you'll run in the
 `google/cloud/websecurityscanner/quickstart/` directory,
-which should give you a taste of the Web Security Scanner API C++ client library API.
+which should give you a taste of the Web Security Scanner C++ client library API.
 
 @include quickstart.cc
 

--- a/google/cloud/websecurityscanner/quickstart/CMakeLists.txt
+++ b/google/cloud/websecurityscanner/quickstart/CMakeLists.txt
@@ -12,8 +12,8 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-# This file shows how to use the Web Security Scanner API C++ client library
-# from a larger CMake project.
+# This file shows how to use the Web Security Scanner C++ client library from a
+# larger CMake project.
 
 cmake_minimum_required(VERSION 3.5)
 project(google-cloud-cpp-websecurityscanner-quickstart CXX)

--- a/google/cloud/websecurityscanner/quickstart/README.md
+++ b/google/cloud/websecurityscanner/quickstart/README.md
@@ -1,6 +1,6 @@
-# HOWTO: using the Web Security Scanner API C++ client in your project
+# HOWTO: using the Web Security Scanner C++ client in your project
 
-This directory contains small examples showing how to use the Web Security Scanner API C++
+This directory contains small examples showing how to use the Web Security Scanner C++
 client library in your own project. These instructions assume that you have
 some experience as a C++ developer and that you have a working C++ toolchain
 (compiler, linker, etc.) installed on your platform.

--- a/google/cloud/workflows/CMakeLists.txt
+++ b/google/cloud/workflows/CMakeLists.txt
@@ -15,9 +15,9 @@
 # ~~~
 
 include(GoogleapisConfig)
-set(DOXYGEN_PROJECT_NAME "Workflow Executions API C++ Client")
+set(DOXYGEN_PROJECT_NAME "Workflow Executions C++ Client")
 set(DOXYGEN_PROJECT_BRIEF
-    "A C++ Client Library for the Workflow Executions API")
+    "A C++ Client Library for the Workflow Executions service")
 set(DOXYGEN_PROJECT_NUMBER "${PROJECT_VERSION} (Experimental)")
 set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "workflows_internal" "workflows_testing"
                             "examples")
@@ -169,9 +169,9 @@ google_cloud_cpp_install_headers("google_cloud_cpp_workflows_mocks"
 set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
 set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
 set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
-set(GOOGLE_CLOUD_PC_NAME "The Workflow Executions API C++ Client Library")
+set(GOOGLE_CLOUD_PC_NAME "The Workflow Executions C++ Client Library")
 set(GOOGLE_CLOUD_PC_DESCRIPTION
-    "Provides C++ APIs to access Workflow Executions API.")
+    "Provides C++ APIs to access the Workflow Executions service.")
 set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_workflows")
 string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common" " google_cloud_cpp_workflows_protos")

--- a/google/cloud/workflows/README.md
+++ b/google/cloud/workflows/README.md
@@ -1,9 +1,9 @@
-# Workflow Executions API C++ Client Library
+# Workflow Executions C++ Client Library
 
 :construction:
 
 This directory contains an idiomatic C++ client library for the
-[Workflows API][cloud-service-docs], a service to orchestrate and automate
+[Workflows][cloud-service], a service to orchestrate and automate
 Google Cloud and HTTP-based API services with serverless workflows.
 
 This library is **experimental**. Its APIs are subject to change without notice.
@@ -21,12 +21,13 @@ Please note that the Google Cloud C++ client libraries do **not** follow
 
 ## Documentation
 
-* Official documentation about the [Workflow Executions API][cloud-service-docs] service
+* Official documentation about the [Workflow Executions][cloud-service-docs] service
 * [Reference doxygen documentation][doxygen-link] for each release of this
   client library
 * Detailed header comments in our [public `.h`][source-link] files
 
-[cloud-service-docs]: https://cloud.google.com/workflows
+[cloud-service]: https://cloud.google.com/workflows
+[cloud-service-docs]: https://cloud.google.com/workflows/docs
 [doxygen-link]: https://googleapis.dev/cpp/google-cloud-workflows/latest/
 [source-link]: https://github.com/googleapis/google-cloud-cpp/tree/main/google/cloud/workflows
 

--- a/google/cloud/workflows/doc/main.dox
+++ b/google/cloud/workflows/doc/main.dox
@@ -1,9 +1,9 @@
 /*!
 
-@mainpage Workflows API C++ Client Library
+@mainpage Workflows C++ Client Library
 
 An idiomatic C++ client library for
-[Workflows API](https://cloud.google.com/workflows/), a service to orchestrate
+[Workflows](https://cloud.google.com/workflows/), a service to orchestrate
 and automate Google Cloud and HTTP-based API services with serverless workflows.
 
 This library is **experimental**. Its APIs are subject to change without notice.
@@ -16,7 +16,7 @@ the client library.
 
 ### Setting up your repo
 
-In order to use the Workflow Executions API C++ client library from your own code,
+In order to use the Workflow Executions C++ client library from your own code,
 you'll need to configure your build system to discover and compile the Cloud
 C++ client libraries. In some cases your build system or package manager may
 need to download the libraries too. The Cloud C++ client libraries natively
@@ -34,7 +34,7 @@ cd google-cloud-cpp/google/cloud/workflows/quickstart
 
 The following shows the code that you'll run in the
 `google/cloud/workflows/quickstart/` directory,
-which should give you a taste of the Workflow Executions API C++ client library API.
+which should give you a taste of the Workflow Executions C++ client library API.
 
 @include quickstart.cc
 

--- a/google/cloud/workflows/quickstart/CMakeLists.txt
+++ b/google/cloud/workflows/quickstart/CMakeLists.txt
@@ -12,8 +12,8 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-# This file shows how to use the Workflow Executions API C++ client library from
-# a larger CMake project.
+# This file shows how to use the Workflow Executions C++ client library from a
+# larger CMake project.
 
 cmake_minimum_required(VERSION 3.5)
 project(google-cloud-cpp-workflows-quickstart CXX)

--- a/google/cloud/workflows/quickstart/README.md
+++ b/google/cloud/workflows/quickstart/README.md
@@ -1,6 +1,6 @@
-# HOWTO: using the Workflows API C++ client in your project
+# HOWTO: using the Workflows C++ client in your project
 
-This directory contains small examples showing how to use the Workflow Executions API C++
+This directory contains small examples showing how to use the Workflow Executions C++
 client library in your own project. These instructions assume that you have
 some experience as a C++ developer and that you have a working C++ toolchain
 (compiler, linker, etc.) installed on your platform.


### PR DESCRIPTION
Also, split up the link to the cloud service root page and cloud service documentation page, where possible.

The first commit has the scaffolding changes. The second commit has all of the retroactive changes. Eventually I gave up making edits to the `CMakeLists.txt`.