### PR TITLE
feat(generator): always hand-craft bidir streaming body

### DIFF
--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_connection_impl.cc
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_connection_impl.cc
@@ -146,14 +146,6 @@ GoldenKitchenSinkConnectionImpl::DoNothing(google::protobuf::Empty const& reques
       request, __func__);
 }
 
-std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
-    google::test::admin::database::v1::AppendRowsRequest,
-    google::test::admin::database::v1::AppendRowsResponse>>
-GoldenKitchenSinkConnectionImpl::AsyncAppendRows() {
-  return stub_->AsyncAppendRows(
-      background_->cq(), absl::make_unique<grpc::ClientContext>());
-}
-
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace golden_internal
 }  // namespace cloud

--- a/generator/integration_tests/golden/streaming.cc
+++ b/generator/integration_tests/golden/streaming.cc
@@ -41,7 +41,6 @@ void GoldenKitchenSinkTailLogEntriesStreamingUpdater(
   // implementation here
 }
 
-
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace golden
 }  // namespace cloud

--- a/generator/integration_tests/golden/streaming.cc
+++ b/generator/integration_tests/golden/streaming.cc
@@ -11,11 +11,27 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 #include "generator/integration_tests/golden/golden_kitchen_sink_connection.h"
+#include "generator/integration_tests/golden/internal/golden_kitchen_sink_connection_impl.h"
 #include "google/cloud/version.h"
 
 namespace google {
 namespace cloud {
+namespace golden_internal {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+
+std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
+    google::test::admin::database::v1::AppendRowsRequest,
+    google::test::admin::database::v1::AppendRowsResponse>>
+GoldenKitchenSinkConnectionImpl::AsyncAppendRows() {
+  return stub_->AsyncAppendRows(
+      background_->cq(), absl::make_unique<grpc::ClientContext>());
+}
+
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace golden_internal
+
 namespace golden {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
@@ -24,6 +40,7 @@ void GoldenKitchenSinkTailLogEntriesStreamingUpdater(
     ::google::test::admin::database::v1::TailLogEntriesRequest&) {
   // implementation here
 }
+
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace golden

--- a/generator/internal/connection_impl_generator.cc
+++ b/generator/internal/connection_impl_generator.cc
@@ -281,15 +281,10 @@ std::string ConnectionImplGenerator::AsyncMethodDeclaration(
 std::string ConnectionImplGenerator::MethodDefinition(
     google::protobuf::MethodDescriptor const& method) {
   if (IsBidirStreaming(method)) {
-    return R"""(
-std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
-    $request_type$,
-    $response_type$>>
-$connection_class_name$Impl::Async$method_name$() {
-  return stub_->Async$method_name$(
-      background_->cq(), absl::make_unique<grpc::ClientContext>());
-}
-)""";
+    // We do not generate definitions for bidir streaming RPCs. Their retry or
+    // resume loops are so custom (if possible at all), and their usage so rare,
+    // that it is easier to hand-craft these functions in a streaming.cc file.
+    return R"""()""";
   }
 
   if (IsStreamingRead(method)) {

--- a/google/cloud/logging/CMakeLists.txt
+++ b/google/cloud/logging/CMakeLists.txt
@@ -47,6 +47,7 @@ add_library(
     internal/logging_service_v2_stub.h
     internal/logging_service_v2_stub_factory.cc
     internal/logging_service_v2_stub_factory.h
+    internal/streaming.cc
     logging_service_v2_client.cc
     logging_service_v2_client.h
     logging_service_v2_connection.cc

--- a/google/cloud/logging/README.md
+++ b/google/cloud/logging/README.md
@@ -6,6 +6,8 @@ This directory contains an idiomatic C++ client library for interacting with
 [Cloud Logging](https://cloud.google.com/logging/),
 a service for real-time log management and analysis at scale.
 
+<!-- TODO(#7796) - delay GA until we implement TailLogEntries()'s retry loop -->
+
 This library is **experimental**. Its APIs are subject to change without notice.
 
 Please note that the Google Cloud C++ client libraries do **not** follow

--- a/google/cloud/logging/google_cloud_cpp_logging.bzl
+++ b/google/cloud/logging/google_cloud_cpp_logging.bzl
@@ -39,6 +39,7 @@ google_cloud_cpp_logging_srcs = [
     "internal/logging_service_v2_option_defaults.cc",
     "internal/logging_service_v2_stub.cc",
     "internal/logging_service_v2_stub_factory.cc",
+    "internal/streaming.cc",
     "logging_service_v2_client.cc",
     "logging_service_v2_connection.cc",
     "logging_service_v2_connection_idempotency_policy.cc",

--- a/google/cloud/logging/internal/logging_service_v2_connection_impl.cc
+++ b/google/cloud/logging/internal/logging_service_v2_connection_impl.cc
@@ -160,14 +160,6 @@ StreamRange<std::string> LoggingServiceV2ConnectionImpl::ListLogs(
       });
 }
 
-std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
-    google::logging::v2::TailLogEntriesRequest,
-    google::logging::v2::TailLogEntriesResponse>>
-LoggingServiceV2ConnectionImpl::AsyncTailLogEntries() {
-  return stub_->AsyncTailLogEntries(background_->cq(),
-                                    absl::make_unique<grpc::ClientContext>());
-}
-
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace logging_internal
 }  // namespace cloud

--- a/google/cloud/logging/internal/streaming.cc
+++ b/google/cloud/logging/internal/streaming.cc
@@ -1,0 +1,35 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/logging/internal/logging_service_v2_connection_impl.h"
+#include <memory>
+
+namespace google {
+namespace cloud {
+namespace logging_internal {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+
+std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
+    google::logging::v2::TailLogEntriesRequest,
+    google::logging::v2::TailLogEntriesResponse>>
+LoggingServiceV2ConnectionImpl::AsyncTailLogEntries() {
+  // TODO(#7796) - add resume loop
+  return stub_->AsyncTailLogEntries(background_->cq(),
+                                    absl::make_unique<grpc::ClientContext>());
+}
+
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace logging_internal
+}  // namespace cloud
+}  // namespace google


### PR DESCRIPTION
This changes the generator to **not** emit the body of the bidirectional streaming RPC.  There are very few services that need these RPCs, many are hand-crafted in full, many need a very unique implementation for this function, some do not need a retry / resume loop at all.

We will be implementing these functions by hand, in a `internal/streaming.cc` file (or similar).  In this PR only the golden files and `google/cloud/logging` are affected.  I am not implementing interesting versions of the function body, that will come in separate PRs.

Part of the work for #7795.  I added some TODO entries to prevent accidentally declaring GA for the logging library.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8170)
<!-- Reviewable:end -->
