### PR TITLE
impl(storage): make patch objects accessible

### DIFF
--- a/google/cloud/storage/CMakeLists.txt
+++ b/google/cloud/storage/CMakeLists.txt
@@ -165,6 +165,7 @@ add_library(
     internal/parameter_pack_validation.h
     internal/patch_builder.cc
     internal/patch_builder.h
+    internal/patch_builder_details.h
     internal/policy_document_request.cc
     internal/policy_document_request.h
     internal/raw_client.cc

--- a/google/cloud/storage/bucket_metadata.h
+++ b/google/cloud/storage/bucket_metadata.h
@@ -37,6 +37,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace internal {
 struct BucketMetadataParser;
 struct GrpcBucketMetadataParser;
+struct GrpcBucketRequestParser;
 }  // namespace internal
 
 /**
@@ -1006,6 +1007,8 @@ class BucketMetadataPatchBuilder {
   BucketMetadataPatchBuilder& ResetWebsite();
 
  private:
+  friend struct internal::GrpcBucketRequestParser;
+
   internal::PatchBuilder impl_;
   bool labels_subpatch_dirty_{false};
   internal::PatchBuilder labels_subpatch_;

--- a/google/cloud/storage/google_cloud_cpp_storage.bzl
+++ b/google/cloud/storage/google_cloud_cpp_storage.bzl
@@ -82,6 +82,7 @@ google_cloud_cpp_storage_hdrs = [
     "internal/openssl_util.h",
     "internal/parameter_pack_validation.h",
     "internal/patch_builder.h",
+    "internal/patch_builder_details.h",
     "internal/policy_document_request.h",
     "internal/raw_client.h",
     "internal/raw_client_wrapper_utils.h",

--- a/google/cloud/storage/internal/bucket_acl_requests.h
+++ b/google/cloud/storage/internal/bucket_acl_requests.h
@@ -154,12 +154,13 @@ class PatchBucketAclRequest
                         BucketAccessControl const& original,
                         BucketAccessControl const& new_acl);
   PatchBucketAclRequest(std::string bucket, std::string entity,
-                        BucketAccessControlPatchBuilder const& patch);
+                        BucketAccessControlPatchBuilder patch);
 
-  std::string const& payload() const { return payload_; }
+  BucketAccessControlPatchBuilder const& patch() const { return patch_; }
+  std::string payload() const { return patch_.BuildPatch(); }
 
  private:
-  std::string payload_;
+  BucketAccessControlPatchBuilder patch_;
 };
 
 std::ostream& operator<<(std::ostream& os, PatchBucketAclRequest const& r);

--- a/google/cloud/storage/internal/bucket_requests.cc
+++ b/google/cloud/storage/internal/bucket_requests.cc
@@ -278,12 +278,12 @@ std::ostream& operator<<(std::ostream& os, UpdateBucketRequest const& r) {
 PatchBucketRequest::PatchBucketRequest(std::string bucket,
                                        BucketMetadata const& original,
                                        BucketMetadata const& updated)
-    : bucket_(std::move(bucket)),
-      payload_(DiffBucketMetadata(original, updated).BuildPatch()) {}
+    : PatchBucketRequest(std::move(bucket),
+                         DiffBucketMetadata(original, updated)) {}
 
 PatchBucketRequest::PatchBucketRequest(std::string bucket,
-                                       BucketMetadataPatchBuilder const& patch)
-    : bucket_(std::move(bucket)), payload_(patch.BuildPatch()) {}
+                                       BucketMetadataPatchBuilder patch)
+    : patch_(std::move(patch)), bucket_(std::move(bucket)) {}
 
 std::ostream& operator<<(std::ostream& os, PatchBucketRequest const& r) {
   os << "PatchBucketRequest={bucket_name=" << r.bucket();

--- a/google/cloud/storage/internal/bucket_requests.h
+++ b/google/cloud/storage/internal/bucket_requests.h
@@ -174,14 +174,15 @@ class PatchBucketRequest
                               BucketMetadata const& original,
                               BucketMetadata const& updated);
   explicit PatchBucketRequest(std::string bucket,
-                              BucketMetadataPatchBuilder const& patch);
+                              BucketMetadataPatchBuilder patch);
 
+  BucketMetadataPatchBuilder const& patch() const { return patch_; }
   std::string const& bucket() const { return bucket_; }
-  std::string const& payload() const { return payload_; }
+  std::string payload() const { return patch_.BuildPatch(); }
 
  private:
+  BucketMetadataPatchBuilder patch_;
   std::string bucket_;
-  std::string payload_;
 };
 
 std::ostream& operator<<(std::ostream& os, PatchBucketRequest const& r);

--- a/google/cloud/storage/internal/default_object_acl_requests.cc
+++ b/google/cloud/storage/internal/default_object_acl_requests.cc
@@ -24,6 +24,7 @@ namespace cloud {
 namespace storage {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace internal {
+
 std::ostream& operator<<(std::ostream& os,
                          ListDefaultObjectAclRequest const& r) {
   os << "ListDefaultObjectAclRequest={bucket_name=" << r.bucket_name();
@@ -91,18 +92,15 @@ std::ostream& operator<<(std::ostream& os,
 PatchDefaultObjectAclRequest::PatchDefaultObjectAclRequest(
     std::string bucket, std::string entity, ObjectAccessControl const& original,
     ObjectAccessControl const& new_acl)
-    : GenericDefaultObjectAclRequest(std::move(bucket), std::move(entity)) {
-  PatchBuilder build_patch;
-  build_patch.AddStringField("entity", original.entity(), new_acl.entity());
-  build_patch.AddStringField("role", original.role(), new_acl.role());
-  payload_ = build_patch.ToString();
+    : PatchDefaultObjectAclRequest(std::move(bucket), std::move(entity),
+                                   DiffObjectAccessControl(original, new_acl)) {
 }
 
 PatchDefaultObjectAclRequest::PatchDefaultObjectAclRequest(
     std::string bucket, std::string entity,
-    ObjectAccessControlPatchBuilder const& patch)
+    ObjectAccessControlPatchBuilder patch)
     : GenericDefaultObjectAclRequest(std::move(bucket), std::move(entity)),
-      payload_(patch.BuildPatch()) {}
+      patch_(std::move(patch)) {}
 
 std::ostream& operator<<(std::ostream& os,
                          PatchDefaultObjectAclRequest const& r) {

--- a/google/cloud/storage/internal/default_object_acl_requests.h
+++ b/google/cloud/storage/internal/default_object_acl_requests.h
@@ -170,12 +170,13 @@ class PatchDefaultObjectAclRequest
                                ObjectAccessControl const& original,
                                ObjectAccessControl const& new_acl);
   PatchDefaultObjectAclRequest(std::string bucket, std::string entity,
-                               ObjectAccessControlPatchBuilder const& patch);
+                               ObjectAccessControlPatchBuilder patch);
 
-  std::string const& payload() const { return payload_; }
+  ObjectAccessControlPatchBuilder const& patch() const { return patch_; }
+  std::string payload() const { return patch_.BuildPatch(); }
 
  private:
-  std::string payload_;
+  ObjectAccessControlPatchBuilder patch_;
 };
 
 std::ostream& operator<<(std::ostream& os,

--- a/google/cloud/storage/internal/object_acl_requests.h
+++ b/google/cloud/storage/internal/object_acl_requests.h
@@ -155,15 +155,20 @@ class PatchObjectAclRequest
                         ObjectAccessControl const& new_acl);
   PatchObjectAclRequest(std::string bucket, std::string object,
                         std::string entity,
-                        ObjectAccessControlPatchBuilder const& patch);
+                        ObjectAccessControlPatchBuilder patch);
 
-  std::string const& payload() const { return payload_; }
+  ObjectAccessControlPatchBuilder const& patch() const { return patch_; }
+  std::string payload() const { return patch_.BuildPatch(); }
 
  private:
+  ObjectAccessControlPatchBuilder patch_;
   std::string payload_;
 };
 
 std::ostream& operator<<(std::ostream& os, PatchObjectAclRequest const& r);
+
+ObjectAccessControlPatchBuilder DiffObjectAccessControl(
+    ObjectAccessControl const& original, ObjectAccessControl const& new_acl);
 
 }  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/storage/internal/object_requests.h
+++ b/google/cloud/storage/internal/object_requests.h
@@ -254,12 +254,13 @@ class PatchObjectRequest
                               ObjectMetadata const& original,
                               ObjectMetadata const& updated);
   explicit PatchObjectRequest(std::string bucket_name, std::string object_name,
-                              ObjectMetadataPatchBuilder const& patch);
+                              ObjectMetadataPatchBuilder patch);
 
-  std::string const& payload() const { return payload_; }
+  ObjectMetadataPatchBuilder const& patch() const { return patch_; }
+  std::string payload() const { return patch_.BuildPatch(); }
 
  private:
-  std::string payload_;
+  ObjectMetadataPatchBuilder patch_;
 };
 
 std::ostream& operator<<(std::ostream& os, PatchObjectRequest const& r);

--- a/google/cloud/storage/internal/patch_builder.cc
+++ b/google/cloud/storage/internal/patch_builder.cc
@@ -13,11 +13,11 @@
 // limitations under the License.
 
 #include "google/cloud/storage/internal/patch_builder.h"
+#include "google/cloud/storage/internal/patch_builder_details.h"
 #include "google/cloud/storage/version.h"
 #include "absl/memory/memory.h"
 #include "absl/types/optional.h"
 #include <nlohmann/json.hpp>
-#include <iostream>
 #include <memory>
 #include <string>
 #include <vector>
@@ -27,8 +27,8 @@ namespace cloud {
 namespace storage {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace internal {
+
 struct PatchBuilder::Impl {
- public:
   std::string ToString() const {
     if (empty()) {
       return "{}";
@@ -104,7 +104,6 @@ struct PatchBuilder::Impl {
     patch_[field_name] = v;
   }
 
- private:
   template <typename Integer>
   void AddIntegerField(char const* field_name, Integer lhs, Integer rhs,
                        Integer null_value) {
@@ -235,6 +234,10 @@ PatchBuilder& PatchBuilder::SetArrayField(
   pimpl_->SetArrayField(field_name,
                         nlohmann::json::parse(json_stringified_object));
   return *this;
+}
+
+nlohmann::json const& PatchBuilderDetails::GetPatch(PatchBuilder const& patch) {
+  return patch.pimpl_->patch_;
 }
 
 }  // namespace internal

--- a/google/cloud/storage/internal/patch_builder.h
+++ b/google/cloud/storage/internal/patch_builder.h
@@ -16,6 +16,7 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_PATCH_BUILDER_H
 
 #include "google/cloud/storage/version.h"
+#include <cstdint>
 #include <memory>
 #include <string>
 
@@ -44,7 +45,7 @@ class PatchBuilder {
   PatchBuilder(PatchBuilder const& other);
   PatchBuilder& operator=(PatchBuilder const& other);
 
-  // This have to be declared explicitly and defined out of line because `Impl`
+  // These have to be declared explicitly and defined out of line because `Impl`
   // is incomplete at this point.
   PatchBuilder(PatchBuilder&&) noexcept;
   PatchBuilder& operator=(PatchBuilder&&) noexcept;
@@ -122,10 +123,13 @@ class PatchBuilder {
                               std::string const& json_stringified_object);
 
  private:
+  friend struct PatchBuilderDetails;
+
   struct Impl;
   explicit PatchBuilder(std::unique_ptr<Impl> impl);
   std::unique_ptr<Impl> pimpl_;
 };
+
 }  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace storage

--- a/google/cloud/storage/internal/patch_builder_details.h
+++ b/google/cloud/storage/internal/patch_builder_details.h
@@ -1,4 +1,4 @@
-// Copyright 2018 Google LLC
+// Copyright 2022 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/google/cloud/storage/internal/patch_builder_details.h
+++ b/google/cloud/storage/internal/patch_builder_details.h
@@ -1,0 +1,48 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_PATCH_BUILDER_DETAILS_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_PATCH_BUILDER_DETAILS_H
+
+#include "google/cloud/storage/version.h"
+#include <nlohmann/json.hpp>
+
+namespace google {
+namespace cloud {
+namespace storage {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+namespace internal {
+
+class PatchBuilder;
+
+/**
+ * Get a JSON patch from a PatchBuilder.
+ *
+ * The PatchBuilder class cannot expose any API returning `nlohmann::json`
+ * because we do not want to expose the `nlohmann::json` in any of our public
+ * headers. However, in the implementation of GCS+gRPC we do need access to the
+ * JSON patch object.  We use a couple of forward declarations and some
+ * `friend`s to achieve this.
+ */
+struct PatchBuilderDetails {
+  static nlohmann::json const& GetPatch(PatchBuilder const& patch);
+};
+
+}  // namespace internal
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace storage
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_PATCH_BUILDER_DETAILS_H

--- a/google/cloud/storage/object_metadata.h
+++ b/google/cloud/storage/object_metadata.h
@@ -34,6 +34,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace internal {
 struct ObjectMetadataParser;
 struct GrpcObjectMetadataParser;
+struct GrpcObjectRequestParser;
 }  // namespace internal
 
 /// A simple representation for the customerEncryption field.
@@ -342,6 +343,8 @@ class ObjectMetadataPatchBuilder {
   ObjectMetadataPatchBuilder& ResetCustomTime();
 
  private:
+  friend struct internal::GrpcObjectRequestParser;
+
   internal::PatchBuilder impl_;
   bool metadata_subpatch_dirty_{false};
   internal::PatchBuilder metadata_subpatch_;


### PR DESCRIPTION
So far we have been using strings to represent "patch" requests. For
JSON this works, just store the string representation of a JSON patch.
For gRPC this will not work anymore, we need the actual patch to compute
the corresponding gRPC request.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8122)
<!-- Reviewable:end -->
