### PR TITLE
chore(ci): ensure that integration-daily runs inside a git repo

### DIFF
--- a/ci/cloudbuild/builds/integration-daily.sh
+++ b/ci/cloudbuild/builds/integration-daily.sh
@@ -29,6 +29,7 @@ set -euo pipefail
 
 source "$(dirname "$0")/../../lib/init.sh"
 source module ci/cloudbuild/builds/lib/bazel.sh
+source module ci/cloudbuild/builds/lib/git.sh
 source module ci/cloudbuild/builds/lib/integration.sh
 source module ci/lib/io.sh
 

--- a/ci/cloudbuild/builds/lib/git.sh
+++ b/ci/cloudbuild/builds/lib/git.sh
@@ -27,11 +27,11 @@ fi # include guard
 source module ci/lib/io.sh
 
 io::log "Checking for a valid git environment..."
-if [[ -d .git ]]; then
-  io::log_green "Found .git directory"
+if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  io::log_green "Inside a git repository"
 else
-  # This .git dir is thrown away at the end of the build.
-  io::log "Initializing .git directory"
+  # This repository is thrown away at the end of the build.
+  io::log "Creating a git repository"
   git init --initial-branch=ephemeral-branch
   git config --local user.email "ephemeral@fake"
   git config --local user.name "ephemeral"


### PR DESCRIPTION
Ensure that `integration-daily` runs within a git repository so
that the recently added "git diff" in the generator integration
test knows what to do.

Also take this opportunity to have git tell us whether we are
inside a repository, rather that checking for `.git` directly.