### PR TITLE
feat(generator): handle proto fields named with C++ keywords

### DIFF
--- a/generator/internal/descriptor_utils.cc
+++ b/generator/internal/descriptor_utils.cc
@@ -38,28 +38,20 @@
 #include <regex>
 #include <string>
 
-// #include <google/protobuf/compiler/cpp/cpp_helpers.h> doesn't work with the
-// existing cmake support because it includes other files that are not part of
-// ${libprotoc_headers}. So, we just directly declare what we want to use.
-namespace google {
-namespace protobuf {
-namespace compiler {
-namespace cpp {
-std::string ResolveKeyword(std::string const&);
-}  // namespace cpp
-}  // namespace compiler
-}  // namespace protobuf
-}  // namespace google
-
 using ::google::protobuf::FieldDescriptor;
 using ::google::protobuf::MethodDescriptor;
 using ::google::protobuf::ServiceDescriptor;
-using ::google::protobuf::compiler::cpp::ResolveKeyword;
 
 namespace google {
 namespace cloud {
 namespace generator_internal {
 namespace {
+
+// Mimic the keyword mapping of the protocol compiler.
+std::string ResolveKeyword(std::string const& name) {
+  if (name == "namespace") return name + '_';
+  return name;
+}
 
 std::string CppTypeToString(FieldDescriptor const* field) {
   switch (field->cpp_type()) {

--- a/generator/internal/descriptor_utils.cc
+++ b/generator/internal/descriptor_utils.cc
@@ -38,9 +38,23 @@
 #include <regex>
 #include <string>
 
+// #include <google/protobuf/compiler/cpp/cpp_helpers.h> doesn't work with the
+// existing cmake support because it includes other files that are not part of
+// ${libprotoc_headers}. So, we just directly declare what we want to use.
+namespace google {
+namespace protobuf {
+namespace compiler {
+namespace cpp {
+std::string ResolveKeyword(std::string const&);
+}  // namespace cpp
+}  // namespace compiler
+}  // namespace protobuf
+}  // namespace google
+
 using ::google::protobuf::FieldDescriptor;
 using ::google::protobuf::MethodDescriptor;
 using ::google::protobuf::ServiceDescriptor;
+using ::google::protobuf::compiler::cpp::ResolveKeyword;
 
 namespace google {
 namespace cloud {
@@ -186,41 +200,43 @@ void SetMethodSignatureMethodVars(
       absl::StripAsciiWhitespace(&parameter);
       google::protobuf::FieldDescriptor const* parameter_descriptor =
           input_type->FindFieldByName(parameter);
+      auto const parameter_name = ResolveKeyword(parameter);
       if (parameter_descriptor->is_map()) {
         method_signature += absl::StrFormat(
             "std::map<%s, %s> const& %s",
             CppTypeToString(parameter_descriptor->message_type()->map_key()),
             CppTypeToString(parameter_descriptor->message_type()->map_value()),
-            parameter);
+            parameter_name);
         method_request_setters += absl::StrFormat(
-            "  *request.mutable_%s() = {%s.begin(), %s.end()};\n", parameter,
-            parameter, parameter);
+            "  *request.mutable_%s() = {%s.begin(), %s.end()};\n",
+            parameter_name, parameter_name, parameter_name);
       } else if (parameter_descriptor->is_repeated()) {
-        method_signature +=
-            absl::StrFormat("std::vector<%s> const& %s",
-                            CppTypeToString(parameter_descriptor), parameter);
+        method_signature += absl::StrFormat(
+            "std::vector<%s> const& %s", CppTypeToString(parameter_descriptor),
+            parameter_name);
         method_request_setters += absl::StrFormat(
-            "  *request.mutable_%s() = {%s.begin(), %s.end()};\n", parameter,
-            parameter, parameter);
+            "  *request.mutable_%s() = {%s.begin(), %s.end()};\n",
+            parameter_name, parameter_name, parameter_name);
       } else if (parameter_descriptor->type() ==
                  FieldDescriptor::TYPE_MESSAGE) {
         method_signature += absl::StrFormat(
-            "%s const& %s", CppTypeToString(parameter_descriptor), parameter);
+            "%s const& %s", CppTypeToString(parameter_descriptor),
+            parameter_name);
         method_request_setters += absl::StrFormat(
-            "  *request.mutable_%s() = %s;\n", parameter, parameter);
+            "  *request.mutable_%s() = %s;\n", parameter_name, parameter_name);
       } else {
         switch (parameter_descriptor->cpp_type()) {
           case FieldDescriptor::CPPTYPE_STRING:
             method_signature += absl::StrFormat(
                 "%s const& %s", CppTypeToString(parameter_descriptor),
-                parameter);
+                parameter_name);
             break;
           default:
             method_signature += absl::StrFormat(
-                "%s %s", CppTypeToString(parameter_descriptor), parameter);
+                "%s %s", CppTypeToString(parameter_descriptor), parameter_name);
         }
-        method_request_setters +=
-            absl::StrFormat("  request.set_%s(%s);\n", parameter, parameter);
+        method_request_setters += absl::StrFormat(
+            "  request.set_%s(%s);\n", parameter_name, parameter_name);
       }
       method_signature += ", ";
     }
@@ -240,7 +256,10 @@ void SetResourceRoutingMethodVars(
     method_vars["method_request_url_substitution"] = result->url_substitution;
     std::string param = result->param_key;
     method_vars["method_request_param_key"] = param;
-    std::vector<std::string> chunks = absl::StrSplit(param, '.');
+    std::vector<std::string> chunks;
+    for (const auto sv : absl::StrSplit(param, '.')) {
+      chunks.push_back(ResolveKeyword(std::string(sv)));
+    }
     method_vars["method_request_param_value"] =
         absl::StrJoin(chunks, "().") + "()";
     method_vars["method_request_body"] = result->body;
@@ -334,7 +353,7 @@ std::string FormatApiMethodSignatureParameters(
         EscapePrinterDelimiter(ChompByValue(loc.leading_comments)),
         {{"\n\n", "\n  /// "}, {"\n", "\n  /// "}});
     absl::StrAppendFormat(&parameter_comments, "  /// @param %s %s\n",
-                          parameter, std::move(comment));
+                          ResolveKeyword(parameter), std::move(comment));
   }
   return parameter_comments;
 }

