### PR TITLE
cleanup(common): make Idempotency enum public

### DIFF
--- a/generator/integration_tests/golden/golden_kitchen_sink_connection_idempotency_policy.cc
+++ b/generator/integration_tests/golden/golden_kitchen_sink_connection_idempotency_policy.cc
@@ -25,7 +25,7 @@ namespace cloud {
 namespace golden {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-using ::google::cloud::internal::Idempotency;
+using ::google::cloud::Idempotency;
 
 GoldenKitchenSinkConnectionIdempotencyPolicy::~GoldenKitchenSinkConnectionIdempotencyPolicy() = default;
 

--- a/generator/integration_tests/golden/golden_kitchen_sink_connection_idempotency_policy.h
+++ b/generator/integration_tests/golden/golden_kitchen_sink_connection_idempotency_policy.h
@@ -19,8 +19,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_GOLDEN_KITCHEN_SINK_CONNECTION_IDEMPOTENCY_POLICY_H
 #define GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_GOLDEN_KITCHEN_SINK_CONNECTION_IDEMPOTENCY_POLICY_H
 
+#include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
-#include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include <generator/integration_tests/test.grpc.pb.h>
 #include <memory>
@@ -37,22 +37,22 @@ class GoldenKitchenSinkConnectionIdempotencyPolicy {
   /// Create a new copy of this object.
   virtual std::unique_ptr<GoldenKitchenSinkConnectionIdempotencyPolicy> clone() const = 0;
 
-  virtual google::cloud::internal::Idempotency
+  virtual google::cloud::Idempotency
   GenerateAccessToken(google::test::admin::database::v1::GenerateAccessTokenRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency
+  virtual google::cloud::Idempotency
   GenerateIdToken(google::test::admin::database::v1::GenerateIdTokenRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency
+  virtual google::cloud::Idempotency
   WriteLogEntries(google::test::admin::database::v1::WriteLogEntriesRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency
+  virtual google::cloud::Idempotency
   ListLogs(google::test::admin::database::v1::ListLogsRequest request) = 0;
 
-  virtual google::cloud::internal::Idempotency
+  virtual google::cloud::Idempotency
   ListServiceAccountKeys(google::test::admin::database::v1::ListServiceAccountKeysRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency
+  virtual google::cloud::Idempotency
   DoNothing(google::protobuf::Empty const& request) = 0;
 };
 

--- a/generator/integration_tests/golden/golden_thing_admin_connection_idempotency_policy.cc
+++ b/generator/integration_tests/golden/golden_thing_admin_connection_idempotency_policy.cc
@@ -25,7 +25,7 @@ namespace cloud {
 namespace golden {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-using ::google::cloud::internal::Idempotency;
+using ::google::cloud::Idempotency;
 
 GoldenThingAdminConnectionIdempotencyPolicy::~GoldenThingAdminConnectionIdempotencyPolicy() = default;
 

--- a/generator/integration_tests/golden/golden_thing_admin_connection_idempotency_policy.h
+++ b/generator/integration_tests/golden/golden_thing_admin_connection_idempotency_policy.h
@@ -19,9 +19,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_GOLDEN_THING_ADMIN_CONNECTION_IDEMPOTENCY_POLICY_H
 #define GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_GOLDEN_THING_ADMIN_CONNECTION_IDEMPOTENCY_POLICY_H
 
-#include "google/cloud/future.h"
+#include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
-#include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include <generator/integration_tests/test.grpc.pb.h>
 #include <memory>
@@ -38,58 +37,58 @@ class GoldenThingAdminConnectionIdempotencyPolicy {
   /// Create a new copy of this object.
   virtual std::unique_ptr<GoldenThingAdminConnectionIdempotencyPolicy> clone() const = 0;
 
-  virtual google::cloud::internal::Idempotency
+  virtual google::cloud::Idempotency
   ListDatabases(google::test::admin::database::v1::ListDatabasesRequest request) = 0;
 
-  virtual google::cloud::internal::Idempotency
+  virtual google::cloud::Idempotency
   CreateDatabase(google::test::admin::database::v1::CreateDatabaseRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency
+  virtual google::cloud::Idempotency
   GetDatabase(google::test::admin::database::v1::GetDatabaseRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency
+  virtual google::cloud::Idempotency
   UpdateDatabaseDdl(google::test::admin::database::v1::UpdateDatabaseDdlRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency
+  virtual google::cloud::Idempotency
   DropDatabase(google::test::admin::database::v1::DropDatabaseRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency
+  virtual google::cloud::Idempotency
   GetDatabaseDdl(google::test::admin::database::v1::GetDatabaseDdlRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency
+  virtual google::cloud::Idempotency
   SetIamPolicy(google::iam::v1::SetIamPolicyRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency
+  virtual google::cloud::Idempotency
   GetIamPolicy(google::iam::v1::GetIamPolicyRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency
+  virtual google::cloud::Idempotency
   TestIamPermissions(google::iam::v1::TestIamPermissionsRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency
+  virtual google::cloud::Idempotency
   CreateBackup(google::test::admin::database::v1::CreateBackupRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency
+  virtual google::cloud::Idempotency
   GetBackup(google::test::admin::database::v1::GetBackupRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency
+  virtual google::cloud::Idempotency
   UpdateBackup(google::test::admin::database::v1::UpdateBackupRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency
+  virtual google::cloud::Idempotency
   DeleteBackup(google::test::admin::database::v1::DeleteBackupRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency
+  virtual google::cloud::Idempotency
   ListBackups(google::test::admin::database::v1::ListBackupsRequest request) = 0;
 
-  virtual google::cloud::internal::Idempotency
+  virtual google::cloud::Idempotency
   RestoreDatabase(google::test::admin::database::v1::RestoreDatabaseRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency
+  virtual google::cloud::Idempotency
   ListDatabaseOperations(google::test::admin::database::v1::ListDatabaseOperationsRequest request) = 0;
 
-  virtual google::cloud::internal::Idempotency
+  virtual google::cloud::Idempotency
   ListBackupOperations(google::test::admin::database::v1::ListBackupOperationsRequest request) = 0;
 
-  virtual google::cloud::internal::Idempotency
+  virtual google::cloud::Idempotency
   LongRunningWithoutRouting(google::test::admin::database::v1::RestoreDatabaseRequest const& request) = 0;
 };
 

--- a/generator/integration_tests/golden/tests/golden_kitchen_sink_idempotency_policy_test.cc
+++ b/generator/integration_tests/golden/tests/golden_kitchen_sink_idempotency_policy_test.cc
@@ -22,7 +22,7 @@ namespace golden_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
-using ::google::cloud::internal::Idempotency;
+using ::google::cloud::Idempotency;
 
 class GoldenKitchenSinkIdempotencyPolicyTest : public ::testing::Test {
  protected:

--- a/generator/integration_tests/golden/tests/golden_thing_admin_idempotency_policy_test.cc
+++ b/generator/integration_tests/golden/tests/golden_thing_admin_idempotency_policy_test.cc
@@ -22,7 +22,7 @@ namespace golden_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
-using ::google::cloud::internal::Idempotency;
+using ::google::cloud::Idempotency;
 namespace gtab = ::google::test::admin::database::v1;
 
 class GoldenIdempotencyPolicyTest : public ::testing::Test {

--- a/generator/internal/idempotency_policy_generator.cc
+++ b/generator/internal/idempotency_policy_generator.cc
@@ -49,9 +49,9 @@ Status IdempotencyPolicyGenerator::GenerateHeader() {
 
   // includes
   HeaderPrint("\n");
-  HeaderLocalIncludes({HasLongrunningMethod() ? "google/cloud/future.h" : "",
+  HeaderLocalIncludes({"google/cloud/idempotency.h",
                        "google/cloud/internal/retry_policy.h",
-                       "google/cloud/status_or.h", "google/cloud/version.h"});
+                       "google/cloud/version.h"});
   HeaderSystemIncludes({vars("proto_grpc_header_path"), "memory"});
 
   auto result = HeaderOpenNamespaces();
@@ -78,7 +78,7 @@ Status IdempotencyPolicyGenerator::GenerateHeader() {
              {
                  // clang-format off
    {"\n"
-    "  virtual google::cloud::internal::Idempotency\n"
+    "  virtual google::cloud::Idempotency\n"
     "  $method_name$($request_type$ const& request) = 0;\n"}
                  // clang-format on
              },
@@ -87,7 +87,7 @@ Status IdempotencyPolicyGenerator::GenerateHeader() {
              {
                  // clang-format off
    {"\n"
-    "  virtual google::cloud::internal::Idempotency\n"
+    "  virtual google::cloud::Idempotency\n"
     "  $method_name$($request_type$ request) = 0;\n"}
                  // clang-format on
              },
@@ -130,7 +130,7 @@ Status IdempotencyPolicyGenerator::GenerateCc() {
   auto result = CcOpenNamespaces();
   if (!result.ok()) return result;
 
-  CcPrint("\nusing ::google::cloud::internal::Idempotency;\n");
+  CcPrint("\nusing ::google::cloud::Idempotency;\n");
 
   CcPrint(  // clang-format off
     "\n$idempotency_class_name$::~$idempotency_class_name$() = default;\n");

--- a/google/cloud/CMakeLists.txt
+++ b/google/cloud/CMakeLists.txt
@@ -61,6 +61,7 @@ add_library(
     iam_bindings.h
     iam_policy.cc
     iam_policy.h
+    idempotency.h
     internal/absl_str_cat_quiet.h
     internal/absl_str_join_quiet.h
     internal/absl_str_replace_quiet.h

--- a/google/cloud/accessapproval/access_approval_connection_idempotency_policy.cc
+++ b/google/cloud/accessapproval/access_approval_connection_idempotency_policy.cc
@@ -25,7 +25,7 @@ namespace cloud {
 namespace accessapproval {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-using ::google::cloud::internal::Idempotency;
+using ::google::cloud::Idempotency;
 
 AccessApprovalConnectionIdempotencyPolicy::
     ~AccessApprovalConnectionIdempotencyPolicy() = default;

--- a/google/cloud/accessapproval/access_approval_connection_idempotency_policy.h
+++ b/google/cloud/accessapproval/access_approval_connection_idempotency_policy.h
@@ -19,8 +19,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_ACCESSAPPROVAL_ACCESS_APPROVAL_CONNECTION_IDEMPOTENCY_POLICY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_ACCESSAPPROVAL_ACCESS_APPROVAL_CONNECTION_IDEMPOTENCY_POLICY_H
 
+#include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
-#include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include <google/cloud/accessapproval/v1/accessapproval.grpc.pb.h>
 #include <memory>
@@ -38,31 +38,31 @@ class AccessApprovalConnectionIdempotencyPolicy {
   virtual std::unique_ptr<AccessApprovalConnectionIdempotencyPolicy> clone()
       const = 0;
 
-  virtual google::cloud::internal::Idempotency ListApprovalRequests(
+  virtual google::cloud::Idempotency ListApprovalRequests(
       google::cloud::accessapproval::v1::ListApprovalRequestsMessage
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetApprovalRequest(
+  virtual google::cloud::Idempotency GetApprovalRequest(
       google::cloud::accessapproval::v1::GetApprovalRequestMessage const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency ApproveApprovalRequest(
+  virtual google::cloud::Idempotency ApproveApprovalRequest(
       google::cloud::accessapproval::v1::ApproveApprovalRequestMessage const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency DismissApprovalRequest(
+  virtual google::cloud::Idempotency DismissApprovalRequest(
       google::cloud::accessapproval::v1::DismissApprovalRequestMessage const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetAccessApprovalSettings(
+  virtual google::cloud::Idempotency GetAccessApprovalSettings(
       google::cloud::accessapproval::v1::GetAccessApprovalSettingsMessage const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency UpdateAccessApprovalSettings(
+  virtual google::cloud::Idempotency UpdateAccessApprovalSettings(
       google::cloud::accessapproval::v1::
           UpdateAccessApprovalSettingsMessage const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency DeleteAccessApprovalSettings(
+  virtual google::cloud::Idempotency DeleteAccessApprovalSettings(
       google::cloud::accessapproval::v1::
           DeleteAccessApprovalSettingsMessage const& request) = 0;
 };

--- a/google/cloud/accesscontextmanager/access_context_manager_connection_idempotency_policy.cc
+++ b/google/cloud/accesscontextmanager/access_context_manager_connection_idempotency_policy.cc
@@ -25,7 +25,7 @@ namespace cloud {
 namespace accesscontextmanager {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-using ::google::cloud::internal::Idempotency;
+using ::google::cloud::Idempotency;
 
 AccessContextManagerConnectionIdempotencyPolicy::
     ~AccessContextManagerConnectionIdempotencyPolicy() = default;

--- a/google/cloud/accesscontextmanager/access_context_manager_connection_idempotency_policy.h
+++ b/google/cloud/accesscontextmanager/access_context_manager_connection_idempotency_policy.h
@@ -19,9 +19,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_ACCESSCONTEXTMANAGER_ACCESS_CONTEXT_MANAGER_CONNECTION_IDEMPOTENCY_POLICY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_ACCESSCONTEXTMANAGER_ACCESS_CONTEXT_MANAGER_CONNECTION_IDEMPOTENCY_POLICY_H
 
-#include "google/cloud/future.h"
+#include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
-#include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include <google/identity/accesscontextmanager/v1/access_context_manager.grpc.pb.h>
 #include <memory>
@@ -39,95 +38,95 @@ class AccessContextManagerConnectionIdempotencyPolicy {
   virtual std::unique_ptr<AccessContextManagerConnectionIdempotencyPolicy>
   clone() const = 0;
 
-  virtual google::cloud::internal::Idempotency ListAccessPolicies(
+  virtual google::cloud::Idempotency ListAccessPolicies(
       google::identity::accesscontextmanager::v1::ListAccessPoliciesRequest
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetAccessPolicy(
+  virtual google::cloud::Idempotency GetAccessPolicy(
       google::identity::accesscontextmanager::v1::GetAccessPolicyRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency CreateAccessPolicy(
+  virtual google::cloud::Idempotency CreateAccessPolicy(
       google::identity::accesscontextmanager::v1::AccessPolicy const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency UpdateAccessPolicy(
+  virtual google::cloud::Idempotency UpdateAccessPolicy(
       google::identity::accesscontextmanager::v1::
           UpdateAccessPolicyRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency DeleteAccessPolicy(
+  virtual google::cloud::Idempotency DeleteAccessPolicy(
       google::identity::accesscontextmanager::v1::
           DeleteAccessPolicyRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency ListAccessLevels(
+  virtual google::cloud::Idempotency ListAccessLevels(
       google::identity::accesscontextmanager::v1::ListAccessLevelsRequest
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetAccessLevel(
+  virtual google::cloud::Idempotency GetAccessLevel(
       google::identity::accesscontextmanager::v1::GetAccessLevelRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency CreateAccessLevel(
+  virtual google::cloud::Idempotency CreateAccessLevel(
       google::identity::accesscontextmanager::v1::
           CreateAccessLevelRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency UpdateAccessLevel(
+  virtual google::cloud::Idempotency UpdateAccessLevel(
       google::identity::accesscontextmanager::v1::
           UpdateAccessLevelRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency DeleteAccessLevel(
+  virtual google::cloud::Idempotency DeleteAccessLevel(
       google::identity::accesscontextmanager::v1::
           DeleteAccessLevelRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency ReplaceAccessLevels(
+  virtual google::cloud::Idempotency ReplaceAccessLevels(
       google::identity::accesscontextmanager::v1::
           ReplaceAccessLevelsRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency ListServicePerimeters(
+  virtual google::cloud::Idempotency ListServicePerimeters(
       google::identity::accesscontextmanager::v1::ListServicePerimetersRequest
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetServicePerimeter(
+  virtual google::cloud::Idempotency GetServicePerimeter(
       google::identity::accesscontextmanager::v1::
           GetServicePerimeterRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency CreateServicePerimeter(
+  virtual google::cloud::Idempotency CreateServicePerimeter(
       google::identity::accesscontextmanager::v1::
           CreateServicePerimeterRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency UpdateServicePerimeter(
+  virtual google::cloud::Idempotency UpdateServicePerimeter(
       google::identity::accesscontextmanager::v1::
           UpdateServicePerimeterRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency DeleteServicePerimeter(
+  virtual google::cloud::Idempotency DeleteServicePerimeter(
       google::identity::accesscontextmanager::v1::
           DeleteServicePerimeterRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency ReplaceServicePerimeters(
+  virtual google::cloud::Idempotency ReplaceServicePerimeters(
       google::identity::accesscontextmanager::v1::
           ReplaceServicePerimetersRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency CommitServicePerimeters(
+  virtual google::cloud::Idempotency CommitServicePerimeters(
       google::identity::accesscontextmanager::v1::
           CommitServicePerimetersRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency ListGcpUserAccessBindings(
+  virtual google::cloud::Idempotency ListGcpUserAccessBindings(
       google::identity::accesscontextmanager::v1::
           ListGcpUserAccessBindingsRequest request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetGcpUserAccessBinding(
+  virtual google::cloud::Idempotency GetGcpUserAccessBinding(
       google::identity::accesscontextmanager::v1::
           GetGcpUserAccessBindingRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency CreateGcpUserAccessBinding(
+  virtual google::cloud::Idempotency CreateGcpUserAccessBinding(
       google::identity::accesscontextmanager::v1::
           CreateGcpUserAccessBindingRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency UpdateGcpUserAccessBinding(
+  virtual google::cloud::Idempotency UpdateGcpUserAccessBinding(
       google::identity::accesscontextmanager::v1::
           UpdateGcpUserAccessBindingRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency DeleteGcpUserAccessBinding(
+  virtual google::cloud::Idempotency DeleteGcpUserAccessBinding(
       google::identity::accesscontextmanager::v1::
           DeleteGcpUserAccessBindingRequest const& request) = 0;
 };

--- a/google/cloud/apigateway/api_gateway_connection_idempotency_policy.cc
+++ b/google/cloud/apigateway/api_gateway_connection_idempotency_policy.cc
@@ -25,7 +25,7 @@ namespace cloud {
 namespace apigateway {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-using ::google::cloud::internal::Idempotency;
+using ::google::cloud::Idempotency;
 
 ApiGatewayServiceConnectionIdempotencyPolicy::
     ~ApiGatewayServiceConnectionIdempotencyPolicy() = default;

--- a/google/cloud/apigateway/api_gateway_connection_idempotency_policy.h
+++ b/google/cloud/apigateway/api_gateway_connection_idempotency_policy.h
@@ -19,9 +19,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_APIGATEWAY_API_GATEWAY_CONNECTION_IDEMPOTENCY_POLICY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_APIGATEWAY_API_GATEWAY_CONNECTION_IDEMPOTENCY_POLICY_H
 
-#include "google/cloud/future.h"
+#include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
-#include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include <google/cloud/apigateway/v1/apigateway_service.grpc.pb.h>
 #include <memory>
@@ -39,49 +38,49 @@ class ApiGatewayServiceConnectionIdempotencyPolicy {
   virtual std::unique_ptr<ApiGatewayServiceConnectionIdempotencyPolicy> clone()
       const = 0;
 
-  virtual google::cloud::internal::Idempotency ListGateways(
+  virtual google::cloud::Idempotency ListGateways(
       google::cloud::apigateway::v1::ListGatewaysRequest request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetGateway(
+  virtual google::cloud::Idempotency GetGateway(
       google::cloud::apigateway::v1::GetGatewayRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency CreateGateway(
+  virtual google::cloud::Idempotency CreateGateway(
       google::cloud::apigateway::v1::CreateGatewayRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency UpdateGateway(
+  virtual google::cloud::Idempotency UpdateGateway(
       google::cloud::apigateway::v1::UpdateGatewayRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency DeleteGateway(
+  virtual google::cloud::Idempotency DeleteGateway(
       google::cloud::apigateway::v1::DeleteGatewayRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency ListApis(
+  virtual google::cloud::Idempotency ListApis(
       google::cloud::apigateway::v1::ListApisRequest request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetApi(
+  virtual google::cloud::Idempotency GetApi(
       google::cloud::apigateway::v1::GetApiRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency CreateApi(
+  virtual google::cloud::Idempotency CreateApi(
       google::cloud::apigateway::v1::CreateApiRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency UpdateApi(
+  virtual google::cloud::Idempotency UpdateApi(
       google::cloud::apigateway::v1::UpdateApiRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency DeleteApi(
+  virtual google::cloud::Idempotency DeleteApi(
       google::cloud::apigateway::v1::DeleteApiRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency ListApiConfigs(
+  virtual google::cloud::Idempotency ListApiConfigs(
       google::cloud::apigateway::v1::ListApiConfigsRequest request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetApiConfig(
+  virtual google::cloud::Idempotency GetApiConfig(
       google::cloud::apigateway::v1::GetApiConfigRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency CreateApiConfig(
+  virtual google::cloud::Idempotency CreateApiConfig(
       google::cloud::apigateway::v1::CreateApiConfigRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency UpdateApiConfig(
+  virtual google::cloud::Idempotency UpdateApiConfig(
       google::cloud::apigateway::v1::UpdateApiConfigRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency DeleteApiConfig(
+  virtual google::cloud::Idempotency DeleteApiConfig(
       google::cloud::apigateway::v1::DeleteApiConfigRequest const& request) = 0;
 };
 

--- a/google/cloud/appengine/applications_connection_idempotency_policy.cc
+++ b/google/cloud/appengine/applications_connection_idempotency_policy.cc
@@ -25,7 +25,7 @@ namespace cloud {
 namespace appengine {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-using ::google::cloud::internal::Idempotency;
+using ::google::cloud::Idempotency;
 
 ApplicationsConnectionIdempotencyPolicy::
     ~ApplicationsConnectionIdempotencyPolicy() = default;

--- a/google/cloud/appengine/applications_connection_idempotency_policy.h
+++ b/google/cloud/appengine/applications_connection_idempotency_policy.h
@@ -19,9 +19,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_APPENGINE_APPLICATIONS_CONNECTION_IDEMPOTENCY_POLICY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_APPENGINE_APPLICATIONS_CONNECTION_IDEMPOTENCY_POLICY_H
 
-#include "google/cloud/future.h"
+#include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
-#include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include <google/appengine/v1/appengine.grpc.pb.h>
 #include <memory>
@@ -39,16 +38,16 @@ class ApplicationsConnectionIdempotencyPolicy {
   virtual std::unique_ptr<ApplicationsConnectionIdempotencyPolicy> clone()
       const = 0;
 
-  virtual google::cloud::internal::Idempotency GetApplication(
+  virtual google::cloud::Idempotency GetApplication(
       google::appengine::v1::GetApplicationRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency CreateApplication(
+  virtual google::cloud::Idempotency CreateApplication(
       google::appengine::v1::CreateApplicationRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency UpdateApplication(
+  virtual google::cloud::Idempotency UpdateApplication(
       google::appengine::v1::UpdateApplicationRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency RepairApplication(
+  virtual google::cloud::Idempotency RepairApplication(
       google::appengine::v1::RepairApplicationRequest const& request) = 0;
 };
 

--- a/google/cloud/appengine/authorized_certificates_connection_idempotency_policy.cc
+++ b/google/cloud/appengine/authorized_certificates_connection_idempotency_policy.cc
@@ -25,7 +25,7 @@ namespace cloud {
 namespace appengine {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-using ::google::cloud::internal::Idempotency;
+using ::google::cloud::Idempotency;
 
 AuthorizedCertificatesConnectionIdempotencyPolicy::
     ~AuthorizedCertificatesConnectionIdempotencyPolicy() = default;

--- a/google/cloud/appengine/authorized_certificates_connection_idempotency_policy.h
+++ b/google/cloud/appengine/authorized_certificates_connection_idempotency_policy.h
@@ -19,8 +19,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_APPENGINE_AUTHORIZED_CERTIFICATES_CONNECTION_IDEMPOTENCY_POLICY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_APPENGINE_AUTHORIZED_CERTIFICATES_CONNECTION_IDEMPOTENCY_POLICY_H
 
+#include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
-#include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include <google/appengine/v1/appengine.grpc.pb.h>
 #include <memory>
@@ -38,22 +38,22 @@ class AuthorizedCertificatesConnectionIdempotencyPolicy {
   virtual std::unique_ptr<AuthorizedCertificatesConnectionIdempotencyPolicy>
   clone() const = 0;
 
-  virtual google::cloud::internal::Idempotency ListAuthorizedCertificates(
+  virtual google::cloud::Idempotency ListAuthorizedCertificates(
       google::appengine::v1::ListAuthorizedCertificatesRequest request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetAuthorizedCertificate(
+  virtual google::cloud::Idempotency GetAuthorizedCertificate(
       google::appengine::v1::GetAuthorizedCertificateRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency CreateAuthorizedCertificate(
+  virtual google::cloud::Idempotency CreateAuthorizedCertificate(
       google::appengine::v1::CreateAuthorizedCertificateRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency UpdateAuthorizedCertificate(
+  virtual google::cloud::Idempotency UpdateAuthorizedCertificate(
       google::appengine::v1::UpdateAuthorizedCertificateRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency DeleteAuthorizedCertificate(
+  virtual google::cloud::Idempotency DeleteAuthorizedCertificate(
       google::appengine::v1::DeleteAuthorizedCertificateRequest const&
           request) = 0;
 };

--- a/google/cloud/appengine/authorized_domains_connection_idempotency_policy.cc
+++ b/google/cloud/appengine/authorized_domains_connection_idempotency_policy.cc
@@ -25,7 +25,7 @@ namespace cloud {
 namespace appengine {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-using ::google::cloud::internal::Idempotency;
+using ::google::cloud::Idempotency;
 
 AuthorizedDomainsConnectionIdempotencyPolicy::
     ~AuthorizedDomainsConnectionIdempotencyPolicy() = default;

--- a/google/cloud/appengine/authorized_domains_connection_idempotency_policy.h
+++ b/google/cloud/appengine/authorized_domains_connection_idempotency_policy.h
@@ -19,8 +19,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_APPENGINE_AUTHORIZED_DOMAINS_CONNECTION_IDEMPOTENCY_POLICY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_APPENGINE_AUTHORIZED_DOMAINS_CONNECTION_IDEMPOTENCY_POLICY_H
 
+#include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
-#include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include <google/appengine/v1/appengine.grpc.pb.h>
 #include <memory>
@@ -38,7 +38,7 @@ class AuthorizedDomainsConnectionIdempotencyPolicy {
   virtual std::unique_ptr<AuthorizedDomainsConnectionIdempotencyPolicy> clone()
       const = 0;
 
-  virtual google::cloud::internal::Idempotency ListAuthorizedDomains(
+  virtual google::cloud::Idempotency ListAuthorizedDomains(
       google::appengine::v1::ListAuthorizedDomainsRequest request) = 0;
 };
 

--- a/google/cloud/appengine/domain_mappings_connection_idempotency_policy.cc
+++ b/google/cloud/appengine/domain_mappings_connection_idempotency_policy.cc
@@ -25,7 +25,7 @@ namespace cloud {
 namespace appengine {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-using ::google::cloud::internal::Idempotency;
+using ::google::cloud::Idempotency;
 
 DomainMappingsConnectionIdempotencyPolicy::
     ~DomainMappingsConnectionIdempotencyPolicy() = default;

--- a/google/cloud/appengine/domain_mappings_connection_idempotency_policy.h
+++ b/google/cloud/appengine/domain_mappings_connection_idempotency_policy.h
@@ -19,9 +19,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_APPENGINE_DOMAIN_MAPPINGS_CONNECTION_IDEMPOTENCY_POLICY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_APPENGINE_DOMAIN_MAPPINGS_CONNECTION_IDEMPOTENCY_POLICY_H
 
-#include "google/cloud/future.h"
+#include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
-#include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include <google/appengine/v1/appengine.grpc.pb.h>
 #include <memory>
@@ -39,19 +38,19 @@ class DomainMappingsConnectionIdempotencyPolicy {
   virtual std::unique_ptr<DomainMappingsConnectionIdempotencyPolicy> clone()
       const = 0;
 
-  virtual google::cloud::internal::Idempotency ListDomainMappings(
+  virtual google::cloud::Idempotency ListDomainMappings(
       google::appengine::v1::ListDomainMappingsRequest request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetDomainMapping(
+  virtual google::cloud::Idempotency GetDomainMapping(
       google::appengine::v1::GetDomainMappingRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency CreateDomainMapping(
+  virtual google::cloud::Idempotency CreateDomainMapping(
       google::appengine::v1::CreateDomainMappingRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency UpdateDomainMapping(
+  virtual google::cloud::Idempotency UpdateDomainMapping(
       google::appengine::v1::UpdateDomainMappingRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency DeleteDomainMapping(
+  virtual google::cloud::Idempotency DeleteDomainMapping(
       google::appengine::v1::DeleteDomainMappingRequest const& request) = 0;
 };
 

--- a/google/cloud/appengine/firewall_connection_idempotency_policy.cc
+++ b/google/cloud/appengine/firewall_connection_idempotency_policy.cc
@@ -25,7 +25,7 @@ namespace cloud {
 namespace appengine {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-using ::google::cloud::internal::Idempotency;
+using ::google::cloud::Idempotency;
 
 FirewallConnectionIdempotencyPolicy::~FirewallConnectionIdempotencyPolicy() =
     default;

--- a/google/cloud/appengine/firewall_connection_idempotency_policy.h
+++ b/google/cloud/appengine/firewall_connection_idempotency_policy.h
@@ -19,8 +19,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_APPENGINE_FIREWALL_CONNECTION_IDEMPOTENCY_POLICY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_APPENGINE_FIREWALL_CONNECTION_IDEMPOTENCY_POLICY_H
 
+#include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
-#include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include <google/appengine/v1/appengine.grpc.pb.h>
 #include <memory>
@@ -38,22 +38,22 @@ class FirewallConnectionIdempotencyPolicy {
   virtual std::unique_ptr<FirewallConnectionIdempotencyPolicy> clone()
       const = 0;
 
-  virtual google::cloud::internal::Idempotency ListIngressRules(
+  virtual google::cloud::Idempotency ListIngressRules(
       google::appengine::v1::ListIngressRulesRequest request) = 0;
 
-  virtual google::cloud::internal::Idempotency BatchUpdateIngressRules(
+  virtual google::cloud::Idempotency BatchUpdateIngressRules(
       google::appengine::v1::BatchUpdateIngressRulesRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency CreateIngressRule(
+  virtual google::cloud::Idempotency CreateIngressRule(
       google::appengine::v1::CreateIngressRuleRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetIngressRule(
+  virtual google::cloud::Idempotency GetIngressRule(
       google::appengine::v1::GetIngressRuleRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency UpdateIngressRule(
+  virtual google::cloud::Idempotency UpdateIngressRule(
       google::appengine::v1::UpdateIngressRuleRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency DeleteIngressRule(
+  virtual google::cloud::Idempotency DeleteIngressRule(
       google::appengine::v1::DeleteIngressRuleRequest const& request) = 0;
 };
 

--- a/google/cloud/appengine/instances_connection_idempotency_policy.cc
+++ b/google/cloud/appengine/instances_connection_idempotency_policy.cc
@@ -25,7 +25,7 @@ namespace cloud {
 namespace appengine {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-using ::google::cloud::internal::Idempotency;
+using ::google::cloud::Idempotency;
 
 InstancesConnectionIdempotencyPolicy::~InstancesConnectionIdempotencyPolicy() =
     default;

--- a/google/cloud/appengine/instances_connection_idempotency_policy.h
+++ b/google/cloud/appengine/instances_connection_idempotency_policy.h
@@ -19,9 +19,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_APPENGINE_INSTANCES_CONNECTION_IDEMPOTENCY_POLICY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_APPENGINE_INSTANCES_CONNECTION_IDEMPOTENCY_POLICY_H
 
-#include "google/cloud/future.h"
+#include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
-#include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include <google/appengine/v1/appengine.grpc.pb.h>
 #include <memory>
@@ -39,16 +38,16 @@ class InstancesConnectionIdempotencyPolicy {
   virtual std::unique_ptr<InstancesConnectionIdempotencyPolicy> clone()
       const = 0;
 
-  virtual google::cloud::internal::Idempotency ListInstances(
+  virtual google::cloud::Idempotency ListInstances(
       google::appengine::v1::ListInstancesRequest request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetInstance(
+  virtual google::cloud::Idempotency GetInstance(
       google::appengine::v1::GetInstanceRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency DeleteInstance(
+  virtual google::cloud::Idempotency DeleteInstance(
       google::appengine::v1::DeleteInstanceRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency DebugInstance(
+  virtual google::cloud::Idempotency DebugInstance(
       google::appengine::v1::DebugInstanceRequest const& request) = 0;
 };
 

--- a/google/cloud/appengine/services_connection_idempotency_policy.cc
+++ b/google/cloud/appengine/services_connection_idempotency_policy.cc
@@ -25,7 +25,7 @@ namespace cloud {
 namespace appengine {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-using ::google::cloud::internal::Idempotency;
+using ::google::cloud::Idempotency;
 
 ServicesConnectionIdempotencyPolicy::~ServicesConnectionIdempotencyPolicy() =
     default;

--- a/google/cloud/appengine/services_connection_idempotency_policy.h
+++ b/google/cloud/appengine/services_connection_idempotency_policy.h
@@ -19,9 +19,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_APPENGINE_SERVICES_CONNECTION_IDEMPOTENCY_POLICY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_APPENGINE_SERVICES_CONNECTION_IDEMPOTENCY_POLICY_H
 
-#include "google/cloud/future.h"
+#include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
-#include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include <google/appengine/v1/appengine.grpc.pb.h>
 #include <memory>
@@ -39,16 +38,16 @@ class ServicesConnectionIdempotencyPolicy {
   virtual std::unique_ptr<ServicesConnectionIdempotencyPolicy> clone()
       const = 0;
 
-  virtual google::cloud::internal::Idempotency ListServices(
+  virtual google::cloud::Idempotency ListServices(
       google::appengine::v1::ListServicesRequest request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetService(
+  virtual google::cloud::Idempotency GetService(
       google::appengine::v1::GetServiceRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency UpdateService(
+  virtual google::cloud::Idempotency UpdateService(
       google::appengine::v1::UpdateServiceRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency DeleteService(
+  virtual google::cloud::Idempotency DeleteService(
       google::appengine::v1::DeleteServiceRequest const& request) = 0;
 };
 

--- a/google/cloud/appengine/versions_connection_idempotency_policy.cc
+++ b/google/cloud/appengine/versions_connection_idempotency_policy.cc
@@ -25,7 +25,7 @@ namespace cloud {
 namespace appengine {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-using ::google::cloud::internal::Idempotency;
+using ::google::cloud::Idempotency;
 
 VersionsConnectionIdempotencyPolicy::~VersionsConnectionIdempotencyPolicy() =
     default;

--- a/google/cloud/appengine/versions_connection_idempotency_policy.h
+++ b/google/cloud/appengine/versions_connection_idempotency_policy.h
@@ -19,9 +19,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_APPENGINE_VERSIONS_CONNECTION_IDEMPOTENCY_POLICY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_APPENGINE_VERSIONS_CONNECTION_IDEMPOTENCY_POLICY_H
 
-#include "google/cloud/future.h"
+#include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
-#include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include <google/appengine/v1/appengine.grpc.pb.h>
 #include <memory>
@@ -39,19 +38,19 @@ class VersionsConnectionIdempotencyPolicy {
   virtual std::unique_ptr<VersionsConnectionIdempotencyPolicy> clone()
       const = 0;
 
-  virtual google::cloud::internal::Idempotency ListVersions(
+  virtual google::cloud::Idempotency ListVersions(
       google::appengine::v1::ListVersionsRequest request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetVersion(
+  virtual google::cloud::Idempotency GetVersion(
       google::appengine::v1::GetVersionRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency CreateVersion(
+  virtual google::cloud::Idempotency CreateVersion(
       google::appengine::v1::CreateVersionRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency UpdateVersion(
+  virtual google::cloud::Idempotency UpdateVersion(
       google::appengine::v1::UpdateVersionRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency DeleteVersion(
+  virtual google::cloud::Idempotency DeleteVersion(
       google::appengine::v1::DeleteVersionRequest const& request) = 0;
 };
 

--- a/google/cloud/artifactregistry/artifact_registry_connection_idempotency_policy.cc
+++ b/google/cloud/artifactregistry/artifact_registry_connection_idempotency_policy.cc
@@ -25,7 +25,7 @@ namespace cloud {
 namespace artifactregistry {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-using ::google::cloud::internal::Idempotency;
+using ::google::cloud::Idempotency;
 
 ArtifactRegistryConnectionIdempotencyPolicy::
     ~ArtifactRegistryConnectionIdempotencyPolicy() = default;

--- a/google/cloud/artifactregistry/artifact_registry_connection_idempotency_policy.h
+++ b/google/cloud/artifactregistry/artifact_registry_connection_idempotency_policy.h
@@ -19,8 +19,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_ARTIFACTREGISTRY_ARTIFACT_REGISTRY_CONNECTION_IDEMPOTENCY_POLICY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_ARTIFACTREGISTRY_ARTIFACT_REGISTRY_CONNECTION_IDEMPOTENCY_POLICY_H
 
+#include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
-#include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include <google/devtools/artifactregistry/v1/service.grpc.pb.h>
 #include <memory>
@@ -38,15 +38,15 @@ class ArtifactRegistryConnectionIdempotencyPolicy {
   virtual std::unique_ptr<ArtifactRegistryConnectionIdempotencyPolicy> clone()
       const = 0;
 
-  virtual google::cloud::internal::Idempotency ListDockerImages(
+  virtual google::cloud::Idempotency ListDockerImages(
       google::devtools::artifactregistry::v1::ListDockerImagesRequest
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency ListRepositories(
+  virtual google::cloud::Idempotency ListRepositories(
       google::devtools::artifactregistry::v1::ListRepositoriesRequest
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetRepository(
+  virtual google::cloud::Idempotency GetRepository(
       google::devtools::artifactregistry::v1::GetRepositoryRequest const&
           request) = 0;
 };

--- a/google/cloud/assuredworkloads/assured_workloads_connection_idempotency_policy.cc
+++ b/google/cloud/assuredworkloads/assured_workloads_connection_idempotency_policy.cc
@@ -25,7 +25,7 @@ namespace cloud {
 namespace assuredworkloads {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-using ::google::cloud::internal::Idempotency;
+using ::google::cloud::Idempotency;
 
 AssuredWorkloadsServiceConnectionIdempotencyPolicy::
     ~AssuredWorkloadsServiceConnectionIdempotencyPolicy() = default;

--- a/google/cloud/assuredworkloads/assured_workloads_connection_idempotency_policy.h
+++ b/google/cloud/assuredworkloads/assured_workloads_connection_idempotency_policy.h
@@ -19,9 +19,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_ASSUREDWORKLOADS_ASSURED_WORKLOADS_CONNECTION_IDEMPOTENCY_POLICY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_ASSUREDWORKLOADS_ASSURED_WORKLOADS_CONNECTION_IDEMPOTENCY_POLICY_H
 
-#include "google/cloud/future.h"
+#include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
-#include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include <google/cloud/assuredworkloads/v1/assuredworkloads.grpc.pb.h>
 #include <memory>
@@ -39,23 +38,23 @@ class AssuredWorkloadsServiceConnectionIdempotencyPolicy {
   virtual std::unique_ptr<AssuredWorkloadsServiceConnectionIdempotencyPolicy>
   clone() const = 0;
 
-  virtual google::cloud::internal::Idempotency CreateWorkload(
+  virtual google::cloud::Idempotency CreateWorkload(
       google::cloud::assuredworkloads::v1::CreateWorkloadRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency UpdateWorkload(
+  virtual google::cloud::Idempotency UpdateWorkload(
       google::cloud::assuredworkloads::v1::UpdateWorkloadRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency DeleteWorkload(
+  virtual google::cloud::Idempotency DeleteWorkload(
       google::cloud::assuredworkloads::v1::DeleteWorkloadRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetWorkload(
+  virtual google::cloud::Idempotency GetWorkload(
       google::cloud::assuredworkloads::v1::GetWorkloadRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency ListWorkloads(
+  virtual google::cloud::Idempotency ListWorkloads(
       google::cloud::assuredworkloads::v1::ListWorkloadsRequest request) = 0;
 };
 

--- a/google/cloud/automl/auto_ml_connection_idempotency_policy.cc
+++ b/google/cloud/automl/auto_ml_connection_idempotency_policy.cc
@@ -25,7 +25,7 @@ namespace cloud {
 namespace automl {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-using ::google::cloud::internal::Idempotency;
+using ::google::cloud::Idempotency;
 
 AutoMlConnectionIdempotencyPolicy::~AutoMlConnectionIdempotencyPolicy() =
     default;

--- a/google/cloud/automl/auto_ml_connection_idempotency_policy.h
+++ b/google/cloud/automl/auto_ml_connection_idempotency_policy.h
@@ -19,9 +19,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_AUTOML_AUTO_ML_CONNECTION_IDEMPOTENCY_POLICY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_AUTOML_AUTO_ML_CONNECTION_IDEMPOTENCY_POLICY_H
 
-#include "google/cloud/future.h"
+#include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
-#include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include <google/cloud/automl/v1/service.grpc.pb.h>
 #include <memory>
@@ -38,58 +37,58 @@ class AutoMlConnectionIdempotencyPolicy {
   /// Create a new copy of this object.
   virtual std::unique_ptr<AutoMlConnectionIdempotencyPolicy> clone() const = 0;
 
-  virtual google::cloud::internal::Idempotency CreateDataset(
+  virtual google::cloud::Idempotency CreateDataset(
       google::cloud::automl::v1::CreateDatasetRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetDataset(
+  virtual google::cloud::Idempotency GetDataset(
       google::cloud::automl::v1::GetDatasetRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency ListDatasets(
+  virtual google::cloud::Idempotency ListDatasets(
       google::cloud::automl::v1::ListDatasetsRequest request) = 0;
 
-  virtual google::cloud::internal::Idempotency UpdateDataset(
+  virtual google::cloud::Idempotency UpdateDataset(
       google::cloud::automl::v1::UpdateDatasetRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency DeleteDataset(
+  virtual google::cloud::Idempotency DeleteDataset(
       google::cloud::automl::v1::DeleteDatasetRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency ImportData(
+  virtual google::cloud::Idempotency ImportData(
       google::cloud::automl::v1::ImportDataRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency ExportData(
+  virtual google::cloud::Idempotency ExportData(
       google::cloud::automl::v1::ExportDataRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetAnnotationSpec(
+  virtual google::cloud::Idempotency GetAnnotationSpec(
       google::cloud::automl::v1::GetAnnotationSpecRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency CreateModel(
+  virtual google::cloud::Idempotency CreateModel(
       google::cloud::automl::v1::CreateModelRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetModel(
+  virtual google::cloud::Idempotency GetModel(
       google::cloud::automl::v1::GetModelRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency ListModels(
+  virtual google::cloud::Idempotency ListModels(
       google::cloud::automl::v1::ListModelsRequest request) = 0;
 
-  virtual google::cloud::internal::Idempotency DeleteModel(
+  virtual google::cloud::Idempotency DeleteModel(
       google::cloud::automl::v1::DeleteModelRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency UpdateModel(
+  virtual google::cloud::Idempotency UpdateModel(
       google::cloud::automl::v1::UpdateModelRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency DeployModel(
+  virtual google::cloud::Idempotency DeployModel(
       google::cloud::automl::v1::DeployModelRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency UndeployModel(
+  virtual google::cloud::Idempotency UndeployModel(
       google::cloud::automl::v1::UndeployModelRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency ExportModel(
+  virtual google::cloud::Idempotency ExportModel(
       google::cloud::automl::v1::ExportModelRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetModelEvaluation(
+  virtual google::cloud::Idempotency GetModelEvaluation(
       google::cloud::automl::v1::GetModelEvaluationRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency ListModelEvaluations(
+  virtual google::cloud::Idempotency ListModelEvaluations(
       google::cloud::automl::v1::ListModelEvaluationsRequest request) = 0;
 };
 

--- a/google/cloud/automl/prediction_connection_idempotency_policy.cc
+++ b/google/cloud/automl/prediction_connection_idempotency_policy.cc
@@ -25,7 +25,7 @@ namespace cloud {
 namespace automl {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-using ::google::cloud::internal::Idempotency;
+using ::google::cloud::Idempotency;
 
 PredictionServiceConnectionIdempotencyPolicy::
     ~PredictionServiceConnectionIdempotencyPolicy() = default;

--- a/google/cloud/automl/prediction_connection_idempotency_policy.h
+++ b/google/cloud/automl/prediction_connection_idempotency_policy.h
@@ -19,9 +19,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_AUTOML_PREDICTION_CONNECTION_IDEMPOTENCY_POLICY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_AUTOML_PREDICTION_CONNECTION_IDEMPOTENCY_POLICY_H
 
-#include "google/cloud/future.h"
+#include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
-#include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include <google/cloud/automl/v1/prediction_service.grpc.pb.h>
 #include <memory>
@@ -39,10 +38,10 @@ class PredictionServiceConnectionIdempotencyPolicy {
   virtual std::unique_ptr<PredictionServiceConnectionIdempotencyPolicy> clone()
       const = 0;
 
-  virtual google::cloud::internal::Idempotency Predict(
+  virtual google::cloud::Idempotency Predict(
       google::cloud::automl::v1::PredictRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency BatchPredict(
+  virtual google::cloud::Idempotency BatchPredict(
       google::cloud::automl::v1::BatchPredictRequest const& request) = 0;
 };
 

--- a/google/cloud/bigquery/bigquery_read_connection_idempotency_policy.cc
+++ b/google/cloud/bigquery/bigquery_read_connection_idempotency_policy.cc
@@ -25,7 +25,7 @@ namespace cloud {
 namespace bigquery {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-using ::google::cloud::internal::Idempotency;
+using ::google::cloud::Idempotency;
 
 BigQueryReadConnectionIdempotencyPolicy::
     ~BigQueryReadConnectionIdempotencyPolicy() = default;

--- a/google/cloud/bigquery/bigquery_read_connection_idempotency_policy.h
+++ b/google/cloud/bigquery/bigquery_read_connection_idempotency_policy.h
@@ -19,8 +19,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_BIGQUERY_READ_CONNECTION_IDEMPOTENCY_POLICY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGQUERY_BIGQUERY_READ_CONNECTION_IDEMPOTENCY_POLICY_H
 
+#include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
-#include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include <google/cloud/bigquery/storage/v1/storage.grpc.pb.h>
 #include <memory>
@@ -38,11 +38,11 @@ class BigQueryReadConnectionIdempotencyPolicy {
   virtual std::unique_ptr<BigQueryReadConnectionIdempotencyPolicy> clone()
       const = 0;
 
-  virtual google::cloud::internal::Idempotency CreateReadSession(
+  virtual google::cloud::Idempotency CreateReadSession(
       google::cloud::bigquery::storage::v1::CreateReadSessionRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency SplitReadStream(
+  virtual google::cloud::Idempotency SplitReadStream(
       google::cloud::bigquery::storage::v1::SplitReadStreamRequest const&
           request) = 0;
 };

--- a/google/cloud/bigtable/admin/bigtable_instance_admin_connection_idempotency_policy.cc
+++ b/google/cloud/bigtable/admin/bigtable_instance_admin_connection_idempotency_policy.cc
@@ -25,7 +25,7 @@ namespace cloud {
 namespace bigtable_admin {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-using ::google::cloud::internal::Idempotency;
+using ::google::cloud::Idempotency;
 
 BigtableInstanceAdminConnectionIdempotencyPolicy::
     ~BigtableInstanceAdminConnectionIdempotencyPolicy() = default;

--- a/google/cloud/bigtable/admin/bigtable_instance_admin_connection_idempotency_policy.h
+++ b/google/cloud/bigtable/admin/bigtable_instance_admin_connection_idempotency_policy.h
@@ -19,9 +19,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_ADMIN_BIGTABLE_INSTANCE_ADMIN_CONNECTION_IDEMPOTENCY_POLICY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_ADMIN_BIGTABLE_INSTANCE_ADMIN_CONNECTION_IDEMPOTENCY_POLICY_H
 
-#include "google/cloud/future.h"
+#include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
-#include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include <google/bigtable/admin/v2/bigtable_instance_admin.grpc.pb.h>
 #include <memory>
@@ -39,66 +38,66 @@ class BigtableInstanceAdminConnectionIdempotencyPolicy {
   virtual std::unique_ptr<BigtableInstanceAdminConnectionIdempotencyPolicy>
   clone() const = 0;
 
-  virtual google::cloud::internal::Idempotency CreateInstance(
+  virtual google::cloud::Idempotency CreateInstance(
       google::bigtable::admin::v2::CreateInstanceRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetInstance(
+  virtual google::cloud::Idempotency GetInstance(
       google::bigtable::admin::v2::GetInstanceRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency ListInstances(
+  virtual google::cloud::Idempotency ListInstances(
       google::bigtable::admin::v2::ListInstancesRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency UpdateInstance(
+  virtual google::cloud::Idempotency UpdateInstance(
       google::bigtable::admin::v2::Instance const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency PartialUpdateInstance(
+  virtual google::cloud::Idempotency PartialUpdateInstance(
       google::bigtable::admin::v2::PartialUpdateInstanceRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency DeleteInstance(
+  virtual google::cloud::Idempotency DeleteInstance(
       google::bigtable::admin::v2::DeleteInstanceRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency CreateCluster(
+  virtual google::cloud::Idempotency CreateCluster(
       google::bigtable::admin::v2::CreateClusterRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetCluster(
+  virtual google::cloud::Idempotency GetCluster(
       google::bigtable::admin::v2::GetClusterRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency ListClusters(
+  virtual google::cloud::Idempotency ListClusters(
       google::bigtable::admin::v2::ListClustersRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency UpdateCluster(
+  virtual google::cloud::Idempotency UpdateCluster(
       google::bigtable::admin::v2::Cluster const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency PartialUpdateCluster(
+  virtual google::cloud::Idempotency PartialUpdateCluster(
       google::bigtable::admin::v2::PartialUpdateClusterRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency DeleteCluster(
+  virtual google::cloud::Idempotency DeleteCluster(
       google::bigtable::admin::v2::DeleteClusterRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency CreateAppProfile(
+  virtual google::cloud::Idempotency CreateAppProfile(
       google::bigtable::admin::v2::CreateAppProfileRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetAppProfile(
+  virtual google::cloud::Idempotency GetAppProfile(
       google::bigtable::admin::v2::GetAppProfileRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency ListAppProfiles(
+  virtual google::cloud::Idempotency ListAppProfiles(
       google::bigtable::admin::v2::ListAppProfilesRequest request) = 0;
 
-  virtual google::cloud::internal::Idempotency UpdateAppProfile(
+  virtual google::cloud::Idempotency UpdateAppProfile(
       google::bigtable::admin::v2::UpdateAppProfileRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency DeleteAppProfile(
+  virtual google::cloud::Idempotency DeleteAppProfile(
       google::bigtable::admin::v2::DeleteAppProfileRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetIamPolicy(
+  virtual google::cloud::Idempotency GetIamPolicy(
       google::iam::v1::GetIamPolicyRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency SetIamPolicy(
+  virtual google::cloud::Idempotency SetIamPolicy(
       google::iam::v1::SetIamPolicyRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency TestIamPermissions(
+  virtual google::cloud::Idempotency TestIamPermissions(
       google::iam::v1::TestIamPermissionsRequest const& request) = 0;
 };
 

--- a/google/cloud/bigtable/admin/bigtable_table_admin_connection_idempotency_policy.cc
+++ b/google/cloud/bigtable/admin/bigtable_table_admin_connection_idempotency_policy.cc
@@ -25,7 +25,7 @@ namespace cloud {
 namespace bigtable_admin {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-using ::google::cloud::internal::Idempotency;
+using ::google::cloud::Idempotency;
 
 BigtableTableAdminConnectionIdempotencyPolicy::
     ~BigtableTableAdminConnectionIdempotencyPolicy() = default;

--- a/google/cloud/bigtable/admin/bigtable_table_admin_connection_idempotency_policy.h
+++ b/google/cloud/bigtable/admin/bigtable_table_admin_connection_idempotency_policy.h
@@ -19,9 +19,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_ADMIN_BIGTABLE_TABLE_ADMIN_CONNECTION_IDEMPOTENCY_POLICY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_ADMIN_BIGTABLE_TABLE_ADMIN_CONNECTION_IDEMPOTENCY_POLICY_H
 
-#include "google/cloud/future.h"
+#include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
-#include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include <google/bigtable/admin/v2/bigtable_table_admin.grpc.pb.h>
 #include <memory>
@@ -39,57 +38,57 @@ class BigtableTableAdminConnectionIdempotencyPolicy {
   virtual std::unique_ptr<BigtableTableAdminConnectionIdempotencyPolicy> clone()
       const = 0;
 
-  virtual google::cloud::internal::Idempotency CreateTable(
+  virtual google::cloud::Idempotency CreateTable(
       google::bigtable::admin::v2::CreateTableRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency ListTables(
+  virtual google::cloud::Idempotency ListTables(
       google::bigtable::admin::v2::ListTablesRequest request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetTable(
+  virtual google::cloud::Idempotency GetTable(
       google::bigtable::admin::v2::GetTableRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency DeleteTable(
+  virtual google::cloud::Idempotency DeleteTable(
       google::bigtable::admin::v2::DeleteTableRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency ModifyColumnFamilies(
+  virtual google::cloud::Idempotency ModifyColumnFamilies(
       google::bigtable::admin::v2::ModifyColumnFamiliesRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency DropRowRange(
+  virtual google::cloud::Idempotency DropRowRange(
       google::bigtable::admin::v2::DropRowRangeRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency GenerateConsistencyToken(
+  virtual google::cloud::Idempotency GenerateConsistencyToken(
       google::bigtable::admin::v2::GenerateConsistencyTokenRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency CheckConsistency(
+  virtual google::cloud::Idempotency CheckConsistency(
       google::bigtable::admin::v2::CheckConsistencyRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency CreateBackup(
+  virtual google::cloud::Idempotency CreateBackup(
       google::bigtable::admin::v2::CreateBackupRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetBackup(
+  virtual google::cloud::Idempotency GetBackup(
       google::bigtable::admin::v2::GetBackupRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency UpdateBackup(
+  virtual google::cloud::Idempotency UpdateBackup(
       google::bigtable::admin::v2::UpdateBackupRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency DeleteBackup(
+  virtual google::cloud::Idempotency DeleteBackup(
       google::bigtable::admin::v2::DeleteBackupRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency ListBackups(
+  virtual google::cloud::Idempotency ListBackups(
       google::bigtable::admin::v2::ListBackupsRequest request) = 0;
 
-  virtual google::cloud::internal::Idempotency RestoreTable(
+  virtual google::cloud::Idempotency RestoreTable(
       google::bigtable::admin::v2::RestoreTableRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetIamPolicy(
+  virtual google::cloud::Idempotency GetIamPolicy(
       google::iam::v1::GetIamPolicyRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency SetIamPolicy(
+  virtual google::cloud::Idempotency SetIamPolicy(
       google::iam::v1::SetIamPolicyRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency TestIamPermissions(
+  virtual google::cloud::Idempotency TestIamPermissions(
       google::iam::v1::TestIamPermissionsRequest const& request) = 0;
 };
 

--- a/google/cloud/bigtable/instance_admin.cc
+++ b/google/cloud/bigtable/instance_admin.cc
@@ -37,7 +37,7 @@ static_assert(std::is_copy_assignable<bigtable::InstanceAdmin>::value,
               "bigtable::InstanceAdmin must be CopyAssignable");
 
 using ClientUtils = bigtable::internal::UnaryClientUtils<InstanceAdminClient>;
-using ::google::cloud::internal::Idempotency;
+using ::google::cloud::Idempotency;
 
 StatusOr<InstanceList> InstanceAdmin::ListInstances() {
   grpc::Status status;

--- a/google/cloud/bigtable/internal/async_retry_op.h
+++ b/google/cloud/bigtable/internal/async_retry_op.h
@@ -41,19 +41,19 @@ namespace internal {
 class ConstantIdempotencyPolicy {
  public:
   explicit ConstantIdempotencyPolicy(
-      google::cloud::internal::Idempotency idempotency)
+      google::cloud::Idempotency idempotency)
       : idempotency_(idempotency) {}
 
   bool is_idempotent() const {
-    return idempotency_ == google::cloud::internal::Idempotency::kIdempotent;
+    return idempotency_ == google::cloud::Idempotency::kIdempotent;
   }
 
-  google::cloud::internal::Idempotency idempotency() const {
+  google::cloud::Idempotency idempotency() const {
     return idempotency_;
   }
 
  private:
-  google::cloud::internal::Idempotency idempotency_;
+  google::cloud::Idempotency idempotency_;
 };
 
 }  // namespace internal

--- a/google/cloud/bigtable/internal/async_retry_op.h
+++ b/google/cloud/bigtable/internal/async_retry_op.h
@@ -40,17 +40,14 @@ namespace internal {
  */
 class ConstantIdempotencyPolicy {
  public:
-  explicit ConstantIdempotencyPolicy(
-      google::cloud::Idempotency idempotency)
+  explicit ConstantIdempotencyPolicy(google::cloud::Idempotency idempotency)
       : idempotency_(idempotency) {}
 
   bool is_idempotent() const {
     return idempotency_ == google::cloud::Idempotency::kIdempotent;
   }
 
-  google::cloud::Idempotency idempotency() const {
-    return idempotency_;
-  }
+  google::cloud::Idempotency idempotency() const { return idempotency_; }
 
  private:
   google::cloud::Idempotency idempotency_;

--- a/google/cloud/bigtable/internal/async_retry_unary_rpc_and_poll_test.cc
+++ b/google/cloud/bigtable/internal/async_retry_unary_rpc_and_poll_test.cc
@@ -148,7 +148,7 @@ class AsyncStartPollAfterRetryUnaryRpcTest
         __func__, std::move(polling_policy), std::move(rpc_retry_policy),
         std::move(rpc_backoff_policy),
         internal::ConstantIdempotencyPolicy(
-            google::cloud::internal::Idempotency::kNonIdempotent),
+            google::cloud::Idempotency::kNonIdempotent),
         std::move(metadata_update_policy), client,
         [this](grpc::ClientContext* context,
                btproto::CreateClusterRequest const& request,

--- a/google/cloud/bigtable/internal/bulk_mutator.cc
+++ b/google/cloud/bigtable/internal/bulk_mutator.cc
@@ -26,7 +26,7 @@ namespace internal {
 
 namespace btproto = ::google::bigtable::v2;
 
-using ::google::cloud::internal::Idempotency;
+using ::google::cloud::Idempotency;
 
 BulkMutatorState::BulkMutatorState(std::string const& app_profile_id,
                                    std::string const& table_name,

--- a/google/cloud/bigtable/internal/bulk_mutator.h
+++ b/google/cloud/bigtable/internal/bulk_mutator.h
@@ -88,7 +88,7 @@ class BulkMutatorState {
      * request provided by the application.
      */
     int original_index;
-    google::cloud::internal::Idempotency idempotency;
+    google::cloud::Idempotency idempotency;
     /// Set to `false` if the result is unknown.
     bool has_mutation_result;
   };

--- a/google/cloud/bigtable/internal/unary_client_utils.h
+++ b/google/cloud/bigtable/internal/unary_client_utils.h
@@ -105,7 +105,7 @@ struct UnaryClientUtils {
       MemberFunction function,
       typename Signature<MemberFunction>::RequestType const& request,
       char const* error_message, grpc::Status& status,
-      google::cloud::internal::Idempotency retry_on_failure) {
+      google::cloud::Idempotency retry_on_failure) {
     return MakeCall(client, *rpc_policy, *backoff_policy,
                     metadata_update_policy, function, request, error_message,
                     status, retry_on_failure);
@@ -140,7 +140,7 @@ struct UnaryClientUtils {
       MemberFunction function,
       typename Signature<MemberFunction>::RequestType const& request,
       char const* error_message, grpc::Status& status,
-      google::cloud::internal::Idempotency idempotency) {
+      google::cloud::Idempotency idempotency) {
     typename Signature<MemberFunction>::ResponseType response;
     do {
       grpc::ClientContext client_context;
@@ -162,7 +162,7 @@ struct UnaryClientUtils {
       }
       auto delay = backoff_policy.OnCompletion(status);
       std::this_thread::sleep_for(delay);
-    } while (idempotency == google::cloud::internal::Idempotency::kIdempotent);
+    } while (idempotency == google::cloud::Idempotency::kIdempotent);
     return response;
   }
 

--- a/google/cloud/bigtable/table.cc
+++ b/google/cloud/bigtable/table.cc
@@ -27,7 +27,7 @@ namespace cloud {
 namespace bigtable {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-using ::google::cloud::internal::Idempotency;
+using ::google::cloud::Idempotency;
 
 namespace {
 template <typename Request>

--- a/google/cloud/bigtable/table_admin.cc
+++ b/google/cloud/bigtable/table_admin.cc
@@ -49,7 +49,7 @@ constexpr TableAdmin::TableView TableAdmin::VIEW_UNSPECIFIED;
 
 /// Shortcuts to avoid typing long names over and over.
 using ClientUtils = bigtable::internal::UnaryClientUtils<AdminClient>;
-using ::google::cloud::internal::Idempotency;
+using ::google::cloud::Idempotency;
 
 StatusOr<btadmin::Table> TableAdmin::CreateTable(std::string table_id,
                                                  TableConfig config) {

--- a/google/cloud/billing/budget_connection_idempotency_policy.cc
+++ b/google/cloud/billing/budget_connection_idempotency_policy.cc
@@ -25,7 +25,7 @@ namespace cloud {
 namespace billing {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-using ::google::cloud::internal::Idempotency;
+using ::google::cloud::Idempotency;
 
 BudgetServiceConnectionIdempotencyPolicy::
     ~BudgetServiceConnectionIdempotencyPolicy() = default;

--- a/google/cloud/billing/budget_connection_idempotency_policy.h
+++ b/google/cloud/billing/budget_connection_idempotency_policy.h
@@ -19,8 +19,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BILLING_BUDGET_CONNECTION_IDEMPOTENCY_POLICY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BILLING_BUDGET_CONNECTION_IDEMPOTENCY_POLICY_H
 
+#include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
-#include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include <google/cloud/billing/budgets/v1/budget_service.grpc.pb.h>
 #include <memory>
@@ -38,21 +38,21 @@ class BudgetServiceConnectionIdempotencyPolicy {
   virtual std::unique_ptr<BudgetServiceConnectionIdempotencyPolicy> clone()
       const = 0;
 
-  virtual google::cloud::internal::Idempotency CreateBudget(
+  virtual google::cloud::Idempotency CreateBudget(
       google::cloud::billing::budgets::v1::CreateBudgetRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency UpdateBudget(
+  virtual google::cloud::Idempotency UpdateBudget(
       google::cloud::billing::budgets::v1::UpdateBudgetRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetBudget(
+  virtual google::cloud::Idempotency GetBudget(
       google::cloud::billing::budgets::v1::GetBudgetRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency ListBudgets(
+  virtual google::cloud::Idempotency ListBudgets(
       google::cloud::billing::budgets::v1::ListBudgetsRequest request) = 0;
 
-  virtual google::cloud::internal::Idempotency DeleteBudget(
+  virtual google::cloud::Idempotency DeleteBudget(
       google::cloud::billing::budgets::v1::DeleteBudgetRequest const&
           request) = 0;
 };

--- a/google/cloud/billing/cloud_billing_connection_idempotency_policy.cc
+++ b/google/cloud/billing/cloud_billing_connection_idempotency_policy.cc
@@ -25,7 +25,7 @@ namespace cloud {
 namespace billing {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-using ::google::cloud::internal::Idempotency;
+using ::google::cloud::Idempotency;
 
 CloudBillingConnectionIdempotencyPolicy::
     ~CloudBillingConnectionIdempotencyPolicy() = default;

--- a/google/cloud/billing/cloud_billing_connection_idempotency_policy.h
+++ b/google/cloud/billing/cloud_billing_connection_idempotency_policy.h
@@ -19,8 +19,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BILLING_CLOUD_BILLING_CONNECTION_IDEMPOTENCY_POLICY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BILLING_CLOUD_BILLING_CONNECTION_IDEMPOTENCY_POLICY_H
 
+#include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
-#include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include <google/cloud/billing/v1/cloud_billing.grpc.pb.h>
 #include <memory>
@@ -38,38 +38,38 @@ class CloudBillingConnectionIdempotencyPolicy {
   virtual std::unique_ptr<CloudBillingConnectionIdempotencyPolicy> clone()
       const = 0;
 
-  virtual google::cloud::internal::Idempotency GetBillingAccount(
+  virtual google::cloud::Idempotency GetBillingAccount(
       google::cloud::billing::v1::GetBillingAccountRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency ListBillingAccounts(
+  virtual google::cloud::Idempotency ListBillingAccounts(
       google::cloud::billing::v1::ListBillingAccountsRequest request) = 0;
 
-  virtual google::cloud::internal::Idempotency UpdateBillingAccount(
+  virtual google::cloud::Idempotency UpdateBillingAccount(
       google::cloud::billing::v1::UpdateBillingAccountRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency CreateBillingAccount(
+  virtual google::cloud::Idempotency CreateBillingAccount(
       google::cloud::billing::v1::CreateBillingAccountRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency ListProjectBillingInfo(
+  virtual google::cloud::Idempotency ListProjectBillingInfo(
       google::cloud::billing::v1::ListProjectBillingInfoRequest request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetProjectBillingInfo(
+  virtual google::cloud::Idempotency GetProjectBillingInfo(
       google::cloud::billing::v1::GetProjectBillingInfoRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency UpdateProjectBillingInfo(
+  virtual google::cloud::Idempotency UpdateProjectBillingInfo(
       google::cloud::billing::v1::UpdateProjectBillingInfoRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetIamPolicy(
+  virtual google::cloud::Idempotency GetIamPolicy(
       google::iam::v1::GetIamPolicyRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency SetIamPolicy(
+  virtual google::cloud::Idempotency SetIamPolicy(
       google::iam::v1::SetIamPolicyRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency TestIamPermissions(
+  virtual google::cloud::Idempotency TestIamPermissions(
       google::iam::v1::TestIamPermissionsRequest const& request) = 0;
 };
 

--- a/google/cloud/billing/cloud_catalog_connection_idempotency_policy.cc
+++ b/google/cloud/billing/cloud_catalog_connection_idempotency_policy.cc
@@ -25,7 +25,7 @@ namespace cloud {
 namespace billing {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-using ::google::cloud::internal::Idempotency;
+using ::google::cloud::Idempotency;
 
 CloudCatalogConnectionIdempotencyPolicy::
     ~CloudCatalogConnectionIdempotencyPolicy() = default;

--- a/google/cloud/billing/cloud_catalog_connection_idempotency_policy.h
+++ b/google/cloud/billing/cloud_catalog_connection_idempotency_policy.h
@@ -19,8 +19,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BILLING_CLOUD_CATALOG_CONNECTION_IDEMPOTENCY_POLICY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BILLING_CLOUD_CATALOG_CONNECTION_IDEMPOTENCY_POLICY_H
 
+#include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
-#include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include <google/cloud/billing/v1/cloud_catalog.grpc.pb.h>
 #include <memory>
@@ -38,10 +38,10 @@ class CloudCatalogConnectionIdempotencyPolicy {
   virtual std::unique_ptr<CloudCatalogConnectionIdempotencyPolicy> clone()
       const = 0;
 
-  virtual google::cloud::internal::Idempotency ListServices(
+  virtual google::cloud::Idempotency ListServices(
       google::cloud::billing::v1::ListServicesRequest request) = 0;
 
-  virtual google::cloud::internal::Idempotency ListSkus(
+  virtual google::cloud::Idempotency ListSkus(
       google::cloud::billing::v1::ListSkusRequest request) = 0;
 };
 

--- a/google/cloud/cloudbuild/cloud_build_connection_idempotency_policy.cc
+++ b/google/cloud/cloudbuild/cloud_build_connection_idempotency_policy.cc
@@ -25,7 +25,7 @@ namespace cloud {
 namespace cloudbuild {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-using ::google::cloud::internal::Idempotency;
+using ::google::cloud::Idempotency;
 
 CloudBuildConnectionIdempotencyPolicy::
     ~CloudBuildConnectionIdempotencyPolicy() = default;

--- a/google/cloud/cloudbuild/cloud_build_connection_idempotency_policy.h
+++ b/google/cloud/cloudbuild/cloud_build_connection_idempotency_policy.h
@@ -19,9 +19,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CLOUDBUILD_CLOUD_BUILD_CONNECTION_IDEMPOTENCY_POLICY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CLOUDBUILD_CLOUD_BUILD_CONNECTION_IDEMPOTENCY_POLICY_H
 
-#include "google/cloud/future.h"
+#include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
-#include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include <google/devtools/cloudbuild/v1/cloudbuild.grpc.pb.h>
 #include <memory>
@@ -39,68 +38,68 @@ class CloudBuildConnectionIdempotencyPolicy {
   virtual std::unique_ptr<CloudBuildConnectionIdempotencyPolicy> clone()
       const = 0;
 
-  virtual google::cloud::internal::Idempotency CreateBuild(
+  virtual google::cloud::Idempotency CreateBuild(
       google::devtools::cloudbuild::v1::CreateBuildRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetBuild(
+  virtual google::cloud::Idempotency GetBuild(
       google::devtools::cloudbuild::v1::GetBuildRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency ListBuilds(
+  virtual google::cloud::Idempotency ListBuilds(
       google::devtools::cloudbuild::v1::ListBuildsRequest request) = 0;
 
-  virtual google::cloud::internal::Idempotency CancelBuild(
+  virtual google::cloud::Idempotency CancelBuild(
       google::devtools::cloudbuild::v1::CancelBuildRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency RetryBuild(
+  virtual google::cloud::Idempotency RetryBuild(
       google::devtools::cloudbuild::v1::RetryBuildRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency ApproveBuild(
+  virtual google::cloud::Idempotency ApproveBuild(
       google::devtools::cloudbuild::v1::ApproveBuildRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency CreateBuildTrigger(
+  virtual google::cloud::Idempotency CreateBuildTrigger(
       google::devtools::cloudbuild::v1::CreateBuildTriggerRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetBuildTrigger(
+  virtual google::cloud::Idempotency GetBuildTrigger(
       google::devtools::cloudbuild::v1::GetBuildTriggerRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency ListBuildTriggers(
+  virtual google::cloud::Idempotency ListBuildTriggers(
       google::devtools::cloudbuild::v1::ListBuildTriggersRequest request) = 0;
 
-  virtual google::cloud::internal::Idempotency DeleteBuildTrigger(
+  virtual google::cloud::Idempotency DeleteBuildTrigger(
       google::devtools::cloudbuild::v1::DeleteBuildTriggerRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency UpdateBuildTrigger(
+  virtual google::cloud::Idempotency UpdateBuildTrigger(
       google::devtools::cloudbuild::v1::UpdateBuildTriggerRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency RunBuildTrigger(
+  virtual google::cloud::Idempotency RunBuildTrigger(
       google::devtools::cloudbuild::v1::RunBuildTriggerRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency ReceiveTriggerWebhook(
+  virtual google::cloud::Idempotency ReceiveTriggerWebhook(
       google::devtools::cloudbuild::v1::ReceiveTriggerWebhookRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency CreateWorkerPool(
+  virtual google::cloud::Idempotency CreateWorkerPool(
       google::devtools::cloudbuild::v1::CreateWorkerPoolRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetWorkerPool(
+  virtual google::cloud::Idempotency GetWorkerPool(
       google::devtools::cloudbuild::v1::GetWorkerPoolRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency DeleteWorkerPool(
+  virtual google::cloud::Idempotency DeleteWorkerPool(
       google::devtools::cloudbuild::v1::DeleteWorkerPoolRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency UpdateWorkerPool(
+  virtual google::cloud::Idempotency UpdateWorkerPool(
       google::devtools::cloudbuild::v1::UpdateWorkerPoolRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency ListWorkerPools(
+  virtual google::cloud::Idempotency ListWorkerPools(
       google::devtools::cloudbuild::v1::ListWorkerPoolsRequest request) = 0;
 };
 

--- a/google/cloud/composer/environments_connection_idempotency_policy.cc
+++ b/google/cloud/composer/environments_connection_idempotency_policy.cc
@@ -25,7 +25,7 @@ namespace cloud {
 namespace composer {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-using ::google::cloud::internal::Idempotency;
+using ::google::cloud::Idempotency;
 
 EnvironmentsConnectionIdempotencyPolicy::
     ~EnvironmentsConnectionIdempotencyPolicy() = default;

--- a/google/cloud/composer/environments_connection_idempotency_policy.h
+++ b/google/cloud/composer/environments_connection_idempotency_policy.h
@@ -19,9 +19,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_COMPOSER_ENVIRONMENTS_CONNECTION_IDEMPOTENCY_POLICY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_COMPOSER_ENVIRONMENTS_CONNECTION_IDEMPOTENCY_POLICY_H
 
-#include "google/cloud/future.h"
+#include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
-#include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include <google/cloud/orchestration/airflow/service/v1/environments.grpc.pb.h>
 #include <memory>
@@ -39,23 +38,23 @@ class EnvironmentsConnectionIdempotencyPolicy {
   virtual std::unique_ptr<EnvironmentsConnectionIdempotencyPolicy> clone()
       const = 0;
 
-  virtual google::cloud::internal::Idempotency CreateEnvironment(
+  virtual google::cloud::Idempotency CreateEnvironment(
       google::cloud::orchestration::airflow::service::v1::
           CreateEnvironmentRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetEnvironment(
+  virtual google::cloud::Idempotency GetEnvironment(
       google::cloud::orchestration::airflow::service::v1::
           GetEnvironmentRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency ListEnvironments(
+  virtual google::cloud::Idempotency ListEnvironments(
       google::cloud::orchestration::airflow::service::v1::
           ListEnvironmentsRequest request) = 0;
 
-  virtual google::cloud::internal::Idempotency UpdateEnvironment(
+  virtual google::cloud::Idempotency UpdateEnvironment(
       google::cloud::orchestration::airflow::service::v1::
           UpdateEnvironmentRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency DeleteEnvironment(
+  virtual google::cloud::Idempotency DeleteEnvironment(
       google::cloud::orchestration::airflow::service::v1::
           DeleteEnvironmentRequest const& request) = 0;
 };

--- a/google/cloud/composer/image_versions_connection_idempotency_policy.cc
+++ b/google/cloud/composer/image_versions_connection_idempotency_policy.cc
@@ -25,7 +25,7 @@ namespace cloud {
 namespace composer {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-using ::google::cloud::internal::Idempotency;
+using ::google::cloud::Idempotency;
 
 ImageVersionsConnectionIdempotencyPolicy::
     ~ImageVersionsConnectionIdempotencyPolicy() = default;

--- a/google/cloud/composer/image_versions_connection_idempotency_policy.h
+++ b/google/cloud/composer/image_versions_connection_idempotency_policy.h
@@ -19,8 +19,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_COMPOSER_IMAGE_VERSIONS_CONNECTION_IDEMPOTENCY_POLICY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_COMPOSER_IMAGE_VERSIONS_CONNECTION_IDEMPOTENCY_POLICY_H
 
+#include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
-#include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include <google/cloud/orchestration/airflow/service/v1/image_versions.grpc.pb.h>
 #include <memory>
@@ -38,7 +38,7 @@ class ImageVersionsConnectionIdempotencyPolicy {
   virtual std::unique_ptr<ImageVersionsConnectionIdempotencyPolicy> clone()
       const = 0;
 
-  virtual google::cloud::internal::Idempotency ListImageVersions(
+  virtual google::cloud::Idempotency ListImageVersions(
       google::cloud::orchestration::airflow::service::v1::
           ListImageVersionsRequest request) = 0;
 };

--- a/google/cloud/datamigration/data_migration_connection_idempotency_policy.cc
+++ b/google/cloud/datamigration/data_migration_connection_idempotency_policy.cc
@@ -25,7 +25,7 @@ namespace cloud {
 namespace datamigration {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-using ::google::cloud::internal::Idempotency;
+using ::google::cloud::Idempotency;
 
 DataMigrationServiceConnectionIdempotencyPolicy::
     ~DataMigrationServiceConnectionIdempotencyPolicy() = default;

--- a/google/cloud/datamigration/data_migration_connection_idempotency_policy.h
+++ b/google/cloud/datamigration/data_migration_connection_idempotency_policy.h
@@ -19,9 +19,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_DATAMIGRATION_DATA_MIGRATION_CONNECTION_IDEMPOTENCY_POLICY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_DATAMIGRATION_DATA_MIGRATION_CONNECTION_IDEMPOTENCY_POLICY_H
 
-#include "google/cloud/future.h"
+#include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
-#include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include <google/cloud/clouddms/v1/clouddms.grpc.pb.h>
 #include <memory>
@@ -39,65 +38,65 @@ class DataMigrationServiceConnectionIdempotencyPolicy {
   virtual std::unique_ptr<DataMigrationServiceConnectionIdempotencyPolicy>
   clone() const = 0;
 
-  virtual google::cloud::internal::Idempotency ListMigrationJobs(
+  virtual google::cloud::Idempotency ListMigrationJobs(
       google::cloud::clouddms::v1::ListMigrationJobsRequest request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetMigrationJob(
+  virtual google::cloud::Idempotency GetMigrationJob(
       google::cloud::clouddms::v1::GetMigrationJobRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency CreateMigrationJob(
+  virtual google::cloud::Idempotency CreateMigrationJob(
       google::cloud::clouddms::v1::CreateMigrationJobRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency UpdateMigrationJob(
+  virtual google::cloud::Idempotency UpdateMigrationJob(
       google::cloud::clouddms::v1::UpdateMigrationJobRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency DeleteMigrationJob(
+  virtual google::cloud::Idempotency DeleteMigrationJob(
       google::cloud::clouddms::v1::DeleteMigrationJobRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency StartMigrationJob(
+  virtual google::cloud::Idempotency StartMigrationJob(
       google::cloud::clouddms::v1::StartMigrationJobRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency StopMigrationJob(
+  virtual google::cloud::Idempotency StopMigrationJob(
       google::cloud::clouddms::v1::StopMigrationJobRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency ResumeMigrationJob(
+  virtual google::cloud::Idempotency ResumeMigrationJob(
       google::cloud::clouddms::v1::ResumeMigrationJobRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency PromoteMigrationJob(
+  virtual google::cloud::Idempotency PromoteMigrationJob(
       google::cloud::clouddms::v1::PromoteMigrationJobRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency VerifyMigrationJob(
+  virtual google::cloud::Idempotency VerifyMigrationJob(
       google::cloud::clouddms::v1::VerifyMigrationJobRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency RestartMigrationJob(
+  virtual google::cloud::Idempotency RestartMigrationJob(
       google::cloud::clouddms::v1::RestartMigrationJobRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency GenerateSshScript(
+  virtual google::cloud::Idempotency GenerateSshScript(
       google::cloud::clouddms::v1::GenerateSshScriptRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency ListConnectionProfiles(
+  virtual google::cloud::Idempotency ListConnectionProfiles(
       google::cloud::clouddms::v1::ListConnectionProfilesRequest request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetConnectionProfile(
+  virtual google::cloud::Idempotency GetConnectionProfile(
       google::cloud::clouddms::v1::GetConnectionProfileRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency CreateConnectionProfile(
+  virtual google::cloud::Idempotency CreateConnectionProfile(
       google::cloud::clouddms::v1::CreateConnectionProfileRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency UpdateConnectionProfile(
+  virtual google::cloud::Idempotency UpdateConnectionProfile(
       google::cloud::clouddms::v1::UpdateConnectionProfileRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency DeleteConnectionProfile(
+  virtual google::cloud::Idempotency DeleteConnectionProfile(
       google::cloud::clouddms::v1::DeleteConnectionProfileRequest const&
           request) = 0;
 };

--- a/google/cloud/dlp/dlp_connection_idempotency_policy.cc
+++ b/google/cloud/dlp/dlp_connection_idempotency_policy.cc
@@ -25,7 +25,7 @@ namespace cloud {
 namespace dlp {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-using ::google::cloud::internal::Idempotency;
+using ::google::cloud::Idempotency;
 
 DlpServiceConnectionIdempotencyPolicy::
     ~DlpServiceConnectionIdempotencyPolicy() = default;

--- a/google/cloud/dlp/dlp_connection_idempotency_policy.h
+++ b/google/cloud/dlp/dlp_connection_idempotency_policy.h
@@ -19,8 +19,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_DLP_DLP_CONNECTION_IDEMPOTENCY_POLICY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_DLP_DLP_CONNECTION_IDEMPOTENCY_POLICY_H
 
+#include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
-#include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include <google/privacy/dlp/v2/dlp.grpc.pb.h>
 #include <memory>
@@ -38,114 +38,114 @@ class DlpServiceConnectionIdempotencyPolicy {
   virtual std::unique_ptr<DlpServiceConnectionIdempotencyPolicy> clone()
       const = 0;
 
-  virtual google::cloud::internal::Idempotency InspectContent(
+  virtual google::cloud::Idempotency InspectContent(
       google::privacy::dlp::v2::InspectContentRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency RedactImage(
+  virtual google::cloud::Idempotency RedactImage(
       google::privacy::dlp::v2::RedactImageRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency DeidentifyContent(
+  virtual google::cloud::Idempotency DeidentifyContent(
       google::privacy::dlp::v2::DeidentifyContentRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency ReidentifyContent(
+  virtual google::cloud::Idempotency ReidentifyContent(
       google::privacy::dlp::v2::ReidentifyContentRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency ListInfoTypes(
+  virtual google::cloud::Idempotency ListInfoTypes(
       google::privacy::dlp::v2::ListInfoTypesRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency CreateInspectTemplate(
+  virtual google::cloud::Idempotency CreateInspectTemplate(
       google::privacy::dlp::v2::CreateInspectTemplateRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency UpdateInspectTemplate(
+  virtual google::cloud::Idempotency UpdateInspectTemplate(
       google::privacy::dlp::v2::UpdateInspectTemplateRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetInspectTemplate(
+  virtual google::cloud::Idempotency GetInspectTemplate(
       google::privacy::dlp::v2::GetInspectTemplateRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency ListInspectTemplates(
+  virtual google::cloud::Idempotency ListInspectTemplates(
       google::privacy::dlp::v2::ListInspectTemplatesRequest request) = 0;
 
-  virtual google::cloud::internal::Idempotency DeleteInspectTemplate(
+  virtual google::cloud::Idempotency DeleteInspectTemplate(
       google::privacy::dlp::v2::DeleteInspectTemplateRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency CreateDeidentifyTemplate(
+  virtual google::cloud::Idempotency CreateDeidentifyTemplate(
       google::privacy::dlp::v2::CreateDeidentifyTemplateRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency UpdateDeidentifyTemplate(
+  virtual google::cloud::Idempotency UpdateDeidentifyTemplate(
       google::privacy::dlp::v2::UpdateDeidentifyTemplateRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetDeidentifyTemplate(
+  virtual google::cloud::Idempotency GetDeidentifyTemplate(
       google::privacy::dlp::v2::GetDeidentifyTemplateRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency ListDeidentifyTemplates(
+  virtual google::cloud::Idempotency ListDeidentifyTemplates(
       google::privacy::dlp::v2::ListDeidentifyTemplatesRequest request) = 0;
 
-  virtual google::cloud::internal::Idempotency DeleteDeidentifyTemplate(
+  virtual google::cloud::Idempotency DeleteDeidentifyTemplate(
       google::privacy::dlp::v2::DeleteDeidentifyTemplateRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency CreateJobTrigger(
+  virtual google::cloud::Idempotency CreateJobTrigger(
       google::privacy::dlp::v2::CreateJobTriggerRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency UpdateJobTrigger(
+  virtual google::cloud::Idempotency UpdateJobTrigger(
       google::privacy::dlp::v2::UpdateJobTriggerRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency HybridInspectJobTrigger(
+  virtual google::cloud::Idempotency HybridInspectJobTrigger(
       google::privacy::dlp::v2::HybridInspectJobTriggerRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetJobTrigger(
+  virtual google::cloud::Idempotency GetJobTrigger(
       google::privacy::dlp::v2::GetJobTriggerRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency ListJobTriggers(
+  virtual google::cloud::Idempotency ListJobTriggers(
       google::privacy::dlp::v2::ListJobTriggersRequest request) = 0;
 
-  virtual google::cloud::internal::Idempotency DeleteJobTrigger(
+  virtual google::cloud::Idempotency DeleteJobTrigger(
       google::privacy::dlp::v2::DeleteJobTriggerRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency ActivateJobTrigger(
+  virtual google::cloud::Idempotency ActivateJobTrigger(
       google::privacy::dlp::v2::ActivateJobTriggerRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency CreateDlpJob(
+  virtual google::cloud::Idempotency CreateDlpJob(
       google::privacy::dlp::v2::CreateDlpJobRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency ListDlpJobs(
+  virtual google::cloud::Idempotency ListDlpJobs(
       google::privacy::dlp::v2::ListDlpJobsRequest request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetDlpJob(
+  virtual google::cloud::Idempotency GetDlpJob(
       google::privacy::dlp::v2::GetDlpJobRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency DeleteDlpJob(
+  virtual google::cloud::Idempotency DeleteDlpJob(
       google::privacy::dlp::v2::DeleteDlpJobRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency CancelDlpJob(
+  virtual google::cloud::Idempotency CancelDlpJob(
       google::privacy::dlp::v2::CancelDlpJobRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency CreateStoredInfoType(
+  virtual google::cloud::Idempotency CreateStoredInfoType(
       google::privacy::dlp::v2::CreateStoredInfoTypeRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency UpdateStoredInfoType(
+  virtual google::cloud::Idempotency UpdateStoredInfoType(
       google::privacy::dlp::v2::UpdateStoredInfoTypeRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetStoredInfoType(
+  virtual google::cloud::Idempotency GetStoredInfoType(
       google::privacy::dlp::v2::GetStoredInfoTypeRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency ListStoredInfoTypes(
+  virtual google::cloud::Idempotency ListStoredInfoTypes(
       google::privacy::dlp::v2::ListStoredInfoTypesRequest request) = 0;
 
-  virtual google::cloud::internal::Idempotency DeleteStoredInfoType(
+  virtual google::cloud::Idempotency DeleteStoredInfoType(
       google::privacy::dlp::v2::DeleteStoredInfoTypeRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency HybridInspectDlpJob(
+  virtual google::cloud::Idempotency HybridInspectDlpJob(
       google::privacy::dlp::v2::HybridInspectDlpJobRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency FinishDlpJob(
+  virtual google::cloud::Idempotency FinishDlpJob(
       google::privacy::dlp::v2::FinishDlpJobRequest const& request) = 0;
 };
 

--- a/google/cloud/eventarc/eventarc_connection_idempotency_policy.cc
+++ b/google/cloud/eventarc/eventarc_connection_idempotency_policy.cc
@@ -25,7 +25,7 @@ namespace cloud {
 namespace eventarc {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-using ::google::cloud::internal::Idempotency;
+using ::google::cloud::Idempotency;
 
 EventarcConnectionIdempotencyPolicy::~EventarcConnectionIdempotencyPolicy() =
     default;

--- a/google/cloud/eventarc/eventarc_connection_idempotency_policy.h
+++ b/google/cloud/eventarc/eventarc_connection_idempotency_policy.h
@@ -19,9 +19,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_EVENTARC_EVENTARC_CONNECTION_IDEMPOTENCY_POLICY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_EVENTARC_EVENTARC_CONNECTION_IDEMPOTENCY_POLICY_H
 
-#include "google/cloud/future.h"
+#include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
-#include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include <google/cloud/eventarc/v1/eventarc.grpc.pb.h>
 #include <memory>
@@ -39,19 +38,19 @@ class EventarcConnectionIdempotencyPolicy {
   virtual std::unique_ptr<EventarcConnectionIdempotencyPolicy> clone()
       const = 0;
 
-  virtual google::cloud::internal::Idempotency GetTrigger(
+  virtual google::cloud::Idempotency GetTrigger(
       google::cloud::eventarc::v1::GetTriggerRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency ListTriggers(
+  virtual google::cloud::Idempotency ListTriggers(
       google::cloud::eventarc::v1::ListTriggersRequest request) = 0;
 
-  virtual google::cloud::internal::Idempotency CreateTrigger(
+  virtual google::cloud::Idempotency CreateTrigger(
       google::cloud::eventarc::v1::CreateTriggerRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency UpdateTrigger(
+  virtual google::cloud::Idempotency UpdateTrigger(
       google::cloud::eventarc::v1::UpdateTriggerRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency DeleteTrigger(
+  virtual google::cloud::Idempotency DeleteTrigger(
       google::cloud::eventarc::v1::DeleteTriggerRequest const& request) = 0;
 };
 

--- a/google/cloud/eventarc/publisher_connection_idempotency_policy.cc
+++ b/google/cloud/eventarc/publisher_connection_idempotency_policy.cc
@@ -25,7 +25,7 @@ namespace cloud {
 namespace eventarc {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-using ::google::cloud::internal::Idempotency;
+using ::google::cloud::Idempotency;
 
 PublisherConnectionIdempotencyPolicy::~PublisherConnectionIdempotencyPolicy() =
     default;

--- a/google/cloud/eventarc/publisher_connection_idempotency_policy.h
+++ b/google/cloud/eventarc/publisher_connection_idempotency_policy.h
@@ -19,8 +19,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_EVENTARC_PUBLISHER_CONNECTION_IDEMPOTENCY_POLICY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_EVENTARC_PUBLISHER_CONNECTION_IDEMPOTENCY_POLICY_H
 
+#include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
-#include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include <google/cloud/eventarc/publishing/v1/publisher.grpc.pb.h>
 #include <memory>
@@ -38,7 +38,7 @@ class PublisherConnectionIdempotencyPolicy {
   virtual std::unique_ptr<PublisherConnectionIdempotencyPolicy> clone()
       const = 0;
 
-  virtual google::cloud::internal::Idempotency PublishChannelConnectionEvents(
+  virtual google::cloud::Idempotency PublishChannelConnectionEvents(
       google::cloud::eventarc::publishing::v1::
           PublishChannelConnectionEventsRequest const& request) = 0;
 };

--- a/google/cloud/gameservices/game_server_clusters_connection_idempotency_policy.cc
+++ b/google/cloud/gameservices/game_server_clusters_connection_idempotency_policy.cc
@@ -25,7 +25,7 @@ namespace cloud {
 namespace gameservices {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-using ::google::cloud::internal::Idempotency;
+using ::google::cloud::Idempotency;
 
 GameServerClustersServiceConnectionIdempotencyPolicy::
     ~GameServerClustersServiceConnectionIdempotencyPolicy() = default;

--- a/google/cloud/gameservices/game_server_clusters_connection_idempotency_policy.h
+++ b/google/cloud/gameservices/game_server_clusters_connection_idempotency_policy.h
@@ -19,9 +19,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_GAMESERVICES_GAME_SERVER_CLUSTERS_CONNECTION_IDEMPOTENCY_POLICY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_GAMESERVICES_GAME_SERVER_CLUSTERS_CONNECTION_IDEMPOTENCY_POLICY_H
 
-#include "google/cloud/future.h"
+#include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
-#include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include <google/cloud/gaming/v1/game_server_clusters_service.grpc.pb.h>
 #include <memory>
@@ -39,34 +38,34 @@ class GameServerClustersServiceConnectionIdempotencyPolicy {
   virtual std::unique_ptr<GameServerClustersServiceConnectionIdempotencyPolicy>
   clone() const = 0;
 
-  virtual google::cloud::internal::Idempotency ListGameServerClusters(
+  virtual google::cloud::Idempotency ListGameServerClusters(
       google::cloud::gaming::v1::ListGameServerClustersRequest request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetGameServerCluster(
+  virtual google::cloud::Idempotency GetGameServerCluster(
       google::cloud::gaming::v1::GetGameServerClusterRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency CreateGameServerCluster(
+  virtual google::cloud::Idempotency CreateGameServerCluster(
       google::cloud::gaming::v1::CreateGameServerClusterRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency PreviewCreateGameServerCluster(
+  virtual google::cloud::Idempotency PreviewCreateGameServerCluster(
       google::cloud::gaming::v1::PreviewCreateGameServerClusterRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency DeleteGameServerCluster(
+  virtual google::cloud::Idempotency DeleteGameServerCluster(
       google::cloud::gaming::v1::DeleteGameServerClusterRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency PreviewDeleteGameServerCluster(
+  virtual google::cloud::Idempotency PreviewDeleteGameServerCluster(
       google::cloud::gaming::v1::PreviewDeleteGameServerClusterRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency UpdateGameServerCluster(
+  virtual google::cloud::Idempotency UpdateGameServerCluster(
       google::cloud::gaming::v1::UpdateGameServerClusterRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency PreviewUpdateGameServerCluster(
+  virtual google::cloud::Idempotency PreviewUpdateGameServerCluster(
       google::cloud::gaming::v1::PreviewUpdateGameServerClusterRequest const&
           request) = 0;
 };

--- a/google/cloud/gameservices/game_server_configs_connection_idempotency_policy.cc
+++ b/google/cloud/gameservices/game_server_configs_connection_idempotency_policy.cc
@@ -25,7 +25,7 @@ namespace cloud {
 namespace gameservices {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-using ::google::cloud::internal::Idempotency;
+using ::google::cloud::Idempotency;
 
 GameServerConfigsServiceConnectionIdempotencyPolicy::
     ~GameServerConfigsServiceConnectionIdempotencyPolicy() = default;

--- a/google/cloud/gameservices/game_server_configs_connection_idempotency_policy.h
+++ b/google/cloud/gameservices/game_server_configs_connection_idempotency_policy.h
@@ -19,9 +19,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_GAMESERVICES_GAME_SERVER_CONFIGS_CONNECTION_IDEMPOTENCY_POLICY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_GAMESERVICES_GAME_SERVER_CONFIGS_CONNECTION_IDEMPOTENCY_POLICY_H
 
-#include "google/cloud/future.h"
+#include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
-#include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include <google/cloud/gaming/v1/game_server_configs_service.grpc.pb.h>
 #include <memory>
@@ -39,17 +38,17 @@ class GameServerConfigsServiceConnectionIdempotencyPolicy {
   virtual std::unique_ptr<GameServerConfigsServiceConnectionIdempotencyPolicy>
   clone() const = 0;
 
-  virtual google::cloud::internal::Idempotency ListGameServerConfigs(
+  virtual google::cloud::Idempotency ListGameServerConfigs(
       google::cloud::gaming::v1::ListGameServerConfigsRequest request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetGameServerConfig(
+  virtual google::cloud::Idempotency GetGameServerConfig(
       google::cloud::gaming::v1::GetGameServerConfigRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency CreateGameServerConfig(
+  virtual google::cloud::Idempotency CreateGameServerConfig(
       google::cloud::gaming::v1::CreateGameServerConfigRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency DeleteGameServerConfig(
+  virtual google::cloud::Idempotency DeleteGameServerConfig(
       google::cloud::gaming::v1::DeleteGameServerConfigRequest const&
           request) = 0;
 };

--- a/google/cloud/gameservices/game_server_deployments_connection_idempotency_policy.cc
+++ b/google/cloud/gameservices/game_server_deployments_connection_idempotency_policy.cc
@@ -25,7 +25,7 @@ namespace cloud {
 namespace gameservices {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-using ::google::cloud::internal::Idempotency;
+using ::google::cloud::Idempotency;
 
 GameServerDeploymentsServiceConnectionIdempotencyPolicy::
     ~GameServerDeploymentsServiceConnectionIdempotencyPolicy() = default;

--- a/google/cloud/gameservices/game_server_deployments_connection_idempotency_policy.h
+++ b/google/cloud/gameservices/game_server_deployments_connection_idempotency_policy.h
@@ -19,9 +19,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_GAMESERVICES_GAME_SERVER_DEPLOYMENTS_CONNECTION_IDEMPOTENCY_POLICY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_GAMESERVICES_GAME_SERVER_DEPLOYMENTS_CONNECTION_IDEMPOTENCY_POLICY_H
 
-#include "google/cloud/future.h"
+#include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
-#include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include <google/cloud/gaming/v1/game_server_deployments_service.grpc.pb.h>
 #include <memory>
@@ -40,40 +39,38 @@ class GameServerDeploymentsServiceConnectionIdempotencyPolicy {
       GameServerDeploymentsServiceConnectionIdempotencyPolicy>
   clone() const = 0;
 
-  virtual google::cloud::internal::Idempotency ListGameServerDeployments(
+  virtual google::cloud::Idempotency ListGameServerDeployments(
       google::cloud::gaming::v1::ListGameServerDeploymentsRequest request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetGameServerDeployment(
+  virtual google::cloud::Idempotency GetGameServerDeployment(
       google::cloud::gaming::v1::GetGameServerDeploymentRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency CreateGameServerDeployment(
+  virtual google::cloud::Idempotency CreateGameServerDeployment(
       google::cloud::gaming::v1::CreateGameServerDeploymentRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency DeleteGameServerDeployment(
+  virtual google::cloud::Idempotency DeleteGameServerDeployment(
       google::cloud::gaming::v1::DeleteGameServerDeploymentRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency UpdateGameServerDeployment(
+  virtual google::cloud::Idempotency UpdateGameServerDeployment(
       google::cloud::gaming::v1::UpdateGameServerDeploymentRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetGameServerDeploymentRollout(
+  virtual google::cloud::Idempotency GetGameServerDeploymentRollout(
       google::cloud::gaming::v1::GetGameServerDeploymentRolloutRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency
-  UpdateGameServerDeploymentRollout(
+  virtual google::cloud::Idempotency UpdateGameServerDeploymentRollout(
       google::cloud::gaming::v1::UpdateGameServerDeploymentRolloutRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency
-  PreviewGameServerDeploymentRollout(
+  virtual google::cloud::Idempotency PreviewGameServerDeploymentRollout(
       google::cloud::gaming::v1::
           PreviewGameServerDeploymentRolloutRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency FetchDeploymentState(
+  virtual google::cloud::Idempotency FetchDeploymentState(
       google::cloud::gaming::v1::FetchDeploymentStateRequest const&
           request) = 0;
 };

--- a/google/cloud/gameservices/realms_connection_idempotency_policy.cc
+++ b/google/cloud/gameservices/realms_connection_idempotency_policy.cc
@@ -25,7 +25,7 @@ namespace cloud {
 namespace gameservices {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-using ::google::cloud::internal::Idempotency;
+using ::google::cloud::Idempotency;
 
 RealmsServiceConnectionIdempotencyPolicy::
     ~RealmsServiceConnectionIdempotencyPolicy() = default;

--- a/google/cloud/gameservices/realms_connection_idempotency_policy.h
+++ b/google/cloud/gameservices/realms_connection_idempotency_policy.h
@@ -19,9 +19,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_GAMESERVICES_REALMS_CONNECTION_IDEMPOTENCY_POLICY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_GAMESERVICES_REALMS_CONNECTION_IDEMPOTENCY_POLICY_H
 
-#include "google/cloud/future.h"
+#include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
-#include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include <google/cloud/gaming/v1/realms_service.grpc.pb.h>
 #include <memory>
@@ -39,22 +38,22 @@ class RealmsServiceConnectionIdempotencyPolicy {
   virtual std::unique_ptr<RealmsServiceConnectionIdempotencyPolicy> clone()
       const = 0;
 
-  virtual google::cloud::internal::Idempotency ListRealms(
+  virtual google::cloud::Idempotency ListRealms(
       google::cloud::gaming::v1::ListRealmsRequest request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetRealm(
+  virtual google::cloud::Idempotency GetRealm(
       google::cloud::gaming::v1::GetRealmRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency CreateRealm(
+  virtual google::cloud::Idempotency CreateRealm(
       google::cloud::gaming::v1::CreateRealmRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency DeleteRealm(
+  virtual google::cloud::Idempotency DeleteRealm(
       google::cloud::gaming::v1::DeleteRealmRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency UpdateRealm(
+  virtual google::cloud::Idempotency UpdateRealm(
       google::cloud::gaming::v1::UpdateRealmRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency PreviewRealmUpdate(
+  virtual google::cloud::Idempotency PreviewRealmUpdate(
       google::cloud::gaming::v1::PreviewRealmUpdateRequest const& request) = 0;
 };
 

--- a/google/cloud/gkehub/gke_hub_connection_idempotency_policy.cc
+++ b/google/cloud/gkehub/gke_hub_connection_idempotency_policy.cc
@@ -25,7 +25,7 @@ namespace cloud {
 namespace gkehub {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-using ::google::cloud::internal::Idempotency;
+using ::google::cloud::Idempotency;
 
 GkeHubConnectionIdempotencyPolicy::~GkeHubConnectionIdempotencyPolicy() =
     default;

--- a/google/cloud/gkehub/gke_hub_connection_idempotency_policy.h
+++ b/google/cloud/gkehub/gke_hub_connection_idempotency_policy.h
@@ -19,9 +19,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_GKEHUB_GKE_HUB_CONNECTION_IDEMPOTENCY_POLICY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_GKEHUB_GKE_HUB_CONNECTION_IDEMPOTENCY_POLICY_H
 
-#include "google/cloud/future.h"
+#include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
-#include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include <google/cloud/gkehub/v1/service.grpc.pb.h>
 #include <memory>
@@ -38,37 +37,37 @@ class GkeHubConnectionIdempotencyPolicy {
   /// Create a new copy of this object.
   virtual std::unique_ptr<GkeHubConnectionIdempotencyPolicy> clone() const = 0;
 
-  virtual google::cloud::internal::Idempotency ListMemberships(
+  virtual google::cloud::Idempotency ListMemberships(
       google::cloud::gkehub::v1::ListMembershipsRequest request) = 0;
 
-  virtual google::cloud::internal::Idempotency ListFeatures(
+  virtual google::cloud::Idempotency ListFeatures(
       google::cloud::gkehub::v1::ListFeaturesRequest request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetMembership(
+  virtual google::cloud::Idempotency GetMembership(
       google::cloud::gkehub::v1::GetMembershipRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetFeature(
+  virtual google::cloud::Idempotency GetFeature(
       google::cloud::gkehub::v1::GetFeatureRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency CreateMembership(
+  virtual google::cloud::Idempotency CreateMembership(
       google::cloud::gkehub::v1::CreateMembershipRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency CreateFeature(
+  virtual google::cloud::Idempotency CreateFeature(
       google::cloud::gkehub::v1::CreateFeatureRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency DeleteMembership(
+  virtual google::cloud::Idempotency DeleteMembership(
       google::cloud::gkehub::v1::DeleteMembershipRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency DeleteFeature(
+  virtual google::cloud::Idempotency DeleteFeature(
       google::cloud::gkehub::v1::DeleteFeatureRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency UpdateMembership(
+  virtual google::cloud::Idempotency UpdateMembership(
       google::cloud::gkehub::v1::UpdateMembershipRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency UpdateFeature(
+  virtual google::cloud::Idempotency UpdateFeature(
       google::cloud::gkehub::v1::UpdateFeatureRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency GenerateConnectManifest(
+  virtual google::cloud::Idempotency GenerateConnectManifest(
       google::cloud::gkehub::v1::GenerateConnectManifestRequest const&
           request) = 0;
 };

--- a/google/cloud/google_cloud_cpp_common.bzl
+++ b/google/cloud/google_cloud_cpp_common.bzl
@@ -26,6 +26,7 @@ google_cloud_cpp_common_hdrs = [
     "iam_binding.h",
     "iam_bindings.h",
     "iam_policy.h",
+    "idempotency.h",
     "internal/absl_str_cat_quiet.h",
     "internal/absl_str_join_quiet.h",
     "internal/absl_str_replace_quiet.h",

--- a/google/cloud/iam/iam_connection_idempotency_policy.cc
+++ b/google/cloud/iam/iam_connection_idempotency_policy.cc
@@ -25,7 +25,7 @@ namespace cloud {
 namespace iam {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-using ::google::cloud::internal::Idempotency;
+using ::google::cloud::Idempotency;
 
 IAMConnectionIdempotencyPolicy::~IAMConnectionIdempotencyPolicy() = default;
 

--- a/google/cloud/iam/iam_connection_idempotency_policy.h
+++ b/google/cloud/iam/iam_connection_idempotency_policy.h
@@ -19,8 +19,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_IAM_IAM_CONNECTION_IDEMPOTENCY_POLICY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_IAM_IAM_CONNECTION_IDEMPOTENCY_POLICY_H
 
+#include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
-#include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include <google/iam/admin/v1/iam.grpc.pb.h>
 #include <memory>
@@ -37,85 +37,85 @@ class IAMConnectionIdempotencyPolicy {
   /// Create a new copy of this object.
   virtual std::unique_ptr<IAMConnectionIdempotencyPolicy> clone() const = 0;
 
-  virtual google::cloud::internal::Idempotency ListServiceAccounts(
+  virtual google::cloud::Idempotency ListServiceAccounts(
       google::iam::admin::v1::ListServiceAccountsRequest request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetServiceAccount(
+  virtual google::cloud::Idempotency GetServiceAccount(
       google::iam::admin::v1::GetServiceAccountRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency CreateServiceAccount(
+  virtual google::cloud::Idempotency CreateServiceAccount(
       google::iam::admin::v1::CreateServiceAccountRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency PatchServiceAccount(
+  virtual google::cloud::Idempotency PatchServiceAccount(
       google::iam::admin::v1::PatchServiceAccountRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency DeleteServiceAccount(
+  virtual google::cloud::Idempotency DeleteServiceAccount(
       google::iam::admin::v1::DeleteServiceAccountRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency UndeleteServiceAccount(
+  virtual google::cloud::Idempotency UndeleteServiceAccount(
       google::iam::admin::v1::UndeleteServiceAccountRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency EnableServiceAccount(
+  virtual google::cloud::Idempotency EnableServiceAccount(
       google::iam::admin::v1::EnableServiceAccountRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency DisableServiceAccount(
+  virtual google::cloud::Idempotency DisableServiceAccount(
       google::iam::admin::v1::DisableServiceAccountRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency ListServiceAccountKeys(
+  virtual google::cloud::Idempotency ListServiceAccountKeys(
       google::iam::admin::v1::ListServiceAccountKeysRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetServiceAccountKey(
+  virtual google::cloud::Idempotency GetServiceAccountKey(
       google::iam::admin::v1::GetServiceAccountKeyRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency CreateServiceAccountKey(
+  virtual google::cloud::Idempotency CreateServiceAccountKey(
       google::iam::admin::v1::CreateServiceAccountKeyRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency UploadServiceAccountKey(
+  virtual google::cloud::Idempotency UploadServiceAccountKey(
       google::iam::admin::v1::UploadServiceAccountKeyRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency DeleteServiceAccountKey(
+  virtual google::cloud::Idempotency DeleteServiceAccountKey(
       google::iam::admin::v1::DeleteServiceAccountKeyRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetIamPolicy(
+  virtual google::cloud::Idempotency GetIamPolicy(
       google::iam::v1::GetIamPolicyRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency SetIamPolicy(
+  virtual google::cloud::Idempotency SetIamPolicy(
       google::iam::v1::SetIamPolicyRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency TestIamPermissions(
+  virtual google::cloud::Idempotency TestIamPermissions(
       google::iam::v1::TestIamPermissionsRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency QueryGrantableRoles(
+  virtual google::cloud::Idempotency QueryGrantableRoles(
       google::iam::admin::v1::QueryGrantableRolesRequest request) = 0;
 
-  virtual google::cloud::internal::Idempotency ListRoles(
+  virtual google::cloud::Idempotency ListRoles(
       google::iam::admin::v1::ListRolesRequest request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetRole(
+  virtual google::cloud::Idempotency GetRole(
       google::iam::admin::v1::GetRoleRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency CreateRole(
+  virtual google::cloud::Idempotency CreateRole(
       google::iam::admin::v1::CreateRoleRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency UpdateRole(
+  virtual google::cloud::Idempotency UpdateRole(
       google::iam::admin::v1::UpdateRoleRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency DeleteRole(
+  virtual google::cloud::Idempotency DeleteRole(
       google::iam::admin::v1::DeleteRoleRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency UndeleteRole(
+  virtual google::cloud::Idempotency UndeleteRole(
       google::iam::admin::v1::UndeleteRoleRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency QueryTestablePermissions(
+  virtual google::cloud::Idempotency QueryTestablePermissions(
       google::iam::admin::v1::QueryTestablePermissionsRequest request) = 0;
 
-  virtual google::cloud::internal::Idempotency QueryAuditableServices(
+  virtual google::cloud::Idempotency QueryAuditableServices(
       google::iam::admin::v1::QueryAuditableServicesRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency LintPolicy(
+  virtual google::cloud::Idempotency LintPolicy(
       google::iam::admin::v1::LintPolicyRequest const& request) = 0;
 };
 

--- a/google/cloud/iam/iam_credentials_connection_idempotency_policy.cc
+++ b/google/cloud/iam/iam_credentials_connection_idempotency_policy.cc
@@ -25,7 +25,7 @@ namespace cloud {
 namespace iam {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-using ::google::cloud::internal::Idempotency;
+using ::google::cloud::Idempotency;
 
 IAMCredentialsConnectionIdempotencyPolicy::
     ~IAMCredentialsConnectionIdempotencyPolicy() = default;

--- a/google/cloud/iam/iam_credentials_connection_idempotency_policy.h
+++ b/google/cloud/iam/iam_credentials_connection_idempotency_policy.h
@@ -19,8 +19,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_IAM_IAM_CREDENTIALS_CONNECTION_IDEMPOTENCY_POLICY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_IAM_IAM_CREDENTIALS_CONNECTION_IDEMPOTENCY_POLICY_H
 
+#include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
-#include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include <google/iam/credentials/v1/iamcredentials.grpc.pb.h>
 #include <memory>
@@ -38,17 +38,17 @@ class IAMCredentialsConnectionIdempotencyPolicy {
   virtual std::unique_ptr<IAMCredentialsConnectionIdempotencyPolicy> clone()
       const = 0;
 
-  virtual google::cloud::internal::Idempotency GenerateAccessToken(
+  virtual google::cloud::Idempotency GenerateAccessToken(
       google::iam::credentials::v1::GenerateAccessTokenRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency GenerateIdToken(
+  virtual google::cloud::Idempotency GenerateIdToken(
       google::iam::credentials::v1::GenerateIdTokenRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency SignBlob(
+  virtual google::cloud::Idempotency SignBlob(
       google::iam::credentials::v1::SignBlobRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency SignJwt(
+  virtual google::cloud::Idempotency SignJwt(
       google::iam::credentials::v1::SignJwtRequest const& request) = 0;
 };
 

--- a/google/cloud/iam/integration_tests/iam_integration_test.cc
+++ b/google/cloud/iam/integration_tests/iam_integration_test.cc
@@ -36,7 +36,7 @@ namespace iam {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
-using ::google::cloud::internal::Idempotency;
+using ::google::cloud::Idempotency;
 using ::google::cloud::testing_util::IsOk;
 using ::google::cloud::testing_util::StatusIs;
 using ::testing::AnyOf;

--- a/google/cloud/idempotency.h
+++ b/google/cloud/idempotency.h
@@ -1,0 +1,67 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_IDEMPOTENCY_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_IDEMPOTENCY_H
+
+#include "google/cloud/status.h"
+#include "google/cloud/version.h"
+#include <chrono>
+#include <memory>
+
+namespace google {
+namespace cloud {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+
+/**
+ * Whether a request is [idempotent][wikipedia-idempotence].
+ *
+ * When a RPC fails with a retryable error, the `google-cloud-cpp` client
+ * libraries automatically retry the RPC **if** the RPC is
+ * [idempotent][wikipedia-idempotence].  For each service, the library define
+ * a policy that determines whether a given request is idempotent.  In many
+ * cases this can be determined statically, for example, read-only operations
+ * are always idempotent. In some cases, the contents of the request may need to
+ * be examined to determine if the operation is idempotent. For example,
+ * performing operations with pre-conditions, such that the pre-conditions
+ * change when the operation succeed, is typically idempotent.
+ *
+ * Applications may override the default idempotency policy, though we
+ * anticipate that this would be needed only in very rare circumstances. A few
+ * examples include:
+ *
+ * - In some services deleting "the most recent" entry may be idempotent if the
+ *   system has been configured to keep no history or versions, as the deletion
+ *   may succeed only once. In contrast, deleting "the most recent entry" is
+ *   **not** idempotent if the system keeps multiple versions. Google Cloud
+ *   Storage or Bigtable can be configured either way.
+ * - In some applications, creating a duplicate entry may be acceptable as the
+ *   system will deduplicate them later.  In such systems it may be preferable
+ *   to retry the operation even though it is not idempotent.
+ *
+ * [wikipedia-idempotence]: https://en.wikipedia.org/wiki/Idempotence
+ */
+enum class Idempotency {
+  /// The operation is idempotent and can be retried after a transient failure.
+  kIdempotent,
+  /// The operation is not idempotent and should **not** be retried after a
+  /// transient failure.
+  kNonIdempotent
+};
+
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_IDEMPOTENCY_H

--- a/google/cloud/ids/ids_connection_idempotency_policy.cc
+++ b/google/cloud/ids/ids_connection_idempotency_policy.cc
@@ -25,7 +25,7 @@ namespace cloud {
 namespace ids {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-using ::google::cloud::internal::Idempotency;
+using ::google::cloud::Idempotency;
 
 IDSConnectionIdempotencyPolicy::~IDSConnectionIdempotencyPolicy() = default;
 

--- a/google/cloud/ids/ids_connection_idempotency_policy.h
+++ b/google/cloud/ids/ids_connection_idempotency_policy.h
@@ -19,9 +19,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_IDS_IDS_CONNECTION_IDEMPOTENCY_POLICY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_IDS_IDS_CONNECTION_IDEMPOTENCY_POLICY_H
 
-#include "google/cloud/future.h"
+#include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
-#include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include <google/cloud/ids/v1/ids.grpc.pb.h>
 #include <memory>
@@ -38,16 +37,16 @@ class IDSConnectionIdempotencyPolicy {
   /// Create a new copy of this object.
   virtual std::unique_ptr<IDSConnectionIdempotencyPolicy> clone() const = 0;
 
-  virtual google::cloud::internal::Idempotency ListEndpoints(
+  virtual google::cloud::Idempotency ListEndpoints(
       google::cloud::ids::v1::ListEndpointsRequest request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetEndpoint(
+  virtual google::cloud::Idempotency GetEndpoint(
       google::cloud::ids::v1::GetEndpointRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency CreateEndpoint(
+  virtual google::cloud::Idempotency CreateEndpoint(
       google::cloud::ids::v1::CreateEndpointRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency DeleteEndpoint(
+  virtual google::cloud::Idempotency DeleteEndpoint(
       google::cloud::ids::v1::DeleteEndpointRequest const& request) = 0;
 };
 

--- a/google/cloud/internal/retry_policy.h
+++ b/google/cloud/internal/retry_policy.h
@@ -15,6 +15,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_RETRY_POLICY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_RETRY_POLICY_H
 
+#include "google/cloud/idempotency.h"
 #include "google/cloud/status.h"
 #include "google/cloud/version.h"
 #include <chrono>
@@ -25,7 +26,8 @@ namespace cloud {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace internal {
 
-enum class Idempotency { kIdempotent, kNonIdempotent };
+// TODO(#....) - cleanup once the code is merged.
+using Idempotency = ::google::cloud::Idempotency;
 
 /**
  * Define the interface for retry policies.

--- a/google/cloud/internal/retry_policy.h
+++ b/google/cloud/internal/retry_policy.h
@@ -26,9 +26,6 @@ namespace cloud {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace internal {
 
-// TODO(#....) - cleanup once the code is merged.
-using Idempotency = ::google::cloud::Idempotency;
-
 /**
  * Define the interface for retry policies.
  */

--- a/google/cloud/iot/device_manager_connection_idempotency_policy.cc
+++ b/google/cloud/iot/device_manager_connection_idempotency_policy.cc
@@ -25,7 +25,7 @@ namespace cloud {
 namespace iot {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-using ::google::cloud::internal::Idempotency;
+using ::google::cloud::Idempotency;
 
 DeviceManagerConnectionIdempotencyPolicy::
     ~DeviceManagerConnectionIdempotencyPolicy() = default;

--- a/google/cloud/iot/device_manager_connection_idempotency_policy.h
+++ b/google/cloud/iot/device_manager_connection_idempotency_policy.h
@@ -19,8 +19,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_IOT_DEVICE_MANAGER_CONNECTION_IDEMPOTENCY_POLICY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_IOT_DEVICE_MANAGER_CONNECTION_IDEMPOTENCY_POLICY_H
 
+#include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
-#include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include <google/cloud/iot/v1/device_manager.grpc.pb.h>
 #include <memory>
@@ -38,63 +38,63 @@ class DeviceManagerConnectionIdempotencyPolicy {
   virtual std::unique_ptr<DeviceManagerConnectionIdempotencyPolicy> clone()
       const = 0;
 
-  virtual google::cloud::internal::Idempotency CreateDeviceRegistry(
+  virtual google::cloud::Idempotency CreateDeviceRegistry(
       google::cloud::iot::v1::CreateDeviceRegistryRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetDeviceRegistry(
+  virtual google::cloud::Idempotency GetDeviceRegistry(
       google::cloud::iot::v1::GetDeviceRegistryRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency UpdateDeviceRegistry(
+  virtual google::cloud::Idempotency UpdateDeviceRegistry(
       google::cloud::iot::v1::UpdateDeviceRegistryRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency DeleteDeviceRegistry(
+  virtual google::cloud::Idempotency DeleteDeviceRegistry(
       google::cloud::iot::v1::DeleteDeviceRegistryRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency ListDeviceRegistries(
+  virtual google::cloud::Idempotency ListDeviceRegistries(
       google::cloud::iot::v1::ListDeviceRegistriesRequest request) = 0;
 
-  virtual google::cloud::internal::Idempotency CreateDevice(
+  virtual google::cloud::Idempotency CreateDevice(
       google::cloud::iot::v1::CreateDeviceRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetDevice(
+  virtual google::cloud::Idempotency GetDevice(
       google::cloud::iot::v1::GetDeviceRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency UpdateDevice(
+  virtual google::cloud::Idempotency UpdateDevice(
       google::cloud::iot::v1::UpdateDeviceRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency DeleteDevice(
+  virtual google::cloud::Idempotency DeleteDevice(
       google::cloud::iot::v1::DeleteDeviceRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency ListDevices(
+  virtual google::cloud::Idempotency ListDevices(
       google::cloud::iot::v1::ListDevicesRequest request) = 0;
 
-  virtual google::cloud::internal::Idempotency ModifyCloudToDeviceConfig(
+  virtual google::cloud::Idempotency ModifyCloudToDeviceConfig(
       google::cloud::iot::v1::ModifyCloudToDeviceConfigRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency ListDeviceConfigVersions(
+  virtual google::cloud::Idempotency ListDeviceConfigVersions(
       google::cloud::iot::v1::ListDeviceConfigVersionsRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency ListDeviceStates(
+  virtual google::cloud::Idempotency ListDeviceStates(
       google::cloud::iot::v1::ListDeviceStatesRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency SetIamPolicy(
+  virtual google::cloud::Idempotency SetIamPolicy(
       google::iam::v1::SetIamPolicyRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetIamPolicy(
+  virtual google::cloud::Idempotency GetIamPolicy(
       google::iam::v1::GetIamPolicyRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency TestIamPermissions(
+  virtual google::cloud::Idempotency TestIamPermissions(
       google::iam::v1::TestIamPermissionsRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency SendCommandToDevice(
+  virtual google::cloud::Idempotency SendCommandToDevice(
       google::cloud::iot::v1::SendCommandToDeviceRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency BindDeviceToGateway(
+  virtual google::cloud::Idempotency BindDeviceToGateway(
       google::cloud::iot::v1::BindDeviceToGatewayRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency UnbindDeviceFromGateway(
+  virtual google::cloud::Idempotency UnbindDeviceFromGateway(
       google::cloud::iot::v1::UnbindDeviceFromGatewayRequest const&
           request) = 0;
 };

--- a/google/cloud/kms/key_management_connection_idempotency_policy.cc
+++ b/google/cloud/kms/key_management_connection_idempotency_policy.cc
@@ -25,7 +25,7 @@ namespace cloud {
 namespace kms {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-using ::google::cloud::internal::Idempotency;
+using ::google::cloud::Idempotency;
 
 KeyManagementServiceConnectionIdempotencyPolicy::
     ~KeyManagementServiceConnectionIdempotencyPolicy() = default;

--- a/google/cloud/kms/key_management_connection_idempotency_policy.h
+++ b/google/cloud/kms/key_management_connection_idempotency_policy.h
@@ -19,8 +19,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_KMS_KEY_MANAGEMENT_CONNECTION_IDEMPOTENCY_POLICY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_KMS_KEY_MANAGEMENT_CONNECTION_IDEMPOTENCY_POLICY_H
 
+#include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
-#include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include <google/cloud/kms/v1/service.grpc.pb.h>
 #include <memory>
@@ -38,85 +38,85 @@ class KeyManagementServiceConnectionIdempotencyPolicy {
   virtual std::unique_ptr<KeyManagementServiceConnectionIdempotencyPolicy>
   clone() const = 0;
 
-  virtual google::cloud::internal::Idempotency ListKeyRings(
+  virtual google::cloud::Idempotency ListKeyRings(
       google::cloud::kms::v1::ListKeyRingsRequest request) = 0;
 
-  virtual google::cloud::internal::Idempotency ListCryptoKeys(
+  virtual google::cloud::Idempotency ListCryptoKeys(
       google::cloud::kms::v1::ListCryptoKeysRequest request) = 0;
 
-  virtual google::cloud::internal::Idempotency ListCryptoKeyVersions(
+  virtual google::cloud::Idempotency ListCryptoKeyVersions(
       google::cloud::kms::v1::ListCryptoKeyVersionsRequest request) = 0;
 
-  virtual google::cloud::internal::Idempotency ListImportJobs(
+  virtual google::cloud::Idempotency ListImportJobs(
       google::cloud::kms::v1::ListImportJobsRequest request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetKeyRing(
+  virtual google::cloud::Idempotency GetKeyRing(
       google::cloud::kms::v1::GetKeyRingRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetCryptoKey(
+  virtual google::cloud::Idempotency GetCryptoKey(
       google::cloud::kms::v1::GetCryptoKeyRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetCryptoKeyVersion(
+  virtual google::cloud::Idempotency GetCryptoKeyVersion(
       google::cloud::kms::v1::GetCryptoKeyVersionRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetPublicKey(
+  virtual google::cloud::Idempotency GetPublicKey(
       google::cloud::kms::v1::GetPublicKeyRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetImportJob(
+  virtual google::cloud::Idempotency GetImportJob(
       google::cloud::kms::v1::GetImportJobRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency CreateKeyRing(
+  virtual google::cloud::Idempotency CreateKeyRing(
       google::cloud::kms::v1::CreateKeyRingRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency CreateCryptoKey(
+  virtual google::cloud::Idempotency CreateCryptoKey(
       google::cloud::kms::v1::CreateCryptoKeyRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency CreateCryptoKeyVersion(
+  virtual google::cloud::Idempotency CreateCryptoKeyVersion(
       google::cloud::kms::v1::CreateCryptoKeyVersionRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency ImportCryptoKeyVersion(
+  virtual google::cloud::Idempotency ImportCryptoKeyVersion(
       google::cloud::kms::v1::ImportCryptoKeyVersionRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency CreateImportJob(
+  virtual google::cloud::Idempotency CreateImportJob(
       google::cloud::kms::v1::CreateImportJobRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency UpdateCryptoKey(
+  virtual google::cloud::Idempotency UpdateCryptoKey(
       google::cloud::kms::v1::UpdateCryptoKeyRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency UpdateCryptoKeyVersion(
+  virtual google::cloud::Idempotency UpdateCryptoKeyVersion(
       google::cloud::kms::v1::UpdateCryptoKeyVersionRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency UpdateCryptoKeyPrimaryVersion(
+  virtual google::cloud::Idempotency UpdateCryptoKeyPrimaryVersion(
       google::cloud::kms::v1::UpdateCryptoKeyPrimaryVersionRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency DestroyCryptoKeyVersion(
+  virtual google::cloud::Idempotency DestroyCryptoKeyVersion(
       google::cloud::kms::v1::DestroyCryptoKeyVersionRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency RestoreCryptoKeyVersion(
+  virtual google::cloud::Idempotency RestoreCryptoKeyVersion(
       google::cloud::kms::v1::RestoreCryptoKeyVersionRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency Encrypt(
+  virtual google::cloud::Idempotency Encrypt(
       google::cloud::kms::v1::EncryptRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency Decrypt(
+  virtual google::cloud::Idempotency Decrypt(
       google::cloud::kms::v1::DecryptRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency AsymmetricSign(
+  virtual google::cloud::Idempotency AsymmetricSign(
       google::cloud::kms::v1::AsymmetricSignRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency AsymmetricDecrypt(
+  virtual google::cloud::Idempotency AsymmetricDecrypt(
       google::cloud::kms::v1::AsymmetricDecryptRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency MacSign(
+  virtual google::cloud::Idempotency MacSign(
       google::cloud::kms::v1::MacSignRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency MacVerify(
+  virtual google::cloud::Idempotency MacVerify(
       google::cloud::kms::v1::MacVerifyRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency GenerateRandomBytes(
+  virtual google::cloud::Idempotency GenerateRandomBytes(
       google::cloud::kms::v1::GenerateRandomBytesRequest const& request) = 0;
 };
 

--- a/google/cloud/logging/logging_service_v2_connection_idempotency_policy.cc
+++ b/google/cloud/logging/logging_service_v2_connection_idempotency_policy.cc
@@ -25,7 +25,7 @@ namespace cloud {
 namespace logging {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-using ::google::cloud::internal::Idempotency;
+using ::google::cloud::Idempotency;
 
 LoggingServiceV2ConnectionIdempotencyPolicy::
     ~LoggingServiceV2ConnectionIdempotencyPolicy() = default;

--- a/google/cloud/logging/logging_service_v2_connection_idempotency_policy.h
+++ b/google/cloud/logging/logging_service_v2_connection_idempotency_policy.h
@@ -19,8 +19,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_LOGGING_LOGGING_SERVICE_V2_CONNECTION_IDEMPOTENCY_POLICY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_LOGGING_LOGGING_SERVICE_V2_CONNECTION_IDEMPOTENCY_POLICY_H
 
+#include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
-#include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include <google/logging/v2/logging.grpc.pb.h>
 #include <memory>
@@ -38,19 +38,19 @@ class LoggingServiceV2ConnectionIdempotencyPolicy {
   virtual std::unique_ptr<LoggingServiceV2ConnectionIdempotencyPolicy> clone()
       const = 0;
 
-  virtual google::cloud::internal::Idempotency DeleteLog(
+  virtual google::cloud::Idempotency DeleteLog(
       google::logging::v2::DeleteLogRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency WriteLogEntries(
+  virtual google::cloud::Idempotency WriteLogEntries(
       google::logging::v2::WriteLogEntriesRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency ListLogEntries(
+  virtual google::cloud::Idempotency ListLogEntries(
       google::logging::v2::ListLogEntriesRequest request) = 0;
 
-  virtual google::cloud::internal::Idempotency ListMonitoredResourceDescriptors(
+  virtual google::cloud::Idempotency ListMonitoredResourceDescriptors(
       google::logging::v2::ListMonitoredResourceDescriptorsRequest request) = 0;
 
-  virtual google::cloud::internal::Idempotency ListLogs(
+  virtual google::cloud::Idempotency ListLogs(
       google::logging::v2::ListLogsRequest request) = 0;
 };
 

--- a/google/cloud/networkmanagement/reachability_connection_idempotency_policy.cc
+++ b/google/cloud/networkmanagement/reachability_connection_idempotency_policy.cc
@@ -25,7 +25,7 @@ namespace cloud {
 namespace networkmanagement {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-using ::google::cloud::internal::Idempotency;
+using ::google::cloud::Idempotency;
 
 ReachabilityServiceConnectionIdempotencyPolicy::
     ~ReachabilityServiceConnectionIdempotencyPolicy() = default;

--- a/google/cloud/networkmanagement/reachability_connection_idempotency_policy.h
+++ b/google/cloud/networkmanagement/reachability_connection_idempotency_policy.h
@@ -19,9 +19,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_NETWORKMANAGEMENT_REACHABILITY_CONNECTION_IDEMPOTENCY_POLICY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_NETWORKMANAGEMENT_REACHABILITY_CONNECTION_IDEMPOTENCY_POLICY_H
 
-#include "google/cloud/future.h"
+#include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
-#include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include <google/cloud/networkmanagement/v1/reachability.grpc.pb.h>
 #include <memory>
@@ -39,27 +38,27 @@ class ReachabilityServiceConnectionIdempotencyPolicy {
   virtual std::unique_ptr<ReachabilityServiceConnectionIdempotencyPolicy>
   clone() const = 0;
 
-  virtual google::cloud::internal::Idempotency ListConnectivityTests(
+  virtual google::cloud::Idempotency ListConnectivityTests(
       google::cloud::networkmanagement::v1::ListConnectivityTestsRequest
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetConnectivityTest(
+  virtual google::cloud::Idempotency GetConnectivityTest(
       google::cloud::networkmanagement::v1::GetConnectivityTestRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency CreateConnectivityTest(
+  virtual google::cloud::Idempotency CreateConnectivityTest(
       google::cloud::networkmanagement::v1::CreateConnectivityTestRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency UpdateConnectivityTest(
+  virtual google::cloud::Idempotency UpdateConnectivityTest(
       google::cloud::networkmanagement::v1::UpdateConnectivityTestRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency RerunConnectivityTest(
+  virtual google::cloud::Idempotency RerunConnectivityTest(
       google::cloud::networkmanagement::v1::RerunConnectivityTestRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency DeleteConnectivityTest(
+  virtual google::cloud::Idempotency DeleteConnectivityTest(
       google::cloud::networkmanagement::v1::DeleteConnectivityTestRequest const&
           request) = 0;
 };

--- a/google/cloud/notebooks/managed_notebook_connection_idempotency_policy.cc
+++ b/google/cloud/notebooks/managed_notebook_connection_idempotency_policy.cc
@@ -25,7 +25,7 @@ namespace cloud {
 namespace notebooks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-using ::google::cloud::internal::Idempotency;
+using ::google::cloud::Idempotency;
 
 ManagedNotebookServiceConnectionIdempotencyPolicy::
     ~ManagedNotebookServiceConnectionIdempotencyPolicy() = default;

--- a/google/cloud/notebooks/managed_notebook_connection_idempotency_policy.h
+++ b/google/cloud/notebooks/managed_notebook_connection_idempotency_policy.h
@@ -19,9 +19,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_NOTEBOOKS_MANAGED_NOTEBOOK_CONNECTION_IDEMPOTENCY_POLICY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_NOTEBOOKS_MANAGED_NOTEBOOK_CONNECTION_IDEMPOTENCY_POLICY_H
 
-#include "google/cloud/future.h"
+#include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
-#include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include <google/cloud/notebooks/v1/managed_service.grpc.pb.h>
 #include <memory>
@@ -39,31 +38,31 @@ class ManagedNotebookServiceConnectionIdempotencyPolicy {
   virtual std::unique_ptr<ManagedNotebookServiceConnectionIdempotencyPolicy>
   clone() const = 0;
 
-  virtual google::cloud::internal::Idempotency ListRuntimes(
+  virtual google::cloud::Idempotency ListRuntimes(
       google::cloud::notebooks::v1::ListRuntimesRequest request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetRuntime(
+  virtual google::cloud::Idempotency GetRuntime(
       google::cloud::notebooks::v1::GetRuntimeRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency CreateRuntime(
+  virtual google::cloud::Idempotency CreateRuntime(
       google::cloud::notebooks::v1::CreateRuntimeRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency DeleteRuntime(
+  virtual google::cloud::Idempotency DeleteRuntime(
       google::cloud::notebooks::v1::DeleteRuntimeRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency StartRuntime(
+  virtual google::cloud::Idempotency StartRuntime(
       google::cloud::notebooks::v1::StartRuntimeRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency StopRuntime(
+  virtual google::cloud::Idempotency StopRuntime(
       google::cloud::notebooks::v1::StopRuntimeRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency SwitchRuntime(
+  virtual google::cloud::Idempotency SwitchRuntime(
       google::cloud::notebooks::v1::SwitchRuntimeRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency ResetRuntime(
+  virtual google::cloud::Idempotency ResetRuntime(
       google::cloud::notebooks::v1::ResetRuntimeRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency ReportRuntimeEvent(
+  virtual google::cloud::Idempotency ReportRuntimeEvent(
       google::cloud::notebooks::v1::ReportRuntimeEventRequest const&
           request) = 0;
 };

--- a/google/cloud/notebooks/notebook_connection_idempotency_policy.cc
+++ b/google/cloud/notebooks/notebook_connection_idempotency_policy.cc
@@ -25,7 +25,7 @@ namespace cloud {
 namespace notebooks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-using ::google::cloud::internal::Idempotency;
+using ::google::cloud::Idempotency;
 
 NotebookServiceConnectionIdempotencyPolicy::
     ~NotebookServiceConnectionIdempotencyPolicy() = default;

--- a/google/cloud/notebooks/notebook_connection_idempotency_policy.h
+++ b/google/cloud/notebooks/notebook_connection_idempotency_policy.h
@@ -19,9 +19,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_NOTEBOOKS_NOTEBOOK_CONNECTION_IDEMPOTENCY_POLICY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_NOTEBOOKS_NOTEBOOK_CONNECTION_IDEMPOTENCY_POLICY_H
 
-#include "google/cloud/future.h"
+#include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
-#include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include <google/cloud/notebooks/v1/service.grpc.pb.h>
 #include <memory>
@@ -39,111 +38,111 @@ class NotebookServiceConnectionIdempotencyPolicy {
   virtual std::unique_ptr<NotebookServiceConnectionIdempotencyPolicy> clone()
       const = 0;
 
-  virtual google::cloud::internal::Idempotency ListInstances(
+  virtual google::cloud::Idempotency ListInstances(
       google::cloud::notebooks::v1::ListInstancesRequest request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetInstance(
+  virtual google::cloud::Idempotency GetInstance(
       google::cloud::notebooks::v1::GetInstanceRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency CreateInstance(
+  virtual google::cloud::Idempotency CreateInstance(
       google::cloud::notebooks::v1::CreateInstanceRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency RegisterInstance(
+  virtual google::cloud::Idempotency RegisterInstance(
       google::cloud::notebooks::v1::RegisterInstanceRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency SetInstanceAccelerator(
+  virtual google::cloud::Idempotency SetInstanceAccelerator(
       google::cloud::notebooks::v1::SetInstanceAcceleratorRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency SetInstanceMachineType(
+  virtual google::cloud::Idempotency SetInstanceMachineType(
       google::cloud::notebooks::v1::SetInstanceMachineTypeRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency UpdateInstanceConfig(
+  virtual google::cloud::Idempotency UpdateInstanceConfig(
       google::cloud::notebooks::v1::UpdateInstanceConfigRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency UpdateShieldedInstanceConfig(
+  virtual google::cloud::Idempotency UpdateShieldedInstanceConfig(
       google::cloud::notebooks::v1::UpdateShieldedInstanceConfigRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency SetInstanceLabels(
+  virtual google::cloud::Idempotency SetInstanceLabels(
       google::cloud::notebooks::v1::SetInstanceLabelsRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency DeleteInstance(
+  virtual google::cloud::Idempotency DeleteInstance(
       google::cloud::notebooks::v1::DeleteInstanceRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency StartInstance(
+  virtual google::cloud::Idempotency StartInstance(
       google::cloud::notebooks::v1::StartInstanceRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency StopInstance(
+  virtual google::cloud::Idempotency StopInstance(
       google::cloud::notebooks::v1::StopInstanceRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency ResetInstance(
+  virtual google::cloud::Idempotency ResetInstance(
       google::cloud::notebooks::v1::ResetInstanceRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency ReportInstanceInfo(
+  virtual google::cloud::Idempotency ReportInstanceInfo(
       google::cloud::notebooks::v1::ReportInstanceInfoRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency IsInstanceUpgradeable(
+  virtual google::cloud::Idempotency IsInstanceUpgradeable(
       google::cloud::notebooks::v1::IsInstanceUpgradeableRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetInstanceHealth(
+  virtual google::cloud::Idempotency GetInstanceHealth(
       google::cloud::notebooks::v1::GetInstanceHealthRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency UpgradeInstance(
+  virtual google::cloud::Idempotency UpgradeInstance(
       google::cloud::notebooks::v1::UpgradeInstanceRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency RollbackInstance(
+  virtual google::cloud::Idempotency RollbackInstance(
       google::cloud::notebooks::v1::RollbackInstanceRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency UpgradeInstanceInternal(
+  virtual google::cloud::Idempotency UpgradeInstanceInternal(
       google::cloud::notebooks::v1::UpgradeInstanceInternalRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency ListEnvironments(
+  virtual google::cloud::Idempotency ListEnvironments(
       google::cloud::notebooks::v1::ListEnvironmentsRequest request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetEnvironment(
+  virtual google::cloud::Idempotency GetEnvironment(
       google::cloud::notebooks::v1::GetEnvironmentRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency CreateEnvironment(
+  virtual google::cloud::Idempotency CreateEnvironment(
       google::cloud::notebooks::v1::CreateEnvironmentRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency DeleteEnvironment(
+  virtual google::cloud::Idempotency DeleteEnvironment(
       google::cloud::notebooks::v1::DeleteEnvironmentRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency ListSchedules(
+  virtual google::cloud::Idempotency ListSchedules(
       google::cloud::notebooks::v1::ListSchedulesRequest request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetSchedule(
+  virtual google::cloud::Idempotency GetSchedule(
       google::cloud::notebooks::v1::GetScheduleRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency DeleteSchedule(
+  virtual google::cloud::Idempotency DeleteSchedule(
       google::cloud::notebooks::v1::DeleteScheduleRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency CreateSchedule(
+  virtual google::cloud::Idempotency CreateSchedule(
       google::cloud::notebooks::v1::CreateScheduleRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency TriggerSchedule(
+  virtual google::cloud::Idempotency TriggerSchedule(
       google::cloud::notebooks::v1::TriggerScheduleRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency ListExecutions(
+  virtual google::cloud::Idempotency ListExecutions(
       google::cloud::notebooks::v1::ListExecutionsRequest request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetExecution(
+  virtual google::cloud::Idempotency GetExecution(
       google::cloud::notebooks::v1::GetExecutionRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency DeleteExecution(
+  virtual google::cloud::Idempotency DeleteExecution(
       google::cloud::notebooks::v1::DeleteExecutionRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency CreateExecution(
+  virtual google::cloud::Idempotency CreateExecution(
       google::cloud::notebooks::v1::CreateExecutionRequest const& request) = 0;
 };
 

--- a/google/cloud/orgpolicy/org_policy_connection_idempotency_policy.cc
+++ b/google/cloud/orgpolicy/org_policy_connection_idempotency_policy.cc
@@ -25,7 +25,7 @@ namespace cloud {
 namespace orgpolicy {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-using ::google::cloud::internal::Idempotency;
+using ::google::cloud::Idempotency;
 
 OrgPolicyConnectionIdempotencyPolicy::~OrgPolicyConnectionIdempotencyPolicy() =
     default;

--- a/google/cloud/orgpolicy/org_policy_connection_idempotency_policy.h
+++ b/google/cloud/orgpolicy/org_policy_connection_idempotency_policy.h
@@ -19,8 +19,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_ORGPOLICY_ORG_POLICY_CONNECTION_IDEMPOTENCY_POLICY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_ORGPOLICY_ORG_POLICY_CONNECTION_IDEMPOTENCY_POLICY_H
 
+#include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
-#include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include <google/cloud/orgpolicy/v2/orgpolicy.grpc.pb.h>
 #include <memory>
@@ -38,26 +38,26 @@ class OrgPolicyConnectionIdempotencyPolicy {
   virtual std::unique_ptr<OrgPolicyConnectionIdempotencyPolicy> clone()
       const = 0;
 
-  virtual google::cloud::internal::Idempotency ListConstraints(
+  virtual google::cloud::Idempotency ListConstraints(
       google::cloud::orgpolicy::v2::ListConstraintsRequest request) = 0;
 
-  virtual google::cloud::internal::Idempotency ListPolicies(
+  virtual google::cloud::Idempotency ListPolicies(
       google::cloud::orgpolicy::v2::ListPoliciesRequest request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetPolicy(
+  virtual google::cloud::Idempotency GetPolicy(
       google::cloud::orgpolicy::v2::GetPolicyRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetEffectivePolicy(
+  virtual google::cloud::Idempotency GetEffectivePolicy(
       google::cloud::orgpolicy::v2::GetEffectivePolicyRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency CreatePolicy(
+  virtual google::cloud::Idempotency CreatePolicy(
       google::cloud::orgpolicy::v2::CreatePolicyRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency UpdatePolicy(
+  virtual google::cloud::Idempotency UpdatePolicy(
       google::cloud::orgpolicy::v2::UpdatePolicyRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency DeletePolicy(
+  virtual google::cloud::Idempotency DeletePolicy(
       google::cloud::orgpolicy::v2::DeletePolicyRequest const& request) = 0;
 };
 

--- a/google/cloud/oslogin/os_login_connection_idempotency_policy.cc
+++ b/google/cloud/oslogin/os_login_connection_idempotency_policy.cc
@@ -25,7 +25,7 @@ namespace cloud {
 namespace oslogin {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-using ::google::cloud::internal::Idempotency;
+using ::google::cloud::Idempotency;
 
 OsLoginServiceConnectionIdempotencyPolicy::
     ~OsLoginServiceConnectionIdempotencyPolicy() = default;

--- a/google/cloud/oslogin/os_login_connection_idempotency_policy.h
+++ b/google/cloud/oslogin/os_login_connection_idempotency_policy.h
@@ -19,8 +19,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_OSLOGIN_OS_LOGIN_CONNECTION_IDEMPOTENCY_POLICY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_OSLOGIN_OS_LOGIN_CONNECTION_IDEMPOTENCY_POLICY_H
 
+#include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
-#include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include <google/cloud/oslogin/v1/oslogin.grpc.pb.h>
 #include <memory>
@@ -38,22 +38,22 @@ class OsLoginServiceConnectionIdempotencyPolicy {
   virtual std::unique_ptr<OsLoginServiceConnectionIdempotencyPolicy> clone()
       const = 0;
 
-  virtual google::cloud::internal::Idempotency DeletePosixAccount(
+  virtual google::cloud::Idempotency DeletePosixAccount(
       google::cloud::oslogin::v1::DeletePosixAccountRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency DeleteSshPublicKey(
+  virtual google::cloud::Idempotency DeleteSshPublicKey(
       google::cloud::oslogin::v1::DeleteSshPublicKeyRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetLoginProfile(
+  virtual google::cloud::Idempotency GetLoginProfile(
       google::cloud::oslogin::v1::GetLoginProfileRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetSshPublicKey(
+  virtual google::cloud::Idempotency GetSshPublicKey(
       google::cloud::oslogin::v1::GetSshPublicKeyRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency ImportSshPublicKey(
+  virtual google::cloud::Idempotency ImportSshPublicKey(
       google::cloud::oslogin::v1::ImportSshPublicKeyRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency UpdateSshPublicKey(
+  virtual google::cloud::Idempotency UpdateSshPublicKey(
       google::cloud::oslogin::v1::UpdateSshPublicKeyRequest const& request) = 0;
 };
 

--- a/google/cloud/policytroubleshooter/iam_checker_connection_idempotency_policy.cc
+++ b/google/cloud/policytroubleshooter/iam_checker_connection_idempotency_policy.cc
@@ -25,7 +25,7 @@ namespace cloud {
 namespace policytroubleshooter {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-using ::google::cloud::internal::Idempotency;
+using ::google::cloud::Idempotency;
 
 IamCheckerConnectionIdempotencyPolicy::
     ~IamCheckerConnectionIdempotencyPolicy() = default;

--- a/google/cloud/policytroubleshooter/iam_checker_connection_idempotency_policy.h
+++ b/google/cloud/policytroubleshooter/iam_checker_connection_idempotency_policy.h
@@ -19,8 +19,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_POLICYTROUBLESHOOTER_IAM_CHECKER_CONNECTION_IDEMPOTENCY_POLICY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_POLICYTROUBLESHOOTER_IAM_CHECKER_CONNECTION_IDEMPOTENCY_POLICY_H
 
+#include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
-#include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include <google/cloud/policytroubleshooter/v1/checker.grpc.pb.h>
 #include <memory>
@@ -38,7 +38,7 @@ class IamCheckerConnectionIdempotencyPolicy {
   virtual std::unique_ptr<IamCheckerConnectionIdempotencyPolicy> clone()
       const = 0;
 
-  virtual google::cloud::internal::Idempotency TroubleshootIamPolicy(
+  virtual google::cloud::Idempotency TroubleshootIamPolicy(
       google::cloud::policytroubleshooter::v1::
           TroubleshootIamPolicyRequest const& request) = 0;
 };

--- a/google/cloud/privateca/certificate_authority_connection_idempotency_policy.cc
+++ b/google/cloud/privateca/certificate_authority_connection_idempotency_policy.cc
@@ -25,7 +25,7 @@ namespace cloud {
 namespace privateca {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-using ::google::cloud::internal::Idempotency;
+using ::google::cloud::Idempotency;
 
 CertificateAuthorityServiceConnectionIdempotencyPolicy::
     ~CertificateAuthorityServiceConnectionIdempotencyPolicy() = default;

--- a/google/cloud/privateca/certificate_authority_connection_idempotency_policy.h
+++ b/google/cloud/privateca/certificate_authority_connection_idempotency_policy.h
@@ -19,9 +19,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PRIVATECA_CERTIFICATE_AUTHORITY_CONNECTION_IDEMPOTENCY_POLICY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PRIVATECA_CERTIFICATE_AUTHORITY_CONNECTION_IDEMPOTENCY_POLICY_H
 
-#include "google/cloud/future.h"
+#include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
-#include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include <google/cloud/security/privateca/v1/service.grpc.pb.h>
 #include <memory>
@@ -40,118 +39,118 @@ class CertificateAuthorityServiceConnectionIdempotencyPolicy {
       CertificateAuthorityServiceConnectionIdempotencyPolicy>
   clone() const = 0;
 
-  virtual google::cloud::internal::Idempotency CreateCertificate(
+  virtual google::cloud::Idempotency CreateCertificate(
       google::cloud::security::privateca::v1::CreateCertificateRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetCertificate(
+  virtual google::cloud::Idempotency GetCertificate(
       google::cloud::security::privateca::v1::GetCertificateRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency ListCertificates(
+  virtual google::cloud::Idempotency ListCertificates(
       google::cloud::security::privateca::v1::ListCertificatesRequest
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency RevokeCertificate(
+  virtual google::cloud::Idempotency RevokeCertificate(
       google::cloud::security::privateca::v1::RevokeCertificateRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency UpdateCertificate(
+  virtual google::cloud::Idempotency UpdateCertificate(
       google::cloud::security::privateca::v1::UpdateCertificateRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency ActivateCertificateAuthority(
+  virtual google::cloud::Idempotency ActivateCertificateAuthority(
       google::cloud::security::privateca::v1::
           ActivateCertificateAuthorityRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency CreateCertificateAuthority(
+  virtual google::cloud::Idempotency CreateCertificateAuthority(
       google::cloud::security::privateca::v1::
           CreateCertificateAuthorityRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency DisableCertificateAuthority(
+  virtual google::cloud::Idempotency DisableCertificateAuthority(
       google::cloud::security::privateca::v1::
           DisableCertificateAuthorityRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency EnableCertificateAuthority(
+  virtual google::cloud::Idempotency EnableCertificateAuthority(
       google::cloud::security::privateca::v1::
           EnableCertificateAuthorityRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency FetchCertificateAuthorityCsr(
+  virtual google::cloud::Idempotency FetchCertificateAuthorityCsr(
       google::cloud::security::privateca::v1::
           FetchCertificateAuthorityCsrRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetCertificateAuthority(
+  virtual google::cloud::Idempotency GetCertificateAuthority(
       google::cloud::security::privateca::v1::
           GetCertificateAuthorityRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency ListCertificateAuthorities(
+  virtual google::cloud::Idempotency ListCertificateAuthorities(
       google::cloud::security::privateca::v1::ListCertificateAuthoritiesRequest
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency UndeleteCertificateAuthority(
+  virtual google::cloud::Idempotency UndeleteCertificateAuthority(
       google::cloud::security::privateca::v1::
           UndeleteCertificateAuthorityRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency DeleteCertificateAuthority(
+  virtual google::cloud::Idempotency DeleteCertificateAuthority(
       google::cloud::security::privateca::v1::
           DeleteCertificateAuthorityRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency UpdateCertificateAuthority(
+  virtual google::cloud::Idempotency UpdateCertificateAuthority(
       google::cloud::security::privateca::v1::
           UpdateCertificateAuthorityRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency CreateCaPool(
+  virtual google::cloud::Idempotency CreateCaPool(
       google::cloud::security::privateca::v1::CreateCaPoolRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency UpdateCaPool(
+  virtual google::cloud::Idempotency UpdateCaPool(
       google::cloud::security::privateca::v1::UpdateCaPoolRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetCaPool(
+  virtual google::cloud::Idempotency GetCaPool(
       google::cloud::security::privateca::v1::GetCaPoolRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency ListCaPools(
+  virtual google::cloud::Idempotency ListCaPools(
       google::cloud::security::privateca::v1::ListCaPoolsRequest request) = 0;
 
-  virtual google::cloud::internal::Idempotency DeleteCaPool(
+  virtual google::cloud::Idempotency DeleteCaPool(
       google::cloud::security::privateca::v1::DeleteCaPoolRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency FetchCaCerts(
+  virtual google::cloud::Idempotency FetchCaCerts(
       google::cloud::security::privateca::v1::FetchCaCertsRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetCertificateRevocationList(
+  virtual google::cloud::Idempotency GetCertificateRevocationList(
       google::cloud::security::privateca::v1::
           GetCertificateRevocationListRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency ListCertificateRevocationLists(
+  virtual google::cloud::Idempotency ListCertificateRevocationLists(
       google::cloud::security::privateca::v1::
           ListCertificateRevocationListsRequest request) = 0;
 
-  virtual google::cloud::internal::Idempotency UpdateCertificateRevocationList(
+  virtual google::cloud::Idempotency UpdateCertificateRevocationList(
       google::cloud::security::privateca::v1::
           UpdateCertificateRevocationListRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency CreateCertificateTemplate(
+  virtual google::cloud::Idempotency CreateCertificateTemplate(
       google::cloud::security::privateca::v1::
           CreateCertificateTemplateRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency DeleteCertificateTemplate(
+  virtual google::cloud::Idempotency DeleteCertificateTemplate(
       google::cloud::security::privateca::v1::
           DeleteCertificateTemplateRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetCertificateTemplate(
+  virtual google::cloud::Idempotency GetCertificateTemplate(
       google::cloud::security::privateca::v1::
           GetCertificateTemplateRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency ListCertificateTemplates(
+  virtual google::cloud::Idempotency ListCertificateTemplates(
       google::cloud::security::privateca::v1::ListCertificateTemplatesRequest
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency UpdateCertificateTemplate(
+  virtual google::cloud::Idempotency UpdateCertificateTemplate(
       google::cloud::security::privateca::v1::
           UpdateCertificateTemplateRequest const& request) = 0;
 };

--- a/google/cloud/pubsub/internal/default_batch_sink.cc
+++ b/google/cloud/pubsub/internal/default_batch_sink.cc
@@ -33,7 +33,7 @@ DefaultBatchSink::AsyncPublish(google::pubsub::v1::PublishRequest request) {
   auto& stub = stub_;
   return internal::AsyncRetryLoop(
       retry_policy_->clone(), backoff_policy_->clone(),
-      internal::Idempotency::kIdempotent, cq_,
+      Idempotency::kIdempotent, cq_,
       [stub](CompletionQueue& cq, std::unique_ptr<grpc::ClientContext> context,
              google::pubsub::v1::PublishRequest const& request) {
         return stub->AsyncPublish(cq, std::move(context), request);

--- a/google/cloud/pubsub/schema_admin_connection.cc
+++ b/google/cloud/pubsub/schema_admin_connection.cc
@@ -30,7 +30,7 @@ namespace pubsub {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
-using ::google::cloud::internal::Idempotency;
+using ::google::cloud::Idempotency;
 using ::google::cloud::internal::RetryLoop;
 
 class SchemaAdminConnectionImpl : public pubsub::SchemaAdminConnection {

--- a/google/cloud/pubsub/subscription_admin_connection.cc
+++ b/google/cloud/pubsub/subscription_admin_connection.cc
@@ -29,7 +29,7 @@ namespace pubsub {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
-using ::google::cloud::internal::Idempotency;
+using ::google::cloud::Idempotency;
 using ::google::cloud::internal::RetryLoop;
 
 class SubscriptionAdminConnectionImpl

--- a/google/cloud/pubsub/topic_admin_connection.cc
+++ b/google/cloud/pubsub/topic_admin_connection.cc
@@ -32,7 +32,7 @@ namespace pubsub {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
-using ::google::cloud::internal::Idempotency;
+using ::google::cloud::Idempotency;
 using ::google::cloud::internal::RetryLoop;
 
 class TopicAdminConnectionImpl : public pubsub::TopicAdminConnection {

--- a/google/cloud/pubsublite/admin_connection_idempotency_policy.cc
+++ b/google/cloud/pubsublite/admin_connection_idempotency_policy.cc
@@ -25,7 +25,7 @@ namespace cloud {
 namespace pubsublite {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-using ::google::cloud::internal::Idempotency;
+using ::google::cloud::Idempotency;
 
 AdminServiceConnectionIdempotencyPolicy::
     ~AdminServiceConnectionIdempotencyPolicy() = default;

--- a/google/cloud/pubsublite/admin_connection_idempotency_policy.h
+++ b/google/cloud/pubsublite/admin_connection_idempotency_policy.h
@@ -19,9 +19,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PUBSUBLITE_ADMIN_CONNECTION_IDEMPOTENCY_POLICY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PUBSUBLITE_ADMIN_CONNECTION_IDEMPOTENCY_POLICY_H
 
-#include "google/cloud/future.h"
+#include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
-#include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include <google/cloud/pubsublite/v1/admin.grpc.pb.h>
 #include <memory>
@@ -39,69 +38,69 @@ class AdminServiceConnectionIdempotencyPolicy {
   virtual std::unique_ptr<AdminServiceConnectionIdempotencyPolicy> clone()
       const = 0;
 
-  virtual google::cloud::internal::Idempotency CreateTopic(
+  virtual google::cloud::Idempotency CreateTopic(
       google::cloud::pubsublite::v1::CreateTopicRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetTopic(
+  virtual google::cloud::Idempotency GetTopic(
       google::cloud::pubsublite::v1::GetTopicRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetTopicPartitions(
+  virtual google::cloud::Idempotency GetTopicPartitions(
       google::cloud::pubsublite::v1::GetTopicPartitionsRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency ListTopics(
+  virtual google::cloud::Idempotency ListTopics(
       google::cloud::pubsublite::v1::ListTopicsRequest request) = 0;
 
-  virtual google::cloud::internal::Idempotency UpdateTopic(
+  virtual google::cloud::Idempotency UpdateTopic(
       google::cloud::pubsublite::v1::UpdateTopicRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency DeleteTopic(
+  virtual google::cloud::Idempotency DeleteTopic(
       google::cloud::pubsublite::v1::DeleteTopicRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency ListTopicSubscriptions(
+  virtual google::cloud::Idempotency ListTopicSubscriptions(
       google::cloud::pubsublite::v1::ListTopicSubscriptionsRequest request) = 0;
 
-  virtual google::cloud::internal::Idempotency CreateSubscription(
+  virtual google::cloud::Idempotency CreateSubscription(
       google::cloud::pubsublite::v1::CreateSubscriptionRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetSubscription(
+  virtual google::cloud::Idempotency GetSubscription(
       google::cloud::pubsublite::v1::GetSubscriptionRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency ListSubscriptions(
+  virtual google::cloud::Idempotency ListSubscriptions(
       google::cloud::pubsublite::v1::ListSubscriptionsRequest request) = 0;
 
-  virtual google::cloud::internal::Idempotency UpdateSubscription(
+  virtual google::cloud::Idempotency UpdateSubscription(
       google::cloud::pubsublite::v1::UpdateSubscriptionRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency DeleteSubscription(
+  virtual google::cloud::Idempotency DeleteSubscription(
       google::cloud::pubsublite::v1::DeleteSubscriptionRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency SeekSubscription(
+  virtual google::cloud::Idempotency SeekSubscription(
       google::cloud::pubsublite::v1::SeekSubscriptionRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency CreateReservation(
+  virtual google::cloud::Idempotency CreateReservation(
       google::cloud::pubsublite::v1::CreateReservationRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetReservation(
+  virtual google::cloud::Idempotency GetReservation(
       google::cloud::pubsublite::v1::GetReservationRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency ListReservations(
+  virtual google::cloud::Idempotency ListReservations(
       google::cloud::pubsublite::v1::ListReservationsRequest request) = 0;
 
-  virtual google::cloud::internal::Idempotency UpdateReservation(
+  virtual google::cloud::Idempotency UpdateReservation(
       google::cloud::pubsublite::v1::UpdateReservationRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency DeleteReservation(
+  virtual google::cloud::Idempotency DeleteReservation(
       google::cloud::pubsublite::v1::DeleteReservationRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency ListReservationTopics(
+  virtual google::cloud::Idempotency ListReservationTopics(
       google::cloud::pubsublite::v1::ListReservationTopicsRequest request) = 0;
 };
 

--- a/google/cloud/pubsublite/topic_stats_connection_idempotency_policy.cc
+++ b/google/cloud/pubsublite/topic_stats_connection_idempotency_policy.cc
@@ -25,7 +25,7 @@ namespace cloud {
 namespace pubsublite {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-using ::google::cloud::internal::Idempotency;
+using ::google::cloud::Idempotency;
 
 TopicStatsServiceConnectionIdempotencyPolicy::
     ~TopicStatsServiceConnectionIdempotencyPolicy() = default;

--- a/google/cloud/pubsublite/topic_stats_connection_idempotency_policy.h
+++ b/google/cloud/pubsublite/topic_stats_connection_idempotency_policy.h
@@ -19,8 +19,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PUBSUBLITE_TOPIC_STATS_CONNECTION_IDEMPOTENCY_POLICY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PUBSUBLITE_TOPIC_STATS_CONNECTION_IDEMPOTENCY_POLICY_H
 
+#include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
-#include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include <google/cloud/pubsublite/v1/topic_stats.grpc.pb.h>
 #include <memory>
@@ -38,15 +38,15 @@ class TopicStatsServiceConnectionIdempotencyPolicy {
   virtual std::unique_ptr<TopicStatsServiceConnectionIdempotencyPolicy> clone()
       const = 0;
 
-  virtual google::cloud::internal::Idempotency ComputeMessageStats(
+  virtual google::cloud::Idempotency ComputeMessageStats(
       google::cloud::pubsublite::v1::ComputeMessageStatsRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency ComputeHeadCursor(
+  virtual google::cloud::Idempotency ComputeHeadCursor(
       google::cloud::pubsublite::v1::ComputeHeadCursorRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency ComputeTimeCursor(
+  virtual google::cloud::Idempotency ComputeTimeCursor(
       google::cloud::pubsublite::v1::ComputeTimeCursorRequest const&
           request) = 0;
 };

--- a/google/cloud/recommender/recommender_connection_idempotency_policy.cc
+++ b/google/cloud/recommender/recommender_connection_idempotency_policy.cc
@@ -25,7 +25,7 @@ namespace cloud {
 namespace recommender {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-using ::google::cloud::internal::Idempotency;
+using ::google::cloud::Idempotency;
 
 RecommenderConnectionIdempotencyPolicy::
     ~RecommenderConnectionIdempotencyPolicy() = default;

--- a/google/cloud/recommender/recommender_connection_idempotency_policy.h
+++ b/google/cloud/recommender/recommender_connection_idempotency_policy.h
@@ -19,8 +19,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_RECOMMENDER_RECOMMENDER_CONNECTION_IDEMPOTENCY_POLICY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_RECOMMENDER_RECOMMENDER_CONNECTION_IDEMPOTENCY_POLICY_H
 
+#include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
-#include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include <google/cloud/recommender/v1/recommender_service.grpc.pb.h>
 #include <memory>
@@ -38,32 +38,32 @@ class RecommenderConnectionIdempotencyPolicy {
   virtual std::unique_ptr<RecommenderConnectionIdempotencyPolicy> clone()
       const = 0;
 
-  virtual google::cloud::internal::Idempotency ListInsights(
+  virtual google::cloud::Idempotency ListInsights(
       google::cloud::recommender::v1::ListInsightsRequest request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetInsight(
+  virtual google::cloud::Idempotency GetInsight(
       google::cloud::recommender::v1::GetInsightRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency MarkInsightAccepted(
+  virtual google::cloud::Idempotency MarkInsightAccepted(
       google::cloud::recommender::v1::MarkInsightAcceptedRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency ListRecommendations(
+  virtual google::cloud::Idempotency ListRecommendations(
       google::cloud::recommender::v1::ListRecommendationsRequest request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetRecommendation(
+  virtual google::cloud::Idempotency GetRecommendation(
       google::cloud::recommender::v1::GetRecommendationRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency MarkRecommendationClaimed(
+  virtual google::cloud::Idempotency MarkRecommendationClaimed(
       google::cloud::recommender::v1::MarkRecommendationClaimedRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency MarkRecommendationSucceeded(
+  virtual google::cloud::Idempotency MarkRecommendationSucceeded(
       google::cloud::recommender::v1::MarkRecommendationSucceededRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency MarkRecommendationFailed(
+  virtual google::cloud::Idempotency MarkRecommendationFailed(
       google::cloud::recommender::v1::MarkRecommendationFailedRequest const&
           request) = 0;
 };

--- a/google/cloud/resourcemanager/folders_connection_idempotency_policy.cc
+++ b/google/cloud/resourcemanager/folders_connection_idempotency_policy.cc
@@ -25,7 +25,7 @@ namespace cloud {
 namespace resourcemanager {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-using ::google::cloud::internal::Idempotency;
+using ::google::cloud::Idempotency;
 
 FoldersConnectionIdempotencyPolicy::~FoldersConnectionIdempotencyPolicy() =
     default;

--- a/google/cloud/resourcemanager/folders_connection_idempotency_policy.h
+++ b/google/cloud/resourcemanager/folders_connection_idempotency_policy.h
@@ -19,9 +19,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_RESOURCEMANAGER_FOLDERS_CONNECTION_IDEMPOTENCY_POLICY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_RESOURCEMANAGER_FOLDERS_CONNECTION_IDEMPOTENCY_POLICY_H
 
-#include "google/cloud/future.h"
+#include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
-#include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include <google/cloud/resourcemanager/v3/folders.grpc.pb.h>
 #include <memory>
@@ -38,41 +37,41 @@ class FoldersConnectionIdempotencyPolicy {
   /// Create a new copy of this object.
   virtual std::unique_ptr<FoldersConnectionIdempotencyPolicy> clone() const = 0;
 
-  virtual google::cloud::internal::Idempotency GetFolder(
+  virtual google::cloud::Idempotency GetFolder(
       google::cloud::resourcemanager::v3::GetFolderRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency ListFolders(
+  virtual google::cloud::Idempotency ListFolders(
       google::cloud::resourcemanager::v3::ListFoldersRequest request) = 0;
 
-  virtual google::cloud::internal::Idempotency SearchFolders(
+  virtual google::cloud::Idempotency SearchFolders(
       google::cloud::resourcemanager::v3::SearchFoldersRequest request) = 0;
 
-  virtual google::cloud::internal::Idempotency CreateFolder(
+  virtual google::cloud::Idempotency CreateFolder(
       google::cloud::resourcemanager::v3::CreateFolderRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency UpdateFolder(
+  virtual google::cloud::Idempotency UpdateFolder(
       google::cloud::resourcemanager::v3::UpdateFolderRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency MoveFolder(
+  virtual google::cloud::Idempotency MoveFolder(
       google::cloud::resourcemanager::v3::MoveFolderRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency DeleteFolder(
+  virtual google::cloud::Idempotency DeleteFolder(
       google::cloud::resourcemanager::v3::DeleteFolderRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency UndeleteFolder(
+  virtual google::cloud::Idempotency UndeleteFolder(
       google::cloud::resourcemanager::v3::UndeleteFolderRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetIamPolicy(
+  virtual google::cloud::Idempotency GetIamPolicy(
       google::iam::v1::GetIamPolicyRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency SetIamPolicy(
+  virtual google::cloud::Idempotency SetIamPolicy(
       google::iam::v1::SetIamPolicyRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency TestIamPermissions(
+  virtual google::cloud::Idempotency TestIamPermissions(
       google::iam::v1::TestIamPermissionsRequest const& request) = 0;
 };
 

--- a/google/cloud/resourcemanager/organizations_connection_idempotency_policy.cc
+++ b/google/cloud/resourcemanager/organizations_connection_idempotency_policy.cc
@@ -25,7 +25,7 @@ namespace cloud {
 namespace resourcemanager {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-using ::google::cloud::internal::Idempotency;
+using ::google::cloud::Idempotency;
 
 OrganizationsConnectionIdempotencyPolicy::
     ~OrganizationsConnectionIdempotencyPolicy() = default;

--- a/google/cloud/resourcemanager/organizations_connection_idempotency_policy.h
+++ b/google/cloud/resourcemanager/organizations_connection_idempotency_policy.h
@@ -19,8 +19,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_RESOURCEMANAGER_ORGANIZATIONS_CONNECTION_IDEMPOTENCY_POLICY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_RESOURCEMANAGER_ORGANIZATIONS_CONNECTION_IDEMPOTENCY_POLICY_H
 
+#include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
-#include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include <google/cloud/resourcemanager/v3/organizations.grpc.pb.h>
 #include <memory>
@@ -38,21 +38,21 @@ class OrganizationsConnectionIdempotencyPolicy {
   virtual std::unique_ptr<OrganizationsConnectionIdempotencyPolicy> clone()
       const = 0;
 
-  virtual google::cloud::internal::Idempotency GetOrganization(
+  virtual google::cloud::Idempotency GetOrganization(
       google::cloud::resourcemanager::v3::GetOrganizationRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency SearchOrganizations(
+  virtual google::cloud::Idempotency SearchOrganizations(
       google::cloud::resourcemanager::v3::SearchOrganizationsRequest
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetIamPolicy(
+  virtual google::cloud::Idempotency GetIamPolicy(
       google::iam::v1::GetIamPolicyRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency SetIamPolicy(
+  virtual google::cloud::Idempotency SetIamPolicy(
       google::iam::v1::SetIamPolicyRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency TestIamPermissions(
+  virtual google::cloud::Idempotency TestIamPermissions(
       google::iam::v1::TestIamPermissionsRequest const& request) = 0;
 };
 

--- a/google/cloud/resourcemanager/projects_connection_idempotency_policy.cc
+++ b/google/cloud/resourcemanager/projects_connection_idempotency_policy.cc
@@ -25,7 +25,7 @@ namespace cloud {
 namespace resourcemanager {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-using ::google::cloud::internal::Idempotency;
+using ::google::cloud::Idempotency;
 
 ProjectsConnectionIdempotencyPolicy::~ProjectsConnectionIdempotencyPolicy() =
     default;

--- a/google/cloud/resourcemanager/projects_connection_idempotency_policy.h
+++ b/google/cloud/resourcemanager/projects_connection_idempotency_policy.h
@@ -19,9 +19,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_RESOURCEMANAGER_PROJECTS_CONNECTION_IDEMPOTENCY_POLICY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_RESOURCEMANAGER_PROJECTS_CONNECTION_IDEMPOTENCY_POLICY_H
 
-#include "google/cloud/future.h"
+#include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
-#include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include <google/cloud/resourcemanager/v3/projects.grpc.pb.h>
 #include <memory>
@@ -39,42 +38,42 @@ class ProjectsConnectionIdempotencyPolicy {
   virtual std::unique_ptr<ProjectsConnectionIdempotencyPolicy> clone()
       const = 0;
 
-  virtual google::cloud::internal::Idempotency GetProject(
+  virtual google::cloud::Idempotency GetProject(
       google::cloud::resourcemanager::v3::GetProjectRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency ListProjects(
+  virtual google::cloud::Idempotency ListProjects(
       google::cloud::resourcemanager::v3::ListProjectsRequest request) = 0;
 
-  virtual google::cloud::internal::Idempotency SearchProjects(
+  virtual google::cloud::Idempotency SearchProjects(
       google::cloud::resourcemanager::v3::SearchProjectsRequest request) = 0;
 
-  virtual google::cloud::internal::Idempotency CreateProject(
+  virtual google::cloud::Idempotency CreateProject(
       google::cloud::resourcemanager::v3::CreateProjectRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency UpdateProject(
+  virtual google::cloud::Idempotency UpdateProject(
       google::cloud::resourcemanager::v3::UpdateProjectRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency MoveProject(
+  virtual google::cloud::Idempotency MoveProject(
       google::cloud::resourcemanager::v3::MoveProjectRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency DeleteProject(
+  virtual google::cloud::Idempotency DeleteProject(
       google::cloud::resourcemanager::v3::DeleteProjectRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency UndeleteProject(
+  virtual google::cloud::Idempotency UndeleteProject(
       google::cloud::resourcemanager::v3::UndeleteProjectRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetIamPolicy(
+  virtual google::cloud::Idempotency GetIamPolicy(
       google::iam::v1::GetIamPolicyRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency SetIamPolicy(
+  virtual google::cloud::Idempotency SetIamPolicy(
       google::iam::v1::SetIamPolicyRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency TestIamPermissions(
+  virtual google::cloud::Idempotency TestIamPermissions(
       google::iam::v1::TestIamPermissionsRequest const& request) = 0;
 };
 

--- a/google/cloud/retail/catalog_connection_idempotency_policy.cc
+++ b/google/cloud/retail/catalog_connection_idempotency_policy.cc
@@ -25,7 +25,7 @@ namespace cloud {
 namespace retail {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-using ::google::cloud::internal::Idempotency;
+using ::google::cloud::Idempotency;
 
 CatalogServiceConnectionIdempotencyPolicy::
     ~CatalogServiceConnectionIdempotencyPolicy() = default;

--- a/google/cloud/retail/catalog_connection_idempotency_policy.h
+++ b/google/cloud/retail/catalog_connection_idempotency_policy.h
@@ -19,8 +19,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_RETAIL_CATALOG_CONNECTION_IDEMPOTENCY_POLICY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_RETAIL_CATALOG_CONNECTION_IDEMPOTENCY_POLICY_H
 
+#include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
-#include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include <google/cloud/retail/v2/catalog_service.grpc.pb.h>
 #include <memory>
@@ -38,16 +38,16 @@ class CatalogServiceConnectionIdempotencyPolicy {
   virtual std::unique_ptr<CatalogServiceConnectionIdempotencyPolicy> clone()
       const = 0;
 
-  virtual google::cloud::internal::Idempotency ListCatalogs(
+  virtual google::cloud::Idempotency ListCatalogs(
       google::cloud::retail::v2::ListCatalogsRequest request) = 0;
 
-  virtual google::cloud::internal::Idempotency UpdateCatalog(
+  virtual google::cloud::Idempotency UpdateCatalog(
       google::cloud::retail::v2::UpdateCatalogRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency SetDefaultBranch(
+  virtual google::cloud::Idempotency SetDefaultBranch(
       google::cloud::retail::v2::SetDefaultBranchRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetDefaultBranch(
+  virtual google::cloud::Idempotency GetDefaultBranch(
       google::cloud::retail::v2::GetDefaultBranchRequest const& request) = 0;
 };
 

--- a/google/cloud/retail/completion_connection_idempotency_policy.cc
+++ b/google/cloud/retail/completion_connection_idempotency_policy.cc
@@ -25,7 +25,7 @@ namespace cloud {
 namespace retail {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-using ::google::cloud::internal::Idempotency;
+using ::google::cloud::Idempotency;
 
 CompletionServiceConnectionIdempotencyPolicy::
     ~CompletionServiceConnectionIdempotencyPolicy() = default;

--- a/google/cloud/retail/completion_connection_idempotency_policy.h
+++ b/google/cloud/retail/completion_connection_idempotency_policy.h
@@ -19,9 +19,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_RETAIL_COMPLETION_CONNECTION_IDEMPOTENCY_POLICY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_RETAIL_COMPLETION_CONNECTION_IDEMPOTENCY_POLICY_H
 
-#include "google/cloud/future.h"
+#include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
-#include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include <google/cloud/retail/v2/completion_service.grpc.pb.h>
 #include <memory>
@@ -39,10 +38,10 @@ class CompletionServiceConnectionIdempotencyPolicy {
   virtual std::unique_ptr<CompletionServiceConnectionIdempotencyPolicy> clone()
       const = 0;
 
-  virtual google::cloud::internal::Idempotency CompleteQuery(
+  virtual google::cloud::Idempotency CompleteQuery(
       google::cloud::retail::v2::CompleteQueryRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency ImportCompletionData(
+  virtual google::cloud::Idempotency ImportCompletionData(
       google::cloud::retail::v2::ImportCompletionDataRequest const&
           request) = 0;
 };

--- a/google/cloud/retail/prediction_connection_idempotency_policy.cc
+++ b/google/cloud/retail/prediction_connection_idempotency_policy.cc
@@ -25,7 +25,7 @@ namespace cloud {
 namespace retail {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-using ::google::cloud::internal::Idempotency;
+using ::google::cloud::Idempotency;
 
 PredictionServiceConnectionIdempotencyPolicy::
     ~PredictionServiceConnectionIdempotencyPolicy() = default;

--- a/google/cloud/retail/prediction_connection_idempotency_policy.h
+++ b/google/cloud/retail/prediction_connection_idempotency_policy.h
@@ -19,8 +19,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_RETAIL_PREDICTION_CONNECTION_IDEMPOTENCY_POLICY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_RETAIL_PREDICTION_CONNECTION_IDEMPOTENCY_POLICY_H
 
+#include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
-#include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include <google/cloud/retail/v2/prediction_service.grpc.pb.h>
 #include <memory>
@@ -38,7 +38,7 @@ class PredictionServiceConnectionIdempotencyPolicy {
   virtual std::unique_ptr<PredictionServiceConnectionIdempotencyPolicy> clone()
       const = 0;
 
-  virtual google::cloud::internal::Idempotency Predict(
+  virtual google::cloud::Idempotency Predict(
       google::cloud::retail::v2::PredictRequest const& request) = 0;
 };
 

--- a/google/cloud/retail/product_connection_idempotency_policy.cc
+++ b/google/cloud/retail/product_connection_idempotency_policy.cc
@@ -25,7 +25,7 @@ namespace cloud {
 namespace retail {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-using ::google::cloud::internal::Idempotency;
+using ::google::cloud::Idempotency;
 
 ProductServiceConnectionIdempotencyPolicy::
     ~ProductServiceConnectionIdempotencyPolicy() = default;

--- a/google/cloud/retail/product_connection_idempotency_policy.h
+++ b/google/cloud/retail/product_connection_idempotency_policy.h
@@ -19,9 +19,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_RETAIL_PRODUCT_CONNECTION_IDEMPOTENCY_POLICY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_RETAIL_PRODUCT_CONNECTION_IDEMPOTENCY_POLICY_H
 
-#include "google/cloud/future.h"
+#include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
-#include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include <google/cloud/retail/v2/product_service.grpc.pb.h>
 #include <memory>
@@ -39,32 +38,32 @@ class ProductServiceConnectionIdempotencyPolicy {
   virtual std::unique_ptr<ProductServiceConnectionIdempotencyPolicy> clone()
       const = 0;
 
-  virtual google::cloud::internal::Idempotency CreateProduct(
+  virtual google::cloud::Idempotency CreateProduct(
       google::cloud::retail::v2::CreateProductRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetProduct(
+  virtual google::cloud::Idempotency GetProduct(
       google::cloud::retail::v2::GetProductRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency ListProducts(
+  virtual google::cloud::Idempotency ListProducts(
       google::cloud::retail::v2::ListProductsRequest request) = 0;
 
-  virtual google::cloud::internal::Idempotency UpdateProduct(
+  virtual google::cloud::Idempotency UpdateProduct(
       google::cloud::retail::v2::UpdateProductRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency DeleteProduct(
+  virtual google::cloud::Idempotency DeleteProduct(
       google::cloud::retail::v2::DeleteProductRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency ImportProducts(
+  virtual google::cloud::Idempotency ImportProducts(
       google::cloud::retail::v2::ImportProductsRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency SetInventory(
+  virtual google::cloud::Idempotency SetInventory(
       google::cloud::retail::v2::SetInventoryRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency AddFulfillmentPlaces(
+  virtual google::cloud::Idempotency AddFulfillmentPlaces(
       google::cloud::retail::v2::AddFulfillmentPlacesRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency RemoveFulfillmentPlaces(
+  virtual google::cloud::Idempotency RemoveFulfillmentPlaces(
       google::cloud::retail::v2::RemoveFulfillmentPlacesRequest const&
           request) = 0;
 };

--- a/google/cloud/retail/search_connection_idempotency_policy.cc
+++ b/google/cloud/retail/search_connection_idempotency_policy.cc
@@ -25,7 +25,7 @@ namespace cloud {
 namespace retail {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-using ::google::cloud::internal::Idempotency;
+using ::google::cloud::Idempotency;
 
 SearchServiceConnectionIdempotencyPolicy::
     ~SearchServiceConnectionIdempotencyPolicy() = default;

--- a/google/cloud/retail/search_connection_idempotency_policy.h
+++ b/google/cloud/retail/search_connection_idempotency_policy.h
@@ -19,8 +19,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_RETAIL_SEARCH_CONNECTION_IDEMPOTENCY_POLICY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_RETAIL_SEARCH_CONNECTION_IDEMPOTENCY_POLICY_H
 
+#include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
-#include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include <google/cloud/retail/v2/search_service.grpc.pb.h>
 #include <memory>
@@ -38,7 +38,7 @@ class SearchServiceConnectionIdempotencyPolicy {
   virtual std::unique_ptr<SearchServiceConnectionIdempotencyPolicy> clone()
       const = 0;
 
-  virtual google::cloud::internal::Idempotency Search(
+  virtual google::cloud::Idempotency Search(
       google::cloud::retail::v2::SearchRequest request) = 0;
 };
 

--- a/google/cloud/retail/user_event_connection_idempotency_policy.cc
+++ b/google/cloud/retail/user_event_connection_idempotency_policy.cc
@@ -25,7 +25,7 @@ namespace cloud {
 namespace retail {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-using ::google::cloud::internal::Idempotency;
+using ::google::cloud::Idempotency;
 
 UserEventServiceConnectionIdempotencyPolicy::
     ~UserEventServiceConnectionIdempotencyPolicy() = default;

--- a/google/cloud/retail/user_event_connection_idempotency_policy.h
+++ b/google/cloud/retail/user_event_connection_idempotency_policy.h
@@ -19,9 +19,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_RETAIL_USER_EVENT_CONNECTION_IDEMPOTENCY_POLICY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_RETAIL_USER_EVENT_CONNECTION_IDEMPOTENCY_POLICY_H
 
-#include "google/cloud/future.h"
+#include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
-#include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include <google/cloud/retail/v2/user_event_service.grpc.pb.h>
 #include <memory>
@@ -39,19 +38,19 @@ class UserEventServiceConnectionIdempotencyPolicy {
   virtual std::unique_ptr<UserEventServiceConnectionIdempotencyPolicy> clone()
       const = 0;
 
-  virtual google::cloud::internal::Idempotency WriteUserEvent(
+  virtual google::cloud::Idempotency WriteUserEvent(
       google::cloud::retail::v2::WriteUserEventRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency CollectUserEvent(
+  virtual google::cloud::Idempotency CollectUserEvent(
       google::cloud::retail::v2::CollectUserEventRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency PurgeUserEvents(
+  virtual google::cloud::Idempotency PurgeUserEvents(
       google::cloud::retail::v2::PurgeUserEventsRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency ImportUserEvents(
+  virtual google::cloud::Idempotency ImportUserEvents(
       google::cloud::retail::v2::ImportUserEventsRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency RejoinUserEvents(
+  virtual google::cloud::Idempotency RejoinUserEvents(
       google::cloud::retail::v2::RejoinUserEventsRequest const& request) = 0;
 };
 

--- a/google/cloud/scheduler/cloud_scheduler_connection_idempotency_policy.cc
+++ b/google/cloud/scheduler/cloud_scheduler_connection_idempotency_policy.cc
@@ -25,7 +25,7 @@ namespace cloud {
 namespace scheduler {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-using ::google::cloud::internal::Idempotency;
+using ::google::cloud::Idempotency;
 
 CloudSchedulerConnectionIdempotencyPolicy::
     ~CloudSchedulerConnectionIdempotencyPolicy() = default;

--- a/google/cloud/scheduler/cloud_scheduler_connection_idempotency_policy.h
+++ b/google/cloud/scheduler/cloud_scheduler_connection_idempotency_policy.h
@@ -19,8 +19,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SCHEDULER_CLOUD_SCHEDULER_CONNECTION_IDEMPOTENCY_POLICY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SCHEDULER_CLOUD_SCHEDULER_CONNECTION_IDEMPOTENCY_POLICY_H
 
+#include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
-#include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include <google/cloud/scheduler/v1/cloudscheduler.grpc.pb.h>
 #include <memory>
@@ -38,28 +38,28 @@ class CloudSchedulerConnectionIdempotencyPolicy {
   virtual std::unique_ptr<CloudSchedulerConnectionIdempotencyPolicy> clone()
       const = 0;
 
-  virtual google::cloud::internal::Idempotency ListJobs(
+  virtual google::cloud::Idempotency ListJobs(
       google::cloud::scheduler::v1::ListJobsRequest request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetJob(
+  virtual google::cloud::Idempotency GetJob(
       google::cloud::scheduler::v1::GetJobRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency CreateJob(
+  virtual google::cloud::Idempotency CreateJob(
       google::cloud::scheduler::v1::CreateJobRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency UpdateJob(
+  virtual google::cloud::Idempotency UpdateJob(
       google::cloud::scheduler::v1::UpdateJobRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency DeleteJob(
+  virtual google::cloud::Idempotency DeleteJob(
       google::cloud::scheduler::v1::DeleteJobRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency PauseJob(
+  virtual google::cloud::Idempotency PauseJob(
       google::cloud::scheduler::v1::PauseJobRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency ResumeJob(
+  virtual google::cloud::Idempotency ResumeJob(
       google::cloud::scheduler::v1::ResumeJobRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency RunJob(
+  virtual google::cloud::Idempotency RunJob(
       google::cloud::scheduler::v1::RunJobRequest const& request) = 0;
 };
 

--- a/google/cloud/secretmanager/secret_manager_connection_idempotency_policy.cc
+++ b/google/cloud/secretmanager/secret_manager_connection_idempotency_policy.cc
@@ -25,7 +25,7 @@ namespace cloud {
 namespace secretmanager {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-using ::google::cloud::internal::Idempotency;
+using ::google::cloud::Idempotency;
 
 SecretManagerServiceConnectionIdempotencyPolicy::
     ~SecretManagerServiceConnectionIdempotencyPolicy() = default;

--- a/google/cloud/secretmanager/secret_manager_connection_idempotency_policy.h
+++ b/google/cloud/secretmanager/secret_manager_connection_idempotency_policy.h
@@ -19,8 +19,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SECRETMANAGER_SECRET_MANAGER_CONNECTION_IDEMPOTENCY_POLICY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SECRETMANAGER_SECRET_MANAGER_CONNECTION_IDEMPOTENCY_POLICY_H
 
+#include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
-#include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include <google/cloud/secretmanager/v1/service.grpc.pb.h>
 #include <memory>
@@ -38,55 +38,55 @@ class SecretManagerServiceConnectionIdempotencyPolicy {
   virtual std::unique_ptr<SecretManagerServiceConnectionIdempotencyPolicy>
   clone() const = 0;
 
-  virtual google::cloud::internal::Idempotency ListSecrets(
+  virtual google::cloud::Idempotency ListSecrets(
       google::cloud::secretmanager::v1::ListSecretsRequest request) = 0;
 
-  virtual google::cloud::internal::Idempotency CreateSecret(
+  virtual google::cloud::Idempotency CreateSecret(
       google::cloud::secretmanager::v1::CreateSecretRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency AddSecretVersion(
+  virtual google::cloud::Idempotency AddSecretVersion(
       google::cloud::secretmanager::v1::AddSecretVersionRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetSecret(
+  virtual google::cloud::Idempotency GetSecret(
       google::cloud::secretmanager::v1::GetSecretRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency UpdateSecret(
+  virtual google::cloud::Idempotency UpdateSecret(
       google::cloud::secretmanager::v1::UpdateSecretRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency DeleteSecret(
+  virtual google::cloud::Idempotency DeleteSecret(
       google::cloud::secretmanager::v1::DeleteSecretRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency ListSecretVersions(
+  virtual google::cloud::Idempotency ListSecretVersions(
       google::cloud::secretmanager::v1::ListSecretVersionsRequest request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetSecretVersion(
+  virtual google::cloud::Idempotency GetSecretVersion(
       google::cloud::secretmanager::v1::GetSecretVersionRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency AccessSecretVersion(
+  virtual google::cloud::Idempotency AccessSecretVersion(
       google::cloud::secretmanager::v1::AccessSecretVersionRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency DisableSecretVersion(
+  virtual google::cloud::Idempotency DisableSecretVersion(
       google::cloud::secretmanager::v1::DisableSecretVersionRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency EnableSecretVersion(
+  virtual google::cloud::Idempotency EnableSecretVersion(
       google::cloud::secretmanager::v1::EnableSecretVersionRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency DestroySecretVersion(
+  virtual google::cloud::Idempotency DestroySecretVersion(
       google::cloud::secretmanager::v1::DestroySecretVersionRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency SetIamPolicy(
+  virtual google::cloud::Idempotency SetIamPolicy(
       google::iam::v1::SetIamPolicyRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetIamPolicy(
+  virtual google::cloud::Idempotency GetIamPolicy(
       google::iam::v1::GetIamPolicyRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency TestIamPermissions(
+  virtual google::cloud::Idempotency TestIamPermissions(
       google::iam::v1::TestIamPermissionsRequest const& request) = 0;
 };
 

--- a/google/cloud/serviceusage/service_usage_connection_idempotency_policy.cc
+++ b/google/cloud/serviceusage/service_usage_connection_idempotency_policy.cc
@@ -25,7 +25,7 @@ namespace cloud {
 namespace serviceusage {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-using ::google::cloud::internal::Idempotency;
+using ::google::cloud::Idempotency;
 
 ServiceUsageConnectionIdempotencyPolicy::
     ~ServiceUsageConnectionIdempotencyPolicy() = default;

--- a/google/cloud/serviceusage/service_usage_connection_idempotency_policy.h
+++ b/google/cloud/serviceusage/service_usage_connection_idempotency_policy.h
@@ -19,9 +19,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SERVICEUSAGE_SERVICE_USAGE_CONNECTION_IDEMPOTENCY_POLICY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SERVICEUSAGE_SERVICE_USAGE_CONNECTION_IDEMPOTENCY_POLICY_H
 
-#include "google/cloud/future.h"
+#include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
-#include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include <google/api/serviceusage/v1/serviceusage.grpc.pb.h>
 #include <memory>
@@ -39,23 +38,23 @@ class ServiceUsageConnectionIdempotencyPolicy {
   virtual std::unique_ptr<ServiceUsageConnectionIdempotencyPolicy> clone()
       const = 0;
 
-  virtual google::cloud::internal::Idempotency EnableService(
+  virtual google::cloud::Idempotency EnableService(
       google::api::serviceusage::v1::EnableServiceRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency DisableService(
+  virtual google::cloud::Idempotency DisableService(
       google::api::serviceusage::v1::DisableServiceRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetService(
+  virtual google::cloud::Idempotency GetService(
       google::api::serviceusage::v1::GetServiceRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency ListServices(
+  virtual google::cloud::Idempotency ListServices(
       google::api::serviceusage::v1::ListServicesRequest request) = 0;
 
-  virtual google::cloud::internal::Idempotency BatchEnableServices(
+  virtual google::cloud::Idempotency BatchEnableServices(
       google::api::serviceusage::v1::BatchEnableServicesRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency BatchGetServices(
+  virtual google::cloud::Idempotency BatchGetServices(
       google::api::serviceusage::v1::BatchGetServicesRequest const&
           request) = 0;
 };

--- a/google/cloud/shell/cloud_shell_connection_idempotency_policy.cc
+++ b/google/cloud/shell/cloud_shell_connection_idempotency_policy.cc
@@ -25,7 +25,7 @@ namespace cloud {
 namespace shell {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-using ::google::cloud::internal::Idempotency;
+using ::google::cloud::Idempotency;
 
 CloudShellServiceConnectionIdempotencyPolicy::
     ~CloudShellServiceConnectionIdempotencyPolicy() = default;

--- a/google/cloud/shell/cloud_shell_connection_idempotency_policy.h
+++ b/google/cloud/shell/cloud_shell_connection_idempotency_policy.h
@@ -19,9 +19,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SHELL_CLOUD_SHELL_CONNECTION_IDEMPOTENCY_POLICY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SHELL_CLOUD_SHELL_CONNECTION_IDEMPOTENCY_POLICY_H
 
-#include "google/cloud/future.h"
+#include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
-#include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include <google/cloud/shell/v1/cloudshell.grpc.pb.h>
 #include <memory>
@@ -39,19 +38,19 @@ class CloudShellServiceConnectionIdempotencyPolicy {
   virtual std::unique_ptr<CloudShellServiceConnectionIdempotencyPolicy> clone()
       const = 0;
 
-  virtual google::cloud::internal::Idempotency GetEnvironment(
+  virtual google::cloud::Idempotency GetEnvironment(
       google::cloud::shell::v1::GetEnvironmentRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency StartEnvironment(
+  virtual google::cloud::Idempotency StartEnvironment(
       google::cloud::shell::v1::StartEnvironmentRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency AuthorizeEnvironment(
+  virtual google::cloud::Idempotency AuthorizeEnvironment(
       google::cloud::shell::v1::AuthorizeEnvironmentRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency AddPublicKey(
+  virtual google::cloud::Idempotency AddPublicKey(
       google::cloud::shell::v1::AddPublicKeyRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency RemovePublicKey(
+  virtual google::cloud::Idempotency RemovePublicKey(
       google::cloud::shell::v1::RemovePublicKeyRequest const& request) = 0;
 };
 

--- a/google/cloud/spanner/admin/database_admin_connection_idempotency_policy.cc
+++ b/google/cloud/spanner/admin/database_admin_connection_idempotency_policy.cc
@@ -25,7 +25,7 @@ namespace cloud {
 namespace spanner_admin {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-using ::google::cloud::internal::Idempotency;
+using ::google::cloud::Idempotency;
 
 DatabaseAdminConnectionIdempotencyPolicy::
     ~DatabaseAdminConnectionIdempotencyPolicy() = default;

--- a/google/cloud/spanner/admin/database_admin_connection_idempotency_policy.h
+++ b/google/cloud/spanner/admin/database_admin_connection_idempotency_policy.h
@@ -19,9 +19,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_ADMIN_DATABASE_ADMIN_CONNECTION_IDEMPOTENCY_POLICY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_ADMIN_DATABASE_ADMIN_CONNECTION_IDEMPOTENCY_POLICY_H
 
-#include "google/cloud/future.h"
+#include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
-#include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include <google/spanner/admin/database/v1/spanner_database_admin.grpc.pb.h>
 #include <memory>
@@ -39,66 +38,66 @@ class DatabaseAdminConnectionIdempotencyPolicy {
   virtual std::unique_ptr<DatabaseAdminConnectionIdempotencyPolicy> clone()
       const = 0;
 
-  virtual google::cloud::internal::Idempotency ListDatabases(
+  virtual google::cloud::Idempotency ListDatabases(
       google::spanner::admin::database::v1::ListDatabasesRequest request) = 0;
 
-  virtual google::cloud::internal::Idempotency CreateDatabase(
+  virtual google::cloud::Idempotency CreateDatabase(
       google::spanner::admin::database::v1::CreateDatabaseRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetDatabase(
+  virtual google::cloud::Idempotency GetDatabase(
       google::spanner::admin::database::v1::GetDatabaseRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency UpdateDatabaseDdl(
+  virtual google::cloud::Idempotency UpdateDatabaseDdl(
       google::spanner::admin::database::v1::UpdateDatabaseDdlRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency DropDatabase(
+  virtual google::cloud::Idempotency DropDatabase(
       google::spanner::admin::database::v1::DropDatabaseRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetDatabaseDdl(
+  virtual google::cloud::Idempotency GetDatabaseDdl(
       google::spanner::admin::database::v1::GetDatabaseDdlRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency SetIamPolicy(
+  virtual google::cloud::Idempotency SetIamPolicy(
       google::iam::v1::SetIamPolicyRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetIamPolicy(
+  virtual google::cloud::Idempotency GetIamPolicy(
       google::iam::v1::GetIamPolicyRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency TestIamPermissions(
+  virtual google::cloud::Idempotency TestIamPermissions(
       google::iam::v1::TestIamPermissionsRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency CreateBackup(
+  virtual google::cloud::Idempotency CreateBackup(
       google::spanner::admin::database::v1::CreateBackupRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetBackup(
+  virtual google::cloud::Idempotency GetBackup(
       google::spanner::admin::database::v1::GetBackupRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency UpdateBackup(
+  virtual google::cloud::Idempotency UpdateBackup(
       google::spanner::admin::database::v1::UpdateBackupRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency DeleteBackup(
+  virtual google::cloud::Idempotency DeleteBackup(
       google::spanner::admin::database::v1::DeleteBackupRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency ListBackups(
+  virtual google::cloud::Idempotency ListBackups(
       google::spanner::admin::database::v1::ListBackupsRequest request) = 0;
 
-  virtual google::cloud::internal::Idempotency RestoreDatabase(
+  virtual google::cloud::Idempotency RestoreDatabase(
       google::spanner::admin::database::v1::RestoreDatabaseRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency ListDatabaseOperations(
+  virtual google::cloud::Idempotency ListDatabaseOperations(
       google::spanner::admin::database::v1::ListDatabaseOperationsRequest
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency ListBackupOperations(
+  virtual google::cloud::Idempotency ListBackupOperations(
       google::spanner::admin::database::v1::ListBackupOperationsRequest
           request) = 0;
 };

--- a/google/cloud/spanner/admin/instance_admin_connection_idempotency_policy.cc
+++ b/google/cloud/spanner/admin/instance_admin_connection_idempotency_policy.cc
@@ -25,7 +25,7 @@ namespace cloud {
 namespace spanner_admin {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-using ::google::cloud::internal::Idempotency;
+using ::google::cloud::Idempotency;
 
 InstanceAdminConnectionIdempotencyPolicy::
     ~InstanceAdminConnectionIdempotencyPolicy() = default;

--- a/google/cloud/spanner/admin/instance_admin_connection_idempotency_policy.h
+++ b/google/cloud/spanner/admin/instance_admin_connection_idempotency_policy.h
@@ -19,9 +19,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_ADMIN_INSTANCE_ADMIN_CONNECTION_IDEMPOTENCY_POLICY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_ADMIN_INSTANCE_ADMIN_CONNECTION_IDEMPOTENCY_POLICY_H
 
-#include "google/cloud/future.h"
+#include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
-#include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include <google/spanner/admin/instance/v1/spanner_instance_admin.grpc.pb.h>
 #include <memory>
@@ -39,40 +38,40 @@ class InstanceAdminConnectionIdempotencyPolicy {
   virtual std::unique_ptr<InstanceAdminConnectionIdempotencyPolicy> clone()
       const = 0;
 
-  virtual google::cloud::internal::Idempotency ListInstanceConfigs(
+  virtual google::cloud::Idempotency ListInstanceConfigs(
       google::spanner::admin::instance::v1::ListInstanceConfigsRequest
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetInstanceConfig(
+  virtual google::cloud::Idempotency GetInstanceConfig(
       google::spanner::admin::instance::v1::GetInstanceConfigRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency ListInstances(
+  virtual google::cloud::Idempotency ListInstances(
       google::spanner::admin::instance::v1::ListInstancesRequest request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetInstance(
+  virtual google::cloud::Idempotency GetInstance(
       google::spanner::admin::instance::v1::GetInstanceRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency CreateInstance(
+  virtual google::cloud::Idempotency CreateInstance(
       google::spanner::admin::instance::v1::CreateInstanceRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency UpdateInstance(
+  virtual google::cloud::Idempotency UpdateInstance(
       google::spanner::admin::instance::v1::UpdateInstanceRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency DeleteInstance(
+  virtual google::cloud::Idempotency DeleteInstance(
       google::spanner::admin::instance::v1::DeleteInstanceRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency SetIamPolicy(
+  virtual google::cloud::Idempotency SetIamPolicy(
       google::iam::v1::SetIamPolicyRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetIamPolicy(
+  virtual google::cloud::Idempotency GetIamPolicy(
       google::iam::v1::GetIamPolicyRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency TestIamPermissions(
+  virtual google::cloud::Idempotency TestIamPermissions(
       google::iam::v1::TestIamPermissionsRequest const& request) = 0;
 };
 

--- a/google/cloud/spanner/database_admin_connection.cc
+++ b/google/cloud/spanner/database_admin_connection.cc
@@ -33,7 +33,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 namespace gcsa = ::google::spanner::admin::database::v1;
 
-using ::google::cloud::internal::Idempotency;
+using ::google::cloud::Idempotency;
 using ::google::cloud::internal::RetryLoop;
 
 future<StatusOr<google::spanner::admin::database::v1::Backup>>

--- a/google/cloud/spanner/instance_admin_connection.cc
+++ b/google/cloud/spanner/instance_admin_connection.cc
@@ -30,7 +30,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 namespace gcsa = ::google::spanner::admin::instance::v1;
 namespace giam = ::google::iam::v1;
-using ::google::cloud::internal::Idempotency;
+using ::google::cloud::Idempotency;
 
 namespace {
 

--- a/google/cloud/spanner/internal/connection_impl.cc
+++ b/google/cloud/spanner/internal/connection_impl.cc
@@ -35,7 +35,7 @@ namespace cloud {
 namespace spanner_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-using ::google::cloud::internal::Idempotency;
+using ::google::cloud::Idempotency;
 
 class DefaultPartialResultSetReader : public PartialResultSetReader {
  public:

--- a/google/cloud/spanner/internal/partial_result_set_resume.cc
+++ b/google/cloud/spanner/internal/partial_result_set_resume.cc
@@ -33,7 +33,7 @@ PartialResultSetResume::Read() {
     }
     auto status = Finish();
     if (status.ok()) return {};
-    if (idempotency_ == google::cloud::internal::Idempotency::kNonIdempotent ||
+    if (idempotency_ == google::cloud::Idempotency::kNonIdempotent ||
         !retry_policy_prototype_->OnFailure(status)) {
       return {};
     }

--- a/google/cloud/spanner/internal/partial_result_set_resume.h
+++ b/google/cloud/spanner/internal/partial_result_set_resume.h
@@ -41,7 +41,7 @@ using PartialResultSetReaderFactory =
 class PartialResultSetResume : public PartialResultSetReader {
  public:
   PartialResultSetResume(PartialResultSetReaderFactory factory,
-                         google::cloud::internal::Idempotency idempotency,
+                         google::cloud::Idempotency idempotency,
                          std::unique_ptr<spanner::RetryPolicy> retry_policy,
                          std::unique_ptr<spanner::BackoffPolicy> backoff_policy)
       : factory_(std::move(factory)),
@@ -58,7 +58,7 @@ class PartialResultSetResume : public PartialResultSetReader {
 
  private:
   PartialResultSetReaderFactory factory_;
-  google::cloud::internal::Idempotency idempotency_;
+  google::cloud::Idempotency idempotency_;
   std::unique_ptr<spanner::RetryPolicy> retry_policy_prototype_;
   std::unique_ptr<spanner::BackoffPolicy> backoff_policy_prototype_;
   std::string last_resume_token_;

--- a/google/cloud/spanner/internal/partial_result_set_resume_test.cc
+++ b/google/cloud/spanner/internal/partial_result_set_resume_test.cc
@@ -32,7 +32,7 @@ namespace {
 
 namespace spanner_proto = ::google::spanner::v1;
 
-using ::google::cloud::internal::Idempotency;
+using ::google::cloud::Idempotency;
 using ::google::cloud::spanner_testing::MockPartialResultSetReader;
 using ::google::cloud::testing_util::IsProtoEqual;
 using ::google::cloud::testing_util::StatusIs;

--- a/google/cloud/spanner/internal/session_pool.cc
+++ b/google/cloud/spanner/internal/session_pool.cc
@@ -37,7 +37,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 namespace spanner_proto = ::google::spanner::v1;
 
-using ::google::cloud::internal::Idempotency;
+using ::google::cloud::Idempotency;
 
 std::shared_ptr<SessionPool> MakeSessionPool(
     spanner::Database db, std::vector<std::shared_ptr<SpannerStub>> stubs,
@@ -366,7 +366,7 @@ Status SessionPool::CreateSessionsSync(
   auto const& stub = channel->stub;
   auto response = RetryLoop(
       retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-      google::cloud::internal::Idempotency::kIdempotent,
+      google::cloud::Idempotency::kIdempotent,
       [&stub](grpc::ClientContext& context,
               spanner_proto::BatchCreateSessionsRequest const& request) {
         return stub->BatchCreateSessions(context, request);

--- a/google/cloud/storage/internal/retry_client.cc
+++ b/google/cloud/storage/internal/retry_client.cc
@@ -28,7 +28,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace internal {
 namespace {
 
-using ::google::cloud::internal::Idempotency;
+using ::google::cloud::Idempotency;
 using ::google::cloud::storage::internal::raw_client_wrapper_utils::Signature;
 
 /**

--- a/google/cloud/storagetransfer/storage_transfer_connection_idempotency_policy.cc
+++ b/google/cloud/storagetransfer/storage_transfer_connection_idempotency_policy.cc
@@ -25,7 +25,7 @@ namespace cloud {
 namespace storagetransfer {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-using ::google::cloud::internal::Idempotency;
+using ::google::cloud::Idempotency;
 
 StorageTransferServiceConnectionIdempotencyPolicy::
     ~StorageTransferServiceConnectionIdempotencyPolicy() = default;

--- a/google/cloud/storagetransfer/storage_transfer_connection_idempotency_policy.h
+++ b/google/cloud/storagetransfer/storage_transfer_connection_idempotency_policy.h
@@ -19,9 +19,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGETRANSFER_STORAGE_TRANSFER_CONNECTION_IDEMPOTENCY_POLICY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGETRANSFER_STORAGE_TRANSFER_CONNECTION_IDEMPOTENCY_POLICY_H
 
-#include "google/cloud/future.h"
+#include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
-#include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include <google/storagetransfer/v1/transfer.grpc.pb.h>
 #include <memory>
@@ -39,31 +38,31 @@ class StorageTransferServiceConnectionIdempotencyPolicy {
   virtual std::unique_ptr<StorageTransferServiceConnectionIdempotencyPolicy>
   clone() const = 0;
 
-  virtual google::cloud::internal::Idempotency GetGoogleServiceAccount(
+  virtual google::cloud::Idempotency GetGoogleServiceAccount(
       google::storagetransfer::v1::GetGoogleServiceAccountRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency CreateTransferJob(
+  virtual google::cloud::Idempotency CreateTransferJob(
       google::storagetransfer::v1::CreateTransferJobRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency UpdateTransferJob(
+  virtual google::cloud::Idempotency UpdateTransferJob(
       google::storagetransfer::v1::UpdateTransferJobRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetTransferJob(
+  virtual google::cloud::Idempotency GetTransferJob(
       google::storagetransfer::v1::GetTransferJobRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency ListTransferJobs(
+  virtual google::cloud::Idempotency ListTransferJobs(
       google::storagetransfer::v1::ListTransferJobsRequest request) = 0;
 
-  virtual google::cloud::internal::Idempotency PauseTransferOperation(
+  virtual google::cloud::Idempotency PauseTransferOperation(
       google::storagetransfer::v1::PauseTransferOperationRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency ResumeTransferOperation(
+  virtual google::cloud::Idempotency ResumeTransferOperation(
       google::storagetransfer::v1::ResumeTransferOperationRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency RunTransferJob(
+  virtual google::cloud::Idempotency RunTransferJob(
       google::storagetransfer::v1::RunTransferJobRequest const& request) = 0;
 };
 

--- a/google/cloud/talent/company_connection_idempotency_policy.cc
+++ b/google/cloud/talent/company_connection_idempotency_policy.cc
@@ -25,7 +25,7 @@ namespace cloud {
 namespace talent {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-using ::google::cloud::internal::Idempotency;
+using ::google::cloud::Idempotency;
 
 CompanyServiceConnectionIdempotencyPolicy::
     ~CompanyServiceConnectionIdempotencyPolicy() = default;

--- a/google/cloud/talent/company_connection_idempotency_policy.h
+++ b/google/cloud/talent/company_connection_idempotency_policy.h
@@ -19,8 +19,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_TALENT_COMPANY_CONNECTION_IDEMPOTENCY_POLICY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_TALENT_COMPANY_CONNECTION_IDEMPOTENCY_POLICY_H
 
+#include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
-#include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include <google/cloud/talent/v4/company_service.grpc.pb.h>
 #include <memory>
@@ -38,19 +38,19 @@ class CompanyServiceConnectionIdempotencyPolicy {
   virtual std::unique_ptr<CompanyServiceConnectionIdempotencyPolicy> clone()
       const = 0;
 
-  virtual google::cloud::internal::Idempotency CreateCompany(
+  virtual google::cloud::Idempotency CreateCompany(
       google::cloud::talent::v4::CreateCompanyRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetCompany(
+  virtual google::cloud::Idempotency GetCompany(
       google::cloud::talent::v4::GetCompanyRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency UpdateCompany(
+  virtual google::cloud::Idempotency UpdateCompany(
       google::cloud::talent::v4::UpdateCompanyRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency DeleteCompany(
+  virtual google::cloud::Idempotency DeleteCompany(
       google::cloud::talent::v4::DeleteCompanyRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency ListCompanies(
+  virtual google::cloud::Idempotency ListCompanies(
       google::cloud::talent::v4::ListCompaniesRequest request) = 0;
 };
 

--- a/google/cloud/talent/completion_connection_idempotency_policy.cc
+++ b/google/cloud/talent/completion_connection_idempotency_policy.cc
@@ -25,7 +25,7 @@ namespace cloud {
 namespace talent {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-using ::google::cloud::internal::Idempotency;
+using ::google::cloud::Idempotency;
 
 CompletionConnectionIdempotencyPolicy::
     ~CompletionConnectionIdempotencyPolicy() = default;

--- a/google/cloud/talent/completion_connection_idempotency_policy.h
+++ b/google/cloud/talent/completion_connection_idempotency_policy.h
@@ -19,8 +19,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_TALENT_COMPLETION_CONNECTION_IDEMPOTENCY_POLICY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_TALENT_COMPLETION_CONNECTION_IDEMPOTENCY_POLICY_H
 
+#include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
-#include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include <google/cloud/talent/v4/completion_service.grpc.pb.h>
 #include <memory>
@@ -38,7 +38,7 @@ class CompletionConnectionIdempotencyPolicy {
   virtual std::unique_ptr<CompletionConnectionIdempotencyPolicy> clone()
       const = 0;
 
-  virtual google::cloud::internal::Idempotency CompleteQuery(
+  virtual google::cloud::Idempotency CompleteQuery(
       google::cloud::talent::v4::CompleteQueryRequest const& request) = 0;
 };
 

--- a/google/cloud/talent/event_connection_idempotency_policy.cc
+++ b/google/cloud/talent/event_connection_idempotency_policy.cc
@@ -25,7 +25,7 @@ namespace cloud {
 namespace talent {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-using ::google::cloud::internal::Idempotency;
+using ::google::cloud::Idempotency;
 
 EventServiceConnectionIdempotencyPolicy::
     ~EventServiceConnectionIdempotencyPolicy() = default;

--- a/google/cloud/talent/event_connection_idempotency_policy.h
+++ b/google/cloud/talent/event_connection_idempotency_policy.h
@@ -19,8 +19,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_TALENT_EVENT_CONNECTION_IDEMPOTENCY_POLICY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_TALENT_EVENT_CONNECTION_IDEMPOTENCY_POLICY_H
 
+#include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
-#include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include <google/cloud/talent/v4/event_service.grpc.pb.h>
 #include <memory>
@@ -38,7 +38,7 @@ class EventServiceConnectionIdempotencyPolicy {
   virtual std::unique_ptr<EventServiceConnectionIdempotencyPolicy> clone()
       const = 0;
 
-  virtual google::cloud::internal::Idempotency CreateClientEvent(
+  virtual google::cloud::Idempotency CreateClientEvent(
       google::cloud::talent::v4::CreateClientEventRequest const& request) = 0;
 };
 

--- a/google/cloud/talent/job_connection_idempotency_policy.cc
+++ b/google/cloud/talent/job_connection_idempotency_policy.cc
@@ -25,7 +25,7 @@ namespace cloud {
 namespace talent {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-using ::google::cloud::internal::Idempotency;
+using ::google::cloud::Idempotency;
 
 JobServiceConnectionIdempotencyPolicy::
     ~JobServiceConnectionIdempotencyPolicy() = default;

--- a/google/cloud/talent/job_connection_idempotency_policy.h
+++ b/google/cloud/talent/job_connection_idempotency_policy.h
@@ -19,9 +19,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_TALENT_JOB_CONNECTION_IDEMPOTENCY_POLICY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_TALENT_JOB_CONNECTION_IDEMPOTENCY_POLICY_H
 
-#include "google/cloud/future.h"
+#include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
-#include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include <google/cloud/talent/v4/job_service.grpc.pb.h>
 #include <memory>
@@ -39,34 +38,34 @@ class JobServiceConnectionIdempotencyPolicy {
   virtual std::unique_ptr<JobServiceConnectionIdempotencyPolicy> clone()
       const = 0;
 
-  virtual google::cloud::internal::Idempotency CreateJob(
+  virtual google::cloud::Idempotency CreateJob(
       google::cloud::talent::v4::CreateJobRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency BatchCreateJobs(
+  virtual google::cloud::Idempotency BatchCreateJobs(
       google::cloud::talent::v4::BatchCreateJobsRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetJob(
+  virtual google::cloud::Idempotency GetJob(
       google::cloud::talent::v4::GetJobRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency UpdateJob(
+  virtual google::cloud::Idempotency UpdateJob(
       google::cloud::talent::v4::UpdateJobRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency BatchUpdateJobs(
+  virtual google::cloud::Idempotency BatchUpdateJobs(
       google::cloud::talent::v4::BatchUpdateJobsRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency DeleteJob(
+  virtual google::cloud::Idempotency DeleteJob(
       google::cloud::talent::v4::DeleteJobRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency BatchDeleteJobs(
+  virtual google::cloud::Idempotency BatchDeleteJobs(
       google::cloud::talent::v4::BatchDeleteJobsRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency ListJobs(
+  virtual google::cloud::Idempotency ListJobs(
       google::cloud::talent::v4::ListJobsRequest request) = 0;
 
-  virtual google::cloud::internal::Idempotency SearchJobs(
+  virtual google::cloud::Idempotency SearchJobs(
       google::cloud::talent::v4::SearchJobsRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency SearchJobsForAlert(
+  virtual google::cloud::Idempotency SearchJobsForAlert(
       google::cloud::talent::v4::SearchJobsRequest const& request) = 0;
 };
 

--- a/google/cloud/talent/tenant_connection_idempotency_policy.cc
+++ b/google/cloud/talent/tenant_connection_idempotency_policy.cc
@@ -25,7 +25,7 @@ namespace cloud {
 namespace talent {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-using ::google::cloud::internal::Idempotency;
+using ::google::cloud::Idempotency;
 
 TenantServiceConnectionIdempotencyPolicy::
     ~TenantServiceConnectionIdempotencyPolicy() = default;

--- a/google/cloud/talent/tenant_connection_idempotency_policy.h
+++ b/google/cloud/talent/tenant_connection_idempotency_policy.h
@@ -19,8 +19,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_TALENT_TENANT_CONNECTION_IDEMPOTENCY_POLICY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_TALENT_TENANT_CONNECTION_IDEMPOTENCY_POLICY_H
 
+#include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
-#include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include <google/cloud/talent/v4/tenant_service.grpc.pb.h>
 #include <memory>
@@ -38,19 +38,19 @@ class TenantServiceConnectionIdempotencyPolicy {
   virtual std::unique_ptr<TenantServiceConnectionIdempotencyPolicy> clone()
       const = 0;
 
-  virtual google::cloud::internal::Idempotency CreateTenant(
+  virtual google::cloud::Idempotency CreateTenant(
       google::cloud::talent::v4::CreateTenantRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetTenant(
+  virtual google::cloud::Idempotency GetTenant(
       google::cloud::talent::v4::GetTenantRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency UpdateTenant(
+  virtual google::cloud::Idempotency UpdateTenant(
       google::cloud::talent::v4::UpdateTenantRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency DeleteTenant(
+  virtual google::cloud::Idempotency DeleteTenant(
       google::cloud::talent::v4::DeleteTenantRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency ListTenants(
+  virtual google::cloud::Idempotency ListTenants(
       google::cloud::talent::v4::ListTenantsRequest request) = 0;
 };
 

--- a/google/cloud/tasks/cloud_tasks_connection_idempotency_policy.cc
+++ b/google/cloud/tasks/cloud_tasks_connection_idempotency_policy.cc
@@ -25,7 +25,7 @@ namespace cloud {
 namespace tasks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-using ::google::cloud::internal::Idempotency;
+using ::google::cloud::Idempotency;
 
 CloudTasksConnectionIdempotencyPolicy::
     ~CloudTasksConnectionIdempotencyPolicy() = default;

--- a/google/cloud/tasks/cloud_tasks_connection_idempotency_policy.h
+++ b/google/cloud/tasks/cloud_tasks_connection_idempotency_policy.h
@@ -19,8 +19,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_TASKS_CLOUD_TASKS_CONNECTION_IDEMPOTENCY_POLICY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_TASKS_CLOUD_TASKS_CONNECTION_IDEMPOTENCY_POLICY_H
 
+#include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
-#include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include <google/cloud/tasks/v2/cloudtasks.grpc.pb.h>
 #include <memory>
@@ -38,52 +38,52 @@ class CloudTasksConnectionIdempotencyPolicy {
   virtual std::unique_ptr<CloudTasksConnectionIdempotencyPolicy> clone()
       const = 0;
 
-  virtual google::cloud::internal::Idempotency ListQueues(
+  virtual google::cloud::Idempotency ListQueues(
       google::cloud::tasks::v2::ListQueuesRequest request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetQueue(
+  virtual google::cloud::Idempotency GetQueue(
       google::cloud::tasks::v2::GetQueueRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency CreateQueue(
+  virtual google::cloud::Idempotency CreateQueue(
       google::cloud::tasks::v2::CreateQueueRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency UpdateQueue(
+  virtual google::cloud::Idempotency UpdateQueue(
       google::cloud::tasks::v2::UpdateQueueRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency DeleteQueue(
+  virtual google::cloud::Idempotency DeleteQueue(
       google::cloud::tasks::v2::DeleteQueueRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency PurgeQueue(
+  virtual google::cloud::Idempotency PurgeQueue(
       google::cloud::tasks::v2::PurgeQueueRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency PauseQueue(
+  virtual google::cloud::Idempotency PauseQueue(
       google::cloud::tasks::v2::PauseQueueRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency ResumeQueue(
+  virtual google::cloud::Idempotency ResumeQueue(
       google::cloud::tasks::v2::ResumeQueueRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetIamPolicy(
+  virtual google::cloud::Idempotency GetIamPolicy(
       google::iam::v1::GetIamPolicyRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency SetIamPolicy(
+  virtual google::cloud::Idempotency SetIamPolicy(
       google::iam::v1::SetIamPolicyRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency TestIamPermissions(
+  virtual google::cloud::Idempotency TestIamPermissions(
       google::iam::v1::TestIamPermissionsRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency ListTasks(
+  virtual google::cloud::Idempotency ListTasks(
       google::cloud::tasks::v2::ListTasksRequest request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetTask(
+  virtual google::cloud::Idempotency GetTask(
       google::cloud::tasks::v2::GetTaskRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency CreateTask(
+  virtual google::cloud::Idempotency CreateTask(
       google::cloud::tasks::v2::CreateTaskRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency DeleteTask(
+  virtual google::cloud::Idempotency DeleteTask(
       google::cloud::tasks::v2::DeleteTaskRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency RunTask(
+  virtual google::cloud::Idempotency RunTask(
       google::cloud::tasks::v2::RunTaskRequest const& request) = 0;
 };
 

--- a/google/cloud/texttospeech/text_to_speech_connection_idempotency_policy.cc
+++ b/google/cloud/texttospeech/text_to_speech_connection_idempotency_policy.cc
@@ -25,7 +25,7 @@ namespace cloud {
 namespace texttospeech {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-using ::google::cloud::internal::Idempotency;
+using ::google::cloud::Idempotency;
 
 TextToSpeechConnectionIdempotencyPolicy::
     ~TextToSpeechConnectionIdempotencyPolicy() = default;

--- a/google/cloud/texttospeech/text_to_speech_connection_idempotency_policy.h
+++ b/google/cloud/texttospeech/text_to_speech_connection_idempotency_policy.h
@@ -19,8 +19,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_TEXTTOSPEECH_TEXT_TO_SPEECH_CONNECTION_IDEMPOTENCY_POLICY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_TEXTTOSPEECH_TEXT_TO_SPEECH_CONNECTION_IDEMPOTENCY_POLICY_H
 
+#include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
-#include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include <google/cloud/texttospeech/v1/cloud_tts.grpc.pb.h>
 #include <memory>
@@ -38,10 +38,10 @@ class TextToSpeechConnectionIdempotencyPolicy {
   virtual std::unique_ptr<TextToSpeechConnectionIdempotencyPolicy> clone()
       const = 0;
 
-  virtual google::cloud::internal::Idempotency ListVoices(
+  virtual google::cloud::Idempotency ListVoices(
       google::cloud::texttospeech::v1::ListVoicesRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency SynthesizeSpeech(
+  virtual google::cloud::Idempotency SynthesizeSpeech(
       google::cloud::texttospeech::v1::SynthesizeSpeechRequest const&
           request) = 0;
 };

--- a/google/cloud/tpu/tpu_connection_idempotency_policy.cc
+++ b/google/cloud/tpu/tpu_connection_idempotency_policy.cc
@@ -25,7 +25,7 @@ namespace cloud {
 namespace tpu {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-using ::google::cloud::internal::Idempotency;
+using ::google::cloud::Idempotency;
 
 TpuConnectionIdempotencyPolicy::~TpuConnectionIdempotencyPolicy() = default;
 

--- a/google/cloud/tpu/tpu_connection_idempotency_policy.h
+++ b/google/cloud/tpu/tpu_connection_idempotency_policy.h
@@ -19,9 +19,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_TPU_TPU_CONNECTION_IDEMPOTENCY_POLICY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_TPU_TPU_CONNECTION_IDEMPOTENCY_POLICY_H
 
-#include "google/cloud/future.h"
+#include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
-#include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include <google/cloud/tpu/v1/cloud_tpu.grpc.pb.h>
 #include <memory>
@@ -38,37 +37,37 @@ class TpuConnectionIdempotencyPolicy {
   /// Create a new copy of this object.
   virtual std::unique_ptr<TpuConnectionIdempotencyPolicy> clone() const = 0;
 
-  virtual google::cloud::internal::Idempotency ListNodes(
+  virtual google::cloud::Idempotency ListNodes(
       google::cloud::tpu::v1::ListNodesRequest request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetNode(
+  virtual google::cloud::Idempotency GetNode(
       google::cloud::tpu::v1::GetNodeRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency CreateNode(
+  virtual google::cloud::Idempotency CreateNode(
       google::cloud::tpu::v1::CreateNodeRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency DeleteNode(
+  virtual google::cloud::Idempotency DeleteNode(
       google::cloud::tpu::v1::DeleteNodeRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency ReimageNode(
+  virtual google::cloud::Idempotency ReimageNode(
       google::cloud::tpu::v1::ReimageNodeRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency StopNode(
+  virtual google::cloud::Idempotency StopNode(
       google::cloud::tpu::v1::StopNodeRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency StartNode(
+  virtual google::cloud::Idempotency StartNode(
       google::cloud::tpu::v1::StartNodeRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency ListTensorFlowVersions(
+  virtual google::cloud::Idempotency ListTensorFlowVersions(
       google::cloud::tpu::v1::ListTensorFlowVersionsRequest request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetTensorFlowVersion(
+  virtual google::cloud::Idempotency GetTensorFlowVersion(
       google::cloud::tpu::v1::GetTensorFlowVersionRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency ListAcceleratorTypes(
+  virtual google::cloud::Idempotency ListAcceleratorTypes(
       google::cloud::tpu::v1::ListAcceleratorTypesRequest request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetAcceleratorType(
+  virtual google::cloud::Idempotency GetAcceleratorType(
       google::cloud::tpu::v1::GetAcceleratorTypeRequest const& request) = 0;
 };
 

--- a/google/cloud/translate/translation_connection_idempotency_policy.cc
+++ b/google/cloud/translate/translation_connection_idempotency_policy.cc
@@ -25,7 +25,7 @@ namespace cloud {
 namespace translate {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-using ::google::cloud::internal::Idempotency;
+using ::google::cloud::Idempotency;
 
 TranslationServiceConnectionIdempotencyPolicy::
     ~TranslationServiceConnectionIdempotencyPolicy() = default;

--- a/google/cloud/translate/translation_connection_idempotency_policy.h
+++ b/google/cloud/translate/translation_connection_idempotency_policy.h
@@ -19,9 +19,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_TRANSLATE_TRANSLATION_CONNECTION_IDEMPOTENCY_POLICY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_TRANSLATE_TRANSLATION_CONNECTION_IDEMPOTENCY_POLICY_H
 
-#include "google/cloud/future.h"
+#include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
-#include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include <google/cloud/translate/v3/translation_service.grpc.pb.h>
 #include <memory>
@@ -39,38 +38,38 @@ class TranslationServiceConnectionIdempotencyPolicy {
   virtual std::unique_ptr<TranslationServiceConnectionIdempotencyPolicy> clone()
       const = 0;
 
-  virtual google::cloud::internal::Idempotency TranslateText(
+  virtual google::cloud::Idempotency TranslateText(
       google::cloud::translation::v3::TranslateTextRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency DetectLanguage(
+  virtual google::cloud::Idempotency DetectLanguage(
       google::cloud::translation::v3::DetectLanguageRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetSupportedLanguages(
+  virtual google::cloud::Idempotency GetSupportedLanguages(
       google::cloud::translation::v3::GetSupportedLanguagesRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency TranslateDocument(
+  virtual google::cloud::Idempotency TranslateDocument(
       google::cloud::translation::v3::TranslateDocumentRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency BatchTranslateText(
+  virtual google::cloud::Idempotency BatchTranslateText(
       google::cloud::translation::v3::BatchTranslateTextRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency BatchTranslateDocument(
+  virtual google::cloud::Idempotency BatchTranslateDocument(
       google::cloud::translation::v3::BatchTranslateDocumentRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency CreateGlossary(
+  virtual google::cloud::Idempotency CreateGlossary(
       google::cloud::translation::v3::CreateGlossaryRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency ListGlossaries(
+  virtual google::cloud::Idempotency ListGlossaries(
       google::cloud::translation::v3::ListGlossariesRequest request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetGlossary(
+  virtual google::cloud::Idempotency GetGlossary(
       google::cloud::translation::v3::GetGlossaryRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency DeleteGlossary(
+  virtual google::cloud::Idempotency DeleteGlossary(
       google::cloud::translation::v3::DeleteGlossaryRequest const& request) = 0;
 };
 

--- a/google/cloud/videointelligence/video_intelligence_connection_idempotency_policy.cc
+++ b/google/cloud/videointelligence/video_intelligence_connection_idempotency_policy.cc
@@ -25,7 +25,7 @@ namespace cloud {
 namespace videointelligence {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-using ::google::cloud::internal::Idempotency;
+using ::google::cloud::Idempotency;
 
 VideoIntelligenceServiceConnectionIdempotencyPolicy::
     ~VideoIntelligenceServiceConnectionIdempotencyPolicy() = default;

--- a/google/cloud/videointelligence/video_intelligence_connection_idempotency_policy.h
+++ b/google/cloud/videointelligence/video_intelligence_connection_idempotency_policy.h
@@ -19,9 +19,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_VIDEOINTELLIGENCE_VIDEO_INTELLIGENCE_CONNECTION_IDEMPOTENCY_POLICY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_VIDEOINTELLIGENCE_VIDEO_INTELLIGENCE_CONNECTION_IDEMPOTENCY_POLICY_H
 
-#include "google/cloud/future.h"
+#include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
-#include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include <google/cloud/videointelligence/v1/video_intelligence.grpc.pb.h>
 #include <memory>
@@ -39,7 +38,7 @@ class VideoIntelligenceServiceConnectionIdempotencyPolicy {
   virtual std::unique_ptr<VideoIntelligenceServiceConnectionIdempotencyPolicy>
   clone() const = 0;
 
-  virtual google::cloud::internal::Idempotency AnnotateVideo(
+  virtual google::cloud::Idempotency AnnotateVideo(
       google::cloud::videointelligence::v1::AnnotateVideoRequest const&
           request) = 0;
 };

--- a/google/cloud/vision/image_annotator_connection_idempotency_policy.cc
+++ b/google/cloud/vision/image_annotator_connection_idempotency_policy.cc
@@ -25,7 +25,7 @@ namespace cloud {
 namespace vision {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-using ::google::cloud::internal::Idempotency;
+using ::google::cloud::Idempotency;
 
 ImageAnnotatorConnectionIdempotencyPolicy::
     ~ImageAnnotatorConnectionIdempotencyPolicy() = default;

--- a/google/cloud/vision/image_annotator_connection_idempotency_policy.h
+++ b/google/cloud/vision/image_annotator_connection_idempotency_policy.h
@@ -19,9 +19,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_VISION_IMAGE_ANNOTATOR_CONNECTION_IDEMPOTENCY_POLICY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_VISION_IMAGE_ANNOTATOR_CONNECTION_IDEMPOTENCY_POLICY_H
 
-#include "google/cloud/future.h"
+#include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
-#include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include <google/cloud/vision/v1/image_annotator.grpc.pb.h>
 #include <memory>
@@ -39,17 +38,17 @@ class ImageAnnotatorConnectionIdempotencyPolicy {
   virtual std::unique_ptr<ImageAnnotatorConnectionIdempotencyPolicy> clone()
       const = 0;
 
-  virtual google::cloud::internal::Idempotency BatchAnnotateImages(
+  virtual google::cloud::Idempotency BatchAnnotateImages(
       google::cloud::vision::v1::BatchAnnotateImagesRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency BatchAnnotateFiles(
+  virtual google::cloud::Idempotency BatchAnnotateFiles(
       google::cloud::vision::v1::BatchAnnotateFilesRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency AsyncBatchAnnotateImages(
+  virtual google::cloud::Idempotency AsyncBatchAnnotateImages(
       google::cloud::vision::v1::AsyncBatchAnnotateImagesRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency AsyncBatchAnnotateFiles(
+  virtual google::cloud::Idempotency AsyncBatchAnnotateFiles(
       google::cloud::vision::v1::AsyncBatchAnnotateFilesRequest const&
           request) = 0;
 };

--- a/google/cloud/vision/product_search_connection_idempotency_policy.cc
+++ b/google/cloud/vision/product_search_connection_idempotency_policy.cc
@@ -25,7 +25,7 @@ namespace cloud {
 namespace vision {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-using ::google::cloud::internal::Idempotency;
+using ::google::cloud::Idempotency;
 
 ProductSearchConnectionIdempotencyPolicy::
     ~ProductSearchConnectionIdempotencyPolicy() = default;

--- a/google/cloud/vision/product_search_connection_idempotency_policy.h
+++ b/google/cloud/vision/product_search_connection_idempotency_policy.h
@@ -19,9 +19,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_VISION_PRODUCT_SEARCH_CONNECTION_IDEMPOTENCY_POLICY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_VISION_PRODUCT_SEARCH_CONNECTION_IDEMPOTENCY_POLICY_H
 
-#include "google/cloud/future.h"
+#include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
-#include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include <google/cloud/vision/v1/product_search_service.grpc.pb.h>
 #include <memory>
@@ -39,65 +38,65 @@ class ProductSearchConnectionIdempotencyPolicy {
   virtual std::unique_ptr<ProductSearchConnectionIdempotencyPolicy> clone()
       const = 0;
 
-  virtual google::cloud::internal::Idempotency CreateProductSet(
+  virtual google::cloud::Idempotency CreateProductSet(
       google::cloud::vision::v1::CreateProductSetRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency ListProductSets(
+  virtual google::cloud::Idempotency ListProductSets(
       google::cloud::vision::v1::ListProductSetsRequest request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetProductSet(
+  virtual google::cloud::Idempotency GetProductSet(
       google::cloud::vision::v1::GetProductSetRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency UpdateProductSet(
+  virtual google::cloud::Idempotency UpdateProductSet(
       google::cloud::vision::v1::UpdateProductSetRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency DeleteProductSet(
+  virtual google::cloud::Idempotency DeleteProductSet(
       google::cloud::vision::v1::DeleteProductSetRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency CreateProduct(
+  virtual google::cloud::Idempotency CreateProduct(
       google::cloud::vision::v1::CreateProductRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency ListProducts(
+  virtual google::cloud::Idempotency ListProducts(
       google::cloud::vision::v1::ListProductsRequest request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetProduct(
+  virtual google::cloud::Idempotency GetProduct(
       google::cloud::vision::v1::GetProductRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency UpdateProduct(
+  virtual google::cloud::Idempotency UpdateProduct(
       google::cloud::vision::v1::UpdateProductRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency DeleteProduct(
+  virtual google::cloud::Idempotency DeleteProduct(
       google::cloud::vision::v1::DeleteProductRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency CreateReferenceImage(
+  virtual google::cloud::Idempotency CreateReferenceImage(
       google::cloud::vision::v1::CreateReferenceImageRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency DeleteReferenceImage(
+  virtual google::cloud::Idempotency DeleteReferenceImage(
       google::cloud::vision::v1::DeleteReferenceImageRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency ListReferenceImages(
+  virtual google::cloud::Idempotency ListReferenceImages(
       google::cloud::vision::v1::ListReferenceImagesRequest request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetReferenceImage(
+  virtual google::cloud::Idempotency GetReferenceImage(
       google::cloud::vision::v1::GetReferenceImageRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency AddProductToProductSet(
+  virtual google::cloud::Idempotency AddProductToProductSet(
       google::cloud::vision::v1::AddProductToProductSetRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency RemoveProductFromProductSet(
+  virtual google::cloud::Idempotency RemoveProductFromProductSet(
       google::cloud::vision::v1::RemoveProductFromProductSetRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency ListProductsInProductSet(
+  virtual google::cloud::Idempotency ListProductsInProductSet(
       google::cloud::vision::v1::ListProductsInProductSetRequest request) = 0;
 
-  virtual google::cloud::internal::Idempotency ImportProductSets(
+  virtual google::cloud::Idempotency ImportProductSets(
       google::cloud::vision::v1::ImportProductSetsRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency PurgeProducts(
+  virtual google::cloud::Idempotency PurgeProducts(
       google::cloud::vision::v1::PurgeProductsRequest const& request) = 0;
 };
 

--- a/google/cloud/vmmigration/vm_migration_connection_idempotency_policy.cc
+++ b/google/cloud/vmmigration/vm_migration_connection_idempotency_policy.cc
@@ -25,7 +25,7 @@ namespace cloud {
 namespace vmmigration {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-using ::google::cloud::internal::Idempotency;
+using ::google::cloud::Idempotency;
 
 VmMigrationConnectionIdempotencyPolicy::
     ~VmMigrationConnectionIdempotencyPolicy() = default;

--- a/google/cloud/vmmigration/vm_migration_connection_idempotency_policy.h
+++ b/google/cloud/vmmigration/vm_migration_connection_idempotency_policy.h
@@ -19,9 +19,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_VMMIGRATION_VM_MIGRATION_CONNECTION_IDEMPOTENCY_POLICY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_VMMIGRATION_VM_MIGRATION_CONNECTION_IDEMPOTENCY_POLICY_H
 
-#include "google/cloud/future.h"
+#include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
-#include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include <google/cloud/vmmigration/v1/vmmigration.grpc.pb.h>
 #include <memory>
@@ -39,153 +38,153 @@ class VmMigrationConnectionIdempotencyPolicy {
   virtual std::unique_ptr<VmMigrationConnectionIdempotencyPolicy> clone()
       const = 0;
 
-  virtual google::cloud::internal::Idempotency ListSources(
+  virtual google::cloud::Idempotency ListSources(
       google::cloud::vmmigration::v1::ListSourcesRequest request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetSource(
+  virtual google::cloud::Idempotency GetSource(
       google::cloud::vmmigration::v1::GetSourceRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency CreateSource(
+  virtual google::cloud::Idempotency CreateSource(
       google::cloud::vmmigration::v1::CreateSourceRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency UpdateSource(
+  virtual google::cloud::Idempotency UpdateSource(
       google::cloud::vmmigration::v1::UpdateSourceRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency DeleteSource(
+  virtual google::cloud::Idempotency DeleteSource(
       google::cloud::vmmigration::v1::DeleteSourceRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency FetchInventory(
+  virtual google::cloud::Idempotency FetchInventory(
       google::cloud::vmmigration::v1::FetchInventoryRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency ListUtilizationReports(
+  virtual google::cloud::Idempotency ListUtilizationReports(
       google::cloud::vmmigration::v1::ListUtilizationReportsRequest
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetUtilizationReport(
+  virtual google::cloud::Idempotency GetUtilizationReport(
       google::cloud::vmmigration::v1::GetUtilizationReportRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency CreateUtilizationReport(
+  virtual google::cloud::Idempotency CreateUtilizationReport(
       google::cloud::vmmigration::v1::CreateUtilizationReportRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency DeleteUtilizationReport(
+  virtual google::cloud::Idempotency DeleteUtilizationReport(
       google::cloud::vmmigration::v1::DeleteUtilizationReportRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency ListDatacenterConnectors(
+  virtual google::cloud::Idempotency ListDatacenterConnectors(
       google::cloud::vmmigration::v1::ListDatacenterConnectorsRequest
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetDatacenterConnector(
+  virtual google::cloud::Idempotency GetDatacenterConnector(
       google::cloud::vmmigration::v1::GetDatacenterConnectorRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency CreateDatacenterConnector(
+  virtual google::cloud::Idempotency CreateDatacenterConnector(
       google::cloud::vmmigration::v1::CreateDatacenterConnectorRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency DeleteDatacenterConnector(
+  virtual google::cloud::Idempotency DeleteDatacenterConnector(
       google::cloud::vmmigration::v1::DeleteDatacenterConnectorRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency CreateMigratingVm(
+  virtual google::cloud::Idempotency CreateMigratingVm(
       google::cloud::vmmigration::v1::CreateMigratingVmRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency ListMigratingVms(
+  virtual google::cloud::Idempotency ListMigratingVms(
       google::cloud::vmmigration::v1::ListMigratingVmsRequest request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetMigratingVm(
+  virtual google::cloud::Idempotency GetMigratingVm(
       google::cloud::vmmigration::v1::GetMigratingVmRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency UpdateMigratingVm(
+  virtual google::cloud::Idempotency UpdateMigratingVm(
       google::cloud::vmmigration::v1::UpdateMigratingVmRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency DeleteMigratingVm(
+  virtual google::cloud::Idempotency DeleteMigratingVm(
       google::cloud::vmmigration::v1::DeleteMigratingVmRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency StartMigration(
+  virtual google::cloud::Idempotency StartMigration(
       google::cloud::vmmigration::v1::StartMigrationRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency ResumeMigration(
+  virtual google::cloud::Idempotency ResumeMigration(
       google::cloud::vmmigration::v1::ResumeMigrationRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency PauseMigration(
+  virtual google::cloud::Idempotency PauseMigration(
       google::cloud::vmmigration::v1::PauseMigrationRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency FinalizeMigration(
+  virtual google::cloud::Idempotency FinalizeMigration(
       google::cloud::vmmigration::v1::FinalizeMigrationRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency CreateCloneJob(
+  virtual google::cloud::Idempotency CreateCloneJob(
       google::cloud::vmmigration::v1::CreateCloneJobRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency CancelCloneJob(
+  virtual google::cloud::Idempotency CancelCloneJob(
       google::cloud::vmmigration::v1::CancelCloneJobRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency ListCloneJobs(
+  virtual google::cloud::Idempotency ListCloneJobs(
       google::cloud::vmmigration::v1::ListCloneJobsRequest request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetCloneJob(
+  virtual google::cloud::Idempotency GetCloneJob(
       google::cloud::vmmigration::v1::GetCloneJobRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency CreateCutoverJob(
+  virtual google::cloud::Idempotency CreateCutoverJob(
       google::cloud::vmmigration::v1::CreateCutoverJobRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency CancelCutoverJob(
+  virtual google::cloud::Idempotency CancelCutoverJob(
       google::cloud::vmmigration::v1::CancelCutoverJobRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency ListCutoverJobs(
+  virtual google::cloud::Idempotency ListCutoverJobs(
       google::cloud::vmmigration::v1::ListCutoverJobsRequest request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetCutoverJob(
+  virtual google::cloud::Idempotency GetCutoverJob(
       google::cloud::vmmigration::v1::GetCutoverJobRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency ListGroups(
+  virtual google::cloud::Idempotency ListGroups(
       google::cloud::vmmigration::v1::ListGroupsRequest request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetGroup(
+  virtual google::cloud::Idempotency GetGroup(
       google::cloud::vmmigration::v1::GetGroupRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency CreateGroup(
+  virtual google::cloud::Idempotency CreateGroup(
       google::cloud::vmmigration::v1::CreateGroupRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency UpdateGroup(
+  virtual google::cloud::Idempotency UpdateGroup(
       google::cloud::vmmigration::v1::UpdateGroupRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency DeleteGroup(
+  virtual google::cloud::Idempotency DeleteGroup(
       google::cloud::vmmigration::v1::DeleteGroupRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency AddGroupMigration(
+  virtual google::cloud::Idempotency AddGroupMigration(
       google::cloud::vmmigration::v1::AddGroupMigrationRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency RemoveGroupMigration(
+  virtual google::cloud::Idempotency RemoveGroupMigration(
       google::cloud::vmmigration::v1::RemoveGroupMigrationRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency ListTargetProjects(
+  virtual google::cloud::Idempotency ListTargetProjects(
       google::cloud::vmmigration::v1::ListTargetProjectsRequest request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetTargetProject(
+  virtual google::cloud::Idempotency GetTargetProject(
       google::cloud::vmmigration::v1::GetTargetProjectRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency CreateTargetProject(
+  virtual google::cloud::Idempotency CreateTargetProject(
       google::cloud::vmmigration::v1::CreateTargetProjectRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency UpdateTargetProject(
+  virtual google::cloud::Idempotency UpdateTargetProject(
       google::cloud::vmmigration::v1::UpdateTargetProjectRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency DeleteTargetProject(
+  virtual google::cloud::Idempotency DeleteTargetProject(
       google::cloud::vmmigration::v1::DeleteTargetProjectRequest const&
           request) = 0;
 };

--- a/google/cloud/vpcaccess/vpc_access_connection_idempotency_policy.cc
+++ b/google/cloud/vpcaccess/vpc_access_connection_idempotency_policy.cc
@@ -25,7 +25,7 @@ namespace cloud {
 namespace vpcaccess {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-using ::google::cloud::internal::Idempotency;
+using ::google::cloud::Idempotency;
 
 VpcAccessServiceConnectionIdempotencyPolicy::
     ~VpcAccessServiceConnectionIdempotencyPolicy() = default;

--- a/google/cloud/vpcaccess/vpc_access_connection_idempotency_policy.h
+++ b/google/cloud/vpcaccess/vpc_access_connection_idempotency_policy.h
@@ -19,9 +19,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_VPCACCESS_VPC_ACCESS_CONNECTION_IDEMPOTENCY_POLICY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_VPCACCESS_VPC_ACCESS_CONNECTION_IDEMPOTENCY_POLICY_H
 
-#include "google/cloud/future.h"
+#include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
-#include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include <google/cloud/vpcaccess/v1/vpc_access.grpc.pb.h>
 #include <memory>
@@ -39,16 +38,16 @@ class VpcAccessServiceConnectionIdempotencyPolicy {
   virtual std::unique_ptr<VpcAccessServiceConnectionIdempotencyPolicy> clone()
       const = 0;
 
-  virtual google::cloud::internal::Idempotency CreateConnector(
+  virtual google::cloud::Idempotency CreateConnector(
       google::cloud::vpcaccess::v1::CreateConnectorRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetConnector(
+  virtual google::cloud::Idempotency GetConnector(
       google::cloud::vpcaccess::v1::GetConnectorRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency ListConnectors(
+  virtual google::cloud::Idempotency ListConnectors(
       google::cloud::vpcaccess::v1::ListConnectorsRequest request) = 0;
 
-  virtual google::cloud::internal::Idempotency DeleteConnector(
+  virtual google::cloud::Idempotency DeleteConnector(
       google::cloud::vpcaccess::v1::DeleteConnectorRequest const& request) = 0;
 };
 

--- a/google/cloud/webrisk/web_risk_connection_idempotency_policy.cc
+++ b/google/cloud/webrisk/web_risk_connection_idempotency_policy.cc
@@ -25,7 +25,7 @@ namespace cloud {
 namespace webrisk {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-using ::google::cloud::internal::Idempotency;
+using ::google::cloud::Idempotency;
 
 WebRiskServiceConnectionIdempotencyPolicy::
     ~WebRiskServiceConnectionIdempotencyPolicy() = default;

--- a/google/cloud/webrisk/web_risk_connection_idempotency_policy.h
+++ b/google/cloud/webrisk/web_risk_connection_idempotency_policy.h
@@ -19,8 +19,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_WEBRISK_WEB_RISK_CONNECTION_IDEMPOTENCY_POLICY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_WEBRISK_WEB_RISK_CONNECTION_IDEMPOTENCY_POLICY_H
 
+#include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
-#include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include <google/cloud/webrisk/v1/webrisk.grpc.pb.h>
 #include <memory>
@@ -38,17 +38,17 @@ class WebRiskServiceConnectionIdempotencyPolicy {
   virtual std::unique_ptr<WebRiskServiceConnectionIdempotencyPolicy> clone()
       const = 0;
 
-  virtual google::cloud::internal::Idempotency ComputeThreatListDiff(
+  virtual google::cloud::Idempotency ComputeThreatListDiff(
       google::cloud::webrisk::v1::ComputeThreatListDiffRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency SearchUris(
+  virtual google::cloud::Idempotency SearchUris(
       google::cloud::webrisk::v1::SearchUrisRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency SearchHashes(
+  virtual google::cloud::Idempotency SearchHashes(
       google::cloud::webrisk::v1::SearchHashesRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency CreateSubmission(
+  virtual google::cloud::Idempotency CreateSubmission(
       google::cloud::webrisk::v1::CreateSubmissionRequest const& request) = 0;
 };
 

--- a/google/cloud/websecurityscanner/web_security_scanner_connection_idempotency_policy.cc
+++ b/google/cloud/websecurityscanner/web_security_scanner_connection_idempotency_policy.cc
@@ -25,7 +25,7 @@ namespace cloud {
 namespace websecurityscanner {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-using ::google::cloud::internal::Idempotency;
+using ::google::cloud::Idempotency;
 
 WebSecurityScannerConnectionIdempotencyPolicy::
     ~WebSecurityScannerConnectionIdempotencyPolicy() = default;

--- a/google/cloud/websecurityscanner/web_security_scanner_connection_idempotency_policy.h
+++ b/google/cloud/websecurityscanner/web_security_scanner_connection_idempotency_policy.h
@@ -19,8 +19,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_WEBSECURITYSCANNER_WEB_SECURITY_SCANNER_CONNECTION_IDEMPOTENCY_POLICY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_WEBSECURITYSCANNER_WEB_SECURITY_SCANNER_CONNECTION_IDEMPOTENCY_POLICY_H
 
+#include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
-#include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include <google/cloud/websecurityscanner/v1/web_security_scanner.grpc.pb.h>
 #include <memory>
@@ -38,53 +38,53 @@ class WebSecurityScannerConnectionIdempotencyPolicy {
   virtual std::unique_ptr<WebSecurityScannerConnectionIdempotencyPolicy> clone()
       const = 0;
 
-  virtual google::cloud::internal::Idempotency CreateScanConfig(
+  virtual google::cloud::Idempotency CreateScanConfig(
       google::cloud::websecurityscanner::v1::CreateScanConfigRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency DeleteScanConfig(
+  virtual google::cloud::Idempotency DeleteScanConfig(
       google::cloud::websecurityscanner::v1::DeleteScanConfigRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetScanConfig(
+  virtual google::cloud::Idempotency GetScanConfig(
       google::cloud::websecurityscanner::v1::GetScanConfigRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency ListScanConfigs(
+  virtual google::cloud::Idempotency ListScanConfigs(
       google::cloud::websecurityscanner::v1::ListScanConfigsRequest
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency UpdateScanConfig(
+  virtual google::cloud::Idempotency UpdateScanConfig(
       google::cloud::websecurityscanner::v1::UpdateScanConfigRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency StartScanRun(
+  virtual google::cloud::Idempotency StartScanRun(
       google::cloud::websecurityscanner::v1::StartScanRunRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetScanRun(
+  virtual google::cloud::Idempotency GetScanRun(
       google::cloud::websecurityscanner::v1::GetScanRunRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency ListScanRuns(
+  virtual google::cloud::Idempotency ListScanRuns(
       google::cloud::websecurityscanner::v1::ListScanRunsRequest request) = 0;
 
-  virtual google::cloud::internal::Idempotency StopScanRun(
+  virtual google::cloud::Idempotency StopScanRun(
       google::cloud::websecurityscanner::v1::StopScanRunRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency ListCrawledUrls(
+  virtual google::cloud::Idempotency ListCrawledUrls(
       google::cloud::websecurityscanner::v1::ListCrawledUrlsRequest
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetFinding(
+  virtual google::cloud::Idempotency GetFinding(
       google::cloud::websecurityscanner::v1::GetFindingRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency ListFindings(
+  virtual google::cloud::Idempotency ListFindings(
       google::cloud::websecurityscanner::v1::ListFindingsRequest request) = 0;
 
-  virtual google::cloud::internal::Idempotency ListFindingTypeStats(
+  virtual google::cloud::Idempotency ListFindingTypeStats(
       google::cloud::websecurityscanner::v1::ListFindingTypeStatsRequest const&
           request) = 0;
 };

--- a/google/cloud/workflows/executions_connection_idempotency_policy.cc
+++ b/google/cloud/workflows/executions_connection_idempotency_policy.cc
@@ -25,7 +25,7 @@ namespace cloud {
 namespace workflows {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-using ::google::cloud::internal::Idempotency;
+using ::google::cloud::Idempotency;
 
 ExecutionsConnectionIdempotencyPolicy::
     ~ExecutionsConnectionIdempotencyPolicy() = default;

--- a/google/cloud/workflows/executions_connection_idempotency_policy.h
+++ b/google/cloud/workflows/executions_connection_idempotency_policy.h
@@ -19,8 +19,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_WORKFLOWS_EXECUTIONS_CONNECTION_IDEMPOTENCY_POLICY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_WORKFLOWS_EXECUTIONS_CONNECTION_IDEMPOTENCY_POLICY_H
 
+#include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
-#include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include <google/cloud/workflows/executions/v1/executions.grpc.pb.h>
 #include <memory>
@@ -38,19 +38,19 @@ class ExecutionsConnectionIdempotencyPolicy {
   virtual std::unique_ptr<ExecutionsConnectionIdempotencyPolicy> clone()
       const = 0;
 
-  virtual google::cloud::internal::Idempotency ListExecutions(
+  virtual google::cloud::Idempotency ListExecutions(
       google::cloud::workflows::executions::v1::ListExecutionsRequest
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency CreateExecution(
+  virtual google::cloud::Idempotency CreateExecution(
       google::cloud::workflows::executions::v1::CreateExecutionRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetExecution(
+  virtual google::cloud::Idempotency GetExecution(
       google::cloud::workflows::executions::v1::GetExecutionRequest const&
           request) = 0;
 
-  virtual google::cloud::internal::Idempotency CancelExecution(
+  virtual google::cloud::Idempotency CancelExecution(
       google::cloud::workflows::executions::v1::CancelExecutionRequest const&
           request) = 0;
 };

--- a/google/cloud/workflows/workflows_connection_idempotency_policy.cc
+++ b/google/cloud/workflows/workflows_connection_idempotency_policy.cc
@@ -25,7 +25,7 @@ namespace cloud {
 namespace workflows {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-using ::google::cloud::internal::Idempotency;
+using ::google::cloud::Idempotency;
 
 WorkflowsConnectionIdempotencyPolicy::~WorkflowsConnectionIdempotencyPolicy() =
     default;

--- a/google/cloud/workflows/workflows_connection_idempotency_policy.h
+++ b/google/cloud/workflows/workflows_connection_idempotency_policy.h
@@ -19,9 +19,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_WORKFLOWS_WORKFLOWS_CONNECTION_IDEMPOTENCY_POLICY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_WORKFLOWS_WORKFLOWS_CONNECTION_IDEMPOTENCY_POLICY_H
 
-#include "google/cloud/future.h"
+#include "google/cloud/idempotency.h"
 #include "google/cloud/internal/retry_policy.h"
-#include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include <google/cloud/workflows/v1/workflows.grpc.pb.h>
 #include <memory>
@@ -39,19 +38,19 @@ class WorkflowsConnectionIdempotencyPolicy {
   virtual std::unique_ptr<WorkflowsConnectionIdempotencyPolicy> clone()
       const = 0;
 
-  virtual google::cloud::internal::Idempotency ListWorkflows(
+  virtual google::cloud::Idempotency ListWorkflows(
       google::cloud::workflows::v1::ListWorkflowsRequest request) = 0;
 
-  virtual google::cloud::internal::Idempotency GetWorkflow(
+  virtual google::cloud::Idempotency GetWorkflow(
       google::cloud::workflows::v1::GetWorkflowRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency CreateWorkflow(
+  virtual google::cloud::Idempotency CreateWorkflow(
       google::cloud::workflows::v1::CreateWorkflowRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency DeleteWorkflow(
+  virtual google::cloud::Idempotency DeleteWorkflow(
       google::cloud::workflows::v1::DeleteWorkflowRequest const& request) = 0;
 
-  virtual google::cloud::internal::Idempotency UpdateWorkflow(
+  virtual google::cloud::Idempotency UpdateWorkflow(
       google::cloud::workflows::v1::UpdateWorkflowRequest const& request) = 0;
 };
 


### PR DESCRIPTION
Ugh, I did not realize this was so big.  I can break it down if needed, though hopefully each commit is easy to grok?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8049)
<!-- Reviewable:end -->
