### PR TITLE
test(storage): fix unsigned vs. signed warnings

### DIFF
--- a/google/cloud/storage/internal/resumable_upload_session_test.cc
+++ b/google/cloud/storage/internal/resumable_upload_session_test.cc
@@ -37,7 +37,7 @@ TEST(ResumableUploadResponseTest, Base) {
   ASSERT_TRUE(actual.payload.has_value());
   EXPECT_EQ("test-object-name", actual.payload->name());
   EXPECT_EQ("location-value", actual.upload_session_url);
-  EXPECT_EQ(2000, actual.committed_size);
+  EXPECT_EQ(2000, actual.committed_size.value_or(0));
   EXPECT_EQ(ResumableUploadResponse::kDone, actual.upload_state);
 
   std::ostringstream os;
@@ -54,7 +54,7 @@ TEST(ResumableUploadResponseTest, NoLocation) {
                     .value();
   EXPECT_FALSE(actual.payload.has_value());
   EXPECT_EQ("", actual.upload_session_url);
-  EXPECT_EQ(2000, actual.committed_size);
+  EXPECT_EQ(2000, actual.committed_size.value_or(0));
   EXPECT_EQ(ResumableUploadResponse::kInProgress, actual.upload_state);
 }
 


### PR DESCRIPTION
I am not sure why we don't get this warning in the clang-tidy build, but fixing anyway:


```
external/com_google_absl/absl/types/optional.h: In instantiation of 'constexpr decltype (absl::lts_20211102::optional_internal::convertible_to_bool((v == (* x)))) absl::lts_20211102::operator==(const U&, const absl::lts_20211102::optional<T>&) [with T = long unsigned int; U = int; decltype (absl::lts_20211102::optional_internal::convertible_to_bool((v == (* x)))) = bool]':
external/com_google_googletest/googletest/include/gtest/gtest.h:1545:11:   required from 'testing::AssertionResult testing::internal::CmpHelperEQ(const char*, const char*, const T1&, const T2&) [with T1 = int; T2 = absl::lts_20211102::optional<long unsigned int>]'
external/com_google_googletest/googletest/include/gtest/gtest.h:1564:23:   required from 'static testing::AssertionResult testing::internal::EqHelper::Compare(const char*, const char*, const T1&, const T2&) [with T1 = int; T2 = absl::lts_20211102::optional<long unsigned int>; typename std::enable_if<((! std::is_integral<_Tp>::value) || (! std::is_pointer<_Dp>::value))>::type* <anonymous> = 0]'
google/cloud/storage/internal/resumable_upload_session_test.cc:40:3:   required from here
external/com_google_absl/absl/types/optional.h:707:53: warning: comparison of integer expressions of different signedness: 'const int' and 'const long unsigned int' [-Wsign-compare]
  707 |   return static_cast<bool>(x) ? static_cast<bool>(v == *x) : false;
      |                                                   ~~^~~~~
INFO: Elapsed time: 3.086s, Critical Path: 2.52s
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8071)
<!-- Reviewable:end -->
