### PR TITLE
fix(generator): do not use connection files in stub files

### DIFF
--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_stub_factory.cc
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_stub_factory.cc
@@ -26,6 +26,7 @@
 #include "google/cloud/internal/algorithm.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
+#include <generator/integration_tests/test.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_stub_factory.h
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_stub_factory.h
@@ -19,7 +19,6 @@
 #ifndef GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_INTERNAL_GOLDEN_KITCHEN_SINK_STUB_FACTORY_H
 #define GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_INTERNAL_GOLDEN_KITCHEN_SINK_STUB_FACTORY_H
 
-#include "generator/integration_tests/golden/golden_kitchen_sink_connection.h"
 #include "generator/integration_tests/golden/internal/golden_kitchen_sink_stub.h"
 #include "google/cloud/completion_queue.h"
 #include "google/cloud/credentials.h"

--- a/generator/integration_tests/golden/internal/golden_thing_admin_stub_factory.cc
+++ b/generator/integration_tests/golden/internal/golden_thing_admin_stub_factory.cc
@@ -26,6 +26,7 @@
 #include "google/cloud/internal/algorithm.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
+#include <generator/integration_tests/test.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/generator/integration_tests/golden/internal/golden_thing_admin_stub_factory.h
+++ b/generator/integration_tests/golden/internal/golden_thing_admin_stub_factory.h
@@ -19,7 +19,6 @@
 #ifndef GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_INTERNAL_GOLDEN_THING_ADMIN_STUB_FACTORY_H
 #define GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_INTERNAL_GOLDEN_THING_ADMIN_STUB_FACTORY_H
 
-#include "generator/integration_tests/golden/golden_thing_admin_connection.h"
 #include "generator/integration_tests/golden/internal/golden_thing_admin_stub.h"
 #include "google/cloud/completion_queue.h"
 #include "google/cloud/credentials.h"

