### PR TITLE
fix(texttospeech): remove duplicate protos

### DIFF
--- a/google/cloud/texttospeech/CMakeLists.txt
+++ b/google/cloud/texttospeech/CMakeLists.txt
@@ -40,22 +40,17 @@ if (PROTO_INCLUDE_DIR)
 endif ()
 
 include(CompileProtos)
-google_cloud_cpp_grpcpp_library(
-    google_cloud_cpp_texttospeech_protos
-    # cmake-format: sort
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/texttospeech/v1/cloud_tts.proto
-    PROTO_PATH_DIRECTORIES
-    "${EXTERNAL_GOOGLEAPIS_SOURCE}"
-    "${PROTO_INCLUDE_DIR}")
+add_library(google_cloud_cpp_texttospeech_protos INTERFACE)
 external_googleapis_set_version_and_alias(texttospeech_protos)
 target_link_libraries(
     google_cloud_cpp_texttospeech_protos
-    PUBLIC #
-           google-cloud-cpp::api_annotations_protos
-           google-cloud-cpp::api_client_protos
-           google-cloud-cpp::api_field_behavior_protos
-           google-cloud-cpp::api_http_protos
-           google-cloud-cpp::api_resource_protos)
+    INTERFACE #
+              google-cloud-cpp::cloud_texttospeech_protos
+              google-cloud-cpp::api_annotations_protos
+              google-cloud-cpp::api_client_protos
+              google-cloud-cpp::api_field_behavior_protos
+              google-cloud-cpp::api_http_protos
+              google-cloud-cpp::api_resource_protos)
 
 file(
     GLOB source_files


### PR DESCRIPTION
We had two libraries that compiled the same proto files.  That was a
recipe to create ODR violations.  With this PR one of the libraries
depends on the other, avoiding the duplicates.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8169)
<!-- Reviewable:end -->
