### PR TITLE
impl(bigtable): convert policies to options in InstanceAdmin

### DIFF
--- a/google/cloud/bigtable/instance_admin_test.cc
+++ b/google/cloud/bigtable/instance_admin_test.cc
@@ -14,6 +14,7 @@
 
 #include "google/cloud/bigtable/instance_admin.h"
 #include "google/cloud/bigtable/admin/mocks/mock_bigtable_instance_admin_connection.h"
+#include "google/cloud/bigtable/testing/mock_policies.h"
 #include <gmock/gmock.h>
 
 namespace google {
@@ -28,14 +29,34 @@ class InstanceAdminTester {
   Connection(InstanceAdmin const& admin) {
     return admin.connection_;
   }
+
+  static Options Policies(InstanceAdmin const& admin) {
+    return admin.policies_;
+  }
 };
 
 namespace {
+
+using ::google::cloud::bigtable::testing::MockBackoffPolicy;
+using ::google::cloud::bigtable::testing::MockPollingPolicy;
+using ::google::cloud::bigtable::testing::MockRetryPolicy;
+using ::testing::An;
 
 using MockConnection =
     ::google::cloud::bigtable_admin_mocks::MockBigtableInstanceAdminConnection;
 
 std::string const kProjectId = "the-project";
+
+void CheckPolicies(Options const& options) {
+  EXPECT_TRUE(
+      options.has<bigtable_admin::BigtableInstanceAdminRetryPolicyOption>());
+  EXPECT_TRUE(
+      options.has<bigtable_admin::BigtableInstanceAdminBackoffPolicyOption>());
+  EXPECT_TRUE(
+      options.has<bigtable_admin::BigtableInstanceAdminPollingPolicyOption>());
+  EXPECT_TRUE(options.has<google::cloud::internal::GrpcSetupOption>());
+  EXPECT_TRUE(options.has<google::cloud::internal::GrpcSetupPollOption>());
+}
 
 /// A fixture for the bigtable::InstanceAdmin tests.
 class InstanceAdminTest : public ::testing::Test {
@@ -98,6 +119,76 @@ TEST_F(InstanceAdminTest, LegacyConstructorSharesConnection) {
   auto conn_2 = InstanceAdminTester::Connection(admin_2);
 
   EXPECT_EQ(conn_1, conn_2);
+}
+
+TEST_F(InstanceAdminTest, LegacyConstructorDefaultsPolicies) {
+  auto admin_client = MakeInstanceAdminClient("test-project");
+  auto admin = InstanceAdmin(std::move(admin_client));
+  auto policies = InstanceAdminTester::Policies(admin);
+  CheckPolicies(policies);
+}
+
+TEST_F(InstanceAdminTest, LegacyConstructorWithPolicies) {
+  // In this test, we make a series of simple calls to verify that the policies
+  // passed to the `InstanceAdmin` constructor are actually collected as
+  // `Options`.
+  //
+  // Upon construction of an InstanceAdmin, each policy is cloned twice: Once
+  // while processing the variadic parameters, once while converting from
+  // Bigtable policies to common policies. This should explain the nested mocks
+  // below.
+
+  auto mock_r = std::make_shared<MockRetryPolicy>();
+  auto mock_b = std::make_shared<MockBackoffPolicy>();
+  auto mock_p = std::make_shared<MockPollingPolicy>();
+
+  EXPECT_CALL(*mock_r, clone).WillOnce([] {
+    auto clone_1 = absl::make_unique<MockRetryPolicy>();
+    EXPECT_CALL(*clone_1, clone).WillOnce([] {
+      auto clone_2 = absl::make_unique<MockRetryPolicy>();
+      EXPECT_CALL(*clone_2, OnFailure(An<Status const&>()));
+      return clone_2;
+    });
+    return clone_1;
+  });
+
+  EXPECT_CALL(*mock_b, clone).WillOnce([] {
+    auto clone_1 = absl::make_unique<MockBackoffPolicy>();
+    EXPECT_CALL(*clone_1, clone).WillOnce([] {
+      auto clone_2 = absl::make_unique<MockBackoffPolicy>();
+      EXPECT_CALL(*clone_2, OnCompletion(An<Status const&>()));
+      return clone_2;
+    });
+    return clone_1;
+  });
+
+  EXPECT_CALL(*mock_p, clone).WillOnce([] {
+    auto clone_1 = absl::make_unique<MockPollingPolicy>();
+    EXPECT_CALL(*clone_1, clone).WillOnce([] {
+      auto clone_2 = absl::make_unique<MockPollingPolicy>();
+      EXPECT_CALL(*clone_2, WaitPeriod);
+      return clone_2;
+    });
+    return clone_1;
+  });
+
+  auto admin_client = MakeInstanceAdminClient("test-project");
+  auto admin =
+      InstanceAdmin(std::move(admin_client), *mock_r, *mock_b, *mock_p);
+  auto policies = InstanceAdminTester::Policies(admin);
+  CheckPolicies(policies);
+
+  auto const& common_retry =
+      policies.get<bigtable_admin::BigtableInstanceAdminRetryPolicyOption>();
+  (void)common_retry->OnFailure({});
+
+  auto const& common_backoff =
+      policies.get<bigtable_admin::BigtableInstanceAdminBackoffPolicyOption>();
+  (void)common_backoff->OnCompletion();
+
+  auto const& common_polling =
+      policies.get<bigtable_admin::BigtableInstanceAdminPollingPolicyOption>();
+  (void)common_polling->WaitPeriod();
 }
 
 }  // namespace


### PR DESCRIPTION
Part of the work for #7534 

Convert bigtable policies to common policies (stored as `Options policies_`) upon construction of the `InstanceAdmin` class. We do not use these yet. They will eventually be passed in calls made to the `Connection`. For example, like [this](https://github.com/dbolduc/google-cloud-cpp/blob/7d95be046ae60682ba533eba0f2162aecc0da29c/google/cloud/bigtable/instance_admin.cc#L78-L80).

The plan is to use the `LegacyConstructorWithPolicies` test to ensure that custom policies passed in the constructor are stored in `policies_`. Then for each individual RPC, we will only check that the expected policy options are set (but we will not check their values). For example, like [this](https://github.com/dbolduc/google-cloud-cpp/blob/7d95be046ae60682ba533eba0f2162aecc0da29c/google/cloud/bigtable/instance_admin_test.cc#L140).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8086)
<!-- Reviewable:end -->
