### PR TITLE
feat(generator): add option to disable *Connection

### DIFF
--- a/generator/generator_config.proto
+++ b/generator/generator_config.proto
@@ -54,6 +54,18 @@ message ServiceConfiguration {
   // rows or values).
   bool omit_client = 11;
 
+  // If set, the `*Connection` class and its helpers are not generated. This
+  // is useful in services where the `*Connection` requires very custom code,
+  // for example:
+  // * Storage already had a hand-crafted analog to the `*Connection` class.
+  // * Pub/Sub Lite, where we think the generated `*Stub` classes are useful,
+  //   but the `*Connection` requires custom algorithms.
+  // * Anything that requires a custom resume algorithm for streaming RPCs.
+  //
+  // In most cases one would want to set `omit_client` to true if this flag
+  // is also set.
+  bool omit_connection = 13;
+
   // If additional proto files are needed that aren't imported by the service
   // file, add them using this field. This typically happens when an annotation
   // lists a type that is not defined in any of the imported proto files.

--- a/generator/internal/codegen_utils_test.cc
+++ b/generator/internal/codegen_utils_test.cc
@@ -296,6 +296,14 @@ TEST(ProcessCommandLineArgs, ProcessOmitClient) {
   EXPECT_THAT(*result, Contains(Pair("omit_client", "true")));
 }
 
+TEST(ProcessCommandLineArgs, ProcessOmitConnection) {
+  auto result = ProcessCommandLineArgs(
+      "product_path=google/cloud/spanner/"
+      ",omit_connection=true");
+  ASSERT_THAT(result, IsOk());
+  EXPECT_THAT(*result, Contains(Pair("omit_connection", "true")));
+}
+
 }  // namespace
 }  // namespace generator_internal
 }  // namespace cloud

--- a/generator/internal/descriptor_utils.cc
+++ b/generator/internal/descriptor_utils.cc
@@ -652,19 +652,38 @@ std::vector<std::unique_ptr<GeneratorInterface>> MakeGenerators(
     std::vector<std::pair<std::string, std::string>> const& vars) {
   std::vector<std::unique_ptr<GeneratorInterface>> code_generators;
   VarsDictionary service_vars = CreateServiceVars(*service, vars);
-  auto found = service_vars.find("omit_client");
-  if (found == service_vars.end() || found->second != "true") {
+  auto const omit_client = service_vars.find("omit_client");
+  if (omit_client == service_vars.end() || omit_client->second != "true") {
     code_generators.push_back(absl::make_unique<ClientGenerator>(
         service, service_vars, CreateMethodVars(*service, service_vars),
         context));
   }
+  auto const omit_connection = service_vars.find("omit_connection");
+  if (omit_connection == service_vars.end() ||
+      omit_connection->second != "true") {
+    code_generators.push_back(absl::make_unique<ConnectionGenerator>(
+        service, service_vars, CreateMethodVars(*service, service_vars),
+        context));
+    code_generators.push_back(absl::make_unique<IdempotencyPolicyGenerator>(
+        service, service_vars, CreateMethodVars(*service, service_vars),
+        context));
+    code_generators.push_back(absl::make_unique<MockConnectionGenerator>(
+        service, service_vars, CreateMethodVars(*service, service_vars),
+        context));
+    code_generators.push_back(absl::make_unique<OptionDefaultsGenerator>(
+        service, service_vars, CreateMethodVars(*service, service_vars),
+        context));
+    code_generators.push_back(absl::make_unique<OptionsGenerator>(
+        service, service_vars, CreateMethodVars(*service, service_vars),
+        context));
+    if (service_vars.find("retry_status_code_expression") !=
+        service_vars.end()) {
+      code_generators.push_back(absl::make_unique<RetryTraitsGenerator>(
+          service, service_vars, CreateMethodVars(*service, service_vars),
+          context));
+    }
+  }
   code_generators.push_back(absl::make_unique<AuthDecoratorGenerator>(
-      service, service_vars, CreateMethodVars(*service, service_vars),
-      context));
-  code_generators.push_back(absl::make_unique<ConnectionGenerator>(
-      service, service_vars, CreateMethodVars(*service, service_vars),
-      context));
-  code_generators.push_back(absl::make_unique<IdempotencyPolicyGenerator>(
       service, service_vars, CreateMethodVars(*service, service_vars),
       context));
   code_generators.push_back(absl::make_unique<LoggingDecoratorGenerator>(
@@ -673,20 +692,6 @@ std::vector<std::unique_ptr<GeneratorInterface>> MakeGenerators(
   code_generators.push_back(absl::make_unique<MetadataDecoratorGenerator>(
       service, service_vars, CreateMethodVars(*service, service_vars),
       context));
-  code_generators.push_back(absl::make_unique<MockConnectionGenerator>(
-      service, service_vars, CreateMethodVars(*service, service_vars),
-      context));
-  code_generators.push_back(absl::make_unique<OptionDefaultsGenerator>(
-      service, service_vars, CreateMethodVars(*service, service_vars),
-      context));
-  code_generators.push_back(absl::make_unique<OptionsGenerator>(
-      service, service_vars, CreateMethodVars(*service, service_vars),
-      context));
-  if (service_vars.find("retry_status_code_expression") != service_vars.end()) {
-    code_generators.push_back(absl::make_unique<RetryTraitsGenerator>(
-        service, service_vars, CreateMethodVars(*service, service_vars),
-        context));
-  }
   code_generators.push_back(absl::make_unique<StubGenerator>(
       service, service_vars, CreateMethodVars(*service, service_vars),
       context));

--- a/generator/standalone_main.cc
+++ b/generator/standalone_main.cc
@@ -212,6 +212,9 @@ int main(int argc, char** argv) {
     if (service.omit_client()) {
       args.emplace_back("--cpp_codegen_opt=omit_client=true");
     }
+    if (service.omit_connection()) {
+      args.emplace_back("--cpp_codegen_opt=omit_connection=true");
+    }
     args.emplace_back("--cpp_codegen_opt=service_endpoint_env_var=" +
                       service.service_endpoint_env_var());
     args.emplace_back("--cpp_codegen_opt=emulator_endpoint_env_var=" +


### PR DESCRIPTION
Sometimes it is useful to not generate the `*Connection` class and its
friends.

Part of the work for #7963

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7965)
<!-- Reviewable:end -->
