### PR TITLE
refactor(GCS+gRPC): move stubs to `storage_internal`

### DIFF
--- a/google/cloud/storage/CMakeLists.txt
+++ b/google/cloud/storage/CMakeLists.txt
@@ -22,7 +22,8 @@ set(DOXYGEN_PROJECT_BRIEF "A C++ Client Library for Google Cloud Storage")
 set(DOXYGEN_PROJECT_NUMBER "${PROJECT_VERSION}")
 set(DOXYGEN_EXAMPLE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/examples"
                          "${CMAKE_CURRENT_SOURCE_DIR}/quickstart")
-set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "storage_benchmarks" "examples")
+set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "storage_benchmarks" "storage_internal"
+                            "examples")
 
 # Creates the proto headers needed by doxygen.
 set(GOOGLE_CLOUD_CPP_DOXYGEN_DEPS google-cloud-cpp::storage_protos)

--- a/google/cloud/storage/internal/grpc_client.cc
+++ b/google/cloud/storage/internal/grpc_client.cc
@@ -77,7 +77,7 @@ std::shared_ptr<GrpcClient> GrpcClient::Create(Options opts) {
 }
 
 std::shared_ptr<GrpcClient> GrpcClient::CreateMock(
-    std::shared_ptr<StorageStub> stub, Options opts) {
+    std::shared_ptr<storage_internal::StorageStub> stub, Options opts) {
   return std::shared_ptr<GrpcClient>(
       new GrpcClient(std::move(stub), DefaultOptionsGrpc(std::move(opts))));
 }
@@ -87,9 +87,10 @@ GrpcClient::GrpcClient(Options opts)
       backwards_compatibility_options_(
           MakeBackwardsCompatibleClientOptions(options_)),
       background_(MakeBackgroundThreadsFactory(options_)()),
-      stub_(CreateStorageStub(background_->cq(), options_)) {}
+      stub_(storage_internal::CreateStorageStub(background_->cq(), options_)) {}
 
-GrpcClient::GrpcClient(std::shared_ptr<StorageStub> stub, Options opts)
+GrpcClient::GrpcClient(std::shared_ptr<storage_internal::StorageStub> stub,
+                       Options opts)
     : options_(std::move(opts)),
       backwards_compatibility_options_(
           MakeBackwardsCompatibleClientOptions(options_)),

