### PR TITLE
refactor(bigtable): use `EndpointOption`

### DIFF
--- a/google/cloud/bigtable/admin_client.cc
+++ b/google/cloud/bigtable/admin_client.cc
@@ -394,21 +394,15 @@ class DefaultAdminClient : public google::cloud::bigtable::AdminClient {
     return impl_.BackgroundThreadsFactory();
   }
 
-  struct Traits {
-    static std::string const& Endpoint(Options const& options) {
-      return options.get<AdminEndpointOption>();
-    }
-  };
-
   std::string project_;
-  internal::CommonClient<Traits, btadmin::BigtableTableAdmin> impl_;
+  internal::CommonClient<btadmin::BigtableTableAdmin> impl_;
 };
 
 }  // namespace
 
 std::shared_ptr<AdminClient> MakeAdminClient(std::string project,
                                              Options options) {
-  options = internal::DefaultOptions(std::move(options));
+  options = internal::DefaultTableAdminOptions(std::move(options));
   bool tracing_enabled = google::cloud::internal::Contains(
       options.get<TracingComponentsOption>(), "rpc");
   auto tracing_options = options.get<GrpcTracingOptionsOption>();

--- a/google/cloud/bigtable/data_client.cc
+++ b/google/cloud/bigtable/data_client.cc
@@ -169,15 +169,9 @@ class DefaultDataClient : public DataClient {
     return impl_.BackgroundThreadsFactory();
   }
 
-  struct Traits {
-    static std::string const& Endpoint(Options const& options) {
-      return options.get<DataEndpointOption>();
-    }
-  };
-
   std::string project_;
   std::string instance_;
-  internal::CommonClient<Traits, btproto::Bigtable> impl_;
+  internal::CommonClient<btproto::Bigtable> impl_;
 };
 
 }  // namespace
