### PR TITLE
fix(pubsublite): Restructure stream_factory.h to use generated stubs

### DIFF
--- a/google/cloud/pubsublite/internal/stream_factory.h
+++ b/google/cloud/pubsublite/internal/stream_factory.h
@@ -32,12 +32,8 @@ namespace pubsublite_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 template <class Request, class Response>
-using BidiStream =
-    ::google::cloud::AsyncStreamingReadWriteRpc<Request, Response>;
-
-template <class Request, class Response>
-using StreamFactory =
-    std::function<std::unique_ptr<BidiStream<Request, Response>>()>;
+using StreamFactory = std::function<
+    std::unique_ptr<AsyncStreamingReadWriteRpc<Request, Response>>()>;
 
 using ClientMetadata = std::unordered_map<std::string, std::string>;
 
@@ -61,10 +57,9 @@ MakeStreamFactory(std::shared_ptr<PublisherServiceStub> const& stub,
 
 inline StreamFactory<pubsublite::v1::SubscribeRequest,
                      pubsublite::v1::SubscribeResponse>
-MakeStreamFactory(
-    // NOLINTNEXTLINE(performance-unnecessary-value-param)
-    std::shared_ptr<SubscriberServiceStub> const& stub,
-    google::cloud::CompletionQueue const& cq, ClientMetadata const& metadata) {
+MakeStreamFactory(std::shared_ptr<SubscriberServiceStub> const& stub,
+                  google::cloud::CompletionQueue const& cq,
+                  ClientMetadata const& metadata) {
   return
       [=] { return stub->AsyncSubscribe(cq, MakeGrpcClientContext(metadata)); };
 }

--- a/google/cloud/pubsublite/internal/stream_factory.h
+++ b/google/cloud/pubsublite/internal/stream_factory.h
@@ -15,6 +15,10 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PUBSUBLITE_INTERNAL_STREAM_FACTORY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PUBSUBLITE_INTERNAL_STREAM_FACTORY_H
 
+#include "google/cloud/pubsublite/internal/cursor_stub.h"
+#include "google/cloud/pubsublite/internal/partition_assignment_stub.h"
+#include "google/cloud/pubsublite/internal/publisher_stub.h"
+#include "google/cloud/pubsublite/internal/subscriber_stub.h"
 #include "google/cloud/internal/async_read_write_stream_impl.h"
 #include "google/cloud/version.h"
 #include <google/cloud/pubsublite/v1/cursor.grpc.pb.h>
@@ -48,71 +52,41 @@ inline std::unique_ptr<grpc::ClientContext> MakeGrpcClientContext(
 
 inline StreamFactory<pubsublite::v1::PublishRequest,
                      pubsublite::v1::PublishResponse>
-MakeStreamFactory(
-    // NOLINTNEXTLINE(performance-unnecessary-value-param)
-    std::shared_ptr<pubsublite::v1::PublisherService::StubInterface> stub,
-    google::cloud::CompletionQueue const& cq,
-    ClientMetadata const& metadata = {}) {
-  return [=] {
-    return internal::MakeStreamingReadWriteRpc<pubsublite::v1::PublishRequest,
-                                               pubsublite::v1::PublishResponse>(
-        cq, MakeGrpcClientContext(metadata),
-        [stub](grpc::ClientContext* context, grpc::CompletionQueue* cq) {
-          return stub->PrepareAsyncPublish(context, cq);
-        });
-  };
+MakeStreamFactory(std::shared_ptr<PublisherServiceStub> const& stub,
+                  google::cloud::CompletionQueue const& cq,
+                  ClientMetadata const& metadata) {
+  return
+      [=] { return stub->AsyncPublish(cq, MakeGrpcClientContext(metadata)); };
 }
 
 inline StreamFactory<pubsublite::v1::SubscribeRequest,
                      pubsublite::v1::SubscribeResponse>
 MakeStreamFactory(
     // NOLINTNEXTLINE(performance-unnecessary-value-param)
-    std::shared_ptr<pubsublite::v1::SubscriberService::StubInterface> stub,
-    google::cloud::CompletionQueue const& cq,
-    ClientMetadata const& metadata = {}) {
-  return [=] {
-    return google::cloud::internal::MakeStreamingReadWriteRpc<
-        pubsublite::v1::SubscribeRequest, pubsublite::v1::SubscribeResponse>(
-        cq, MakeGrpcClientContext(metadata),
-        [stub](grpc::ClientContext* context, grpc::CompletionQueue* cq) {
-          return stub->PrepareAsyncSubscribe(context, cq);
-        });
-  };
+    std::shared_ptr<SubscriberServiceStub> const& stub,
+    google::cloud::CompletionQueue const& cq, ClientMetadata const& metadata) {
+  return
+      [=] { return stub->AsyncSubscribe(cq, MakeGrpcClientContext(metadata)); };
 }
 
 inline StreamFactory<pubsublite::v1::StreamingCommitCursorRequest,
                      pubsublite::v1::StreamingCommitCursorResponse>
-MakeStreamFactory(
-    // NOLINTNEXTLINE(performance-unnecessary-value-param)
-    std::shared_ptr<pubsublite::v1::CursorService::StubInterface> stub,
-    google::cloud::CompletionQueue const& cq,
-    ClientMetadata const& metadata = {}) {
+MakeStreamFactory(std::shared_ptr<CursorServiceStub> const& stub,
+                  google::cloud::CompletionQueue const& cq,
+                  ClientMetadata const& metadata) {
   return [=] {
-    return google::cloud::internal::MakeStreamingReadWriteRpc<
-        pubsublite::v1::StreamingCommitCursorRequest,
-        pubsublite::v1::StreamingCommitCursorResponse>(
-        cq, MakeGrpcClientContext(metadata),
-        [stub](grpc::ClientContext* context, grpc::CompletionQueue* cq) {
-          return stub->PrepareAsyncStreamingCommitCursor(context, cq);
-        });
+    return stub->AsyncStreamingCommitCursor(cq,
+                                            MakeGrpcClientContext(metadata));
   };
 }
 
 inline StreamFactory<pubsublite::v1::PartitionAssignmentRequest,
                      pubsublite::v1::PartitionAssignment>
-MakeStreamFactory(
-    std::shared_ptr<pubsublite::v1::PartitionAssignmentService::StubInterface>
-        stub,  // NOLINT(performance-unnecessary-value-param)
-    google::cloud::CompletionQueue const& cq,
-    ClientMetadata const& metadata = {}) {
+MakeStreamFactory(std::shared_ptr<PartitionAssignmentServiceStub> const& stub,
+                  google::cloud::CompletionQueue const& cq,
+                  ClientMetadata const& metadata) {
   return [=] {
-    return google::cloud::internal::MakeStreamingReadWriteRpc<
-        pubsublite::v1::PartitionAssignmentRequest,
-        pubsublite::v1::PartitionAssignment>(
-        cq, MakeGrpcClientContext(metadata),
-        [stub](grpc::ClientContext* context, grpc::CompletionQueue* cq) {
-          return stub->PrepareAsyncAssignPartitions(context, cq);
-        });
+    return stub->AsyncAssignPartitions(cq, MakeGrpcClientContext(metadata));
   };
 }
 

--- a/google/cloud/pubsublite/internal/stream_factory_test.cc
+++ b/google/cloud/pubsublite/internal/stream_factory_test.cc
@@ -23,19 +23,14 @@ TEST(StreamFactoryTest, CreateStreams) {
   CompletionQueue queue;
   ClientMetadata metadata{{"key1", "value1"}, {"key2", "value2"}};
   auto publish_factory = MakeStreamFactory(
-      std::shared_ptr<pubsublite::v1::PublisherService::StubInterface>(nullptr),
-      queue, metadata);
+      std::shared_ptr<PublisherServiceStub>(nullptr), queue, metadata);
   auto subscribe_factory = MakeStreamFactory(
-      std::shared_ptr<pubsublite::v1::SubscriberService::StubInterface>(
-          nullptr),
-      queue, metadata);
+      std::shared_ptr<SubscriberServiceStub>(nullptr), queue, metadata);
   auto cursor_factory = MakeStreamFactory(
-      std::shared_ptr<pubsublite::v1::CursorService::StubInterface>(nullptr),
-      queue, metadata);
+      std::shared_ptr<CursorServiceStub>(nullptr), queue, metadata);
   auto assignment_factory = MakeStreamFactory(
-      std::shared_ptr<
-          pubsublite::v1::PartitionAssignmentService::StubInterface>(nullptr),
-      queue, metadata);
+      std::shared_ptr<PartitionAssignmentServiceStub>(nullptr), queue,
+      metadata);
 }
 
 }  // namespace pubsublite_internal


### PR DESCRIPTION
These are still useful to provide the input factory in a structured way for the (eventual) ResumableStreamingReadWriteRpc matching the patterns of https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/internal/resumable_streaming_read_rpc.h

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8075)
<!-- Reviewable:end -->
