### PR TITLE
fix(spanner): apply policy options in (generated) client ctor

### DIFF
--- a/google/cloud/spanner/admin/integration_tests/backup_extra_integration_test.cc
+++ b/google/cloud/spanner/admin/integration_tests/backup_extra_integration_test.cc
@@ -79,7 +79,8 @@ class BackupExtraIntegrationTest
  public:
   BackupExtraIntegrationTest()
       : generator_(google::cloud::internal::MakeDefaultPRNG()),
-        database_admin_client_(spanner_admin::MakeDatabaseAdminConnection(
+        database_admin_client_(
+            spanner_admin::MakeDatabaseAdminConnection(),
             Options{}
                 .set<spanner_admin::DatabaseAdminRetryPolicyOption>(
                     spanner_admin::DatabaseAdminLimitedTimeRetryPolicy(
@@ -94,7 +95,7 @@ class BackupExtraIntegrationTest
                         LimitedTimeRetryPolicy(std::chrono::hours(3)),
                         ExponentialBackoffPolicy(std::chrono::seconds(1),
                                                  std::chrono::minutes(1), 2.0))
-                        .clone()))) {}
+                        .clone())) {}
 
  protected:
   google::cloud::internal::DefaultPRNG generator_;

--- a/google/cloud/spanner/admin/integration_tests/backup_integration_test.cc
+++ b/google/cloud/spanner/admin/integration_tests/backup_integration_test.cc
@@ -69,7 +69,8 @@ class BackupIntegrationTest
  public:
   BackupIntegrationTest()
       : generator_(google::cloud::internal::MakeDefaultPRNG()),
-        database_admin_client_(spanner_admin::MakeDatabaseAdminConnection(
+        database_admin_client_(
+            spanner_admin::MakeDatabaseAdminConnection(),
             Options{}
                 .set<spanner_admin::DatabaseAdminRetryPolicyOption>(
                     spanner_admin::DatabaseAdminLimitedTimeRetryPolicy(
@@ -84,7 +85,7 @@ class BackupIntegrationTest
                         LimitedTimeRetryPolicy(std::chrono::hours(3)),
                         ExponentialBackoffPolicy(std::chrono::seconds(1),
                                                  std::chrono::minutes(1), 2.0))
-                        .clone()))) {}
+                        .clone())) {}
 
  protected:
   google::cloud::internal::DefaultPRNG generator_;

--- a/google/cloud/spanner/samples/samples.cc
+++ b/google/cloud/spanner/samples/samples.cc
@@ -3064,17 +3064,16 @@ void CustomInstanceAdminPolicies(std::vector<std::string> argv) {
                 /*scaling=*/4.0))
             .clone();
     auto client = google::cloud::spanner_admin::InstanceAdminClient(
-        google::cloud::spanner_admin::MakeInstanceAdminConnection(
-            google::cloud::Options{}
-                .set<google::cloud::spanner_admin::
-                         InstanceAdminRetryPolicyOption>(
-                    std::move(retry_policy))
-                .set<google::cloud::spanner_admin::
-                         InstanceAdminBackoffPolicyOption>(
-                    std::move(backoff_policy))
-                .set<google::cloud::spanner_admin::
-                         InstanceAdminPollingPolicyOption>(
-                    std::move(polling_policy))));
+        google::cloud::spanner_admin::MakeInstanceAdminConnection(),
+        google::cloud::Options{}
+            .set<google::cloud::spanner_admin::InstanceAdminRetryPolicyOption>(
+                std::move(retry_policy))
+            .set<
+                google::cloud::spanner_admin::InstanceAdminBackoffPolicyOption>(
+                std::move(backoff_policy))
+            .set<
+                google::cloud::spanner_admin::InstanceAdminPollingPolicyOption>(
+                std::move(polling_policy)));
 
     // Use the client as usual.
     std::cout << "Available configs for project " << project_id << "\n";
@@ -3129,17 +3128,16 @@ void CustomDatabaseAdminPolicies(std::vector<std::string> argv) {
                 /*scaling=*/4.0))
             .clone();
     auto client = google::cloud::spanner_admin::DatabaseAdminClient(
-        google::cloud::spanner_admin::MakeDatabaseAdminConnection(
-            google::cloud::Options{}
-                .set<google::cloud::spanner_admin::
-                         DatabaseAdminRetryPolicyOption>(
-                    std::move(retry_policy))
-                .set<google::cloud::spanner_admin::
-                         DatabaseAdminBackoffPolicyOption>(
-                    std::move(backoff_policy))
-                .set<google::cloud::spanner_admin::
-                         DatabaseAdminPollingPolicyOption>(
-                    std::move(polling_policy))));
+        google::cloud::spanner_admin::MakeDatabaseAdminConnection(),
+        google::cloud::Options{}
+            .set<google::cloud::spanner_admin::DatabaseAdminRetryPolicyOption>(
+                std::move(retry_policy))
+            .set<
+                google::cloud::spanner_admin::DatabaseAdminBackoffPolicyOption>(
+                std::move(backoff_policy))
+            .set<
+                google::cloud::spanner_admin::DatabaseAdminPollingPolicyOption>(
+                std::move(polling_policy)));
 
     // Use the client as usual.
     spanner::Instance instance(project_id, instance_id);
