### PR TITLE
feat(generator): connection respects per call policies

### DIFF
--- a/generator/integration_tests/golden/CMakeLists.txt
+++ b/generator/integration_tests/golden/CMakeLists.txt
@@ -151,7 +151,8 @@ function (google_cloud_cpp_generator_define_golden_tests)
         tests/golden_thing_admin_metadata_decorator_test.cc
         tests/golden_thing_admin_option_defaults_test.cc
         tests/golden_thing_admin_stub_factory_test.cc
-        tests/golden_thing_admin_stub_test.cc)
+        tests/golden_thing_admin_stub_test.cc
+        tests/plumbing_test.cc)
 
     # Export the list of unit tests to a .bzl file so we do not need to maintain
     # the list in two places.

--- a/generator/integration_tests/golden/golden_thing_admin_connection.cc
+++ b/generator/integration_tests/golden/golden_thing_admin_connection.cc
@@ -216,10 +216,10 @@ class GoldenThingAdminConnectionImpl : public GoldenThingAdminConnection {
     request.clear_page_token();
     auto stub = stub_;
     auto retry =
-        std::shared_ptr<GoldenThingAdminRetryPolicy const>(retry_policy_prototype_->clone());
+        std::shared_ptr<GoldenThingAdminRetryPolicy const>(retry_policy());
     auto backoff = std::shared_ptr<BackoffPolicy const>(
-        backoff_policy_prototype_->clone());
-    auto idempotency = idempotency_policy_->ListDatabases(request);
+        backoff_policy());
+    auto idempotency = idempotency_policy()->ListDatabases(request);
     char const* function_name = __func__;
     return google::cloud::internal::MakePaginationRange<StreamRange<
         google::test::admin::database::v1::Database>>(
@@ -263,17 +263,17 @@ class GoldenThingAdminConnectionImpl : public GoldenThingAdminConnection {
             return stub->AsyncCancelOperation(cq, std::move(context), request);
           },
           &google::cloud::internal::ExtractLongRunningResultResponse<google::test::admin::database::v1::Database>,
-          retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-          idempotency_policy_->CreateDatabase(request),
-          polling_policy_prototype_->clone(), __func__);
+          retry_policy(), backoff_policy(),
+          idempotency_policy()->CreateDatabase(request),
+          polling_policy(), __func__);
   }
 
   StatusOr<google::test::admin::database::v1::Database>
   GetDatabase(
       google::test::admin::database::v1::GetDatabaseRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetDatabase(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GetDatabase(request),
         [this](grpc::ClientContext& context,
             google::test::admin::database::v1::GetDatabaseRequest const& request) {
           return stub_->GetDatabase(context, request);
@@ -302,17 +302,17 @@ class GoldenThingAdminConnectionImpl : public GoldenThingAdminConnection {
             return stub->AsyncCancelOperation(cq, std::move(context), request);
           },
           &google::cloud::internal::ExtractLongRunningResultMetadata<google::test::admin::database::v1::UpdateDatabaseDdlMetadata>,
-          retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-          idempotency_policy_->UpdateDatabaseDdl(request),
-          polling_policy_prototype_->clone(), __func__);
+          retry_policy(), backoff_policy(),
+          idempotency_policy()->UpdateDatabaseDdl(request),
+          polling_policy(), __func__);
   }
 
   Status
   DropDatabase(
       google::test::admin::database::v1::DropDatabaseRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->DropDatabase(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->DropDatabase(request),
         [this](grpc::ClientContext& context,
             google::test::admin::database::v1::DropDatabaseRequest const& request) {
           return stub_->DropDatabase(context, request);
@@ -324,8 +324,8 @@ class GoldenThingAdminConnectionImpl : public GoldenThingAdminConnection {
   GetDatabaseDdl(
       google::test::admin::database::v1::GetDatabaseDdlRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetDatabaseDdl(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GetDatabaseDdl(request),
         [this](grpc::ClientContext& context,
             google::test::admin::database::v1::GetDatabaseDdlRequest const& request) {
           return stub_->GetDatabaseDdl(context, request);
@@ -337,8 +337,8 @@ class GoldenThingAdminConnectionImpl : public GoldenThingAdminConnection {
   SetIamPolicy(
       google::iam::v1::SetIamPolicyRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->SetIamPolicy(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->SetIamPolicy(request),
         [this](grpc::ClientContext& context,
             google::iam::v1::SetIamPolicyRequest const& request) {
           return stub_->SetIamPolicy(context, request);
@@ -350,8 +350,8 @@ class GoldenThingAdminConnectionImpl : public GoldenThingAdminConnection {
   GetIamPolicy(
       google::iam::v1::GetIamPolicyRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetIamPolicy(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GetIamPolicy(request),
         [this](grpc::ClientContext& context,
             google::iam::v1::GetIamPolicyRequest const& request) {
           return stub_->GetIamPolicy(context, request);
@@ -363,8 +363,8 @@ class GoldenThingAdminConnectionImpl : public GoldenThingAdminConnection {
   TestIamPermissions(
       google::iam::v1::TestIamPermissionsRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->TestIamPermissions(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->TestIamPermissions(request),
         [this](grpc::ClientContext& context,
             google::iam::v1::TestIamPermissionsRequest const& request) {
           return stub_->TestIamPermissions(context, request);
@@ -393,17 +393,17 @@ class GoldenThingAdminConnectionImpl : public GoldenThingAdminConnection {
             return stub->AsyncCancelOperation(cq, std::move(context), request);
           },
           &google::cloud::internal::ExtractLongRunningResultResponse<google::test::admin::database::v1::Backup>,
-          retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-          idempotency_policy_->CreateBackup(request),
-          polling_policy_prototype_->clone(), __func__);
+          retry_policy(), backoff_policy(),
+          idempotency_policy()->CreateBackup(request),
+          polling_policy(), __func__);
   }
 
   StatusOr<google::test::admin::database::v1::Backup>
   GetBackup(
       google::test::admin::database::v1::GetBackupRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetBackup(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GetBackup(request),
         [this](grpc::ClientContext& context,
             google::test::admin::database::v1::GetBackupRequest const& request) {
           return stub_->GetBackup(context, request);
@@ -415,8 +415,8 @@ class GoldenThingAdminConnectionImpl : public GoldenThingAdminConnection {
   UpdateBackup(
       google::test::admin::database::v1::UpdateBackupRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->UpdateBackup(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->UpdateBackup(request),
         [this](grpc::ClientContext& context,
             google::test::admin::database::v1::UpdateBackupRequest const& request) {
           return stub_->UpdateBackup(context, request);
@@ -428,8 +428,8 @@ class GoldenThingAdminConnectionImpl : public GoldenThingAdminConnection {
   DeleteBackup(
       google::test::admin::database::v1::DeleteBackupRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->DeleteBackup(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->DeleteBackup(request),
         [this](grpc::ClientContext& context,
             google::test::admin::database::v1::DeleteBackupRequest const& request) {
           return stub_->DeleteBackup(context, request);
@@ -442,10 +442,10 @@ class GoldenThingAdminConnectionImpl : public GoldenThingAdminConnection {
     request.clear_page_token();
     auto stub = stub_;
     auto retry =
-        std::shared_ptr<GoldenThingAdminRetryPolicy const>(retry_policy_prototype_->clone());
+        std::shared_ptr<GoldenThingAdminRetryPolicy const>(retry_policy());
     auto backoff = std::shared_ptr<BackoffPolicy const>(
-        backoff_policy_prototype_->clone());
-    auto idempotency = idempotency_policy_->ListBackups(request);
+        backoff_policy());
+    auto idempotency = idempotency_policy()->ListBackups(request);
     char const* function_name = __func__;
     return google::cloud::internal::MakePaginationRange<StreamRange<
         google::test::admin::database::v1::Backup>>(
@@ -489,9 +489,9 @@ class GoldenThingAdminConnectionImpl : public GoldenThingAdminConnection {
             return stub->AsyncCancelOperation(cq, std::move(context), request);
           },
           &google::cloud::internal::ExtractLongRunningResultResponse<google::test::admin::database::v1::Database>,
-          retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-          idempotency_policy_->RestoreDatabase(request),
-          polling_policy_prototype_->clone(), __func__);
+          retry_policy(), backoff_policy(),
+          idempotency_policy()->RestoreDatabase(request),
+          polling_policy(), __func__);
   }
 
   StreamRange<google::longrunning::Operation> ListDatabaseOperations(
@@ -499,10 +499,10 @@ class GoldenThingAdminConnectionImpl : public GoldenThingAdminConnection {
     request.clear_page_token();
     auto stub = stub_;
     auto retry =
-        std::shared_ptr<GoldenThingAdminRetryPolicy const>(retry_policy_prototype_->clone());
+        std::shared_ptr<GoldenThingAdminRetryPolicy const>(retry_policy());
     auto backoff = std::shared_ptr<BackoffPolicy const>(
-        backoff_policy_prototype_->clone());
-    auto idempotency = idempotency_policy_->ListDatabaseOperations(request);
+        backoff_policy());
+    auto idempotency = idempotency_policy()->ListDatabaseOperations(request);
     char const* function_name = __func__;
     return google::cloud::internal::MakePaginationRange<StreamRange<
         google::longrunning::Operation>>(
@@ -530,10 +530,10 @@ class GoldenThingAdminConnectionImpl : public GoldenThingAdminConnection {
     request.clear_page_token();
     auto stub = stub_;
     auto retry =
-        std::shared_ptr<GoldenThingAdminRetryPolicy const>(retry_policy_prototype_->clone());
+        std::shared_ptr<GoldenThingAdminRetryPolicy const>(retry_policy());
     auto backoff = std::shared_ptr<BackoffPolicy const>(
-        backoff_policy_prototype_->clone());
-    auto idempotency = idempotency_policy_->ListBackupOperations(request);
+        backoff_policy());
+    auto idempotency = idempotency_policy()->ListBackupOperations(request);
     char const* function_name = __func__;
     return google::cloud::internal::MakePaginationRange<StreamRange<
         google::longrunning::Operation>>(
@@ -577,9 +577,9 @@ class GoldenThingAdminConnectionImpl : public GoldenThingAdminConnection {
             return stub->AsyncCancelOperation(cq, std::move(context), request);
           },
           &google::cloud::internal::ExtractLongRunningResultResponse<google::test::admin::database::v1::Database>,
-          retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-          idempotency_policy_->LongRunningWithoutRouting(request),
-          polling_policy_prototype_->clone(), __func__);
+          retry_policy(), backoff_policy(),
+          idempotency_policy()->LongRunningWithoutRouting(request),
+          polling_policy(), __func__);
   }
 
   future<StatusOr<google::test::admin::database::v1::Database>>
@@ -587,8 +587,8 @@ class GoldenThingAdminConnectionImpl : public GoldenThingAdminConnection {
       google::test::admin::database::v1::GetDatabaseRequest const& request) override {
     auto& stub = stub_;
     return google::cloud::internal::AsyncRetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetDatabase(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GetDatabase(request),
         background_->cq(),
         [stub](CompletionQueue& cq,
                std::unique_ptr<grpc::ClientContext> context,
@@ -603,8 +603,8 @@ class GoldenThingAdminConnectionImpl : public GoldenThingAdminConnection {
       google::test::admin::database::v1::DropDatabaseRequest const& request) override {
     auto& stub = stub_;
     return google::cloud::internal::AsyncRetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->DropDatabase(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->DropDatabase(request),
         background_->cq(),
         [stub](CompletionQueue& cq,
                std::unique_ptr<grpc::ClientContext> context,
@@ -615,6 +615,38 @@ class GoldenThingAdminConnectionImpl : public GoldenThingAdminConnection {
   }
 
  private:
+  std::unique_ptr<GoldenThingAdminRetryPolicy> retry_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<GoldenThingAdminRetryPolicyOption>()) {
+      return options.get<GoldenThingAdminRetryPolicyOption>()->clone();
+    }
+    return retry_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<BackoffPolicy> backoff_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<GoldenThingAdminBackoffPolicyOption>()) {
+      return options.get<GoldenThingAdminBackoffPolicyOption>()->clone();
+    }
+    return backoff_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<PollingPolicy> polling_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<GoldenThingAdminPollingPolicyOption>()) {
+      return options.get<GoldenThingAdminPollingPolicyOption>()->clone();
+    }
+    return polling_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<GoldenThingAdminConnectionIdempotencyPolicy> idempotency_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<GoldenThingAdminConnectionIdempotencyPolicyOption>()) {
+      return options.get<GoldenThingAdminConnectionIdempotencyPolicyOption>()->clone();
+    }
+    return idempotency_policy_->clone();
+  }
+
   std::unique_ptr<google::cloud::BackgroundThreads> background_;
   std::shared_ptr<golden_internal::GoldenThingAdminStub> stub_;
   std::unique_ptr<GoldenThingAdminRetryPolicy const> retry_policy_prototype_;

--- a/generator/integration_tests/golden/google_cloud_cpp_generator_golden_tests.bzl
+++ b/generator/integration_tests/golden/google_cloud_cpp_generator_golden_tests.bzl
@@ -35,4 +35,5 @@ google_cloud_cpp_generator_golden_tests = [
     "tests/golden_thing_admin_option_defaults_test.cc",
     "tests/golden_thing_admin_stub_factory_test.cc",
     "tests/golden_thing_admin_stub_test.cc",
+    "tests/plumbing_test.cc",
 ]

--- a/generator/integration_tests/golden/tests/plumbing_test.cc
+++ b/generator/integration_tests/golden/tests/plumbing_test.cc
@@ -25,6 +25,7 @@ namespace golden {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
+using ::testing::AtLeast;
 using ::testing::Return;
 using ms = std::chrono::milliseconds;
 
@@ -53,7 +54,9 @@ TEST(PlumbingTest, RetryLoopUsesPerCallPolicies) {
     auto clone = absl::make_unique<MockRetryPolicy>();
     // We will just say the policy is never exhausted, and use a permanent error
     // to break out of the loop.
-    EXPECT_CALL(*clone, IsExhausted).WillRepeatedly(Return(false));
+    EXPECT_CALL(*clone, IsExhausted)
+        .Times(AtLeast(1))
+        .WillRepeatedly(Return(false));
     EXPECT_CALL(*clone, OnFailureImpl);
     return clone;
   });

--- a/generator/integration_tests/golden/tests/plumbing_test.cc
+++ b/generator/integration_tests/golden/tests/plumbing_test.cc
@@ -1,0 +1,123 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/testing_util/status_matchers.h"
+#include "generator/integration_tests/golden/golden_thing_admin_client.h"
+#include "generator/integration_tests/golden/golden_thing_admin_options.h"
+#include "generator/integration_tests/golden/mocks/mock_golden_thing_admin_stub.h"
+#include <gmock/gmock.h>
+#include <memory>
+
+namespace google {
+namespace cloud {
+namespace golden {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+namespace {
+
+using ::testing::Return;
+using ms = std::chrono::milliseconds;
+
+class MockRetryPolicy : public GoldenThingAdminRetryPolicy {
+ public:
+  MOCK_METHOD(std::unique_ptr<TraitBasedRetryPolicy>, clone, (),
+              (const, override));
+  MOCK_METHOD(bool, IsExhausted, (), (const, override));
+  MOCK_METHOD(void, OnFailureImpl, (), (override));
+};
+
+class MockBackoffPolicy : public BackoffPolicy {
+ public:
+  MOCK_METHOD(std::unique_ptr<BackoffPolicy>, clone, (), (const, override));
+  MOCK_METHOD(std::chrono::milliseconds, OnCompletion, (), (override));
+};
+
+TEST(PlumbingTest, RetryLoopUsesPerCallPolicies) {
+  auto call_r = std::make_shared<MockRetryPolicy>();
+  auto call_b = std::make_shared<MockBackoffPolicy>();
+  auto call_options = Options{}
+                          .set<GoldenThingAdminRetryPolicyOption>(call_r)
+                          .set<GoldenThingAdminBackoffPolicyOption>(call_b);
+
+  EXPECT_CALL(*call_r, clone).WillOnce([] {
+    auto clone = absl::make_unique<MockRetryPolicy>();
+    // We will just say the policy is never exhausted, and use a permanent error
+    // to break out of the loop.
+    EXPECT_CALL(*clone, IsExhausted).WillRepeatedly(Return(false));
+    EXPECT_CALL(*clone, OnFailureImpl);
+    return clone;
+  });
+
+  EXPECT_CALL(*call_b, clone).WillOnce([] {
+    auto clone = absl::make_unique<MockBackoffPolicy>();
+    EXPECT_CALL(*clone, OnCompletion).WillOnce(Return(ms(0)));
+    return clone;
+  });
+
+  auto stub = std::make_shared<golden_internal::MockGoldenThingAdminStub>();
+  EXPECT_CALL(*stub, GetDatabase)
+      .WillOnce(Return(Status(StatusCode::kUnavailable, "try again")))
+      .WillOnce(Return(Status(StatusCode::kPermissionDenied, "fail")));
+  auto conn = golden_internal::MakeGoldenThingAdminConnection(stub, {});
+  auto client = GoldenThingAdminClient(std::move(conn));
+
+  (void)client.GetDatabase("name", std::move(call_options));
+}
+
+class MockPollingPolicy : public PollingPolicy {
+ public:
+  MOCK_METHOD(std::unique_ptr<PollingPolicy>, clone, (), (const, override));
+  MOCK_METHOD(bool, OnFailure, (Status const&), (override));
+  MOCK_METHOD(std::chrono::milliseconds, WaitPeriod, (), (override));
+};
+
+TEST(PlumbingTest, PollingLoopUsesPerCallPolicies) {
+  auto call_p = std::make_shared<MockPollingPolicy>();
+  auto call_options =
+      Options{}.set<GoldenThingAdminPollingPolicyOption>(call_p);
+
+  EXPECT_CALL(*call_p, clone).WillOnce([] {
+    auto clone = absl::make_unique<MockPollingPolicy>();
+    EXPECT_CALL(*clone, WaitPeriod).WillOnce(Return(ms(0)));
+    return clone;
+  });
+
+  auto stub = std::make_shared<golden_internal::MockGoldenThingAdminStub>();
+  EXPECT_CALL(*stub, AsyncCreateDatabase)
+      .WillOnce([](CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
+                   ::google::test::admin::database::v1::
+                       CreateDatabaseRequest const&) {
+        google::longrunning::Operation op;
+        op.set_name("test-operation-name");
+        op.set_done(false);
+        return make_ready_future(make_status_or(op));
+      });
+  EXPECT_CALL(*stub, AsyncGetOperation)
+      .WillOnce([](CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
+                   google::longrunning::GetOperationRequest const&) {
+        google::longrunning::Operation op;
+        op.set_name("test-operation-name");
+        op.set_done(true);
+        return make_ready_future(make_status_or(op));
+      });
+  auto conn = golden_internal::MakeGoldenThingAdminConnection(stub, {});
+  auto client = GoldenThingAdminClient(std::move(conn));
+
+  (void)client.CreateDatabase({}, std::move(call_options));
+}
+
+}  // namespace
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace golden
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/accessapproval/access_approval_connection.cc
+++ b/google/cloud/accessapproval/access_approval_connection.cc
@@ -115,11 +115,10 @@ class AccessApprovalConnectionImpl : public AccessApprovalConnection {
       override {
     request.clear_page_token();
     auto stub = stub_;
-    auto retry = std::shared_ptr<AccessApprovalRetryPolicy const>(
-        retry_policy_prototype_->clone());
-    auto backoff = std::shared_ptr<BackoffPolicy const>(
-        backoff_policy_prototype_->clone());
-    auto idempotency = idempotency_policy_->ListApprovalRequests(request);
+    auto retry =
+        std::shared_ptr<AccessApprovalRetryPolicy const>(retry_policy());
+    auto backoff = std::shared_ptr<BackoffPolicy const>(backoff_policy());
+    auto idempotency = idempotency_policy()->ListApprovalRequests(request);
     char const* function_name = __func__;
     return google::cloud::internal::MakePaginationRange<
         StreamRange<google::cloud::accessapproval::v1::ApprovalRequest>>(
@@ -150,8 +149,8 @@ class AccessApprovalConnectionImpl : public AccessApprovalConnection {
       google::cloud::accessapproval::v1::GetApprovalRequestMessage const&
           request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetApprovalRequest(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GetApprovalRequest(request),
         [this](
             grpc::ClientContext& context,
             google::cloud::accessapproval::v1::GetApprovalRequestMessage const&
@@ -166,8 +165,8 @@ class AccessApprovalConnectionImpl : public AccessApprovalConnection {
       google::cloud::accessapproval::v1::ApproveApprovalRequestMessage const&
           request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->ApproveApprovalRequest(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->ApproveApprovalRequest(request),
         [this](grpc::ClientContext& context,
                google::cloud::accessapproval::v1::
                    ApproveApprovalRequestMessage const& request) {
@@ -181,8 +180,8 @@ class AccessApprovalConnectionImpl : public AccessApprovalConnection {
       google::cloud::accessapproval::v1::DismissApprovalRequestMessage const&
           request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->DismissApprovalRequest(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->DismissApprovalRequest(request),
         [this](grpc::ClientContext& context,
                google::cloud::accessapproval::v1::
                    DismissApprovalRequestMessage const& request) {
@@ -196,8 +195,8 @@ class AccessApprovalConnectionImpl : public AccessApprovalConnection {
       google::cloud::accessapproval::v1::GetAccessApprovalSettingsMessage const&
           request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetAccessApprovalSettings(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GetAccessApprovalSettings(request),
         [this](grpc::ClientContext& context,
                google::cloud::accessapproval::v1::
                    GetAccessApprovalSettingsMessage const& request) {
@@ -211,8 +210,8 @@ class AccessApprovalConnectionImpl : public AccessApprovalConnection {
       google::cloud::accessapproval::v1::
           UpdateAccessApprovalSettingsMessage const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->UpdateAccessApprovalSettings(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->UpdateAccessApprovalSettings(request),
         [this](grpc::ClientContext& context,
                google::cloud::accessapproval::v1::
                    UpdateAccessApprovalSettingsMessage const& request) {
@@ -225,8 +224,8 @@ class AccessApprovalConnectionImpl : public AccessApprovalConnection {
       google::cloud::accessapproval::v1::
           DeleteAccessApprovalSettingsMessage const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->DeleteAccessApprovalSettings(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->DeleteAccessApprovalSettings(request),
         [this](grpc::ClientContext& context,
                google::cloud::accessapproval::v1::
                    DeleteAccessApprovalSettingsMessage const& request) {
@@ -236,6 +235,32 @@ class AccessApprovalConnectionImpl : public AccessApprovalConnection {
   }
 
  private:
+  std::unique_ptr<AccessApprovalRetryPolicy> retry_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<AccessApprovalRetryPolicyOption>()) {
+      return options.get<AccessApprovalRetryPolicyOption>()->clone();
+    }
+    return retry_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<BackoffPolicy> backoff_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<AccessApprovalBackoffPolicyOption>()) {
+      return options.get<AccessApprovalBackoffPolicyOption>()->clone();
+    }
+    return backoff_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<AccessApprovalConnectionIdempotencyPolicy>
+  idempotency_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<AccessApprovalConnectionIdempotencyPolicyOption>()) {
+      return options.get<AccessApprovalConnectionIdempotencyPolicyOption>()
+          ->clone();
+    }
+    return idempotency_policy_->clone();
+  }
+
   std::unique_ptr<google::cloud::BackgroundThreads> background_;
   std::shared_ptr<accessapproval_internal::AccessApprovalStub> stub_;
   std::unique_ptr<AccessApprovalRetryPolicy const> retry_policy_prototype_;

--- a/google/cloud/accesscontextmanager/access_context_manager_connection.cc
+++ b/google/cloud/accesscontextmanager/access_context_manager_connection.cc
@@ -316,11 +316,10 @@ class AccessContextManagerConnectionImpl
           request) override {
     request.clear_page_token();
     auto stub = stub_;
-    auto retry = std::shared_ptr<AccessContextManagerRetryPolicy const>(
-        retry_policy_prototype_->clone());
-    auto backoff = std::shared_ptr<BackoffPolicy const>(
-        backoff_policy_prototype_->clone());
-    auto idempotency = idempotency_policy_->ListAccessPolicies(request);
+    auto retry =
+        std::shared_ptr<AccessContextManagerRetryPolicy const>(retry_policy());
+    auto backoff = std::shared_ptr<BackoffPolicy const>(backoff_policy());
+    auto idempotency = idempotency_policy()->ListAccessPolicies(request);
     char const* function_name = __func__;
     return google::cloud::internal::MakePaginationRange<
         StreamRange<google::identity::accesscontextmanager::v1::AccessPolicy>>(
@@ -352,8 +351,8 @@ class AccessContextManagerConnectionImpl
       google::identity::accesscontextmanager::v1::GetAccessPolicyRequest const&
           request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetAccessPolicy(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GetAccessPolicy(request),
         [this](grpc::ClientContext& context,
                google::identity::accesscontextmanager::v1::
                    GetAccessPolicyRequest const& request) {
@@ -388,9 +387,9 @@ class AccessContextManagerConnectionImpl
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::identity::accesscontextmanager::v1::AccessPolicy>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->CreateAccessPolicy(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->CreateAccessPolicy(request), polling_policy(),
+        __func__);
   }
 
   future<StatusOr<google::identity::accesscontextmanager::v1::AccessPolicy>>
@@ -418,9 +417,9 @@ class AccessContextManagerConnectionImpl
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::identity::accesscontextmanager::v1::AccessPolicy>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->UpdateAccessPolicy(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->UpdateAccessPolicy(request), polling_policy(),
+        __func__);
   }
 
   future<StatusOr<google::identity::accesscontextmanager::v1::
@@ -451,9 +450,9 @@ class AccessContextManagerConnectionImpl
         &google::cloud::internal::ExtractLongRunningResultMetadata<
             google::identity::accesscontextmanager::v1::
                 AccessContextManagerOperationMetadata>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->DeleteAccessPolicy(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->DeleteAccessPolicy(request), polling_policy(),
+        __func__);
   }
 
   StreamRange<google::identity::accesscontextmanager::v1::AccessLevel>
@@ -462,11 +461,10 @@ class AccessContextManagerConnectionImpl
           request) override {
     request.clear_page_token();
     auto stub = stub_;
-    auto retry = std::shared_ptr<AccessContextManagerRetryPolicy const>(
-        retry_policy_prototype_->clone());
-    auto backoff = std::shared_ptr<BackoffPolicy const>(
-        backoff_policy_prototype_->clone());
-    auto idempotency = idempotency_policy_->ListAccessLevels(request);
+    auto retry =
+        std::shared_ptr<AccessContextManagerRetryPolicy const>(retry_policy());
+    auto backoff = std::shared_ptr<BackoffPolicy const>(backoff_policy());
+    auto idempotency = idempotency_policy()->ListAccessLevels(request);
     char const* function_name = __func__;
     return google::cloud::internal::MakePaginationRange<
         StreamRange<google::identity::accesscontextmanager::v1::AccessLevel>>(
@@ -498,8 +496,8 @@ class AccessContextManagerConnectionImpl
       google::identity::accesscontextmanager::v1::GetAccessLevelRequest const&
           request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetAccessLevel(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GetAccessLevel(request),
         [this](grpc::ClientContext& context,
                google::identity::accesscontextmanager::v1::
                    GetAccessLevelRequest const& request) {
@@ -533,9 +531,9 @@ class AccessContextManagerConnectionImpl
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::identity::accesscontextmanager::v1::AccessLevel>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->CreateAccessLevel(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->CreateAccessLevel(request), polling_policy(),
+        __func__);
   }
 
   future<StatusOr<google::identity::accesscontextmanager::v1::AccessLevel>>
@@ -563,9 +561,9 @@ class AccessContextManagerConnectionImpl
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::identity::accesscontextmanager::v1::AccessLevel>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->UpdateAccessLevel(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->UpdateAccessLevel(request), polling_policy(),
+        __func__);
   }
 
   future<StatusOr<google::identity::accesscontextmanager::v1::
@@ -596,9 +594,9 @@ class AccessContextManagerConnectionImpl
         &google::cloud::internal::ExtractLongRunningResultMetadata<
             google::identity::accesscontextmanager::v1::
                 AccessContextManagerOperationMetadata>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->DeleteAccessLevel(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->DeleteAccessLevel(request), polling_policy(),
+        __func__);
   }
 
   future<StatusOr<
@@ -630,9 +628,9 @@ class AccessContextManagerConnectionImpl
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::identity::accesscontextmanager::v1::
                 ReplaceAccessLevelsResponse>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->ReplaceAccessLevels(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->ReplaceAccessLevels(request), polling_policy(),
+        __func__);
   }
 
   StreamRange<google::identity::accesscontextmanager::v1::ServicePerimeter>
@@ -641,11 +639,10 @@ class AccessContextManagerConnectionImpl
           request) override {
     request.clear_page_token();
     auto stub = stub_;
-    auto retry = std::shared_ptr<AccessContextManagerRetryPolicy const>(
-        retry_policy_prototype_->clone());
-    auto backoff = std::shared_ptr<BackoffPolicy const>(
-        backoff_policy_prototype_->clone());
-    auto idempotency = idempotency_policy_->ListServicePerimeters(request);
+    auto retry =
+        std::shared_ptr<AccessContextManagerRetryPolicy const>(retry_policy());
+    auto backoff = std::shared_ptr<BackoffPolicy const>(backoff_policy());
+    auto idempotency = idempotency_policy()->ListServicePerimeters(request);
     char const* function_name = __func__;
     return google::cloud::internal::MakePaginationRange<StreamRange<
         google::identity::accesscontextmanager::v1::ServicePerimeter>>(
@@ -677,8 +674,8 @@ class AccessContextManagerConnectionImpl
   GetServicePerimeter(google::identity::accesscontextmanager::v1::
                           GetServicePerimeterRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetServicePerimeter(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GetServicePerimeter(request),
         [this](grpc::ClientContext& context,
                google::identity::accesscontextmanager::v1::
                    GetServicePerimeterRequest const& request) {
@@ -714,9 +711,9 @@ class AccessContextManagerConnectionImpl
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::identity::accesscontextmanager::v1::ServicePerimeter>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->CreateServicePerimeter(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->CreateServicePerimeter(request), polling_policy(),
+        __func__);
   }
 
   future<StatusOr<google::identity::accesscontextmanager::v1::ServicePerimeter>>
@@ -746,9 +743,9 @@ class AccessContextManagerConnectionImpl
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::identity::accesscontextmanager::v1::ServicePerimeter>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->UpdateServicePerimeter(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->UpdateServicePerimeter(request), polling_policy(),
+        __func__);
   }
 
   future<StatusOr<google::identity::accesscontextmanager::v1::
@@ -781,9 +778,9 @@ class AccessContextManagerConnectionImpl
         &google::cloud::internal::ExtractLongRunningResultMetadata<
             google::identity::accesscontextmanager::v1::
                 AccessContextManagerOperationMetadata>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->DeleteServicePerimeter(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->DeleteServicePerimeter(request), polling_policy(),
+        __func__);
   }
 
   future<StatusOr<google::identity::accesscontextmanager::v1::
@@ -816,9 +813,9 @@ class AccessContextManagerConnectionImpl
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::identity::accesscontextmanager::v1::
                 ReplaceServicePerimetersResponse>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->ReplaceServicePerimeters(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->ReplaceServicePerimeters(request),
+        polling_policy(), __func__);
   }
 
   future<StatusOr<google::identity::accesscontextmanager::v1::
@@ -851,9 +848,9 @@ class AccessContextManagerConnectionImpl
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::identity::accesscontextmanager::v1::
                 CommitServicePerimetersResponse>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->CommitServicePerimeters(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->CommitServicePerimeters(request),
+        polling_policy(), __func__);
   }
 
   StreamRange<google::identity::accesscontextmanager::v1::GcpUserAccessBinding>
@@ -862,11 +859,10 @@ class AccessContextManagerConnectionImpl
           ListGcpUserAccessBindingsRequest request) override {
     request.clear_page_token();
     auto stub = stub_;
-    auto retry = std::shared_ptr<AccessContextManagerRetryPolicy const>(
-        retry_policy_prototype_->clone());
-    auto backoff = std::shared_ptr<BackoffPolicy const>(
-        backoff_policy_prototype_->clone());
-    auto idempotency = idempotency_policy_->ListGcpUserAccessBindings(request);
+    auto retry =
+        std::shared_ptr<AccessContextManagerRetryPolicy const>(retry_policy());
+    auto backoff = std::shared_ptr<BackoffPolicy const>(backoff_policy());
+    auto idempotency = idempotency_policy()->ListGcpUserAccessBindings(request);
     char const* function_name = __func__;
     return google::cloud::internal::MakePaginationRange<StreamRange<
         google::identity::accesscontextmanager::v1::GcpUserAccessBinding>>(
@@ -899,8 +895,8 @@ class AccessContextManagerConnectionImpl
       google::identity::accesscontextmanager::v1::
           GetGcpUserAccessBindingRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetGcpUserAccessBinding(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GetGcpUserAccessBinding(request),
         [this](grpc::ClientContext& context,
                google::identity::accesscontextmanager::v1::
                    GetGcpUserAccessBindingRequest const& request) {
@@ -937,9 +933,9 @@ class AccessContextManagerConnectionImpl
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::identity::accesscontextmanager::v1::GcpUserAccessBinding>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->CreateGcpUserAccessBinding(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->CreateGcpUserAccessBinding(request),
+        polling_policy(), __func__);
   }
 
   future<StatusOr<
@@ -970,9 +966,9 @@ class AccessContextManagerConnectionImpl
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::identity::accesscontextmanager::v1::GcpUserAccessBinding>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->UpdateGcpUserAccessBinding(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->UpdateGcpUserAccessBinding(request),
+        polling_policy(), __func__);
   }
 
   future<StatusOr<google::identity::accesscontextmanager::v1::
@@ -1005,12 +1001,47 @@ class AccessContextManagerConnectionImpl
         &google::cloud::internal::ExtractLongRunningResultMetadata<
             google::identity::accesscontextmanager::v1::
                 GcpUserAccessBindingOperationMetadata>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->DeleteGcpUserAccessBinding(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->DeleteGcpUserAccessBinding(request),
+        polling_policy(), __func__);
   }
 
  private:
+  std::unique_ptr<AccessContextManagerRetryPolicy> retry_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<AccessContextManagerRetryPolicyOption>()) {
+      return options.get<AccessContextManagerRetryPolicyOption>()->clone();
+    }
+    return retry_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<BackoffPolicy> backoff_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<AccessContextManagerBackoffPolicyOption>()) {
+      return options.get<AccessContextManagerBackoffPolicyOption>()->clone();
+    }
+    return backoff_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<PollingPolicy> polling_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<AccessContextManagerPollingPolicyOption>()) {
+      return options.get<AccessContextManagerPollingPolicyOption>()->clone();
+    }
+    return polling_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<AccessContextManagerConnectionIdempotencyPolicy>
+  idempotency_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<AccessContextManagerConnectionIdempotencyPolicyOption>()) {
+      return options
+          .get<AccessContextManagerConnectionIdempotencyPolicyOption>()
+          ->clone();
+    }
+    return idempotency_policy_->clone();
+  }
+
   std::unique_ptr<google::cloud::BackgroundThreads> background_;
   std::shared_ptr<accesscontextmanager_internal::AccessContextManagerStub>
       stub_;

--- a/google/cloud/apigateway/api_gateway_connection.cc
+++ b/google/cloud/apigateway/api_gateway_connection.cc
@@ -193,11 +193,10 @@ class ApiGatewayServiceConnectionImpl : public ApiGatewayServiceConnection {
       google::cloud::apigateway::v1::ListGatewaysRequest request) override {
     request.clear_page_token();
     auto stub = stub_;
-    auto retry = std::shared_ptr<ApiGatewayServiceRetryPolicy const>(
-        retry_policy_prototype_->clone());
-    auto backoff = std::shared_ptr<BackoffPolicy const>(
-        backoff_policy_prototype_->clone());
-    auto idempotency = idempotency_policy_->ListGateways(request);
+    auto retry =
+        std::shared_ptr<ApiGatewayServiceRetryPolicy const>(retry_policy());
+    auto backoff = std::shared_ptr<BackoffPolicy const>(backoff_policy());
+    auto idempotency = idempotency_policy()->ListGateways(request);
     char const* function_name = __func__;
     return google::cloud::internal::MakePaginationRange<
         StreamRange<google::cloud::apigateway::v1::Gateway>>(
@@ -226,8 +225,8 @@ class ApiGatewayServiceConnectionImpl : public ApiGatewayServiceConnection {
       google::cloud::apigateway::v1::GetGatewayRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetGateway(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GetGateway(request),
         [this](
             grpc::ClientContext& context,
             google::cloud::apigateway::v1::GetGatewayRequest const& request) {
@@ -261,9 +260,9 @@ class ApiGatewayServiceConnectionImpl : public ApiGatewayServiceConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::cloud::apigateway::v1::Gateway>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->CreateGateway(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->CreateGateway(request), polling_policy(),
+        __func__);
   }
 
   future<StatusOr<google::cloud::apigateway::v1::Gateway>> UpdateGateway(
@@ -291,9 +290,9 @@ class ApiGatewayServiceConnectionImpl : public ApiGatewayServiceConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::cloud::apigateway::v1::Gateway>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->UpdateGateway(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->UpdateGateway(request), polling_policy(),
+        __func__);
   }
 
   future<StatusOr<google::cloud::apigateway::v1::OperationMetadata>>
@@ -321,20 +320,19 @@ class ApiGatewayServiceConnectionImpl : public ApiGatewayServiceConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultMetadata<
             google::cloud::apigateway::v1::OperationMetadata>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->DeleteGateway(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->DeleteGateway(request), polling_policy(),
+        __func__);
   }
 
   StreamRange<google::cloud::apigateway::v1::Api> ListApis(
       google::cloud::apigateway::v1::ListApisRequest request) override {
     request.clear_page_token();
     auto stub = stub_;
-    auto retry = std::shared_ptr<ApiGatewayServiceRetryPolicy const>(
-        retry_policy_prototype_->clone());
-    auto backoff = std::shared_ptr<BackoffPolicy const>(
-        backoff_policy_prototype_->clone());
-    auto idempotency = idempotency_policy_->ListApis(request);
+    auto retry =
+        std::shared_ptr<ApiGatewayServiceRetryPolicy const>(retry_policy());
+    auto backoff = std::shared_ptr<BackoffPolicy const>(backoff_policy());
+    auto idempotency = idempotency_policy()->ListApis(request);
     char const* function_name = __func__;
     return google::cloud::internal::MakePaginationRange<
         StreamRange<google::cloud::apigateway::v1::Api>>(
@@ -360,8 +358,7 @@ class ApiGatewayServiceConnectionImpl : public ApiGatewayServiceConnection {
   StatusOr<google::cloud::apigateway::v1::Api> GetApi(
       google::cloud::apigateway::v1::GetApiRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetApi(request),
+        retry_policy(), backoff_policy(), idempotency_policy()->GetApi(request),
         [this](grpc::ClientContext& context,
                google::cloud::apigateway::v1::GetApiRequest const& request) {
           return stub_->GetApi(context, request);
@@ -392,9 +389,8 @@ class ApiGatewayServiceConnectionImpl : public ApiGatewayServiceConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::cloud::apigateway::v1::Api>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->CreateApi(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->CreateApi(request), polling_policy(), __func__);
   }
 
   future<StatusOr<google::cloud::apigateway::v1::Api>> UpdateApi(
@@ -420,9 +416,8 @@ class ApiGatewayServiceConnectionImpl : public ApiGatewayServiceConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::cloud::apigateway::v1::Api>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->UpdateApi(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->UpdateApi(request), polling_policy(), __func__);
   }
 
   future<StatusOr<google::cloud::apigateway::v1::OperationMetadata>> DeleteApi(
@@ -448,20 +443,18 @@ class ApiGatewayServiceConnectionImpl : public ApiGatewayServiceConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultMetadata<
             google::cloud::apigateway::v1::OperationMetadata>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->DeleteApi(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->DeleteApi(request), polling_policy(), __func__);
   }
 
   StreamRange<google::cloud::apigateway::v1::ApiConfig> ListApiConfigs(
       google::cloud::apigateway::v1::ListApiConfigsRequest request) override {
     request.clear_page_token();
     auto stub = stub_;
-    auto retry = std::shared_ptr<ApiGatewayServiceRetryPolicy const>(
-        retry_policy_prototype_->clone());
-    auto backoff = std::shared_ptr<BackoffPolicy const>(
-        backoff_policy_prototype_->clone());
-    auto idempotency = idempotency_policy_->ListApiConfigs(request);
+    auto retry =
+        std::shared_ptr<ApiGatewayServiceRetryPolicy const>(retry_policy());
+    auto backoff = std::shared_ptr<BackoffPolicy const>(backoff_policy());
+    auto idempotency = idempotency_policy()->ListApiConfigs(request);
     char const* function_name = __func__;
     return google::cloud::internal::MakePaginationRange<
         StreamRange<google::cloud::apigateway::v1::ApiConfig>>(
@@ -490,8 +483,8 @@ class ApiGatewayServiceConnectionImpl : public ApiGatewayServiceConnection {
       google::cloud::apigateway::v1::GetApiConfigRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetApiConfig(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GetApiConfig(request),
         [this](
             grpc::ClientContext& context,
             google::cloud::apigateway::v1::GetApiConfigRequest const& request) {
@@ -525,9 +518,9 @@ class ApiGatewayServiceConnectionImpl : public ApiGatewayServiceConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::cloud::apigateway::v1::ApiConfig>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->CreateApiConfig(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->CreateApiConfig(request), polling_policy(),
+        __func__);
   }
 
   future<StatusOr<google::cloud::apigateway::v1::ApiConfig>> UpdateApiConfig(
@@ -555,9 +548,9 @@ class ApiGatewayServiceConnectionImpl : public ApiGatewayServiceConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::cloud::apigateway::v1::ApiConfig>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->UpdateApiConfig(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->UpdateApiConfig(request), polling_policy(),
+        __func__);
   }
 
   future<StatusOr<google::cloud::apigateway::v1::OperationMetadata>>
@@ -585,12 +578,46 @@ class ApiGatewayServiceConnectionImpl : public ApiGatewayServiceConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultMetadata<
             google::cloud::apigateway::v1::OperationMetadata>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->DeleteApiConfig(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->DeleteApiConfig(request), polling_policy(),
+        __func__);
   }
 
  private:
+  std::unique_ptr<ApiGatewayServiceRetryPolicy> retry_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<ApiGatewayServiceRetryPolicyOption>()) {
+      return options.get<ApiGatewayServiceRetryPolicyOption>()->clone();
+    }
+    return retry_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<BackoffPolicy> backoff_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<ApiGatewayServiceBackoffPolicyOption>()) {
+      return options.get<ApiGatewayServiceBackoffPolicyOption>()->clone();
+    }
+    return backoff_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<PollingPolicy> polling_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<ApiGatewayServicePollingPolicyOption>()) {
+      return options.get<ApiGatewayServicePollingPolicyOption>()->clone();
+    }
+    return polling_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<ApiGatewayServiceConnectionIdempotencyPolicy>
+  idempotency_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<ApiGatewayServiceConnectionIdempotencyPolicyOption>()) {
+      return options.get<ApiGatewayServiceConnectionIdempotencyPolicyOption>()
+          ->clone();
+    }
+    return idempotency_policy_->clone();
+  }
+
   std::unique_ptr<google::cloud::BackgroundThreads> background_;
   std::shared_ptr<apigateway_internal::ApiGatewayServiceStub> stub_;
   std::unique_ptr<ApiGatewayServiceRetryPolicy const> retry_policy_prototype_;

--- a/google/cloud/appengine/applications_connection.cc
+++ b/google/cloud/appengine/applications_connection.cc
@@ -88,8 +88,8 @@ class ApplicationsConnectionImpl : public ApplicationsConnection {
   StatusOr<google::appengine::v1::Application> GetApplication(
       google::appengine::v1::GetApplicationRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetApplication(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GetApplication(request),
         [this](grpc::ClientContext& context,
                google::appengine::v1::GetApplicationRequest const& request) {
           return stub_->GetApplication(context, request);
@@ -120,9 +120,9 @@ class ApplicationsConnectionImpl : public ApplicationsConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::appengine::v1::Application>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->CreateApplication(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->CreateApplication(request), polling_policy(),
+        __func__);
   }
 
   future<StatusOr<google::appengine::v1::Application>> UpdateApplication(
@@ -148,9 +148,9 @@ class ApplicationsConnectionImpl : public ApplicationsConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::appengine::v1::Application>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->UpdateApplication(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->UpdateApplication(request), polling_policy(),
+        __func__);
   }
 
   future<StatusOr<google::appengine::v1::Application>> RepairApplication(
@@ -176,12 +176,46 @@ class ApplicationsConnectionImpl : public ApplicationsConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::appengine::v1::Application>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->RepairApplication(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->RepairApplication(request), polling_policy(),
+        __func__);
   }
 
  private:
+  std::unique_ptr<ApplicationsRetryPolicy> retry_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<ApplicationsRetryPolicyOption>()) {
+      return options.get<ApplicationsRetryPolicyOption>()->clone();
+    }
+    return retry_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<BackoffPolicy> backoff_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<ApplicationsBackoffPolicyOption>()) {
+      return options.get<ApplicationsBackoffPolicyOption>()->clone();
+    }
+    return backoff_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<PollingPolicy> polling_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<ApplicationsPollingPolicyOption>()) {
+      return options.get<ApplicationsPollingPolicyOption>()->clone();
+    }
+    return polling_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<ApplicationsConnectionIdempotencyPolicy>
+  idempotency_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<ApplicationsConnectionIdempotencyPolicyOption>()) {
+      return options.get<ApplicationsConnectionIdempotencyPolicyOption>()
+          ->clone();
+    }
+    return idempotency_policy_->clone();
+  }
+
   std::unique_ptr<google::cloud::BackgroundThreads> background_;
   std::shared_ptr<appengine_internal::ApplicationsStub> stub_;
   std::unique_ptr<ApplicationsRetryPolicy const> retry_policy_prototype_;

--- a/google/cloud/appengine/authorized_certificates_connection.cc
+++ b/google/cloud/appengine/authorized_certificates_connection.cc
@@ -100,10 +100,10 @@ class AuthorizedCertificatesConnectionImpl
     request.clear_page_token();
     auto stub = stub_;
     auto retry = std::shared_ptr<AuthorizedCertificatesRetryPolicy const>(
-        retry_policy_prototype_->clone());
-    auto backoff = std::shared_ptr<BackoffPolicy const>(
-        backoff_policy_prototype_->clone());
-    auto idempotency = idempotency_policy_->ListAuthorizedCertificates(request);
+        retry_policy());
+    auto backoff = std::shared_ptr<BackoffPolicy const>(backoff_policy());
+    auto idempotency =
+        idempotency_policy()->ListAuthorizedCertificates(request);
     char const* function_name = __func__;
     return google::cloud::internal::MakePaginationRange<
         StreamRange<google::appengine::v1::AuthorizedCertificate>>(
@@ -133,8 +133,8 @@ class AuthorizedCertificatesConnectionImpl
       google::appengine::v1::GetAuthorizedCertificateRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetAuthorizedCertificate(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GetAuthorizedCertificate(request),
         [this](grpc::ClientContext& context,
                google::appengine::v1::GetAuthorizedCertificateRequest const&
                    request) {
@@ -148,8 +148,8 @@ class AuthorizedCertificatesConnectionImpl
       google::appengine::v1::CreateAuthorizedCertificateRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->CreateAuthorizedCertificate(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->CreateAuthorizedCertificate(request),
         [this](grpc::ClientContext& context,
                google::appengine::v1::CreateAuthorizedCertificateRequest const&
                    request) {
@@ -163,8 +163,8 @@ class AuthorizedCertificatesConnectionImpl
       google::appengine::v1::UpdateAuthorizedCertificateRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->UpdateAuthorizedCertificate(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->UpdateAuthorizedCertificate(request),
         [this](grpc::ClientContext& context,
                google::appengine::v1::UpdateAuthorizedCertificateRequest const&
                    request) {
@@ -177,8 +177,8 @@ class AuthorizedCertificatesConnectionImpl
       google::appengine::v1::DeleteAuthorizedCertificateRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->DeleteAuthorizedCertificate(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->DeleteAuthorizedCertificate(request),
         [this](grpc::ClientContext& context,
                google::appengine::v1::DeleteAuthorizedCertificateRequest const&
                    request) {
@@ -188,6 +188,34 @@ class AuthorizedCertificatesConnectionImpl
   }
 
  private:
+  std::unique_ptr<AuthorizedCertificatesRetryPolicy> retry_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<AuthorizedCertificatesRetryPolicyOption>()) {
+      return options.get<AuthorizedCertificatesRetryPolicyOption>()->clone();
+    }
+    return retry_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<BackoffPolicy> backoff_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<AuthorizedCertificatesBackoffPolicyOption>()) {
+      return options.get<AuthorizedCertificatesBackoffPolicyOption>()->clone();
+    }
+    return backoff_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<AuthorizedCertificatesConnectionIdempotencyPolicy>
+  idempotency_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options
+            .has<AuthorizedCertificatesConnectionIdempotencyPolicyOption>()) {
+      return options
+          .get<AuthorizedCertificatesConnectionIdempotencyPolicyOption>()
+          ->clone();
+    }
+    return idempotency_policy_->clone();
+  }
+
   std::unique_ptr<google::cloud::BackgroundThreads> background_;
   std::shared_ptr<appengine_internal::AuthorizedCertificatesStub> stub_;
   std::unique_ptr<AuthorizedCertificatesRetryPolicy const>

--- a/google/cloud/artifactregistry/artifact_registry_connection.cc
+++ b/google/cloud/artifactregistry/artifact_registry_connection.cc
@@ -101,11 +101,10 @@ class ArtifactRegistryConnectionImpl : public ArtifactRegistryConnection {
       override {
     request.clear_page_token();
     auto stub = stub_;
-    auto retry = std::shared_ptr<ArtifactRegistryRetryPolicy const>(
-        retry_policy_prototype_->clone());
-    auto backoff = std::shared_ptr<BackoffPolicy const>(
-        backoff_policy_prototype_->clone());
-    auto idempotency = idempotency_policy_->ListDockerImages(request);
+    auto retry =
+        std::shared_ptr<ArtifactRegistryRetryPolicy const>(retry_policy());
+    auto backoff = std::shared_ptr<BackoffPolicy const>(backoff_policy());
+    auto idempotency = idempotency_policy()->ListDockerImages(request);
     char const* function_name = __func__;
     return google::cloud::internal::MakePaginationRange<
         StreamRange<google::devtools::artifactregistry::v1::DockerImage>>(
@@ -137,11 +136,10 @@ class ArtifactRegistryConnectionImpl : public ArtifactRegistryConnection {
       override {
     request.clear_page_token();
     auto stub = stub_;
-    auto retry = std::shared_ptr<ArtifactRegistryRetryPolicy const>(
-        retry_policy_prototype_->clone());
-    auto backoff = std::shared_ptr<BackoffPolicy const>(
-        backoff_policy_prototype_->clone());
-    auto idempotency = idempotency_policy_->ListRepositories(request);
+    auto retry =
+        std::shared_ptr<ArtifactRegistryRetryPolicy const>(retry_policy());
+    auto backoff = std::shared_ptr<BackoffPolicy const>(backoff_policy());
+    auto idempotency = idempotency_policy()->ListRepositories(request);
     char const* function_name = __func__;
     return google::cloud::internal::MakePaginationRange<
         StreamRange<google::devtools::artifactregistry::v1::Repository>>(
@@ -171,8 +169,8 @@ class ArtifactRegistryConnectionImpl : public ArtifactRegistryConnection {
       google::devtools::artifactregistry::v1::GetRepositoryRequest const&
           request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetRepository(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GetRepository(request),
         [this](
             grpc::ClientContext& context,
             google::devtools::artifactregistry::v1::GetRepositoryRequest const&
@@ -181,6 +179,32 @@ class ArtifactRegistryConnectionImpl : public ArtifactRegistryConnection {
   }
 
  private:
+  std::unique_ptr<ArtifactRegistryRetryPolicy> retry_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<ArtifactRegistryRetryPolicyOption>()) {
+      return options.get<ArtifactRegistryRetryPolicyOption>()->clone();
+    }
+    return retry_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<BackoffPolicy> backoff_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<ArtifactRegistryBackoffPolicyOption>()) {
+      return options.get<ArtifactRegistryBackoffPolicyOption>()->clone();
+    }
+    return backoff_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<ArtifactRegistryConnectionIdempotencyPolicy>
+  idempotency_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<ArtifactRegistryConnectionIdempotencyPolicyOption>()) {
+      return options.get<ArtifactRegistryConnectionIdempotencyPolicyOption>()
+          ->clone();
+    }
+    return idempotency_policy_->clone();
+  }
+
   std::unique_ptr<google::cloud::BackgroundThreads> background_;
   std::shared_ptr<artifactregistry_internal::ArtifactRegistryStub> stub_;
   std::unique_ptr<ArtifactRegistryRetryPolicy const> retry_policy_prototype_;

--- a/google/cloud/assuredworkloads/assured_workloads_connection.cc
+++ b/google/cloud/assuredworkloads/assured_workloads_connection.cc
@@ -126,17 +126,17 @@ class AssuredWorkloadsServiceConnectionImpl
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::cloud::assuredworkloads::v1::Workload>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->CreateWorkload(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->CreateWorkload(request), polling_policy(),
+        __func__);
   }
 
   StatusOr<google::cloud::assuredworkloads::v1::Workload> UpdateWorkload(
       google::cloud::assuredworkloads::v1::UpdateWorkloadRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->UpdateWorkload(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->UpdateWorkload(request),
         [this](grpc::ClientContext& context,
                google::cloud::assuredworkloads::v1::UpdateWorkloadRequest const&
                    request) { return stub_->UpdateWorkload(context, request); },
@@ -147,8 +147,8 @@ class AssuredWorkloadsServiceConnectionImpl
       google::cloud::assuredworkloads::v1::DeleteWorkloadRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->DeleteWorkload(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->DeleteWorkload(request),
         [this](grpc::ClientContext& context,
                google::cloud::assuredworkloads::v1::DeleteWorkloadRequest const&
                    request) { return stub_->DeleteWorkload(context, request); },
@@ -159,8 +159,8 @@ class AssuredWorkloadsServiceConnectionImpl
       google::cloud::assuredworkloads::v1::GetWorkloadRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetWorkload(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GetWorkload(request),
         [this](grpc::ClientContext& context,
                google::cloud::assuredworkloads::v1::GetWorkloadRequest const&
                    request) { return stub_->GetWorkload(context, request); },
@@ -173,10 +173,9 @@ class AssuredWorkloadsServiceConnectionImpl
     request.clear_page_token();
     auto stub = stub_;
     auto retry = std::shared_ptr<AssuredWorkloadsServiceRetryPolicy const>(
-        retry_policy_prototype_->clone());
-    auto backoff = std::shared_ptr<BackoffPolicy const>(
-        backoff_policy_prototype_->clone());
-    auto idempotency = idempotency_policy_->ListWorkloads(request);
+        retry_policy());
+    auto backoff = std::shared_ptr<BackoffPolicy const>(backoff_policy());
+    auto idempotency = idempotency_policy()->ListWorkloads(request);
     char const* function_name = __func__;
     return google::cloud::internal::MakePaginationRange<
         StreamRange<google::cloud::assuredworkloads::v1::Workload>>(
@@ -203,6 +202,42 @@ class AssuredWorkloadsServiceConnectionImpl
   }
 
  private:
+  std::unique_ptr<AssuredWorkloadsServiceRetryPolicy> retry_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<AssuredWorkloadsServiceRetryPolicyOption>()) {
+      return options.get<AssuredWorkloadsServiceRetryPolicyOption>()->clone();
+    }
+    return retry_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<BackoffPolicy> backoff_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<AssuredWorkloadsServiceBackoffPolicyOption>()) {
+      return options.get<AssuredWorkloadsServiceBackoffPolicyOption>()->clone();
+    }
+    return backoff_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<PollingPolicy> polling_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<AssuredWorkloadsServicePollingPolicyOption>()) {
+      return options.get<AssuredWorkloadsServicePollingPolicyOption>()->clone();
+    }
+    return polling_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<AssuredWorkloadsServiceConnectionIdempotencyPolicy>
+  idempotency_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options
+            .has<AssuredWorkloadsServiceConnectionIdempotencyPolicyOption>()) {
+      return options
+          .get<AssuredWorkloadsServiceConnectionIdempotencyPolicyOption>()
+          ->clone();
+    }
+    return idempotency_policy_->clone();
+  }
+
   std::unique_ptr<google::cloud::BackgroundThreads> background_;
   std::shared_ptr<assuredworkloads_internal::AssuredWorkloadsServiceStub> stub_;
   std::unique_ptr<AssuredWorkloadsServiceRetryPolicy const>

--- a/google/cloud/automl/auto_ml_connection.cc
+++ b/google/cloud/automl/auto_ml_connection.cc
@@ -222,16 +222,16 @@ class AutoMlConnectionImpl : public AutoMlConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::cloud::automl::v1::Dataset>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->CreateDataset(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->CreateDataset(request), polling_policy(),
+        __func__);
   }
 
   StatusOr<google::cloud::automl::v1::Dataset> GetDataset(
       google::cloud::automl::v1::GetDatasetRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetDataset(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GetDataset(request),
         [this](grpc::ClientContext& context,
                google::cloud::automl::v1::GetDatasetRequest const& request) {
           return stub_->GetDataset(context, request);
@@ -243,11 +243,9 @@ class AutoMlConnectionImpl : public AutoMlConnection {
       google::cloud::automl::v1::ListDatasetsRequest request) override {
     request.clear_page_token();
     auto stub = stub_;
-    auto retry = std::shared_ptr<AutoMlRetryPolicy const>(
-        retry_policy_prototype_->clone());
-    auto backoff = std::shared_ptr<BackoffPolicy const>(
-        backoff_policy_prototype_->clone());
-    auto idempotency = idempotency_policy_->ListDatasets(request);
+    auto retry = std::shared_ptr<AutoMlRetryPolicy const>(retry_policy());
+    auto backoff = std::shared_ptr<BackoffPolicy const>(backoff_policy());
+    auto idempotency = idempotency_policy()->ListDatasets(request);
     char const* function_name = __func__;
     return google::cloud::internal::MakePaginationRange<
         StreamRange<google::cloud::automl::v1::Dataset>>(
@@ -275,8 +273,8 @@ class AutoMlConnectionImpl : public AutoMlConnection {
   StatusOr<google::cloud::automl::v1::Dataset> UpdateDataset(
       google::cloud::automl::v1::UpdateDatasetRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->UpdateDataset(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->UpdateDataset(request),
         [this](grpc::ClientContext& context,
                google::cloud::automl::v1::UpdateDatasetRequest const& request) {
           return stub_->UpdateDataset(context, request);
@@ -307,9 +305,9 @@ class AutoMlConnectionImpl : public AutoMlConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultMetadata<
             google::cloud::automl::v1::OperationMetadata>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->DeleteDataset(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->DeleteDataset(request), polling_policy(),
+        __func__);
   }
 
   future<StatusOr<google::cloud::automl::v1::OperationMetadata>> ImportData(
@@ -335,9 +333,8 @@ class AutoMlConnectionImpl : public AutoMlConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultMetadata<
             google::cloud::automl::v1::OperationMetadata>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->ImportData(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->ImportData(request), polling_policy(), __func__);
   }
 
   future<StatusOr<google::cloud::automl::v1::OperationMetadata>> ExportData(
@@ -363,17 +360,16 @@ class AutoMlConnectionImpl : public AutoMlConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultMetadata<
             google::cloud::automl::v1::OperationMetadata>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->ExportData(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->ExportData(request), polling_policy(), __func__);
   }
 
   StatusOr<google::cloud::automl::v1::AnnotationSpec> GetAnnotationSpec(
       google::cloud::automl::v1::GetAnnotationSpecRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetAnnotationSpec(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GetAnnotationSpec(request),
         [this](grpc::ClientContext& context,
                google::cloud::automl::v1::GetAnnotationSpecRequest const&
                    request) {
@@ -405,16 +401,15 @@ class AutoMlConnectionImpl : public AutoMlConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::cloud::automl::v1::Model>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->CreateModel(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->CreateModel(request), polling_policy(), __func__);
   }
 
   StatusOr<google::cloud::automl::v1::Model> GetModel(
       google::cloud::automl::v1::GetModelRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetModel(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GetModel(request),
         [this](grpc::ClientContext& context,
                google::cloud::automl::v1::GetModelRequest const& request) {
           return stub_->GetModel(context, request);
@@ -426,11 +421,9 @@ class AutoMlConnectionImpl : public AutoMlConnection {
       google::cloud::automl::v1::ListModelsRequest request) override {
     request.clear_page_token();
     auto stub = stub_;
-    auto retry = std::shared_ptr<AutoMlRetryPolicy const>(
-        retry_policy_prototype_->clone());
-    auto backoff = std::shared_ptr<BackoffPolicy const>(
-        backoff_policy_prototype_->clone());
-    auto idempotency = idempotency_policy_->ListModels(request);
+    auto retry = std::shared_ptr<AutoMlRetryPolicy const>(retry_policy());
+    auto backoff = std::shared_ptr<BackoffPolicy const>(backoff_policy());
+    auto idempotency = idempotency_policy()->ListModels(request);
     char const* function_name = __func__;
     return google::cloud::internal::MakePaginationRange<
         StreamRange<google::cloud::automl::v1::Model>>(
@@ -478,16 +471,15 @@ class AutoMlConnectionImpl : public AutoMlConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultMetadata<
             google::cloud::automl::v1::OperationMetadata>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->DeleteModel(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->DeleteModel(request), polling_policy(), __func__);
   }
 
   StatusOr<google::cloud::automl::v1::Model> UpdateModel(
       google::cloud::automl::v1::UpdateModelRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->UpdateModel(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->UpdateModel(request),
         [this](grpc::ClientContext& context,
                google::cloud::automl::v1::UpdateModelRequest const& request) {
           return stub_->UpdateModel(context, request);
@@ -518,9 +510,8 @@ class AutoMlConnectionImpl : public AutoMlConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultMetadata<
             google::cloud::automl::v1::OperationMetadata>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->DeployModel(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->DeployModel(request), polling_policy(), __func__);
   }
 
   future<StatusOr<google::cloud::automl::v1::OperationMetadata>> UndeployModel(
@@ -546,9 +537,9 @@ class AutoMlConnectionImpl : public AutoMlConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultMetadata<
             google::cloud::automl::v1::OperationMetadata>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->UndeployModel(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->UndeployModel(request), polling_policy(),
+        __func__);
   }
 
   future<StatusOr<google::cloud::automl::v1::OperationMetadata>> ExportModel(
@@ -574,17 +565,16 @@ class AutoMlConnectionImpl : public AutoMlConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultMetadata<
             google::cloud::automl::v1::OperationMetadata>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->ExportModel(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->ExportModel(request), polling_policy(), __func__);
   }
 
   StatusOr<google::cloud::automl::v1::ModelEvaluation> GetModelEvaluation(
       google::cloud::automl::v1::GetModelEvaluationRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetModelEvaluation(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GetModelEvaluation(request),
         [this](grpc::ClientContext& context,
                google::cloud::automl::v1::GetModelEvaluationRequest const&
                    request) {
@@ -597,11 +587,9 @@ class AutoMlConnectionImpl : public AutoMlConnection {
       google::cloud::automl::v1::ListModelEvaluationsRequest request) override {
     request.clear_page_token();
     auto stub = stub_;
-    auto retry = std::shared_ptr<AutoMlRetryPolicy const>(
-        retry_policy_prototype_->clone());
-    auto backoff = std::shared_ptr<BackoffPolicy const>(
-        backoff_policy_prototype_->clone());
-    auto idempotency = idempotency_policy_->ListModelEvaluations(request);
+    auto retry = std::shared_ptr<AutoMlRetryPolicy const>(retry_policy());
+    auto backoff = std::shared_ptr<BackoffPolicy const>(backoff_policy());
+    auto idempotency = idempotency_policy()->ListModelEvaluations(request);
     char const* function_name = __func__;
     return google::cloud::internal::MakePaginationRange<
         StreamRange<google::cloud::automl::v1::ModelEvaluation>>(
@@ -628,6 +616,38 @@ class AutoMlConnectionImpl : public AutoMlConnection {
   }
 
  private:
+  std::unique_ptr<AutoMlRetryPolicy> retry_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<AutoMlRetryPolicyOption>()) {
+      return options.get<AutoMlRetryPolicyOption>()->clone();
+    }
+    return retry_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<BackoffPolicy> backoff_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<AutoMlBackoffPolicyOption>()) {
+      return options.get<AutoMlBackoffPolicyOption>()->clone();
+    }
+    return backoff_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<PollingPolicy> polling_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<AutoMlPollingPolicyOption>()) {
+      return options.get<AutoMlPollingPolicyOption>()->clone();
+    }
+    return polling_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<AutoMlConnectionIdempotencyPolicy> idempotency_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<AutoMlConnectionIdempotencyPolicyOption>()) {
+      return options.get<AutoMlConnectionIdempotencyPolicyOption>()->clone();
+    }
+    return idempotency_policy_->clone();
+  }
+
   std::unique_ptr<google::cloud::BackgroundThreads> background_;
   std::shared_ptr<automl_internal::AutoMlStub> stub_;
   std::unique_ptr<AutoMlRetryPolicy const> retry_policy_prototype_;

--- a/google/cloud/bigtable/admin/bigtable_instance_admin_connection.cc
+++ b/google/cloud/bigtable/admin/bigtable_instance_admin_connection.cc
@@ -218,16 +218,16 @@ class BigtableInstanceAdminConnectionImpl
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::bigtable::admin::v2::Instance>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->CreateInstance(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->CreateInstance(request), polling_policy(),
+        __func__);
   }
 
   StatusOr<google::bigtable::admin::v2::Instance> GetInstance(
       google::bigtable::admin::v2::GetInstanceRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetInstance(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GetInstance(request),
         [this](grpc::ClientContext& context,
                google::bigtable::admin::v2::GetInstanceRequest const& request) {
           return stub_->GetInstance(context, request);
@@ -239,8 +239,8 @@ class BigtableInstanceAdminConnectionImpl
       google::bigtable::admin::v2::ListInstancesRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->ListInstances(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->ListInstances(request),
         [this](
             grpc::ClientContext& context,
             google::bigtable::admin::v2::ListInstancesRequest const& request) {
@@ -252,8 +252,8 @@ class BigtableInstanceAdminConnectionImpl
   StatusOr<google::bigtable::admin::v2::Instance> UpdateInstance(
       google::bigtable::admin::v2::Instance const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->UpdateInstance(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->UpdateInstance(request),
         [this](grpc::ClientContext& context,
                google::bigtable::admin::v2::Instance const& request) {
           return stub_->UpdateInstance(context, request);
@@ -287,17 +287,17 @@ class BigtableInstanceAdminConnectionImpl
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::bigtable::admin::v2::Instance>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->PartialUpdateInstance(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->PartialUpdateInstance(request), polling_policy(),
+        __func__);
   }
 
   Status DeleteInstance(
       google::bigtable::admin::v2::DeleteInstanceRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->DeleteInstance(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->DeleteInstance(request),
         [this](
             grpc::ClientContext& context,
             google::bigtable::admin::v2::DeleteInstanceRequest const& request) {
@@ -331,16 +331,16 @@ class BigtableInstanceAdminConnectionImpl
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::bigtable::admin::v2::Cluster>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->CreateCluster(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->CreateCluster(request), polling_policy(),
+        __func__);
   }
 
   StatusOr<google::bigtable::admin::v2::Cluster> GetCluster(
       google::bigtable::admin::v2::GetClusterRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetCluster(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GetCluster(request),
         [this](grpc::ClientContext& context,
                google::bigtable::admin::v2::GetClusterRequest const& request) {
           return stub_->GetCluster(context, request);
@@ -352,8 +352,8 @@ class BigtableInstanceAdminConnectionImpl
       google::bigtable::admin::v2::ListClustersRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->ListClusters(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->ListClusters(request),
         [this](
             grpc::ClientContext& context,
             google::bigtable::admin::v2::ListClustersRequest const& request) {
@@ -385,9 +385,9 @@ class BigtableInstanceAdminConnectionImpl
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::bigtable::admin::v2::Cluster>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->UpdateCluster(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->UpdateCluster(request), polling_policy(),
+        __func__);
   }
 
   future<StatusOr<google::bigtable::admin::v2::Cluster>> PartialUpdateCluster(
@@ -416,16 +416,16 @@ class BigtableInstanceAdminConnectionImpl
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::bigtable::admin::v2::Cluster>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->PartialUpdateCluster(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->PartialUpdateCluster(request), polling_policy(),
+        __func__);
   }
 
   Status DeleteCluster(google::bigtable::admin::v2::DeleteClusterRequest const&
                            request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->DeleteCluster(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->DeleteCluster(request),
         [this](
             grpc::ClientContext& context,
             google::bigtable::admin::v2::DeleteClusterRequest const& request) {
@@ -438,8 +438,8 @@ class BigtableInstanceAdminConnectionImpl
       google::bigtable::admin::v2::CreateAppProfileRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->CreateAppProfile(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->CreateAppProfile(request),
         [this](grpc::ClientContext& context,
                google::bigtable::admin::v2::CreateAppProfileRequest const&
                    request) {
@@ -452,8 +452,8 @@ class BigtableInstanceAdminConnectionImpl
       google::bigtable::admin::v2::GetAppProfileRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetAppProfile(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GetAppProfile(request),
         [this](
             grpc::ClientContext& context,
             google::bigtable::admin::v2::GetAppProfileRequest const& request) {
@@ -466,11 +466,10 @@ class BigtableInstanceAdminConnectionImpl
       google::bigtable::admin::v2::ListAppProfilesRequest request) override {
     request.clear_page_token();
     auto stub = stub_;
-    auto retry = std::shared_ptr<BigtableInstanceAdminRetryPolicy const>(
-        retry_policy_prototype_->clone());
-    auto backoff = std::shared_ptr<BackoffPolicy const>(
-        backoff_policy_prototype_->clone());
-    auto idempotency = idempotency_policy_->ListAppProfiles(request);
+    auto retry =
+        std::shared_ptr<BigtableInstanceAdminRetryPolicy const>(retry_policy());
+    auto backoff = std::shared_ptr<BackoffPolicy const>(backoff_policy());
+    auto idempotency = idempotency_policy()->ListAppProfiles(request);
     char const* function_name = __func__;
     return google::cloud::internal::MakePaginationRange<
         StreamRange<google::bigtable::admin::v2::AppProfile>>(
@@ -520,17 +519,17 @@ class BigtableInstanceAdminConnectionImpl
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::bigtable::admin::v2::AppProfile>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->UpdateAppProfile(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->UpdateAppProfile(request), polling_policy(),
+        __func__);
   }
 
   Status DeleteAppProfile(
       google::bigtable::admin::v2::DeleteAppProfileRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->DeleteAppProfile(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->DeleteAppProfile(request),
         [this](grpc::ClientContext& context,
                google::bigtable::admin::v2::DeleteAppProfileRequest const&
                    request) {
@@ -542,8 +541,8 @@ class BigtableInstanceAdminConnectionImpl
   StatusOr<google::iam::v1::Policy> GetIamPolicy(
       google::iam::v1::GetIamPolicyRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetIamPolicy(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GetIamPolicy(request),
         [this](grpc::ClientContext& context,
                google::iam::v1::GetIamPolicyRequest const& request) {
           return stub_->GetIamPolicy(context, request);
@@ -554,8 +553,8 @@ class BigtableInstanceAdminConnectionImpl
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
       google::iam::v1::SetIamPolicyRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->SetIamPolicy(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->SetIamPolicy(request),
         [this](grpc::ClientContext& context,
                google::iam::v1::SetIamPolicyRequest const& request) {
           return stub_->SetIamPolicy(context, request);
@@ -566,8 +565,8 @@ class BigtableInstanceAdminConnectionImpl
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
       google::iam::v1::TestIamPermissionsRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->TestIamPermissions(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->TestIamPermissions(request),
         [this](grpc::ClientContext& context,
                google::iam::v1::TestIamPermissionsRequest const& request) {
           return stub_->TestIamPermissions(context, request);
@@ -576,6 +575,41 @@ class BigtableInstanceAdminConnectionImpl
   }
 
  private:
+  std::unique_ptr<BigtableInstanceAdminRetryPolicy> retry_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<BigtableInstanceAdminRetryPolicyOption>()) {
+      return options.get<BigtableInstanceAdminRetryPolicyOption>()->clone();
+    }
+    return retry_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<BackoffPolicy> backoff_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<BigtableInstanceAdminBackoffPolicyOption>()) {
+      return options.get<BigtableInstanceAdminBackoffPolicyOption>()->clone();
+    }
+    return backoff_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<PollingPolicy> polling_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<BigtableInstanceAdminPollingPolicyOption>()) {
+      return options.get<BigtableInstanceAdminPollingPolicyOption>()->clone();
+    }
+    return polling_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<BigtableInstanceAdminConnectionIdempotencyPolicy>
+  idempotency_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<BigtableInstanceAdminConnectionIdempotencyPolicyOption>()) {
+      return options
+          .get<BigtableInstanceAdminConnectionIdempotencyPolicyOption>()
+          ->clone();
+    }
+    return idempotency_policy_->clone();
+  }
+
   std::unique_ptr<google::cloud::BackgroundThreads> background_;
   std::shared_ptr<bigtable_admin_internal::BigtableInstanceAdminStub> stub_;
   std::unique_ptr<BigtableInstanceAdminRetryPolicy const>

--- a/google/cloud/bigtable/admin/bigtable_table_admin_connection.cc
+++ b/google/cloud/bigtable/admin/bigtable_table_admin_connection.cc
@@ -184,8 +184,8 @@ class BigtableTableAdminConnectionImpl : public BigtableTableAdminConnection {
   StatusOr<google::bigtable::admin::v2::Table> CreateTable(
       google::bigtable::admin::v2::CreateTableRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->CreateTable(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->CreateTable(request),
         [this](grpc::ClientContext& context,
                google::bigtable::admin::v2::CreateTableRequest const& request) {
           return stub_->CreateTable(context, request);
@@ -197,11 +197,10 @@ class BigtableTableAdminConnectionImpl : public BigtableTableAdminConnection {
       google::bigtable::admin::v2::ListTablesRequest request) override {
     request.clear_page_token();
     auto stub = stub_;
-    auto retry = std::shared_ptr<BigtableTableAdminRetryPolicy const>(
-        retry_policy_prototype_->clone());
-    auto backoff = std::shared_ptr<BackoffPolicy const>(
-        backoff_policy_prototype_->clone());
-    auto idempotency = idempotency_policy_->ListTables(request);
+    auto retry =
+        std::shared_ptr<BigtableTableAdminRetryPolicy const>(retry_policy());
+    auto backoff = std::shared_ptr<BackoffPolicy const>(backoff_policy());
+    auto idempotency = idempotency_policy()->ListTables(request);
     char const* function_name = __func__;
     return google::cloud::internal::MakePaginationRange<
         StreamRange<google::bigtable::admin::v2::Table>>(
@@ -229,8 +228,8 @@ class BigtableTableAdminConnectionImpl : public BigtableTableAdminConnection {
   StatusOr<google::bigtable::admin::v2::Table> GetTable(
       google::bigtable::admin::v2::GetTableRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetTable(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GetTable(request),
         [this](grpc::ClientContext& context,
                google::bigtable::admin::v2::GetTableRequest const& request) {
           return stub_->GetTable(context, request);
@@ -241,8 +240,8 @@ class BigtableTableAdminConnectionImpl : public BigtableTableAdminConnection {
   Status DeleteTable(
       google::bigtable::admin::v2::DeleteTableRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->DeleteTable(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->DeleteTable(request),
         [this](grpc::ClientContext& context,
                google::bigtable::admin::v2::DeleteTableRequest const& request) {
           return stub_->DeleteTable(context, request);
@@ -254,8 +253,8 @@ class BigtableTableAdminConnectionImpl : public BigtableTableAdminConnection {
       google::bigtable::admin::v2::ModifyColumnFamiliesRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->ModifyColumnFamilies(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->ModifyColumnFamilies(request),
         [this](grpc::ClientContext& context,
                google::bigtable::admin::v2::ModifyColumnFamiliesRequest const&
                    request) {
@@ -267,8 +266,8 @@ class BigtableTableAdminConnectionImpl : public BigtableTableAdminConnection {
   Status DropRowRange(google::bigtable::admin::v2::DropRowRangeRequest const&
                           request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->DropRowRange(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->DropRowRange(request),
         [this](
             grpc::ClientContext& context,
             google::bigtable::admin::v2::DropRowRangeRequest const& request) {
@@ -282,8 +281,8 @@ class BigtableTableAdminConnectionImpl : public BigtableTableAdminConnection {
       google::bigtable::admin::v2::GenerateConsistencyTokenRequest const&
           request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GenerateConsistencyToken(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GenerateConsistencyToken(request),
         [this](
             grpc::ClientContext& context,
             google::bigtable::admin::v2::GenerateConsistencyTokenRequest const&
@@ -297,8 +296,8 @@ class BigtableTableAdminConnectionImpl : public BigtableTableAdminConnection {
   CheckConsistency(google::bigtable::admin::v2::CheckConsistencyRequest const&
                        request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->CheckConsistency(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->CheckConsistency(request),
         [this](grpc::ClientContext& context,
                google::bigtable::admin::v2::CheckConsistencyRequest const&
                    request) {
@@ -332,16 +331,16 @@ class BigtableTableAdminConnectionImpl : public BigtableTableAdminConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::bigtable::admin::v2::Backup>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->CreateBackup(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->CreateBackup(request), polling_policy(),
+        __func__);
   }
 
   StatusOr<google::bigtable::admin::v2::Backup> GetBackup(
       google::bigtable::admin::v2::GetBackupRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetBackup(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GetBackup(request),
         [this](grpc::ClientContext& context,
                google::bigtable::admin::v2::GetBackupRequest const& request) {
           return stub_->GetBackup(context, request);
@@ -353,8 +352,8 @@ class BigtableTableAdminConnectionImpl : public BigtableTableAdminConnection {
       google::bigtable::admin::v2::UpdateBackupRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->UpdateBackup(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->UpdateBackup(request),
         [this](
             grpc::ClientContext& context,
             google::bigtable::admin::v2::UpdateBackupRequest const& request) {
@@ -366,8 +365,8 @@ class BigtableTableAdminConnectionImpl : public BigtableTableAdminConnection {
   Status DeleteBackup(google::bigtable::admin::v2::DeleteBackupRequest const&
                           request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->DeleteBackup(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->DeleteBackup(request),
         [this](
             grpc::ClientContext& context,
             google::bigtable::admin::v2::DeleteBackupRequest const& request) {
@@ -380,11 +379,10 @@ class BigtableTableAdminConnectionImpl : public BigtableTableAdminConnection {
       google::bigtable::admin::v2::ListBackupsRequest request) override {
     request.clear_page_token();
     auto stub = stub_;
-    auto retry = std::shared_ptr<BigtableTableAdminRetryPolicy const>(
-        retry_policy_prototype_->clone());
-    auto backoff = std::shared_ptr<BackoffPolicy const>(
-        backoff_policy_prototype_->clone());
-    auto idempotency = idempotency_policy_->ListBackups(request);
+    auto retry =
+        std::shared_ptr<BigtableTableAdminRetryPolicy const>(retry_policy());
+    auto backoff = std::shared_ptr<BackoffPolicy const>(backoff_policy());
+    auto idempotency = idempotency_policy()->ListBackups(request);
     char const* function_name = __func__;
     return google::cloud::internal::MakePaginationRange<
         StreamRange<google::bigtable::admin::v2::Backup>>(
@@ -434,16 +432,16 @@ class BigtableTableAdminConnectionImpl : public BigtableTableAdminConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::bigtable::admin::v2::Table>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->RestoreTable(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->RestoreTable(request), polling_policy(),
+        __func__);
   }
 
   StatusOr<google::iam::v1::Policy> GetIamPolicy(
       google::iam::v1::GetIamPolicyRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetIamPolicy(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GetIamPolicy(request),
         [this](grpc::ClientContext& context,
                google::iam::v1::GetIamPolicyRequest const& request) {
           return stub_->GetIamPolicy(context, request);
@@ -454,8 +452,8 @@ class BigtableTableAdminConnectionImpl : public BigtableTableAdminConnection {
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
       google::iam::v1::SetIamPolicyRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->SetIamPolicy(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->SetIamPolicy(request),
         [this](grpc::ClientContext& context,
                google::iam::v1::SetIamPolicyRequest const& request) {
           return stub_->SetIamPolicy(context, request);
@@ -466,8 +464,8 @@ class BigtableTableAdminConnectionImpl : public BigtableTableAdminConnection {
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
       google::iam::v1::TestIamPermissionsRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->TestIamPermissions(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->TestIamPermissions(request),
         [this](grpc::ClientContext& context,
                google::iam::v1::TestIamPermissionsRequest const& request) {
           return stub_->TestIamPermissions(context, request);
@@ -481,8 +479,8 @@ class BigtableTableAdminConnectionImpl : public BigtableTableAdminConnection {
       override {
     auto& stub = stub_;
     return google::cloud::internal::AsyncRetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->CheckConsistency(request), background_->cq(),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->CheckConsistency(request), background_->cq(),
         [stub](CompletionQueue& cq,
                std::unique_ptr<grpc::ClientContext> context,
                google::bigtable::admin::v2::CheckConsistencyRequest const&
@@ -493,6 +491,40 @@ class BigtableTableAdminConnectionImpl : public BigtableTableAdminConnection {
   }
 
  private:
+  std::unique_ptr<BigtableTableAdminRetryPolicy> retry_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<BigtableTableAdminRetryPolicyOption>()) {
+      return options.get<BigtableTableAdminRetryPolicyOption>()->clone();
+    }
+    return retry_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<BackoffPolicy> backoff_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<BigtableTableAdminBackoffPolicyOption>()) {
+      return options.get<BigtableTableAdminBackoffPolicyOption>()->clone();
+    }
+    return backoff_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<PollingPolicy> polling_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<BigtableTableAdminPollingPolicyOption>()) {
+      return options.get<BigtableTableAdminPollingPolicyOption>()->clone();
+    }
+    return polling_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<BigtableTableAdminConnectionIdempotencyPolicy>
+  idempotency_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<BigtableTableAdminConnectionIdempotencyPolicyOption>()) {
+      return options.get<BigtableTableAdminConnectionIdempotencyPolicyOption>()
+          ->clone();
+    }
+    return idempotency_policy_->clone();
+  }
+
   std::unique_ptr<google::cloud::BackgroundThreads> background_;
   std::shared_ptr<bigtable_admin_internal::BigtableTableAdminStub> stub_;
   std::unique_ptr<BigtableTableAdminRetryPolicy const> retry_policy_prototype_;

--- a/google/cloud/billing/budget_connection.cc
+++ b/google/cloud/billing/budget_connection.cc
@@ -95,8 +95,8 @@ class BudgetServiceConnectionImpl : public BudgetServiceConnection {
       google::cloud::billing::budgets::v1::CreateBudgetRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->CreateBudget(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->CreateBudget(request),
         [this](grpc::ClientContext& context,
                google::cloud::billing::budgets::v1::CreateBudgetRequest const&
                    request) { return stub_->CreateBudget(context, request); },
@@ -107,8 +107,8 @@ class BudgetServiceConnectionImpl : public BudgetServiceConnection {
       google::cloud::billing::budgets::v1::UpdateBudgetRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->UpdateBudget(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->UpdateBudget(request),
         [this](grpc::ClientContext& context,
                google::cloud::billing::budgets::v1::UpdateBudgetRequest const&
                    request) { return stub_->UpdateBudget(context, request); },
@@ -119,8 +119,8 @@ class BudgetServiceConnectionImpl : public BudgetServiceConnection {
       google::cloud::billing::budgets::v1::GetBudgetRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetBudget(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GetBudget(request),
         [this](grpc::ClientContext& context,
                google::cloud::billing::budgets::v1::GetBudgetRequest const&
                    request) { return stub_->GetBudget(context, request); },
@@ -132,11 +132,10 @@ class BudgetServiceConnectionImpl : public BudgetServiceConnection {
       override {
     request.clear_page_token();
     auto stub = stub_;
-    auto retry = std::shared_ptr<BudgetServiceRetryPolicy const>(
-        retry_policy_prototype_->clone());
-    auto backoff = std::shared_ptr<BackoffPolicy const>(
-        backoff_policy_prototype_->clone());
-    auto idempotency = idempotency_policy_->ListBudgets(request);
+    auto retry =
+        std::shared_ptr<BudgetServiceRetryPolicy const>(retry_policy());
+    auto backoff = std::shared_ptr<BackoffPolicy const>(backoff_policy());
+    auto idempotency = idempotency_policy()->ListBudgets(request);
     char const* function_name = __func__;
     return google::cloud::internal::MakePaginationRange<
         StreamRange<google::cloud::billing::budgets::v1::Budget>>(
@@ -164,8 +163,8 @@ class BudgetServiceConnectionImpl : public BudgetServiceConnection {
       google::cloud::billing::budgets::v1::DeleteBudgetRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->DeleteBudget(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->DeleteBudget(request),
         [this](grpc::ClientContext& context,
                google::cloud::billing::budgets::v1::DeleteBudgetRequest const&
                    request) { return stub_->DeleteBudget(context, request); },
@@ -173,6 +172,32 @@ class BudgetServiceConnectionImpl : public BudgetServiceConnection {
   }
 
  private:
+  std::unique_ptr<BudgetServiceRetryPolicy> retry_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<BudgetServiceRetryPolicyOption>()) {
+      return options.get<BudgetServiceRetryPolicyOption>()->clone();
+    }
+    return retry_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<BackoffPolicy> backoff_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<BudgetServiceBackoffPolicyOption>()) {
+      return options.get<BudgetServiceBackoffPolicyOption>()->clone();
+    }
+    return backoff_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<BudgetServiceConnectionIdempotencyPolicy>
+  idempotency_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<BudgetServiceConnectionIdempotencyPolicyOption>()) {
+      return options.get<BudgetServiceConnectionIdempotencyPolicyOption>()
+          ->clone();
+    }
+    return idempotency_policy_->clone();
+  }
+
   std::unique_ptr<google::cloud::BackgroundThreads> background_;
   std::shared_ptr<billing_internal::BudgetServiceStub> stub_;
   std::unique_ptr<BudgetServiceRetryPolicy const> retry_policy_prototype_;

--- a/google/cloud/billing/cloud_billing_connection.cc
+++ b/google/cloud/billing/cloud_billing_connection.cc
@@ -133,8 +133,8 @@ class CloudBillingConnectionImpl : public CloudBillingConnection {
       google::cloud::billing::v1::GetBillingAccountRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetBillingAccount(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GetBillingAccount(request),
         [this](grpc::ClientContext& context,
                google::cloud::billing::v1::GetBillingAccountRequest const&
                    request) {
@@ -147,11 +147,9 @@ class CloudBillingConnectionImpl : public CloudBillingConnection {
       google::cloud::billing::v1::ListBillingAccountsRequest request) override {
     request.clear_page_token();
     auto stub = stub_;
-    auto retry = std::shared_ptr<CloudBillingRetryPolicy const>(
-        retry_policy_prototype_->clone());
-    auto backoff = std::shared_ptr<BackoffPolicy const>(
-        backoff_policy_prototype_->clone());
-    auto idempotency = idempotency_policy_->ListBillingAccounts(request);
+    auto retry = std::shared_ptr<CloudBillingRetryPolicy const>(retry_policy());
+    auto backoff = std::shared_ptr<BackoffPolicy const>(backoff_policy());
+    auto idempotency = idempotency_policy()->ListBillingAccounts(request);
     char const* function_name = __func__;
     return google::cloud::internal::MakePaginationRange<
         StreamRange<google::cloud::billing::v1::BillingAccount>>(
@@ -181,8 +179,8 @@ class CloudBillingConnectionImpl : public CloudBillingConnection {
       google::cloud::billing::v1::UpdateBillingAccountRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->UpdateBillingAccount(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->UpdateBillingAccount(request),
         [this](grpc::ClientContext& context,
                google::cloud::billing::v1::UpdateBillingAccountRequest const&
                    request) {
@@ -195,8 +193,8 @@ class CloudBillingConnectionImpl : public CloudBillingConnection {
       google::cloud::billing::v1::CreateBillingAccountRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->CreateBillingAccount(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->CreateBillingAccount(request),
         [this](grpc::ClientContext& context,
                google::cloud::billing::v1::CreateBillingAccountRequest const&
                    request) {
@@ -211,11 +209,9 @@ class CloudBillingConnectionImpl : public CloudBillingConnection {
       override {
     request.clear_page_token();
     auto stub = stub_;
-    auto retry = std::shared_ptr<CloudBillingRetryPolicy const>(
-        retry_policy_prototype_->clone());
-    auto backoff = std::shared_ptr<BackoffPolicy const>(
-        backoff_policy_prototype_->clone());
-    auto idempotency = idempotency_policy_->ListProjectBillingInfo(request);
+    auto retry = std::shared_ptr<CloudBillingRetryPolicy const>(retry_policy());
+    auto backoff = std::shared_ptr<BackoffPolicy const>(backoff_policy());
+    auto idempotency = idempotency_policy()->ListProjectBillingInfo(request);
     char const* function_name = __func__;
     return google::cloud::internal::MakePaginationRange<
         StreamRange<google::cloud::billing::v1::ProjectBillingInfo>>(
@@ -246,8 +242,8 @@ class CloudBillingConnectionImpl : public CloudBillingConnection {
       google::cloud::billing::v1::GetProjectBillingInfoRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetProjectBillingInfo(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GetProjectBillingInfo(request),
         [this](grpc::ClientContext& context,
                google::cloud::billing::v1::GetProjectBillingInfoRequest const&
                    request) {
@@ -261,8 +257,8 @@ class CloudBillingConnectionImpl : public CloudBillingConnection {
       google::cloud::billing::v1::UpdateProjectBillingInfoRequest const&
           request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->UpdateProjectBillingInfo(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->UpdateProjectBillingInfo(request),
         [this](
             grpc::ClientContext& context,
             google::cloud::billing::v1::UpdateProjectBillingInfoRequest const&
@@ -275,8 +271,8 @@ class CloudBillingConnectionImpl : public CloudBillingConnection {
   StatusOr<google::iam::v1::Policy> GetIamPolicy(
       google::iam::v1::GetIamPolicyRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetIamPolicy(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GetIamPolicy(request),
         [this](grpc::ClientContext& context,
                google::iam::v1::GetIamPolicyRequest const& request) {
           return stub_->GetIamPolicy(context, request);
@@ -287,8 +283,8 @@ class CloudBillingConnectionImpl : public CloudBillingConnection {
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
       google::iam::v1::SetIamPolicyRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->SetIamPolicy(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->SetIamPolicy(request),
         [this](grpc::ClientContext& context,
                google::iam::v1::SetIamPolicyRequest const& request) {
           return stub_->SetIamPolicy(context, request);
@@ -299,8 +295,8 @@ class CloudBillingConnectionImpl : public CloudBillingConnection {
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
       google::iam::v1::TestIamPermissionsRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->TestIamPermissions(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->TestIamPermissions(request),
         [this](grpc::ClientContext& context,
                google::iam::v1::TestIamPermissionsRequest const& request) {
           return stub_->TestIamPermissions(context, request);
@@ -309,6 +305,32 @@ class CloudBillingConnectionImpl : public CloudBillingConnection {
   }
 
  private:
+  std::unique_ptr<CloudBillingRetryPolicy> retry_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<CloudBillingRetryPolicyOption>()) {
+      return options.get<CloudBillingRetryPolicyOption>()->clone();
+    }
+    return retry_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<BackoffPolicy> backoff_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<CloudBillingBackoffPolicyOption>()) {
+      return options.get<CloudBillingBackoffPolicyOption>()->clone();
+    }
+    return backoff_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<CloudBillingConnectionIdempotencyPolicy>
+  idempotency_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<CloudBillingConnectionIdempotencyPolicyOption>()) {
+      return options.get<CloudBillingConnectionIdempotencyPolicyOption>()
+          ->clone();
+    }
+    return idempotency_policy_->clone();
+  }
+
   std::unique_ptr<google::cloud::BackgroundThreads> background_;
   std::shared_ptr<billing_internal::CloudBillingStub> stub_;
   std::unique_ptr<CloudBillingRetryPolicy const> retry_policy_prototype_;

--- a/google/cloud/billing/cloud_catalog_connection.cc
+++ b/google/cloud/billing/cloud_catalog_connection.cc
@@ -84,11 +84,9 @@ class CloudCatalogConnectionImpl : public CloudCatalogConnection {
       google::cloud::billing::v1::ListServicesRequest request) override {
     request.clear_page_token();
     auto stub = stub_;
-    auto retry = std::shared_ptr<CloudCatalogRetryPolicy const>(
-        retry_policy_prototype_->clone());
-    auto backoff = std::shared_ptr<BackoffPolicy const>(
-        backoff_policy_prototype_->clone());
-    auto idempotency = idempotency_policy_->ListServices(request);
+    auto retry = std::shared_ptr<CloudCatalogRetryPolicy const>(retry_policy());
+    auto backoff = std::shared_ptr<BackoffPolicy const>(backoff_policy());
+    auto idempotency = idempotency_policy()->ListServices(request);
     char const* function_name = __func__;
     return google::cloud::internal::MakePaginationRange<
         StreamRange<google::cloud::billing::v1::Service>>(
@@ -117,11 +115,9 @@ class CloudCatalogConnectionImpl : public CloudCatalogConnection {
       google::cloud::billing::v1::ListSkusRequest request) override {
     request.clear_page_token();
     auto stub = stub_;
-    auto retry = std::shared_ptr<CloudCatalogRetryPolicy const>(
-        retry_policy_prototype_->clone());
-    auto backoff = std::shared_ptr<BackoffPolicy const>(
-        backoff_policy_prototype_->clone());
-    auto idempotency = idempotency_policy_->ListSkus(request);
+    auto retry = std::shared_ptr<CloudCatalogRetryPolicy const>(retry_policy());
+    auto backoff = std::shared_ptr<BackoffPolicy const>(backoff_policy());
+    auto idempotency = idempotency_policy()->ListSkus(request);
     char const* function_name = __func__;
     return google::cloud::internal::MakePaginationRange<
         StreamRange<google::cloud::billing::v1::Sku>>(
@@ -146,6 +142,32 @@ class CloudCatalogConnectionImpl : public CloudCatalogConnection {
   }
 
  private:
+  std::unique_ptr<CloudCatalogRetryPolicy> retry_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<CloudCatalogRetryPolicyOption>()) {
+      return options.get<CloudCatalogRetryPolicyOption>()->clone();
+    }
+    return retry_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<BackoffPolicy> backoff_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<CloudCatalogBackoffPolicyOption>()) {
+      return options.get<CloudCatalogBackoffPolicyOption>()->clone();
+    }
+    return backoff_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<CloudCatalogConnectionIdempotencyPolicy>
+  idempotency_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<CloudCatalogConnectionIdempotencyPolicyOption>()) {
+      return options.get<CloudCatalogConnectionIdempotencyPolicyOption>()
+          ->clone();
+    }
+    return idempotency_policy_->clone();
+  }
+
   std::unique_ptr<google::cloud::BackgroundThreads> background_;
   std::shared_ptr<billing_internal::CloudCatalogStub> stub_;
   std::unique_ptr<CloudCatalogRetryPolicy const> retry_policy_prototype_;

--- a/google/cloud/composer/environments_connection.cc
+++ b/google/cloud/composer/environments_connection.cc
@@ -138,17 +138,17 @@ class EnvironmentsConnectionImpl : public EnvironmentsConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::cloud::orchestration::airflow::service::v1::Environment>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->CreateEnvironment(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->CreateEnvironment(request), polling_policy(),
+        __func__);
   }
 
   StatusOr<google::cloud::orchestration::airflow::service::v1::Environment>
   GetEnvironment(google::cloud::orchestration::airflow::service::v1::
                      GetEnvironmentRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetEnvironment(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GetEnvironment(request),
         [this](grpc::ClientContext& context,
                google::cloud::orchestration::airflow::service::v1::
                    GetEnvironmentRequest const& request) {
@@ -162,11 +162,9 @@ class EnvironmentsConnectionImpl : public EnvironmentsConnection {
                        ListEnvironmentsRequest request) override {
     request.clear_page_token();
     auto stub = stub_;
-    auto retry = std::shared_ptr<EnvironmentsRetryPolicy const>(
-        retry_policy_prototype_->clone());
-    auto backoff = std::shared_ptr<BackoffPolicy const>(
-        backoff_policy_prototype_->clone());
-    auto idempotency = idempotency_policy_->ListEnvironments(request);
+    auto retry = std::shared_ptr<EnvironmentsRetryPolicy const>(retry_policy());
+    auto backoff = std::shared_ptr<BackoffPolicy const>(backoff_policy());
+    auto idempotency = idempotency_policy()->ListEnvironments(request);
     char const* function_name = __func__;
     return google::cloud::internal::MakePaginationRange<StreamRange<
         google::cloud::orchestration::airflow::service::v1::Environment>>(
@@ -220,9 +218,9 @@ class EnvironmentsConnectionImpl : public EnvironmentsConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::cloud::orchestration::airflow::service::v1::Environment>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->UpdateEnvironment(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->UpdateEnvironment(request), polling_policy(),
+        __func__);
   }
 
   future<StatusOr<
@@ -252,12 +250,46 @@ class EnvironmentsConnectionImpl : public EnvironmentsConnection {
         &google::cloud::internal::ExtractLongRunningResultMetadata<
             google::cloud::orchestration::airflow::service::v1::
                 OperationMetadata>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->DeleteEnvironment(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->DeleteEnvironment(request), polling_policy(),
+        __func__);
   }
 
  private:
+  std::unique_ptr<EnvironmentsRetryPolicy> retry_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<EnvironmentsRetryPolicyOption>()) {
+      return options.get<EnvironmentsRetryPolicyOption>()->clone();
+    }
+    return retry_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<BackoffPolicy> backoff_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<EnvironmentsBackoffPolicyOption>()) {
+      return options.get<EnvironmentsBackoffPolicyOption>()->clone();
+    }
+    return backoff_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<PollingPolicy> polling_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<EnvironmentsPollingPolicyOption>()) {
+      return options.get<EnvironmentsPollingPolicyOption>()->clone();
+    }
+    return polling_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<EnvironmentsConnectionIdempotencyPolicy>
+  idempotency_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<EnvironmentsConnectionIdempotencyPolicyOption>()) {
+      return options.get<EnvironmentsConnectionIdempotencyPolicyOption>()
+          ->clone();
+    }
+    return idempotency_policy_->clone();
+  }
+
   std::unique_ptr<google::cloud::BackgroundThreads> background_;
   std::shared_ptr<composer_internal::EnvironmentsStub> stub_;
   std::unique_ptr<EnvironmentsRetryPolicy const> retry_policy_prototype_;

--- a/google/cloud/composer/image_versions_connection.cc
+++ b/google/cloud/composer/image_versions_connection.cc
@@ -77,11 +77,10 @@ class ImageVersionsConnectionImpl : public ImageVersionsConnection {
                         ListImageVersionsRequest request) override {
     request.clear_page_token();
     auto stub = stub_;
-    auto retry = std::shared_ptr<ImageVersionsRetryPolicy const>(
-        retry_policy_prototype_->clone());
-    auto backoff = std::shared_ptr<BackoffPolicy const>(
-        backoff_policy_prototype_->clone());
-    auto idempotency = idempotency_policy_->ListImageVersions(request);
+    auto retry =
+        std::shared_ptr<ImageVersionsRetryPolicy const>(retry_policy());
+    auto backoff = std::shared_ptr<BackoffPolicy const>(backoff_policy());
+    auto idempotency = idempotency_policy()->ListImageVersions(request);
     char const* function_name = __func__;
     return google::cloud::internal::MakePaginationRange<StreamRange<
         google::cloud::orchestration::airflow::service::v1::ImageVersion>>(
@@ -110,6 +109,32 @@ class ImageVersionsConnectionImpl : public ImageVersionsConnection {
   }
 
  private:
+  std::unique_ptr<ImageVersionsRetryPolicy> retry_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<ImageVersionsRetryPolicyOption>()) {
+      return options.get<ImageVersionsRetryPolicyOption>()->clone();
+    }
+    return retry_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<BackoffPolicy> backoff_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<ImageVersionsBackoffPolicyOption>()) {
+      return options.get<ImageVersionsBackoffPolicyOption>()->clone();
+    }
+    return backoff_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<ImageVersionsConnectionIdempotencyPolicy>
+  idempotency_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<ImageVersionsConnectionIdempotencyPolicyOption>()) {
+      return options.get<ImageVersionsConnectionIdempotencyPolicyOption>()
+          ->clone();
+    }
+    return idempotency_policy_->clone();
+  }
+
   std::unique_ptr<google::cloud::BackgroundThreads> background_;
   std::shared_ptr<composer_internal::ImageVersionsStub> stub_;
   std::unique_ptr<ImageVersionsRetryPolicy const> retry_policy_prototype_;

--- a/google/cloud/datamigration/data_migration_connection.cc
+++ b/google/cloud/datamigration/data_migration_connection.cc
@@ -206,11 +206,10 @@ class DataMigrationServiceConnectionImpl
       google::cloud::clouddms::v1::ListMigrationJobsRequest request) override {
     request.clear_page_token();
     auto stub = stub_;
-    auto retry = std::shared_ptr<DataMigrationServiceRetryPolicy const>(
-        retry_policy_prototype_->clone());
-    auto backoff = std::shared_ptr<BackoffPolicy const>(
-        backoff_policy_prototype_->clone());
-    auto idempotency = idempotency_policy_->ListMigrationJobs(request);
+    auto retry =
+        std::shared_ptr<DataMigrationServiceRetryPolicy const>(retry_policy());
+    auto backoff = std::shared_ptr<BackoffPolicy const>(backoff_policy());
+    auto idempotency = idempotency_policy()->ListMigrationJobs(request);
     char const* function_name = __func__;
     return google::cloud::internal::MakePaginationRange<
         StreamRange<google::cloud::clouddms::v1::MigrationJob>>(
@@ -240,8 +239,8 @@ class DataMigrationServiceConnectionImpl
       google::cloud::clouddms::v1::GetMigrationJobRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetMigrationJob(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GetMigrationJob(request),
         [this](grpc::ClientContext& context,
                google::cloud::clouddms::v1::GetMigrationJobRequest const&
                    request) {
@@ -276,9 +275,9 @@ class DataMigrationServiceConnectionImpl
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::cloud::clouddms::v1::MigrationJob>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->CreateMigrationJob(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->CreateMigrationJob(request), polling_policy(),
+        __func__);
   }
 
   future<StatusOr<google::cloud::clouddms::v1::MigrationJob>>
@@ -307,9 +306,9 @@ class DataMigrationServiceConnectionImpl
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::cloud::clouddms::v1::MigrationJob>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->UpdateMigrationJob(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->UpdateMigrationJob(request), polling_policy(),
+        __func__);
   }
 
   future<StatusOr<google::cloud::clouddms::v1::OperationMetadata>>
@@ -338,9 +337,9 @@ class DataMigrationServiceConnectionImpl
         },
         &google::cloud::internal::ExtractLongRunningResultMetadata<
             google::cloud::clouddms::v1::OperationMetadata>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->DeleteMigrationJob(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->DeleteMigrationJob(request), polling_policy(),
+        __func__);
   }
 
   future<StatusOr<google::cloud::clouddms::v1::MigrationJob>> StartMigrationJob(
@@ -368,9 +367,9 @@ class DataMigrationServiceConnectionImpl
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::cloud::clouddms::v1::MigrationJob>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->StartMigrationJob(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->StartMigrationJob(request), polling_policy(),
+        __func__);
   }
 
   future<StatusOr<google::cloud::clouddms::v1::MigrationJob>> StopMigrationJob(
@@ -398,9 +397,9 @@ class DataMigrationServiceConnectionImpl
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::cloud::clouddms::v1::MigrationJob>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->StopMigrationJob(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->StopMigrationJob(request), polling_policy(),
+        __func__);
   }
 
   future<StatusOr<google::cloud::clouddms::v1::MigrationJob>>
@@ -429,9 +428,9 @@ class DataMigrationServiceConnectionImpl
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::cloud::clouddms::v1::MigrationJob>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->ResumeMigrationJob(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->ResumeMigrationJob(request), polling_policy(),
+        __func__);
   }
 
   future<StatusOr<google::cloud::clouddms::v1::MigrationJob>>
@@ -461,9 +460,9 @@ class DataMigrationServiceConnectionImpl
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::cloud::clouddms::v1::MigrationJob>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->PromoteMigrationJob(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->PromoteMigrationJob(request), polling_policy(),
+        __func__);
   }
 
   future<StatusOr<google::cloud::clouddms::v1::MigrationJob>>
@@ -492,9 +491,9 @@ class DataMigrationServiceConnectionImpl
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::cloud::clouddms::v1::MigrationJob>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->VerifyMigrationJob(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->VerifyMigrationJob(request), polling_policy(),
+        __func__);
   }
 
   future<StatusOr<google::cloud::clouddms::v1::MigrationJob>>
@@ -524,17 +523,17 @@ class DataMigrationServiceConnectionImpl
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::cloud::clouddms::v1::MigrationJob>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->RestartMigrationJob(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->RestartMigrationJob(request), polling_policy(),
+        __func__);
   }
 
   StatusOr<google::cloud::clouddms::v1::SshScript> GenerateSshScript(
       google::cloud::clouddms::v1::GenerateSshScriptRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GenerateSshScript(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GenerateSshScript(request),
         [this](grpc::ClientContext& context,
                google::cloud::clouddms::v1::GenerateSshScriptRequest const&
                    request) {
@@ -549,11 +548,10 @@ class DataMigrationServiceConnectionImpl
       override {
     request.clear_page_token();
     auto stub = stub_;
-    auto retry = std::shared_ptr<DataMigrationServiceRetryPolicy const>(
-        retry_policy_prototype_->clone());
-    auto backoff = std::shared_ptr<BackoffPolicy const>(
-        backoff_policy_prototype_->clone());
-    auto idempotency = idempotency_policy_->ListConnectionProfiles(request);
+    auto retry =
+        std::shared_ptr<DataMigrationServiceRetryPolicy const>(retry_policy());
+    auto backoff = std::shared_ptr<BackoffPolicy const>(backoff_policy());
+    auto idempotency = idempotency_policy()->ListConnectionProfiles(request);
     char const* function_name = __func__;
     return google::cloud::internal::MakePaginationRange<
         StreamRange<google::cloud::clouddms::v1::ConnectionProfile>>(
@@ -583,8 +581,8 @@ class DataMigrationServiceConnectionImpl
       google::cloud::clouddms::v1::GetConnectionProfileRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetConnectionProfile(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GetConnectionProfile(request),
         [this](grpc::ClientContext& context,
                google::cloud::clouddms::v1::GetConnectionProfileRequest const&
                    request) {
@@ -621,9 +619,9 @@ class DataMigrationServiceConnectionImpl
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::cloud::clouddms::v1::ConnectionProfile>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->CreateConnectionProfile(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->CreateConnectionProfile(request),
+        polling_policy(), __func__);
   }
 
   future<StatusOr<google::cloud::clouddms::v1::ConnectionProfile>>
@@ -654,9 +652,9 @@ class DataMigrationServiceConnectionImpl
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::cloud::clouddms::v1::ConnectionProfile>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->UpdateConnectionProfile(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->UpdateConnectionProfile(request),
+        polling_policy(), __func__);
   }
 
   future<StatusOr<google::cloud::clouddms::v1::OperationMetadata>>
@@ -687,12 +685,47 @@ class DataMigrationServiceConnectionImpl
         },
         &google::cloud::internal::ExtractLongRunningResultMetadata<
             google::cloud::clouddms::v1::OperationMetadata>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->DeleteConnectionProfile(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->DeleteConnectionProfile(request),
+        polling_policy(), __func__);
   }
 
  private:
+  std::unique_ptr<DataMigrationServiceRetryPolicy> retry_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<DataMigrationServiceRetryPolicyOption>()) {
+      return options.get<DataMigrationServiceRetryPolicyOption>()->clone();
+    }
+    return retry_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<BackoffPolicy> backoff_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<DataMigrationServiceBackoffPolicyOption>()) {
+      return options.get<DataMigrationServiceBackoffPolicyOption>()->clone();
+    }
+    return backoff_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<PollingPolicy> polling_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<DataMigrationServicePollingPolicyOption>()) {
+      return options.get<DataMigrationServicePollingPolicyOption>()->clone();
+    }
+    return polling_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<DataMigrationServiceConnectionIdempotencyPolicy>
+  idempotency_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<DataMigrationServiceConnectionIdempotencyPolicyOption>()) {
+      return options
+          .get<DataMigrationServiceConnectionIdempotencyPolicyOption>()
+          ->clone();
+    }
+    return idempotency_policy_->clone();
+  }
+
   std::unique_ptr<google::cloud::BackgroundThreads> background_;
   std::shared_ptr<datamigration_internal::DataMigrationServiceStub> stub_;
   std::unique_ptr<DataMigrationServiceRetryPolicy const>

--- a/google/cloud/iam/iam_connection.cc
+++ b/google/cloud/iam/iam_connection.cc
@@ -229,11 +229,9 @@ class IAMConnectionImpl : public IAMConnection {
       google::iam::admin::v1::ListServiceAccountsRequest request) override {
     request.clear_page_token();
     auto stub = stub_;
-    auto retry =
-        std::shared_ptr<IAMRetryPolicy const>(retry_policy_prototype_->clone());
-    auto backoff = std::shared_ptr<BackoffPolicy const>(
-        backoff_policy_prototype_->clone());
-    auto idempotency = idempotency_policy_->ListServiceAccounts(request);
+    auto retry = std::shared_ptr<IAMRetryPolicy const>(retry_policy());
+    auto backoff = std::shared_ptr<BackoffPolicy const>(backoff_policy());
+    auto idempotency = idempotency_policy()->ListServiceAccounts(request);
     char const* function_name = __func__;
     return google::cloud::internal::MakePaginationRange<
         StreamRange<google::iam::admin::v1::ServiceAccount>>(
@@ -262,8 +260,8 @@ class IAMConnectionImpl : public IAMConnection {
       google::iam::admin::v1::GetServiceAccountRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetServiceAccount(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GetServiceAccount(request),
         [this](
             grpc::ClientContext& context,
             google::iam::admin::v1::GetServiceAccountRequest const& request) {
@@ -276,8 +274,8 @@ class IAMConnectionImpl : public IAMConnection {
       google::iam::admin::v1::CreateServiceAccountRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->CreateServiceAccount(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->CreateServiceAccount(request),
         [this](grpc::ClientContext& context,
                google::iam::admin::v1::CreateServiceAccountRequest const&
                    request) {
@@ -290,8 +288,8 @@ class IAMConnectionImpl : public IAMConnection {
       google::iam::admin::v1::PatchServiceAccountRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->PatchServiceAccount(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->PatchServiceAccount(request),
         [this](
             grpc::ClientContext& context,
             google::iam::admin::v1::PatchServiceAccountRequest const& request) {
@@ -304,8 +302,8 @@ class IAMConnectionImpl : public IAMConnection {
       google::iam::admin::v1::DeleteServiceAccountRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->DeleteServiceAccount(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->DeleteServiceAccount(request),
         [this](grpc::ClientContext& context,
                google::iam::admin::v1::DeleteServiceAccountRequest const&
                    request) {
@@ -319,8 +317,8 @@ class IAMConnectionImpl : public IAMConnection {
       google::iam::admin::v1::UndeleteServiceAccountRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->UndeleteServiceAccount(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->UndeleteServiceAccount(request),
         [this](grpc::ClientContext& context,
                google::iam::admin::v1::UndeleteServiceAccountRequest const&
                    request) {
@@ -333,8 +331,8 @@ class IAMConnectionImpl : public IAMConnection {
       google::iam::admin::v1::EnableServiceAccountRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->EnableServiceAccount(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->EnableServiceAccount(request),
         [this](grpc::ClientContext& context,
                google::iam::admin::v1::EnableServiceAccountRequest const&
                    request) {
@@ -347,8 +345,8 @@ class IAMConnectionImpl : public IAMConnection {
       google::iam::admin::v1::DisableServiceAccountRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->DisableServiceAccount(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->DisableServiceAccount(request),
         [this](grpc::ClientContext& context,
                google::iam::admin::v1::DisableServiceAccountRequest const&
                    request) {
@@ -362,8 +360,8 @@ class IAMConnectionImpl : public IAMConnection {
       google::iam::admin::v1::ListServiceAccountKeysRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->ListServiceAccountKeys(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->ListServiceAccountKeys(request),
         [this](grpc::ClientContext& context,
                google::iam::admin::v1::ListServiceAccountKeysRequest const&
                    request) {
@@ -376,8 +374,8 @@ class IAMConnectionImpl : public IAMConnection {
       google::iam::admin::v1::GetServiceAccountKeyRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetServiceAccountKey(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GetServiceAccountKey(request),
         [this](grpc::ClientContext& context,
                google::iam::admin::v1::GetServiceAccountKeyRequest const&
                    request) {
@@ -390,8 +388,8 @@ class IAMConnectionImpl : public IAMConnection {
       google::iam::admin::v1::CreateServiceAccountKeyRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->CreateServiceAccountKey(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->CreateServiceAccountKey(request),
         [this](grpc::ClientContext& context,
                google::iam::admin::v1::CreateServiceAccountKeyRequest const&
                    request) {
@@ -404,8 +402,8 @@ class IAMConnectionImpl : public IAMConnection {
       google::iam::admin::v1::UploadServiceAccountKeyRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->UploadServiceAccountKey(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->UploadServiceAccountKey(request),
         [this](grpc::ClientContext& context,
                google::iam::admin::v1::UploadServiceAccountKeyRequest const&
                    request) {
@@ -418,8 +416,8 @@ class IAMConnectionImpl : public IAMConnection {
       google::iam::admin::v1::DeleteServiceAccountKeyRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->DeleteServiceAccountKey(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->DeleteServiceAccountKey(request),
         [this](grpc::ClientContext& context,
                google::iam::admin::v1::DeleteServiceAccountKeyRequest const&
                    request) {
@@ -431,8 +429,8 @@ class IAMConnectionImpl : public IAMConnection {
   StatusOr<google::iam::v1::Policy> GetIamPolicy(
       google::iam::v1::GetIamPolicyRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetIamPolicy(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GetIamPolicy(request),
         [this](grpc::ClientContext& context,
                google::iam::v1::GetIamPolicyRequest const& request) {
           return stub_->GetIamPolicy(context, request);
@@ -443,8 +441,8 @@ class IAMConnectionImpl : public IAMConnection {
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
       google::iam::v1::SetIamPolicyRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->SetIamPolicy(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->SetIamPolicy(request),
         [this](grpc::ClientContext& context,
                google::iam::v1::SetIamPolicyRequest const& request) {
           return stub_->SetIamPolicy(context, request);
@@ -455,8 +453,8 @@ class IAMConnectionImpl : public IAMConnection {
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
       google::iam::v1::TestIamPermissionsRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->TestIamPermissions(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->TestIamPermissions(request),
         [this](grpc::ClientContext& context,
                google::iam::v1::TestIamPermissionsRequest const& request) {
           return stub_->TestIamPermissions(context, request);
@@ -468,11 +466,9 @@ class IAMConnectionImpl : public IAMConnection {
       google::iam::admin::v1::QueryGrantableRolesRequest request) override {
     request.clear_page_token();
     auto stub = stub_;
-    auto retry =
-        std::shared_ptr<IAMRetryPolicy const>(retry_policy_prototype_->clone());
-    auto backoff = std::shared_ptr<BackoffPolicy const>(
-        backoff_policy_prototype_->clone());
-    auto idempotency = idempotency_policy_->QueryGrantableRoles(request);
+    auto retry = std::shared_ptr<IAMRetryPolicy const>(retry_policy());
+    auto backoff = std::shared_ptr<BackoffPolicy const>(backoff_policy());
+    auto idempotency = idempotency_policy()->QueryGrantableRoles(request);
     char const* function_name = __func__;
     return google::cloud::internal::MakePaginationRange<
         StreamRange<google::iam::admin::v1::Role>>(
@@ -500,11 +496,9 @@ class IAMConnectionImpl : public IAMConnection {
       google::iam::admin::v1::ListRolesRequest request) override {
     request.clear_page_token();
     auto stub = stub_;
-    auto retry =
-        std::shared_ptr<IAMRetryPolicy const>(retry_policy_prototype_->clone());
-    auto backoff = std::shared_ptr<BackoffPolicy const>(
-        backoff_policy_prototype_->clone());
-    auto idempotency = idempotency_policy_->ListRoles(request);
+    auto retry = std::shared_ptr<IAMRetryPolicy const>(retry_policy());
+    auto backoff = std::shared_ptr<BackoffPolicy const>(backoff_policy());
+    auto idempotency = idempotency_policy()->ListRoles(request);
     char const* function_name = __func__;
     return google::cloud::internal::MakePaginationRange<
         StreamRange<google::iam::admin::v1::Role>>(
@@ -530,8 +524,8 @@ class IAMConnectionImpl : public IAMConnection {
   StatusOr<google::iam::admin::v1::Role> GetRole(
       google::iam::admin::v1::GetRoleRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetRole(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GetRole(request),
         [this](grpc::ClientContext& context,
                google::iam::admin::v1::GetRoleRequest const& request) {
           return stub_->GetRole(context, request);
@@ -542,8 +536,8 @@ class IAMConnectionImpl : public IAMConnection {
   StatusOr<google::iam::admin::v1::Role> CreateRole(
       google::iam::admin::v1::CreateRoleRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->CreateRole(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->CreateRole(request),
         [this](grpc::ClientContext& context,
                google::iam::admin::v1::CreateRoleRequest const& request) {
           return stub_->CreateRole(context, request);
@@ -554,8 +548,8 @@ class IAMConnectionImpl : public IAMConnection {
   StatusOr<google::iam::admin::v1::Role> UpdateRole(
       google::iam::admin::v1::UpdateRoleRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->UpdateRole(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->UpdateRole(request),
         [this](grpc::ClientContext& context,
                google::iam::admin::v1::UpdateRoleRequest const& request) {
           return stub_->UpdateRole(context, request);
@@ -566,8 +560,8 @@ class IAMConnectionImpl : public IAMConnection {
   StatusOr<google::iam::admin::v1::Role> DeleteRole(
       google::iam::admin::v1::DeleteRoleRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->DeleteRole(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->DeleteRole(request),
         [this](grpc::ClientContext& context,
                google::iam::admin::v1::DeleteRoleRequest const& request) {
           return stub_->DeleteRole(context, request);
@@ -578,8 +572,8 @@ class IAMConnectionImpl : public IAMConnection {
   StatusOr<google::iam::admin::v1::Role> UndeleteRole(
       google::iam::admin::v1::UndeleteRoleRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->UndeleteRole(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->UndeleteRole(request),
         [this](grpc::ClientContext& context,
                google::iam::admin::v1::UndeleteRoleRequest const& request) {
           return stub_->UndeleteRole(context, request);
@@ -592,11 +586,9 @@ class IAMConnectionImpl : public IAMConnection {
       override {
     request.clear_page_token();
     auto stub = stub_;
-    auto retry =
-        std::shared_ptr<IAMRetryPolicy const>(retry_policy_prototype_->clone());
-    auto backoff = std::shared_ptr<BackoffPolicy const>(
-        backoff_policy_prototype_->clone());
-    auto idempotency = idempotency_policy_->QueryTestablePermissions(request);
+    auto retry = std::shared_ptr<IAMRetryPolicy const>(retry_policy());
+    auto backoff = std::shared_ptr<BackoffPolicy const>(backoff_policy());
+    auto idempotency = idempotency_policy()->QueryTestablePermissions(request);
     char const* function_name = __func__;
     return google::cloud::internal::MakePaginationRange<
         StreamRange<google::iam::admin::v1::Permission>>(
@@ -627,8 +619,8 @@ class IAMConnectionImpl : public IAMConnection {
       google::iam::admin::v1::QueryAuditableServicesRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->QueryAuditableServices(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->QueryAuditableServices(request),
         [this](grpc::ClientContext& context,
                google::iam::admin::v1::QueryAuditableServicesRequest const&
                    request) {
@@ -640,8 +632,8 @@ class IAMConnectionImpl : public IAMConnection {
   StatusOr<google::iam::admin::v1::LintPolicyResponse> LintPolicy(
       google::iam::admin::v1::LintPolicyRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->LintPolicy(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->LintPolicy(request),
         [this](grpc::ClientContext& context,
                google::iam::admin::v1::LintPolicyRequest const& request) {
           return stub_->LintPolicy(context, request);
@@ -650,6 +642,30 @@ class IAMConnectionImpl : public IAMConnection {
   }
 
  private:
+  std::unique_ptr<IAMRetryPolicy> retry_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<IAMRetryPolicyOption>()) {
+      return options.get<IAMRetryPolicyOption>()->clone();
+    }
+    return retry_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<BackoffPolicy> backoff_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<IAMBackoffPolicyOption>()) {
+      return options.get<IAMBackoffPolicyOption>()->clone();
+    }
+    return backoff_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<IAMConnectionIdempotencyPolicy> idempotency_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<IAMConnectionIdempotencyPolicyOption>()) {
+      return options.get<IAMConnectionIdempotencyPolicyOption>()->clone();
+    }
+    return idempotency_policy_->clone();
+  }
+
   std::unique_ptr<google::cloud::BackgroundThreads> background_;
   std::shared_ptr<iam_internal::IAMStub> stub_;
   std::unique_ptr<IAMRetryPolicy const> retry_policy_prototype_;

--- a/google/cloud/iam/iam_credentials_connection.cc
+++ b/google/cloud/iam/iam_credentials_connection.cc
@@ -81,8 +81,8 @@ class IAMCredentialsConnectionImpl : public IAMCredentialsConnection {
       google::iam::credentials::v1::GenerateAccessTokenRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GenerateAccessToken(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GenerateAccessToken(request),
         [this](grpc::ClientContext& context,
                google::iam::credentials::v1::GenerateAccessTokenRequest const&
                    request) {
@@ -95,8 +95,8 @@ class IAMCredentialsConnectionImpl : public IAMCredentialsConnection {
   GenerateIdToken(google::iam::credentials::v1::GenerateIdTokenRequest const&
                       request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GenerateIdToken(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GenerateIdToken(request),
         [this](grpc::ClientContext& context,
                google::iam::credentials::v1::GenerateIdTokenRequest const&
                    request) {
@@ -108,8 +108,8 @@ class IAMCredentialsConnectionImpl : public IAMCredentialsConnection {
   StatusOr<google::iam::credentials::v1::SignBlobResponse> SignBlob(
       google::iam::credentials::v1::SignBlobRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->SignBlob(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->SignBlob(request),
         [this](grpc::ClientContext& context,
                google::iam::credentials::v1::SignBlobRequest const& request) {
           return stub_->SignBlob(context, request);
@@ -120,8 +120,8 @@ class IAMCredentialsConnectionImpl : public IAMCredentialsConnection {
   StatusOr<google::iam::credentials::v1::SignJwtResponse> SignJwt(
       google::iam::credentials::v1::SignJwtRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->SignJwt(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->SignJwt(request),
         [this](grpc::ClientContext& context,
                google::iam::credentials::v1::SignJwtRequest const& request) {
           return stub_->SignJwt(context, request);
@@ -130,6 +130,32 @@ class IAMCredentialsConnectionImpl : public IAMCredentialsConnection {
   }
 
  private:
+  std::unique_ptr<IAMCredentialsRetryPolicy> retry_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<IAMCredentialsRetryPolicyOption>()) {
+      return options.get<IAMCredentialsRetryPolicyOption>()->clone();
+    }
+    return retry_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<BackoffPolicy> backoff_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<IAMCredentialsBackoffPolicyOption>()) {
+      return options.get<IAMCredentialsBackoffPolicyOption>()->clone();
+    }
+    return backoff_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<IAMCredentialsConnectionIdempotencyPolicy>
+  idempotency_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<IAMCredentialsConnectionIdempotencyPolicyOption>()) {
+      return options.get<IAMCredentialsConnectionIdempotencyPolicyOption>()
+          ->clone();
+    }
+    return idempotency_policy_->clone();
+  }
+
   std::unique_ptr<google::cloud::BackgroundThreads> background_;
   std::shared_ptr<iam_internal::IAMCredentialsStub> stub_;
   std::unique_ptr<IAMCredentialsRetryPolicy const> retry_policy_prototype_;

--- a/google/cloud/iot/device_manager_connection.cc
+++ b/google/cloud/iot/device_manager_connection.cc
@@ -180,8 +180,8 @@ class DeviceManagerConnectionImpl : public DeviceManagerConnection {
       google::cloud::iot::v1::CreateDeviceRegistryRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->CreateDeviceRegistry(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->CreateDeviceRegistry(request),
         [this](grpc::ClientContext& context,
                google::cloud::iot::v1::CreateDeviceRegistryRequest const&
                    request) {
@@ -194,8 +194,8 @@ class DeviceManagerConnectionImpl : public DeviceManagerConnection {
       google::cloud::iot::v1::GetDeviceRegistryRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetDeviceRegistry(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GetDeviceRegistry(request),
         [this](
             grpc::ClientContext& context,
             google::cloud::iot::v1::GetDeviceRegistryRequest const& request) {
@@ -208,8 +208,8 @@ class DeviceManagerConnectionImpl : public DeviceManagerConnection {
       google::cloud::iot::v1::UpdateDeviceRegistryRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->UpdateDeviceRegistry(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->UpdateDeviceRegistry(request),
         [this](grpc::ClientContext& context,
                google::cloud::iot::v1::UpdateDeviceRegistryRequest const&
                    request) {
@@ -222,8 +222,8 @@ class DeviceManagerConnectionImpl : public DeviceManagerConnection {
       google::cloud::iot::v1::DeleteDeviceRegistryRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->DeleteDeviceRegistry(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->DeleteDeviceRegistry(request),
         [this](grpc::ClientContext& context,
                google::cloud::iot::v1::DeleteDeviceRegistryRequest const&
                    request) {
@@ -236,11 +236,10 @@ class DeviceManagerConnectionImpl : public DeviceManagerConnection {
       google::cloud::iot::v1::ListDeviceRegistriesRequest request) override {
     request.clear_page_token();
     auto stub = stub_;
-    auto retry = std::shared_ptr<DeviceManagerRetryPolicy const>(
-        retry_policy_prototype_->clone());
-    auto backoff = std::shared_ptr<BackoffPolicy const>(
-        backoff_policy_prototype_->clone());
-    auto idempotency = idempotency_policy_->ListDeviceRegistries(request);
+    auto retry =
+        std::shared_ptr<DeviceManagerRetryPolicy const>(retry_policy());
+    auto backoff = std::shared_ptr<BackoffPolicy const>(backoff_policy());
+    auto idempotency = idempotency_policy()->ListDeviceRegistries(request);
     char const* function_name = __func__;
     return google::cloud::internal::MakePaginationRange<
         StreamRange<google::cloud::iot::v1::DeviceRegistry>>(
@@ -268,8 +267,8 @@ class DeviceManagerConnectionImpl : public DeviceManagerConnection {
   StatusOr<google::cloud::iot::v1::Device> CreateDevice(
       google::cloud::iot::v1::CreateDeviceRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->CreateDevice(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->CreateDevice(request),
         [this](grpc::ClientContext& context,
                google::cloud::iot::v1::CreateDeviceRequest const& request) {
           return stub_->CreateDevice(context, request);
@@ -280,8 +279,8 @@ class DeviceManagerConnectionImpl : public DeviceManagerConnection {
   StatusOr<google::cloud::iot::v1::Device> GetDevice(
       google::cloud::iot::v1::GetDeviceRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetDevice(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GetDevice(request),
         [this](grpc::ClientContext& context,
                google::cloud::iot::v1::GetDeviceRequest const& request) {
           return stub_->GetDevice(context, request);
@@ -292,8 +291,8 @@ class DeviceManagerConnectionImpl : public DeviceManagerConnection {
   StatusOr<google::cloud::iot::v1::Device> UpdateDevice(
       google::cloud::iot::v1::UpdateDeviceRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->UpdateDevice(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->UpdateDevice(request),
         [this](grpc::ClientContext& context,
                google::cloud::iot::v1::UpdateDeviceRequest const& request) {
           return stub_->UpdateDevice(context, request);
@@ -304,8 +303,8 @@ class DeviceManagerConnectionImpl : public DeviceManagerConnection {
   Status DeleteDevice(
       google::cloud::iot::v1::DeleteDeviceRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->DeleteDevice(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->DeleteDevice(request),
         [this](grpc::ClientContext& context,
                google::cloud::iot::v1::DeleteDeviceRequest const& request) {
           return stub_->DeleteDevice(context, request);
@@ -317,11 +316,10 @@ class DeviceManagerConnectionImpl : public DeviceManagerConnection {
       google::cloud::iot::v1::ListDevicesRequest request) override {
     request.clear_page_token();
     auto stub = stub_;
-    auto retry = std::shared_ptr<DeviceManagerRetryPolicy const>(
-        retry_policy_prototype_->clone());
-    auto backoff = std::shared_ptr<BackoffPolicy const>(
-        backoff_policy_prototype_->clone());
-    auto idempotency = idempotency_policy_->ListDevices(request);
+    auto retry =
+        std::shared_ptr<DeviceManagerRetryPolicy const>(retry_policy());
+    auto backoff = std::shared_ptr<BackoffPolicy const>(backoff_policy());
+    auto idempotency = idempotency_policy()->ListDevices(request);
     char const* function_name = __func__;
     return google::cloud::internal::MakePaginationRange<
         StreamRange<google::cloud::iot::v1::Device>>(
@@ -350,8 +348,8 @@ class DeviceManagerConnectionImpl : public DeviceManagerConnection {
       google::cloud::iot::v1::ModifyCloudToDeviceConfigRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->ModifyCloudToDeviceConfig(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->ModifyCloudToDeviceConfig(request),
         [this](grpc::ClientContext& context,
                google::cloud::iot::v1::ModifyCloudToDeviceConfigRequest const&
                    request) {
@@ -365,8 +363,8 @@ class DeviceManagerConnectionImpl : public DeviceManagerConnection {
       google::cloud::iot::v1::ListDeviceConfigVersionsRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->ListDeviceConfigVersions(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->ListDeviceConfigVersions(request),
         [this](grpc::ClientContext& context,
                google::cloud::iot::v1::ListDeviceConfigVersionsRequest const&
                    request) {
@@ -378,8 +376,8 @@ class DeviceManagerConnectionImpl : public DeviceManagerConnection {
   StatusOr<google::cloud::iot::v1::ListDeviceStatesResponse> ListDeviceStates(
       google::cloud::iot::v1::ListDeviceStatesRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->ListDeviceStates(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->ListDeviceStates(request),
         [this](grpc::ClientContext& context,
                google::cloud::iot::v1::ListDeviceStatesRequest const& request) {
           return stub_->ListDeviceStates(context, request);
@@ -390,8 +388,8 @@ class DeviceManagerConnectionImpl : public DeviceManagerConnection {
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
       google::iam::v1::SetIamPolicyRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->SetIamPolicy(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->SetIamPolicy(request),
         [this](grpc::ClientContext& context,
                google::iam::v1::SetIamPolicyRequest const& request) {
           return stub_->SetIamPolicy(context, request);
@@ -402,8 +400,8 @@ class DeviceManagerConnectionImpl : public DeviceManagerConnection {
   StatusOr<google::iam::v1::Policy> GetIamPolicy(
       google::iam::v1::GetIamPolicyRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetIamPolicy(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GetIamPolicy(request),
         [this](grpc::ClientContext& context,
                google::iam::v1::GetIamPolicyRequest const& request) {
           return stub_->GetIamPolicy(context, request);
@@ -414,8 +412,8 @@ class DeviceManagerConnectionImpl : public DeviceManagerConnection {
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
       google::iam::v1::TestIamPermissionsRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->TestIamPermissions(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->TestIamPermissions(request),
         [this](grpc::ClientContext& context,
                google::iam::v1::TestIamPermissionsRequest const& request) {
           return stub_->TestIamPermissions(context, request);
@@ -427,8 +425,8 @@ class DeviceManagerConnectionImpl : public DeviceManagerConnection {
   SendCommandToDevice(google::cloud::iot::v1::SendCommandToDeviceRequest const&
                           request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->SendCommandToDevice(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->SendCommandToDevice(request),
         [this](
             grpc::ClientContext& context,
             google::cloud::iot::v1::SendCommandToDeviceRequest const& request) {
@@ -441,8 +439,8 @@ class DeviceManagerConnectionImpl : public DeviceManagerConnection {
   BindDeviceToGateway(google::cloud::iot::v1::BindDeviceToGatewayRequest const&
                           request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->BindDeviceToGateway(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->BindDeviceToGateway(request),
         [this](
             grpc::ClientContext& context,
             google::cloud::iot::v1::BindDeviceToGatewayRequest const& request) {
@@ -456,8 +454,8 @@ class DeviceManagerConnectionImpl : public DeviceManagerConnection {
       google::cloud::iot::v1::UnbindDeviceFromGatewayRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->UnbindDeviceFromGateway(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->UnbindDeviceFromGateway(request),
         [this](grpc::ClientContext& context,
                google::cloud::iot::v1::UnbindDeviceFromGatewayRequest const&
                    request) {
@@ -467,6 +465,32 @@ class DeviceManagerConnectionImpl : public DeviceManagerConnection {
   }
 
  private:
+  std::unique_ptr<DeviceManagerRetryPolicy> retry_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<DeviceManagerRetryPolicyOption>()) {
+      return options.get<DeviceManagerRetryPolicyOption>()->clone();
+    }
+    return retry_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<BackoffPolicy> backoff_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<DeviceManagerBackoffPolicyOption>()) {
+      return options.get<DeviceManagerBackoffPolicyOption>()->clone();
+    }
+    return backoff_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<DeviceManagerConnectionIdempotencyPolicy>
+  idempotency_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<DeviceManagerConnectionIdempotencyPolicyOption>()) {
+      return options.get<DeviceManagerConnectionIdempotencyPolicyOption>()
+          ->clone();
+    }
+    return idempotency_policy_->clone();
+  }
+
   std::unique_ptr<google::cloud::BackgroundThreads> background_;
   std::shared_ptr<iot_internal::DeviceManagerStub> stub_;
   std::unique_ptr<DeviceManagerRetryPolicy const> retry_policy_prototype_;

--- a/google/cloud/kms/key_management_connection.cc
+++ b/google/cloud/kms/key_management_connection.cc
@@ -248,11 +248,10 @@ class KeyManagementServiceConnectionImpl
       google::cloud::kms::v1::ListKeyRingsRequest request) override {
     request.clear_page_token();
     auto stub = stub_;
-    auto retry = std::shared_ptr<KeyManagementServiceRetryPolicy const>(
-        retry_policy_prototype_->clone());
-    auto backoff = std::shared_ptr<BackoffPolicy const>(
-        backoff_policy_prototype_->clone());
-    auto idempotency = idempotency_policy_->ListKeyRings(request);
+    auto retry =
+        std::shared_ptr<KeyManagementServiceRetryPolicy const>(retry_policy());
+    auto backoff = std::shared_ptr<BackoffPolicy const>(backoff_policy());
+    auto idempotency = idempotency_policy()->ListKeyRings(request);
     char const* function_name = __func__;
     return google::cloud::internal::MakePaginationRange<
         StreamRange<google::cloud::kms::v1::KeyRing>>(
@@ -281,11 +280,10 @@ class KeyManagementServiceConnectionImpl
       google::cloud::kms::v1::ListCryptoKeysRequest request) override {
     request.clear_page_token();
     auto stub = stub_;
-    auto retry = std::shared_ptr<KeyManagementServiceRetryPolicy const>(
-        retry_policy_prototype_->clone());
-    auto backoff = std::shared_ptr<BackoffPolicy const>(
-        backoff_policy_prototype_->clone());
-    auto idempotency = idempotency_policy_->ListCryptoKeys(request);
+    auto retry =
+        std::shared_ptr<KeyManagementServiceRetryPolicy const>(retry_policy());
+    auto backoff = std::shared_ptr<BackoffPolicy const>(backoff_policy());
+    auto idempotency = idempotency_policy()->ListCryptoKeys(request);
     char const* function_name = __func__;
     return google::cloud::internal::MakePaginationRange<
         StreamRange<google::cloud::kms::v1::CryptoKey>>(
@@ -314,11 +312,10 @@ class KeyManagementServiceConnectionImpl
       google::cloud::kms::v1::ListCryptoKeyVersionsRequest request) override {
     request.clear_page_token();
     auto stub = stub_;
-    auto retry = std::shared_ptr<KeyManagementServiceRetryPolicy const>(
-        retry_policy_prototype_->clone());
-    auto backoff = std::shared_ptr<BackoffPolicy const>(
-        backoff_policy_prototype_->clone());
-    auto idempotency = idempotency_policy_->ListCryptoKeyVersions(request);
+    auto retry =
+        std::shared_ptr<KeyManagementServiceRetryPolicy const>(retry_policy());
+    auto backoff = std::shared_ptr<BackoffPolicy const>(backoff_policy());
+    auto idempotency = idempotency_policy()->ListCryptoKeyVersions(request);
     char const* function_name = __func__;
     return google::cloud::internal::MakePaginationRange<
         StreamRange<google::cloud::kms::v1::CryptoKeyVersion>>(
@@ -347,11 +344,10 @@ class KeyManagementServiceConnectionImpl
       google::cloud::kms::v1::ListImportJobsRequest request) override {
     request.clear_page_token();
     auto stub = stub_;
-    auto retry = std::shared_ptr<KeyManagementServiceRetryPolicy const>(
-        retry_policy_prototype_->clone());
-    auto backoff = std::shared_ptr<BackoffPolicy const>(
-        backoff_policy_prototype_->clone());
-    auto idempotency = idempotency_policy_->ListImportJobs(request);
+    auto retry =
+        std::shared_ptr<KeyManagementServiceRetryPolicy const>(retry_policy());
+    auto backoff = std::shared_ptr<BackoffPolicy const>(backoff_policy());
+    auto idempotency = idempotency_policy()->ListImportJobs(request);
     char const* function_name = __func__;
     return google::cloud::internal::MakePaginationRange<
         StreamRange<google::cloud::kms::v1::ImportJob>>(
@@ -379,8 +375,8 @@ class KeyManagementServiceConnectionImpl
   StatusOr<google::cloud::kms::v1::KeyRing> GetKeyRing(
       google::cloud::kms::v1::GetKeyRingRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetKeyRing(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GetKeyRing(request),
         [this](grpc::ClientContext& context,
                google::cloud::kms::v1::GetKeyRingRequest const& request) {
           return stub_->GetKeyRing(context, request);
@@ -391,8 +387,8 @@ class KeyManagementServiceConnectionImpl
   StatusOr<google::cloud::kms::v1::CryptoKey> GetCryptoKey(
       google::cloud::kms::v1::GetCryptoKeyRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetCryptoKey(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GetCryptoKey(request),
         [this](grpc::ClientContext& context,
                google::cloud::kms::v1::GetCryptoKeyRequest const& request) {
           return stub_->GetCryptoKey(context, request);
@@ -404,8 +400,8 @@ class KeyManagementServiceConnectionImpl
       google::cloud::kms::v1::GetCryptoKeyVersionRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetCryptoKeyVersion(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GetCryptoKeyVersion(request),
         [this](
             grpc::ClientContext& context,
             google::cloud::kms::v1::GetCryptoKeyVersionRequest const& request) {
@@ -417,8 +413,8 @@ class KeyManagementServiceConnectionImpl
   StatusOr<google::cloud::kms::v1::PublicKey> GetPublicKey(
       google::cloud::kms::v1::GetPublicKeyRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetPublicKey(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GetPublicKey(request),
         [this](grpc::ClientContext& context,
                google::cloud::kms::v1::GetPublicKeyRequest const& request) {
           return stub_->GetPublicKey(context, request);
@@ -429,8 +425,8 @@ class KeyManagementServiceConnectionImpl
   StatusOr<google::cloud::kms::v1::ImportJob> GetImportJob(
       google::cloud::kms::v1::GetImportJobRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetImportJob(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GetImportJob(request),
         [this](grpc::ClientContext& context,
                google::cloud::kms::v1::GetImportJobRequest const& request) {
           return stub_->GetImportJob(context, request);
@@ -441,8 +437,8 @@ class KeyManagementServiceConnectionImpl
   StatusOr<google::cloud::kms::v1::KeyRing> CreateKeyRing(
       google::cloud::kms::v1::CreateKeyRingRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->CreateKeyRing(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->CreateKeyRing(request),
         [this](grpc::ClientContext& context,
                google::cloud::kms::v1::CreateKeyRingRequest const& request) {
           return stub_->CreateKeyRing(context, request);
@@ -453,8 +449,8 @@ class KeyManagementServiceConnectionImpl
   StatusOr<google::cloud::kms::v1::CryptoKey> CreateCryptoKey(
       google::cloud::kms::v1::CreateCryptoKeyRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->CreateCryptoKey(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->CreateCryptoKey(request),
         [this](grpc::ClientContext& context,
                google::cloud::kms::v1::CreateCryptoKeyRequest const& request) {
           return stub_->CreateCryptoKey(context, request);
@@ -466,8 +462,8 @@ class KeyManagementServiceConnectionImpl
       google::cloud::kms::v1::CreateCryptoKeyVersionRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->CreateCryptoKeyVersion(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->CreateCryptoKeyVersion(request),
         [this](grpc::ClientContext& context,
                google::cloud::kms::v1::CreateCryptoKeyVersionRequest const&
                    request) {
@@ -480,8 +476,8 @@ class KeyManagementServiceConnectionImpl
       google::cloud::kms::v1::ImportCryptoKeyVersionRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->ImportCryptoKeyVersion(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->ImportCryptoKeyVersion(request),
         [this](grpc::ClientContext& context,
                google::cloud::kms::v1::ImportCryptoKeyVersionRequest const&
                    request) {
@@ -493,8 +489,8 @@ class KeyManagementServiceConnectionImpl
   StatusOr<google::cloud::kms::v1::ImportJob> CreateImportJob(
       google::cloud::kms::v1::CreateImportJobRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->CreateImportJob(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->CreateImportJob(request),
         [this](grpc::ClientContext& context,
                google::cloud::kms::v1::CreateImportJobRequest const& request) {
           return stub_->CreateImportJob(context, request);
@@ -505,8 +501,8 @@ class KeyManagementServiceConnectionImpl
   StatusOr<google::cloud::kms::v1::CryptoKey> UpdateCryptoKey(
       google::cloud::kms::v1::UpdateCryptoKeyRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->UpdateCryptoKey(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->UpdateCryptoKey(request),
         [this](grpc::ClientContext& context,
                google::cloud::kms::v1::UpdateCryptoKeyRequest const& request) {
           return stub_->UpdateCryptoKey(context, request);
@@ -518,8 +514,8 @@ class KeyManagementServiceConnectionImpl
       google::cloud::kms::v1::UpdateCryptoKeyVersionRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->UpdateCryptoKeyVersion(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->UpdateCryptoKeyVersion(request),
         [this](grpc::ClientContext& context,
                google::cloud::kms::v1::UpdateCryptoKeyVersionRequest const&
                    request) {
@@ -532,8 +528,8 @@ class KeyManagementServiceConnectionImpl
       google::cloud::kms::v1::UpdateCryptoKeyPrimaryVersionRequest const&
           request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->UpdateCryptoKeyPrimaryVersion(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->UpdateCryptoKeyPrimaryVersion(request),
         [this](
             grpc::ClientContext& context,
             google::cloud::kms::v1::UpdateCryptoKeyPrimaryVersionRequest const&
@@ -547,8 +543,8 @@ class KeyManagementServiceConnectionImpl
       google::cloud::kms::v1::DestroyCryptoKeyVersionRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->DestroyCryptoKeyVersion(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->DestroyCryptoKeyVersion(request),
         [this](grpc::ClientContext& context,
                google::cloud::kms::v1::DestroyCryptoKeyVersionRequest const&
                    request) {
@@ -561,8 +557,8 @@ class KeyManagementServiceConnectionImpl
       google::cloud::kms::v1::RestoreCryptoKeyVersionRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->RestoreCryptoKeyVersion(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->RestoreCryptoKeyVersion(request),
         [this](grpc::ClientContext& context,
                google::cloud::kms::v1::RestoreCryptoKeyVersionRequest const&
                    request) {
@@ -574,8 +570,8 @@ class KeyManagementServiceConnectionImpl
   StatusOr<google::cloud::kms::v1::EncryptResponse> Encrypt(
       google::cloud::kms::v1::EncryptRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->Encrypt(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->Encrypt(request),
         [this](grpc::ClientContext& context,
                google::cloud::kms::v1::EncryptRequest const& request) {
           return stub_->Encrypt(context, request);
@@ -586,8 +582,8 @@ class KeyManagementServiceConnectionImpl
   StatusOr<google::cloud::kms::v1::DecryptResponse> Decrypt(
       google::cloud::kms::v1::DecryptRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->Decrypt(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->Decrypt(request),
         [this](grpc::ClientContext& context,
                google::cloud::kms::v1::DecryptRequest const& request) {
           return stub_->Decrypt(context, request);
@@ -598,8 +594,8 @@ class KeyManagementServiceConnectionImpl
   StatusOr<google::cloud::kms::v1::AsymmetricSignResponse> AsymmetricSign(
       google::cloud::kms::v1::AsymmetricSignRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->AsymmetricSign(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->AsymmetricSign(request),
         [this](grpc::ClientContext& context,
                google::cloud::kms::v1::AsymmetricSignRequest const& request) {
           return stub_->AsymmetricSign(context, request);
@@ -611,8 +607,8 @@ class KeyManagementServiceConnectionImpl
       google::cloud::kms::v1::AsymmetricDecryptRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->AsymmetricDecrypt(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->AsymmetricDecrypt(request),
         [this](
             grpc::ClientContext& context,
             google::cloud::kms::v1::AsymmetricDecryptRequest const& request) {
@@ -624,8 +620,8 @@ class KeyManagementServiceConnectionImpl
   StatusOr<google::cloud::kms::v1::MacSignResponse> MacSign(
       google::cloud::kms::v1::MacSignRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->MacSign(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->MacSign(request),
         [this](grpc::ClientContext& context,
                google::cloud::kms::v1::MacSignRequest const& request) {
           return stub_->MacSign(context, request);
@@ -636,8 +632,8 @@ class KeyManagementServiceConnectionImpl
   StatusOr<google::cloud::kms::v1::MacVerifyResponse> MacVerify(
       google::cloud::kms::v1::MacVerifyRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->MacVerify(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->MacVerify(request),
         [this](grpc::ClientContext& context,
                google::cloud::kms::v1::MacVerifyRequest const& request) {
           return stub_->MacVerify(context, request);
@@ -649,8 +645,8 @@ class KeyManagementServiceConnectionImpl
   GenerateRandomBytes(google::cloud::kms::v1::GenerateRandomBytesRequest const&
                           request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GenerateRandomBytes(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GenerateRandomBytes(request),
         [this](
             grpc::ClientContext& context,
             google::cloud::kms::v1::GenerateRandomBytesRequest const& request) {
@@ -660,6 +656,33 @@ class KeyManagementServiceConnectionImpl
   }
 
  private:
+  std::unique_ptr<KeyManagementServiceRetryPolicy> retry_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<KeyManagementServiceRetryPolicyOption>()) {
+      return options.get<KeyManagementServiceRetryPolicyOption>()->clone();
+    }
+    return retry_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<BackoffPolicy> backoff_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<KeyManagementServiceBackoffPolicyOption>()) {
+      return options.get<KeyManagementServiceBackoffPolicyOption>()->clone();
+    }
+    return backoff_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<KeyManagementServiceConnectionIdempotencyPolicy>
+  idempotency_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<KeyManagementServiceConnectionIdempotencyPolicyOption>()) {
+      return options
+          .get<KeyManagementServiceConnectionIdempotencyPolicyOption>()
+          ->clone();
+    }
+    return idempotency_policy_->clone();
+  }
+
   std::unique_ptr<google::cloud::BackgroundThreads> background_;
   std::shared_ptr<kms_internal::KeyManagementServiceStub> stub_;
   std::unique_ptr<KeyManagementServiceRetryPolicy const>

--- a/google/cloud/logging/logging_service_v2_connection.cc
+++ b/google/cloud/logging/logging_service_v2_connection.cc
@@ -119,8 +119,8 @@ class LoggingServiceV2ConnectionImpl : public LoggingServiceV2Connection {
   Status DeleteLog(
       google::logging::v2::DeleteLogRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->DeleteLog(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->DeleteLog(request),
         [this](grpc::ClientContext& context,
                google::logging::v2::DeleteLogRequest const& request) {
           return stub_->DeleteLog(context, request);
@@ -131,8 +131,8 @@ class LoggingServiceV2ConnectionImpl : public LoggingServiceV2Connection {
   StatusOr<google::logging::v2::WriteLogEntriesResponse> WriteLogEntries(
       google::logging::v2::WriteLogEntriesRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->WriteLogEntries(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->WriteLogEntries(request),
         [this](grpc::ClientContext& context,
                google::logging::v2::WriteLogEntriesRequest const& request) {
           return stub_->WriteLogEntries(context, request);
@@ -144,11 +144,10 @@ class LoggingServiceV2ConnectionImpl : public LoggingServiceV2Connection {
       google::logging::v2::ListLogEntriesRequest request) override {
     request.clear_page_token();
     auto stub = stub_;
-    auto retry = std::shared_ptr<LoggingServiceV2RetryPolicy const>(
-        retry_policy_prototype_->clone());
-    auto backoff = std::shared_ptr<BackoffPolicy const>(
-        backoff_policy_prototype_->clone());
-    auto idempotency = idempotency_policy_->ListLogEntries(request);
+    auto retry =
+        std::shared_ptr<LoggingServiceV2RetryPolicy const>(retry_policy());
+    auto backoff = std::shared_ptr<BackoffPolicy const>(backoff_policy());
+    auto idempotency = idempotency_policy()->ListLogEntries(request);
     char const* function_name = __func__;
     return google::cloud::internal::MakePaginationRange<
         StreamRange<google::logging::v2::LogEntry>>(
@@ -178,12 +177,11 @@ class LoggingServiceV2ConnectionImpl : public LoggingServiceV2Connection {
       override {
     request.clear_page_token();
     auto stub = stub_;
-    auto retry = std::shared_ptr<LoggingServiceV2RetryPolicy const>(
-        retry_policy_prototype_->clone());
-    auto backoff = std::shared_ptr<BackoffPolicy const>(
-        backoff_policy_prototype_->clone());
+    auto retry =
+        std::shared_ptr<LoggingServiceV2RetryPolicy const>(retry_policy());
+    auto backoff = std::shared_ptr<BackoffPolicy const>(backoff_policy());
     auto idempotency =
-        idempotency_policy_->ListMonitoredResourceDescriptors(request);
+        idempotency_policy()->ListMonitoredResourceDescriptors(request);
     char const* function_name = __func__;
     return google::cloud::internal::MakePaginationRange<
         StreamRange<google::api::MonitoredResourceDescriptor>>(
@@ -214,11 +212,10 @@ class LoggingServiceV2ConnectionImpl : public LoggingServiceV2Connection {
       google::logging::v2::ListLogsRequest request) override {
     request.clear_page_token();
     auto stub = stub_;
-    auto retry = std::shared_ptr<LoggingServiceV2RetryPolicy const>(
-        retry_policy_prototype_->clone());
-    auto backoff = std::shared_ptr<BackoffPolicy const>(
-        backoff_policy_prototype_->clone());
-    auto idempotency = idempotency_policy_->ListLogs(request);
+    auto retry =
+        std::shared_ptr<LoggingServiceV2RetryPolicy const>(retry_policy());
+    auto backoff = std::shared_ptr<BackoffPolicy const>(backoff_policy());
+    auto idempotency = idempotency_policy()->ListLogs(request);
     char const* function_name = __func__;
     return google::cloud::internal::MakePaginationRange<
         StreamRange<std::string>>(
@@ -250,6 +247,32 @@ class LoggingServiceV2ConnectionImpl : public LoggingServiceV2Connection {
   }
 
  private:
+  std::unique_ptr<LoggingServiceV2RetryPolicy> retry_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<LoggingServiceV2RetryPolicyOption>()) {
+      return options.get<LoggingServiceV2RetryPolicyOption>()->clone();
+    }
+    return retry_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<BackoffPolicy> backoff_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<LoggingServiceV2BackoffPolicyOption>()) {
+      return options.get<LoggingServiceV2BackoffPolicyOption>()->clone();
+    }
+    return backoff_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<LoggingServiceV2ConnectionIdempotencyPolicy>
+  idempotency_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<LoggingServiceV2ConnectionIdempotencyPolicyOption>()) {
+      return options.get<LoggingServiceV2ConnectionIdempotencyPolicyOption>()
+          ->clone();
+    }
+    return idempotency_policy_->clone();
+  }
+
   std::unique_ptr<google::cloud::BackgroundThreads> background_;
   std::shared_ptr<logging_internal::LoggingServiceV2Stub> stub_;
   std::unique_ptr<LoggingServiceV2RetryPolicy const> retry_policy_prototype_;

--- a/google/cloud/notebooks/managed_notebook_connection.cc
+++ b/google/cloud/notebooks/managed_notebook_connection.cc
@@ -139,10 +139,9 @@ class ManagedNotebookServiceConnectionImpl
     request.clear_page_token();
     auto stub = stub_;
     auto retry = std::shared_ptr<ManagedNotebookServiceRetryPolicy const>(
-        retry_policy_prototype_->clone());
-    auto backoff = std::shared_ptr<BackoffPolicy const>(
-        backoff_policy_prototype_->clone());
-    auto idempotency = idempotency_policy_->ListRuntimes(request);
+        retry_policy());
+    auto backoff = std::shared_ptr<BackoffPolicy const>(backoff_policy());
+    auto idempotency = idempotency_policy()->ListRuntimes(request);
     char const* function_name = __func__;
     return google::cloud::internal::MakePaginationRange<
         StreamRange<google::cloud::notebooks::v1::Runtime>>(
@@ -170,8 +169,8 @@ class ManagedNotebookServiceConnectionImpl
   StatusOr<google::cloud::notebooks::v1::Runtime> GetRuntime(
       google::cloud::notebooks::v1::GetRuntimeRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetRuntime(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GetRuntime(request),
         [this](grpc::ClientContext& context,
                google::cloud::notebooks::v1::GetRuntimeRequest const& request) {
           return stub_->GetRuntime(context, request);
@@ -204,9 +203,9 @@ class ManagedNotebookServiceConnectionImpl
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::cloud::notebooks::v1::Runtime>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->CreateRuntime(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->CreateRuntime(request), polling_policy(),
+        __func__);
   }
 
   future<StatusOr<google::cloud::notebooks::v1::OperationMetadata>>
@@ -234,9 +233,9 @@ class ManagedNotebookServiceConnectionImpl
         },
         &google::cloud::internal::ExtractLongRunningResultMetadata<
             google::cloud::notebooks::v1::OperationMetadata>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->DeleteRuntime(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->DeleteRuntime(request), polling_policy(),
+        __func__);
   }
 
   future<StatusOr<google::cloud::notebooks::v1::Runtime>> StartRuntime(
@@ -264,9 +263,9 @@ class ManagedNotebookServiceConnectionImpl
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::cloud::notebooks::v1::Runtime>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->StartRuntime(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->StartRuntime(request), polling_policy(),
+        __func__);
   }
 
   future<StatusOr<google::cloud::notebooks::v1::Runtime>> StopRuntime(
@@ -294,9 +293,8 @@ class ManagedNotebookServiceConnectionImpl
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::cloud::notebooks::v1::Runtime>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->StopRuntime(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->StopRuntime(request), polling_policy(), __func__);
   }
 
   future<StatusOr<google::cloud::notebooks::v1::Runtime>> SwitchRuntime(
@@ -324,9 +322,9 @@ class ManagedNotebookServiceConnectionImpl
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::cloud::notebooks::v1::Runtime>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->SwitchRuntime(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->SwitchRuntime(request), polling_policy(),
+        __func__);
   }
 
   future<StatusOr<google::cloud::notebooks::v1::Runtime>> ResetRuntime(
@@ -354,9 +352,9 @@ class ManagedNotebookServiceConnectionImpl
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::cloud::notebooks::v1::Runtime>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->ResetRuntime(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->ResetRuntime(request), polling_policy(),
+        __func__);
   }
 
   future<StatusOr<google::cloud::notebooks::v1::Runtime>> ReportRuntimeEvent(
@@ -384,12 +382,48 @@ class ManagedNotebookServiceConnectionImpl
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::cloud::notebooks::v1::Runtime>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->ReportRuntimeEvent(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->ReportRuntimeEvent(request), polling_policy(),
+        __func__);
   }
 
  private:
+  std::unique_ptr<ManagedNotebookServiceRetryPolicy> retry_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<ManagedNotebookServiceRetryPolicyOption>()) {
+      return options.get<ManagedNotebookServiceRetryPolicyOption>()->clone();
+    }
+    return retry_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<BackoffPolicy> backoff_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<ManagedNotebookServiceBackoffPolicyOption>()) {
+      return options.get<ManagedNotebookServiceBackoffPolicyOption>()->clone();
+    }
+    return backoff_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<PollingPolicy> polling_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<ManagedNotebookServicePollingPolicyOption>()) {
+      return options.get<ManagedNotebookServicePollingPolicyOption>()->clone();
+    }
+    return polling_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<ManagedNotebookServiceConnectionIdempotencyPolicy>
+  idempotency_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options
+            .has<ManagedNotebookServiceConnectionIdempotencyPolicyOption>()) {
+      return options
+          .get<ManagedNotebookServiceConnectionIdempotencyPolicyOption>()
+          ->clone();
+    }
+    return idempotency_policy_->clone();
+  }
+
   std::unique_ptr<google::cloud::BackgroundThreads> background_;
   std::shared_ptr<notebooks_internal::ManagedNotebookServiceStub> stub_;
   std::unique_ptr<ManagedNotebookServiceRetryPolicy const>

--- a/google/cloud/notebooks/notebook_connection.cc
+++ b/google/cloud/notebooks/notebook_connection.cc
@@ -329,11 +329,10 @@ class NotebookServiceConnectionImpl : public NotebookServiceConnection {
       google::cloud::notebooks::v1::ListInstancesRequest request) override {
     request.clear_page_token();
     auto stub = stub_;
-    auto retry = std::shared_ptr<NotebookServiceRetryPolicy const>(
-        retry_policy_prototype_->clone());
-    auto backoff = std::shared_ptr<BackoffPolicy const>(
-        backoff_policy_prototype_->clone());
-    auto idempotency = idempotency_policy_->ListInstances(request);
+    auto retry =
+        std::shared_ptr<NotebookServiceRetryPolicy const>(retry_policy());
+    auto backoff = std::shared_ptr<BackoffPolicy const>(backoff_policy());
+    auto idempotency = idempotency_policy()->ListInstances(request);
     char const* function_name = __func__;
     return google::cloud::internal::MakePaginationRange<
         StreamRange<google::cloud::notebooks::v1::Instance>>(
@@ -362,8 +361,8 @@ class NotebookServiceConnectionImpl : public NotebookServiceConnection {
       google::cloud::notebooks::v1::GetInstanceRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetInstance(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GetInstance(request),
         [this](
             grpc::ClientContext& context,
             google::cloud::notebooks::v1::GetInstanceRequest const& request) {
@@ -397,9 +396,9 @@ class NotebookServiceConnectionImpl : public NotebookServiceConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::cloud::notebooks::v1::Instance>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->CreateInstance(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->CreateInstance(request), polling_policy(),
+        __func__);
   }
 
   future<StatusOr<google::cloud::notebooks::v1::Instance>> RegisterInstance(
@@ -427,9 +426,9 @@ class NotebookServiceConnectionImpl : public NotebookServiceConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::cloud::notebooks::v1::Instance>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->RegisterInstance(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->RegisterInstance(request), polling_policy(),
+        __func__);
   }
 
   future<StatusOr<google::cloud::notebooks::v1::Instance>>
@@ -460,9 +459,9 @@ class NotebookServiceConnectionImpl : public NotebookServiceConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::cloud::notebooks::v1::Instance>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->SetInstanceAccelerator(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->SetInstanceAccelerator(request), polling_policy(),
+        __func__);
   }
 
   future<StatusOr<google::cloud::notebooks::v1::Instance>>
@@ -493,9 +492,9 @@ class NotebookServiceConnectionImpl : public NotebookServiceConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::cloud::notebooks::v1::Instance>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->SetInstanceMachineType(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->SetInstanceMachineType(request), polling_policy(),
+        __func__);
   }
 
   future<StatusOr<google::cloud::notebooks::v1::Instance>> UpdateInstanceConfig(
@@ -524,9 +523,9 @@ class NotebookServiceConnectionImpl : public NotebookServiceConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::cloud::notebooks::v1::Instance>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->UpdateInstanceConfig(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->UpdateInstanceConfig(request), polling_policy(),
+        __func__);
   }
 
   future<StatusOr<google::cloud::notebooks::v1::Instance>>
@@ -556,9 +555,9 @@ class NotebookServiceConnectionImpl : public NotebookServiceConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::cloud::notebooks::v1::Instance>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->UpdateShieldedInstanceConfig(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->UpdateShieldedInstanceConfig(request),
+        polling_policy(), __func__);
   }
 
   future<StatusOr<google::cloud::notebooks::v1::Instance>> SetInstanceLabels(
@@ -586,9 +585,9 @@ class NotebookServiceConnectionImpl : public NotebookServiceConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::cloud::notebooks::v1::Instance>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->SetInstanceLabels(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->SetInstanceLabels(request), polling_policy(),
+        __func__);
   }
 
   future<StatusOr<google::cloud::notebooks::v1::OperationMetadata>>
@@ -616,9 +615,9 @@ class NotebookServiceConnectionImpl : public NotebookServiceConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultMetadata<
             google::cloud::notebooks::v1::OperationMetadata>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->DeleteInstance(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->DeleteInstance(request), polling_policy(),
+        __func__);
   }
 
   future<StatusOr<google::cloud::notebooks::v1::Instance>> StartInstance(
@@ -646,9 +645,9 @@ class NotebookServiceConnectionImpl : public NotebookServiceConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::cloud::notebooks::v1::Instance>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->StartInstance(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->StartInstance(request), polling_policy(),
+        __func__);
   }
 
   future<StatusOr<google::cloud::notebooks::v1::Instance>> StopInstance(
@@ -676,9 +675,9 @@ class NotebookServiceConnectionImpl : public NotebookServiceConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::cloud::notebooks::v1::Instance>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->StopInstance(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->StopInstance(request), polling_policy(),
+        __func__);
   }
 
   future<StatusOr<google::cloud::notebooks::v1::Instance>> ResetInstance(
@@ -706,9 +705,9 @@ class NotebookServiceConnectionImpl : public NotebookServiceConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::cloud::notebooks::v1::Instance>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->ResetInstance(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->ResetInstance(request), polling_policy(),
+        __func__);
   }
 
   future<StatusOr<google::cloud::notebooks::v1::Instance>> ReportInstanceInfo(
@@ -736,9 +735,9 @@ class NotebookServiceConnectionImpl : public NotebookServiceConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::cloud::notebooks::v1::Instance>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->ReportInstanceInfo(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->ReportInstanceInfo(request), polling_policy(),
+        __func__);
   }
 
   StatusOr<google::cloud::notebooks::v1::IsInstanceUpgradeableResponse>
@@ -746,8 +745,8 @@ class NotebookServiceConnectionImpl : public NotebookServiceConnection {
       google::cloud::notebooks::v1::IsInstanceUpgradeableRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->IsInstanceUpgradeable(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->IsInstanceUpgradeable(request),
         [this](grpc::ClientContext& context,
                google::cloud::notebooks::v1::IsInstanceUpgradeableRequest const&
                    request) {
@@ -761,8 +760,8 @@ class NotebookServiceConnectionImpl : public NotebookServiceConnection {
       google::cloud::notebooks::v1::GetInstanceHealthRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetInstanceHealth(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GetInstanceHealth(request),
         [this](grpc::ClientContext& context,
                google::cloud::notebooks::v1::GetInstanceHealthRequest const&
                    request) {
@@ -796,9 +795,9 @@ class NotebookServiceConnectionImpl : public NotebookServiceConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::cloud::notebooks::v1::Instance>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->UpgradeInstance(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->UpgradeInstance(request), polling_policy(),
+        __func__);
   }
 
   future<StatusOr<google::cloud::notebooks::v1::Instance>> RollbackInstance(
@@ -826,9 +825,9 @@ class NotebookServiceConnectionImpl : public NotebookServiceConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::cloud::notebooks::v1::Instance>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->RollbackInstance(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->RollbackInstance(request), polling_policy(),
+        __func__);
   }
 
   future<StatusOr<google::cloud::notebooks::v1::Instance>>
@@ -859,20 +858,19 @@ class NotebookServiceConnectionImpl : public NotebookServiceConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::cloud::notebooks::v1::Instance>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->UpgradeInstanceInternal(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->UpgradeInstanceInternal(request),
+        polling_policy(), __func__);
   }
 
   StreamRange<google::cloud::notebooks::v1::Environment> ListEnvironments(
       google::cloud::notebooks::v1::ListEnvironmentsRequest request) override {
     request.clear_page_token();
     auto stub = stub_;
-    auto retry = std::shared_ptr<NotebookServiceRetryPolicy const>(
-        retry_policy_prototype_->clone());
-    auto backoff = std::shared_ptr<BackoffPolicy const>(
-        backoff_policy_prototype_->clone());
-    auto idempotency = idempotency_policy_->ListEnvironments(request);
+    auto retry =
+        std::shared_ptr<NotebookServiceRetryPolicy const>(retry_policy());
+    auto backoff = std::shared_ptr<BackoffPolicy const>(backoff_policy());
+    auto idempotency = idempotency_policy()->ListEnvironments(request);
     char const* function_name = __func__;
     return google::cloud::internal::MakePaginationRange<
         StreamRange<google::cloud::notebooks::v1::Environment>>(
@@ -902,8 +900,8 @@ class NotebookServiceConnectionImpl : public NotebookServiceConnection {
       google::cloud::notebooks::v1::GetEnvironmentRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetEnvironment(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GetEnvironment(request),
         [this](grpc::ClientContext& context,
                google::cloud::notebooks::v1::GetEnvironmentRequest const&
                    request) { return stub_->GetEnvironment(context, request); },
@@ -935,9 +933,9 @@ class NotebookServiceConnectionImpl : public NotebookServiceConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::cloud::notebooks::v1::Environment>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->CreateEnvironment(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->CreateEnvironment(request), polling_policy(),
+        __func__);
   }
 
   future<StatusOr<google::cloud::notebooks::v1::OperationMetadata>>
@@ -966,20 +964,19 @@ class NotebookServiceConnectionImpl : public NotebookServiceConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultMetadata<
             google::cloud::notebooks::v1::OperationMetadata>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->DeleteEnvironment(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->DeleteEnvironment(request), polling_policy(),
+        __func__);
   }
 
   StreamRange<google::cloud::notebooks::v1::Schedule> ListSchedules(
       google::cloud::notebooks::v1::ListSchedulesRequest request) override {
     request.clear_page_token();
     auto stub = stub_;
-    auto retry = std::shared_ptr<NotebookServiceRetryPolicy const>(
-        retry_policy_prototype_->clone());
-    auto backoff = std::shared_ptr<BackoffPolicy const>(
-        backoff_policy_prototype_->clone());
-    auto idempotency = idempotency_policy_->ListSchedules(request);
+    auto retry =
+        std::shared_ptr<NotebookServiceRetryPolicy const>(retry_policy());
+    auto backoff = std::shared_ptr<BackoffPolicy const>(backoff_policy());
+    auto idempotency = idempotency_policy()->ListSchedules(request);
     char const* function_name = __func__;
     return google::cloud::internal::MakePaginationRange<
         StreamRange<google::cloud::notebooks::v1::Schedule>>(
@@ -1008,8 +1005,8 @@ class NotebookServiceConnectionImpl : public NotebookServiceConnection {
       google::cloud::notebooks::v1::GetScheduleRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetSchedule(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GetSchedule(request),
         [this](
             grpc::ClientContext& context,
             google::cloud::notebooks::v1::GetScheduleRequest const& request) {
@@ -1043,9 +1040,9 @@ class NotebookServiceConnectionImpl : public NotebookServiceConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultMetadata<
             google::cloud::notebooks::v1::OperationMetadata>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->DeleteSchedule(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->DeleteSchedule(request), polling_policy(),
+        __func__);
   }
 
   future<StatusOr<google::cloud::notebooks::v1::Schedule>> CreateSchedule(
@@ -1073,9 +1070,9 @@ class NotebookServiceConnectionImpl : public NotebookServiceConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::cloud::notebooks::v1::Schedule>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->CreateSchedule(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->CreateSchedule(request), polling_policy(),
+        __func__);
   }
 
   future<StatusOr<google::cloud::notebooks::v1::Schedule>> TriggerSchedule(
@@ -1103,20 +1100,19 @@ class NotebookServiceConnectionImpl : public NotebookServiceConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::cloud::notebooks::v1::Schedule>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->TriggerSchedule(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->TriggerSchedule(request), polling_policy(),
+        __func__);
   }
 
   StreamRange<google::cloud::notebooks::v1::Execution> ListExecutions(
       google::cloud::notebooks::v1::ListExecutionsRequest request) override {
     request.clear_page_token();
     auto stub = stub_;
-    auto retry = std::shared_ptr<NotebookServiceRetryPolicy const>(
-        retry_policy_prototype_->clone());
-    auto backoff = std::shared_ptr<BackoffPolicy const>(
-        backoff_policy_prototype_->clone());
-    auto idempotency = idempotency_policy_->ListExecutions(request);
+    auto retry =
+        std::shared_ptr<NotebookServiceRetryPolicy const>(retry_policy());
+    auto backoff = std::shared_ptr<BackoffPolicy const>(backoff_policy());
+    auto idempotency = idempotency_policy()->ListExecutions(request);
     char const* function_name = __func__;
     return google::cloud::internal::MakePaginationRange<
         StreamRange<google::cloud::notebooks::v1::Execution>>(
@@ -1145,8 +1141,8 @@ class NotebookServiceConnectionImpl : public NotebookServiceConnection {
       google::cloud::notebooks::v1::GetExecutionRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetExecution(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GetExecution(request),
         [this](
             grpc::ClientContext& context,
             google::cloud::notebooks::v1::GetExecutionRequest const& request) {
@@ -1180,9 +1176,9 @@ class NotebookServiceConnectionImpl : public NotebookServiceConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultMetadata<
             google::cloud::notebooks::v1::OperationMetadata>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->DeleteExecution(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->DeleteExecution(request), polling_policy(),
+        __func__);
   }
 
   future<StatusOr<google::cloud::notebooks::v1::Execution>> CreateExecution(
@@ -1210,12 +1206,46 @@ class NotebookServiceConnectionImpl : public NotebookServiceConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::cloud::notebooks::v1::Execution>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->CreateExecution(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->CreateExecution(request), polling_policy(),
+        __func__);
   }
 
  private:
+  std::unique_ptr<NotebookServiceRetryPolicy> retry_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<NotebookServiceRetryPolicyOption>()) {
+      return options.get<NotebookServiceRetryPolicyOption>()->clone();
+    }
+    return retry_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<BackoffPolicy> backoff_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<NotebookServiceBackoffPolicyOption>()) {
+      return options.get<NotebookServiceBackoffPolicyOption>()->clone();
+    }
+    return backoff_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<PollingPolicy> polling_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<NotebookServicePollingPolicyOption>()) {
+      return options.get<NotebookServicePollingPolicyOption>()->clone();
+    }
+    return polling_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<NotebookServiceConnectionIdempotencyPolicy>
+  idempotency_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<NotebookServiceConnectionIdempotencyPolicyOption>()) {
+      return options.get<NotebookServiceConnectionIdempotencyPolicyOption>()
+          ->clone();
+    }
+    return idempotency_policy_->clone();
+  }
+
   std::unique_ptr<google::cloud::BackgroundThreads> background_;
   std::shared_ptr<notebooks_internal::NotebookServiceStub> stub_;
   std::unique_ptr<NotebookServiceRetryPolicy const> retry_policy_prototype_;

--- a/google/cloud/oslogin/os_login_connection.cc
+++ b/google/cloud/oslogin/os_login_connection.cc
@@ -90,8 +90,8 @@ class OsLoginServiceConnectionImpl : public OsLoginServiceConnection {
       google::cloud::oslogin::v1::DeletePosixAccountRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->DeletePosixAccount(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->DeletePosixAccount(request),
         [this](grpc::ClientContext& context,
                google::cloud::oslogin::v1::DeletePosixAccountRequest const&
                    request) {
@@ -104,8 +104,8 @@ class OsLoginServiceConnectionImpl : public OsLoginServiceConnection {
       google::cloud::oslogin::v1::DeleteSshPublicKeyRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->DeleteSshPublicKey(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->DeleteSshPublicKey(request),
         [this](grpc::ClientContext& context,
                google::cloud::oslogin::v1::DeleteSshPublicKeyRequest const&
                    request) {
@@ -118,8 +118,8 @@ class OsLoginServiceConnectionImpl : public OsLoginServiceConnection {
       google::cloud::oslogin::v1::GetLoginProfileRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetLoginProfile(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GetLoginProfile(request),
         [this](
             grpc::ClientContext& context,
             google::cloud::oslogin::v1::GetLoginProfileRequest const& request) {
@@ -132,8 +132,8 @@ class OsLoginServiceConnectionImpl : public OsLoginServiceConnection {
       google::cloud::oslogin::v1::GetSshPublicKeyRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetSshPublicKey(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GetSshPublicKey(request),
         [this](
             grpc::ClientContext& context,
             google::cloud::oslogin::v1::GetSshPublicKeyRequest const& request) {
@@ -147,8 +147,8 @@ class OsLoginServiceConnectionImpl : public OsLoginServiceConnection {
       google::cloud::oslogin::v1::ImportSshPublicKeyRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->ImportSshPublicKey(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->ImportSshPublicKey(request),
         [this](grpc::ClientContext& context,
                google::cloud::oslogin::v1::ImportSshPublicKeyRequest const&
                    request) {
@@ -161,8 +161,8 @@ class OsLoginServiceConnectionImpl : public OsLoginServiceConnection {
       google::cloud::oslogin::v1::UpdateSshPublicKeyRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->UpdateSshPublicKey(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->UpdateSshPublicKey(request),
         [this](grpc::ClientContext& context,
                google::cloud::oslogin::v1::UpdateSshPublicKeyRequest const&
                    request) {
@@ -172,6 +172,32 @@ class OsLoginServiceConnectionImpl : public OsLoginServiceConnection {
   }
 
  private:
+  std::unique_ptr<OsLoginServiceRetryPolicy> retry_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<OsLoginServiceRetryPolicyOption>()) {
+      return options.get<OsLoginServiceRetryPolicyOption>()->clone();
+    }
+    return retry_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<BackoffPolicy> backoff_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<OsLoginServiceBackoffPolicyOption>()) {
+      return options.get<OsLoginServiceBackoffPolicyOption>()->clone();
+    }
+    return backoff_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<OsLoginServiceConnectionIdempotencyPolicy>
+  idempotency_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<OsLoginServiceConnectionIdempotencyPolicyOption>()) {
+      return options.get<OsLoginServiceConnectionIdempotencyPolicyOption>()
+          ->clone();
+    }
+    return idempotency_policy_->clone();
+  }
+
   std::unique_ptr<google::cloud::BackgroundThreads> background_;
   std::shared_ptr<oslogin_internal::OsLoginServiceStub> stub_;
   std::unique_ptr<OsLoginServiceRetryPolicy const> retry_policy_prototype_;

--- a/google/cloud/policytroubleshooter/iam_checker_connection.cc
+++ b/google/cloud/policytroubleshooter/iam_checker_connection.cc
@@ -65,8 +65,8 @@ class IamCheckerConnectionImpl : public IamCheckerConnection {
       google::cloud::policytroubleshooter::v1::
           TroubleshootIamPolicyRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->TroubleshootIamPolicy(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->TroubleshootIamPolicy(request),
         [this](grpc::ClientContext& context,
                google::cloud::policytroubleshooter::v1::
                    TroubleshootIamPolicyRequest const& request) {
@@ -76,6 +76,31 @@ class IamCheckerConnectionImpl : public IamCheckerConnection {
   }
 
  private:
+  std::unique_ptr<IamCheckerRetryPolicy> retry_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<IamCheckerRetryPolicyOption>()) {
+      return options.get<IamCheckerRetryPolicyOption>()->clone();
+    }
+    return retry_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<BackoffPolicy> backoff_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<IamCheckerBackoffPolicyOption>()) {
+      return options.get<IamCheckerBackoffPolicyOption>()->clone();
+    }
+    return backoff_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<IamCheckerConnectionIdempotencyPolicy> idempotency_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<IamCheckerConnectionIdempotencyPolicyOption>()) {
+      return options.get<IamCheckerConnectionIdempotencyPolicyOption>()
+          ->clone();
+    }
+    return idempotency_policy_->clone();
+  }
+
   std::unique_ptr<google::cloud::BackgroundThreads> background_;
   std::shared_ptr<policytroubleshooter_internal::IamCheckerStub> stub_;
   std::unique_ptr<IamCheckerRetryPolicy const> retry_policy_prototype_;

--- a/google/cloud/pubsublite/admin_connection.cc
+++ b/google/cloud/pubsublite/admin_connection.cc
@@ -212,8 +212,8 @@ class AdminServiceConnectionImpl : public AdminServiceConnection {
       google::cloud::pubsublite::v1::CreateTopicRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->CreateTopic(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->CreateTopic(request),
         [this](
             grpc::ClientContext& context,
             google::cloud::pubsublite::v1::CreateTopicRequest const& request) {
@@ -225,8 +225,8 @@ class AdminServiceConnectionImpl : public AdminServiceConnection {
   StatusOr<google::cloud::pubsublite::v1::Topic> GetTopic(
       google::cloud::pubsublite::v1::GetTopicRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetTopic(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GetTopic(request),
         [this](grpc::ClientContext& context,
                google::cloud::pubsublite::v1::GetTopicRequest const& request) {
           return stub_->GetTopic(context, request);
@@ -238,8 +238,8 @@ class AdminServiceConnectionImpl : public AdminServiceConnection {
       google::cloud::pubsublite::v1::GetTopicPartitionsRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetTopicPartitions(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GetTopicPartitions(request),
         [this](grpc::ClientContext& context,
                google::cloud::pubsublite::v1::GetTopicPartitionsRequest const&
                    request) {
@@ -252,11 +252,9 @@ class AdminServiceConnectionImpl : public AdminServiceConnection {
       google::cloud::pubsublite::v1::ListTopicsRequest request) override {
     request.clear_page_token();
     auto stub = stub_;
-    auto retry = std::shared_ptr<AdminServiceRetryPolicy const>(
-        retry_policy_prototype_->clone());
-    auto backoff = std::shared_ptr<BackoffPolicy const>(
-        backoff_policy_prototype_->clone());
-    auto idempotency = idempotency_policy_->ListTopics(request);
+    auto retry = std::shared_ptr<AdminServiceRetryPolicy const>(retry_policy());
+    auto backoff = std::shared_ptr<BackoffPolicy const>(backoff_policy());
+    auto idempotency = idempotency_policy()->ListTopics(request);
     char const* function_name = __func__;
     return google::cloud::internal::MakePaginationRange<
         StreamRange<google::cloud::pubsublite::v1::Topic>>(
@@ -285,8 +283,8 @@ class AdminServiceConnectionImpl : public AdminServiceConnection {
       google::cloud::pubsublite::v1::UpdateTopicRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->UpdateTopic(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->UpdateTopic(request),
         [this](
             grpc::ClientContext& context,
             google::cloud::pubsublite::v1::UpdateTopicRequest const& request) {
@@ -298,8 +296,8 @@ class AdminServiceConnectionImpl : public AdminServiceConnection {
   Status DeleteTopic(google::cloud::pubsublite::v1::DeleteTopicRequest const&
                          request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->DeleteTopic(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->DeleteTopic(request),
         [this](
             grpc::ClientContext& context,
             google::cloud::pubsublite::v1::DeleteTopicRequest const& request) {
@@ -313,11 +311,9 @@ class AdminServiceConnectionImpl : public AdminServiceConnection {
       override {
     request.clear_page_token();
     auto stub = stub_;
-    auto retry = std::shared_ptr<AdminServiceRetryPolicy const>(
-        retry_policy_prototype_->clone());
-    auto backoff = std::shared_ptr<BackoffPolicy const>(
-        backoff_policy_prototype_->clone());
-    auto idempotency = idempotency_policy_->ListTopicSubscriptions(request);
+    auto retry = std::shared_ptr<AdminServiceRetryPolicy const>(retry_policy());
+    auto backoff = std::shared_ptr<BackoffPolicy const>(backoff_policy());
+    auto idempotency = idempotency_policy()->ListTopicSubscriptions(request);
     char const* function_name = __func__;
     return google::cloud::internal::MakePaginationRange<
         StreamRange<std::string>>(
@@ -346,8 +342,8 @@ class AdminServiceConnectionImpl : public AdminServiceConnection {
       google::cloud::pubsublite::v1::CreateSubscriptionRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->CreateSubscription(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->CreateSubscription(request),
         [this](grpc::ClientContext& context,
                google::cloud::pubsublite::v1::CreateSubscriptionRequest const&
                    request) {
@@ -360,8 +356,8 @@ class AdminServiceConnectionImpl : public AdminServiceConnection {
       google::cloud::pubsublite::v1::GetSubscriptionRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetSubscription(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GetSubscription(request),
         [this](grpc::ClientContext& context,
                google::cloud::pubsublite::v1::GetSubscriptionRequest const&
                    request) {
@@ -375,11 +371,9 @@ class AdminServiceConnectionImpl : public AdminServiceConnection {
       override {
     request.clear_page_token();
     auto stub = stub_;
-    auto retry = std::shared_ptr<AdminServiceRetryPolicy const>(
-        retry_policy_prototype_->clone());
-    auto backoff = std::shared_ptr<BackoffPolicy const>(
-        backoff_policy_prototype_->clone());
-    auto idempotency = idempotency_policy_->ListSubscriptions(request);
+    auto retry = std::shared_ptr<AdminServiceRetryPolicy const>(retry_policy());
+    auto backoff = std::shared_ptr<BackoffPolicy const>(backoff_policy());
+    auto idempotency = idempotency_policy()->ListSubscriptions(request);
     char const* function_name = __func__;
     return google::cloud::internal::MakePaginationRange<
         StreamRange<google::cloud::pubsublite::v1::Subscription>>(
@@ -409,8 +403,8 @@ class AdminServiceConnectionImpl : public AdminServiceConnection {
       google::cloud::pubsublite::v1::UpdateSubscriptionRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->UpdateSubscription(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->UpdateSubscription(request),
         [this](grpc::ClientContext& context,
                google::cloud::pubsublite::v1::UpdateSubscriptionRequest const&
                    request) {
@@ -423,8 +417,8 @@ class AdminServiceConnectionImpl : public AdminServiceConnection {
       google::cloud::pubsublite::v1::DeleteSubscriptionRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->DeleteSubscription(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->DeleteSubscription(request),
         [this](grpc::ClientContext& context,
                google::cloud::pubsublite::v1::DeleteSubscriptionRequest const&
                    request) {
@@ -458,17 +452,17 @@ class AdminServiceConnectionImpl : public AdminServiceConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::cloud::pubsublite::v1::SeekSubscriptionResponse>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->SeekSubscription(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->SeekSubscription(request), polling_policy(),
+        __func__);
   }
 
   StatusOr<google::cloud::pubsublite::v1::Reservation> CreateReservation(
       google::cloud::pubsublite::v1::CreateReservationRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->CreateReservation(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->CreateReservation(request),
         [this](grpc::ClientContext& context,
                google::cloud::pubsublite::v1::CreateReservationRequest const&
                    request) {
@@ -481,8 +475,8 @@ class AdminServiceConnectionImpl : public AdminServiceConnection {
       google::cloud::pubsublite::v1::GetReservationRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetReservation(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GetReservation(request),
         [this](grpc::ClientContext& context,
                google::cloud::pubsublite::v1::GetReservationRequest const&
                    request) { return stub_->GetReservation(context, request); },
@@ -493,11 +487,9 @@ class AdminServiceConnectionImpl : public AdminServiceConnection {
       google::cloud::pubsublite::v1::ListReservationsRequest request) override {
     request.clear_page_token();
     auto stub = stub_;
-    auto retry = std::shared_ptr<AdminServiceRetryPolicy const>(
-        retry_policy_prototype_->clone());
-    auto backoff = std::shared_ptr<BackoffPolicy const>(
-        backoff_policy_prototype_->clone());
-    auto idempotency = idempotency_policy_->ListReservations(request);
+    auto retry = std::shared_ptr<AdminServiceRetryPolicy const>(retry_policy());
+    auto backoff = std::shared_ptr<BackoffPolicy const>(backoff_policy());
+    auto idempotency = idempotency_policy()->ListReservations(request);
     char const* function_name = __func__;
     return google::cloud::internal::MakePaginationRange<
         StreamRange<google::cloud::pubsublite::v1::Reservation>>(
@@ -527,8 +519,8 @@ class AdminServiceConnectionImpl : public AdminServiceConnection {
       google::cloud::pubsublite::v1::UpdateReservationRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->UpdateReservation(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->UpdateReservation(request),
         [this](grpc::ClientContext& context,
                google::cloud::pubsublite::v1::UpdateReservationRequest const&
                    request) {
@@ -541,8 +533,8 @@ class AdminServiceConnectionImpl : public AdminServiceConnection {
       google::cloud::pubsublite::v1::DeleteReservationRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->DeleteReservation(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->DeleteReservation(request),
         [this](grpc::ClientContext& context,
                google::cloud::pubsublite::v1::DeleteReservationRequest const&
                    request) {
@@ -556,11 +548,9 @@ class AdminServiceConnectionImpl : public AdminServiceConnection {
       override {
     request.clear_page_token();
     auto stub = stub_;
-    auto retry = std::shared_ptr<AdminServiceRetryPolicy const>(
-        retry_policy_prototype_->clone());
-    auto backoff = std::shared_ptr<BackoffPolicy const>(
-        backoff_policy_prototype_->clone());
-    auto idempotency = idempotency_policy_->ListReservationTopics(request);
+    auto retry = std::shared_ptr<AdminServiceRetryPolicy const>(retry_policy());
+    auto backoff = std::shared_ptr<BackoffPolicy const>(backoff_policy());
+    auto idempotency = idempotency_policy()->ListReservationTopics(request);
     char const* function_name = __func__;
     return google::cloud::internal::MakePaginationRange<
         StreamRange<std::string>>(
@@ -586,6 +576,40 @@ class AdminServiceConnectionImpl : public AdminServiceConnection {
   }
 
  private:
+  std::unique_ptr<AdminServiceRetryPolicy> retry_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<AdminServiceRetryPolicyOption>()) {
+      return options.get<AdminServiceRetryPolicyOption>()->clone();
+    }
+    return retry_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<BackoffPolicy> backoff_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<AdminServiceBackoffPolicyOption>()) {
+      return options.get<AdminServiceBackoffPolicyOption>()->clone();
+    }
+    return backoff_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<PollingPolicy> polling_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<AdminServicePollingPolicyOption>()) {
+      return options.get<AdminServicePollingPolicyOption>()->clone();
+    }
+    return polling_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<AdminServiceConnectionIdempotencyPolicy>
+  idempotency_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<AdminServiceConnectionIdempotencyPolicyOption>()) {
+      return options.get<AdminServiceConnectionIdempotencyPolicyOption>()
+          ->clone();
+    }
+    return idempotency_policy_->clone();
+  }
+
   std::unique_ptr<google::cloud::BackgroundThreads> background_;
   std::shared_ptr<pubsublite_internal::AdminServiceStub> stub_;
   std::unique_ptr<AdminServiceRetryPolicy const> retry_policy_prototype_;

--- a/google/cloud/pubsublite/topic_stats_connection.cc
+++ b/google/cloud/pubsublite/topic_stats_connection.cc
@@ -75,8 +75,8 @@ class TopicStatsServiceConnectionImpl : public TopicStatsServiceConnection {
       google::cloud::pubsublite::v1::ComputeMessageStatsRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->ComputeMessageStats(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->ComputeMessageStats(request),
         [this](grpc::ClientContext& context,
                google::cloud::pubsublite::v1::ComputeMessageStatsRequest const&
                    request) {
@@ -90,8 +90,8 @@ class TopicStatsServiceConnectionImpl : public TopicStatsServiceConnection {
       google::cloud::pubsublite::v1::ComputeHeadCursorRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->ComputeHeadCursor(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->ComputeHeadCursor(request),
         [this](grpc::ClientContext& context,
                google::cloud::pubsublite::v1::ComputeHeadCursorRequest const&
                    request) {
@@ -105,8 +105,8 @@ class TopicStatsServiceConnectionImpl : public TopicStatsServiceConnection {
       google::cloud::pubsublite::v1::ComputeTimeCursorRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->ComputeTimeCursor(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->ComputeTimeCursor(request),
         [this](grpc::ClientContext& context,
                google::cloud::pubsublite::v1::ComputeTimeCursorRequest const&
                    request) {
@@ -116,6 +116,32 @@ class TopicStatsServiceConnectionImpl : public TopicStatsServiceConnection {
   }
 
  private:
+  std::unique_ptr<TopicStatsServiceRetryPolicy> retry_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<TopicStatsServiceRetryPolicyOption>()) {
+      return options.get<TopicStatsServiceRetryPolicyOption>()->clone();
+    }
+    return retry_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<BackoffPolicy> backoff_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<TopicStatsServiceBackoffPolicyOption>()) {
+      return options.get<TopicStatsServiceBackoffPolicyOption>()->clone();
+    }
+    return backoff_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<TopicStatsServiceConnectionIdempotencyPolicy>
+  idempotency_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<TopicStatsServiceConnectionIdempotencyPolicyOption>()) {
+      return options.get<TopicStatsServiceConnectionIdempotencyPolicyOption>()
+          ->clone();
+    }
+    return idempotency_policy_->clone();
+  }
+
   std::unique_ptr<google::cloud::BackgroundThreads> background_;
   std::shared_ptr<pubsublite_internal::TopicStatsServiceStub> stub_;
   std::unique_ptr<TopicStatsServiceRetryPolicy const> retry_policy_prototype_;

--- a/google/cloud/recommender/recommender_connection.cc
+++ b/google/cloud/recommender/recommender_connection.cc
@@ -122,11 +122,9 @@ class RecommenderConnectionImpl : public RecommenderConnection {
       google::cloud::recommender::v1::ListInsightsRequest request) override {
     request.clear_page_token();
     auto stub = stub_;
-    auto retry = std::shared_ptr<RecommenderRetryPolicy const>(
-        retry_policy_prototype_->clone());
-    auto backoff = std::shared_ptr<BackoffPolicy const>(
-        backoff_policy_prototype_->clone());
-    auto idempotency = idempotency_policy_->ListInsights(request);
+    auto retry = std::shared_ptr<RecommenderRetryPolicy const>(retry_policy());
+    auto backoff = std::shared_ptr<BackoffPolicy const>(backoff_policy());
+    auto idempotency = idempotency_policy()->ListInsights(request);
     char const* function_name = __func__;
     return google::cloud::internal::MakePaginationRange<
         StreamRange<google::cloud::recommender::v1::Insight>>(
@@ -155,8 +153,8 @@ class RecommenderConnectionImpl : public RecommenderConnection {
       google::cloud::recommender::v1::GetInsightRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetInsight(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GetInsight(request),
         [this](
             grpc::ClientContext& context,
             google::cloud::recommender::v1::GetInsightRequest const& request) {
@@ -169,8 +167,8 @@ class RecommenderConnectionImpl : public RecommenderConnection {
       google::cloud::recommender::v1::MarkInsightAcceptedRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->MarkInsightAccepted(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->MarkInsightAccepted(request),
         [this](grpc::ClientContext& context,
                google::cloud::recommender::v1::MarkInsightAcceptedRequest const&
                    request) {
@@ -184,11 +182,9 @@ class RecommenderConnectionImpl : public RecommenderConnection {
                           request) override {
     request.clear_page_token();
     auto stub = stub_;
-    auto retry = std::shared_ptr<RecommenderRetryPolicy const>(
-        retry_policy_prototype_->clone());
-    auto backoff = std::shared_ptr<BackoffPolicy const>(
-        backoff_policy_prototype_->clone());
-    auto idempotency = idempotency_policy_->ListRecommendations(request);
+    auto retry = std::shared_ptr<RecommenderRetryPolicy const>(retry_policy());
+    auto backoff = std::shared_ptr<BackoffPolicy const>(backoff_policy());
+    auto idempotency = idempotency_policy()->ListRecommendations(request);
     char const* function_name = __func__;
     return google::cloud::internal::MakePaginationRange<
         StreamRange<google::cloud::recommender::v1::Recommendation>>(
@@ -218,8 +214,8 @@ class RecommenderConnectionImpl : public RecommenderConnection {
       google::cloud::recommender::v1::GetRecommendationRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetRecommendation(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GetRecommendation(request),
         [this](grpc::ClientContext& context,
                google::cloud::recommender::v1::GetRecommendationRequest const&
                    request) {
@@ -233,8 +229,8 @@ class RecommenderConnectionImpl : public RecommenderConnection {
       google::cloud::recommender::v1::MarkRecommendationClaimedRequest const&
           request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->MarkRecommendationClaimed(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->MarkRecommendationClaimed(request),
         [this](grpc::ClientContext& context,
                google::cloud::recommender::v1::
                    MarkRecommendationClaimedRequest const& request) {
@@ -248,8 +244,8 @@ class RecommenderConnectionImpl : public RecommenderConnection {
       google::cloud::recommender::v1::MarkRecommendationSucceededRequest const&
           request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->MarkRecommendationSucceeded(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->MarkRecommendationSucceeded(request),
         [this](grpc::ClientContext& context,
                google::cloud::recommender::v1::
                    MarkRecommendationSucceededRequest const& request) {
@@ -263,8 +259,8 @@ class RecommenderConnectionImpl : public RecommenderConnection {
       google::cloud::recommender::v1::MarkRecommendationFailedRequest const&
           request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->MarkRecommendationFailed(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->MarkRecommendationFailed(request),
         [this](grpc::ClientContext& context,
                google::cloud::recommender::v1::
                    MarkRecommendationFailedRequest const& request) {
@@ -274,6 +270,31 @@ class RecommenderConnectionImpl : public RecommenderConnection {
   }
 
  private:
+  std::unique_ptr<RecommenderRetryPolicy> retry_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<RecommenderRetryPolicyOption>()) {
+      return options.get<RecommenderRetryPolicyOption>()->clone();
+    }
+    return retry_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<BackoffPolicy> backoff_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<RecommenderBackoffPolicyOption>()) {
+      return options.get<RecommenderBackoffPolicyOption>()->clone();
+    }
+    return backoff_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<RecommenderConnectionIdempotencyPolicy> idempotency_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<RecommenderConnectionIdempotencyPolicyOption>()) {
+      return options.get<RecommenderConnectionIdempotencyPolicyOption>()
+          ->clone();
+    }
+    return idempotency_policy_->clone();
+  }
+
   std::unique_ptr<google::cloud::BackgroundThreads> background_;
   std::shared_ptr<recommender_internal::RecommenderStub> stub_;
   std::unique_ptr<RecommenderRetryPolicy const> retry_policy_prototype_;

--- a/google/cloud/resourcemanager/folders_connection.cc
+++ b/google/cloud/resourcemanager/folders_connection.cc
@@ -151,8 +151,8 @@ class FoldersConnectionImpl : public FoldersConnection {
       google::cloud::resourcemanager::v3::GetFolderRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetFolder(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GetFolder(request),
         [this](grpc::ClientContext& context,
                google::cloud::resourcemanager::v3::GetFolderRequest const&
                    request) { return stub_->GetFolder(context, request); },
@@ -163,11 +163,9 @@ class FoldersConnectionImpl : public FoldersConnection {
       google::cloud::resourcemanager::v3::ListFoldersRequest request) override {
     request.clear_page_token();
     auto stub = stub_;
-    auto retry = std::shared_ptr<FoldersRetryPolicy const>(
-        retry_policy_prototype_->clone());
-    auto backoff = std::shared_ptr<BackoffPolicy const>(
-        backoff_policy_prototype_->clone());
-    auto idempotency = idempotency_policy_->ListFolders(request);
+    auto retry = std::shared_ptr<FoldersRetryPolicy const>(retry_policy());
+    auto backoff = std::shared_ptr<BackoffPolicy const>(backoff_policy());
+    auto idempotency = idempotency_policy()->ListFolders(request);
     char const* function_name = __func__;
     return google::cloud::internal::MakePaginationRange<
         StreamRange<google::cloud::resourcemanager::v3::Folder>>(
@@ -196,11 +194,9 @@ class FoldersConnectionImpl : public FoldersConnection {
       override {
     request.clear_page_token();
     auto stub = stub_;
-    auto retry = std::shared_ptr<FoldersRetryPolicy const>(
-        retry_policy_prototype_->clone());
-    auto backoff = std::shared_ptr<BackoffPolicy const>(
-        backoff_policy_prototype_->clone());
-    auto idempotency = idempotency_policy_->SearchFolders(request);
+    auto retry = std::shared_ptr<FoldersRetryPolicy const>(retry_policy());
+    auto backoff = std::shared_ptr<BackoffPolicy const>(backoff_policy());
+    auto idempotency = idempotency_policy()->SearchFolders(request);
     char const* function_name = __func__;
     return google::cloud::internal::MakePaginationRange<
         StreamRange<google::cloud::resourcemanager::v3::Folder>>(
@@ -250,9 +246,9 @@ class FoldersConnectionImpl : public FoldersConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::cloud::resourcemanager::v3::Folder>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->CreateFolder(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->CreateFolder(request), polling_policy(),
+        __func__);
   }
 
   future<StatusOr<google::cloud::resourcemanager::v3::Folder>> UpdateFolder(
@@ -280,9 +276,9 @@ class FoldersConnectionImpl : public FoldersConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::cloud::resourcemanager::v3::Folder>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->UpdateFolder(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->UpdateFolder(request), polling_policy(),
+        __func__);
   }
 
   future<StatusOr<google::cloud::resourcemanager::v3::Folder>> MoveFolder(
@@ -310,9 +306,8 @@ class FoldersConnectionImpl : public FoldersConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::cloud::resourcemanager::v3::Folder>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->MoveFolder(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->MoveFolder(request), polling_policy(), __func__);
   }
 
   future<StatusOr<google::cloud::resourcemanager::v3::Folder>> DeleteFolder(
@@ -340,9 +335,9 @@ class FoldersConnectionImpl : public FoldersConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::cloud::resourcemanager::v3::Folder>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->DeleteFolder(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->DeleteFolder(request), polling_policy(),
+        __func__);
   }
 
   future<StatusOr<google::cloud::resourcemanager::v3::Folder>> UndeleteFolder(
@@ -370,16 +365,16 @@ class FoldersConnectionImpl : public FoldersConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::cloud::resourcemanager::v3::Folder>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->UndeleteFolder(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->UndeleteFolder(request), polling_policy(),
+        __func__);
   }
 
   StatusOr<google::iam::v1::Policy> GetIamPolicy(
       google::iam::v1::GetIamPolicyRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetIamPolicy(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GetIamPolicy(request),
         [this](grpc::ClientContext& context,
                google::iam::v1::GetIamPolicyRequest const& request) {
           return stub_->GetIamPolicy(context, request);
@@ -390,8 +385,8 @@ class FoldersConnectionImpl : public FoldersConnection {
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
       google::iam::v1::SetIamPolicyRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->SetIamPolicy(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->SetIamPolicy(request),
         [this](grpc::ClientContext& context,
                google::iam::v1::SetIamPolicyRequest const& request) {
           return stub_->SetIamPolicy(context, request);
@@ -402,8 +397,8 @@ class FoldersConnectionImpl : public FoldersConnection {
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
       google::iam::v1::TestIamPermissionsRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->TestIamPermissions(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->TestIamPermissions(request),
         [this](grpc::ClientContext& context,
                google::iam::v1::TestIamPermissionsRequest const& request) {
           return stub_->TestIamPermissions(context, request);
@@ -412,6 +407,38 @@ class FoldersConnectionImpl : public FoldersConnection {
   }
 
  private:
+  std::unique_ptr<FoldersRetryPolicy> retry_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<FoldersRetryPolicyOption>()) {
+      return options.get<FoldersRetryPolicyOption>()->clone();
+    }
+    return retry_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<BackoffPolicy> backoff_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<FoldersBackoffPolicyOption>()) {
+      return options.get<FoldersBackoffPolicyOption>()->clone();
+    }
+    return backoff_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<PollingPolicy> polling_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<FoldersPollingPolicyOption>()) {
+      return options.get<FoldersPollingPolicyOption>()->clone();
+    }
+    return polling_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<FoldersConnectionIdempotencyPolicy> idempotency_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<FoldersConnectionIdempotencyPolicyOption>()) {
+      return options.get<FoldersConnectionIdempotencyPolicyOption>()->clone();
+    }
+    return idempotency_policy_->clone();
+  }
+
   std::unique_ptr<google::cloud::BackgroundThreads> background_;
   std::shared_ptr<resourcemanager_internal::FoldersStub> stub_;
   std::unique_ptr<FoldersRetryPolicy const> retry_policy_prototype_;

--- a/google/cloud/resourcemanager/org_policy_connection.cc
+++ b/google/cloud/resourcemanager/org_policy_connection.cc
@@ -114,11 +114,9 @@ class OrgPolicyConnectionImpl : public OrgPolicyConnection {
       google::cloud::orgpolicy::v2::ListConstraintsRequest request) override {
     request.clear_page_token();
     auto stub = stub_;
-    auto retry = std::shared_ptr<OrgPolicyRetryPolicy const>(
-        retry_policy_prototype_->clone());
-    auto backoff = std::shared_ptr<BackoffPolicy const>(
-        backoff_policy_prototype_->clone());
-    auto idempotency = idempotency_policy_->ListConstraints(request);
+    auto retry = std::shared_ptr<OrgPolicyRetryPolicy const>(retry_policy());
+    auto backoff = std::shared_ptr<BackoffPolicy const>(backoff_policy());
+    auto idempotency = idempotency_policy()->ListConstraints(request);
     char const* function_name = __func__;
     return google::cloud::internal::MakePaginationRange<
         StreamRange<google::cloud::orgpolicy::v2::Constraint>>(
@@ -147,11 +145,9 @@ class OrgPolicyConnectionImpl : public OrgPolicyConnection {
       google::cloud::orgpolicy::v2::ListPoliciesRequest request) override {
     request.clear_page_token();
     auto stub = stub_;
-    auto retry = std::shared_ptr<OrgPolicyRetryPolicy const>(
-        retry_policy_prototype_->clone());
-    auto backoff = std::shared_ptr<BackoffPolicy const>(
-        backoff_policy_prototype_->clone());
-    auto idempotency = idempotency_policy_->ListPolicies(request);
+    auto retry = std::shared_ptr<OrgPolicyRetryPolicy const>(retry_policy());
+    auto backoff = std::shared_ptr<BackoffPolicy const>(backoff_policy());
+    auto idempotency = idempotency_policy()->ListPolicies(request);
     char const* function_name = __func__;
     return google::cloud::internal::MakePaginationRange<
         StreamRange<google::cloud::orgpolicy::v2::Policy>>(
@@ -179,8 +175,8 @@ class OrgPolicyConnectionImpl : public OrgPolicyConnection {
   StatusOr<google::cloud::orgpolicy::v2::Policy> GetPolicy(
       google::cloud::orgpolicy::v2::GetPolicyRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetPolicy(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GetPolicy(request),
         [this](grpc::ClientContext& context,
                google::cloud::orgpolicy::v2::GetPolicyRequest const& request) {
           return stub_->GetPolicy(context, request);
@@ -192,8 +188,8 @@ class OrgPolicyConnectionImpl : public OrgPolicyConnection {
       google::cloud::orgpolicy::v2::GetEffectivePolicyRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetEffectivePolicy(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GetEffectivePolicy(request),
         [this](grpc::ClientContext& context,
                google::cloud::orgpolicy::v2::GetEffectivePolicyRequest const&
                    request) {
@@ -206,8 +202,8 @@ class OrgPolicyConnectionImpl : public OrgPolicyConnection {
       google::cloud::orgpolicy::v2::CreatePolicyRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->CreatePolicy(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->CreatePolicy(request),
         [this](
             grpc::ClientContext& context,
             google::cloud::orgpolicy::v2::CreatePolicyRequest const& request) {
@@ -220,8 +216,8 @@ class OrgPolicyConnectionImpl : public OrgPolicyConnection {
       google::cloud::orgpolicy::v2::UpdatePolicyRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->UpdatePolicy(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->UpdatePolicy(request),
         [this](
             grpc::ClientContext& context,
             google::cloud::orgpolicy::v2::UpdatePolicyRequest const& request) {
@@ -233,8 +229,8 @@ class OrgPolicyConnectionImpl : public OrgPolicyConnection {
   Status DeletePolicy(google::cloud::orgpolicy::v2::DeletePolicyRequest const&
                           request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->DeletePolicy(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->DeletePolicy(request),
         [this](
             grpc::ClientContext& context,
             google::cloud::orgpolicy::v2::DeletePolicyRequest const& request) {
@@ -244,6 +240,30 @@ class OrgPolicyConnectionImpl : public OrgPolicyConnection {
   }
 
  private:
+  std::unique_ptr<OrgPolicyRetryPolicy> retry_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<OrgPolicyRetryPolicyOption>()) {
+      return options.get<OrgPolicyRetryPolicyOption>()->clone();
+    }
+    return retry_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<BackoffPolicy> backoff_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<OrgPolicyBackoffPolicyOption>()) {
+      return options.get<OrgPolicyBackoffPolicyOption>()->clone();
+    }
+    return backoff_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<OrgPolicyConnectionIdempotencyPolicy> idempotency_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<OrgPolicyConnectionIdempotencyPolicyOption>()) {
+      return options.get<OrgPolicyConnectionIdempotencyPolicyOption>()->clone();
+    }
+    return idempotency_policy_->clone();
+  }
+
   std::unique_ptr<google::cloud::BackgroundThreads> background_;
   std::shared_ptr<resourcemanager_internal::OrgPolicyStub> stub_;
   std::unique_ptr<OrgPolicyRetryPolicy const> retry_policy_prototype_;

--- a/google/cloud/resourcemanager/organizations_connection.cc
+++ b/google/cloud/resourcemanager/organizations_connection.cc
@@ -96,8 +96,8 @@ class OrganizationsConnectionImpl : public OrganizationsConnection {
       google::cloud::resourcemanager::v3::GetOrganizationRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetOrganization(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GetOrganization(request),
         [this](grpc::ClientContext& context,
                google::cloud::resourcemanager::v3::GetOrganizationRequest const&
                    request) {
@@ -112,11 +112,10 @@ class OrganizationsConnectionImpl : public OrganizationsConnection {
       override {
     request.clear_page_token();
     auto stub = stub_;
-    auto retry = std::shared_ptr<OrganizationsRetryPolicy const>(
-        retry_policy_prototype_->clone());
-    auto backoff = std::shared_ptr<BackoffPolicy const>(
-        backoff_policy_prototype_->clone());
-    auto idempotency = idempotency_policy_->SearchOrganizations(request);
+    auto retry =
+        std::shared_ptr<OrganizationsRetryPolicy const>(retry_policy());
+    auto backoff = std::shared_ptr<BackoffPolicy const>(backoff_policy());
+    auto idempotency = idempotency_policy()->SearchOrganizations(request);
     char const* function_name = __func__;
     return google::cloud::internal::MakePaginationRange<
         StreamRange<google::cloud::resourcemanager::v3::Organization>>(
@@ -145,8 +144,8 @@ class OrganizationsConnectionImpl : public OrganizationsConnection {
   StatusOr<google::iam::v1::Policy> GetIamPolicy(
       google::iam::v1::GetIamPolicyRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetIamPolicy(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GetIamPolicy(request),
         [this](grpc::ClientContext& context,
                google::iam::v1::GetIamPolicyRequest const& request) {
           return stub_->GetIamPolicy(context, request);
@@ -157,8 +156,8 @@ class OrganizationsConnectionImpl : public OrganizationsConnection {
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
       google::iam::v1::SetIamPolicyRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->SetIamPolicy(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->SetIamPolicy(request),
         [this](grpc::ClientContext& context,
                google::iam::v1::SetIamPolicyRequest const& request) {
           return stub_->SetIamPolicy(context, request);
@@ -169,8 +168,8 @@ class OrganizationsConnectionImpl : public OrganizationsConnection {
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
       google::iam::v1::TestIamPermissionsRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->TestIamPermissions(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->TestIamPermissions(request),
         [this](grpc::ClientContext& context,
                google::iam::v1::TestIamPermissionsRequest const& request) {
           return stub_->TestIamPermissions(context, request);
@@ -179,6 +178,32 @@ class OrganizationsConnectionImpl : public OrganizationsConnection {
   }
 
  private:
+  std::unique_ptr<OrganizationsRetryPolicy> retry_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<OrganizationsRetryPolicyOption>()) {
+      return options.get<OrganizationsRetryPolicyOption>()->clone();
+    }
+    return retry_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<BackoffPolicy> backoff_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<OrganizationsBackoffPolicyOption>()) {
+      return options.get<OrganizationsBackoffPolicyOption>()->clone();
+    }
+    return backoff_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<OrganizationsConnectionIdempotencyPolicy>
+  idempotency_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<OrganizationsConnectionIdempotencyPolicyOption>()) {
+      return options.get<OrganizationsConnectionIdempotencyPolicyOption>()
+          ->clone();
+    }
+    return idempotency_policy_->clone();
+  }
+
   std::unique_ptr<google::cloud::BackgroundThreads> background_;
   std::shared_ptr<resourcemanager_internal::OrganizationsStub> stub_;
   std::unique_ptr<OrganizationsRetryPolicy const> retry_policy_prototype_;

--- a/google/cloud/resourcemanager/projects_connection.cc
+++ b/google/cloud/resourcemanager/projects_connection.cc
@@ -152,8 +152,8 @@ class ProjectsConnectionImpl : public ProjectsConnection {
       google::cloud::resourcemanager::v3::GetProjectRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetProject(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GetProject(request),
         [this](grpc::ClientContext& context,
                google::cloud::resourcemanager::v3::GetProjectRequest const&
                    request) { return stub_->GetProject(context, request); },
@@ -165,11 +165,9 @@ class ProjectsConnectionImpl : public ProjectsConnection {
       override {
     request.clear_page_token();
     auto stub = stub_;
-    auto retry = std::shared_ptr<ProjectsRetryPolicy const>(
-        retry_policy_prototype_->clone());
-    auto backoff = std::shared_ptr<BackoffPolicy const>(
-        backoff_policy_prototype_->clone());
-    auto idempotency = idempotency_policy_->ListProjects(request);
+    auto retry = std::shared_ptr<ProjectsRetryPolicy const>(retry_policy());
+    auto backoff = std::shared_ptr<BackoffPolicy const>(backoff_policy());
+    auto idempotency = idempotency_policy()->ListProjects(request);
     char const* function_name = __func__;
     return google::cloud::internal::MakePaginationRange<
         StreamRange<google::cloud::resourcemanager::v3::Project>>(
@@ -198,11 +196,9 @@ class ProjectsConnectionImpl : public ProjectsConnection {
       override {
     request.clear_page_token();
     auto stub = stub_;
-    auto retry = std::shared_ptr<ProjectsRetryPolicy const>(
-        retry_policy_prototype_->clone());
-    auto backoff = std::shared_ptr<BackoffPolicy const>(
-        backoff_policy_prototype_->clone());
-    auto idempotency = idempotency_policy_->SearchProjects(request);
+    auto retry = std::shared_ptr<ProjectsRetryPolicy const>(retry_policy());
+    auto backoff = std::shared_ptr<BackoffPolicy const>(backoff_policy());
+    auto idempotency = idempotency_policy()->SearchProjects(request);
     char const* function_name = __func__;
     return google::cloud::internal::MakePaginationRange<
         StreamRange<google::cloud::resourcemanager::v3::Project>>(
@@ -253,9 +249,9 @@ class ProjectsConnectionImpl : public ProjectsConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::cloud::resourcemanager::v3::Project>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->CreateProject(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->CreateProject(request), polling_policy(),
+        __func__);
   }
 
   future<StatusOr<google::cloud::resourcemanager::v3::Project>> UpdateProject(
@@ -283,9 +279,9 @@ class ProjectsConnectionImpl : public ProjectsConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::cloud::resourcemanager::v3::Project>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->UpdateProject(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->UpdateProject(request), polling_policy(),
+        __func__);
   }
 
   future<StatusOr<google::cloud::resourcemanager::v3::Project>> MoveProject(
@@ -313,9 +309,8 @@ class ProjectsConnectionImpl : public ProjectsConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::cloud::resourcemanager::v3::Project>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->MoveProject(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->MoveProject(request), polling_policy(), __func__);
   }
 
   future<StatusOr<google::cloud::resourcemanager::v3::Project>> DeleteProject(
@@ -343,9 +338,9 @@ class ProjectsConnectionImpl : public ProjectsConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::cloud::resourcemanager::v3::Project>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->DeleteProject(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->DeleteProject(request), polling_policy(),
+        __func__);
   }
 
   future<StatusOr<google::cloud::resourcemanager::v3::Project>> UndeleteProject(
@@ -373,16 +368,16 @@ class ProjectsConnectionImpl : public ProjectsConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::cloud::resourcemanager::v3::Project>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->UndeleteProject(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->UndeleteProject(request), polling_policy(),
+        __func__);
   }
 
   StatusOr<google::iam::v1::Policy> GetIamPolicy(
       google::iam::v1::GetIamPolicyRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetIamPolicy(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GetIamPolicy(request),
         [this](grpc::ClientContext& context,
                google::iam::v1::GetIamPolicyRequest const& request) {
           return stub_->GetIamPolicy(context, request);
@@ -393,8 +388,8 @@ class ProjectsConnectionImpl : public ProjectsConnection {
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
       google::iam::v1::SetIamPolicyRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->SetIamPolicy(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->SetIamPolicy(request),
         [this](grpc::ClientContext& context,
                google::iam::v1::SetIamPolicyRequest const& request) {
           return stub_->SetIamPolicy(context, request);
@@ -405,8 +400,8 @@ class ProjectsConnectionImpl : public ProjectsConnection {
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
       google::iam::v1::TestIamPermissionsRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->TestIamPermissions(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->TestIamPermissions(request),
         [this](grpc::ClientContext& context,
                google::iam::v1::TestIamPermissionsRequest const& request) {
           return stub_->TestIamPermissions(context, request);
@@ -415,6 +410,38 @@ class ProjectsConnectionImpl : public ProjectsConnection {
   }
 
  private:
+  std::unique_ptr<ProjectsRetryPolicy> retry_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<ProjectsRetryPolicyOption>()) {
+      return options.get<ProjectsRetryPolicyOption>()->clone();
+    }
+    return retry_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<BackoffPolicy> backoff_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<ProjectsBackoffPolicyOption>()) {
+      return options.get<ProjectsBackoffPolicyOption>()->clone();
+    }
+    return backoff_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<PollingPolicy> polling_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<ProjectsPollingPolicyOption>()) {
+      return options.get<ProjectsPollingPolicyOption>()->clone();
+    }
+    return polling_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<ProjectsConnectionIdempotencyPolicy> idempotency_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<ProjectsConnectionIdempotencyPolicyOption>()) {
+      return options.get<ProjectsConnectionIdempotencyPolicyOption>()->clone();
+    }
+    return idempotency_policy_->clone();
+  }
+
   std::unique_ptr<google::cloud::BackgroundThreads> background_;
   std::shared_ptr<resourcemanager_internal::ProjectsStub> stub_;
   std::unique_ptr<ProjectsRetryPolicy const> retry_policy_prototype_;

--- a/google/cloud/secretmanager/secret_manager_connection.cc
+++ b/google/cloud/secretmanager/secret_manager_connection.cc
@@ -164,11 +164,10 @@ class SecretManagerServiceConnectionImpl
       google::cloud::secretmanager::v1::ListSecretsRequest request) override {
     request.clear_page_token();
     auto stub = stub_;
-    auto retry = std::shared_ptr<SecretManagerServiceRetryPolicy const>(
-        retry_policy_prototype_->clone());
-    auto backoff = std::shared_ptr<BackoffPolicy const>(
-        backoff_policy_prototype_->clone());
-    auto idempotency = idempotency_policy_->ListSecrets(request);
+    auto retry =
+        std::shared_ptr<SecretManagerServiceRetryPolicy const>(retry_policy());
+    auto backoff = std::shared_ptr<BackoffPolicy const>(backoff_policy());
+    auto idempotency = idempotency_policy()->ListSecrets(request);
     char const* function_name = __func__;
     return google::cloud::internal::MakePaginationRange<
         StreamRange<google::cloud::secretmanager::v1::Secret>>(
@@ -197,8 +196,8 @@ class SecretManagerServiceConnectionImpl
       google::cloud::secretmanager::v1::CreateSecretRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->CreateSecret(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->CreateSecret(request),
         [this](grpc::ClientContext& context,
                google::cloud::secretmanager::v1::CreateSecretRequest const&
                    request) { return stub_->CreateSecret(context, request); },
@@ -209,8 +208,8 @@ class SecretManagerServiceConnectionImpl
       google::cloud::secretmanager::v1::AddSecretVersionRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->AddSecretVersion(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->AddSecretVersion(request),
         [this](grpc::ClientContext& context,
                google::cloud::secretmanager::v1::AddSecretVersionRequest const&
                    request) {
@@ -223,8 +222,8 @@ class SecretManagerServiceConnectionImpl
       google::cloud::secretmanager::v1::GetSecretRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetSecret(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GetSecret(request),
         [this](
             grpc::ClientContext& context,
             google::cloud::secretmanager::v1::GetSecretRequest const& request) {
@@ -237,8 +236,8 @@ class SecretManagerServiceConnectionImpl
       google::cloud::secretmanager::v1::UpdateSecretRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->UpdateSecret(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->UpdateSecret(request),
         [this](grpc::ClientContext& context,
                google::cloud::secretmanager::v1::UpdateSecretRequest const&
                    request) { return stub_->UpdateSecret(context, request); },
@@ -249,8 +248,8 @@ class SecretManagerServiceConnectionImpl
       google::cloud::secretmanager::v1::DeleteSecretRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->DeleteSecret(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->DeleteSecret(request),
         [this](grpc::ClientContext& context,
                google::cloud::secretmanager::v1::DeleteSecretRequest const&
                    request) { return stub_->DeleteSecret(context, request); },
@@ -262,11 +261,10 @@ class SecretManagerServiceConnectionImpl
                          request) override {
     request.clear_page_token();
     auto stub = stub_;
-    auto retry = std::shared_ptr<SecretManagerServiceRetryPolicy const>(
-        retry_policy_prototype_->clone());
-    auto backoff = std::shared_ptr<BackoffPolicy const>(
-        backoff_policy_prototype_->clone());
-    auto idempotency = idempotency_policy_->ListSecretVersions(request);
+    auto retry =
+        std::shared_ptr<SecretManagerServiceRetryPolicy const>(retry_policy());
+    auto backoff = std::shared_ptr<BackoffPolicy const>(backoff_policy());
+    auto idempotency = idempotency_policy()->ListSecretVersions(request);
     char const* function_name = __func__;
     return google::cloud::internal::MakePaginationRange<
         StreamRange<google::cloud::secretmanager::v1::SecretVersion>>(
@@ -296,8 +294,8 @@ class SecretManagerServiceConnectionImpl
       google::cloud::secretmanager::v1::GetSecretVersionRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetSecretVersion(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GetSecretVersion(request),
         [this](grpc::ClientContext& context,
                google::cloud::secretmanager::v1::GetSecretVersionRequest const&
                    request) {
@@ -311,8 +309,8 @@ class SecretManagerServiceConnectionImpl
       google::cloud::secretmanager::v1::AccessSecretVersionRequest const&
           request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->AccessSecretVersion(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->AccessSecretVersion(request),
         [this](
             grpc::ClientContext& context,
             google::cloud::secretmanager::v1::AccessSecretVersionRequest const&
@@ -327,8 +325,8 @@ class SecretManagerServiceConnectionImpl
       google::cloud::secretmanager::v1::DisableSecretVersionRequest const&
           request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->DisableSecretVersion(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->DisableSecretVersion(request),
         [this](
             grpc::ClientContext& context,
             google::cloud::secretmanager::v1::DisableSecretVersionRequest const&
@@ -342,8 +340,8 @@ class SecretManagerServiceConnectionImpl
       google::cloud::secretmanager::v1::EnableSecretVersionRequest const&
           request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->EnableSecretVersion(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->EnableSecretVersion(request),
         [this](
             grpc::ClientContext& context,
             google::cloud::secretmanager::v1::EnableSecretVersionRequest const&
@@ -358,8 +356,8 @@ class SecretManagerServiceConnectionImpl
       google::cloud::secretmanager::v1::DestroySecretVersionRequest const&
           request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->DestroySecretVersion(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->DestroySecretVersion(request),
         [this](
             grpc::ClientContext& context,
             google::cloud::secretmanager::v1::DestroySecretVersionRequest const&
@@ -372,8 +370,8 @@ class SecretManagerServiceConnectionImpl
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
       google::iam::v1::SetIamPolicyRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->SetIamPolicy(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->SetIamPolicy(request),
         [this](grpc::ClientContext& context,
                google::iam::v1::SetIamPolicyRequest const& request) {
           return stub_->SetIamPolicy(context, request);
@@ -384,8 +382,8 @@ class SecretManagerServiceConnectionImpl
   StatusOr<google::iam::v1::Policy> GetIamPolicy(
       google::iam::v1::GetIamPolicyRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetIamPolicy(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GetIamPolicy(request),
         [this](grpc::ClientContext& context,
                google::iam::v1::GetIamPolicyRequest const& request) {
           return stub_->GetIamPolicy(context, request);
@@ -396,8 +394,8 @@ class SecretManagerServiceConnectionImpl
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
       google::iam::v1::TestIamPermissionsRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->TestIamPermissions(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->TestIamPermissions(request),
         [this](grpc::ClientContext& context,
                google::iam::v1::TestIamPermissionsRequest const& request) {
           return stub_->TestIamPermissions(context, request);
@@ -406,6 +404,33 @@ class SecretManagerServiceConnectionImpl
   }
 
  private:
+  std::unique_ptr<SecretManagerServiceRetryPolicy> retry_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<SecretManagerServiceRetryPolicyOption>()) {
+      return options.get<SecretManagerServiceRetryPolicyOption>()->clone();
+    }
+    return retry_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<BackoffPolicy> backoff_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<SecretManagerServiceBackoffPolicyOption>()) {
+      return options.get<SecretManagerServiceBackoffPolicyOption>()->clone();
+    }
+    return backoff_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<SecretManagerServiceConnectionIdempotencyPolicy>
+  idempotency_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<SecretManagerServiceConnectionIdempotencyPolicyOption>()) {
+      return options
+          .get<SecretManagerServiceConnectionIdempotencyPolicyOption>()
+          ->clone();
+    }
+    return idempotency_policy_->clone();
+  }
+
   std::unique_ptr<google::cloud::BackgroundThreads> background_;
   std::shared_ptr<secretmanager_internal::SecretManagerServiceStub> stub_;
   std::unique_ptr<SecretManagerServiceRetryPolicy const>

--- a/google/cloud/shell/cloud_shell_connection.cc
+++ b/google/cloud/shell/cloud_shell_connection.cc
@@ -96,8 +96,8 @@ class CloudShellServiceConnectionImpl : public CloudShellServiceConnection {
   StatusOr<google::cloud::shell::v1::Environment> GetEnvironment(
       google::cloud::shell::v1::GetEnvironmentRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetEnvironment(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GetEnvironment(request),
         [this](grpc::ClientContext& context,
                google::cloud::shell::v1::GetEnvironmentRequest const& request) {
           return stub_->GetEnvironment(context, request);
@@ -130,9 +130,9 @@ class CloudShellServiceConnectionImpl : public CloudShellServiceConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::cloud::shell::v1::StartEnvironmentResponse>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->StartEnvironment(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->StartEnvironment(request), polling_policy(),
+        __func__);
   }
 
   future<StatusOr<google::cloud::shell::v1::AuthorizeEnvironmentResponse>>
@@ -162,9 +162,9 @@ class CloudShellServiceConnectionImpl : public CloudShellServiceConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::cloud::shell::v1::AuthorizeEnvironmentResponse>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->AuthorizeEnvironment(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->AuthorizeEnvironment(request), polling_policy(),
+        __func__);
   }
 
   future<StatusOr<google::cloud::shell::v1::AddPublicKeyResponse>> AddPublicKey(
@@ -190,9 +190,9 @@ class CloudShellServiceConnectionImpl : public CloudShellServiceConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::cloud::shell::v1::AddPublicKeyResponse>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->AddPublicKey(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->AddPublicKey(request), polling_policy(),
+        __func__);
   }
 
   future<StatusOr<google::cloud::shell::v1::RemovePublicKeyResponse>>
@@ -220,12 +220,46 @@ class CloudShellServiceConnectionImpl : public CloudShellServiceConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::cloud::shell::v1::RemovePublicKeyResponse>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->RemovePublicKey(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->RemovePublicKey(request), polling_policy(),
+        __func__);
   }
 
  private:
+  std::unique_ptr<CloudShellServiceRetryPolicy> retry_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<CloudShellServiceRetryPolicyOption>()) {
+      return options.get<CloudShellServiceRetryPolicyOption>()->clone();
+    }
+    return retry_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<BackoffPolicy> backoff_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<CloudShellServiceBackoffPolicyOption>()) {
+      return options.get<CloudShellServiceBackoffPolicyOption>()->clone();
+    }
+    return backoff_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<PollingPolicy> polling_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<CloudShellServicePollingPolicyOption>()) {
+      return options.get<CloudShellServicePollingPolicyOption>()->clone();
+    }
+    return polling_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<CloudShellServiceConnectionIdempotencyPolicy>
+  idempotency_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<CloudShellServiceConnectionIdempotencyPolicyOption>()) {
+      return options.get<CloudShellServiceConnectionIdempotencyPolicyOption>()
+          ->clone();
+    }
+    return idempotency_policy_->clone();
+  }
+
   std::unique_ptr<google::cloud::BackgroundThreads> background_;
   std::shared_ptr<shell_internal::CloudShellServiceStub> stub_;
   std::unique_ptr<CloudShellServiceRetryPolicy const> retry_policy_prototype_;

--- a/google/cloud/spanner/admin/database_admin_connection.cc
+++ b/google/cloud/spanner/admin/database_admin_connection.cc
@@ -209,11 +209,10 @@ class DatabaseAdminConnectionImpl : public DatabaseAdminConnection {
       override {
     request.clear_page_token();
     auto stub = stub_;
-    auto retry = std::shared_ptr<DatabaseAdminRetryPolicy const>(
-        retry_policy_prototype_->clone());
-    auto backoff = std::shared_ptr<BackoffPolicy const>(
-        backoff_policy_prototype_->clone());
-    auto idempotency = idempotency_policy_->ListDatabases(request);
+    auto retry =
+        std::shared_ptr<DatabaseAdminRetryPolicy const>(retry_policy());
+    auto backoff = std::shared_ptr<BackoffPolicy const>(backoff_policy());
+    auto idempotency = idempotency_policy()->ListDatabases(request);
     char const* function_name = __func__;
     return google::cloud::internal::MakePaginationRange<
         StreamRange<google::spanner::admin::database::v1::Database>>(
@@ -266,17 +265,17 @@ class DatabaseAdminConnectionImpl : public DatabaseAdminConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::spanner::admin::database::v1::Database>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->CreateDatabase(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->CreateDatabase(request), polling_policy(),
+        __func__);
   }
 
   StatusOr<google::spanner::admin::database::v1::Database> GetDatabase(
       google::spanner::admin::database::v1::GetDatabaseRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetDatabase(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GetDatabase(request),
         [this](grpc::ClientContext& context,
                google::spanner::admin::database::v1::GetDatabaseRequest const&
                    request) { return stub_->GetDatabase(context, request); },
@@ -310,17 +309,17 @@ class DatabaseAdminConnectionImpl : public DatabaseAdminConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultMetadata<
             google::spanner::admin::database::v1::UpdateDatabaseDdlMetadata>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->UpdateDatabaseDdl(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->UpdateDatabaseDdl(request), polling_policy(),
+        __func__);
   }
 
   Status DropDatabase(
       google::spanner::admin::database::v1::DropDatabaseRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->DropDatabase(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->DropDatabase(request),
         [this](grpc::ClientContext& context,
                google::spanner::admin::database::v1::DropDatabaseRequest const&
                    request) { return stub_->DropDatabase(context, request); },
@@ -332,8 +331,8 @@ class DatabaseAdminConnectionImpl : public DatabaseAdminConnection {
       google::spanner::admin::database::v1::GetDatabaseDdlRequest const&
           request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetDatabaseDdl(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GetDatabaseDdl(request),
         [this](
             grpc::ClientContext& context,
             google::spanner::admin::database::v1::GetDatabaseDdlRequest const&
@@ -344,8 +343,8 @@ class DatabaseAdminConnectionImpl : public DatabaseAdminConnection {
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
       google::iam::v1::SetIamPolicyRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->SetIamPolicy(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->SetIamPolicy(request),
         [this](grpc::ClientContext& context,
                google::iam::v1::SetIamPolicyRequest const& request) {
           return stub_->SetIamPolicy(context, request);
@@ -356,8 +355,8 @@ class DatabaseAdminConnectionImpl : public DatabaseAdminConnection {
   StatusOr<google::iam::v1::Policy> GetIamPolicy(
       google::iam::v1::GetIamPolicyRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetIamPolicy(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GetIamPolicy(request),
         [this](grpc::ClientContext& context,
                google::iam::v1::GetIamPolicyRequest const& request) {
           return stub_->GetIamPolicy(context, request);
@@ -368,8 +367,8 @@ class DatabaseAdminConnectionImpl : public DatabaseAdminConnection {
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
       google::iam::v1::TestIamPermissionsRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->TestIamPermissions(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->TestIamPermissions(request),
         [this](grpc::ClientContext& context,
                google::iam::v1::TestIamPermissionsRequest const& request) {
           return stub_->TestIamPermissions(context, request);
@@ -402,17 +401,17 @@ class DatabaseAdminConnectionImpl : public DatabaseAdminConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::spanner::admin::database::v1::Backup>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->CreateBackup(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->CreateBackup(request), polling_policy(),
+        __func__);
   }
 
   StatusOr<google::spanner::admin::database::v1::Backup> GetBackup(
       google::spanner::admin::database::v1::GetBackupRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetBackup(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GetBackup(request),
         [this](grpc::ClientContext& context,
                google::spanner::admin::database::v1::GetBackupRequest const&
                    request) { return stub_->GetBackup(context, request); },
@@ -423,8 +422,8 @@ class DatabaseAdminConnectionImpl : public DatabaseAdminConnection {
       google::spanner::admin::database::v1::UpdateBackupRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->UpdateBackup(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->UpdateBackup(request),
         [this](grpc::ClientContext& context,
                google::spanner::admin::database::v1::UpdateBackupRequest const&
                    request) { return stub_->UpdateBackup(context, request); },
@@ -435,8 +434,8 @@ class DatabaseAdminConnectionImpl : public DatabaseAdminConnection {
       google::spanner::admin::database::v1::DeleteBackupRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->DeleteBackup(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->DeleteBackup(request),
         [this](grpc::ClientContext& context,
                google::spanner::admin::database::v1::DeleteBackupRequest const&
                    request) { return stub_->DeleteBackup(context, request); },
@@ -448,11 +447,10 @@ class DatabaseAdminConnectionImpl : public DatabaseAdminConnection {
       override {
     request.clear_page_token();
     auto stub = stub_;
-    auto retry = std::shared_ptr<DatabaseAdminRetryPolicy const>(
-        retry_policy_prototype_->clone());
-    auto backoff = std::shared_ptr<BackoffPolicy const>(
-        backoff_policy_prototype_->clone());
-    auto idempotency = idempotency_policy_->ListBackups(request);
+    auto retry =
+        std::shared_ptr<DatabaseAdminRetryPolicy const>(retry_policy());
+    auto backoff = std::shared_ptr<BackoffPolicy const>(backoff_policy());
+    auto idempotency = idempotency_policy()->ListBackups(request);
     char const* function_name = __func__;
     return google::cloud::internal::MakePaginationRange<
         StreamRange<google::spanner::admin::database::v1::Backup>>(
@@ -504,9 +502,9 @@ class DatabaseAdminConnectionImpl : public DatabaseAdminConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::spanner::admin::database::v1::Database>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->RestoreDatabase(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->RestoreDatabase(request), polling_policy(),
+        __func__);
   }
 
   StreamRange<google::longrunning::Operation> ListDatabaseOperations(
@@ -514,11 +512,10 @@ class DatabaseAdminConnectionImpl : public DatabaseAdminConnection {
           request) override {
     request.clear_page_token();
     auto stub = stub_;
-    auto retry = std::shared_ptr<DatabaseAdminRetryPolicy const>(
-        retry_policy_prototype_->clone());
-    auto backoff = std::shared_ptr<BackoffPolicy const>(
-        backoff_policy_prototype_->clone());
-    auto idempotency = idempotency_policy_->ListDatabaseOperations(request);
+    auto retry =
+        std::shared_ptr<DatabaseAdminRetryPolicy const>(retry_policy());
+    auto backoff = std::shared_ptr<BackoffPolicy const>(backoff_policy());
+    auto idempotency = idempotency_policy()->ListDatabaseOperations(request);
     char const* function_name = __func__;
     return google::cloud::internal::MakePaginationRange<
         StreamRange<google::longrunning::Operation>>(
@@ -550,11 +547,10 @@ class DatabaseAdminConnectionImpl : public DatabaseAdminConnection {
       override {
     request.clear_page_token();
     auto stub = stub_;
-    auto retry = std::shared_ptr<DatabaseAdminRetryPolicy const>(
-        retry_policy_prototype_->clone());
-    auto backoff = std::shared_ptr<BackoffPolicy const>(
-        backoff_policy_prototype_->clone());
-    auto idempotency = idempotency_policy_->ListBackupOperations(request);
+    auto retry =
+        std::shared_ptr<DatabaseAdminRetryPolicy const>(retry_policy());
+    auto backoff = std::shared_ptr<BackoffPolicy const>(backoff_policy());
+    auto idempotency = idempotency_policy()->ListBackupOperations(request);
     char const* function_name = __func__;
     return google::cloud::internal::MakePaginationRange<
         StreamRange<google::longrunning::Operation>>(
@@ -582,6 +578,40 @@ class DatabaseAdminConnectionImpl : public DatabaseAdminConnection {
   }
 
  private:
+  std::unique_ptr<DatabaseAdminRetryPolicy> retry_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<DatabaseAdminRetryPolicyOption>()) {
+      return options.get<DatabaseAdminRetryPolicyOption>()->clone();
+    }
+    return retry_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<BackoffPolicy> backoff_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<DatabaseAdminBackoffPolicyOption>()) {
+      return options.get<DatabaseAdminBackoffPolicyOption>()->clone();
+    }
+    return backoff_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<PollingPolicy> polling_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<DatabaseAdminPollingPolicyOption>()) {
+      return options.get<DatabaseAdminPollingPolicyOption>()->clone();
+    }
+    return polling_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<DatabaseAdminConnectionIdempotencyPolicy>
+  idempotency_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<DatabaseAdminConnectionIdempotencyPolicyOption>()) {
+      return options.get<DatabaseAdminConnectionIdempotencyPolicyOption>()
+          ->clone();
+    }
+    return idempotency_policy_->clone();
+  }
+
   std::unique_ptr<google::cloud::BackgroundThreads> background_;
   std::shared_ptr<spanner_admin_internal::DatabaseAdminStub> stub_;
   std::unique_ptr<DatabaseAdminRetryPolicy const> retry_policy_prototype_;

--- a/google/cloud/spanner/admin/instance_admin_connection.cc
+++ b/google/cloud/spanner/admin/instance_admin_connection.cc
@@ -144,11 +144,10 @@ class InstanceAdminConnectionImpl : public InstanceAdminConnection {
       override {
     request.clear_page_token();
     auto stub = stub_;
-    auto retry = std::shared_ptr<InstanceAdminRetryPolicy const>(
-        retry_policy_prototype_->clone());
-    auto backoff = std::shared_ptr<BackoffPolicy const>(
-        backoff_policy_prototype_->clone());
-    auto idempotency = idempotency_policy_->ListInstanceConfigs(request);
+    auto retry =
+        std::shared_ptr<InstanceAdminRetryPolicy const>(retry_policy());
+    auto backoff = std::shared_ptr<BackoffPolicy const>(backoff_policy());
+    auto idempotency = idempotency_policy()->ListInstanceConfigs(request);
     char const* function_name = __func__;
     return google::cloud::internal::MakePaginationRange<
         StreamRange<google::spanner::admin::instance::v1::InstanceConfig>>(
@@ -180,8 +179,8 @@ class InstanceAdminConnectionImpl : public InstanceAdminConnection {
       google::spanner::admin::instance::v1::GetInstanceConfigRequest const&
           request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetInstanceConfig(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GetInstanceConfig(request),
         [this](grpc::ClientContext& context,
                google::spanner::admin::instance::v1::
                    GetInstanceConfigRequest const& request) {
@@ -195,11 +194,10 @@ class InstanceAdminConnectionImpl : public InstanceAdminConnection {
       override {
     request.clear_page_token();
     auto stub = stub_;
-    auto retry = std::shared_ptr<InstanceAdminRetryPolicy const>(
-        retry_policy_prototype_->clone());
-    auto backoff = std::shared_ptr<BackoffPolicy const>(
-        backoff_policy_prototype_->clone());
-    auto idempotency = idempotency_policy_->ListInstances(request);
+    auto retry =
+        std::shared_ptr<InstanceAdminRetryPolicy const>(retry_policy());
+    auto backoff = std::shared_ptr<BackoffPolicy const>(backoff_policy());
+    auto idempotency = idempotency_policy()->ListInstances(request);
     char const* function_name = __func__;
     return google::cloud::internal::MakePaginationRange<
         StreamRange<google::spanner::admin::instance::v1::Instance>>(
@@ -229,8 +227,8 @@ class InstanceAdminConnectionImpl : public InstanceAdminConnection {
       google::spanner::admin::instance::v1::GetInstanceRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetInstance(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GetInstance(request),
         [this](grpc::ClientContext& context,
                google::spanner::admin::instance::v1::GetInstanceRequest const&
                    request) { return stub_->GetInstance(context, request); },
@@ -264,9 +262,9 @@ class InstanceAdminConnectionImpl : public InstanceAdminConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::spanner::admin::instance::v1::Instance>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->CreateInstance(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->CreateInstance(request), polling_policy(),
+        __func__);
   }
 
   future<StatusOr<google::spanner::admin::instance::v1::Instance>>
@@ -296,17 +294,17 @@ class InstanceAdminConnectionImpl : public InstanceAdminConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::spanner::admin::instance::v1::Instance>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->UpdateInstance(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->UpdateInstance(request), polling_policy(),
+        __func__);
   }
 
   Status DeleteInstance(
       google::spanner::admin::instance::v1::DeleteInstanceRequest const&
           request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->DeleteInstance(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->DeleteInstance(request),
         [this](
             grpc::ClientContext& context,
             google::spanner::admin::instance::v1::DeleteInstanceRequest const&
@@ -317,8 +315,8 @@ class InstanceAdminConnectionImpl : public InstanceAdminConnection {
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
       google::iam::v1::SetIamPolicyRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->SetIamPolicy(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->SetIamPolicy(request),
         [this](grpc::ClientContext& context,
                google::iam::v1::SetIamPolicyRequest const& request) {
           return stub_->SetIamPolicy(context, request);
@@ -329,8 +327,8 @@ class InstanceAdminConnectionImpl : public InstanceAdminConnection {
   StatusOr<google::iam::v1::Policy> GetIamPolicy(
       google::iam::v1::GetIamPolicyRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetIamPolicy(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GetIamPolicy(request),
         [this](grpc::ClientContext& context,
                google::iam::v1::GetIamPolicyRequest const& request) {
           return stub_->GetIamPolicy(context, request);
@@ -341,8 +339,8 @@ class InstanceAdminConnectionImpl : public InstanceAdminConnection {
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
       google::iam::v1::TestIamPermissionsRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->TestIamPermissions(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->TestIamPermissions(request),
         [this](grpc::ClientContext& context,
                google::iam::v1::TestIamPermissionsRequest const& request) {
           return stub_->TestIamPermissions(context, request);
@@ -351,6 +349,40 @@ class InstanceAdminConnectionImpl : public InstanceAdminConnection {
   }
 
  private:
+  std::unique_ptr<InstanceAdminRetryPolicy> retry_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<InstanceAdminRetryPolicyOption>()) {
+      return options.get<InstanceAdminRetryPolicyOption>()->clone();
+    }
+    return retry_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<BackoffPolicy> backoff_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<InstanceAdminBackoffPolicyOption>()) {
+      return options.get<InstanceAdminBackoffPolicyOption>()->clone();
+    }
+    return backoff_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<PollingPolicy> polling_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<InstanceAdminPollingPolicyOption>()) {
+      return options.get<InstanceAdminPollingPolicyOption>()->clone();
+    }
+    return polling_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<InstanceAdminConnectionIdempotencyPolicy>
+  idempotency_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<InstanceAdminConnectionIdempotencyPolicyOption>()) {
+      return options.get<InstanceAdminConnectionIdempotencyPolicyOption>()
+          ->clone();
+    }
+    return idempotency_policy_->clone();
+  }
+
   std::unique_ptr<google::cloud::BackgroundThreads> background_;
   std::shared_ptr<spanner_admin_internal::InstanceAdminStub> stub_;
   std::unique_ptr<InstanceAdminRetryPolicy const> retry_policy_prototype_;

--- a/google/cloud/storagetransfer/storage_transfer_connection.cc
+++ b/google/cloud/storagetransfer/storage_transfer_connection.cc
@@ -121,8 +121,8 @@ class StorageTransferServiceConnectionImpl
       google::storagetransfer::v1::GetGoogleServiceAccountRequest const&
           request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetGoogleServiceAccount(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GetGoogleServiceAccount(request),
         [this](
             grpc::ClientContext& context,
             google::storagetransfer::v1::GetGoogleServiceAccountRequest const&
@@ -136,8 +136,8 @@ class StorageTransferServiceConnectionImpl
       google::storagetransfer::v1::CreateTransferJobRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->CreateTransferJob(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->CreateTransferJob(request),
         [this](grpc::ClientContext& context,
                google::storagetransfer::v1::CreateTransferJobRequest const&
                    request) {
@@ -150,8 +150,8 @@ class StorageTransferServiceConnectionImpl
       google::storagetransfer::v1::UpdateTransferJobRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->UpdateTransferJob(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->UpdateTransferJob(request),
         [this](grpc::ClientContext& context,
                google::storagetransfer::v1::UpdateTransferJobRequest const&
                    request) {
@@ -164,8 +164,8 @@ class StorageTransferServiceConnectionImpl
       google::storagetransfer::v1::GetTransferJobRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetTransferJob(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GetTransferJob(request),
         [this](
             grpc::ClientContext& context,
             google::storagetransfer::v1::GetTransferJobRequest const& request) {
@@ -179,10 +179,9 @@ class StorageTransferServiceConnectionImpl
     request.clear_page_token();
     auto stub = stub_;
     auto retry = std::shared_ptr<StorageTransferServiceRetryPolicy const>(
-        retry_policy_prototype_->clone());
-    auto backoff = std::shared_ptr<BackoffPolicy const>(
-        backoff_policy_prototype_->clone());
-    auto idempotency = idempotency_policy_->ListTransferJobs(request);
+        retry_policy());
+    auto backoff = std::shared_ptr<BackoffPolicy const>(backoff_policy());
+    auto idempotency = idempotency_policy()->ListTransferJobs(request);
     char const* function_name = __func__;
     return google::cloud::internal::MakePaginationRange<
         StreamRange<google::storagetransfer::v1::TransferJob>>(
@@ -211,8 +210,8 @@ class StorageTransferServiceConnectionImpl
       google::storagetransfer::v1::PauseTransferOperationRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->PauseTransferOperation(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->PauseTransferOperation(request),
         [this](grpc::ClientContext& context,
                google::storagetransfer::v1::PauseTransferOperationRequest const&
                    request) {
@@ -225,8 +224,8 @@ class StorageTransferServiceConnectionImpl
       google::storagetransfer::v1::ResumeTransferOperationRequest const&
           request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->ResumeTransferOperation(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->ResumeTransferOperation(request),
         [this](
             grpc::ClientContext& context,
             google::storagetransfer::v1::ResumeTransferOperationRequest const&
@@ -261,12 +260,48 @@ class StorageTransferServiceConnectionImpl
         },
         &google::cloud::internal::ExtractLongRunningResultMetadata<
             google::storagetransfer::v1::TransferOperation>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->RunTransferJob(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->RunTransferJob(request), polling_policy(),
+        __func__);
   }
 
  private:
+  std::unique_ptr<StorageTransferServiceRetryPolicy> retry_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<StorageTransferServiceRetryPolicyOption>()) {
+      return options.get<StorageTransferServiceRetryPolicyOption>()->clone();
+    }
+    return retry_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<BackoffPolicy> backoff_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<StorageTransferServiceBackoffPolicyOption>()) {
+      return options.get<StorageTransferServiceBackoffPolicyOption>()->clone();
+    }
+    return backoff_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<PollingPolicy> polling_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<StorageTransferServicePollingPolicyOption>()) {
+      return options.get<StorageTransferServicePollingPolicyOption>()->clone();
+    }
+    return polling_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<StorageTransferServiceConnectionIdempotencyPolicy>
+  idempotency_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options
+            .has<StorageTransferServiceConnectionIdempotencyPolicyOption>()) {
+      return options
+          .get<StorageTransferServiceConnectionIdempotencyPolicyOption>()
+          ->clone();
+    }
+    return idempotency_policy_->clone();
+  }
+
   std::unique_ptr<google::cloud::BackgroundThreads> background_;
   std::shared_ptr<storagetransfer_internal::StorageTransferServiceStub> stub_;
   std::unique_ptr<StorageTransferServiceRetryPolicy const>

--- a/google/cloud/talent/company_connection.cc
+++ b/google/cloud/talent/company_connection.cc
@@ -93,8 +93,8 @@ class CompanyServiceConnectionImpl : public CompanyServiceConnection {
   StatusOr<google::cloud::talent::v4::Company> CreateCompany(
       google::cloud::talent::v4::CreateCompanyRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->CreateCompany(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->CreateCompany(request),
         [this](grpc::ClientContext& context,
                google::cloud::talent::v4::CreateCompanyRequest const& request) {
           return stub_->CreateCompany(context, request);
@@ -105,8 +105,8 @@ class CompanyServiceConnectionImpl : public CompanyServiceConnection {
   StatusOr<google::cloud::talent::v4::Company> GetCompany(
       google::cloud::talent::v4::GetCompanyRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetCompany(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GetCompany(request),
         [this](grpc::ClientContext& context,
                google::cloud::talent::v4::GetCompanyRequest const& request) {
           return stub_->GetCompany(context, request);
@@ -117,8 +117,8 @@ class CompanyServiceConnectionImpl : public CompanyServiceConnection {
   StatusOr<google::cloud::talent::v4::Company> UpdateCompany(
       google::cloud::talent::v4::UpdateCompanyRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->UpdateCompany(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->UpdateCompany(request),
         [this](grpc::ClientContext& context,
                google::cloud::talent::v4::UpdateCompanyRequest const& request) {
           return stub_->UpdateCompany(context, request);
@@ -129,8 +129,8 @@ class CompanyServiceConnectionImpl : public CompanyServiceConnection {
   Status DeleteCompany(
       google::cloud::talent::v4::DeleteCompanyRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->DeleteCompany(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->DeleteCompany(request),
         [this](grpc::ClientContext& context,
                google::cloud::talent::v4::DeleteCompanyRequest const& request) {
           return stub_->DeleteCompany(context, request);
@@ -142,11 +142,10 @@ class CompanyServiceConnectionImpl : public CompanyServiceConnection {
       google::cloud::talent::v4::ListCompaniesRequest request) override {
     request.clear_page_token();
     auto stub = stub_;
-    auto retry = std::shared_ptr<CompanyServiceRetryPolicy const>(
-        retry_policy_prototype_->clone());
-    auto backoff = std::shared_ptr<BackoffPolicy const>(
-        backoff_policy_prototype_->clone());
-    auto idempotency = idempotency_policy_->ListCompanies(request);
+    auto retry =
+        std::shared_ptr<CompanyServiceRetryPolicy const>(retry_policy());
+    auto backoff = std::shared_ptr<BackoffPolicy const>(backoff_policy());
+    auto idempotency = idempotency_policy()->ListCompanies(request);
     char const* function_name = __func__;
     return google::cloud::internal::MakePaginationRange<
         StreamRange<google::cloud::talent::v4::Company>>(
@@ -172,6 +171,32 @@ class CompanyServiceConnectionImpl : public CompanyServiceConnection {
   }
 
  private:
+  std::unique_ptr<CompanyServiceRetryPolicy> retry_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<CompanyServiceRetryPolicyOption>()) {
+      return options.get<CompanyServiceRetryPolicyOption>()->clone();
+    }
+    return retry_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<BackoffPolicy> backoff_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<CompanyServiceBackoffPolicyOption>()) {
+      return options.get<CompanyServiceBackoffPolicyOption>()->clone();
+    }
+    return backoff_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<CompanyServiceConnectionIdempotencyPolicy>
+  idempotency_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<CompanyServiceConnectionIdempotencyPolicyOption>()) {
+      return options.get<CompanyServiceConnectionIdempotencyPolicyOption>()
+          ->clone();
+    }
+    return idempotency_policy_->clone();
+  }
+
   std::unique_ptr<google::cloud::BackgroundThreads> background_;
   std::shared_ptr<talent_internal::CompanyServiceStub> stub_;
   std::unique_ptr<CompanyServiceRetryPolicy const> retry_policy_prototype_;

--- a/google/cloud/talent/event_connection.cc
+++ b/google/cloud/talent/event_connection.cc
@@ -62,8 +62,8 @@ class EventServiceConnectionImpl : public EventServiceConnection {
       google::cloud::talent::v4::CreateClientEventRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->CreateClientEvent(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->CreateClientEvent(request),
         [this](grpc::ClientContext& context,
                google::cloud::talent::v4::CreateClientEventRequest const&
                    request) {
@@ -73,6 +73,32 @@ class EventServiceConnectionImpl : public EventServiceConnection {
   }
 
  private:
+  std::unique_ptr<EventServiceRetryPolicy> retry_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<EventServiceRetryPolicyOption>()) {
+      return options.get<EventServiceRetryPolicyOption>()->clone();
+    }
+    return retry_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<BackoffPolicy> backoff_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<EventServiceBackoffPolicyOption>()) {
+      return options.get<EventServiceBackoffPolicyOption>()->clone();
+    }
+    return backoff_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<EventServiceConnectionIdempotencyPolicy>
+  idempotency_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<EventServiceConnectionIdempotencyPolicyOption>()) {
+      return options.get<EventServiceConnectionIdempotencyPolicyOption>()
+          ->clone();
+    }
+    return idempotency_policy_->clone();
+  }
+
   std::unique_ptr<google::cloud::BackgroundThreads> background_;
   std::shared_ptr<talent_internal::EventServiceStub> stub_;
   std::unique_ptr<EventServiceRetryPolicy const> retry_policy_prototype_;

--- a/google/cloud/talent/job_connection.cc
+++ b/google/cloud/talent/job_connection.cc
@@ -128,8 +128,8 @@ class JobServiceConnectionImpl : public JobServiceConnection {
   StatusOr<google::cloud::talent::v4::Job> CreateJob(
       google::cloud::talent::v4::CreateJobRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->CreateJob(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->CreateJob(request),
         [this](grpc::ClientContext& context,
                google::cloud::talent::v4::CreateJobRequest const& request) {
           return stub_->CreateJob(context, request);
@@ -162,16 +162,15 @@ class JobServiceConnectionImpl : public JobServiceConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::cloud::talent::v4::BatchCreateJobsResponse>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->BatchCreateJobs(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->BatchCreateJobs(request), polling_policy(),
+        __func__);
   }
 
   StatusOr<google::cloud::talent::v4::Job> GetJob(
       google::cloud::talent::v4::GetJobRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetJob(request),
+        retry_policy(), backoff_policy(), idempotency_policy()->GetJob(request),
         [this](grpc::ClientContext& context,
                google::cloud::talent::v4::GetJobRequest const& request) {
           return stub_->GetJob(context, request);
@@ -182,8 +181,8 @@ class JobServiceConnectionImpl : public JobServiceConnection {
   StatusOr<google::cloud::talent::v4::Job> UpdateJob(
       google::cloud::talent::v4::UpdateJobRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->UpdateJob(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->UpdateJob(request),
         [this](grpc::ClientContext& context,
                google::cloud::talent::v4::UpdateJobRequest const& request) {
           return stub_->UpdateJob(context, request);
@@ -216,16 +215,16 @@ class JobServiceConnectionImpl : public JobServiceConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::cloud::talent::v4::BatchUpdateJobsResponse>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->BatchUpdateJobs(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->BatchUpdateJobs(request), polling_policy(),
+        __func__);
   }
 
   Status DeleteJob(
       google::cloud::talent::v4::DeleteJobRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->DeleteJob(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->DeleteJob(request),
         [this](grpc::ClientContext& context,
                google::cloud::talent::v4::DeleteJobRequest const& request) {
           return stub_->DeleteJob(context, request);
@@ -258,20 +257,18 @@ class JobServiceConnectionImpl : public JobServiceConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::cloud::talent::v4::BatchDeleteJobsResponse>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->BatchDeleteJobs(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->BatchDeleteJobs(request), polling_policy(),
+        __func__);
   }
 
   StreamRange<google::cloud::talent::v4::Job> ListJobs(
       google::cloud::talent::v4::ListJobsRequest request) override {
     request.clear_page_token();
     auto stub = stub_;
-    auto retry = std::shared_ptr<JobServiceRetryPolicy const>(
-        retry_policy_prototype_->clone());
-    auto backoff = std::shared_ptr<BackoffPolicy const>(
-        backoff_policy_prototype_->clone());
-    auto idempotency = idempotency_policy_->ListJobs(request);
+    auto retry = std::shared_ptr<JobServiceRetryPolicy const>(retry_policy());
+    auto backoff = std::shared_ptr<BackoffPolicy const>(backoff_policy());
+    auto idempotency = idempotency_policy()->ListJobs(request);
     char const* function_name = __func__;
     return google::cloud::internal::MakePaginationRange<
         StreamRange<google::cloud::talent::v4::Job>>(
@@ -298,8 +295,8 @@ class JobServiceConnectionImpl : public JobServiceConnection {
   StatusOr<google::cloud::talent::v4::SearchJobsResponse> SearchJobs(
       google::cloud::talent::v4::SearchJobsRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->SearchJobs(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->SearchJobs(request),
         [this](grpc::ClientContext& context,
                google::cloud::talent::v4::SearchJobsRequest const& request) {
           return stub_->SearchJobs(context, request);
@@ -310,8 +307,8 @@ class JobServiceConnectionImpl : public JobServiceConnection {
   StatusOr<google::cloud::talent::v4::SearchJobsResponse> SearchJobsForAlert(
       google::cloud::talent::v4::SearchJobsRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->SearchJobsForAlert(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->SearchJobsForAlert(request),
         [this](grpc::ClientContext& context,
                google::cloud::talent::v4::SearchJobsRequest const& request) {
           return stub_->SearchJobsForAlert(context, request);
@@ -320,6 +317,39 @@ class JobServiceConnectionImpl : public JobServiceConnection {
   }
 
  private:
+  std::unique_ptr<JobServiceRetryPolicy> retry_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<JobServiceRetryPolicyOption>()) {
+      return options.get<JobServiceRetryPolicyOption>()->clone();
+    }
+    return retry_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<BackoffPolicy> backoff_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<JobServiceBackoffPolicyOption>()) {
+      return options.get<JobServiceBackoffPolicyOption>()->clone();
+    }
+    return backoff_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<PollingPolicy> polling_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<JobServicePollingPolicyOption>()) {
+      return options.get<JobServicePollingPolicyOption>()->clone();
+    }
+    return polling_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<JobServiceConnectionIdempotencyPolicy> idempotency_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<JobServiceConnectionIdempotencyPolicyOption>()) {
+      return options.get<JobServiceConnectionIdempotencyPolicyOption>()
+          ->clone();
+    }
+    return idempotency_policy_->clone();
+  }
+
   std::unique_ptr<google::cloud::BackgroundThreads> background_;
   std::shared_ptr<talent_internal::JobServiceStub> stub_;
   std::unique_ptr<JobServiceRetryPolicy const> retry_policy_prototype_;

--- a/google/cloud/talent/tenant_connection.cc
+++ b/google/cloud/talent/tenant_connection.cc
@@ -92,8 +92,8 @@ class TenantServiceConnectionImpl : public TenantServiceConnection {
   StatusOr<google::cloud::talent::v4::Tenant> CreateTenant(
       google::cloud::talent::v4::CreateTenantRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->CreateTenant(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->CreateTenant(request),
         [this](grpc::ClientContext& context,
                google::cloud::talent::v4::CreateTenantRequest const& request) {
           return stub_->CreateTenant(context, request);
@@ -104,8 +104,8 @@ class TenantServiceConnectionImpl : public TenantServiceConnection {
   StatusOr<google::cloud::talent::v4::Tenant> GetTenant(
       google::cloud::talent::v4::GetTenantRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetTenant(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GetTenant(request),
         [this](grpc::ClientContext& context,
                google::cloud::talent::v4::GetTenantRequest const& request) {
           return stub_->GetTenant(context, request);
@@ -116,8 +116,8 @@ class TenantServiceConnectionImpl : public TenantServiceConnection {
   StatusOr<google::cloud::talent::v4::Tenant> UpdateTenant(
       google::cloud::talent::v4::UpdateTenantRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->UpdateTenant(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->UpdateTenant(request),
         [this](grpc::ClientContext& context,
                google::cloud::talent::v4::UpdateTenantRequest const& request) {
           return stub_->UpdateTenant(context, request);
@@ -128,8 +128,8 @@ class TenantServiceConnectionImpl : public TenantServiceConnection {
   Status DeleteTenant(
       google::cloud::talent::v4::DeleteTenantRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->DeleteTenant(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->DeleteTenant(request),
         [this](grpc::ClientContext& context,
                google::cloud::talent::v4::DeleteTenantRequest const& request) {
           return stub_->DeleteTenant(context, request);
@@ -141,11 +141,10 @@ class TenantServiceConnectionImpl : public TenantServiceConnection {
       google::cloud::talent::v4::ListTenantsRequest request) override {
     request.clear_page_token();
     auto stub = stub_;
-    auto retry = std::shared_ptr<TenantServiceRetryPolicy const>(
-        retry_policy_prototype_->clone());
-    auto backoff = std::shared_ptr<BackoffPolicy const>(
-        backoff_policy_prototype_->clone());
-    auto idempotency = idempotency_policy_->ListTenants(request);
+    auto retry =
+        std::shared_ptr<TenantServiceRetryPolicy const>(retry_policy());
+    auto backoff = std::shared_ptr<BackoffPolicy const>(backoff_policy());
+    auto idempotency = idempotency_policy()->ListTenants(request);
     char const* function_name = __func__;
     return google::cloud::internal::MakePaginationRange<
         StreamRange<google::cloud::talent::v4::Tenant>>(
@@ -171,6 +170,32 @@ class TenantServiceConnectionImpl : public TenantServiceConnection {
   }
 
  private:
+  std::unique_ptr<TenantServiceRetryPolicy> retry_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<TenantServiceRetryPolicyOption>()) {
+      return options.get<TenantServiceRetryPolicyOption>()->clone();
+    }
+    return retry_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<BackoffPolicy> backoff_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<TenantServiceBackoffPolicyOption>()) {
+      return options.get<TenantServiceBackoffPolicyOption>()->clone();
+    }
+    return backoff_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<TenantServiceConnectionIdempotencyPolicy>
+  idempotency_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<TenantServiceConnectionIdempotencyPolicyOption>()) {
+      return options.get<TenantServiceConnectionIdempotencyPolicyOption>()
+          ->clone();
+    }
+    return idempotency_policy_->clone();
+  }
+
   std::unique_ptr<google::cloud::BackgroundThreads> background_;
   std::shared_ptr<talent_internal::TenantServiceStub> stub_;
   std::unique_ptr<TenantServiceRetryPolicy const> retry_policy_prototype_;

--- a/google/cloud/tasks/cloud_tasks_connection.cc
+++ b/google/cloud/tasks/cloud_tasks_connection.cc
@@ -154,11 +154,9 @@ class CloudTasksConnectionImpl : public CloudTasksConnection {
       google::cloud::tasks::v2::ListQueuesRequest request) override {
     request.clear_page_token();
     auto stub = stub_;
-    auto retry = std::shared_ptr<CloudTasksRetryPolicy const>(
-        retry_policy_prototype_->clone());
-    auto backoff = std::shared_ptr<BackoffPolicy const>(
-        backoff_policy_prototype_->clone());
-    auto idempotency = idempotency_policy_->ListQueues(request);
+    auto retry = std::shared_ptr<CloudTasksRetryPolicy const>(retry_policy());
+    auto backoff = std::shared_ptr<BackoffPolicy const>(backoff_policy());
+    auto idempotency = idempotency_policy()->ListQueues(request);
     char const* function_name = __func__;
     return google::cloud::internal::MakePaginationRange<
         StreamRange<google::cloud::tasks::v2::Queue>>(
@@ -186,8 +184,8 @@ class CloudTasksConnectionImpl : public CloudTasksConnection {
   StatusOr<google::cloud::tasks::v2::Queue> GetQueue(
       google::cloud::tasks::v2::GetQueueRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetQueue(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GetQueue(request),
         [this](grpc::ClientContext& context,
                google::cloud::tasks::v2::GetQueueRequest const& request) {
           return stub_->GetQueue(context, request);
@@ -198,8 +196,8 @@ class CloudTasksConnectionImpl : public CloudTasksConnection {
   StatusOr<google::cloud::tasks::v2::Queue> CreateQueue(
       google::cloud::tasks::v2::CreateQueueRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->CreateQueue(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->CreateQueue(request),
         [this](grpc::ClientContext& context,
                google::cloud::tasks::v2::CreateQueueRequest const& request) {
           return stub_->CreateQueue(context, request);
@@ -210,8 +208,8 @@ class CloudTasksConnectionImpl : public CloudTasksConnection {
   StatusOr<google::cloud::tasks::v2::Queue> UpdateQueue(
       google::cloud::tasks::v2::UpdateQueueRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->UpdateQueue(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->UpdateQueue(request),
         [this](grpc::ClientContext& context,
                google::cloud::tasks::v2::UpdateQueueRequest const& request) {
           return stub_->UpdateQueue(context, request);
@@ -222,8 +220,8 @@ class CloudTasksConnectionImpl : public CloudTasksConnection {
   Status DeleteQueue(
       google::cloud::tasks::v2::DeleteQueueRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->DeleteQueue(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->DeleteQueue(request),
         [this](grpc::ClientContext& context,
                google::cloud::tasks::v2::DeleteQueueRequest const& request) {
           return stub_->DeleteQueue(context, request);
@@ -234,8 +232,8 @@ class CloudTasksConnectionImpl : public CloudTasksConnection {
   StatusOr<google::cloud::tasks::v2::Queue> PurgeQueue(
       google::cloud::tasks::v2::PurgeQueueRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->PurgeQueue(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->PurgeQueue(request),
         [this](grpc::ClientContext& context,
                google::cloud::tasks::v2::PurgeQueueRequest const& request) {
           return stub_->PurgeQueue(context, request);
@@ -246,8 +244,8 @@ class CloudTasksConnectionImpl : public CloudTasksConnection {
   StatusOr<google::cloud::tasks::v2::Queue> PauseQueue(
       google::cloud::tasks::v2::PauseQueueRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->PauseQueue(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->PauseQueue(request),
         [this](grpc::ClientContext& context,
                google::cloud::tasks::v2::PauseQueueRequest const& request) {
           return stub_->PauseQueue(context, request);
@@ -258,8 +256,8 @@ class CloudTasksConnectionImpl : public CloudTasksConnection {
   StatusOr<google::cloud::tasks::v2::Queue> ResumeQueue(
       google::cloud::tasks::v2::ResumeQueueRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->ResumeQueue(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->ResumeQueue(request),
         [this](grpc::ClientContext& context,
                google::cloud::tasks::v2::ResumeQueueRequest const& request) {
           return stub_->ResumeQueue(context, request);
@@ -270,8 +268,8 @@ class CloudTasksConnectionImpl : public CloudTasksConnection {
   StatusOr<google::iam::v1::Policy> GetIamPolicy(
       google::iam::v1::GetIamPolicyRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetIamPolicy(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GetIamPolicy(request),
         [this](grpc::ClientContext& context,
                google::iam::v1::GetIamPolicyRequest const& request) {
           return stub_->GetIamPolicy(context, request);
@@ -282,8 +280,8 @@ class CloudTasksConnectionImpl : public CloudTasksConnection {
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
       google::iam::v1::SetIamPolicyRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->SetIamPolicy(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->SetIamPolicy(request),
         [this](grpc::ClientContext& context,
                google::iam::v1::SetIamPolicyRequest const& request) {
           return stub_->SetIamPolicy(context, request);
@@ -294,8 +292,8 @@ class CloudTasksConnectionImpl : public CloudTasksConnection {
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
       google::iam::v1::TestIamPermissionsRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->TestIamPermissions(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->TestIamPermissions(request),
         [this](grpc::ClientContext& context,
                google::iam::v1::TestIamPermissionsRequest const& request) {
           return stub_->TestIamPermissions(context, request);
@@ -307,11 +305,9 @@ class CloudTasksConnectionImpl : public CloudTasksConnection {
       google::cloud::tasks::v2::ListTasksRequest request) override {
     request.clear_page_token();
     auto stub = stub_;
-    auto retry = std::shared_ptr<CloudTasksRetryPolicy const>(
-        retry_policy_prototype_->clone());
-    auto backoff = std::shared_ptr<BackoffPolicy const>(
-        backoff_policy_prototype_->clone());
-    auto idempotency = idempotency_policy_->ListTasks(request);
+    auto retry = std::shared_ptr<CloudTasksRetryPolicy const>(retry_policy());
+    auto backoff = std::shared_ptr<BackoffPolicy const>(backoff_policy());
+    auto idempotency = idempotency_policy()->ListTasks(request);
     char const* function_name = __func__;
     return google::cloud::internal::MakePaginationRange<
         StreamRange<google::cloud::tasks::v2::Task>>(
@@ -338,8 +334,8 @@ class CloudTasksConnectionImpl : public CloudTasksConnection {
   StatusOr<google::cloud::tasks::v2::Task> GetTask(
       google::cloud::tasks::v2::GetTaskRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetTask(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GetTask(request),
         [this](grpc::ClientContext& context,
                google::cloud::tasks::v2::GetTaskRequest const& request) {
           return stub_->GetTask(context, request);
@@ -350,8 +346,8 @@ class CloudTasksConnectionImpl : public CloudTasksConnection {
   StatusOr<google::cloud::tasks::v2::Task> CreateTask(
       google::cloud::tasks::v2::CreateTaskRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->CreateTask(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->CreateTask(request),
         [this](grpc::ClientContext& context,
                google::cloud::tasks::v2::CreateTaskRequest const& request) {
           return stub_->CreateTask(context, request);
@@ -362,8 +358,8 @@ class CloudTasksConnectionImpl : public CloudTasksConnection {
   Status DeleteTask(
       google::cloud::tasks::v2::DeleteTaskRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->DeleteTask(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->DeleteTask(request),
         [this](grpc::ClientContext& context,
                google::cloud::tasks::v2::DeleteTaskRequest const& request) {
           return stub_->DeleteTask(context, request);
@@ -374,8 +370,8 @@ class CloudTasksConnectionImpl : public CloudTasksConnection {
   StatusOr<google::cloud::tasks::v2::Task> RunTask(
       google::cloud::tasks::v2::RunTaskRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->RunTask(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->RunTask(request),
         [this](grpc::ClientContext& context,
                google::cloud::tasks::v2::RunTaskRequest const& request) {
           return stub_->RunTask(context, request);
@@ -384,6 +380,31 @@ class CloudTasksConnectionImpl : public CloudTasksConnection {
   }
 
  private:
+  std::unique_ptr<CloudTasksRetryPolicy> retry_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<CloudTasksRetryPolicyOption>()) {
+      return options.get<CloudTasksRetryPolicyOption>()->clone();
+    }
+    return retry_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<BackoffPolicy> backoff_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<CloudTasksBackoffPolicyOption>()) {
+      return options.get<CloudTasksBackoffPolicyOption>()->clone();
+    }
+    return backoff_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<CloudTasksConnectionIdempotencyPolicy> idempotency_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<CloudTasksConnectionIdempotencyPolicyOption>()) {
+      return options.get<CloudTasksConnectionIdempotencyPolicyOption>()
+          ->clone();
+    }
+    return idempotency_policy_->clone();
+  }
+
   std::unique_ptr<google::cloud::BackgroundThreads> background_;
   std::shared_ptr<tasks_internal::CloudTasksStub> stub_;
   std::unique_ptr<CloudTasksRetryPolicy const> retry_policy_prototype_;

--- a/google/cloud/tpu/tpu_connection.cc
+++ b/google/cloud/tpu/tpu_connection.cc
@@ -151,11 +151,9 @@ class TpuConnectionImpl : public TpuConnection {
       google::cloud::tpu::v1::ListNodesRequest request) override {
     request.clear_page_token();
     auto stub = stub_;
-    auto retry =
-        std::shared_ptr<TpuRetryPolicy const>(retry_policy_prototype_->clone());
-    auto backoff = std::shared_ptr<BackoffPolicy const>(
-        backoff_policy_prototype_->clone());
-    auto idempotency = idempotency_policy_->ListNodes(request);
+    auto retry = std::shared_ptr<TpuRetryPolicy const>(retry_policy());
+    auto backoff = std::shared_ptr<BackoffPolicy const>(backoff_policy());
+    auto idempotency = idempotency_policy()->ListNodes(request);
     char const* function_name = __func__;
     return google::cloud::internal::MakePaginationRange<
         StreamRange<google::cloud::tpu::v1::Node>>(
@@ -181,8 +179,8 @@ class TpuConnectionImpl : public TpuConnection {
   StatusOr<google::cloud::tpu::v1::Node> GetNode(
       google::cloud::tpu::v1::GetNodeRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetNode(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GetNode(request),
         [this](grpc::ClientContext& context,
                google::cloud::tpu::v1::GetNodeRequest const& request) {
           return stub_->GetNode(context, request);
@@ -213,9 +211,8 @@ class TpuConnectionImpl : public TpuConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::cloud::tpu::v1::Node>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->CreateNode(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->CreateNode(request), polling_policy(), __func__);
   }
 
   future<StatusOr<google::cloud::tpu::v1::Node>> DeleteNode(
@@ -241,9 +238,8 @@ class TpuConnectionImpl : public TpuConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::cloud::tpu::v1::Node>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->DeleteNode(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->DeleteNode(request), polling_policy(), __func__);
   }
 
   future<StatusOr<google::cloud::tpu::v1::Node>> ReimageNode(
@@ -269,9 +265,8 @@ class TpuConnectionImpl : public TpuConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::cloud::tpu::v1::Node>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->ReimageNode(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->ReimageNode(request), polling_policy(), __func__);
   }
 
   future<StatusOr<google::cloud::tpu::v1::Node>> StopNode(
@@ -297,9 +292,8 @@ class TpuConnectionImpl : public TpuConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::cloud::tpu::v1::Node>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->StopNode(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->StopNode(request), polling_policy(), __func__);
   }
 
   future<StatusOr<google::cloud::tpu::v1::Node>> StartNode(
@@ -325,20 +319,17 @@ class TpuConnectionImpl : public TpuConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::cloud::tpu::v1::Node>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->StartNode(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->StartNode(request), polling_policy(), __func__);
   }
 
   StreamRange<google::cloud::tpu::v1::TensorFlowVersion> ListTensorFlowVersions(
       google::cloud::tpu::v1::ListTensorFlowVersionsRequest request) override {
     request.clear_page_token();
     auto stub = stub_;
-    auto retry =
-        std::shared_ptr<TpuRetryPolicy const>(retry_policy_prototype_->clone());
-    auto backoff = std::shared_ptr<BackoffPolicy const>(
-        backoff_policy_prototype_->clone());
-    auto idempotency = idempotency_policy_->ListTensorFlowVersions(request);
+    auto retry = std::shared_ptr<TpuRetryPolicy const>(retry_policy());
+    auto backoff = std::shared_ptr<BackoffPolicy const>(backoff_policy());
+    auto idempotency = idempotency_policy()->ListTensorFlowVersions(request);
     char const* function_name = __func__;
     return google::cloud::internal::MakePaginationRange<
         StreamRange<google::cloud::tpu::v1::TensorFlowVersion>>(
@@ -368,8 +359,8 @@ class TpuConnectionImpl : public TpuConnection {
       google::cloud::tpu::v1::GetTensorFlowVersionRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetTensorFlowVersion(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GetTensorFlowVersion(request),
         [this](grpc::ClientContext& context,
                google::cloud::tpu::v1::GetTensorFlowVersionRequest const&
                    request) {
@@ -382,11 +373,9 @@ class TpuConnectionImpl : public TpuConnection {
       google::cloud::tpu::v1::ListAcceleratorTypesRequest request) override {
     request.clear_page_token();
     auto stub = stub_;
-    auto retry =
-        std::shared_ptr<TpuRetryPolicy const>(retry_policy_prototype_->clone());
-    auto backoff = std::shared_ptr<BackoffPolicy const>(
-        backoff_policy_prototype_->clone());
-    auto idempotency = idempotency_policy_->ListAcceleratorTypes(request);
+    auto retry = std::shared_ptr<TpuRetryPolicy const>(retry_policy());
+    auto backoff = std::shared_ptr<BackoffPolicy const>(backoff_policy());
+    auto idempotency = idempotency_policy()->ListAcceleratorTypes(request);
     char const* function_name = __func__;
     return google::cloud::internal::MakePaginationRange<
         StreamRange<google::cloud::tpu::v1::AcceleratorType>>(
@@ -415,8 +404,8 @@ class TpuConnectionImpl : public TpuConnection {
       google::cloud::tpu::v1::GetAcceleratorTypeRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetAcceleratorType(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GetAcceleratorType(request),
         [this](
             grpc::ClientContext& context,
             google::cloud::tpu::v1::GetAcceleratorTypeRequest const& request) {
@@ -426,6 +415,38 @@ class TpuConnectionImpl : public TpuConnection {
   }
 
  private:
+  std::unique_ptr<TpuRetryPolicy> retry_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<TpuRetryPolicyOption>()) {
+      return options.get<TpuRetryPolicyOption>()->clone();
+    }
+    return retry_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<BackoffPolicy> backoff_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<TpuBackoffPolicyOption>()) {
+      return options.get<TpuBackoffPolicyOption>()->clone();
+    }
+    return backoff_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<PollingPolicy> polling_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<TpuPollingPolicyOption>()) {
+      return options.get<TpuPollingPolicyOption>()->clone();
+    }
+    return polling_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<TpuConnectionIdempotencyPolicy> idempotency_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<TpuConnectionIdempotencyPolicyOption>()) {
+      return options.get<TpuConnectionIdempotencyPolicyOption>()->clone();
+    }
+    return idempotency_policy_->clone();
+  }
+
   std::unique_ptr<google::cloud::BackgroundThreads> background_;
   std::shared_ptr<tpu_internal::TpuStub> stub_;
   std::unique_ptr<TpuRetryPolicy const> retry_policy_prototype_;

--- a/google/cloud/translate/translation_connection.cc
+++ b/google/cloud/translate/translation_connection.cc
@@ -137,8 +137,8 @@ class TranslationServiceConnectionImpl : public TranslationServiceConnection {
       google::cloud::translation::v3::TranslateTextRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->TranslateText(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->TranslateText(request),
         [this](grpc::ClientContext& context,
                google::cloud::translation::v3::TranslateTextRequest const&
                    request) { return stub_->TranslateText(context, request); },
@@ -149,8 +149,8 @@ class TranslationServiceConnectionImpl : public TranslationServiceConnection {
   DetectLanguage(google::cloud::translation::v3::DetectLanguageRequest const&
                      request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->DetectLanguage(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->DetectLanguage(request),
         [this](grpc::ClientContext& context,
                google::cloud::translation::v3::DetectLanguageRequest const&
                    request) { return stub_->DetectLanguage(context, request); },
@@ -162,8 +162,8 @@ class TranslationServiceConnectionImpl : public TranslationServiceConnection {
       google::cloud::translation::v3::GetSupportedLanguagesRequest const&
           request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetSupportedLanguages(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GetSupportedLanguages(request),
         [this](
             grpc::ClientContext& context,
             google::cloud::translation::v3::GetSupportedLanguagesRequest const&
@@ -178,8 +178,8 @@ class TranslationServiceConnectionImpl : public TranslationServiceConnection {
       google::cloud::translation::v3::TranslateDocumentRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->TranslateDocument(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->TranslateDocument(request),
         [this](grpc::ClientContext& context,
                google::cloud::translation::v3::TranslateDocumentRequest const&
                    request) {
@@ -214,9 +214,9 @@ class TranslationServiceConnectionImpl : public TranslationServiceConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::cloud::translation::v3::BatchTranslateResponse>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->BatchTranslateText(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->BatchTranslateText(request), polling_policy(),
+        __func__);
   }
 
   future<
@@ -248,9 +248,9 @@ class TranslationServiceConnectionImpl : public TranslationServiceConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::cloud::translation::v3::BatchTranslateDocumentResponse>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->BatchTranslateDocument(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->BatchTranslateDocument(request), polling_policy(),
+        __func__);
   }
 
   future<StatusOr<google::cloud::translation::v3::Glossary>> CreateGlossary(
@@ -278,20 +278,19 @@ class TranslationServiceConnectionImpl : public TranslationServiceConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::cloud::translation::v3::Glossary>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->CreateGlossary(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->CreateGlossary(request), polling_policy(),
+        __func__);
   }
 
   StreamRange<google::cloud::translation::v3::Glossary> ListGlossaries(
       google::cloud::translation::v3::ListGlossariesRequest request) override {
     request.clear_page_token();
     auto stub = stub_;
-    auto retry = std::shared_ptr<TranslationServiceRetryPolicy const>(
-        retry_policy_prototype_->clone());
-    auto backoff = std::shared_ptr<BackoffPolicy const>(
-        backoff_policy_prototype_->clone());
-    auto idempotency = idempotency_policy_->ListGlossaries(request);
+    auto retry =
+        std::shared_ptr<TranslationServiceRetryPolicy const>(retry_policy());
+    auto backoff = std::shared_ptr<BackoffPolicy const>(backoff_policy());
+    auto idempotency = idempotency_policy()->ListGlossaries(request);
     char const* function_name = __func__;
     return google::cloud::internal::MakePaginationRange<
         StreamRange<google::cloud::translation::v3::Glossary>>(
@@ -321,8 +320,8 @@ class TranslationServiceConnectionImpl : public TranslationServiceConnection {
       google::cloud::translation::v3::GetGlossaryRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetGlossary(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GetGlossary(request),
         [this](
             grpc::ClientContext& context,
             google::cloud::translation::v3::GetGlossaryRequest const& request) {
@@ -356,12 +355,46 @@ class TranslationServiceConnectionImpl : public TranslationServiceConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::cloud::translation::v3::DeleteGlossaryResponse>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->DeleteGlossary(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->DeleteGlossary(request), polling_policy(),
+        __func__);
   }
 
  private:
+  std::unique_ptr<TranslationServiceRetryPolicy> retry_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<TranslationServiceRetryPolicyOption>()) {
+      return options.get<TranslationServiceRetryPolicyOption>()->clone();
+    }
+    return retry_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<BackoffPolicy> backoff_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<TranslationServiceBackoffPolicyOption>()) {
+      return options.get<TranslationServiceBackoffPolicyOption>()->clone();
+    }
+    return backoff_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<PollingPolicy> polling_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<TranslationServicePollingPolicyOption>()) {
+      return options.get<TranslationServicePollingPolicyOption>()->clone();
+    }
+    return polling_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<TranslationServiceConnectionIdempotencyPolicy>
+  idempotency_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<TranslationServiceConnectionIdempotencyPolicyOption>()) {
+      return options.get<TranslationServiceConnectionIdempotencyPolicyOption>()
+          ->clone();
+    }
+    return idempotency_policy_->clone();
+  }
+
   std::unique_ptr<google::cloud::BackgroundThreads> background_;
   std::shared_ptr<translate_internal::TranslationServiceStub> stub_;
   std::unique_ptr<TranslationServiceRetryPolicy const> retry_policy_prototype_;

--- a/google/cloud/videointelligence/video_intelligence_connection.cc
+++ b/google/cloud/videointelligence/video_intelligence_connection.cc
@@ -96,12 +96,50 @@ class VideoIntelligenceServiceConnectionImpl
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::cloud::videointelligence::v1::AnnotateVideoResponse>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->AnnotateVideo(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->AnnotateVideo(request), polling_policy(),
+        __func__);
   }
 
  private:
+  std::unique_ptr<VideoIntelligenceServiceRetryPolicy> retry_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<VideoIntelligenceServiceRetryPolicyOption>()) {
+      return options.get<VideoIntelligenceServiceRetryPolicyOption>()->clone();
+    }
+    return retry_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<BackoffPolicy> backoff_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<VideoIntelligenceServiceBackoffPolicyOption>()) {
+      return options.get<VideoIntelligenceServiceBackoffPolicyOption>()
+          ->clone();
+    }
+    return backoff_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<PollingPolicy> polling_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<VideoIntelligenceServicePollingPolicyOption>()) {
+      return options.get<VideoIntelligenceServicePollingPolicyOption>()
+          ->clone();
+    }
+    return polling_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<VideoIntelligenceServiceConnectionIdempotencyPolicy>
+  idempotency_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options
+            .has<VideoIntelligenceServiceConnectionIdempotencyPolicyOption>()) {
+      return options
+          .get<VideoIntelligenceServiceConnectionIdempotencyPolicyOption>()
+          ->clone();
+    }
+    return idempotency_policy_->clone();
+  }
+
   std::unique_ptr<google::cloud::BackgroundThreads> background_;
   std::shared_ptr<videointelligence_internal::VideoIntelligenceServiceStub>
       stub_;

--- a/google/cloud/vision/image_annotator_connection.cc
+++ b/google/cloud/vision/image_annotator_connection.cc
@@ -88,8 +88,8 @@ class ImageAnnotatorConnectionImpl : public ImageAnnotatorConnection {
       google::cloud::vision::v1::BatchAnnotateImagesRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->BatchAnnotateImages(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->BatchAnnotateImages(request),
         [this](grpc::ClientContext& context,
                google::cloud::vision::v1::BatchAnnotateImagesRequest const&
                    request) {
@@ -102,8 +102,8 @@ class ImageAnnotatorConnectionImpl : public ImageAnnotatorConnection {
   BatchAnnotateFiles(google::cloud::vision::v1::BatchAnnotateFilesRequest const&
                          request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->BatchAnnotateFiles(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->BatchAnnotateFiles(request),
         [this](grpc::ClientContext& context,
                google::cloud::vision::v1::BatchAnnotateFilesRequest const&
                    request) {
@@ -139,9 +139,9 @@ class ImageAnnotatorConnectionImpl : public ImageAnnotatorConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::cloud::vision::v1::AsyncBatchAnnotateImagesResponse>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->AsyncBatchAnnotateImages(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->AsyncBatchAnnotateImages(request),
+        polling_policy(), __func__);
   }
 
   future<StatusOr<google::cloud::vision::v1::AsyncBatchAnnotateFilesResponse>>
@@ -171,12 +171,46 @@ class ImageAnnotatorConnectionImpl : public ImageAnnotatorConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::cloud::vision::v1::AsyncBatchAnnotateFilesResponse>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->AsyncBatchAnnotateFiles(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->AsyncBatchAnnotateFiles(request),
+        polling_policy(), __func__);
   }
 
  private:
+  std::unique_ptr<ImageAnnotatorRetryPolicy> retry_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<ImageAnnotatorRetryPolicyOption>()) {
+      return options.get<ImageAnnotatorRetryPolicyOption>()->clone();
+    }
+    return retry_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<BackoffPolicy> backoff_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<ImageAnnotatorBackoffPolicyOption>()) {
+      return options.get<ImageAnnotatorBackoffPolicyOption>()->clone();
+    }
+    return backoff_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<PollingPolicy> polling_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<ImageAnnotatorPollingPolicyOption>()) {
+      return options.get<ImageAnnotatorPollingPolicyOption>()->clone();
+    }
+    return polling_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<ImageAnnotatorConnectionIdempotencyPolicy>
+  idempotency_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<ImageAnnotatorConnectionIdempotencyPolicyOption>()) {
+      return options.get<ImageAnnotatorConnectionIdempotencyPolicyOption>()
+          ->clone();
+    }
+    return idempotency_policy_->clone();
+  }
+
   std::unique_ptr<google::cloud::BackgroundThreads> background_;
   std::shared_ptr<vision_internal::ImageAnnotatorStub> stub_;
   std::unique_ptr<ImageAnnotatorRetryPolicy const> retry_policy_prototype_;

--- a/google/cloud/vision/product_search_connection.cc
+++ b/google/cloud/vision/product_search_connection.cc
@@ -207,8 +207,8 @@ class ProductSearchConnectionImpl : public ProductSearchConnection {
       google::cloud::vision::v1::CreateProductSetRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->CreateProductSet(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->CreateProductSet(request),
         [this](
             grpc::ClientContext& context,
             google::cloud::vision::v1::CreateProductSetRequest const& request) {
@@ -221,11 +221,10 @@ class ProductSearchConnectionImpl : public ProductSearchConnection {
       google::cloud::vision::v1::ListProductSetsRequest request) override {
     request.clear_page_token();
     auto stub = stub_;
-    auto retry = std::shared_ptr<ProductSearchRetryPolicy const>(
-        retry_policy_prototype_->clone());
-    auto backoff = std::shared_ptr<BackoffPolicy const>(
-        backoff_policy_prototype_->clone());
-    auto idempotency = idempotency_policy_->ListProductSets(request);
+    auto retry =
+        std::shared_ptr<ProductSearchRetryPolicy const>(retry_policy());
+    auto backoff = std::shared_ptr<BackoffPolicy const>(backoff_policy());
+    auto idempotency = idempotency_policy()->ListProductSets(request);
     char const* function_name = __func__;
     return google::cloud::internal::MakePaginationRange<
         StreamRange<google::cloud::vision::v1::ProductSet>>(
@@ -253,8 +252,8 @@ class ProductSearchConnectionImpl : public ProductSearchConnection {
   StatusOr<google::cloud::vision::v1::ProductSet> GetProductSet(
       google::cloud::vision::v1::GetProductSetRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetProductSet(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GetProductSet(request),
         [this](grpc::ClientContext& context,
                google::cloud::vision::v1::GetProductSetRequest const& request) {
           return stub_->GetProductSet(context, request);
@@ -266,8 +265,8 @@ class ProductSearchConnectionImpl : public ProductSearchConnection {
       google::cloud::vision::v1::UpdateProductSetRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->UpdateProductSet(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->UpdateProductSet(request),
         [this](
             grpc::ClientContext& context,
             google::cloud::vision::v1::UpdateProductSetRequest const& request) {
@@ -280,8 +279,8 @@ class ProductSearchConnectionImpl : public ProductSearchConnection {
       google::cloud::vision::v1::DeleteProductSetRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->DeleteProductSet(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->DeleteProductSet(request),
         [this](
             grpc::ClientContext& context,
             google::cloud::vision::v1::DeleteProductSetRequest const& request) {
@@ -293,8 +292,8 @@ class ProductSearchConnectionImpl : public ProductSearchConnection {
   StatusOr<google::cloud::vision::v1::Product> CreateProduct(
       google::cloud::vision::v1::CreateProductRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->CreateProduct(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->CreateProduct(request),
         [this](grpc::ClientContext& context,
                google::cloud::vision::v1::CreateProductRequest const& request) {
           return stub_->CreateProduct(context, request);
@@ -306,11 +305,10 @@ class ProductSearchConnectionImpl : public ProductSearchConnection {
       google::cloud::vision::v1::ListProductsRequest request) override {
     request.clear_page_token();
     auto stub = stub_;
-    auto retry = std::shared_ptr<ProductSearchRetryPolicy const>(
-        retry_policy_prototype_->clone());
-    auto backoff = std::shared_ptr<BackoffPolicy const>(
-        backoff_policy_prototype_->clone());
-    auto idempotency = idempotency_policy_->ListProducts(request);
+    auto retry =
+        std::shared_ptr<ProductSearchRetryPolicy const>(retry_policy());
+    auto backoff = std::shared_ptr<BackoffPolicy const>(backoff_policy());
+    auto idempotency = idempotency_policy()->ListProducts(request);
     char const* function_name = __func__;
     return google::cloud::internal::MakePaginationRange<
         StreamRange<google::cloud::vision::v1::Product>>(
@@ -338,8 +336,8 @@ class ProductSearchConnectionImpl : public ProductSearchConnection {
   StatusOr<google::cloud::vision::v1::Product> GetProduct(
       google::cloud::vision::v1::GetProductRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetProduct(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GetProduct(request),
         [this](grpc::ClientContext& context,
                google::cloud::vision::v1::GetProductRequest const& request) {
           return stub_->GetProduct(context, request);
@@ -350,8 +348,8 @@ class ProductSearchConnectionImpl : public ProductSearchConnection {
   StatusOr<google::cloud::vision::v1::Product> UpdateProduct(
       google::cloud::vision::v1::UpdateProductRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->UpdateProduct(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->UpdateProduct(request),
         [this](grpc::ClientContext& context,
                google::cloud::vision::v1::UpdateProductRequest const& request) {
           return stub_->UpdateProduct(context, request);
@@ -362,8 +360,8 @@ class ProductSearchConnectionImpl : public ProductSearchConnection {
   Status DeleteProduct(
       google::cloud::vision::v1::DeleteProductRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->DeleteProduct(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->DeleteProduct(request),
         [this](grpc::ClientContext& context,
                google::cloud::vision::v1::DeleteProductRequest const& request) {
           return stub_->DeleteProduct(context, request);
@@ -375,8 +373,8 @@ class ProductSearchConnectionImpl : public ProductSearchConnection {
       google::cloud::vision::v1::CreateReferenceImageRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->CreateReferenceImage(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->CreateReferenceImage(request),
         [this](grpc::ClientContext& context,
                google::cloud::vision::v1::CreateReferenceImageRequest const&
                    request) {
@@ -389,8 +387,8 @@ class ProductSearchConnectionImpl : public ProductSearchConnection {
       google::cloud::vision::v1::DeleteReferenceImageRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->DeleteReferenceImage(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->DeleteReferenceImage(request),
         [this](grpc::ClientContext& context,
                google::cloud::vision::v1::DeleteReferenceImageRequest const&
                    request) {
@@ -403,11 +401,10 @@ class ProductSearchConnectionImpl : public ProductSearchConnection {
       google::cloud::vision::v1::ListReferenceImagesRequest request) override {
     request.clear_page_token();
     auto stub = stub_;
-    auto retry = std::shared_ptr<ProductSearchRetryPolicy const>(
-        retry_policy_prototype_->clone());
-    auto backoff = std::shared_ptr<BackoffPolicy const>(
-        backoff_policy_prototype_->clone());
-    auto idempotency = idempotency_policy_->ListReferenceImages(request);
+    auto retry =
+        std::shared_ptr<ProductSearchRetryPolicy const>(retry_policy());
+    auto backoff = std::shared_ptr<BackoffPolicy const>(backoff_policy());
+    auto idempotency = idempotency_policy()->ListReferenceImages(request);
     char const* function_name = __func__;
     return google::cloud::internal::MakePaginationRange<
         StreamRange<google::cloud::vision::v1::ReferenceImage>>(
@@ -437,8 +434,8 @@ class ProductSearchConnectionImpl : public ProductSearchConnection {
       google::cloud::vision::v1::GetReferenceImageRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetReferenceImage(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GetReferenceImage(request),
         [this](grpc::ClientContext& context,
                google::cloud::vision::v1::GetReferenceImageRequest const&
                    request) {
@@ -451,8 +448,8 @@ class ProductSearchConnectionImpl : public ProductSearchConnection {
       google::cloud::vision::v1::AddProductToProductSetRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->AddProductToProductSet(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->AddProductToProductSet(request),
         [this](grpc::ClientContext& context,
                google::cloud::vision::v1::AddProductToProductSetRequest const&
                    request) {
@@ -465,8 +462,8 @@ class ProductSearchConnectionImpl : public ProductSearchConnection {
       google::cloud::vision::v1::RemoveProductFromProductSetRequest const&
           request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->RemoveProductFromProductSet(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->RemoveProductFromProductSet(request),
         [this](
             grpc::ClientContext& context,
             google::cloud::vision::v1::RemoveProductFromProductSetRequest const&
@@ -481,11 +478,10 @@ class ProductSearchConnectionImpl : public ProductSearchConnection {
       override {
     request.clear_page_token();
     auto stub = stub_;
-    auto retry = std::shared_ptr<ProductSearchRetryPolicy const>(
-        retry_policy_prototype_->clone());
-    auto backoff = std::shared_ptr<BackoffPolicy const>(
-        backoff_policy_prototype_->clone());
-    auto idempotency = idempotency_policy_->ListProductsInProductSet(request);
+    auto retry =
+        std::shared_ptr<ProductSearchRetryPolicy const>(retry_policy());
+    auto backoff = std::shared_ptr<BackoffPolicy const>(backoff_policy());
+    auto idempotency = idempotency_policy()->ListProductsInProductSet(request);
     char const* function_name = __func__;
     return google::cloud::internal::MakePaginationRange<
         StreamRange<google::cloud::vision::v1::Product>>(
@@ -536,9 +532,9 @@ class ProductSearchConnectionImpl : public ProductSearchConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::cloud::vision::v1::ImportProductSetsResponse>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->ImportProductSets(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->ImportProductSets(request), polling_policy(),
+        __func__);
   }
 
   future<StatusOr<google::cloud::vision::v1::BatchOperationMetadata>>
@@ -565,12 +561,46 @@ class ProductSearchConnectionImpl : public ProductSearchConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultMetadata<
             google::cloud::vision::v1::BatchOperationMetadata>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->PurgeProducts(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->PurgeProducts(request), polling_policy(),
+        __func__);
   }
 
  private:
+  std::unique_ptr<ProductSearchRetryPolicy> retry_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<ProductSearchRetryPolicyOption>()) {
+      return options.get<ProductSearchRetryPolicyOption>()->clone();
+    }
+    return retry_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<BackoffPolicy> backoff_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<ProductSearchBackoffPolicyOption>()) {
+      return options.get<ProductSearchBackoffPolicyOption>()->clone();
+    }
+    return backoff_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<PollingPolicy> polling_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<ProductSearchPollingPolicyOption>()) {
+      return options.get<ProductSearchPollingPolicyOption>()->clone();
+    }
+    return polling_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<ProductSearchConnectionIdempotencyPolicy>
+  idempotency_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<ProductSearchConnectionIdempotencyPolicyOption>()) {
+      return options.get<ProductSearchConnectionIdempotencyPolicyOption>()
+          ->clone();
+    }
+    return idempotency_policy_->clone();
+  }
+
   std::unique_ptr<google::cloud::BackgroundThreads> background_;
   std::shared_ptr<vision_internal::ProductSearchStub> stub_;
   std::unique_ptr<ProductSearchRetryPolicy const> retry_policy_prototype_;

--- a/google/cloud/vmmigration/vm_migration_connection.cc
+++ b/google/cloud/vmmigration/vm_migration_connection.cc
@@ -443,11 +443,9 @@ class VmMigrationConnectionImpl : public VmMigrationConnection {
       google::cloud::vmmigration::v1::ListSourcesRequest request) override {
     request.clear_page_token();
     auto stub = stub_;
-    auto retry = std::shared_ptr<VmMigrationRetryPolicy const>(
-        retry_policy_prototype_->clone());
-    auto backoff = std::shared_ptr<BackoffPolicy const>(
-        backoff_policy_prototype_->clone());
-    auto idempotency = idempotency_policy_->ListSources(request);
+    auto retry = std::shared_ptr<VmMigrationRetryPolicy const>(retry_policy());
+    auto backoff = std::shared_ptr<BackoffPolicy const>(backoff_policy());
+    auto idempotency = idempotency_policy()->ListSources(request);
     char const* function_name = __func__;
     return google::cloud::internal::MakePaginationRange<
         StreamRange<google::cloud::vmmigration::v1::Source>>(
@@ -476,8 +474,8 @@ class VmMigrationConnectionImpl : public VmMigrationConnection {
       google::cloud::vmmigration::v1::GetSourceRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetSource(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GetSource(request),
         [this](
             grpc::ClientContext& context,
             google::cloud::vmmigration::v1::GetSourceRequest const& request) {
@@ -511,9 +509,9 @@ class VmMigrationConnectionImpl : public VmMigrationConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::cloud::vmmigration::v1::Source>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->CreateSource(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->CreateSource(request), polling_policy(),
+        __func__);
   }
 
   future<StatusOr<google::cloud::vmmigration::v1::Source>> UpdateSource(
@@ -541,9 +539,9 @@ class VmMigrationConnectionImpl : public VmMigrationConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::cloud::vmmigration::v1::Source>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->UpdateSource(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->UpdateSource(request), polling_policy(),
+        __func__);
   }
 
   future<StatusOr<google::cloud::vmmigration::v1::OperationMetadata>>
@@ -571,17 +569,17 @@ class VmMigrationConnectionImpl : public VmMigrationConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultMetadata<
             google::cloud::vmmigration::v1::OperationMetadata>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->DeleteSource(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->DeleteSource(request), polling_policy(),
+        __func__);
   }
 
   StatusOr<google::cloud::vmmigration::v1::FetchInventoryResponse>
   FetchInventory(google::cloud::vmmigration::v1::FetchInventoryRequest const&
                      request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->FetchInventory(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->FetchInventory(request),
         [this](grpc::ClientContext& context,
                google::cloud::vmmigration::v1::FetchInventoryRequest const&
                    request) { return stub_->FetchInventory(context, request); },
@@ -594,11 +592,9 @@ class VmMigrationConnectionImpl : public VmMigrationConnection {
       override {
     request.clear_page_token();
     auto stub = stub_;
-    auto retry = std::shared_ptr<VmMigrationRetryPolicy const>(
-        retry_policy_prototype_->clone());
-    auto backoff = std::shared_ptr<BackoffPolicy const>(
-        backoff_policy_prototype_->clone());
-    auto idempotency = idempotency_policy_->ListUtilizationReports(request);
+    auto retry = std::shared_ptr<VmMigrationRetryPolicy const>(retry_policy());
+    auto backoff = std::shared_ptr<BackoffPolicy const>(backoff_policy());
+    auto idempotency = idempotency_policy()->ListUtilizationReports(request);
     char const* function_name = __func__;
     return google::cloud::internal::MakePaginationRange<
         StreamRange<google::cloud::vmmigration::v1::UtilizationReport>>(
@@ -629,8 +625,8 @@ class VmMigrationConnectionImpl : public VmMigrationConnection {
       google::cloud::vmmigration::v1::GetUtilizationReportRequest const&
           request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetUtilizationReport(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GetUtilizationReport(request),
         [this](
             grpc::ClientContext& context,
             google::cloud::vmmigration::v1::GetUtilizationReportRequest const&
@@ -667,9 +663,9 @@ class VmMigrationConnectionImpl : public VmMigrationConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::cloud::vmmigration::v1::UtilizationReport>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->CreateUtilizationReport(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->CreateUtilizationReport(request),
+        polling_policy(), __func__);
   }
 
   future<StatusOr<google::cloud::vmmigration::v1::OperationMetadata>>
@@ -699,9 +695,9 @@ class VmMigrationConnectionImpl : public VmMigrationConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultMetadata<
             google::cloud::vmmigration::v1::OperationMetadata>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->DeleteUtilizationReport(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->DeleteUtilizationReport(request),
+        polling_policy(), __func__);
   }
 
   StreamRange<google::cloud::vmmigration::v1::DatacenterConnector>
@@ -710,11 +706,9 @@ class VmMigrationConnectionImpl : public VmMigrationConnection {
       override {
     request.clear_page_token();
     auto stub = stub_;
-    auto retry = std::shared_ptr<VmMigrationRetryPolicy const>(
-        retry_policy_prototype_->clone());
-    auto backoff = std::shared_ptr<BackoffPolicy const>(
-        backoff_policy_prototype_->clone());
-    auto idempotency = idempotency_policy_->ListDatacenterConnectors(request);
+    auto retry = std::shared_ptr<VmMigrationRetryPolicy const>(retry_policy());
+    auto backoff = std::shared_ptr<BackoffPolicy const>(backoff_policy());
+    auto idempotency = idempotency_policy()->ListDatacenterConnectors(request);
     char const* function_name = __func__;
     return google::cloud::internal::MakePaginationRange<
         StreamRange<google::cloud::vmmigration::v1::DatacenterConnector>>(
@@ -745,8 +739,8 @@ class VmMigrationConnectionImpl : public VmMigrationConnection {
       google::cloud::vmmigration::v1::GetDatacenterConnectorRequest const&
           request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetDatacenterConnector(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GetDatacenterConnector(request),
         [this](
             grpc::ClientContext& context,
             google::cloud::vmmigration::v1::GetDatacenterConnectorRequest const&
@@ -783,9 +777,9 @@ class VmMigrationConnectionImpl : public VmMigrationConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::cloud::vmmigration::v1::DatacenterConnector>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->CreateDatacenterConnector(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->CreateDatacenterConnector(request),
+        polling_policy(), __func__);
   }
 
   future<StatusOr<google::cloud::vmmigration::v1::OperationMetadata>>
@@ -815,9 +809,9 @@ class VmMigrationConnectionImpl : public VmMigrationConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultMetadata<
             google::cloud::vmmigration::v1::OperationMetadata>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->DeleteDatacenterConnector(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->DeleteDatacenterConnector(request),
+        polling_policy(), __func__);
   }
 
   future<StatusOr<google::cloud::vmmigration::v1::MigratingVm>>
@@ -846,9 +840,9 @@ class VmMigrationConnectionImpl : public VmMigrationConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::cloud::vmmigration::v1::MigratingVm>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->CreateMigratingVm(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->CreateMigratingVm(request), polling_policy(),
+        __func__);
   }
 
   StreamRange<google::cloud::vmmigration::v1::MigratingVm> ListMigratingVms(
@@ -856,11 +850,9 @@ class VmMigrationConnectionImpl : public VmMigrationConnection {
       override {
     request.clear_page_token();
     auto stub = stub_;
-    auto retry = std::shared_ptr<VmMigrationRetryPolicy const>(
-        retry_policy_prototype_->clone());
-    auto backoff = std::shared_ptr<BackoffPolicy const>(
-        backoff_policy_prototype_->clone());
-    auto idempotency = idempotency_policy_->ListMigratingVms(request);
+    auto retry = std::shared_ptr<VmMigrationRetryPolicy const>(retry_policy());
+    auto backoff = std::shared_ptr<BackoffPolicy const>(backoff_policy());
+    auto idempotency = idempotency_policy()->ListMigratingVms(request);
     char const* function_name = __func__;
     return google::cloud::internal::MakePaginationRange<
         StreamRange<google::cloud::vmmigration::v1::MigratingVm>>(
@@ -890,8 +882,8 @@ class VmMigrationConnectionImpl : public VmMigrationConnection {
       google::cloud::vmmigration::v1::GetMigratingVmRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetMigratingVm(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GetMigratingVm(request),
         [this](grpc::ClientContext& context,
                google::cloud::vmmigration::v1::GetMigratingVmRequest const&
                    request) { return stub_->GetMigratingVm(context, request); },
@@ -924,9 +916,9 @@ class VmMigrationConnectionImpl : public VmMigrationConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::cloud::vmmigration::v1::MigratingVm>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->UpdateMigratingVm(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->UpdateMigratingVm(request), polling_policy(),
+        __func__);
   }
 
   future<StatusOr<google::cloud::vmmigration::v1::OperationMetadata>>
@@ -955,9 +947,9 @@ class VmMigrationConnectionImpl : public VmMigrationConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultMetadata<
             google::cloud::vmmigration::v1::OperationMetadata>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->DeleteMigratingVm(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->DeleteMigratingVm(request), polling_policy(),
+        __func__);
   }
 
   future<StatusOr<google::cloud::vmmigration::v1::StartMigrationResponse>>
@@ -985,9 +977,9 @@ class VmMigrationConnectionImpl : public VmMigrationConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::cloud::vmmigration::v1::StartMigrationResponse>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->StartMigration(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->StartMigration(request), polling_policy(),
+        __func__);
   }
 
   future<StatusOr<google::cloud::vmmigration::v1::ResumeMigrationResponse>>
@@ -1015,9 +1007,9 @@ class VmMigrationConnectionImpl : public VmMigrationConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::cloud::vmmigration::v1::ResumeMigrationResponse>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->ResumeMigration(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->ResumeMigration(request), polling_policy(),
+        __func__);
   }
 
   future<StatusOr<google::cloud::vmmigration::v1::PauseMigrationResponse>>
@@ -1045,9 +1037,9 @@ class VmMigrationConnectionImpl : public VmMigrationConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::cloud::vmmigration::v1::PauseMigrationResponse>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->PauseMigration(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->PauseMigration(request), polling_policy(),
+        __func__);
   }
 
   future<StatusOr<google::cloud::vmmigration::v1::FinalizeMigrationResponse>>
@@ -1076,9 +1068,9 @@ class VmMigrationConnectionImpl : public VmMigrationConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::cloud::vmmigration::v1::FinalizeMigrationResponse>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->FinalizeMigration(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->FinalizeMigration(request), polling_policy(),
+        __func__);
   }
 
   future<StatusOr<google::cloud::vmmigration::v1::CloneJob>> CreateCloneJob(
@@ -1106,9 +1098,9 @@ class VmMigrationConnectionImpl : public VmMigrationConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::cloud::vmmigration::v1::CloneJob>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->CreateCloneJob(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->CreateCloneJob(request), polling_policy(),
+        __func__);
   }
 
   future<StatusOr<google::cloud::vmmigration::v1::CancelCloneJobResponse>>
@@ -1136,20 +1128,18 @@ class VmMigrationConnectionImpl : public VmMigrationConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::cloud::vmmigration::v1::CancelCloneJobResponse>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->CancelCloneJob(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->CancelCloneJob(request), polling_policy(),
+        __func__);
   }
 
   StreamRange<google::cloud::vmmigration::v1::CloneJob> ListCloneJobs(
       google::cloud::vmmigration::v1::ListCloneJobsRequest request) override {
     request.clear_page_token();
     auto stub = stub_;
-    auto retry = std::shared_ptr<VmMigrationRetryPolicy const>(
-        retry_policy_prototype_->clone());
-    auto backoff = std::shared_ptr<BackoffPolicy const>(
-        backoff_policy_prototype_->clone());
-    auto idempotency = idempotency_policy_->ListCloneJobs(request);
+    auto retry = std::shared_ptr<VmMigrationRetryPolicy const>(retry_policy());
+    auto backoff = std::shared_ptr<BackoffPolicy const>(backoff_policy());
+    auto idempotency = idempotency_policy()->ListCloneJobs(request);
     char const* function_name = __func__;
     return google::cloud::internal::MakePaginationRange<
         StreamRange<google::cloud::vmmigration::v1::CloneJob>>(
@@ -1178,8 +1168,8 @@ class VmMigrationConnectionImpl : public VmMigrationConnection {
       google::cloud::vmmigration::v1::GetCloneJobRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetCloneJob(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GetCloneJob(request),
         [this](
             grpc::ClientContext& context,
             google::cloud::vmmigration::v1::GetCloneJobRequest const& request) {
@@ -1213,9 +1203,9 @@ class VmMigrationConnectionImpl : public VmMigrationConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::cloud::vmmigration::v1::CutoverJob>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->CreateCutoverJob(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->CreateCutoverJob(request), polling_policy(),
+        __func__);
   }
 
   future<StatusOr<google::cloud::vmmigration::v1::CancelCutoverJobResponse>>
@@ -1244,20 +1234,18 @@ class VmMigrationConnectionImpl : public VmMigrationConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::cloud::vmmigration::v1::CancelCutoverJobResponse>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->CancelCutoverJob(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->CancelCutoverJob(request), polling_policy(),
+        __func__);
   }
 
   StreamRange<google::cloud::vmmigration::v1::CutoverJob> ListCutoverJobs(
       google::cloud::vmmigration::v1::ListCutoverJobsRequest request) override {
     request.clear_page_token();
     auto stub = stub_;
-    auto retry = std::shared_ptr<VmMigrationRetryPolicy const>(
-        retry_policy_prototype_->clone());
-    auto backoff = std::shared_ptr<BackoffPolicy const>(
-        backoff_policy_prototype_->clone());
-    auto idempotency = idempotency_policy_->ListCutoverJobs(request);
+    auto retry = std::shared_ptr<VmMigrationRetryPolicy const>(retry_policy());
+    auto backoff = std::shared_ptr<BackoffPolicy const>(backoff_policy());
+    auto idempotency = idempotency_policy()->ListCutoverJobs(request);
     char const* function_name = __func__;
     return google::cloud::internal::MakePaginationRange<
         StreamRange<google::cloud::vmmigration::v1::CutoverJob>>(
@@ -1287,8 +1275,8 @@ class VmMigrationConnectionImpl : public VmMigrationConnection {
       google::cloud::vmmigration::v1::GetCutoverJobRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetCutoverJob(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GetCutoverJob(request),
         [this](grpc::ClientContext& context,
                google::cloud::vmmigration::v1::GetCutoverJobRequest const&
                    request) { return stub_->GetCutoverJob(context, request); },
@@ -1299,11 +1287,9 @@ class VmMigrationConnectionImpl : public VmMigrationConnection {
       google::cloud::vmmigration::v1::ListGroupsRequest request) override {
     request.clear_page_token();
     auto stub = stub_;
-    auto retry = std::shared_ptr<VmMigrationRetryPolicy const>(
-        retry_policy_prototype_->clone());
-    auto backoff = std::shared_ptr<BackoffPolicy const>(
-        backoff_policy_prototype_->clone());
-    auto idempotency = idempotency_policy_->ListGroups(request);
+    auto retry = std::shared_ptr<VmMigrationRetryPolicy const>(retry_policy());
+    auto backoff = std::shared_ptr<BackoffPolicy const>(backoff_policy());
+    auto idempotency = idempotency_policy()->ListGroups(request);
     char const* function_name = __func__;
     return google::cloud::internal::MakePaginationRange<
         StreamRange<google::cloud::vmmigration::v1::Group>>(
@@ -1331,8 +1317,8 @@ class VmMigrationConnectionImpl : public VmMigrationConnection {
   StatusOr<google::cloud::vmmigration::v1::Group> GetGroup(
       google::cloud::vmmigration::v1::GetGroupRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetGroup(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GetGroup(request),
         [this](grpc::ClientContext& context,
                google::cloud::vmmigration::v1::GetGroupRequest const& request) {
           return stub_->GetGroup(context, request);
@@ -1365,9 +1351,8 @@ class VmMigrationConnectionImpl : public VmMigrationConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::cloud::vmmigration::v1::Group>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->CreateGroup(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->CreateGroup(request), polling_policy(), __func__);
   }
 
   future<StatusOr<google::cloud::vmmigration::v1::Group>> UpdateGroup(
@@ -1395,9 +1380,8 @@ class VmMigrationConnectionImpl : public VmMigrationConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::cloud::vmmigration::v1::Group>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->UpdateGroup(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->UpdateGroup(request), polling_policy(), __func__);
   }
 
   future<StatusOr<google::cloud::vmmigration::v1::OperationMetadata>>
@@ -1425,9 +1409,8 @@ class VmMigrationConnectionImpl : public VmMigrationConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultMetadata<
             google::cloud::vmmigration::v1::OperationMetadata>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->DeleteGroup(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->DeleteGroup(request), polling_policy(), __func__);
   }
 
   future<StatusOr<google::cloud::vmmigration::v1::AddGroupMigrationResponse>>
@@ -1456,9 +1439,9 @@ class VmMigrationConnectionImpl : public VmMigrationConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::cloud::vmmigration::v1::AddGroupMigrationResponse>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->AddGroupMigration(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->AddGroupMigration(request), polling_policy(),
+        __func__);
   }
 
   future<StatusOr<google::cloud::vmmigration::v1::RemoveGroupMigrationResponse>>
@@ -1489,9 +1472,9 @@ class VmMigrationConnectionImpl : public VmMigrationConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::cloud::vmmigration::v1::RemoveGroupMigrationResponse>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->RemoveGroupMigration(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->RemoveGroupMigration(request), polling_policy(),
+        __func__);
   }
 
   StreamRange<google::cloud::vmmigration::v1::TargetProject> ListTargetProjects(
@@ -1499,11 +1482,9 @@ class VmMigrationConnectionImpl : public VmMigrationConnection {
       override {
     request.clear_page_token();
     auto stub = stub_;
-    auto retry = std::shared_ptr<VmMigrationRetryPolicy const>(
-        retry_policy_prototype_->clone());
-    auto backoff = std::shared_ptr<BackoffPolicy const>(
-        backoff_policy_prototype_->clone());
-    auto idempotency = idempotency_policy_->ListTargetProjects(request);
+    auto retry = std::shared_ptr<VmMigrationRetryPolicy const>(retry_policy());
+    auto backoff = std::shared_ptr<BackoffPolicy const>(backoff_policy());
+    auto idempotency = idempotency_policy()->ListTargetProjects(request);
     char const* function_name = __func__;
     return google::cloud::internal::MakePaginationRange<
         StreamRange<google::cloud::vmmigration::v1::TargetProject>>(
@@ -1533,8 +1514,8 @@ class VmMigrationConnectionImpl : public VmMigrationConnection {
       google::cloud::vmmigration::v1::GetTargetProjectRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetTargetProject(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GetTargetProject(request),
         [this](grpc::ClientContext& context,
                google::cloud::vmmigration::v1::GetTargetProjectRequest const&
                    request) {
@@ -1570,9 +1551,9 @@ class VmMigrationConnectionImpl : public VmMigrationConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::cloud::vmmigration::v1::TargetProject>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->CreateTargetProject(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->CreateTargetProject(request), polling_policy(),
+        __func__);
   }
 
   future<StatusOr<google::cloud::vmmigration::v1::TargetProject>>
@@ -1602,9 +1583,9 @@ class VmMigrationConnectionImpl : public VmMigrationConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::cloud::vmmigration::v1::TargetProject>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->UpdateTargetProject(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->UpdateTargetProject(request), polling_policy(),
+        __func__);
   }
 
   future<StatusOr<google::cloud::vmmigration::v1::OperationMetadata>>
@@ -1634,12 +1615,45 @@ class VmMigrationConnectionImpl : public VmMigrationConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultMetadata<
             google::cloud::vmmigration::v1::OperationMetadata>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->DeleteTargetProject(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->DeleteTargetProject(request), polling_policy(),
+        __func__);
   }
 
  private:
+  std::unique_ptr<VmMigrationRetryPolicy> retry_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<VmMigrationRetryPolicyOption>()) {
+      return options.get<VmMigrationRetryPolicyOption>()->clone();
+    }
+    return retry_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<BackoffPolicy> backoff_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<VmMigrationBackoffPolicyOption>()) {
+      return options.get<VmMigrationBackoffPolicyOption>()->clone();
+    }
+    return backoff_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<PollingPolicy> polling_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<VmMigrationPollingPolicyOption>()) {
+      return options.get<VmMigrationPollingPolicyOption>()->clone();
+    }
+    return polling_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<VmMigrationConnectionIdempotencyPolicy> idempotency_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<VmMigrationConnectionIdempotencyPolicyOption>()) {
+      return options.get<VmMigrationConnectionIdempotencyPolicyOption>()
+          ->clone();
+    }
+    return idempotency_policy_->clone();
+  }
+
   std::unique_ptr<google::cloud::BackgroundThreads> background_;
   std::shared_ptr<vmmigration_internal::VmMigrationStub> stub_;
   std::unique_ptr<VmMigrationRetryPolicy const> retry_policy_prototype_;

--- a/google/cloud/vpcaccess/vpc_access_connection.cc
+++ b/google/cloud/vpcaccess/vpc_access_connection.cc
@@ -117,17 +117,17 @@ class VpcAccessServiceConnectionImpl : public VpcAccessServiceConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
             google::cloud::vpcaccess::v1::Connector>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->CreateConnector(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->CreateConnector(request), polling_policy(),
+        __func__);
   }
 
   StatusOr<google::cloud::vpcaccess::v1::Connector> GetConnector(
       google::cloud::vpcaccess::v1::GetConnectorRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetConnector(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GetConnector(request),
         [this](
             grpc::ClientContext& context,
             google::cloud::vpcaccess::v1::GetConnectorRequest const& request) {
@@ -140,11 +140,10 @@ class VpcAccessServiceConnectionImpl : public VpcAccessServiceConnection {
       google::cloud::vpcaccess::v1::ListConnectorsRequest request) override {
     request.clear_page_token();
     auto stub = stub_;
-    auto retry = std::shared_ptr<VpcAccessServiceRetryPolicy const>(
-        retry_policy_prototype_->clone());
-    auto backoff = std::shared_ptr<BackoffPolicy const>(
-        backoff_policy_prototype_->clone());
-    auto idempotency = idempotency_policy_->ListConnectors(request);
+    auto retry =
+        std::shared_ptr<VpcAccessServiceRetryPolicy const>(retry_policy());
+    auto backoff = std::shared_ptr<BackoffPolicy const>(backoff_policy());
+    auto idempotency = idempotency_policy()->ListConnectors(request);
     char const* function_name = __func__;
     return google::cloud::internal::MakePaginationRange<
         StreamRange<google::cloud::vpcaccess::v1::Connector>>(
@@ -194,12 +193,46 @@ class VpcAccessServiceConnectionImpl : public VpcAccessServiceConnection {
         },
         &google::cloud::internal::ExtractLongRunningResultMetadata<
             google::cloud::vpcaccess::v1::OperationMetadata>,
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->DeleteConnector(request),
-        polling_policy_prototype_->clone(), __func__);
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->DeleteConnector(request), polling_policy(),
+        __func__);
   }
 
  private:
+  std::unique_ptr<VpcAccessServiceRetryPolicy> retry_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<VpcAccessServiceRetryPolicyOption>()) {
+      return options.get<VpcAccessServiceRetryPolicyOption>()->clone();
+    }
+    return retry_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<BackoffPolicy> backoff_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<VpcAccessServiceBackoffPolicyOption>()) {
+      return options.get<VpcAccessServiceBackoffPolicyOption>()->clone();
+    }
+    return backoff_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<PollingPolicy> polling_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<VpcAccessServicePollingPolicyOption>()) {
+      return options.get<VpcAccessServicePollingPolicyOption>()->clone();
+    }
+    return polling_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<VpcAccessServiceConnectionIdempotencyPolicy>
+  idempotency_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<VpcAccessServiceConnectionIdempotencyPolicyOption>()) {
+      return options.get<VpcAccessServiceConnectionIdempotencyPolicyOption>()
+          ->clone();
+    }
+    return idempotency_policy_->clone();
+  }
+
   std::unique_ptr<google::cloud::BackgroundThreads> background_;
   std::shared_ptr<vpcaccess_internal::VpcAccessServiceStub> stub_;
   std::unique_ptr<VpcAccessServiceRetryPolicy const> retry_policy_prototype_;

--- a/google/cloud/webrisk/web_risk_connection.cc
+++ b/google/cloud/webrisk/web_risk_connection.cc
@@ -81,8 +81,8 @@ class WebRiskServiceConnectionImpl : public WebRiskServiceConnection {
       google::cloud::webrisk::v1::ComputeThreatListDiffRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->ComputeThreatListDiff(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->ComputeThreatListDiff(request),
         [this](grpc::ClientContext& context,
                google::cloud::webrisk::v1::ComputeThreatListDiffRequest const&
                    request) {
@@ -94,8 +94,8 @@ class WebRiskServiceConnectionImpl : public WebRiskServiceConnection {
   StatusOr<google::cloud::webrisk::v1::SearchUrisResponse> SearchUris(
       google::cloud::webrisk::v1::SearchUrisRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->SearchUris(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->SearchUris(request),
         [this](grpc::ClientContext& context,
                google::cloud::webrisk::v1::SearchUrisRequest const& request) {
           return stub_->SearchUris(context, request);
@@ -106,8 +106,8 @@ class WebRiskServiceConnectionImpl : public WebRiskServiceConnection {
   StatusOr<google::cloud::webrisk::v1::SearchHashesResponse> SearchHashes(
       google::cloud::webrisk::v1::SearchHashesRequest const& request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->SearchHashes(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->SearchHashes(request),
         [this](grpc::ClientContext& context,
                google::cloud::webrisk::v1::SearchHashesRequest const& request) {
           return stub_->SearchHashes(context, request);
@@ -119,8 +119,8 @@ class WebRiskServiceConnectionImpl : public WebRiskServiceConnection {
       google::cloud::webrisk::v1::CreateSubmissionRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->CreateSubmission(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->CreateSubmission(request),
         [this](grpc::ClientContext& context,
                google::cloud::webrisk::v1::CreateSubmissionRequest const&
                    request) {
@@ -130,6 +130,32 @@ class WebRiskServiceConnectionImpl : public WebRiskServiceConnection {
   }
 
  private:
+  std::unique_ptr<WebRiskServiceRetryPolicy> retry_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<WebRiskServiceRetryPolicyOption>()) {
+      return options.get<WebRiskServiceRetryPolicyOption>()->clone();
+    }
+    return retry_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<BackoffPolicy> backoff_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<WebRiskServiceBackoffPolicyOption>()) {
+      return options.get<WebRiskServiceBackoffPolicyOption>()->clone();
+    }
+    return backoff_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<WebRiskServiceConnectionIdempotencyPolicy>
+  idempotency_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<WebRiskServiceConnectionIdempotencyPolicyOption>()) {
+      return options.get<WebRiskServiceConnectionIdempotencyPolicyOption>()
+          ->clone();
+    }
+    return idempotency_policy_->clone();
+  }
+
   std::unique_ptr<google::cloud::BackgroundThreads> background_;
   std::shared_ptr<webrisk_internal::WebRiskServiceStub> stub_;
   std::unique_ptr<WebRiskServiceRetryPolicy const> retry_policy_prototype_;

--- a/google/cloud/websecurityscanner/web_security_scanner_connection.cc
+++ b/google/cloud/websecurityscanner/web_security_scanner_connection.cc
@@ -172,8 +172,8 @@ class WebSecurityScannerConnectionImpl : public WebSecurityScannerConnection {
       google::cloud::websecurityscanner::v1::CreateScanConfigRequest const&
           request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->CreateScanConfig(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->CreateScanConfig(request),
         [this](grpc::ClientContext& context,
                google::cloud::websecurityscanner::v1::
                    CreateScanConfigRequest const& request) {
@@ -186,8 +186,8 @@ class WebSecurityScannerConnectionImpl : public WebSecurityScannerConnection {
       google::cloud::websecurityscanner::v1::DeleteScanConfigRequest const&
           request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->DeleteScanConfig(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->DeleteScanConfig(request),
         [this](grpc::ClientContext& context,
                google::cloud::websecurityscanner::v1::
                    DeleteScanConfigRequest const& request) {
@@ -200,8 +200,8 @@ class WebSecurityScannerConnectionImpl : public WebSecurityScannerConnection {
       google::cloud::websecurityscanner::v1::GetScanConfigRequest const&
           request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetScanConfig(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GetScanConfig(request),
         [this](
             grpc::ClientContext& context,
             google::cloud::websecurityscanner::v1::GetScanConfigRequest const&
@@ -214,11 +214,10 @@ class WebSecurityScannerConnectionImpl : public WebSecurityScannerConnection {
                       request) override {
     request.clear_page_token();
     auto stub = stub_;
-    auto retry = std::shared_ptr<WebSecurityScannerRetryPolicy const>(
-        retry_policy_prototype_->clone());
-    auto backoff = std::shared_ptr<BackoffPolicy const>(
-        backoff_policy_prototype_->clone());
-    auto idempotency = idempotency_policy_->ListScanConfigs(request);
+    auto retry =
+        std::shared_ptr<WebSecurityScannerRetryPolicy const>(retry_policy());
+    auto backoff = std::shared_ptr<BackoffPolicy const>(backoff_policy());
+    auto idempotency = idempotency_policy()->ListScanConfigs(request);
     char const* function_name = __func__;
     return google::cloud::internal::MakePaginationRange<
         StreamRange<google::cloud::websecurityscanner::v1::ScanConfig>>(
@@ -248,8 +247,8 @@ class WebSecurityScannerConnectionImpl : public WebSecurityScannerConnection {
       google::cloud::websecurityscanner::v1::UpdateScanConfigRequest const&
           request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->UpdateScanConfig(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->UpdateScanConfig(request),
         [this](grpc::ClientContext& context,
                google::cloud::websecurityscanner::v1::
                    UpdateScanConfigRequest const& request) {
@@ -262,8 +261,8 @@ class WebSecurityScannerConnectionImpl : public WebSecurityScannerConnection {
       google::cloud::websecurityscanner::v1::StartScanRunRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->StartScanRun(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->StartScanRun(request),
         [this](grpc::ClientContext& context,
                google::cloud::websecurityscanner::v1::StartScanRunRequest const&
                    request) { return stub_->StartScanRun(context, request); },
@@ -274,8 +273,8 @@ class WebSecurityScannerConnectionImpl : public WebSecurityScannerConnection {
       google::cloud::websecurityscanner::v1::GetScanRunRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetScanRun(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GetScanRun(request),
         [this](grpc::ClientContext& context,
                google::cloud::websecurityscanner::v1::GetScanRunRequest const&
                    request) { return stub_->GetScanRun(context, request); },
@@ -287,11 +286,10 @@ class WebSecurityScannerConnectionImpl : public WebSecurityScannerConnection {
       override {
     request.clear_page_token();
     auto stub = stub_;
-    auto retry = std::shared_ptr<WebSecurityScannerRetryPolicy const>(
-        retry_policy_prototype_->clone());
-    auto backoff = std::shared_ptr<BackoffPolicy const>(
-        backoff_policy_prototype_->clone());
-    auto idempotency = idempotency_policy_->ListScanRuns(request);
+    auto retry =
+        std::shared_ptr<WebSecurityScannerRetryPolicy const>(retry_policy());
+    auto backoff = std::shared_ptr<BackoffPolicy const>(backoff_policy());
+    auto idempotency = idempotency_policy()->ListScanRuns(request);
     char const* function_name = __func__;
     return google::cloud::internal::MakePaginationRange<
         StreamRange<google::cloud::websecurityscanner::v1::ScanRun>>(
@@ -321,8 +319,8 @@ class WebSecurityScannerConnectionImpl : public WebSecurityScannerConnection {
       google::cloud::websecurityscanner::v1::StopScanRunRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->StopScanRun(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->StopScanRun(request),
         [this](grpc::ClientContext& context,
                google::cloud::websecurityscanner::v1::StopScanRunRequest const&
                    request) { return stub_->StopScanRun(context, request); },
@@ -334,11 +332,10 @@ class WebSecurityScannerConnectionImpl : public WebSecurityScannerConnection {
                       request) override {
     request.clear_page_token();
     auto stub = stub_;
-    auto retry = std::shared_ptr<WebSecurityScannerRetryPolicy const>(
-        retry_policy_prototype_->clone());
-    auto backoff = std::shared_ptr<BackoffPolicy const>(
-        backoff_policy_prototype_->clone());
-    auto idempotency = idempotency_policy_->ListCrawledUrls(request);
+    auto retry =
+        std::shared_ptr<WebSecurityScannerRetryPolicy const>(retry_policy());
+    auto backoff = std::shared_ptr<BackoffPolicy const>(backoff_policy());
+    auto idempotency = idempotency_policy()->ListCrawledUrls(request);
     char const* function_name = __func__;
     return google::cloud::internal::MakePaginationRange<
         StreamRange<google::cloud::websecurityscanner::v1::CrawledUrl>>(
@@ -368,8 +365,8 @@ class WebSecurityScannerConnectionImpl : public WebSecurityScannerConnection {
       google::cloud::websecurityscanner::v1::GetFindingRequest const& request)
       override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->GetFinding(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->GetFinding(request),
         [this](grpc::ClientContext& context,
                google::cloud::websecurityscanner::v1::GetFindingRequest const&
                    request) { return stub_->GetFinding(context, request); },
@@ -381,11 +378,10 @@ class WebSecurityScannerConnectionImpl : public WebSecurityScannerConnection {
       override {
     request.clear_page_token();
     auto stub = stub_;
-    auto retry = std::shared_ptr<WebSecurityScannerRetryPolicy const>(
-        retry_policy_prototype_->clone());
-    auto backoff = std::shared_ptr<BackoffPolicy const>(
-        backoff_policy_prototype_->clone());
-    auto idempotency = idempotency_policy_->ListFindings(request);
+    auto retry =
+        std::shared_ptr<WebSecurityScannerRetryPolicy const>(retry_policy());
+    auto backoff = std::shared_ptr<BackoffPolicy const>(backoff_policy());
+    auto idempotency = idempotency_policy()->ListFindings(request);
     char const* function_name = __func__;
     return google::cloud::internal::MakePaginationRange<
         StreamRange<google::cloud::websecurityscanner::v1::Finding>>(
@@ -416,8 +412,8 @@ class WebSecurityScannerConnectionImpl : public WebSecurityScannerConnection {
       google::cloud::websecurityscanner::v1::ListFindingTypeStatsRequest const&
           request) override {
     return google::cloud::internal::RetryLoop(
-        retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-        idempotency_policy_->ListFindingTypeStats(request),
+        retry_policy(), backoff_policy(),
+        idempotency_policy()->ListFindingTypeStats(request),
         [this](grpc::ClientContext& context,
                google::cloud::websecurityscanner::v1::
                    ListFindingTypeStatsRequest const& request) {
@@ -427,6 +423,32 @@ class WebSecurityScannerConnectionImpl : public WebSecurityScannerConnection {
   }
 
  private:
+  std::unique_ptr<WebSecurityScannerRetryPolicy> retry_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<WebSecurityScannerRetryPolicyOption>()) {
+      return options.get<WebSecurityScannerRetryPolicyOption>()->clone();
+    }
+    return retry_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<BackoffPolicy> backoff_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<WebSecurityScannerBackoffPolicyOption>()) {
+      return options.get<WebSecurityScannerBackoffPolicyOption>()->clone();
+    }
+    return backoff_policy_prototype_->clone();
+  }
+
+  std::unique_ptr<WebSecurityScannerConnectionIdempotencyPolicy>
+  idempotency_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<WebSecurityScannerConnectionIdempotencyPolicyOption>()) {
+      return options.get<WebSecurityScannerConnectionIdempotencyPolicyOption>()
+          ->clone();
+    }
+    return idempotency_policy_->clone();
+  }
+
   std::unique_ptr<google::cloud::BackgroundThreads> background_;
   std::shared_ptr<websecurityscanner_internal::WebSecurityScannerStub> stub_;
   std::unique_ptr<WebSecurityScannerRetryPolicy const> retry_policy_prototype_;


### PR DESCRIPTION
Fixes #8002 

First commit has the logic changes in `generator/`
Second commit has the changes to the golden files
Third commit has the changes to generated libraries in `google/cloud/...`

I decided to use `if` blocks instead of predicates, per [this discussion](https://github.com/googleapis/google-cloud-cpp/pull/7885#discussion_r784161046).

We have the following types of calls:
1. Sync Loops - (**R**, **B**, I)
2. LRO Polling Loops - (R, B, I, **P**)
3. Paginated (StreamRange) - (R, B, I)
4. Streaming Reads (StreamRange) - (R, B)
5. Async Loop - (R, B, I)

Letters in parentheses are the policies used in such a call.
R = Retry, B = Backoff, I = Idempotency, P = Polling.

The **bold** letters are the ones I actually tested for. I did not feel like writing any other tests. I would begrudgingly add more tests, if asked nicely.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8013)
<!-- Reviewable:end -->
