### PR TITLE
ci: increase default timeout for macOS builds

### DIFF
--- a/ci/kokoro/macos/common.cfg
+++ b/ci/kokoro/macos/common.cfg
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 build_file: "google-cloud-cpp/ci/kokoro/macos/build.sh"
-timeout_mins: 60
+timeout_mins: 120
 
 gfile_resources: "/bigstore/cloud-cpp-integration-secrets/build-results-service-account.json"
 gfile_resources: "/bigstore/cloud-cpp-integration-secrets/kokoro-run-key.json"


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8150)
<!-- Reviewable:end -->