@@ -3830,19 +3828,16 @@ void RunAll(bool emulator) {
   std::cout << "Running samples on " << instance_id << std::endl;
 
   google::cloud::spanner_admin::InstanceAdminClient instance_admin_client(
-      google::cloud::spanner_admin::MakeInstanceAdminConnection(
-          google::cloud::Options{}
-              .set<
-                  google::cloud::spanner_admin::InstanceAdminRetryPolicyOption>(
-                  google::cloud::spanner_admin::
-                      InstanceAdminLimitedTimeRetryPolicy(
-                          std::chrono::minutes(60))
-                          .clone())
-              .set<google::cloud::spanner_admin::
-                       InstanceAdminBackoffPolicyOption>(
-                  google::cloud::spanner::ExponentialBackoffPolicy(
-                      std::chrono::seconds(1), std::chrono::minutes(1), 2.0)
-                      .clone())));
+      google::cloud::spanner_admin::MakeInstanceAdminConnection(),
+      google::cloud::Options{}
+          .set<google::cloud::spanner_admin::InstanceAdminRetryPolicyOption>(
+              google::cloud::spanner_admin::InstanceAdminLimitedTimeRetryPolicy(
+                  std::chrono::minutes(60))
+                  .clone())
+          .set<google::cloud::spanner_admin::InstanceAdminBackoffPolicyOption>(
+              google::cloud::spanner::ExponentialBackoffPolicy(
+                  std::chrono::seconds(1), std::chrono::minutes(1), 2.0)
+                  .clone()));
 
   SampleBanner("get-instance");
   GetInstance(instance_admin_client, project_id, instance_id);
@@ -3866,28 +3861,23 @@ void RunAll(bool emulator) {
       google::cloud::spanner_testing::RandomDatabaseName(generator);
 
   google::cloud::spanner_admin::DatabaseAdminClient database_admin_client(
-      google::cloud::spanner_admin::MakeDatabaseAdminConnection(
-          google::cloud::Options{}
-              .set<
-                  google::cloud::spanner_admin::DatabaseAdminRetryPolicyOption>(
-                  google::cloud::spanner_admin::
-                      DatabaseAdminLimitedTimeRetryPolicy(
-                          std::chrono::minutes(60))
-                          .clone())
-              .set<google::cloud::spanner_admin::
-                       DatabaseAdminBackoffPolicyOption>(
+      google::cloud::spanner_admin::MakeDatabaseAdminConnection(),
+      google::cloud::Options{}
+          .set<google::cloud::spanner_admin::DatabaseAdminRetryPolicyOption>(
+              google::cloud::spanner_admin::DatabaseAdminLimitedTimeRetryPolicy(
+                  std::chrono::minutes(60))
+                  .clone())
+          .set<google::cloud::spanner_admin::DatabaseAdminBackoffPolicyOption>(
+              google::cloud::spanner::ExponentialBackoffPolicy(
+                  std::chrono::seconds(1), std::chrono::minutes(1), 2.0)
+                  .clone())
+          .set<google::cloud::spanner_admin::DatabaseAdminPollingPolicyOption>(
+              google::cloud::spanner::GenericPollingPolicy<>(
+                  google::cloud::spanner::LimitedTimeRetryPolicy(
+                      std::chrono::hours(2)),
                   google::cloud::spanner::ExponentialBackoffPolicy(
-                      std::chrono::seconds(1), std::chrono::minutes(1), 2.0)
-                      .clone())
-              .set<google::cloud::spanner_admin::
-                       DatabaseAdminPollingPolicyOption>(
-                  google::cloud::spanner::GenericPollingPolicy<>(
-                      google::cloud::spanner::LimitedTimeRetryPolicy(
-                          std::chrono::hours(2)),
-                      google::cloud::spanner::ExponentialBackoffPolicy(
-                          std::chrono::seconds(1), std::chrono::minutes(1),
-                          2.0))
-                      .clone())));
+                      std::chrono::seconds(1), std::chrono::minutes(1), 2.0))
+                  .clone()));
 
   RunAllSlowInstanceTests(instance_admin_client, database_admin_client,
                           generator, project_id, test_iam_service_account,


### PR DESCRIPTION
Apply any retry/backoff/polling policies in the client options
instead of the connection options.  This makes more logical
sense (particularly so when we consider per-operation options),
and is actually required until we fix #8054.

Fixes #8037.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8064)
<!-- Reviewable:end -->
