### PR TITLE
chore(ci): exclude ungenerated files from post-generation diff

### DIFF
--- a/ci/cloudbuild/builds/lib/integration.sh
+++ b/ci/cloudbuild/builds/lib/integration.sh
@@ -217,7 +217,15 @@ function integration::bazel_with_emulators() {
       --output_path="${PWD}" \
       --update_ci=false \
       --config_file="${PWD}/generator/integration_tests/golden_config.textproto"
-    git diff --exit-code generator/integration_tests/golden/
+    git diff --exit-code \
+      generator/integration_tests/golden/ \
+      ':(exclude)generator/integration_tests/golden/tests/' \
+      ':(exclude)generator/integration_tests/golden/.clang-format' \
+      ':(exclude)generator/integration_tests/golden/BUILD.bazel' \
+      ':(exclude)generator/integration_tests/golden/CMakeLists.txt' \
+      ':(exclude)generator/integration_tests/golden/*.bzl' \
+      ':(exclude)generator/integration_tests/golden/*_stub.h' \
+      ':(exclude)generator/integration_tests/golden/streaming.cc'
   fi
 }
 


### PR DESCRIPTION
Exclude hand-written files from the "generator integration test" diff
used to check that the golden files are up-to-date.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8126)
<!-- Reviewable:end -->
