### PR TITLE
ci(storage): ignore coverage for generated code

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -9,3 +9,11 @@ coverage:
 ignore:
   - "google/cloud/bigtable/admin"
   - "google/cloud/spanner/admin"
+  - "google/cloud/storage/internal/storage_auth_decorator.cc"
+  - "google/cloud/storage/internal/storage_auth_decorator.h"
+  - "google/cloud/storage/internal/storage_logging_decorator.cc"
+  - "google/cloud/storage/internal/storage_logging_decorator.h"
+  - "google/cloud/storage/internal/storage_metadata_decorator.cc"
+  - "google/cloud/storage/internal/storage_metadata_decorator.h"
+  - "google/cloud/storage/internal/storage_stub.cc"
+  - "google/cloud/storage/internal/storage_stub.h"


### PR DESCRIPTION
We do not need to worry about test coverage in generated code, we have
separate tests for the generator (and for the code it generates).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8060)
<!-- Reviewable:end -->