--- a/generator/internal/stub_factory_generator.cc
+++ b/generator/internal/stub_factory_generator.cc
@@ -44,7 +44,7 @@ Status StubFactoryGenerator::GenerateHeader() {
 
   // includes
   HeaderPrint("\n");
-  HeaderLocalIncludes({vars("connection_header_path"), vars("stub_header_path"),
+  HeaderLocalIncludes({vars("stub_header_path"),
                        "google/cloud/completion_queue.h",
                        "google/cloud/credentials.h",
                        "google/cloud/internal/unified_grpc_credentials.h",
@@ -83,7 +83,7 @@ Status StubFactoryGenerator::GenerateCc() {
                    "google/cloud/grpc_options.h",
                    "google/cloud/internal/algorithm.h",
                    "google/cloud/options.h", "google/cloud/log.h"});
-  CcSystemIncludes({"memory"});
+  CcSystemIncludes({vars("proto_grpc_header_path"), "memory"});
 
   auto result = CcOpenNamespaces(NamespaceType::kInternal);
   if (!result.ok()) return result;

--- a/google/cloud/accessapproval/internal/access_approval_stub_factory.cc
+++ b/google/cloud/accessapproval/internal/access_approval_stub_factory.cc
@@ -26,6 +26,7 @@
 #include "google/cloud/internal/algorithm.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
+#include <google/cloud/accessapproval/v1/accessapproval.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/accessapproval/internal/access_approval_stub_factory.h
+++ b/google/cloud/accessapproval/internal/access_approval_stub_factory.h
@@ -19,7 +19,6 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_ACCESSAPPROVAL_INTERNAL_ACCESS_APPROVAL_STUB_FACTORY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_ACCESSAPPROVAL_INTERNAL_ACCESS_APPROVAL_STUB_FACTORY_H
 
-#include "google/cloud/accessapproval/access_approval_connection.h"
 #include "google/cloud/accessapproval/internal/access_approval_stub.h"
 #include "google/cloud/completion_queue.h"
 #include "google/cloud/credentials.h"

--- a/google/cloud/accesscontextmanager/internal/access_context_manager_stub_factory.cc
+++ b/google/cloud/accesscontextmanager/internal/access_context_manager_stub_factory.cc
@@ -26,6 +26,7 @@
 #include "google/cloud/internal/algorithm.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
+#include <google/identity/accesscontextmanager/v1/access_context_manager.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/accesscontextmanager/internal/access_context_manager_stub_factory.h
+++ b/google/cloud/accesscontextmanager/internal/access_context_manager_stub_factory.h
@@ -19,7 +19,6 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_ACCESSCONTEXTMANAGER_INTERNAL_ACCESS_CONTEXT_MANAGER_STUB_FACTORY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_ACCESSCONTEXTMANAGER_INTERNAL_ACCESS_CONTEXT_MANAGER_STUB_FACTORY_H
 
-#include "google/cloud/accesscontextmanager/access_context_manager_connection.h"
 #include "google/cloud/accesscontextmanager/internal/access_context_manager_stub.h"
 #include "google/cloud/completion_queue.h"
 #include "google/cloud/credentials.h"

--- a/google/cloud/apigateway/internal/api_gateway_stub_factory.cc
+++ b/google/cloud/apigateway/internal/api_gateway_stub_factory.cc
@@ -26,6 +26,7 @@
 #include "google/cloud/internal/algorithm.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
+#include <google/cloud/apigateway/v1/apigateway_service.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/apigateway/internal/api_gateway_stub_factory.h
+++ b/google/cloud/apigateway/internal/api_gateway_stub_factory.h
@@ -19,7 +19,6 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_APIGATEWAY_INTERNAL_API_GATEWAY_STUB_FACTORY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_APIGATEWAY_INTERNAL_API_GATEWAY_STUB_FACTORY_H
 
-#include "google/cloud/apigateway/api_gateway_connection.h"
 #include "google/cloud/apigateway/internal/api_gateway_stub.h"
 #include "google/cloud/completion_queue.h"
 #include "google/cloud/credentials.h"

--- a/google/cloud/appengine/internal/applications_stub_factory.cc
+++ b/google/cloud/appengine/internal/applications_stub_factory.cc
@@ -26,6 +26,7 @@
 #include "google/cloud/internal/algorithm.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
+#include <google/appengine/v1/appengine.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/appengine/internal/applications_stub_factory.h
+++ b/google/cloud/appengine/internal/applications_stub_factory.h
@@ -19,7 +19,6 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_APPENGINE_INTERNAL_APPLICATIONS_STUB_FACTORY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_APPENGINE_INTERNAL_APPLICATIONS_STUB_FACTORY_H
 
-#include "google/cloud/appengine/applications_connection.h"
 #include "google/cloud/appengine/internal/applications_stub.h"
 #include "google/cloud/completion_queue.h"
 #include "google/cloud/credentials.h"

--- a/google/cloud/appengine/internal/authorized_certificates_stub_factory.cc
+++ b/google/cloud/appengine/internal/authorized_certificates_stub_factory.cc
@@ -26,6 +26,7 @@
 #include "google/cloud/internal/algorithm.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
+#include <google/appengine/v1/appengine.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/appengine/internal/authorized_certificates_stub_factory.h
+++ b/google/cloud/appengine/internal/authorized_certificates_stub_factory.h
@@ -19,7 +19,6 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_APPENGINE_INTERNAL_AUTHORIZED_CERTIFICATES_STUB_FACTORY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_APPENGINE_INTERNAL_AUTHORIZED_CERTIFICATES_STUB_FACTORY_H
 
-#include "google/cloud/appengine/authorized_certificates_connection.h"
 #include "google/cloud/appengine/internal/authorized_certificates_stub.h"
 #include "google/cloud/completion_queue.h"
 #include "google/cloud/credentials.h"

--- a/google/cloud/appengine/internal/authorized_domains_stub_factory.cc
+++ b/google/cloud/appengine/internal/authorized_domains_stub_factory.cc
@@ -26,6 +26,7 @@
 #include "google/cloud/internal/algorithm.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
+#include <google/appengine/v1/appengine.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/appengine/internal/authorized_domains_stub_factory.h
+++ b/google/cloud/appengine/internal/authorized_domains_stub_factory.h
@@ -19,7 +19,6 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_APPENGINE_INTERNAL_AUTHORIZED_DOMAINS_STUB_FACTORY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_APPENGINE_INTERNAL_AUTHORIZED_DOMAINS_STUB_FACTORY_H
 
-#include "google/cloud/appengine/authorized_domains_connection.h"
 #include "google/cloud/appengine/internal/authorized_domains_stub.h"
 #include "google/cloud/completion_queue.h"
 #include "google/cloud/credentials.h"

--- a/google/cloud/appengine/internal/domain_mappings_stub_factory.cc
+++ b/google/cloud/appengine/internal/domain_mappings_stub_factory.cc
@@ -26,6 +26,7 @@
 #include "google/cloud/internal/algorithm.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
+#include <google/appengine/v1/appengine.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/appengine/internal/domain_mappings_stub_factory.h
+++ b/google/cloud/appengine/internal/domain_mappings_stub_factory.h
@@ -19,7 +19,6 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_APPENGINE_INTERNAL_DOMAIN_MAPPINGS_STUB_FACTORY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_APPENGINE_INTERNAL_DOMAIN_MAPPINGS_STUB_FACTORY_H
 
-#include "google/cloud/appengine/domain_mappings_connection.h"
 #include "google/cloud/appengine/internal/domain_mappings_stub.h"
 #include "google/cloud/completion_queue.h"
 #include "google/cloud/credentials.h"

--- a/google/cloud/appengine/internal/firewall_stub_factory.cc
+++ b/google/cloud/appengine/internal/firewall_stub_factory.cc
@@ -26,6 +26,7 @@
 #include "google/cloud/internal/algorithm.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
+#include <google/appengine/v1/appengine.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/appengine/internal/firewall_stub_factory.h
+++ b/google/cloud/appengine/internal/firewall_stub_factory.h
@@ -19,7 +19,6 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_APPENGINE_INTERNAL_FIREWALL_STUB_FACTORY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_APPENGINE_INTERNAL_FIREWALL_STUB_FACTORY_H
 
-#include "google/cloud/appengine/firewall_connection.h"
 #include "google/cloud/appengine/internal/firewall_stub.h"
 #include "google/cloud/completion_queue.h"
 #include "google/cloud/credentials.h"

--- a/google/cloud/appengine/internal/instances_stub_factory.cc
+++ b/google/cloud/appengine/internal/instances_stub_factory.cc
@@ -26,6 +26,7 @@
 #include "google/cloud/internal/algorithm.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
+#include <google/appengine/v1/appengine.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/appengine/internal/instances_stub_factory.h
+++ b/google/cloud/appengine/internal/instances_stub_factory.h
@@ -19,7 +19,6 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_APPENGINE_INTERNAL_INSTANCES_STUB_FACTORY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_APPENGINE_INTERNAL_INSTANCES_STUB_FACTORY_H
 
-#include "google/cloud/appengine/instances_connection.h"
 #include "google/cloud/appengine/internal/instances_stub.h"
 #include "google/cloud/completion_queue.h"
 #include "google/cloud/credentials.h"

--- a/google/cloud/appengine/internal/services_stub_factory.cc
+++ b/google/cloud/appengine/internal/services_stub_factory.cc
@@ -26,6 +26,7 @@
 #include "google/cloud/internal/algorithm.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
+#include <google/appengine/v1/appengine.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/appengine/internal/services_stub_factory.h
+++ b/google/cloud/appengine/internal/services_stub_factory.h
@@ -20,7 +20,6 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_APPENGINE_INTERNAL_SERVICES_STUB_FACTORY_H
 
 #include "google/cloud/appengine/internal/services_stub.h"
-#include "google/cloud/appengine/services_connection.h"
 #include "google/cloud/completion_queue.h"
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/unified_grpc_credentials.h"

--- a/google/cloud/appengine/internal/versions_stub_factory.cc
+++ b/google/cloud/appengine/internal/versions_stub_factory.cc
@@ -26,6 +26,7 @@
 #include "google/cloud/internal/algorithm.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
+#include <google/appengine/v1/appengine.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/appengine/internal/versions_stub_factory.h
+++ b/google/cloud/appengine/internal/versions_stub_factory.h
@@ -20,7 +20,6 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_APPENGINE_INTERNAL_VERSIONS_STUB_FACTORY_H
 
 #include "google/cloud/appengine/internal/versions_stub.h"
-#include "google/cloud/appengine/versions_connection.h"
 #include "google/cloud/completion_queue.h"
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/unified_grpc_credentials.h"

--- a/google/cloud/assuredworkloads/internal/assured_workloads_stub_factory.cc
+++ b/google/cloud/assuredworkloads/internal/assured_workloads_stub_factory.cc
@@ -26,6 +26,7 @@
 #include "google/cloud/internal/algorithm.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
+#include <google/cloud/assuredworkloads/v1/assuredworkloads.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/assuredworkloads/internal/assured_workloads_stub_factory.h
+++ b/google/cloud/assuredworkloads/internal/assured_workloads_stub_factory.h
@@ -19,7 +19,6 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_ASSUREDWORKLOADS_INTERNAL_ASSURED_WORKLOADS_STUB_FACTORY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_ASSUREDWORKLOADS_INTERNAL_ASSURED_WORKLOADS_STUB_FACTORY_H
 
-#include "google/cloud/assuredworkloads/assured_workloads_connection.h"
 #include "google/cloud/assuredworkloads/internal/assured_workloads_stub.h"
 #include "google/cloud/completion_queue.h"
 #include "google/cloud/credentials.h"

--- a/google/cloud/bigquery/internal/bigquery_read_stub_factory.cc
+++ b/google/cloud/bigquery/internal/bigquery_read_stub_factory.cc
@@ -26,6 +26,7 @@
 #include "google/cloud/internal/algorithm.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
+#include <google/cloud/bigquery/storage/v1/storage.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/bigquery/internal/bigquery_read_stub_factory.h
+++ b/google/cloud/bigquery/internal/bigquery_read_stub_factory.h
@@ -19,7 +19,6 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_INTERNAL_BIGQUERY_READ_STUB_FACTORY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_INTERNAL_BIGQUERY_READ_STUB_FACTORY_H
 
-#include "google/cloud/bigquery/bigquery_read_connection.h"
 #include "google/cloud/bigquery/internal/bigquery_read_stub.h"
 #include "google/cloud/completion_queue.h"
 #include "google/cloud/credentials.h"

--- a/google/cloud/bigtable/admin/internal/bigtable_instance_admin_stub_factory.cc
+++ b/google/cloud/bigtable/admin/internal/bigtable_instance_admin_stub_factory.cc
@@ -26,6 +26,7 @@
 #include "google/cloud/internal/algorithm.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
+#include <google/bigtable/admin/v2/bigtable_instance_admin.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/bigtable/admin/internal/bigtable_instance_admin_stub_factory.h
+++ b/google/cloud/bigtable/admin/internal/bigtable_instance_admin_stub_factory.h
@@ -19,7 +19,6 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_ADMIN_INTERNAL_BIGTABLE_INSTANCE_ADMIN_STUB_FACTORY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_ADMIN_INTERNAL_BIGTABLE_INSTANCE_ADMIN_STUB_FACTORY_H
 
-#include "google/cloud/bigtable/admin/bigtable_instance_admin_connection.h"
 #include "google/cloud/bigtable/admin/internal/bigtable_instance_admin_stub.h"
 #include "google/cloud/completion_queue.h"
 #include "google/cloud/credentials.h"

--- a/google/cloud/bigtable/admin/internal/bigtable_table_admin_stub_factory.cc
+++ b/google/cloud/bigtable/admin/internal/bigtable_table_admin_stub_factory.cc
@@ -26,6 +26,7 @@
 #include "google/cloud/internal/algorithm.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
+#include <google/bigtable/admin/v2/bigtable_table_admin.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/bigtable/admin/internal/bigtable_table_admin_stub_factory.h
+++ b/google/cloud/bigtable/admin/internal/bigtable_table_admin_stub_factory.h
@@ -19,7 +19,6 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_ADMIN_INTERNAL_BIGTABLE_TABLE_ADMIN_STUB_FACTORY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_ADMIN_INTERNAL_BIGTABLE_TABLE_ADMIN_STUB_FACTORY_H
 
-#include "google/cloud/bigtable/admin/bigtable_table_admin_connection.h"
 #include "google/cloud/bigtable/admin/internal/bigtable_table_admin_stub.h"
 #include "google/cloud/completion_queue.h"
 #include "google/cloud/credentials.h"

--- a/google/cloud/billing/internal/budget_stub_factory.cc
+++ b/google/cloud/billing/internal/budget_stub_factory.cc
@@ -26,6 +26,7 @@
 #include "google/cloud/internal/algorithm.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
+#include <google/cloud/billing/budgets/v1/budget_service.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/billing/internal/budget_stub_factory.h
+++ b/google/cloud/billing/internal/budget_stub_factory.h
@@ -19,7 +19,6 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BILLING_INTERNAL_BUDGET_STUB_FACTORY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BILLING_INTERNAL_BUDGET_STUB_FACTORY_H
 
-#include "google/cloud/billing/budget_connection.h"
 #include "google/cloud/billing/internal/budget_stub.h"
 #include "google/cloud/completion_queue.h"
 #include "google/cloud/credentials.h"

--- a/google/cloud/billing/internal/cloud_billing_stub_factory.cc
+++ b/google/cloud/billing/internal/cloud_billing_stub_factory.cc
@@ -26,6 +26,7 @@
 #include "google/cloud/internal/algorithm.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
+#include <google/cloud/billing/v1/cloud_billing.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/billing/internal/cloud_billing_stub_factory.h
+++ b/google/cloud/billing/internal/cloud_billing_stub_factory.h
@@ -19,7 +19,6 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BILLING_INTERNAL_CLOUD_BILLING_STUB_FACTORY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BILLING_INTERNAL_CLOUD_BILLING_STUB_FACTORY_H
 
-#include "google/cloud/billing/cloud_billing_connection.h"
 #include "google/cloud/billing/internal/cloud_billing_stub.h"
 #include "google/cloud/completion_queue.h"
 #include "google/cloud/credentials.h"

--- a/google/cloud/billing/internal/cloud_catalog_stub_factory.cc
+++ b/google/cloud/billing/internal/cloud_catalog_stub_factory.cc
@@ -26,6 +26,7 @@
 #include "google/cloud/internal/algorithm.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
+#include <google/cloud/billing/v1/cloud_catalog.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/billing/internal/cloud_catalog_stub_factory.h
+++ b/google/cloud/billing/internal/cloud_catalog_stub_factory.h
@@ -19,7 +19,6 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BILLING_INTERNAL_CLOUD_CATALOG_STUB_FACTORY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BILLING_INTERNAL_CLOUD_CATALOG_STUB_FACTORY_H
 
-#include "google/cloud/billing/cloud_catalog_connection.h"
 #include "google/cloud/billing/internal/cloud_catalog_stub.h"
 #include "google/cloud/completion_queue.h"
 #include "google/cloud/credentials.h"

--- a/google/cloud/composer/internal/environments_stub_factory.cc
+++ b/google/cloud/composer/internal/environments_stub_factory.cc
@@ -26,6 +26,7 @@
 #include "google/cloud/internal/algorithm.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
+#include <google/cloud/orchestration/airflow/service/v1/environments.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/composer/internal/environments_stub_factory.h
+++ b/google/cloud/composer/internal/environments_stub_factory.h
@@ -19,7 +19,6 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_COMPOSER_INTERNAL_ENVIRONMENTS_STUB_FACTORY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_COMPOSER_INTERNAL_ENVIRONMENTS_STUB_FACTORY_H
 
-#include "google/cloud/composer/environments_connection.h"
 #include "google/cloud/composer/internal/environments_stub.h"
 #include "google/cloud/completion_queue.h"
 #include "google/cloud/credentials.h"

--- a/google/cloud/composer/internal/image_versions_stub_factory.cc
+++ b/google/cloud/composer/internal/image_versions_stub_factory.cc
@@ -26,6 +26,7 @@
 #include "google/cloud/internal/algorithm.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
+#include <google/cloud/orchestration/airflow/service/v1/image_versions.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/composer/internal/image_versions_stub_factory.h
+++ b/google/cloud/composer/internal/image_versions_stub_factory.h
@@ -19,7 +19,6 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_COMPOSER_INTERNAL_IMAGE_VERSIONS_STUB_FACTORY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_COMPOSER_INTERNAL_IMAGE_VERSIONS_STUB_FACTORY_H
 
-#include "google/cloud/composer/image_versions_connection.h"
 #include "google/cloud/composer/internal/image_versions_stub.h"
 #include "google/cloud/completion_queue.h"
 #include "google/cloud/credentials.h"

--- a/google/cloud/datamigration/internal/data_migration_stub_factory.cc
+++ b/google/cloud/datamigration/internal/data_migration_stub_factory.cc
@@ -26,6 +26,7 @@
 #include "google/cloud/internal/algorithm.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
+#include <google/cloud/clouddms/v1/clouddms.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/datamigration/internal/data_migration_stub_factory.h
+++ b/google/cloud/datamigration/internal/data_migration_stub_factory.h
@@ -19,7 +19,6 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_DATAMIGRATION_INTERNAL_DATA_MIGRATION_STUB_FACTORY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_DATAMIGRATION_INTERNAL_DATA_MIGRATION_STUB_FACTORY_H
 
-#include "google/cloud/datamigration/data_migration_connection.h"
 #include "google/cloud/datamigration/internal/data_migration_stub.h"
 #include "google/cloud/completion_queue.h"
 #include "google/cloud/credentials.h"

--- a/google/cloud/eventarc/internal/eventarc_stub_factory.cc
+++ b/google/cloud/eventarc/internal/eventarc_stub_factory.cc
@@ -26,6 +26,7 @@
 #include "google/cloud/internal/algorithm.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
+#include <google/cloud/eventarc/v1/eventarc.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/eventarc/internal/eventarc_stub_factory.h
+++ b/google/cloud/eventarc/internal/eventarc_stub_factory.h
@@ -19,7 +19,6 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_EVENTARC_INTERNAL_EVENTARC_STUB_FACTORY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_EVENTARC_INTERNAL_EVENTARC_STUB_FACTORY_H
 
-#include "google/cloud/eventarc/eventarc_connection.h"
 #include "google/cloud/eventarc/internal/eventarc_stub.h"
 #include "google/cloud/completion_queue.h"
 #include "google/cloud/credentials.h"

--- a/google/cloud/eventarc/internal/publisher_stub_factory.cc
+++ b/google/cloud/eventarc/internal/publisher_stub_factory.cc
@@ -26,6 +26,7 @@
 #include "google/cloud/internal/algorithm.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
+#include <google/cloud/eventarc/publishing/v1/publisher.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/eventarc/internal/publisher_stub_factory.h
+++ b/google/cloud/eventarc/internal/publisher_stub_factory.h
@@ -20,7 +20,6 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_EVENTARC_INTERNAL_PUBLISHER_STUB_FACTORY_H
 
 #include "google/cloud/eventarc/internal/publisher_stub.h"
-#include "google/cloud/eventarc/publisher_connection.h"
 #include "google/cloud/completion_queue.h"
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/unified_grpc_credentials.h"

--- a/google/cloud/iam/internal/iam_credentials_stub_factory.cc
+++ b/google/cloud/iam/internal/iam_credentials_stub_factory.cc
@@ -26,6 +26,7 @@
 #include "google/cloud/internal/algorithm.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
+#include <google/iam/credentials/v1/iamcredentials.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/iam/internal/iam_credentials_stub_factory.h
+++ b/google/cloud/iam/internal/iam_credentials_stub_factory.h
@@ -19,7 +19,6 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_IAM_INTERNAL_IAM_CREDENTIALS_STUB_FACTORY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_IAM_INTERNAL_IAM_CREDENTIALS_STUB_FACTORY_H
 
-#include "google/cloud/iam/iam_credentials_connection.h"
 #include "google/cloud/iam/internal/iam_credentials_stub.h"
 #include "google/cloud/completion_queue.h"
 #include "google/cloud/credentials.h"

--- a/google/cloud/iam/internal/iam_stub_factory.cc
+++ b/google/cloud/iam/internal/iam_stub_factory.cc
@@ -26,6 +26,7 @@
 #include "google/cloud/internal/algorithm.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
+#include <google/iam/admin/v1/iam.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/iam/internal/iam_stub_factory.h
+++ b/google/cloud/iam/internal/iam_stub_factory.h
@@ -19,7 +19,6 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_IAM_INTERNAL_IAM_STUB_FACTORY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_IAM_INTERNAL_IAM_STUB_FACTORY_H
 
-#include "google/cloud/iam/iam_connection.h"
 #include "google/cloud/iam/internal/iam_stub.h"
 #include "google/cloud/completion_queue.h"
 #include "google/cloud/credentials.h"

--- a/google/cloud/ids/internal/ids_stub_factory.cc
+++ b/google/cloud/ids/internal/ids_stub_factory.cc
@@ -26,6 +26,7 @@
 #include "google/cloud/internal/algorithm.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
+#include <google/cloud/ids/v1/ids.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/ids/internal/ids_stub_factory.h
+++ b/google/cloud/ids/internal/ids_stub_factory.h
@@ -19,7 +19,6 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_IDS_INTERNAL_IDS_STUB_FACTORY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_IDS_INTERNAL_IDS_STUB_FACTORY_H
 
-#include "google/cloud/ids/ids_connection.h"
 #include "google/cloud/ids/internal/ids_stub.h"
 #include "google/cloud/completion_queue.h"
 #include "google/cloud/credentials.h"

--- a/google/cloud/iot/internal/device_manager_stub_factory.cc
+++ b/google/cloud/iot/internal/device_manager_stub_factory.cc
@@ -26,6 +26,7 @@
 #include "google/cloud/internal/algorithm.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
+#include <google/cloud/iot/v1/device_manager.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/iot/internal/device_manager_stub_factory.h
+++ b/google/cloud/iot/internal/device_manager_stub_factory.h
@@ -19,7 +19,6 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_IOT_INTERNAL_DEVICE_MANAGER_STUB_FACTORY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_IOT_INTERNAL_DEVICE_MANAGER_STUB_FACTORY_H
 
-#include "google/cloud/iot/device_manager_connection.h"
 #include "google/cloud/iot/internal/device_manager_stub.h"
 #include "google/cloud/completion_queue.h"
 #include "google/cloud/credentials.h"

--- a/google/cloud/kms/internal/key_management_stub_factory.cc
+++ b/google/cloud/kms/internal/key_management_stub_factory.cc
@@ -26,6 +26,7 @@
 #include "google/cloud/internal/algorithm.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
+#include <google/cloud/kms/v1/service.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/kms/internal/key_management_stub_factory.h
+++ b/google/cloud/kms/internal/key_management_stub_factory.h
@@ -20,7 +20,6 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_KMS_INTERNAL_KEY_MANAGEMENT_STUB_FACTORY_H
 
 #include "google/cloud/kms/internal/key_management_stub.h"
-#include "google/cloud/kms/key_management_connection.h"
 #include "google/cloud/completion_queue.h"
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/unified_grpc_credentials.h"

--- a/google/cloud/logging/internal/logging_service_v2_stub_factory.cc
+++ b/google/cloud/logging/internal/logging_service_v2_stub_factory.cc
@@ -26,6 +26,7 @@
 #include "google/cloud/internal/algorithm.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
+#include <google/logging/v2/logging.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/logging/internal/logging_service_v2_stub_factory.h
+++ b/google/cloud/logging/internal/logging_service_v2_stub_factory.h
@@ -20,7 +20,6 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_LOGGING_INTERNAL_LOGGING_SERVICE_V2_STUB_FACTORY_H
 
 #include "google/cloud/logging/internal/logging_service_v2_stub.h"
-#include "google/cloud/logging/logging_service_v2_connection.h"
 #include "google/cloud/completion_queue.h"
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/unified_grpc_credentials.h"

--- a/google/cloud/oslogin/internal/os_login_stub_factory.cc
+++ b/google/cloud/oslogin/internal/os_login_stub_factory.cc
@@ -26,6 +26,7 @@
 #include "google/cloud/internal/algorithm.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
+#include <google/cloud/oslogin/v1/oslogin.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/oslogin/internal/os_login_stub_factory.h
+++ b/google/cloud/oslogin/internal/os_login_stub_factory.h
@@ -20,7 +20,6 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_OSLOGIN_INTERNAL_OS_LOGIN_STUB_FACTORY_H
 
 #include "google/cloud/oslogin/internal/os_login_stub.h"
-#include "google/cloud/oslogin/os_login_connection.h"
 #include "google/cloud/completion_queue.h"
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/unified_grpc_credentials.h"

--- a/google/cloud/pubsublite/internal/admin_stub_factory.cc
+++ b/google/cloud/pubsublite/internal/admin_stub_factory.cc
@@ -26,6 +26,7 @@
 #include "google/cloud/internal/algorithm.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
+#include <google/cloud/pubsublite/v1/admin.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/pubsublite/internal/admin_stub_factory.h
+++ b/google/cloud/pubsublite/internal/admin_stub_factory.h
@@ -19,7 +19,6 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PUBSUBLITE_INTERNAL_ADMIN_STUB_FACTORY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PUBSUBLITE_INTERNAL_ADMIN_STUB_FACTORY_H
 
-#include "google/cloud/pubsublite/admin_connection.h"
 #include "google/cloud/pubsublite/internal/admin_stub.h"
 #include "google/cloud/completion_queue.h"
 #include "google/cloud/credentials.h"

--- a/google/cloud/pubsublite/internal/topic_stats_stub_factory.cc
+++ b/google/cloud/pubsublite/internal/topic_stats_stub_factory.cc
@@ -26,6 +26,7 @@
 #include "google/cloud/internal/algorithm.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
+#include <google/cloud/pubsublite/v1/topic_stats.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/pubsublite/internal/topic_stats_stub_factory.h
+++ b/google/cloud/pubsublite/internal/topic_stats_stub_factory.h
@@ -20,7 +20,6 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PUBSUBLITE_INTERNAL_TOPIC_STATS_STUB_FACTORY_H
 
 #include "google/cloud/pubsublite/internal/topic_stats_stub.h"
-#include "google/cloud/pubsublite/topic_stats_connection.h"
 #include "google/cloud/completion_queue.h"
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/unified_grpc_credentials.h"

--- a/google/cloud/recommender/internal/recommender_stub_factory.cc
+++ b/google/cloud/recommender/internal/recommender_stub_factory.cc
@@ -26,6 +26,7 @@
 #include "google/cloud/internal/algorithm.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
+#include <google/cloud/recommender/v1/recommender_service.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/recommender/internal/recommender_stub_factory.h
+++ b/google/cloud/recommender/internal/recommender_stub_factory.h
@@ -20,7 +20,6 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_RECOMMENDER_INTERNAL_RECOMMENDER_STUB_FACTORY_H
 
 #include "google/cloud/recommender/internal/recommender_stub.h"
-#include "google/cloud/recommender/recommender_connection.h"
 #include "google/cloud/completion_queue.h"
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/unified_grpc_credentials.h"

--- a/google/cloud/resourcemanager/internal/folders_stub_factory.cc
+++ b/google/cloud/resourcemanager/internal/folders_stub_factory.cc
@@ -26,6 +26,7 @@
 #include "google/cloud/internal/algorithm.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
+#include <google/cloud/resourcemanager/v3/folders.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/resourcemanager/internal/folders_stub_factory.h
+++ b/google/cloud/resourcemanager/internal/folders_stub_factory.h
@@ -19,7 +19,6 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_RESOURCEMANAGER_INTERNAL_FOLDERS_STUB_FACTORY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_RESOURCEMANAGER_INTERNAL_FOLDERS_STUB_FACTORY_H
 
-#include "google/cloud/resourcemanager/folders_connection.h"
 #include "google/cloud/resourcemanager/internal/folders_stub.h"
 #include "google/cloud/completion_queue.h"
 #include "google/cloud/credentials.h"

--- a/google/cloud/resourcemanager/internal/org_policy_stub_factory.cc
+++ b/google/cloud/resourcemanager/internal/org_policy_stub_factory.cc
@@ -26,6 +26,7 @@
 #include "google/cloud/internal/algorithm.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
+#include <google/cloud/orgpolicy/v2/orgpolicy.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/resourcemanager/internal/org_policy_stub_factory.h
+++ b/google/cloud/resourcemanager/internal/org_policy_stub_factory.h
@@ -20,7 +20,6 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_RESOURCEMANAGER_INTERNAL_ORG_POLICY_STUB_FACTORY_H
 
 #include "google/cloud/resourcemanager/internal/org_policy_stub.h"
-#include "google/cloud/resourcemanager/org_policy_connection.h"
 #include "google/cloud/completion_queue.h"
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/unified_grpc_credentials.h"

--- a/google/cloud/resourcemanager/internal/organizations_stub_factory.cc
+++ b/google/cloud/resourcemanager/internal/organizations_stub_factory.cc
@@ -26,6 +26,7 @@
 #include "google/cloud/internal/algorithm.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
+#include <google/cloud/resourcemanager/v3/organizations.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/resourcemanager/internal/organizations_stub_factory.h
+++ b/google/cloud/resourcemanager/internal/organizations_stub_factory.h
@@ -20,7 +20,6 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_RESOURCEMANAGER_INTERNAL_ORGANIZATIONS_STUB_FACTORY_H
 
 #include "google/cloud/resourcemanager/internal/organizations_stub.h"
-#include "google/cloud/resourcemanager/organizations_connection.h"
 #include "google/cloud/completion_queue.h"
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/unified_grpc_credentials.h"

--- a/google/cloud/resourcemanager/internal/projects_stub_factory.cc
+++ b/google/cloud/resourcemanager/internal/projects_stub_factory.cc
@@ -26,6 +26,7 @@
 #include "google/cloud/internal/algorithm.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
+#include <google/cloud/resourcemanager/v3/projects.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/resourcemanager/internal/projects_stub_factory.h
+++ b/google/cloud/resourcemanager/internal/projects_stub_factory.h
@@ -20,7 +20,6 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_RESOURCEMANAGER_INTERNAL_PROJECTS_STUB_FACTORY_H
 
 #include "google/cloud/resourcemanager/internal/projects_stub.h"
-#include "google/cloud/resourcemanager/projects_connection.h"
 #include "google/cloud/completion_queue.h"
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/unified_grpc_credentials.h"

--- a/google/cloud/scheduler/internal/cloud_scheduler_stub_factory.cc
+++ b/google/cloud/scheduler/internal/cloud_scheduler_stub_factory.cc
@@ -26,6 +26,7 @@
 #include "google/cloud/internal/algorithm.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
+#include <google/cloud/scheduler/v1/cloudscheduler.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/scheduler/internal/cloud_scheduler_stub_factory.h
+++ b/google/cloud/scheduler/internal/cloud_scheduler_stub_factory.h
@@ -19,7 +19,6 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SCHEDULER_INTERNAL_CLOUD_SCHEDULER_STUB_FACTORY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SCHEDULER_INTERNAL_CLOUD_SCHEDULER_STUB_FACTORY_H
 
-#include "google/cloud/scheduler/cloud_scheduler_connection.h"
 #include "google/cloud/scheduler/internal/cloud_scheduler_stub.h"
 #include "google/cloud/completion_queue.h"
 #include "google/cloud/credentials.h"

--- a/google/cloud/secretmanager/internal/secret_manager_stub_factory.cc
+++ b/google/cloud/secretmanager/internal/secret_manager_stub_factory.cc
@@ -26,6 +26,7 @@
 #include "google/cloud/internal/algorithm.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
+#include <google/cloud/secretmanager/v1/service.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/secretmanager/internal/secret_manager_stub_factory.h
+++ b/google/cloud/secretmanager/internal/secret_manager_stub_factory.h
@@ -20,7 +20,6 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SECRETMANAGER_INTERNAL_SECRET_MANAGER_STUB_FACTORY_H
 
 #include "google/cloud/secretmanager/internal/secret_manager_stub.h"
-#include "google/cloud/secretmanager/secret_manager_connection.h"
 #include "google/cloud/completion_queue.h"
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/unified_grpc_credentials.h"

--- a/google/cloud/shell/internal/cloud_shell_stub_factory.cc
+++ b/google/cloud/shell/internal/cloud_shell_stub_factory.cc
@@ -26,6 +26,7 @@
 #include "google/cloud/internal/algorithm.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
+#include <google/cloud/shell/v1/cloudshell.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/shell/internal/cloud_shell_stub_factory.h
+++ b/google/cloud/shell/internal/cloud_shell_stub_factory.h
@@ -19,7 +19,6 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SHELL_INTERNAL_CLOUD_SHELL_STUB_FACTORY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SHELL_INTERNAL_CLOUD_SHELL_STUB_FACTORY_H
 
-#include "google/cloud/shell/cloud_shell_connection.h"
 #include "google/cloud/shell/internal/cloud_shell_stub.h"
 #include "google/cloud/completion_queue.h"
 #include "google/cloud/credentials.h"

--- a/google/cloud/spanner/admin/internal/database_admin_stub_factory.cc
+++ b/google/cloud/spanner/admin/internal/database_admin_stub_factory.cc
@@ -26,6 +26,7 @@
 #include "google/cloud/internal/algorithm.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
+#include <google/spanner/admin/database/v1/spanner_database_admin.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/spanner/admin/internal/database_admin_stub_factory.h
+++ b/google/cloud/spanner/admin/internal/database_admin_stub_factory.h
@@ -19,7 +19,6 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_ADMIN_INTERNAL_DATABASE_ADMIN_STUB_FACTORY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_ADMIN_INTERNAL_DATABASE_ADMIN_STUB_FACTORY_H
 
-#include "google/cloud/spanner/admin/database_admin_connection.h"
 #include "google/cloud/spanner/admin/internal/database_admin_stub.h"
 #include "google/cloud/completion_queue.h"
 #include "google/cloud/credentials.h"

--- a/google/cloud/spanner/admin/internal/instance_admin_stub_factory.cc
+++ b/google/cloud/spanner/admin/internal/instance_admin_stub_factory.cc
@@ -26,6 +26,7 @@
 #include "google/cloud/internal/algorithm.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
+#include <google/spanner/admin/instance/v1/spanner_instance_admin.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/spanner/admin/internal/instance_admin_stub_factory.h
+++ b/google/cloud/spanner/admin/internal/instance_admin_stub_factory.h
@@ -19,7 +19,6 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_ADMIN_INTERNAL_INSTANCE_ADMIN_STUB_FACTORY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_ADMIN_INTERNAL_INSTANCE_ADMIN_STUB_FACTORY_H
 
-#include "google/cloud/spanner/admin/instance_admin_connection.h"
 #include "google/cloud/spanner/admin/internal/instance_admin_stub.h"
 #include "google/cloud/completion_queue.h"
 #include "google/cloud/credentials.h"

--- a/google/cloud/storagetransfer/internal/storage_transfer_stub_factory.cc
+++ b/google/cloud/storagetransfer/internal/storage_transfer_stub_factory.cc
@@ -26,6 +26,7 @@
 #include "google/cloud/internal/algorithm.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
+#include <google/storagetransfer/v1/transfer.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/storagetransfer/internal/storage_transfer_stub_factory.h
+++ b/google/cloud/storagetransfer/internal/storage_transfer_stub_factory.h
@@ -20,7 +20,6 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGETRANSFER_INTERNAL_STORAGE_TRANSFER_STUB_FACTORY_H
 
 #include "google/cloud/storagetransfer/internal/storage_transfer_stub.h"
-#include "google/cloud/storagetransfer/storage_transfer_connection.h"
 #include "google/cloud/completion_queue.h"
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/unified_grpc_credentials.h"

--- a/google/cloud/talent/internal/company_stub_factory.cc
+++ b/google/cloud/talent/internal/company_stub_factory.cc
@@ -26,6 +26,7 @@
 #include "google/cloud/internal/algorithm.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
+#include <google/cloud/talent/v4/company_service.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/talent/internal/company_stub_factory.h
+++ b/google/cloud/talent/internal/company_stub_factory.h
@@ -19,7 +19,6 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_TALENT_INTERNAL_COMPANY_STUB_FACTORY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_TALENT_INTERNAL_COMPANY_STUB_FACTORY_H
 
-#include "google/cloud/talent/company_connection.h"
 #include "google/cloud/talent/internal/company_stub.h"
 #include "google/cloud/completion_queue.h"
 #include "google/cloud/credentials.h"

--- a/google/cloud/talent/internal/completion_stub_factory.cc
+++ b/google/cloud/talent/internal/completion_stub_factory.cc
@@ -26,6 +26,7 @@
 #include "google/cloud/internal/algorithm.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
+#include <google/cloud/talent/v4/completion_service.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/talent/internal/completion_stub_factory.h
+++ b/google/cloud/talent/internal/completion_stub_factory.h
@@ -19,7 +19,6 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_TALENT_INTERNAL_COMPLETION_STUB_FACTORY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_TALENT_INTERNAL_COMPLETION_STUB_FACTORY_H
 
-#include "google/cloud/talent/completion_connection.h"
 #include "google/cloud/talent/internal/completion_stub.h"
 #include "google/cloud/completion_queue.h"
 #include "google/cloud/credentials.h"

--- a/google/cloud/talent/internal/event_stub_factory.cc
+++ b/google/cloud/talent/internal/event_stub_factory.cc
@@ -26,6 +26,7 @@
 #include "google/cloud/internal/algorithm.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
+#include <google/cloud/talent/v4/event_service.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/talent/internal/event_stub_factory.h
+++ b/google/cloud/talent/internal/event_stub_factory.h
@@ -19,7 +19,6 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_TALENT_INTERNAL_EVENT_STUB_FACTORY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_TALENT_INTERNAL_EVENT_STUB_FACTORY_H
 
-#include "google/cloud/talent/event_connection.h"
 #include "google/cloud/talent/internal/event_stub.h"
 #include "google/cloud/completion_queue.h"
 #include "google/cloud/credentials.h"

--- a/google/cloud/talent/internal/job_stub_factory.cc
+++ b/google/cloud/talent/internal/job_stub_factory.cc
@@ -26,6 +26,7 @@
 #include "google/cloud/internal/algorithm.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
+#include <google/cloud/talent/v4/job_service.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/talent/internal/job_stub_factory.h
+++ b/google/cloud/talent/internal/job_stub_factory.h
@@ -20,7 +20,6 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_TALENT_INTERNAL_JOB_STUB_FACTORY_H
 
 #include "google/cloud/talent/internal/job_stub.h"
-#include "google/cloud/talent/job_connection.h"
 #include "google/cloud/completion_queue.h"
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/unified_grpc_credentials.h"

--- a/google/cloud/talent/internal/tenant_stub_factory.cc
+++ b/google/cloud/talent/internal/tenant_stub_factory.cc
@@ -26,6 +26,7 @@
 #include "google/cloud/internal/algorithm.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
+#include <google/cloud/talent/v4/tenant_service.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/talent/internal/tenant_stub_factory.h
+++ b/google/cloud/talent/internal/tenant_stub_factory.h
@@ -20,7 +20,6 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_TALENT_INTERNAL_TENANT_STUB_FACTORY_H
 
 #include "google/cloud/talent/internal/tenant_stub.h"
-#include "google/cloud/talent/tenant_connection.h"
 #include "google/cloud/completion_queue.h"
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/unified_grpc_credentials.h"

--- a/google/cloud/tasks/internal/cloud_tasks_stub_factory.cc
+++ b/google/cloud/tasks/internal/cloud_tasks_stub_factory.cc
@@ -26,6 +26,7 @@
 #include "google/cloud/internal/algorithm.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
+#include <google/cloud/tasks/v2/cloudtasks.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/tasks/internal/cloud_tasks_stub_factory.h
+++ b/google/cloud/tasks/internal/cloud_tasks_stub_factory.h
@@ -19,7 +19,6 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_TASKS_INTERNAL_CLOUD_TASKS_STUB_FACTORY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_TASKS_INTERNAL_CLOUD_TASKS_STUB_FACTORY_H
 
-#include "google/cloud/tasks/cloud_tasks_connection.h"
 #include "google/cloud/tasks/internal/cloud_tasks_stub.h"
 #include "google/cloud/completion_queue.h"
 #include "google/cloud/credentials.h"

--- a/google/cloud/videointelligence/internal/video_intelligence_stub_factory.cc
+++ b/google/cloud/videointelligence/internal/video_intelligence_stub_factory.cc
@@ -26,6 +26,7 @@
 #include "google/cloud/internal/algorithm.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
+#include <google/cloud/videointelligence/v1/video_intelligence.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/videointelligence/internal/video_intelligence_stub_factory.h
+++ b/google/cloud/videointelligence/internal/video_intelligence_stub_factory.h
@@ -20,7 +20,6 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_VIDEOINTELLIGENCE_INTERNAL_VIDEO_INTELLIGENCE_STUB_FACTORY_H
 
 #include "google/cloud/videointelligence/internal/video_intelligence_stub.h"
-#include "google/cloud/videointelligence/video_intelligence_connection.h"
 #include "google/cloud/completion_queue.h"
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/unified_grpc_credentials.h"

--- a/google/cloud/vision/internal/image_annotator_stub_factory.cc
+++ b/google/cloud/vision/internal/image_annotator_stub_factory.cc
@@ -26,6 +26,7 @@
 #include "google/cloud/internal/algorithm.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
+#include <google/cloud/vision/v1/image_annotator.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/vision/internal/image_annotator_stub_factory.h
+++ b/google/cloud/vision/internal/image_annotator_stub_factory.h
@@ -19,7 +19,6 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_VISION_INTERNAL_IMAGE_ANNOTATOR_STUB_FACTORY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_VISION_INTERNAL_IMAGE_ANNOTATOR_STUB_FACTORY_H
 
-#include "google/cloud/vision/image_annotator_connection.h"
 #include "google/cloud/vision/internal/image_annotator_stub.h"
 #include "google/cloud/completion_queue.h"
 #include "google/cloud/credentials.h"

--- a/google/cloud/vision/internal/product_search_stub_factory.cc
+++ b/google/cloud/vision/internal/product_search_stub_factory.cc
@@ -26,6 +26,7 @@
 #include "google/cloud/internal/algorithm.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
+#include <google/cloud/vision/v1/product_search_service.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/vision/internal/product_search_stub_factory.h
+++ b/google/cloud/vision/internal/product_search_stub_factory.h
@@ -20,7 +20,6 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_VISION_INTERNAL_PRODUCT_SEARCH_STUB_FACTORY_H
 
 #include "google/cloud/vision/internal/product_search_stub.h"
-#include "google/cloud/vision/product_search_connection.h"
 #include "google/cloud/completion_queue.h"
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/unified_grpc_credentials.h"

--- a/google/cloud/vmmigration/internal/vm_migration_stub_factory.cc
+++ b/google/cloud/vmmigration/internal/vm_migration_stub_factory.cc
@@ -26,6 +26,7 @@
 #include "google/cloud/internal/algorithm.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
+#include <google/cloud/vmmigration/v1/vmmigration.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/vmmigration/internal/vm_migration_stub_factory.h
+++ b/google/cloud/vmmigration/internal/vm_migration_stub_factory.h
@@ -20,7 +20,6 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_VMMIGRATION_INTERNAL_VM_MIGRATION_STUB_FACTORY_H
 
 #include "google/cloud/vmmigration/internal/vm_migration_stub.h"
-#include "google/cloud/vmmigration/vm_migration_connection.h"
 #include "google/cloud/completion_queue.h"
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/unified_grpc_credentials.h"

--- a/google/cloud/vpcaccess/internal/vpc_access_stub_factory.cc
+++ b/google/cloud/vpcaccess/internal/vpc_access_stub_factory.cc
@@ -26,6 +26,7 @@
 #include "google/cloud/internal/algorithm.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
+#include <google/cloud/vpcaccess/v1/vpc_access.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/vpcaccess/internal/vpc_access_stub_factory.h
+++ b/google/cloud/vpcaccess/internal/vpc_access_stub_factory.h
@@ -20,7 +20,6 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_VPCACCESS_INTERNAL_VPC_ACCESS_STUB_FACTORY_H
 
 #include "google/cloud/vpcaccess/internal/vpc_access_stub.h"
-#include "google/cloud/vpcaccess/vpc_access_connection.h"
 #include "google/cloud/completion_queue.h"
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/unified_grpc_credentials.h"

--- a/google/cloud/webrisk/internal/web_risk_stub_factory.cc
+++ b/google/cloud/webrisk/internal/web_risk_stub_factory.cc
@@ -26,6 +26,7 @@
 #include "google/cloud/internal/algorithm.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
+#include <google/cloud/webrisk/v1/webrisk.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/webrisk/internal/web_risk_stub_factory.h
+++ b/google/cloud/webrisk/internal/web_risk_stub_factory.h
@@ -20,7 +20,6 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_WEBRISK_INTERNAL_WEB_RISK_STUB_FACTORY_H
 
 #include "google/cloud/webrisk/internal/web_risk_stub.h"
-#include "google/cloud/webrisk/web_risk_connection.h"
 #include "google/cloud/completion_queue.h"
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/unified_grpc_credentials.h"

--- a/google/cloud/websecurityscanner/internal/web_security_scanner_stub_factory.cc
+++ b/google/cloud/websecurityscanner/internal/web_security_scanner_stub_factory.cc
@@ -26,6 +26,7 @@
 #include "google/cloud/internal/algorithm.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
+#include <google/cloud/websecurityscanner/v1/web_security_scanner.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/websecurityscanner/internal/web_security_scanner_stub_factory.h
+++ b/google/cloud/websecurityscanner/internal/web_security_scanner_stub_factory.h
@@ -20,7 +20,6 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_WEBSECURITYSCANNER_INTERNAL_WEB_SECURITY_SCANNER_STUB_FACTORY_H
 
 #include "google/cloud/websecurityscanner/internal/web_security_scanner_stub.h"
-#include "google/cloud/websecurityscanner/web_security_scanner_connection.h"
 #include "google/cloud/completion_queue.h"
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/unified_grpc_credentials.h"

--- a/google/cloud/workflows/internal/executions_stub_factory.cc
+++ b/google/cloud/workflows/internal/executions_stub_factory.cc
@@ -26,6 +26,7 @@
 #include "google/cloud/internal/algorithm.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
+#include <google/cloud/workflows/executions/v1/executions.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/workflows/internal/executions_stub_factory.h
+++ b/google/cloud/workflows/internal/executions_stub_factory.h
@@ -19,7 +19,6 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_WORKFLOWS_INTERNAL_EXECUTIONS_STUB_FACTORY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_WORKFLOWS_INTERNAL_EXECUTIONS_STUB_FACTORY_H
 
-#include "google/cloud/workflows/executions_connection.h"
 #include "google/cloud/workflows/internal/executions_stub.h"
 #include "google/cloud/completion_queue.h"
 #include "google/cloud/credentials.h"

--- a/google/cloud/workflows/internal/workflows_stub_factory.cc
+++ b/google/cloud/workflows/internal/workflows_stub_factory.cc
@@ -26,6 +26,7 @@
 #include "google/cloud/internal/algorithm.h"
 #include "google/cloud/log.h"
 #include "google/cloud/options.h"
+#include <google/cloud/workflows/v1/workflows.grpc.pb.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/workflows/internal/workflows_stub_factory.h
+++ b/google/cloud/workflows/internal/workflows_stub_factory.h
@@ -20,7 +20,6 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_WORKFLOWS_INTERNAL_WORKFLOWS_STUB_FACTORY_H
 
 #include "google/cloud/workflows/internal/workflows_stub.h"
-#include "google/cloud/workflows/workflows_connection.h"
 #include "google/cloud/completion_queue.h"
 #include "google/cloud/credentials.h"
 #include "google/cloud/internal/unified_grpc_credentials.h"


### PR DESCRIPTION
I missed this in #7965.  The only commit with manual changes is the first one.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7969)
<!-- Reviewable:end -->