--- a/generator/internal/descriptor_utils_test.cc
+++ b/generator/internal/descriptor_utils_test.cc
@@ -356,6 +356,8 @@ char const* const kServiceProto =
     "  string baz = 1;\n"
     "  // labels $field comment.\n"
     "  map<string, string> labels = 2;\n"
+    "  // namespace $field comment.\n"
+    "  string namespace = 3;\n"
     "}\n"
     "// Leading comments about message Bar.\n"
     "message Bar {\n"
@@ -441,6 +443,7 @@ char const* const kServiceProto =
     "    };\n"
     "    option (google.api.method_signature) = \"labels\";\n"
     "    option (google.api.method_signature) = \"baz,labels\";\n"
+    "    option (google.api.method_signature) = \"namespace\";\n"
     "  }\n"
     "  // Leading comments about rpc Method7.\n"
     "  rpc Method7(Bar) returns (google.longrunning.Operation) {\n"
@@ -519,7 +522,7 @@ TEST_F(CreateMethodVarsTest, FormatMethodCommentsProtobufRequest) {
               HasSubstr(R"""(  ///
   /// Leading comments about rpc Method0$$.
   ///
-  /// @param request @googleapis_link{google::protobuf::Bar,google/foo/v1/service.proto#L15}
+  /// @param request @googleapis_link{google::protobuf::Bar,google/foo/v1/service.proto#L17}
   /// @param options  Optional. Operation options.
   ///
 )"""));
