### PR TITLE
refactor(GCS+gRPC): reorder GrpcObjectRequestParser

### DIFF
--- a/google/cloud/storage/internal/grpc_object_request_parser.h
+++ b/google/cloud/storage/internal/grpc_object_request_parser.h
@@ -29,6 +29,12 @@ struct GrpcObjectRequestParser {
   static google::storage::v2::PredefinedObjectAcl ToProtoObject(
       PredefinedAcl const& acl);
 
+  static google::storage::v2::GetObjectRequest ToProto(
+      GetObjectMetadataRequest const& request);
+
+  static StatusOr<google::storage::v2::ReadObjectRequest> ToProto(
+      ReadObjectRangeRequest const& request);
+
   static StatusOr<google::storage::v2::WriteObjectRequest> ToProto(
       InsertObjectMediaRequest const& request);
   static ResumableUploadResponse FromProto(
@@ -43,14 +49,9 @@ struct GrpcObjectRequestParser {
 
   static StatusOr<google::storage::v2::StartResumableWriteRequest> ToProto(
       ResumableUploadRequest const& request);
+
   static google::storage::v2::QueryWriteStatusRequest ToProto(
       QueryResumableUploadRequest const& request);
-
-  static StatusOr<google::storage::v2::ReadObjectRequest> ToProto(
-      ReadObjectRangeRequest const& request);
-
-  static google::storage::v2::GetObjectRequest ToProto(
-      GetObjectMetadataRequest const& request);
 };
 
 }  // namespace internal


### PR DESCRIPTION
Sort the functions in this class so they match the order of declaration
in the `StorageStub`. A bit silly, but makes it easier to grok the PR
changes, and possibly allows me to send more PRs in parallel.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8088)
<!-- Reviewable:end -->
