### PR TITLE
fix(storage): improve JSON validation

### DIFF
--- a/google/cloud/internal/rest_response_test.cc
+++ b/google/cloud/internal/rest_response_test.cc
@@ -94,6 +94,13 @@ TEST(AsStatus, HttpStatusCodeIsNotOkNoPayload) {
   EXPECT_THAT(status.message(), Eq("Received HTTP status code: 403"));
 }
 
+TEST(AsStatus, HttpStatusCodeValidJsonButNotErrorCode) {
+  auto status =
+      AsStatus(HttpStatusCode::kForbidden, R"""("valid-but-not-error-code")""");
+  EXPECT_THAT(status, StatusIs(StatusCode::kPermissionDenied));
+  EXPECT_THAT(status.message(), Eq(R"""("valid-but-not-error-code")"""));
+}
+
 TEST(AsStatus, HttpStatusCodeNotFoundPayload) {
   std::string error = R"""(
   {

--- a/google/cloud/storage/oauth2/authorized_user_credentials.cc
+++ b/google/cloud/storage/oauth2/authorized_user_credentials.cc
@@ -24,7 +24,7 @@ StatusOr<AuthorizedUserCredentialsInfo> ParseAuthorizedUserCredentials(
     std::string const& content, std::string const& source,
     std::string const& default_token_uri) {
   auto credentials = nlohmann::json::parse(content, nullptr, false);
-  if (credentials.is_discarded()) {
+  if (!credentials.is_object()) {
     return Status(
         StatusCode::kInvalidArgument,
         "Invalid AuthorizedUserCredentials, parsing failed on data from " +
@@ -64,7 +64,7 @@ ParseAuthorizedUserRefreshResponse(
     storage::internal::HttpResponse const& response,
     std::chrono::system_clock::time_point now) {
   auto access_token = nlohmann::json::parse(response.payload, nullptr, false);
-  if (access_token.is_discarded() || access_token.count("access_token") == 0 ||
+  if (!access_token.is_object() || access_token.count("access_token") == 0 ||
       access_token.count("expires_in") == 0 ||
       access_token.count("id_token") == 0 ||
       access_token.count("token_type") == 0) {

--- a/google/cloud/storage/oauth2/compute_engine_credentials.cc
+++ b/google/cloud/storage/oauth2/compute_engine_credentials.cc
@@ -27,7 +27,7 @@ StatusOr<ServiceAccountMetadata> ParseMetadataServerResponse(
   // JSON array. At minimum, for the request to succeed, the instance must
   // have been granted the scope that allows it to retrieve info from the
   // metadata server.
-  if (response_body.is_discarded() || response_body.count("email") == 0 ||
+  if (!response_body.is_object() || response_body.count("email") == 0 ||
       response_body.count("scopes") == 0) {
     auto payload =
         response.payload +
@@ -52,7 +52,7 @@ ParseComputeEngineRefreshResponse(
   // Response should have the attributes "access_token", "expires_in", and
   // "token_type".
   auto access_token = nlohmann::json::parse(response.payload, nullptr, false);
-  if (access_token.is_discarded() || access_token.count("access_token") == 0 or
+  if (!access_token.is_object() || access_token.count("access_token") == 0 or
       access_token.count("expires_in") == 0 or
       access_token.count("token_type") == 0) {
     auto payload =

--- a/google/cloud/storage/oauth2/google_credentials.cc
+++ b/google/cloud/storage/oauth2/google_credentials.cc
@@ -57,7 +57,7 @@ StatusOr<std::unique_ptr<Credentials>> LoadCredsFromPath(
   }
   std::string contents(std::istreambuf_iterator<char>{ifs}, {});
   auto cred_json = nlohmann::json::parse(contents, nullptr, false);
-  if (cred_json.is_discarded()) {
+  if (!cred_json.is_object()) {
     // This is not a JSON file, try to load it as a P12 service account.
     auto info = ParseServiceAccountP12File(path);
     if (!info) {

--- a/google/cloud/storage/oauth2/service_account_credentials.cc
+++ b/google/cloud/storage/oauth2/service_account_credentials.cc
@@ -33,7 +33,7 @@ StatusOr<ServiceAccountCredentialsInfo> ParseServiceAccountCredentials(
     std::string const& content, std::string const& source,
     std::string const& default_token_uri) {
   auto credentials = nlohmann::json::parse(content, nullptr, false);
-  if (credentials.is_discarded()) {
+  if (!credentials.is_object()) {
     return Status(StatusCode::kInvalidArgument,
                   "Invalid ServiceAccountCredentials,"
                   "parsing failed on data loaded from " +

--- a/google/cloud/storage/storage_iam_policy_test.cc
+++ b/google/cloud/storage/storage_iam_policy_test.cc
@@ -24,6 +24,8 @@ namespace storage {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
+using ::google::cloud::testing_util::StatusIs;
+
 static_assert(std::is_copy_constructible<NativeExpression>::value,
               "NativeExpression should be copy constructible");
 static_assert(std::is_move_constructible<NativeExpression>::value,
@@ -368,6 +370,11 @@ TEST(NativeIamPolicy, ParseBindingsFailures) {
   ASSERT_FALSE(policy);
   EXPECT_THAT(policy.status().message(),
               HasSubstr("expected string for 'members' entry"));
+
+  policy =
+      NativeIamPolicy::CreateFromJson(R"js("valid-json-but-not-an-object")js");
+  ASSERT_THAT(policy, StatusIs(StatusCode::kInvalidArgument,
+                               HasSubstr("top level node")));
 }
 
 // Check that policies are parsed correctly.


### PR DESCRIPTION
Prefer using `!is_object()` over `is_discarded()` to detect parsing
errors. In many cases this change made no difference (e.g. where there
was an implicit check via `.count()`). In a few places the new tests
triggered latent bugs. One of these bugs was real, but it is hard to say
which one.

Fixes #8027

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8033)
<!-- Reviewable:end -->