@@ -185,7 +179,7 @@ class DefaultDataClient : public DataClient {
 std::shared_ptr<DataClient> MakeDataClient(std::string project_id,
                                            std::string instance_id,
                                            Options options) {
-  options = internal::DefaultOptions(std::move(options));
+  options = internal::DefaultDataOptions(std::move(options));
   bool tracing_enabled = google::cloud::internal::Contains(
       options.get<TracingComponentsOption>(), "rpc");
   auto tracing_options = options.get<GrpcTracingOptionsOption>();

--- a/google/cloud/bigtable/instance_admin_client.cc
+++ b/google/cloud/bigtable/instance_admin_client.cc
@@ -327,21 +327,15 @@ class DefaultInstanceAdminClient : public InstanceAdminClient {
     return impl_.BackgroundThreadsFactory();
   }
 
-  struct Traits {
-    static std::string const& Endpoint(Options const& options) {
-      return options.get<InstanceAdminEndpointOption>();
-    }
-  };
-
   std::string project_;
-  internal::CommonClient<Traits, btadmin::BigtableInstanceAdmin> impl_;
+  internal::CommonClient<btadmin::BigtableInstanceAdmin> impl_;
 };
 
 }  // anonymous namespace
 
 std::shared_ptr<InstanceAdminClient> MakeInstanceAdminClient(
     std::string project, Options options) {
-  options = internal::DefaultOptions(std::move(options));
+  options = internal::DefaultInstanceAdminOptions(std::move(options));
   bool tracing_enabled = google::cloud::internal::Contains(
       options.get<TracingComponentsOption>(), "rpc");
   auto tracing_options = options.get<GrpcTracingOptionsOption>();

--- a/google/cloud/bigtable/internal/common_client.h
+++ b/google/cloud/bigtable/internal/common_client.h
@@ -110,11 +110,9 @@ void ScheduleChannelRefresh(
  * The class exposes the channels because they are needed for clients that
  * use more than one type of Stub.
  *
- * @tparam Traits encapsulates variations between the clients.  Currently, which
- *   `*_endpoint()` member function is used.
  * @tparam Interface the gRPC object returned by `Stub()`.
  */
-template <typename Traits, typename Interface>
+template <typename Interface>
 class CommonClient {
  public:
   //@{
@@ -216,7 +214,7 @@ class CommonClient {
     auto args = google::cloud::internal::MakeChannelArguments(opts_);
     args.SetInt(GRPC_ARG_CHANNEL_ID, idx);
     auto res = grpc::CreateCustomChannel(
-        Traits::Endpoint(opts_), opts_.get<GrpcCredentialOption>(), args);
+        opts_.get<EndpointOption>(), opts_.get<GrpcCredentialOption>(), args);
     if (opts_.get<MaxConnectionRefreshOption>().count() == 0) {
       return res;
     }

--- a/google/cloud/bigtable/internal/defaults.cc
+++ b/google/cloud/bigtable/internal/defaults.cc
@@ -156,6 +156,21 @@ Options DefaultOptions(Options opts) {
   return opts;
 }
 
+Options DefaultDataOptions(Options opts) {
+  opts = DefaultOptions(std::move(opts));
+  return opts.set<EndpointOption>(opts.get<DataEndpointOption>());
+}
+
+Options DefaultInstanceAdminOptions(Options opts) {
+  opts = DefaultOptions(std::move(opts));
+  return opts.set<EndpointOption>(opts.get<InstanceAdminEndpointOption>());
+}
+
+Options DefaultTableAdminOptions(Options opts) {
+  opts = DefaultOptions(std::move(opts));
+  return opts.set<EndpointOption>(opts.get<AdminEndpointOption>());
+}
+
 }  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigtable

--- a/google/cloud/bigtable/internal/defaults.h
+++ b/google/cloud/bigtable/internal/defaults.h
@@ -41,6 +41,12 @@ int DefaultConnectionPoolSize();
  */
 Options DefaultOptions(Options opts = {});
 
+Options DefaultDataOptions(Options opts);
+
+Options DefaultInstanceAdminOptions(Options opts);
+
+Options DefaultTableAdminOptions(Options opts);
+
 }  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigtable

--- a/google/cloud/bigtable/internal/defaults_test.cc
+++ b/google/cloud/bigtable/internal/defaults_test.cc
@@ -118,6 +118,36 @@ TEST(OptionsTest, DefaultOptionsDoesNotOverride) {
   EXPECT_THAT(*s, HasSubstr("test-prefix"));
 }
 
+TEST(OptionsTest, DefaultDataOptions) {
+  auto options =
+      Options{}
+          .set<DataEndpointOption>("data.googleapis.com")
+          .set<AdminEndpointOption>("tableadmin.googleapis.com")
+          .set<InstanceAdminEndpointOption>("instanceadmin.googleapis.com");
+  options = DefaultDataOptions(std::move(options));
+  EXPECT_EQ("data.googleapis.com", options.get<EndpointOption>());
+}
+
+TEST(OptionsTest, DefaultInstanceAdminOptions) {
+  auto options =
+      Options{}
+          .set<DataEndpointOption>("data.googleapis.com")
+          .set<AdminEndpointOption>("tableadmin.googleapis.com")
+          .set<InstanceAdminEndpointOption>("instanceadmin.googleapis.com");
+  options = DefaultInstanceAdminOptions(std::move(options));
+  EXPECT_EQ("instanceadmin.googleapis.com", options.get<EndpointOption>());
+}
+
+TEST(OptionsTest, DefaultTableAdminOptions) {
+  auto options =
+      Options{}
+          .set<DataEndpointOption>("data.googleapis.com")
+          .set<AdminEndpointOption>("tableadmin.googleapis.com")
+          .set<InstanceAdminEndpointOption>("instanceadmin.googleapis.com");
+  options = DefaultTableAdminOptions(std::move(options));
+  EXPECT_EQ("tableadmin.googleapis.com", options.get<EndpointOption>());
+}
+
 TEST(EndpointEnvTest, EmulatorEnvOnly) {
   ScopedEnvironment emulator("BIGTABLE_EMULATOR_HOST", "emulator-host:8000");
 


### PR DESCRIPTION
In legacy Bigtable, we compute the default endpoints for the Data, InstanceAdmin, and TableAdmin APIs all at once. They are stored as Bigtable-specific options.

The generated Connection does not know about these options. So we must extract the proper endpoint and set it as the `EndpointOption`. While we're here, simplify the `CommonClient<>` class, even though it will be going [bye-bye](https://www.youtube.com/watch?v=B6XAZgTxbDc) soon.

I should consider deprecating `DataEndpointOption`, `AdminEndpointOption`, `InstanceAdminEndpointOption` in favor of internal versions of those options.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8069)
<!-- Reviewable:end -->
