### PR TITLE
impl(bigtable): implement connection mechanism in legacy InstanceAdmin

### DIFF
--- a/google/cloud/bigtable/instance_admin_client.cc
+++ b/google/cloud/bigtable/instance_admin_client.cc
@@ -325,13 +325,12 @@ class DefaultInstanceAdminClient : public InstanceAdminClient {
         stub->AsyncGetOperation(context, request, cq).release());
   }
 
- protected:
+ private:
   std::shared_ptr<bigtable_admin::BigtableInstanceAdminConnection> connection()
       override {
     return connection_;
   }
 
- private:
   google::cloud::BackgroundThreadsFactory BackgroundThreadsFactory() override {
     return impl_.BackgroundThreadsFactory();
   }

--- a/google/cloud/bigtable/instance_admin_client.cc
+++ b/google/cloud/bigtable/instance_admin_client.cc
@@ -41,7 +41,9 @@ namespace btadmin = ::google::bigtable::admin::v2;
 class DefaultInstanceAdminClient : public InstanceAdminClient {
  public:
   DefaultInstanceAdminClient(std::string project, Options options)
-      : project_(std::move(project)), impl_(std::move(options)) {}
+      : project_(std::move(project)), impl_(options) {
+    MakeConnection(std::move(options));
+  }
 
   std::string const& project() const override { return project_; }
   std::shared_ptr<grpc::Channel> Channel() override { return impl_.Channel(); }

--- a/google/cloud/bigtable/instance_admin_client.cc
+++ b/google/cloud/bigtable/instance_admin_client.cc
@@ -41,9 +41,10 @@ namespace btadmin = ::google::bigtable::admin::v2;
 class DefaultInstanceAdminClient : public InstanceAdminClient {
  public:
   DefaultInstanceAdminClient(std::string project, Options options)
-      : project_(std::move(project)), impl_(options) {
-    MakeConnection(std::move(options));
-  }
+      : project_(std::move(project)),
+        impl_(options),
+        connection_(bigtable_admin::MakeBigtableInstanceAdminConnection(
+            std::move(options))) {}
 
   std::string const& project() const override { return project_; }
   std::shared_ptr<grpc::Channel> Channel() override { return impl_.Channel(); }
@@ -324,6 +325,12 @@ class DefaultInstanceAdminClient : public InstanceAdminClient {
         stub->AsyncGetOperation(context, request, cq).release());
   }
 
+ protected:
+  std::shared_ptr<bigtable_admin::BigtableInstanceAdminConnection> connection()
+      override {
+    return connection_;
+  }
+
  private:
   google::cloud::BackgroundThreadsFactory BackgroundThreadsFactory() override {
     return impl_.BackgroundThreadsFactory();
@@ -331,6 +338,7 @@ class DefaultInstanceAdminClient : public InstanceAdminClient {
 
   std::string project_;
   internal::CommonClient<btadmin::BigtableInstanceAdmin> impl_;
+  std::shared_ptr<bigtable_admin::BigtableInstanceAdminConnection> connection_;
 };
 
 }  // anonymous namespace

--- a/google/cloud/bigtable/instance_admin_client.h
+++ b/google/cloud/bigtable/instance_admin_client.h
@@ -15,6 +15,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_INSTANCE_ADMIN_CLIENT_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_INSTANCE_ADMIN_CLIENT_H
 
+#include "google/cloud/bigtable/admin/bigtable_instance_admin_connection.h"
 #include "google/cloud/bigtable/client_options.h"
 #include "google/cloud/bigtable/version.h"
 #include <google/bigtable/admin/v2/bigtable_instance_admin.grpc.pb.h>
@@ -87,7 +88,11 @@ class InstanceAdminClient {
   // them protected, so the mock classes can override them, and then make the
   // classes that do use them friends.
  protected:
-  friend class InstanceAdmin;
+  void MakeConnection(Options options) {
+    connection_ =
+        bigtable_admin::MakeBigtableInstanceAdminConnection(std::move(options));
+  }
+
   template <typename Client, typename Response>
   friend class internal::AsyncLongrunningOperation;
   friend class internal::LoggingInstanceAdminClient;
@@ -325,6 +330,16 @@ class InstanceAdminClient {
                     google::longrunning::GetOperationRequest const& request,
                     grpc::CompletionQueue* cq) = 0;
   //@}
+
+ private:
+  friend class InstanceAdmin;
+
+  std::shared_ptr<bigtable_admin::BigtableInstanceAdminConnection>
+  connection() {
+    return connection_;
+  }
+
+  std::shared_ptr<bigtable_admin::BigtableInstanceAdminConnection> connection_;
 };
 
 /// Create a new instance admin client configured via @p options.

--- a/google/cloud/bigtable/instance_admin_client.h
+++ b/google/cloud/bigtable/instance_admin_client.h
@@ -88,11 +88,6 @@ class InstanceAdminClient {
   // them protected, so the mock classes can override them, and then make the
   // classes that do use them friends.
  protected:
-  void MakeConnection(Options options) {
-    connection_ =
-        bigtable_admin::MakeBigtableInstanceAdminConnection(std::move(options));
-  }
-
   template <typename Client, typename Response>
   friend class internal::AsyncLongrunningOperation;
   friend class internal::LoggingInstanceAdminClient;
@@ -333,13 +328,11 @@ class InstanceAdminClient {
 
  private:
   friend class InstanceAdmin;
-
-  std::shared_ptr<bigtable_admin::BigtableInstanceAdminConnection>
+  // TODO(#7534): Make this a pure virtual function, when we break the class.
+  virtual std::shared_ptr<bigtable_admin::BigtableInstanceAdminConnection>
   connection() {
-    return connection_;
+    return nullptr;
   }
-
-  std::shared_ptr<bigtable_admin::BigtableInstanceAdminConnection> connection_;
 };
 
 /// Create a new instance admin client configured via @p options.

--- a/google/cloud/bigtable/instance_admin_new_test.cc
+++ b/google/cloud/bigtable/instance_admin_new_test.cc
@@ -1,4 +1,4 @@
-// Copyright 2022 Google Inc.
+// Copyright 2022 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,42 +12,47 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "google/cloud/bigtable/admin/mocks/mock_bigtable_instance_admin_connection.h"
 #include "google/cloud/bigtable/instance_admin.h"
-#include "google/cloud/bigtable/testing/mock_instance_admin_client.h"
 #include <gmock/gmock.h>
 
 namespace google {
 namespace cloud {
 namespace bigtable {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+
+// Helper class for checking that the legacy API still functions correctly
+class InstanceAdminTester {
+ public:
+  static std::shared_ptr<bigtable_admin::BigtableInstanceAdminConnection>
+  Connection(InstanceAdmin const& admin) {
+    return admin.connection_;
+  }
+};
+
 namespace {
 
-using ::testing::ReturnRef;
-
-using MockAdminClient =
-    ::google::cloud::bigtable::testing::MockInstanceAdminClient;
+using MockConnection =
+    ::google::cloud::bigtable_admin_mocks::MockBigtableInstanceAdminConnection;
 
 std::string const kProjectId = "the-project";
 
 /// A fixture for the bigtable::InstanceAdmin tests.
 class InstanceAdminTest : public ::testing::Test {
  protected:
-  void SetUp() override {
-    EXPECT_CALL(*client_, project()).WillRepeatedly(ReturnRef(kProjectId));
-  }
-
-  std::shared_ptr<MockAdminClient> client_ =
-      std::make_shared<MockAdminClient>();
+  std::shared_ptr<MockConnection> connection_ =
+      std::make_shared<MockConnection>();
 };
 
-/// @test Verify basic functionality in the `bigtable::InstanceAdmin` class.
-TEST_F(InstanceAdminTest, Default) {
-  InstanceAdmin tested(client_);
-  EXPECT_EQ("the-project", tested.project_id());
+TEST_F(InstanceAdminTest, Project) {
+  Project p(kProjectId);
+  InstanceAdmin tested(MakeInstanceAdminClient(p.project_id()));
+  EXPECT_EQ(p.project_id(), tested.project_id());
+  EXPECT_EQ(p.FullName(), tested.project_name());
 }
 
 TEST_F(InstanceAdminTest, CopyConstructor) {
-  InstanceAdmin source(client_);
+  auto source = InstanceAdmin(connection_, kProjectId);
   std::string const& expected = source.project_id();
   // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
   InstanceAdmin copy(source);
@@ -55,40 +60,44 @@ TEST_F(InstanceAdminTest, CopyConstructor) {
 }
 
 TEST_F(InstanceAdminTest, MoveConstructor) {
-  InstanceAdmin source(client_);
+  auto source = InstanceAdmin(connection_, kProjectId);
   std::string expected = source.project_id();
   InstanceAdmin copy(std::move(source));
   EXPECT_EQ(expected, copy.project_id());
 }
 
 TEST_F(InstanceAdminTest, CopyAssignment) {
-  std::shared_ptr<MockAdminClient> other_client =
-      std::make_shared<MockAdminClient>();
-  std::string other_project = "other-project";
-  EXPECT_CALL(*other_client, project())
-      .WillRepeatedly(ReturnRef(other_project));
+  std::shared_ptr<MockConnection> other_client =
+      std::make_shared<MockConnection>();
 
-  InstanceAdmin source(client_);
+  auto source = InstanceAdmin(connection_, kProjectId);
   std::string const& expected = source.project_id();
-  InstanceAdmin dest(other_client);
+  auto dest = InstanceAdmin(other_client, "other-project");
   EXPECT_NE(expected, dest.project_id());
   dest = source;
   EXPECT_EQ(expected, dest.project_id());
 }
 
 TEST_F(InstanceAdminTest, MoveAssignment) {
-  std::shared_ptr<MockAdminClient> other_client =
-      std::make_shared<MockAdminClient>();
-  std::string other_project = "other-project";
-  EXPECT_CALL(*other_client, project())
-      .WillRepeatedly(ReturnRef(other_project));
+  std::shared_ptr<MockConnection> other_client =
+      std::make_shared<MockConnection>();
 
-  InstanceAdmin source(client_);
+  auto source = InstanceAdmin(connection_, kProjectId);
   std::string expected = source.project_id();
-  InstanceAdmin dest(other_client);
+  auto dest = InstanceAdmin(other_client, "other-project");
   EXPECT_NE(expected, dest.project_id());
   dest = std::move(source);
   EXPECT_EQ(expected, dest.project_id());
+}
+
+TEST_F(InstanceAdminTest, LegacyConstructorSharesConnection) {
+  auto admin_client = MakeInstanceAdminClient("test-project");
+  auto admin_1 = InstanceAdmin(admin_client);
+  auto admin_2 = InstanceAdmin(admin_client);
+  auto conn_1 = InstanceAdminTester::Connection(admin_1);
+  auto conn_2 = InstanceAdminTester::Connection(admin_2);
+
+  EXPECT_EQ(conn_1, conn_2);
 }
 
 }  // namespace


### PR DESCRIPTION
Part of the work for #7534.

This PR adds the mechanism for storing generated connections in `InstanceAdmin`. This code is unused and sits side by side with the old way (using `InstanceAdminClient`). This PR is one step in the conversion process. The big picture can be found [here](https://github.com/googleapis/google-cloud-cpp/compare/main...dbolduc:bigtable-convert-instance-admin).

Previous code could have one `InstanceAdminClient` that is shared by N `InstanceAdmin`s. In this case, we want the N `InstanceAdmin`s to all share the same `bigtable_admin::BigtableInstanceAdminConnection`. So we make the connection upon construction of the `InstanceAdminClient` and give the `InstanceAdmin` access to it.

Temporary things:
* The added constructor will make an `InstanceAdmin` that cannot make RPC calls. That is okay, it will function by the release.
* Every `InstanceAdminClient` initiates an extra connection it does not use. This is fine, we will get rid of the legacy stuff before release.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8061)
<!-- Reviewable:end -->
