### PR TITLE
ci: speedup generate-libraries build

### DIFF
--- a/ci/cloudbuild/builds/generate-libraries.sh
+++ b/ci/cloudbuild/builds/generate-libraries.sh
@@ -33,13 +33,8 @@ bazel run --action_env=GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes \
 # TODO(#5821): The generator should run clang-format on its output files itself
 # so we don't need this extra step.
 io::log_h2 "Formatting generated code"
-find google/cloud -path google/cloud/examples -prune -o \
-  -path google/cloud/grpc_utils -prune -o \
-  -path google/cloud/internal -prune -o \
-  -path google/cloud/pubsub -prune -o \
-  -path google/cloud/storage -prune -o \
-  -path google/cloud/testing_util -prune -o \
-  \( -name '*.cc' -o -name '*.h' \) -exec clang-format -i {} \;
+git ls-files -z | grep -zE '\.(cc|h)$' |
+  xargs -P "$(nproc)" -n 1 -0 clang-format -i
 
 # This build should fail if any generated files differ from what was checked
 # in. We only look in the google/ directory so that the build doesn't fail if


### PR DESCRIPTION
I find myself running this manually more often these days, and the formatting slowness was bothering me.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/7995)
<!-- Reviewable:end -->
