### PR TITLE
refactor(bigtable): store project id in TableAdmin

### DIFF
--- a/google/cloud/bigtable/CMakeLists.txt
+++ b/google/cloud/bigtable/CMakeLists.txt
@@ -339,6 +339,7 @@ if (BUILD_TESTING)
         rpc_backoff_policy_test.cc
         rpc_retry_policy_test.cc
         table_admin_legacy_test.cc
+        table_admin_test.cc
         table_apply_test.cc
         table_bulk_apply_test.cc
         table_check_and_mutate_row_test.cc

--- a/google/cloud/bigtable/admin_client.h
+++ b/google/cloud/bigtable/admin_client.h
@@ -56,7 +56,7 @@ class AdminClient {
  public:
   virtual ~AdminClient() = default;
 
-  /// The project that this AdminClient works on.
+  /// The project id that this AdminClient works on.
   virtual std::string const& project() const = 0;
 
   /**

--- a/google/cloud/bigtable/bigtable_client_unit_tests.bzl
+++ b/google/cloud/bigtable/bigtable_client_unit_tests.bzl
@@ -65,6 +65,7 @@ bigtable_client_unit_tests = [
     "rpc_backoff_policy_test.cc",
     "rpc_retry_policy_test.cc",
     "table_admin_legacy_test.cc",
+    "table_admin_test.cc",
     "table_apply_test.cc",
     "table_bulk_apply_test.cc",
     "table_check_and_mutate_row_test.cc",

--- a/google/cloud/bigtable/table_admin.cc
+++ b/google/cloud/bigtable/table_admin.cc
@@ -746,8 +746,7 @@ StatusOr<std::vector<std::string>> TableAdmin::TestIamPermissions(
 }
 
 std::string TableAdmin::InstanceName() const {
-  return google::cloud::bigtable::InstanceName(client_->project(),
-                                               instance_id_);
+  return google::cloud::bigtable::InstanceName(project_id_, instance_id_);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/bigtable/table_admin.h
+++ b/google/cloud/bigtable/table_admin.h
@@ -142,6 +142,7 @@ class TableAdmin {
    */
   TableAdmin(std::shared_ptr<AdminClient> client, std::string instance_id)
       : client_(std::move(client)),
+        project_id_(client_->project()),
         instance_id_(std::move(instance_id)),
         instance_name_(InstanceName()),
         rpc_retry_policy_prototype_(
@@ -213,7 +214,7 @@ class TableAdmin {
       google::bigtable::admin::v2::Table::VIEW_UNSPECIFIED;
   //@}
 
-  std::string const& project() const { return client_->project(); }
+  std::string const& project() const { return project_id_; }
   std::string const& instance_id() const { return instance_id_; }
   std::string const& instance_name() const { return instance_name_; }
 
@@ -988,20 +989,20 @@ class TableAdmin {
 
   /// Return the fully qualified name of a table in this object's instance.
   std::string TableName(std::string const& table_id) const {
-    return google::cloud::bigtable::TableName(project(), instance_id(),
+    return google::cloud::bigtable::TableName(project_id_, instance_id_,
                                               table_id);
   }
 
   /// Return the fully qualified name of a Cluster.
   std::string ClusterName(std::string const& cluster_id) const {
-    return google::cloud::bigtable::ClusterName(project(), instance_id(),
+    return google::cloud::bigtable::ClusterName(project_id_, instance_id_,
                                                 cluster_id);
   }
 
   /// Return the fully qualified name of a Backup.
   std::string BackupName(std::string const& cluster_id,
                          std::string const& backup_id) const {
-    return google::cloud::bigtable::BackupName(project(), instance_id(),
+    return google::cloud::bigtable::BackupName(project_id_, instance_id_,
                                                cluster_id, backup_id);
   }
 
@@ -1067,6 +1068,7 @@ class TableAdmin {
       std::string const& consistency_token);
 
   std::shared_ptr<AdminClient> client_;
+  std::string project_id_;
   std::string instance_id_;
   std::string instance_name_;
   std::shared_ptr<RPCRetryPolicy const> rpc_retry_policy_prototype_;

--- a/google/cloud/bigtable/table_admin_test.cc
+++ b/google/cloud/bigtable/table_admin_test.cc
@@ -1,0 +1,54 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/bigtable/table_admin.h"
+#include "google/cloud/bigtable/resource_names.h"
+#include "google/cloud/bigtable/testing/mock_admin_client.h"
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+namespace bigtable {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+namespace {
+
+using ::testing::ReturnRef;
+
+using MockAdminClient = ::google::cloud::bigtable::testing::MockAdminClient;
+
+std::string const kProjectId = "the-project";
+std::string const kInstanceId = "the-instance";
+
+class TableAdminTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    EXPECT_CALL(*client_, project()).WillRepeatedly(ReturnRef(kProjectId));
+  }
+
+  std::shared_ptr<MockAdminClient> client_ =
+      std::make_shared<MockAdminClient>();
+};
+
+TEST_F(TableAdminTest, ResourceNames) {
+  TableAdmin tested(client_, kInstanceId);
+  EXPECT_EQ(kProjectId, tested.project());
+  EXPECT_EQ(kInstanceId, tested.instance_id());
+  EXPECT_EQ(InstanceName(kProjectId, kInstanceId), tested.instance_name());
+}
+
+}  // namespace
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace bigtable
+}  // namespace cloud
+}  // namespace google


### PR DESCRIPTION
Part of the work for #7530 

Store the project id so that we have one less dependence on `client_`. (Eventually `client_` will be removed entirely).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8085)
<!-- Reviewable:end -->
