### PR TITLE
test(bigtable): split instance admin test in two

### DIFF
--- a/google/cloud/bigtable/CMakeLists.txt
+++ b/google/cloud/bigtable/CMakeLists.txt
@@ -304,6 +304,7 @@ if (BUILD_TESTING)
         iam_policy_test.cc
         idempotent_mutation_policy_test.cc
         instance_admin_client_test.cc
+        instance_admin_new_test.cc
         instance_admin_test.cc
         instance_config_test.cc
         instance_update_config_test.cc

--- a/google/cloud/bigtable/bigtable_client_unit_tests.bzl
+++ b/google/cloud/bigtable/bigtable_client_unit_tests.bzl
@@ -34,6 +34,7 @@ bigtable_client_unit_tests = [
     "iam_policy_test.cc",
     "idempotent_mutation_policy_test.cc",
     "instance_admin_client_test.cc",
+    "instance_admin_new_test.cc",
     "instance_admin_test.cc",
     "instance_config_test.cc",
     "instance_update_config_test.cc",

--- a/google/cloud/bigtable/instance_admin_new_test.cc
+++ b/google/cloud/bigtable/instance_admin_new_test.cc
@@ -1,0 +1,98 @@
+// Copyright 2022 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/bigtable/instance_admin.h"
+#include "google/cloud/bigtable/testing/mock_instance_admin_client.h"
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+namespace bigtable {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+namespace {
+
+using ::testing::ReturnRef;
+
+using MockAdminClient =
+    ::google::cloud::bigtable::testing::MockInstanceAdminClient;
+
+std::string const kProjectId = "the-project";
+
+/// A fixture for the bigtable::InstanceAdmin tests.
+class InstanceAdminTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    EXPECT_CALL(*client_, project()).WillRepeatedly(ReturnRef(kProjectId));
+  }
+
+  std::shared_ptr<MockAdminClient> client_ =
+      std::make_shared<MockAdminClient>();
+};
+
+/// @test Verify basic functionality in the `bigtable::InstanceAdmin` class.
+TEST_F(InstanceAdminTest, Default) {
+  InstanceAdmin tested(client_);
+  EXPECT_EQ("the-project", tested.project_id());
+}
+
+TEST_F(InstanceAdminTest, CopyConstructor) {
+  InstanceAdmin source(client_);
+  std::string const& expected = source.project_id();
+  // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
+  InstanceAdmin copy(source);
+  EXPECT_EQ(expected, copy.project_id());
+}
+
+TEST_F(InstanceAdminTest, MoveConstructor) {
+  InstanceAdmin source(client_);
+  std::string expected = source.project_id();
+  InstanceAdmin copy(std::move(source));
+  EXPECT_EQ(expected, copy.project_id());
+}
+
+TEST_F(InstanceAdminTest, CopyAssignment) {
+  std::shared_ptr<MockAdminClient> other_client =
+      std::make_shared<MockAdminClient>();
+  std::string other_project = "other-project";
+  EXPECT_CALL(*other_client, project())
+      .WillRepeatedly(ReturnRef(other_project));
+
+  InstanceAdmin source(client_);
+  std::string const& expected = source.project_id();
+  InstanceAdmin dest(other_client);
+  EXPECT_NE(expected, dest.project_id());
+  dest = source;
+  EXPECT_EQ(expected, dest.project_id());
+}
+
+TEST_F(InstanceAdminTest, MoveAssignment) {
+  std::shared_ptr<MockAdminClient> other_client =
+      std::make_shared<MockAdminClient>();
+  std::string other_project = "other-project";
+  EXPECT_CALL(*other_client, project())
+      .WillRepeatedly(ReturnRef(other_project));
+
+  InstanceAdmin source(client_);
+  std::string expected = source.project_id();
+  InstanceAdmin dest(other_client);
+  EXPECT_NE(expected, dest.project_id());
+  dest = std::move(source);
+  EXPECT_EQ(expected, dest.project_id());
+}
+
+}  // namespace
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace bigtable
+}  // namespace cloud
+}  // namespace google


### PR DESCRIPTION
Split the test in two. I will keep the new one, and eventually delete the old one. I tried to have the new one be named "instance_admin_test.cc" and the old one be named "instance_admin_legacy_test.cc", but I could not get the diff that I wanted.

If we think this is being too careful, we can go with #8055 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8057)
<!-- Reviewable:end -->
