### PR TITLE
impl(cmake): support interface proto libraries

### DIFF
--- a/cmake/CompileProtos.cmake
+++ b/cmake/CompileProtos.cmake
@@ -419,7 +419,12 @@ macro (external_googleapis_install_pc_common target)
         " zlib"
         " libcares")
     string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES ${_target_pc_requires})
-    set(GOOGLE_CLOUD_CPP_PC_LIBS "-l${target}")
+    get_target_property(_target_type ${target} TYPE)
+    if ("${_target_type}" STREQUAL "INTERFACE_LIBRARY")
+        set(GOOGLE_CLOUD_CPP_PC_LIBS "")
+    else ()
+        set(GOOGLE_CLOUD_CPP_PC_LIBS "-l${target}")
+    endif ()
 endmacro ()
 
 # Use a function to create a scope for the variables.


### PR DESCRIPTION
Update the helper functions in CMake to support `INTERFACE` proto
libraries. `INTERFACE` libraries have no filesystem artifacts, there is
no `-l...` option required for them.  They are useful when you want to
create a new name for a CMake target without breaking compatibility, or
when you want to group multiple targets.  They are also useful for
header-only libraries, but that is not the case here.

I am planning to use this feature for Cloud Trace, Cloud Monitoring, and
Text-to-Speech.  All of these have proto libraries in
`external/googleapis`, I can create new libraries for these protos in
`google/cloud/${service}`, but I do not want to introduce potential ODR
violations.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8165)
<!-- Reviewable:end -->
