### PR TITLE
ci: use bazel @platforms for config settings

### DIFF
--- a/bazel/crc32c.BUILD
+++ b/bazel/crc32c.BUILD
@@ -52,8 +52,8 @@ crc32c_SRCS = [
 config_setting(
     name = "windows",
     constraint_values = [
-      "@platforms//os:windows",
-      "@platforms//cpu:x86_64"
+        "@platforms//os:windows",
+        "@platforms//cpu:x86_64",
     ],
     visibility = ["//visibility:public"],
 )
@@ -61,8 +61,8 @@ config_setting(
 config_setting(
     name = "linux_x86_64",
     constraint_values = [
-      "@platforms//os:linux",
-      "@platforms//cpu:x86_64"
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
     ],
     visibility = ["//visibility:public"],
 )
@@ -70,7 +70,7 @@ config_setting(
 config_setting(
     name = "macos",
     constraint_values = [
-      "@platforms//os:macos"
+        "@platforms//os:macos",
     ],
     visibility = ["//visibility:public"],
 )

--- a/bazel/crc32c.BUILD
+++ b/bazel/crc32c.BUILD
@@ -51,33 +51,41 @@ crc32c_SRCS = [
 
 config_setting(
     name = "windows",
-    values = {"cpu": "x64_windows"},
+    constraint_values = [
+      "@platforms//os:windows",
+      "@platforms//cpu:x86_64"
+    ],
     visibility = ["//visibility:public"],
 )
 
 config_setting(
     name = "linux_x86_64",
-    values = {"cpu": "k8"},
+    constraint_values = [
+      "@platforms//os:linux",
+      "@platforms//cpu:x86_64"
+    ],
     visibility = ["//visibility:public"],
 )
 
 config_setting(
-    name = "darwin",
-    values = {"cpu": "darwin"},
+    name = "macos",
+    constraint_values = [
+      "@platforms//os:macos"
+    ],
     visibility = ["//visibility:public"],
 )
 
 sse42_copts = select({
     ":windows": ["/arch:AVX"],
     ":linux_x86_64": ["-msse4.2"],
-    ":darwin": ["-msse4.2"],
+    ":macos": ["-msse4.2"],
     "//conditions:default": [],
 })
 
 sse42_enabled = select({
     ":windows": "1",
     ":linux_x86_64": "1",
-    ":darwin": "1",
+    ":macos": "1",
     "//conditions:default": "0",
 })
 

--- a/bazel/curl.BUILD
+++ b/bazel/curl.BUILD
@@ -10,8 +10,8 @@ exports_files(["COPYING"])
 config_setting(
     name = "windows",
     constraint_values = [
-      "@platforms//os:windows",
-      "@platforms//cpu:x86_64"
+        "@platforms//os:windows",
+        "@platforms//cpu:x86_64",
     ],
     visibility = ["//visibility:public"],
 )
@@ -19,7 +19,7 @@ config_setting(
 config_setting(
     name = "macos",
     constraint_values = [
-      "@platforms//os:macos"
+        "@platforms//os:macos",
     ],
     visibility = ["//visibility:public"],
 )

--- a/bazel/curl.BUILD
+++ b/bazel/curl.BUILD
@@ -9,19 +9,18 @@ exports_files(["COPYING"])
 
 config_setting(
     name = "windows",
-    values = {"cpu": "x64_windows"},
-    visibility = ["//visibility:public"],
-)
-
-config_setting(
-    name = "linux_x86_64",
-    values = {"cpu": "k8"},
+    constraint_values = [
+      "@platforms//os:windows",
+      "@platforms//cpu:x86_64"
+    ],
     visibility = ["//visibility:public"],
 )
 
 config_setting(
     name = "macos",
-    values = {"cpu": "darwin"},
+    constraint_values = [
+      "@platforms//os:macos"
+    ],
     visibility = ["//visibility:public"],
 )
 


### PR DESCRIPTION
Fixes: #8078

Now that we require bazel >= 4.0, we can use the recommended
`@platforms` way to specify build constraints.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8101)
<!-- Reviewable:end -->
