### PR TITLE
feat(generator): add option to omit Stub factory

### DIFF
--- a/generator/generator_config.proto
+++ b/generator/generator_config.proto
@@ -70,6 +70,12 @@ message ServiceConfiguration {
   // file, add them using this field. This typically happens when an annotation
   // lists a type that is not defined in any of the imported proto files.
   repeated string additional_proto_files = 12;
+
+  // If set, the factory function for the `*Stub` class and its decorators is
+  // not generated. This is useful if the library requires a custom set of
+  // decorators, for example, Storage requires a round-robin decorator to get
+  // good performance.
+  bool omit_stub_factory = 14;
 }
 
 message GeneratorConfiguration {

--- a/generator/internal/codegen_utils_test.cc
+++ b/generator/internal/codegen_utils_test.cc
@@ -304,6 +304,14 @@ TEST(ProcessCommandLineArgs, ProcessOmitConnection) {
   EXPECT_THAT(*result, Contains(Pair("omit_connection", "true")));
 }
 
+TEST(ProcessCommandLineArgs, ProcessOmitStubFactory) {
+  auto result = ProcessCommandLineArgs(
+      "product_path=google/cloud/spanner/"
+      ",omit_stub_factory=true");
+  ASSERT_THAT(result, IsOk());
+  EXPECT_THAT(*result, Contains(Pair("omit_stub_factory", "true")));
+}
+
 }  // namespace
 }  // namespace generator_internal
 }  // namespace cloud

--- a/generator/internal/descriptor_utils.cc
+++ b/generator/internal/descriptor_utils.cc
@@ -683,6 +683,13 @@ std::vector<std::unique_ptr<GeneratorInterface>> MakeGenerators(
           context));
     }
   }
+  auto const omit_stub_factory = service_vars.find("omit_stub_factory");
+  if (omit_stub_factory == service_vars.end() ||
+      omit_stub_factory->second != "true") {
+    code_generators.push_back(absl::make_unique<StubFactoryGenerator>(
+        service, service_vars, CreateMethodVars(*service, service_vars),
+        context));
+  }
   code_generators.push_back(absl::make_unique<AuthDecoratorGenerator>(
       service, service_vars, CreateMethodVars(*service, service_vars),
       context));
@@ -693,9 +700,6 @@ std::vector<std::unique_ptr<GeneratorInterface>> MakeGenerators(
       service, service_vars, CreateMethodVars(*service, service_vars),
       context));
   code_generators.push_back(absl::make_unique<StubGenerator>(
-      service, service_vars, CreateMethodVars(*service, service_vars),
-      context));
-  code_generators.push_back(absl::make_unique<StubFactoryGenerator>(
       service, service_vars, CreateMethodVars(*service, service_vars),
       context));
   return code_generators;

--- a/generator/standalone_main.cc
+++ b/generator/standalone_main.cc
@@ -215,6 +215,9 @@ int main(int argc, char** argv) {
     if (service.omit_connection()) {
       args.emplace_back("--cpp_codegen_opt=omit_connection=true");
     }
+    if (service.omit_stub_factory()) {
+      args.emplace_back("--cpp_codegen_opt=omit_stub_factory=true");
+    }
     args.emplace_back("--cpp_codegen_opt=service_endpoint_env_var=" +
                       service.service_endpoint_env_var());
     args.emplace_back("--cpp_codegen_opt=emulator_endpoint_env_var=" +


### PR DESCRIPTION
Part of the work for #7963.  I am planning to generate as much of the code in GCS+gRPC as possible, but
the stub factory needs to be completely custom.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7979)
<!-- Reviewable:end -->
