### PR TITLE
fix(rest): initial partial read could overflow spill buffer

### DIFF
--- a/google/cloud/internal/curl_impl.h
+++ b/google/cloud/internal/curl_impl.h
@@ -149,6 +149,10 @@ class CurlImpl {
   bool in_multi_;
   bool paused_;
 
+  // Track when status and headers from the response are received.
+  bool status_line_received_;
+  bool all_headers_received_;
+
   // Track the usage of the buffer provided to Read.
   absl::Span<char> buffer_;
 
@@ -156,9 +160,7 @@ class CurlImpl {
   // WriteCallback. However, the callback *must* save all the bytes, returning
   // fewer bytes read aborts the download. The application may have requested
   // fewer bytes in the call to `Read()`, so we need a place to store the
-  // additional bytes. Furthermore, when we first make the request we write all
-  // bytes received from libcurl to the spill buffer so the spill buffer is
-  // sized to accommodate the max number of bytes.
+  // additional bytes.
   std::array<char, kDefaultCurlWriteBufferSize> spill_;
   std::size_t spill_offset_;
 


### PR DESCRIPTION
The intent of handling a response by first writing all bytes to the spill buffer was to enable the status code and headers to be interrogated via the `RestResponse` class, without having to read all the bytes in the response body. The initial implementation was based on the model that libcurl would write all of CURLOPT_BUFFERSIZE bytes at once into the spill buffer. This was incorrect and in order to handle multiple writes to the spill buffer new monitoring of when the status line and headers were received was added.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8157)
<!-- Reviewable:end -->
