### PR TITLE
feat(GCS+gRPC): implement `PatchObject()`

### DIFF
--- a/generator/generator_config.textproto
+++ b/generator/generator_config.textproto
@@ -644,7 +644,6 @@ service {
     "CreateNotification",
     "ListNotifications",
     "ComposeObject",
-    "UpdateObject",
     "CreateHmacKey",
     "DeleteHmacKey",
     "GetHmacKey",

--- a/google/cloud/storage/internal/grpc_client.cc
+++ b/google/cloud/storage/internal/grpc_client.cc
@@ -327,8 +327,15 @@ StatusOr<ObjectMetadata> GrpcClient::UpdateObject(UpdateObjectRequest const&) {
   return Status(StatusCode::kUnimplemented, __func__);
 }
 
-StatusOr<ObjectMetadata> GrpcClient::PatchObject(PatchObjectRequest const&) {
-  return Status(StatusCode::kUnimplemented, __func__);
+StatusOr<ObjectMetadata> GrpcClient::PatchObject(
+    PatchObjectRequest const& request) {
+  auto proto = GrpcObjectRequestParser::ToProto(request);
+  if (!proto) return std::move(proto).status();
+  grpc::ClientContext context;
+  ApplyQueryParameters(context, request);
+  auto response = stub_->UpdateObject(context, *proto);
+  if (!response) return std::move(response).status();
+  return GrpcObjectMetadataParser::FromProto(*response, options_);
 }
 
 StatusOr<ObjectMetadata> GrpcClient::ComposeObject(

--- a/google/cloud/storage/internal/grpc_object_request_parser.h
+++ b/google/cloud/storage/internal/grpc_object_request_parser.h
@@ -40,6 +40,9 @@ struct GrpcObjectRequestParser {
   static StatusOr<google::storage::v2::ReadObjectRequest> ToProto(
       ReadObjectRangeRequest const& request);
 
+  static StatusOr<google::storage::v2::UpdateObjectRequest> ToProto(
+      PatchObjectRequest const& request);
+
   static StatusOr<google::storage::v2::WriteObjectRequest> ToProto(
       InsertObjectMediaRequest const& request);
   static ResumableUploadResponse FromProto(

--- a/google/cloud/storage/internal/grpc_object_request_parser_test.cc
+++ b/google/cloud/storage/internal/grpc_object_request_parser_test.cc
@@ -33,6 +33,7 @@ namespace storage_proto = ::google::storage::v2;
 using ::google::cloud::testing_util::IsProtoEqual;
 using ::google::cloud::testing_util::StatusIs;
 using ::testing::ElementsAre;
+using ::testing::UnorderedElementsAre;
 
 // Use gsutil to obtain the CRC32C checksum (in base64):
 //    TEXT="The quick brown fox jumps over the lazy dog"
@@ -227,6 +228,79 @@ TEST(GrpcObjectRequestParser, ReadObjectRangeRequestReadLastZero) {
           .set<EndpointOption>("localhost:1")));
   StatusOr<std::unique_ptr<ObjectReadSource>> reader = client->ReadObject(req);
   EXPECT_THAT(reader, StatusIs(StatusCode::kOutOfRange));
+}
+
+TEST(GrpcObjectRequestParser, PatchObjectRequestAllOptions) {
+  google::storage::v2::UpdateObjectRequest expected;
+  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(
+      R"pb(
+        object {
+          bucket: "projects/_/buckets/bucket-name"
+          name: "object-name"
+          generation: 7
+          acl { entity: "allUsers" role: "READER" }
+          content_encoding: "test-only-content-encoding"
+          content_disposition: "test-only-content-disposition"
+          cache_control: "test-only-cache-control"
+          content_language: "test-only-content-language"
+          content_type: "test-only-content-type"
+          temporary_hold: true
+          metadata { key: "key0" value: "value0" }
+          event_based_hold: true
+          custom_time { seconds: 1643126687 nanos: 123000000 }
+        }
+        predefined_acl: OBJECT_ACL_PROJECT_PRIVATE
+        if_generation_match: 1
+        if_generation_not_match: 2
+        if_metageneration_match: 3
+        if_metageneration_not_match: 4
+        common_object_request_params: {
+          encryption_algorithm: "AES256"
+          encryption_key_bytes: "01234567"
+          encryption_key_sha256_bytes: "\222E\222\271\261\003\361O\203?\252\373g\364\200i\037\001\230\212\244W\300\006\027i\365\214\324s\021\274"
+        }
+        common_request_params: { user_project: "test-user-project" }
+        update_mask {}
+      )pb",
+      &expected));
+
+  PatchObjectRequest req(
+      "bucket-name", "object-name",
+      ObjectMetadataPatchBuilder{}
+          .SetAcl(
+              {ObjectAccessControl{}.set_entity("allUsers").set_role("READER")})
+          .SetContentEncoding("test-only-content-encoding")
+          .SetContentDisposition("test-only-content-disposition")
+          .SetCacheControl("test-only-cache-control")
+          .SetContentLanguage("test-only-content-language")
+          .SetContentType("test-only-content-type")
+          .SetMetadata("key0", "value0")
+          .SetContentType("test-only-content-type")
+          .SetTemporaryHold(true)
+          .SetEventBasedHold(true)
+          .SetCustomTime(std::chrono::system_clock::time_point{} +
+                         std::chrono::seconds(1643126687) +
+                         std::chrono::milliseconds(123)));
+  req.set_multiple_options(
+      Generation(7), IfGenerationMatch(1), IfGenerationNotMatch(2),
+      IfMetagenerationMatch(3), IfMetagenerationNotMatch(4),
+      PredefinedAcl("projectPrivate"), EncryptionKey::FromBinaryKey("01234567"),
+      Projection("full"), UserProject("test-user-project"),
+      QuotaUser("test-quota-user"), UserIp("test-user-ip"));
+
+  auto actual = GrpcObjectRequestParser::ToProto(req);
+  ASSERT_STATUS_OK(actual);
+  // First check the paths, we do not care about their order, so checking them
+  // with IsProtoEqual does not work.
+  EXPECT_THAT(
+      actual->update_mask().paths(),
+      UnorderedElementsAre("acl", "content_encoding", "content_disposition",
+                           "cache_control", "content_language", "content_type",
+                           "metadata", "temporary_hold", "event_based_hold",
+                           "custom_time"));
+  // Clear the paths, which we already compared, and test the rest
+  actual->mutable_update_mask()->clear_paths();
+  EXPECT_THAT(*actual, IsProtoEqual(expected));
 }
 
 TEST(GrpcObjectRequestParser, InsertObjectMediaRequestSimple) {

--- a/google/cloud/storage/internal/storage_auth_decorator.cc
+++ b/google/cloud/storage/internal/storage_auth_decorator.cc
@@ -65,6 +65,14 @@ StorageAuth::ReadObject(std::unique_ptr<grpc::ClientContext> context,
   return child_->ReadObject(std::move(context), request);
 }
 
+StatusOr<google::storage::v2::Object> StorageAuth::UpdateObject(
+    grpc::ClientContext& context,
+    google::storage::v2::UpdateObjectRequest const& request) {
+  auto status = auth_->ConfigureContext(context);
+  if (!status.ok()) return status;
+  return child_->UpdateObject(context, request);
+}
+
 std::unique_ptr<::google::cloud::internal::StreamingWriteRpc<
     google::storage::v2::WriteObjectRequest,
     google::storage::v2::WriteObjectResponse>>

--- a/google/cloud/storage/internal/storage_auth_decorator.h
+++ b/google/cloud/storage/internal/storage_auth_decorator.h
@@ -55,6 +55,10 @@ class StorageAuth : public StorageStub {
   ReadObject(std::unique_ptr<grpc::ClientContext> context,
              google::storage::v2::ReadObjectRequest const& request) override;
 
+  StatusOr<google::storage::v2::Object> UpdateObject(
+      grpc::ClientContext& context,
+      google::storage::v2::UpdateObjectRequest const& request) override;
+
   std::unique_ptr<::google::cloud::internal::StreamingWriteRpc<
       google::storage::v2::WriteObjectRequest,
       google::storage::v2::WriteObjectResponse>>

--- a/google/cloud/storage/internal/storage_logging_decorator.cc
+++ b/google/cloud/storage/internal/storage_logging_decorator.cc
@@ -92,6 +92,17 @@ StorageLogging::ReadObject(
       std::move(context), request, __func__, tracing_options_);
 }
 
+StatusOr<google::storage::v2::Object> StorageLogging::UpdateObject(
+    grpc::ClientContext& context,
+    google::storage::v2::UpdateObjectRequest const& request) {
+  return google::cloud::internal::LogWrapper(
+      [this](grpc::ClientContext& context,
+             google::storage::v2::UpdateObjectRequest const& request) {
+        return child_->UpdateObject(context, request);
+      },
+      context, request, __func__, tracing_options_);
+}
+
 std::unique_ptr<::google::cloud::internal::StreamingWriteRpc<
     google::storage::v2::WriteObjectRequest,
     google::storage::v2::WriteObjectResponse>>

--- a/google/cloud/storage/internal/storage_logging_decorator.h
+++ b/google/cloud/storage/internal/storage_logging_decorator.h
@@ -55,6 +55,10 @@ class StorageLogging : public StorageStub {
   ReadObject(std::unique_ptr<grpc::ClientContext> context,
              google::storage::v2::ReadObjectRequest const& request) override;
 
+  StatusOr<google::storage::v2::Object> UpdateObject(
+      grpc::ClientContext& context,
+      google::storage::v2::UpdateObjectRequest const& request) override;
+
   std::unique_ptr<::google::cloud::internal::StreamingWriteRpc<
       google::storage::v2::WriteObjectRequest,
       google::storage::v2::WriteObjectResponse>>

--- a/google/cloud/storage/internal/storage_metadata_decorator.cc
+++ b/google/cloud/storage/internal/storage_metadata_decorator.cc
@@ -62,6 +62,13 @@ StorageMetadata::ReadObject(
   return child_->ReadObject(std::move(context), request);
 }
 
+StatusOr<google::storage::v2::Object> StorageMetadata::UpdateObject(
+    grpc::ClientContext& context,
+    google::storage::v2::UpdateObjectRequest const& request) {
+  SetMetadata(context, {});
+  return child_->UpdateObject(context, request);
+}
+
 std::unique_ptr<::google::cloud::internal::StreamingWriteRpc<
     google::storage::v2::WriteObjectRequest,
     google::storage::v2::WriteObjectResponse>>

--- a/google/cloud/storage/internal/storage_metadata_decorator.h
+++ b/google/cloud/storage/internal/storage_metadata_decorator.h
@@ -51,6 +51,10 @@ class StorageMetadata : public StorageStub {
   ReadObject(std::unique_ptr<grpc::ClientContext> context,
              google::storage::v2::ReadObjectRequest const& request) override;
 
+  StatusOr<google::storage::v2::Object> UpdateObject(
+      grpc::ClientContext& context,
+      google::storage::v2::UpdateObjectRequest const& request) override;
+
   std::unique_ptr<::google::cloud::internal::StreamingWriteRpc<
       google::storage::v2::WriteObjectRequest,
       google::storage::v2::WriteObjectResponse>>

--- a/google/cloud/storage/internal/storage_round_robin.cc
+++ b/google/cloud/storage/internal/storage_round_robin.cc
@@ -45,6 +45,12 @@ StorageRoundRobin::ReadObject(
   return Child()->ReadObject(std::move(context), request);
 }
 
+StatusOr<google::storage::v2::Object> StorageRoundRobin::UpdateObject(
+    grpc::ClientContext& context,
+    google::storage::v2::UpdateObjectRequest const& request) {
+  return Child()->UpdateObject(context, request);
+}
+
 std::unique_ptr<google::cloud::internal::StreamingWriteRpc<
     google::storage::v2::WriteObjectRequest,
     google::storage::v2::WriteObjectResponse>>

--- a/google/cloud/storage/internal/storage_round_robin.h
+++ b/google/cloud/storage/internal/storage_round_robin.h
@@ -48,6 +48,10 @@ class StorageRoundRobin : public StorageStub {
   ReadObject(std::unique_ptr<grpc::ClientContext> context,
              google::storage::v2::ReadObjectRequest const& request) override;
 
+  StatusOr<google::storage::v2::Object> UpdateObject(
+      grpc::ClientContext& context,
+      google::storage::v2::UpdateObjectRequest const& request) override;
+
   std::unique_ptr<google::cloud::internal::StreamingWriteRpc<
       google::storage::v2::WriteObjectRequest,
       google::storage::v2::WriteObjectResponse>>

--- a/google/cloud/storage/internal/storage_round_robin_test.cc
+++ b/google/cloud/storage/internal/storage_round_robin_test.cc
@@ -148,6 +148,25 @@ TEST(StorageRoundRobinTest, ReadObject) {
   }
 }
 
+TEST(StorageRoundRobinTest, UpdateObject) {
+  auto mocks = MakeMocks();
+  InSequence sequence;
+  for (int i = 0; i != kRepeats; ++i) {
+    for (auto& m : mocks) {
+      EXPECT_CALL(*m, UpdateObject)
+          .WillOnce(Return(Status(StatusCode::kPermissionDenied, "uh-oh")));
+    }
+  }
+
+  StorageRoundRobin under_test(AsPlainStubs(mocks));
+  for (size_t i = 0; i != kRepeats * mocks.size(); ++i) {
+    grpc::ClientContext context;
+    google::storage::v2::UpdateObjectRequest request;
+    auto response = under_test.UpdateObject(context, request);
+    EXPECT_THAT(response, StatusIs(StatusCode::kPermissionDenied));
+  }
+}
+
 TEST(StorageRoundRobinTest, WriteObject) {
   auto mocks = MakeMocks();
   InSequence sequence;

--- a/google/cloud/storage/internal/storage_stub.cc
+++ b/google/cloud/storage/internal/storage_stub.cc
@@ -74,6 +74,17 @@ DefaultStorageStub::ReadObject(
                                                 std::move(stream));
 }
 
+StatusOr<google::storage::v2::Object> DefaultStorageStub::UpdateObject(
+    grpc::ClientContext& client_context,
+    google::storage::v2::UpdateObjectRequest const& request) {
+  google::storage::v2::Object response;
+  auto status = grpc_stub_->UpdateObject(&client_context, request, &response);
+  if (!status.ok()) {
+    return google::cloud::MakeStatusFromRpcError(status);
+  }
+  return response;
+}
+
 std::unique_ptr<::google::cloud::internal::StreamingWriteRpc<
     google::storage::v2::WriteObjectRequest,
     google::storage::v2::WriteObjectResponse>>

--- a/google/cloud/storage/internal/storage_stub.h
+++ b/google/cloud/storage/internal/storage_stub.h
@@ -52,6 +52,10 @@ class StorageStub {
   ReadObject(std::unique_ptr<grpc::ClientContext> context,
              google::storage::v2::ReadObjectRequest const& request) = 0;
 
+  virtual StatusOr<google::storage::v2::Object> UpdateObject(
+      grpc::ClientContext& context,
+      google::storage::v2::UpdateObjectRequest const& request) = 0;
+
   virtual std::unique_ptr<::google::cloud::internal::StreamingWriteRpc<
       google::storage::v2::WriteObjectRequest,
       google::storage::v2::WriteObjectResponse>>
@@ -102,6 +106,10 @@ class DefaultStorageStub : public StorageStub {
       google::storage::v2::ReadObjectResponse>>
   ReadObject(std::unique_ptr<grpc::ClientContext> client_context,
              google::storage::v2::ReadObjectRequest const& request) override;
+
+  StatusOr<google::storage::v2::Object> UpdateObject(
+      grpc::ClientContext& client_context,
+      google::storage::v2::UpdateObjectRequest const& request) override;
 
   std::unique_ptr<::google::cloud::internal::StreamingWriteRpc<
       google::storage::v2::WriteObjectRequest,

--- a/google/cloud/storage/testing/mock_storage_stub.h
+++ b/google/cloud/storage/testing/mock_storage_stub.h
@@ -43,6 +43,10 @@ class MockStorageStub : public storage_internal::StorageStub {
               (std::unique_ptr<grpc::ClientContext>,
                google::storage::v2::ReadObjectRequest const&),
               (override));
+  MOCK_METHOD(StatusOr<google::storage::v2::Object>, UpdateObject,
+              (grpc::ClientContext&,
+               google::storage::v2::UpdateObjectRequest const&),
+              (override));
   MOCK_METHOD((std::unique_ptr<google::cloud::internal::StreamingWriteRpc<
                    google::storage::v2::WriteObjectRequest,
                    google::storage::v2::WriteObjectResponse>>),

--- a/google/cloud/storage/tests/grpc_object_metadata_integration_test.cc
+++ b/google/cloud/storage/tests/grpc_object_metadata_integration_test.cc
@@ -82,6 +82,12 @@ TEST_F(GrpcObjectMetadataIntegrationTest, ObjectMetadataCRUD) {
   ASSERT_STATUS_OK(rewrite);
   ScheduleForDelete(*rewrite);
 
+  auto patch = client->PatchObject(
+      bucket_name, object_name,
+      ObjectMetadataPatchBuilder{}.SetCacheControl("no-cache"));
+  ASSERT_STATUS_OK(patch);
+  EXPECT_EQ(patch->cache_control(), "no-cache");
+
   auto del = client->DeleteObject(bucket_name, object_name);
   ASSERT_STATUS_OK(del);
 


### PR DESCRIPTION
Fixes #4195.  Note that gRPC combines the `PatchObject()` and `UpdateObject()` RPCs into a single RPC.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8142)
<!-- Reviewable:end -->
