### PR TITLE
chore: add cmake target for needed proto file

### DIFF
--- a/ci/cloudbuild/builds/cmake-install.sh
+++ b/ci/cloudbuild/builds/cmake-install.sh
@@ -101,6 +101,8 @@ expected_dirs+=(
   ./include/google/cloud/workflows/type
   ./include/google/devtools/cloudtrace
   ./include/google/devtools/cloudtrace/v2
+  ./include/google/devtools/source
+  ./include/google/devtools/source/v1
   ./include/google/iam/v1
   # no gRPC services in google/identity/accesscontextmanager/type
   ./include/google/identity/accesscontextmanager/type

--- a/external/googleapis/CMakeLists.txt
+++ b/external/googleapis/CMakeLists.txt
@@ -58,6 +58,7 @@ set(EXTERNAL_GOOGLEAPIS_PROTO_FILES
     "google/api/visibility.proto"
     "google/devtools/cloudtrace/v2/trace.proto"
     "google/devtools/cloudtrace/v2/tracing.proto"
+    "google/devtools/source/v1/source_context.proto"
     "google/iam/v1/iam_policy.proto"
     "google/iam/v1/options.proto"
     "google/iam/v1/policy.proto"
@@ -196,6 +197,7 @@ set(external_googleapis_installed_libraries_list
     google_cloud_cpp_cloud_texttospeech_protos
     google_cloud_cpp_devtools_cloudtrace_v2_trace_protos
     google_cloud_cpp_devtools_cloudtrace_v2_tracing_protos
+    google_cloud_cpp_devtools_source_v1_source_context_protos
     google_cloud_cpp_iam_protos
     google_cloud_cpp_iam_v1_iam_policy_protos
     google_cloud_cpp_iam_v1_options_protos
@@ -313,6 +315,9 @@ external_googleapis_add_library(
     "google/devtools/cloudtrace/v2/tracing.proto"
     devtools_cloudtrace_v2_trace_protos api_annotations_protos
     api_client_protos api_field_behavior_protos rpc_status_protos)
+
+external_googleapis_add_library("google/devtools/source/v1/source_context.proto"
+                                api_annotations_protos)
 
 google_cloud_cpp_load_protolist(cloud_bigquery_list "protolists/bigquery.list")
 google_cloud_cpp_load_protodeps(cloud_bigquery_deps "protodeps/bigquery.deps")


### PR DESCRIPTION
Part of: #8118

A CMake target for `google/devtools/source/v1/source_context.proto` is needed by the Cloud Debugger API.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8127)
<!-- Reviewable:end -->
