### PR TITLE
feat(spanner): merge connection options into client options

### DIFF
--- a/google/cloud/spanner/client.cc
+++ b/google/cloud/spanner/client.cc
@@ -357,7 +357,7 @@ std::shared_ptr<spanner::Connection> MakeConnection(spanner::Database const& db,
     return spanner_internal::CreateDefaultSpannerStub(db, auth, opts, id++);
   });
   return std::make_shared<spanner_internal::ConnectionImpl>(
-      std::move(db), std::move(background), std::move(stubs), opts);
+      std::move(db), std::move(background), std::move(stubs), std::move(opts));
 }
 
 std::shared_ptr<Connection> MakeConnection(

--- a/google/cloud/spanner/client.h
+++ b/google/cloud/spanner/client.h
@@ -133,8 +133,7 @@ class Client {
    */
   explicit Client(std::shared_ptr<Connection> conn, Options opts = {})
       : conn_(std::move(conn)),
-        opts_(spanner_internal::DefaultOptions(
-            internal::MergeOptions(std::move(opts), conn_->options()))) {}
+        opts_(internal::MergeOptions(std::move(opts), conn_->options())) {}
 
   //@{
   /// Backwards compatibility for `ClientOptions`.

--- a/google/cloud/spanner/client.h
+++ b/google/cloud/spanner/client.h
@@ -133,7 +133,8 @@ class Client {
    */
   explicit Client(std::shared_ptr<Connection> conn, Options opts = {})
       : conn_(std::move(conn)),
-        opts_(spanner_internal::DefaultOptions(std::move(opts))) {}
+        opts_(spanner_internal::DefaultOptions(
+            internal::MergeOptions(std::move(opts), conn_->options()))) {}
 
   //@{
   /// Backwards compatibility for `ClientOptions`.

--- a/google/cloud/spanner/client_test.cc
+++ b/google/cloud/spanner/client_test.cc
@@ -14,6 +14,7 @@
 
 #include "google/cloud/spanner/client.h"
 #include "google/cloud/spanner/connection.h"
+#include "google/cloud/spanner/internal/defaults.h"
 #include "google/cloud/spanner/mocks/mock_spanner_connection.h"
 #include "google/cloud/spanner/mutations.h"
 #include "google/cloud/spanner/results.h"
@@ -391,7 +392,17 @@ TEST(ClientTest, MakeConnectionOptionalArguments) {
   EXPECT_NE(conn, nullptr);
 
   conn = MakeConnection(db, Options{});
-  EXPECT_NE(conn, nullptr);
+  ASSERT_NE(conn, nullptr);
+  ASSERT_TRUE(conn->options().has<EndpointOption>());
+  EXPECT_EQ(conn->options().get<EndpointOption>(),
+            spanner_internal::DefaultOptions().get<EndpointOption>());
+
+  conn = MakeConnection(db, Options{}.set<EndpointOption>("endpoint"));
+  ASSERT_NE(conn, nullptr);
+  ASSERT_TRUE(conn->options().has<EndpointOption>());
+  EXPECT_NE(conn->options().get<EndpointOption>(),
+            spanner_internal::DefaultOptions().get<EndpointOption>());
+  EXPECT_EQ(conn->options().get<EndpointOption>(), "endpoint");
 }
 
 TEST(ClientTest, CommitMutatorSuccess) {

--- a/google/cloud/spanner/connection.h
+++ b/google/cloud/spanner/connection.h
@@ -128,6 +128,9 @@ class Connection {
   };
   //@}
 
+  /// Returns any options use by the concrete Connection.
+  virtual Options options() { return Options{}; }
+
   /// Defines the interface for `Client::Read()`
   virtual RowStream Read(ReadParams) = 0;
 

--- a/google/cloud/spanner/connection.h
+++ b/google/cloud/spanner/connection.h
@@ -128,7 +128,7 @@ class Connection {
   };
   //@}
 
-  /// Returns any options use by the concrete Connection.
+  /// Returns the options used by the Connection.
   virtual Options options() { return Options{}; }
 
   /// Defines the interface for `Client::Read()`

--- a/google/cloud/spanner/internal/connection_impl.h
+++ b/google/cloud/spanner/internal/connection_impl.h
@@ -70,8 +70,8 @@ class ConnectionImpl : public spanner::Connection {
   Status Rollback(RollbackParams) override;
 
  private:
-  std::shared_ptr<spanner::RetryPolicy> const& RetryPolicy() const;
-  std::shared_ptr<spanner::BackoffPolicy> const& BackoffPolicy() const;
+  std::shared_ptr<spanner::RetryPolicy> const& RetryPolicyPrototype() const;
+  std::shared_ptr<spanner::BackoffPolicy> const& BackoffPolicyPrototype() const;
   bool RpcStreamTracingEnabled() const;
   TracingOptions const& RpcTracingOptions() const;
 

--- a/google/cloud/spanner/internal/connection_impl.h
+++ b/google/cloud/spanner/internal/connection_impl.h
@@ -48,8 +48,9 @@ class ConnectionImpl : public spanner::Connection {
  public:
   ConnectionImpl(spanner::Database db,
                  std::unique_ptr<BackgroundThreads> background_threads,
-                 std::vector<std::shared_ptr<SpannerStub>> stubs,
-                 Options const& opts);
+                 std::vector<std::shared_ptr<SpannerStub>> stubs, Options opts);
+
+  Options options() override { return opts_; }
 
   spanner::RowStream Read(ReadParams) override;
   StatusOr<std::vector<spanner::ReadPartition>> PartitionRead(
@@ -69,6 +70,11 @@ class ConnectionImpl : public spanner::Connection {
   Status Rollback(RollbackParams) override;
 
  private:
+  std::shared_ptr<spanner::RetryPolicy> const& RetryPolicy() const;
+  std::shared_ptr<spanner::BackoffPolicy> const& BackoffPolicy() const;
+  bool RpcStreamTracingEnabled() const;
+  TracingOptions const& RpcTracingOptions() const;
+
   Status PrepareSession(SessionHolder& session,
                         bool dissociate_from_pool = false);
 
@@ -163,12 +169,9 @@ class ConnectionImpl : public spanner::Connection {
       google::spanner::v1::ExecuteSqlRequest::QueryMode query_mode);
 
   spanner::Database db_;
-  std::shared_ptr<spanner::RetryPolicy const> retry_policy_prototype_;
-  std::shared_ptr<spanner::BackoffPolicy const> backoff_policy_prototype_;
   std::unique_ptr<BackgroundThreads> background_threads_;
+  Options opts_;
   std::shared_ptr<SessionPool> session_pool_;
-  bool rpc_stream_tracing_enabled_ = false;
-  TracingOptions tracing_options_;
 };
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/spanner/mocks/mock_spanner_connection.h
+++ b/google/cloud/spanner/mocks/mock_spanner_connection.h
@@ -42,6 +42,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  */
 class MockConnection : public spanner::Connection {
  public:
+  MOCK_METHOD(Options, options, (), (override));
   MOCK_METHOD(spanner::RowStream, Read, (ReadParams), (override));
   MOCK_METHOD(StatusOr<std::vector<spanner::ReadPartition>>, PartitionRead,
               (PartitionReadParams), (override));


### PR DESCRIPTION
Store the `Connection` options so that they may be made available to
merge into the `Client` options.

Use those stored options to implement four `Connection` data elements
that were previously extracted during construction.  (When all `Client`
operations have been taught how to set the "current options" we will
be able to use those instead.)

Part of #7690.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8090)
<!-- Reviewable:end -->
