### PR TITLE
feat: upgrade bazel, require >= 4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ run the examples included with the libraries.
 
 ### Building with Bazel
 
-This library requires Bazel >= 3.0. From the top-level directory, run the usual
+This library requires Bazel >= 4.0. From the top-level directory, run the usual
 commands.
 
 ```shell

--- a/ci/cloudbuild/builds/lib/bazel.sh
+++ b/ci/cloudbuild/builds/lib/bazel.sh
@@ -26,7 +26,7 @@ fi # include guard
 source module ci/lib/io.sh
 
 # Selects a default bazel version, though individual builds can override this.
-: "${USE_BAZEL_VERSION:="3.5.0"}"
+: "${USE_BAZEL_VERSION:="4.0.0"}"
 export USE_BAZEL_VERSION
 io::log "Using bazelisk version"
 bazelisk version

--- a/ci/generate-markdown/generate-readme.sh
+++ b/ci/generate-markdown/generate-readme.sh
@@ -91,7 +91,7 @@ run the examples included with the libraries.
 
 ### Building with Bazel
 
-This library requires Bazel >= 3.0. From the top-level directory, run the usual
+This library requires Bazel >= 4.0. From the top-level directory, run the usual
 commands.
 
 ```shell

--- a/ci/kokoro/macos/builds/bazel.sh
+++ b/ci/kokoro/macos/builds/bazel.sh
@@ -23,7 +23,7 @@ source module ci/lib/io.sh
 # NOTE: In this file use the command `bazelisk` rather than bazel, because
 # Kokoro has both installed and we want to make sure to use the former.
 io::log_h2 "Using bazel version"
-: "${USE_BAZEL_VERSION:="3.5.0"}"
+: "${USE_BAZEL_VERSION:="4.0.0"}"
 export USE_BAZEL_VERSION
 bazelisk version || rm -fr "$HOME"/Library/Caches/bazelisk || bazelisk version
 

--- a/ci/kokoro/macos/builds/quickstart-bazel.sh
+++ b/ci/kokoro/macos/builds/quickstart-bazel.sh
@@ -24,7 +24,7 @@ source module ci/lib/io.sh
 # NOTE: In this file use the command `bazelisk` rather than bazel, because
 # Kokoro has both installed and we want to make sure to use the former.
 io::log_h2 "Using bazel version"
-: "${USE_BAZEL_VERSION:="3.5.0"}"
+: "${USE_BAZEL_VERSION:="4.0.0"}"
 export USE_BAZEL_VERSION
 bazelisk version || rm -fr "$HOME"/Library/Caches/bazelisk || bazelisk version
 # Kokoro needs bazel to be shutdown here, otherwise it will hang. This shutdown


### PR DESCRIPTION
Fixes: #8084
Related to: #8078

Bazel 5.0 is now GA, so we can drop support for 3.x. This will enable us
to use bazel `@platforms`, which will make some of our `select()`s nicer
and work better in a cross-platform way.

Note: our Windows builds already required bazel 4.0, so now they're all consistent.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8095)
<!-- Reviewable:end -->
