### PR TITLE
cleanup(GCS+gRPC): remove aliases for streaming RPC wrappers

### DIFF
--- a/google/cloud/storage/internal/storage_auth.cc
+++ b/google/cloud/storage/internal/storage_auth.cc
@@ -20,9 +20,10 @@ namespace storage {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace internal {
 
-std::unique_ptr<StorageStub::ReadObjectStream> StorageAuth::ReadObject(
-    std::unique_ptr<grpc::ClientContext> context,
-    google::storage::v2::ReadObjectRequest const& request) {
+std::unique_ptr<google::cloud::internal::StreamingReadRpc<
+    google::storage::v2::ReadObjectResponse>>
+StorageAuth::ReadObject(std::unique_ptr<grpc::ClientContext> context,
+                        google::storage::v2::ReadObjectRequest const& request) {
   using ErrorStream = ::google::cloud::internal::StreamingReadRpcError<
       google::storage::v2::ReadObjectResponse>;
   auto status = auth_->ConfigureContext(*context);
@@ -30,8 +31,10 @@ std::unique_ptr<StorageStub::ReadObjectStream> StorageAuth::ReadObject(
   return child_->ReadObject(std::move(context), request);
 }
 
-std::unique_ptr<StorageStub::WriteObjectStream> StorageAuth::WriteObject(
-    std::unique_ptr<grpc::ClientContext> context) {
+std::unique_ptr<google::cloud::internal::StreamingWriteRpc<
+    google::storage::v2::WriteObjectRequest,
+    google::storage::v2::WriteObjectResponse>>
+StorageAuth::WriteObject(std::unique_ptr<grpc::ClientContext> context) {
   using ErrorStream = ::google::cloud::internal::StreamingWriteRpcError<
       google::storage::v2::WriteObjectRequest,
       google::storage::v2::WriteObjectResponse>;

--- a/google/cloud/storage/internal/storage_auth.h
+++ b/google/cloud/storage/internal/storage_auth.h
@@ -33,12 +33,15 @@ class StorageAuth : public StorageStub {
       : auth_(std::move(auth)), child_(std::move(child)) {}
   ~StorageAuth() override = default;
 
-  std::unique_ptr<ReadObjectStream> ReadObject(
-      std::unique_ptr<grpc::ClientContext> context,
-      google::storage::v2::ReadObjectRequest const& request) override;
+  std::unique_ptr<google::cloud::internal::StreamingReadRpc<
+      google::storage::v2::ReadObjectResponse>>
+  ReadObject(std::unique_ptr<grpc::ClientContext> context,
+             google::storage::v2::ReadObjectRequest const& request) override;
 
-  std::unique_ptr<WriteObjectStream> WriteObject(
-      std::unique_ptr<grpc::ClientContext> context) override;
+  std::unique_ptr<google::cloud::internal::StreamingWriteRpc<
+      google::storage::v2::WriteObjectRequest,
+      google::storage::v2::WriteObjectResponse>>
+  WriteObject(std::unique_ptr<grpc::ClientContext> context) override;
 
   StatusOr<google::storage::v2::StartResumableWriteResponse>
   StartResumableWrite(

--- a/google/cloud/storage/internal/storage_auth_test.cc
+++ b/google/cloud/storage/internal/storage_auth_test.cc
@@ -32,17 +32,20 @@ using ::testing::IsNull;
 using ::testing::Not;
 using ::testing::Return;
 
-std::unique_ptr<StorageStub::ReadObjectStream> MakeObjectMediaStream(
-    std::unique_ptr<grpc::ClientContext>,
-    google::storage::v2::ReadObjectRequest const&) {
+std::unique_ptr<google::cloud::internal::StreamingReadRpc<
+    google::storage::v2::ReadObjectResponse>>
+MakeObjectMediaStream(std::unique_ptr<grpc::ClientContext>,
+                      google::storage::v2::ReadObjectRequest const&) {
   using ErrorStream = ::google::cloud::internal::StreamingReadRpcError<
       google::storage::v2::ReadObjectResponse>;
   return absl::make_unique<ErrorStream>(
       Status(StatusCode::kPermissionDenied, "uh-oh"));
 }
 
-std::unique_ptr<StorageStub::WriteObjectStream> MakeInsertStream(
-    std::unique_ptr<grpc::ClientContext>) {
+std::unique_ptr<google::cloud::internal::StreamingWriteRpc<
+    google::storage::v2::WriteObjectRequest,
+    google::storage::v2::WriteObjectResponse>>
+MakeInsertStream(std::unique_ptr<grpc::ClientContext>) {
   using ErrorStream = ::google::cloud::internal::StreamingWriteRpcError<
       google::storage::v2::WriteObjectRequest,
       google::storage::v2::WriteObjectResponse>;

--- a/google/cloud/storage/internal/storage_round_robin.cc
+++ b/google/cloud/storage/internal/storage_round_robin.cc
@@ -20,14 +20,18 @@ namespace storage {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace internal {
 
-std::unique_ptr<StorageStub::ReadObjectStream> StorageRoundRobin::ReadObject(
+std::unique_ptr<google::cloud::internal::StreamingReadRpc<
+    google::storage::v2::ReadObjectResponse>>
+StorageRoundRobin::ReadObject(
     std::unique_ptr<grpc::ClientContext> context,
     google::storage::v2::ReadObjectRequest const& request) {
   return Child()->ReadObject(std::move(context), request);
 }
 
-std::unique_ptr<StorageStub::WriteObjectStream> StorageRoundRobin::WriteObject(
-    std::unique_ptr<grpc::ClientContext> context) {
+std::unique_ptr<google::cloud::internal::StreamingWriteRpc<
+    google::storage::v2::WriteObjectRequest,
+    google::storage::v2::WriteObjectResponse>>
+StorageRoundRobin::WriteObject(std::unique_ptr<grpc::ClientContext> context) {
   return Child()->WriteObject(std::move(context));
 }
 

--- a/google/cloud/storage/internal/storage_round_robin.h
+++ b/google/cloud/storage/internal/storage_round_robin.h
@@ -32,12 +32,15 @@ class StorageRoundRobin : public StorageStub {
       : children_(std::move(children)) {}
   ~StorageRoundRobin() override = default;
 
-  std::unique_ptr<ReadObjectStream> ReadObject(
-      std::unique_ptr<grpc::ClientContext> context,
-      google::storage::v2::ReadObjectRequest const& request) override;
+  std::unique_ptr<google::cloud::internal::StreamingReadRpc<
+      google::storage::v2::ReadObjectResponse>>
+  ReadObject(std::unique_ptr<grpc::ClientContext> context,
+             google::storage::v2::ReadObjectRequest const& request) override;
 
-  std::unique_ptr<WriteObjectStream> WriteObject(
-      std::unique_ptr<grpc::ClientContext> context) override;
+  std::unique_ptr<google::cloud::internal::StreamingWriteRpc<
+      google::storage::v2::WriteObjectRequest,
+      google::storage::v2::WriteObjectResponse>>
+  WriteObject(std::unique_ptr<grpc::ClientContext> context) override;
 
   StatusOr<google::storage::v2::StartResumableWriteResponse>
   StartResumableWrite(

--- a/google/cloud/storage/internal/storage_round_robin_test.cc
+++ b/google/cloud/storage/internal/storage_round_robin_test.cc
@@ -51,17 +51,20 @@ std::vector<std::shared_ptr<StorageStub>> AsPlainStubs(
   return std::vector<std::shared_ptr<StorageStub>>(mocks.begin(), mocks.end());
 }
 
-std::unique_ptr<StorageStub::ReadObjectStream> MakeReadObjectStream(
-    std::unique_ptr<grpc::ClientContext>,
-    google::storage::v2::ReadObjectRequest const&) {
+std::unique_ptr<google::cloud::internal::StreamingReadRpc<
+    google::storage::v2::ReadObjectResponse>>
+MakeReadObjectStream(std::unique_ptr<grpc::ClientContext>,
+                     google::storage::v2::ReadObjectRequest const&) {
   using ErrorStream = ::google::cloud::internal::StreamingReadRpcError<
       google::storage::v2::ReadObjectResponse>;
   return absl::make_unique<ErrorStream>(
       Status(StatusCode::kPermissionDenied, "uh-oh"));
 }
 
-std::unique_ptr<StorageStub::WriteObjectStream> MakeInsertStream(
-    std::unique_ptr<grpc::ClientContext>) {
+std::unique_ptr<google::cloud::internal::StreamingWriteRpc<
+    google::storage::v2::WriteObjectRequest,
+    google::storage::v2::WriteObjectResponse>>
+MakeInsertStream(std::unique_ptr<grpc::ClientContext>) {
   using ErrorStream = ::google::cloud::internal::StreamingWriteRpcError<
       google::storage::v2::WriteObjectRequest,
       google::storage::v2::WriteObjectResponse>;
@@ -69,7 +72,7 @@ std::unique_ptr<StorageStub::WriteObjectStream> MakeInsertStream(
       Status(StatusCode::kPermissionDenied, "uh-oh"));
 }
 
-TEST(StorageAuthTest, ReadObject) {
+TEST(StorageRoundRobinTest, ReadObject) {
   auto mocks = MakeMocks();
   InSequence sequence;
   for (int i = 0; i != kRepeats; ++i) {
@@ -89,7 +92,7 @@ TEST(StorageAuthTest, ReadObject) {
   }
 }
 
-TEST(StorageAuthTest, WriteObject) {
+TEST(StorageRoundRobinTest, WriteObject) {
   auto mocks = MakeMocks();
   InSequence sequence;
   for (int i = 0; i != kRepeats; ++i) {
@@ -106,7 +109,7 @@ TEST(StorageAuthTest, WriteObject) {
   }
 }
 
-TEST(StorageAuthTest, StartResumableWrite) {
+TEST(StorageRoundRobinTest, StartResumableWrite) {
   auto mocks = MakeMocks();
   InSequence sequence;
   for (int i = 0; i != kRepeats; ++i) {
@@ -125,7 +128,7 @@ TEST(StorageAuthTest, StartResumableWrite) {
   }
 }
 
-TEST(StorageAuthTest, QueryWriteStatus) {
+TEST(StorageRoundRobinTest, QueryWriteStatus) {
   auto mocks = MakeMocks();
   InSequence sequence;
   for (int i = 0; i != kRepeats; ++i) {

--- a/google/cloud/storage/internal/storage_stub.cc
+++ b/google/cloud/storage/internal/storage_stub.cc
@@ -32,9 +32,10 @@ class StorageStubImpl : public StorageStub {
       : impl_(std::move(impl)) {}
   ~StorageStubImpl() override = default;
 
-  std::unique_ptr<ReadObjectStream> ReadObject(
-      std::unique_ptr<grpc::ClientContext> context,
-      google::storage::v2::ReadObjectRequest const& request) override {
+  std::unique_ptr<google::cloud::internal::StreamingReadRpc<
+      google::storage::v2::ReadObjectResponse>>
+  ReadObject(std::unique_ptr<grpc::ClientContext> context,
+             google::storage::v2::ReadObjectRequest const& request) override {
     using ::google::cloud::internal::StreamingReadRpcImpl;
     auto stream = impl_->ReadObject(context.get(), request);
     return absl::make_unique<
@@ -42,8 +43,10 @@ class StorageStubImpl : public StorageStub {
         std::move(context), std::move(stream));
   }
 
-  std::unique_ptr<WriteObjectStream> WriteObject(
-      std::unique_ptr<grpc::ClientContext> context) override {
+  std::unique_ptr<google::cloud::internal::StreamingWriteRpc<
+      google::storage::v2::WriteObjectRequest,
+      google::storage::v2::WriteObjectResponse>>
+  WriteObject(std::unique_ptr<grpc::ClientContext> context) override {
     using ::google::cloud::internal::StreamingWriteRpcImpl;
     using ResponseType = ::google::storage::v2::WriteObjectResponse;
     using RequestType = ::google::storage::v2::WriteObjectRequest;

--- a/google/cloud/storage/internal/storage_stub.h
+++ b/google/cloud/storage/internal/storage_stub.h
@@ -32,17 +32,15 @@ class StorageStub {
  public:
   virtual ~StorageStub() = default;
 
-  using ReadObjectStream = ::google::cloud::internal::StreamingReadRpc<
-      google::storage::v2::ReadObjectResponse>;
-  virtual std::unique_ptr<ReadObjectStream> ReadObject(
-      std::unique_ptr<grpc::ClientContext> context,
-      google::storage::v2::ReadObjectRequest const& request) = 0;
+  virtual std::unique_ptr<google::cloud::internal::StreamingReadRpc<
+      google::storage::v2::ReadObjectResponse>>
+  ReadObject(std::unique_ptr<grpc::ClientContext> context,
+             google::storage::v2::ReadObjectRequest const& request) = 0;
 
-  using WriteObjectStream = ::google::cloud::internal::StreamingWriteRpc<
+  virtual std::unique_ptr<google::cloud::internal::StreamingWriteRpc<
       google::storage::v2::WriteObjectRequest,
-      google::storage::v2::WriteObjectResponse>;
-  virtual std::unique_ptr<WriteObjectStream> WriteObject(
-      std::unique_ptr<grpc::ClientContext> context) = 0;
+      google::storage::v2::WriteObjectResponse>>
+  WriteObject(std::unique_ptr<grpc::ClientContext> context) = 0;
 
   virtual StatusOr<google::storage::v2::StartResumableWriteResponse>
   StartResumableWrite(

--- a/google/cloud/storage/testing/mock_storage_stub.h
+++ b/google/cloud/storage/testing/mock_storage_stub.h
@@ -25,12 +25,16 @@ namespace testing {
 
 class MockStorageStub : public internal::StorageStub {
  public:
-  MOCK_METHOD(std::unique_ptr<ReadObjectStream>, ReadObject,
+  MOCK_METHOD(std::unique_ptr<google::cloud::internal::StreamingReadRpc<
+                  google::storage::v2::ReadObjectResponse>>,
+              ReadObject,
               (std::unique_ptr<grpc::ClientContext>,
                google::storage::v2::ReadObjectRequest const&),
               (override));
-  MOCK_METHOD(std::unique_ptr<WriteObjectStream>, WriteObject,
-              (std::unique_ptr<grpc::ClientContext>), (override));
+  MOCK_METHOD((std::unique_ptr<google::cloud::internal::StreamingWriteRpc<
+                   google::storage::v2::WriteObjectRequest,
+                   google::storage::v2::WriteObjectResponse>>),
+              WriteObject, (std::unique_ptr<grpc::ClientContext>), (override));
   MOCK_METHOD(StatusOr<google::storage::v2::StartResumableWriteResponse>,
               StartResumableWrite,
               (grpc::ClientContext&,
@@ -43,7 +47,9 @@ class MockStorageStub : public internal::StorageStub {
               (override));
 };
 
-class MockInsertStream : public internal::StorageStub::WriteObjectStream {
+class MockInsertStream : public google::cloud::internal::StreamingWriteRpc<
+                             google::storage::v2::WriteObjectRequest,
+                             google::storage::v2::WriteObjectResponse> {
  public:
   MOCK_METHOD(void, Cancel, (), (override));
   MOCK_METHOD(bool, Write,
@@ -54,7 +60,8 @@ class MockInsertStream : public internal::StorageStub::WriteObjectStream {
               (override));
 };
 
-class MockObjectMediaStream : public internal::StorageStub::ReadObjectStream {
+class MockObjectMediaStream : public google::cloud::internal::StreamingReadRpc<
+                                  google::storage::v2::ReadObjectResponse> {
  public:
   MOCK_METHOD(void, Cancel, (), (override));
   using ReadResultType =


### PR DESCRIPTION
This will make it easier to use (even via cut&paste) the generated
`StorageStub` and any decorators.

Part of the work for #7963

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7964)
<!-- Reviewable:end -->