@@ -545,6 +548,15 @@ TEST_F(CreateMethodVarsTest, FormatMethodCommentsMethodSignature) {
   ///
   /// @param baz  baz field$$ comment.
   /// @param labels  labels $$field comment.
+  /// @param options  Optional. Operation options.
+  ///
+)"""));
+  EXPECT_THAT(FormatMethodCommentsMethodSignature(
+                  *service_file_descriptor->service(0)->method(6), "namespace"),
+              HasSubstr(R"""(  ///
+  /// Leading comments about rpc $$Method6.
+  ///
+  /// @param namespace_  namespace $$field comment.
   /// @param options  Optional. Operation options.
   ///
 )"""));
@@ -579,7 +591,7 @@ INSTANTIATE_TEST_SUITE_P(
         MethodVarsTestValues("google.protobuf.Service.Method0",
                              "method_return_doxygen_link",
                              "@googleapis_link{google::protobuf::Empty,google/"
-                             "foo/v1/service.proto#L29}"),
+                             "foo/v1/service.proto#L31}"),
         // Method1
         MethodVarsTestValues("google.protobuf.Service.Method1", "method_name",
                              "Method1"),
@@ -592,7 +604,7 @@ INSTANTIATE_TEST_SUITE_P(
         MethodVarsTestValues("google.protobuf.Service.Method1",
                              "method_return_doxygen_link",
                              "@googleapis_link{google::protobuf::Bar,google/"
-                             "foo/v1/service.proto#L15}"),
+                             "foo/v1/service.proto#L17}"),
         // Method2
         MethodVarsTestValues("google.protobuf.Service.Method2",
                              "longrunning_metadata_type",
@@ -621,7 +633,7 @@ INSTANTIATE_TEST_SUITE_P(
         MethodVarsTestValues("google.protobuf.Service.Method2",
                              "method_longrunning_deduced_return_doxygen_link",
                              "@googleapis_link{google::protobuf::Bar,google/"
-                             "foo/v1/service.proto#L15}"),
+                             "foo/v1/service.proto#L17}"),
         // Method3
         MethodVarsTestValues("google.protobuf.Service.Method3",
                              "longrunning_metadata_type",
@@ -724,6 +736,12 @@ INSTANTIATE_TEST_SUITE_P(
         MethodVarsTestValues(
             "google.protobuf.Service.Method6", "method_request_setters0",
             "  *request.mutable_labels() = {labels.begin(), labels.end()};\n"),
+        MethodVarsTestValues("google.protobuf.Service.Method6",
+                             "method_signature2",
+                             "std::string const& namespace_, "),
+        MethodVarsTestValues("google.protobuf.Service.Method6",
+                             "method_request_setters2",
+                             "  request.set_namespace_(namespace_);\n"),
         // Method7
         MethodVarsTestValues("google.protobuf.Service.Method7",
                              "longrunning_metadata_type",
@@ -740,7 +758,7 @@ INSTANTIATE_TEST_SUITE_P(
         MethodVarsTestValues("google.protobuf.Service.Method7",
                              "method_longrunning_deduced_return_doxygen_link",
                              "@googleapis_link{google::protobuf::Bar,google/"
-                             "foo/v1/service.proto#L15}")),
+                             "foo/v1/service.proto#L17}")),
     [](testing::TestParamInfo<CreateMethodVarsTest::ParamType> const& info) {
       std::vector<std::string> pieces = absl::StrSplit(info.param.method, '.');
       return pieces.back() + "_" + info.param.vars_key;


### PR DESCRIPTION
Motivated by a new service with a proto containing a "namespace"
field.  The C++ proto compiler adds a trailing underscore to such
fields and their associated accessors, so we should do the same.
And we should also do it in the parameters to "method_signature"
overloads, and in generated @param annotations.

If anyone has any better ideas for working around the cmake issue,
or for some alternative method to access libprotoc's cpp keyword
mapping, I'm all ears.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8053)
<!-- Reviewable:end -->
