### PR TITLE
fix(storage): add missing options for PatchObject()

### DIFF
--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -1475,7 +1475,7 @@ class Client {
    * @param options a list of optional query parameters and/or request headers.
    *     Valid types for this operation include `Generation`,
    *     `IfGenerationMatch`, `IfGenerationNotMatch`, `IfMetagenerationMatch`,
-   *     `IfMetagenerationNotMatch`, `PredefinedAcl`,
+   *     `IfMetagenerationNotMatch`, `PredefinedAcl`, `EncryptionKey`,
    *     `Projection`, and `UserProject`.
    *
    * @par Idempotency

--- a/google/cloud/storage/internal/object_requests.h
+++ b/google/cloud/storage/internal/object_requests.h
@@ -242,12 +242,19 @@ class ComposeObjectRequest
 std::ostream& operator<<(std::ostream& os, ComposeObjectRequest const& r);
 
 /**
- * Represents a request to the `Buckets: patch` API.
+ * Represents a request to the `Objects: patch` API.
  */
 class PatchObjectRequest
     : public GenericObjectRequest<
-          PatchObjectRequest, IfMetagenerationMatch, IfMetagenerationNotMatch,
-          PredefinedAcl, PredefinedDefaultObjectAcl, Projection, UserProject> {
+          PatchObjectRequest, Generation, IfGenerationMatch,
+          IfGenerationNotMatch, IfMetagenerationMatch, IfMetagenerationNotMatch,
+          PredefinedAcl, EncryptionKey, Projection, UserProject,
+          // PredefinedDefaultObjectAcl has no effect in an `Objects: patch`
+          // request.  We are keeping it here for backwards compatibility. It
+          // was introduced in error (should have been PredefinedAcl), and it
+          // was never documented. The cost of keeping it is small, and there
+          // is very little motivation to remove it.
+          PredefinedDefaultObjectAcl> {
  public:
   PatchObjectRequest() = default;
   explicit PatchObjectRequest(std::string bucket_name, std::string object_name,

--- a/google/cloud/storage/tests/object_basic_crud_integration_test.cc
+++ b/google/cloud/storage/tests/object_basic_crud_integration_test.cc
@@ -156,8 +156,9 @@ TEST_F(ObjectBasicCRUDIntegrationTest, BasicCRUD) {
   desired_patch.set_content_language("en");
   desired_patch.mutable_metadata().erase("updated");
   desired_patch.mutable_metadata().emplace("patched", "true");
-  StatusOr<ObjectMetadata> patched_meta = client->PatchObject(
-      bucket_name_, object_name, *updated_meta, desired_patch);
+  StatusOr<ObjectMetadata> patched_meta =
+      client->PatchObject(bucket_name_, object_name, *updated_meta,
+                          desired_patch, PredefinedAcl::Private());
   ASSERT_STATUS_OK(patched_meta);
 
   EXPECT_EQ(desired_patch.metadata(), patched_meta->metadata())


### PR DESCRIPTION
After all these years, we were missing some options for
`storage::Client::PatchObject()`.  They were in the documentation, but
trying to use them would have resulted in a compilation error.

Part of the work for #4195

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8137)
<!-- Reviewable:end -->
