### PR TITLE
fix(storage): missing option for CopyObject()

### DIFF
--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -1017,8 +1017,8 @@ class Client {
    *     `IfMetagenerationMatch`, `IfMetagenerationNotMatch`,
    *     `IfSourceGenerationMatch`, `IfSourceGenerationNotMatch`,
    *     `IfSourceMetagenerationMatch`, `IfSourceMetagenerationNotMatch`,
-   *     `Projection`, `SourceGeneration`, `UserProject`, and
-   *     `WithObjectMetadata`.
+   *     `Projection`, `SourceGeneration`, `SourceEncryptionKey`, `UserProject`,
+   *     and `WithObjectMetadata`.
    *
    * @par Idempotency
    * This operation is only idempotent if restricted by pre-conditions, in this

--- a/google/cloud/storage/internal/object_requests.h
+++ b/google/cloud/storage/internal/object_requests.h
@@ -133,7 +133,7 @@ class CopyObjectRequest
           IfMetagenerationNotMatch, IfSourceGenerationMatch,
           IfSourceGenerationNotMatch, IfSourceMetagenerationMatch,
           IfSourceMetagenerationNotMatch, Projection, SourceGeneration,
-          UserProject, WithObjectMetadata> {
+          SourceEncryptionKey, UserProject, WithObjectMetadata> {
  public:
   CopyObjectRequest() = default;
   CopyObjectRequest(std::string source_bucket, std::string source_object,


### PR DESCRIPTION
Add missing option (and tests) for `storage::Client::CopyObject()`.

Part of the work for #4199

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8171)
<!-- Reviewable:end -->