--- a/google/cloud/storage/internal/grpc_client.h
+++ b/google/cloud/storage/internal/grpc_client.h
@@ -25,6 +25,13 @@
 
 namespace google {
 namespace cloud {
+
+namespace storage_internal {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+class StorageStub;
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace storage_internal
+
 namespace storage {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace internal {
@@ -36,8 +43,6 @@ namespace internal {
  */
 Options DefaultOptionsGrpc(Options = {});
 
-class StorageStub;
-
 class GrpcClient : public RawClient,
                    public std::enable_shared_from_this<GrpcClient> {
  public:
@@ -46,7 +51,7 @@ class GrpcClient : public RawClient,
 
   // This is used to create a client from a mocked StorageStub.
   static std::shared_ptr<GrpcClient> CreateMock(
-      std::shared_ptr<StorageStub> stub, Options opts = {});
+      std::shared_ptr<storage_internal::StorageStub> stub, Options opts = {});
 
   ~GrpcClient() override = default;
 
@@ -183,13 +188,14 @@ class GrpcClient : public RawClient,
 
  protected:
   explicit GrpcClient(Options opts);
-  explicit GrpcClient(std::shared_ptr<StorageStub> stub, Options opts);
+  explicit GrpcClient(std::shared_ptr<storage_internal::StorageStub> stub,
+                      Options opts);
 
  private:
   Options options_;
   ClientOptions backwards_compatibility_options_;
   std::unique_ptr<google::cloud::BackgroundThreads> background_;
-  std::shared_ptr<StorageStub> stub_;
+  std::shared_ptr<google::cloud::storage_internal::StorageStub> stub_;
 };
 
 }  // namespace internal

--- a/google/cloud/storage/internal/grpc_client.h
+++ b/google/cloud/storage/internal/grpc_client.h
@@ -195,7 +195,7 @@ class GrpcClient : public RawClient,
   Options options_;
   ClientOptions backwards_compatibility_options_;
   std::unique_ptr<google::cloud::BackgroundThreads> background_;
-  std::shared_ptr<google::cloud::storage_internal::StorageStub> stub_;
+  std::shared_ptr<storage_internal::StorageStub> stub_;
 };
 
 }  // namespace internal

--- a/google/cloud/storage/internal/storage_auth_decorator.cc
+++ b/google/cloud/storage/internal/storage_auth_decorator.cc
@@ -16,9 +16,8 @@
 
 namespace google {
 namespace cloud {
-namespace storage {
+namespace storage_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
-namespace internal {
 
 std::unique_ptr<google::cloud::internal::StreamingReadRpc<
     google::storage::v2::ReadObjectResponse>>
@@ -61,8 +60,7 @@ StorageAuth::QueryWriteStatus(
   return child_->QueryWriteStatus(context, request);
 }
 
-}  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-}  // namespace storage
+}  // namespace storage_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/storage/internal/storage_auth_decorator.h
+++ b/google/cloud/storage/internal/storage_auth_decorator.h
@@ -21,9 +21,8 @@
 
 namespace google {
 namespace cloud {
-namespace storage {
+namespace storage_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
-namespace internal {
 
 class StorageAuth : public StorageStub {
  public:
@@ -56,9 +55,8 @@ class StorageAuth : public StorageStub {
   std::shared_ptr<StorageStub> child_;
 };
 
-}  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-}  // namespace storage
+}  // namespace storage_internal
 }  // namespace cloud
 }  // namespace google
 

--- a/google/cloud/storage/internal/storage_auth_decorator_test.cc
+++ b/google/cloud/storage/internal/storage_auth_decorator_test.cc
@@ -20,9 +20,8 @@
 
 namespace google {
 namespace cloud {
-namespace storage {
+namespace storage_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
-namespace internal {
 namespace {
 
 using ::google::cloud::storage::testing::MockStorageStub;
@@ -128,8 +127,7 @@ TEST(StorageAuthTest, QueryWriteStatus) {
 }
 
 }  // namespace
-}  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-}  // namespace storage
+}  // namespace storage_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/storage/internal/storage_logging_decorator.cc
+++ b/google/cloud/storage/internal/storage_logging_decorator.cc
@@ -22,9 +22,8 @@
 
 namespace google {
 namespace cloud {
-namespace storage {
+namespace storage_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
-namespace internal {
 
 StorageLogging::StorageLogging(std::shared_ptr<StorageStub> child,
                                TracingOptions tracing_options,
@@ -98,8 +97,7 @@ StorageLogging::QueryWriteStatus(
       context, request, __func__, tracing_options_);
 }
 
-}  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-}  // namespace storage
+}  // namespace storage_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/storage/internal/storage_logging_decorator.h
+++ b/google/cloud/storage/internal/storage_logging_decorator.h
@@ -24,9 +24,8 @@
 
 namespace google {
 namespace cloud {
-namespace storage {
+namespace storage_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
-namespace internal {
 
 class StorageLogging : public StorageStub {
  public:
@@ -60,9 +59,8 @@ class StorageLogging : public StorageStub {
   std::set<std::string> components_;
 };  // StorageLogging
 
-}  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-}  // namespace storage
+}  // namespace storage_internal
 }  // namespace cloud
 }  // namespace google
 

--- a/google/cloud/storage/internal/storage_metadata_decorator.cc
+++ b/google/cloud/storage/internal/storage_metadata_decorator.cc
@@ -20,9 +20,8 @@
 
 namespace google {
 namespace cloud {
-namespace storage {
+namespace storage_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
-namespace internal {
 
 StorageMetadata::StorageMetadata(std::shared_ptr<StorageStub> child)
     : child_(std::move(child)),
@@ -68,8 +67,7 @@ void StorageMetadata::SetMetadata(grpc::ClientContext& context,
   context.AddMetadata("x-goog-api-client", api_client_header_);
 }
 
-}  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-}  // namespace storage
+}  // namespace storage_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/storage/internal/storage_metadata_decorator.h
+++ b/google/cloud/storage/internal/storage_metadata_decorator.h
@@ -22,9 +22,8 @@
 
 namespace google {
 namespace cloud {
-namespace storage {
+namespace storage_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
-namespace internal {
 
 class StorageMetadata : public StorageStub {
  public:
@@ -57,9 +56,8 @@ class StorageMetadata : public StorageStub {
   std::string api_client_header_;
 };  // StorageMetadata
 
-}  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-}  // namespace storage
+}  // namespace storage_internal
 }  // namespace cloud
 }  // namespace google
 

--- a/google/cloud/storage/internal/storage_round_robin.cc
+++ b/google/cloud/storage/internal/storage_round_robin.cc
@@ -16,9 +16,8 @@
 
 namespace google {
 namespace cloud {
-namespace storage {
+namespace storage_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
-namespace internal {
 
 std::unique_ptr<google::cloud::internal::StreamingReadRpc<
     google::storage::v2::ReadObjectResponse>>
@@ -56,8 +55,7 @@ std::shared_ptr<StorageStub> StorageRoundRobin::Child() {
   return child;
 }
 
-}  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-}  // namespace storage
+}  // namespace storage_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/storage/internal/storage_round_robin.h
+++ b/google/cloud/storage/internal/storage_round_robin.h
@@ -22,9 +22,8 @@
 
 namespace google {
 namespace cloud {
-namespace storage {
+namespace storage_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
-namespace internal {
 
 class StorageRoundRobin : public StorageStub {
  public:
@@ -58,9 +57,8 @@ class StorageRoundRobin : public StorageStub {
   std::size_t current_ = 0;
 };
 
-}  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-}  // namespace storage
+}  // namespace storage_internal
 }  // namespace cloud
 }  // namespace google
 

--- a/google/cloud/storage/internal/storage_round_robin_test.cc
+++ b/google/cloud/storage/internal/storage_round_robin_test.cc
@@ -20,9 +20,8 @@
 
 namespace google {
 namespace cloud {
-namespace storage {
+namespace storage_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
-namespace internal {
 namespace {
 
 using ::google::cloud::storage::testing::MockStorageStub;
@@ -148,8 +147,7 @@ TEST(StorageRoundRobinTest, QueryWriteStatus) {
 }
 
 }  // namespace
-}  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-}  // namespace storage
+}  // namespace storage_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/storage/internal/storage_stub.cc
+++ b/google/cloud/storage/internal/storage_stub.cc
@@ -20,9 +20,8 @@
 
 namespace google {
 namespace cloud {
-namespace storage {
+namespace storage_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
-namespace internal {
 
 std::unique_ptr<google::cloud::internal::StreamingReadRpc<
     google::storage::v2::ReadObjectResponse>>
@@ -69,8 +68,7 @@ DefaultStorageStub::QueryWriteStatus(
   return response;
 }
 
-}  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-}  // namespace storage
+}  // namespace storage_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/storage/internal/storage_stub.h
+++ b/google/cloud/storage/internal/storage_stub.h
@@ -24,9 +24,8 @@
 
 namespace google {
 namespace cloud {
-namespace storage {
+namespace storage_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
-namespace internal {
 
 class StorageStub {
  public:
@@ -81,9 +80,8 @@ class DefaultStorageStub : public StorageStub {
   std::unique_ptr<google::storage::v2::Storage::StubInterface> grpc_stub_;
 };
 
-}  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-}  // namespace storage
+}  // namespace storage_internal
 }  // namespace cloud
 }  // namespace google
 

--- a/google/cloud/storage/internal/storage_stub_factory.cc
+++ b/google/cloud/storage/internal/storage_stub_factory.cc
@@ -27,10 +27,10 @@
 
 namespace google {
 namespace cloud {
-namespace storage {
+namespace storage_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
-namespace internal {
 namespace {
+
 auto constexpr kDirectPathConfig = R"json({
     "loadBalancingConfig": [{
       "grpclb": {
@@ -123,8 +123,7 @@ std::shared_ptr<StorageStub> CreateStorageStub(
       });
 }
 
-}  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-}  // namespace storage
+}  // namespace storage_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/storage/internal/storage_stub_factory.h
+++ b/google/cloud/storage/internal/storage_stub_factory.h
@@ -24,9 +24,8 @@
 
 namespace google {
 namespace cloud {
-namespace storage {
+namespace storage_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
-namespace internal {
 
 using BaseStorageStubFactory =
     std::function<std::shared_ptr<StorageStub>(std::shared_ptr<grpc::Channel>)>;
@@ -44,9 +43,8 @@ std::shared_ptr<StorageStub> CreateDecoratedStubs(
 std::shared_ptr<StorageStub> CreateStorageStub(
     google::cloud::CompletionQueue cq, Options const& options);
 
-}  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-}  // namespace storage
+}  // namespace storage_internal
 }  // namespace cloud
 }  // namespace google
 

--- a/google/cloud/storage/internal/storage_stub_factory_test.cc
+++ b/google/cloud/storage/internal/storage_stub_factory_test.cc
@@ -26,11 +26,13 @@
 
 namespace google {
 namespace cloud {
-namespace storage {
+namespace storage_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
-namespace internal {
 namespace {
 
+using ::google::cloud::storage::testing::MockInsertStream;
+using ::google::cloud::storage::testing::MockObjectMediaStream;
+using ::google::cloud::storage::testing::MockStorageStub;
 using ::google::cloud::testing_util::IsContextMDValid;
 using ::google::cloud::testing_util::ScopedLog;
 using ::google::cloud::testing_util::StatusIs;
@@ -74,7 +76,7 @@ TEST(StorageStubFactory, ReadObject) {
   MockFactory factory;
   EXPECT_CALL(factory, Call)
       .WillOnce([](std::shared_ptr<grpc::Channel> const&) {
-        auto mock = std::make_shared<testing::MockStorageStub>();
+        auto mock = std::make_shared<MockStorageStub>();
         EXPECT_CALL(*mock, ReadObject)
             .WillOnce([](std::unique_ptr<grpc::ClientContext> context,
                          google::storage::v2::ReadObjectRequest const&) {
@@ -84,7 +86,7 @@ TEST(StorageStubFactory, ReadObject) {
               EXPECT_STATUS_OK(IsContextMDValid(
                   *context, "google.storage.v2.Storage.ReadObject",
                   google::cloud::internal::ApiClientHeader("generator")));
-              auto stream = absl::make_unique<testing::MockObjectMediaStream>();
+              auto stream = absl::make_unique<MockObjectMediaStream>();
               EXPECT_CALL(*stream, Read)
                   .WillOnce(
                       Return(Status(StatusCode::kUnavailable, "nothing here")));
@@ -95,7 +97,7 @@ TEST(StorageStubFactory, ReadObject) {
   EXPECT_CALL(factory, Call)
       .Times(kTestChannels - 1)
       .WillRepeatedly([](std::shared_ptr<grpc::Channel> const&) {
-        return std::make_shared<testing::MockStorageStub>();
+        return std::make_shared<MockStorageStub>();
       });
 
   ScopedLog log;
@@ -114,7 +116,7 @@ TEST(StorageStubFactory, WriteObject) {
   MockFactory factory;
   EXPECT_CALL(factory, Call)
       .WillOnce([](std::shared_ptr<grpc::Channel> const&) {
-        auto mock = std::make_shared<testing::MockStorageStub>();
+        auto mock = std::make_shared<MockStorageStub>();
         EXPECT_CALL(*mock, WriteObject)
             .WillOnce([](std::unique_ptr<grpc::ClientContext> context) {
               // Verify the Auth decorator is present
@@ -123,7 +125,7 @@ TEST(StorageStubFactory, WriteObject) {
               EXPECT_STATUS_OK(IsContextMDValid(
                   *context, "google.storage.v2.Storage.WriteObject",
                   google::cloud::internal::ApiClientHeader("generator")));
-              auto stream = absl::make_unique<testing::MockInsertStream>();
+              auto stream = absl::make_unique<MockInsertStream>();
               EXPECT_CALL(*stream, Close)
                   .WillOnce(
                       Return(StatusOr<google::storage::v2::WriteObjectResponse>(
@@ -135,7 +137,7 @@ TEST(StorageStubFactory, WriteObject) {
   EXPECT_CALL(factory, Call)
       .Times(kTestChannels - 1)
       .WillRepeatedly([](std::shared_ptr<grpc::Channel> const&) {
-        return std::make_shared<testing::MockStorageStub>();
+        return std::make_shared<MockStorageStub>();
       });
 
   ScopedLog log;
@@ -152,7 +154,7 @@ TEST(StorageStubFactory, StartResumableWrite) {
   MockFactory factory;
   EXPECT_CALL(factory, Call)
       .WillOnce([](std::shared_ptr<grpc::Channel> const&) {
-        auto mock = std::make_shared<testing::MockStorageStub>();
+        auto mock = std::make_shared<MockStorageStub>();
         EXPECT_CALL(*mock, StartResumableWrite)
             .WillOnce(
                 [](grpc::ClientContext& context,
@@ -172,7 +174,7 @@ TEST(StorageStubFactory, StartResumableWrite) {
   EXPECT_CALL(factory, Call)
       .Times(kTestChannels - 1)
       .WillRepeatedly([](std::shared_ptr<grpc::Channel> const&) {
-        return std::make_shared<testing::MockStorageStub>();
+        return std::make_shared<MockStorageStub>();
       });
 
   ScopedLog log;
@@ -190,7 +192,7 @@ TEST(StorageStubFactory, QueryWriteStatus) {
   MockFactory factory;
   EXPECT_CALL(factory, Call)
       .WillOnce([](std::shared_ptr<grpc::Channel> const&) {
-        auto mock = std::make_shared<testing::MockStorageStub>();
+        auto mock = std::make_shared<MockStorageStub>();
         EXPECT_CALL(*mock, QueryWriteStatus)
             .WillOnce([](grpc::ClientContext& context,
                          google::storage::v2::QueryWriteStatusRequest const&) {
@@ -208,7 +210,7 @@ TEST(StorageStubFactory, QueryWriteStatus) {
   EXPECT_CALL(factory, Call)
       .Times(kTestChannels - 1)
       .WillRepeatedly([](std::shared_ptr<grpc::Channel> const&) {
-        return std::make_shared<testing::MockStorageStub>();
+        return std::make_shared<MockStorageStub>();
       });
 
   ScopedLog log;
@@ -222,8 +224,7 @@ TEST(StorageStubFactory, QueryWriteStatus) {
 }
 
 }  // namespace
-}  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-}  // namespace storage
+}  // namespace storage_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/storage/testing/mock_storage_stub.h
+++ b/google/cloud/storage/testing/mock_storage_stub.h
@@ -23,7 +23,7 @@ namespace cloud {
 namespace storage {
 namespace testing {
 
-class MockStorageStub : public internal::StorageStub {
+class MockStorageStub : public storage_internal::StorageStub {
  public:
   MOCK_METHOD(std::unique_ptr<google::cloud::internal::StreamingReadRpc<
                   google::storage::v2::ReadObjectResponse>>,


### PR DESCRIPTION
Move the `StorageStub` class and its decorators to the
`google::cloud::storage_internal` namespace. This is the namespace used
by the generator. It seems better to move the types than trying to tweak
the generator to use a special namespace just in this case.

Part of the work for #7963

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8001)
<!-- Reviewable:end -->
