### PR TITLE
feat(bigtable): cheap Table creation with different resource name

### DIFF
--- a/google/cloud/bigtable/metadata_update_policy_test.cc
+++ b/google/cloud/bigtable/metadata_update_policy_test.cc
@@ -69,14 +69,17 @@ TEST_F(MetadataUpdatePolicyTest, RunWithEmbeddedServerParamTableName) {
 
 /// @test A test for setting metadata when table is known.
 TEST_F(MetadataUpdatePolicyTest, ModifiedTableName) {
-  std::string const new_project_id = "modified-project";
-  std::string const new_instance_id = "modified-instance";
-  table_->set_project_id(new_project_id);
-  table_->set_instance_id(new_instance_id);
+  std::string const other_project_id = "other-project";
+  std::string const other_instance_id = "other-instance";
+  std::string const other_table_id = "other-table";
+  auto other_table = table_->WithNewTarget(other_project_id, other_instance_id,
+                                           other_table_id);
 
   grpc::string expected =
-      "table_name=" + TableName(new_project_id, new_instance_id, kTableId);
-  auto reader = table_->ReadRows(RowSet("row1"), 1, Filter::PassAllFilter());
+      "table_name=" +
+      TableName(other_project_id, other_instance_id, other_table_id);
+  auto reader =
+      other_table.ReadRows(RowSet("row1"), 1, Filter::PassAllFilter());
   // lets make the RPC call to send metadata
   reader.begin();
   // Get metadata from embedded server

--- a/google/cloud/bigtable/metadata_update_policy_test.cc
+++ b/google/cloud/bigtable/metadata_update_policy_test.cc
@@ -67,6 +67,25 @@ TEST_F(MetadataUpdatePolicyTest, RunWithEmbeddedServerParamTableName) {
   EXPECT_EQ(expected, range.first->second);
 }
 
+/// @test A test for setting metadata when table is known.
+TEST_F(MetadataUpdatePolicyTest, ModifiedTableName) {
+  std::string const new_project_id = "modified-project";
+  std::string const new_instance_id = "modified-instance";
+  table_->set_project_id(new_project_id);
+  table_->set_instance_id(new_instance_id);
+
+  grpc::string expected =
+      "table_name=" + TableName(new_project_id, new_instance_id, kTableId);
+  auto reader = table_->ReadRows(RowSet("row1"), 1, Filter::PassAllFilter());
+  // lets make the RPC call to send metadata
+  reader.begin();
+  // Get metadata from embedded server
+  auto client_metadata = bigtable_service_.client_metadata();
+  auto range = client_metadata.equal_range("x-goog-request-params");
+  ASSERT_EQ(1, std::distance(range.first, range.second));
+  EXPECT_EQ(expected, range.first->second);
+}
+
 /// @test A cloning test for normal construction of metadata .
 TEST_F(MetadataUpdatePolicyTest, SimpleDefault) {
   auto const x_google_request_params = "parent=" + std::string(kInstanceName);

--- a/google/cloud/bigtable/table.h
+++ b/google/cloud/bigtable/table.h
@@ -366,15 +366,8 @@ class Table {
    */
   Table WithNewTarget(std::string project_id, std::string instance_id,
                       std::string table_id) const {
-    auto table = *this;
-    table.instance_id_ = std::move(instance_id);
-    table.project_id_ = std::move(project_id);
-    table.table_id_ = std::move(table_id);
-    table.table_name_ =
-        TableName(table.project_id_, table.instance_id_, table.table_id_);
-    table.metadata_update_policy_ =
-        MetadataUpdatePolicy(table.table_name_, MetadataParamTypes::TABLE_NAME);
-    return table;
+    return WithNewTarget(std::move(project_id), std::move(instance_id),
+                         app_profile_id_, std::move(table_id));
   }
 
   /**

--- a/google/cloud/bigtable/table.h
+++ b/google/cloud/bigtable/table.h
@@ -361,6 +361,8 @@ class Table {
   /**
    * Returns a Table that reuses the connection and configuration of this
    * Table, but with a different resource name.
+   *
+   * @note The app profile id is copied from this Table.
    */
   Table WithNewTarget(std::string project_id, std::string instance_id,
                       std::string table_id) const {
@@ -368,6 +370,24 @@ class Table {
     table.instance_id_ = std::move(instance_id);
     table.project_id_ = std::move(project_id);
     table.table_id_ = std::move(table_id);
+    table.table_name_ =
+        TableName(table.project_id_, table.instance_id_, table.table_id_);
+    table.metadata_update_policy_ =
+        MetadataUpdatePolicy(table.table_name_, MetadataParamTypes::TABLE_NAME);
+    return table;
+  }
+
+  /**
+   * Returns a Table that reuses the connection and configuration of this
+   * Table, but with a different resource name.
+   */
+  Table WithNewTarget(std::string project_id, std::string instance_id,
+                      std::string app_profile_id, std::string table_id) const {
+    auto table = *this;
+    table.instance_id_ = std::move(instance_id);
+    table.project_id_ = std::move(project_id);
+    table.table_id_ = std::move(table_id);
+    table.app_profile_id_ = std::move(app_profile_id);
     table.table_name_ =
         TableName(table.project_id_, table.instance_id_, table.table_id_);
     table.metadata_update_policy_ =

--- a/google/cloud/bigtable/table.h
+++ b/google/cloud/bigtable/table.h
@@ -358,20 +358,21 @@ class Table {
   std::string const& instance_id() const { return instance_id_; }
   std::string const& table_id() const { return table_id_; }
 
-  /// Override the project id
-  void set_project_id(std::string project_id) {
-    project_id_ = std::move(project_id);
-    table_name_ = TableName(project_id_, instance_id_, table_id_);
-    metadata_update_policy_ =
-        MetadataUpdatePolicy(table_name_, MetadataParamTypes::TABLE_NAME);
-  }
-
-  /// Override the instance id
-  void set_instance_id(std::string instance_id) {
-    instance_id_ = std::move(instance_id);
-    table_name_ = TableName(project_id_, instance_id_, table_id_);
-    metadata_update_policy_ =
-        MetadataUpdatePolicy(table_name_, MetadataParamTypes::TABLE_NAME);
+  /**
+   * Returns a Table that reuses the connection and configuration of this
+   * Table, but with a different resource name.
+   */
+  Table WithNewTarget(std::string project_id, std::string instance_id,
+                      std::string table_id) const {
+    auto table = *this;
+    table.instance_id_ = std::move(instance_id);
+    table.project_id_ = std::move(project_id);
+    table.table_id_ = std::move(table_id);
+    table.table_name_ =
+        TableName(table.project_id_, table.instance_id_, table.table_id_);
+    table.metadata_update_policy_ =
+        MetadataUpdatePolicy(table.table_name_, MetadataParamTypes::TABLE_NAME);
+    return table;
   }
 
   /**

--- a/google/cloud/bigtable/table_test.cc
+++ b/google/cloud/bigtable/table_test.cc
@@ -60,15 +60,17 @@ TEST_F(TableTest, OverrideFields) {
   EXPECT_EQ(table.instance_id(), kInstanceId);
   EXPECT_EQ(table.table_name(), TableName(kProjectId, kInstanceId, kTableId));
 
-  std::string const new_project_id = "modified-project";
-  std::string const new_instance_id = "modified-instance";
-  table.set_project_id(new_project_id);
-  table.set_instance_id(new_instance_id);
+  std::string const other_project_id = "other-project";
+  std::string const other_instance_id = "other-instance";
+  std::string const other_table_id = "other-table";
+  auto other_table =
+      table.WithNewTarget(other_project_id, other_instance_id, other_table_id);
 
-  EXPECT_EQ(table.project_id(), new_project_id);
-  EXPECT_EQ(table.instance_id(), new_instance_id);
-  EXPECT_EQ(table.table_name(),
-            TableName(new_project_id, new_instance_id, kTableId));
+  EXPECT_EQ(other_table.project_id(), other_project_id);
+  EXPECT_EQ(other_table.instance_id(), other_instance_id);
+  EXPECT_EQ(other_table.table_id(), other_table_id);
+  EXPECT_EQ(other_table.table_name(),
+            TableName(other_project_id, other_instance_id, other_table_id));
 }
 
 TEST_F(TableTest, TableConstructor) {

--- a/google/cloud/bigtable/table_test.cc
+++ b/google/cloud/bigtable/table_test.cc
@@ -54,6 +54,23 @@ TEST_F(TableTest, StandaloneTableName) {
 
 TEST_F(TableTest, TableName) { EXPECT_EQ(kTableName, table_.table_name()); }
 
+TEST_F(TableTest, OverrideFields) {
+  Table table(client_, kTableId);
+  EXPECT_EQ(table.project_id(), kProjectId);
+  EXPECT_EQ(table.instance_id(), kInstanceId);
+  EXPECT_EQ(table.table_name(), TableName(kProjectId, kInstanceId, kTableId));
+
+  std::string const new_project_id = "modified-project";
+  std::string const new_instance_id = "modified-instance";
+  table.set_project_id(new_project_id);
+  table.set_instance_id(new_instance_id);
+
+  EXPECT_EQ(table.project_id(), new_project_id);
+  EXPECT_EQ(table.instance_id(), new_instance_id);
+  EXPECT_EQ(table.table_name(),
+            TableName(new_project_id, new_instance_id, kTableId));
+}
+
 TEST_F(TableTest, TableConstructor) {
   std::string const other_table_id = "my-table";
   std::string const other_table_name = TableName(client_, other_table_id);

--- a/google/cloud/bigtable/table_test.cc
+++ b/google/cloud/bigtable/table_test.cc
@@ -54,11 +54,13 @@ TEST_F(TableTest, StandaloneTableName) {
 
 TEST_F(TableTest, TableName) { EXPECT_EQ(kTableName, table_.table_name()); }
 
-TEST_F(TableTest, OverrideFields) {
-  Table table(client_, kTableId);
+TEST_F(TableTest, WithNewTarget) {
+  Table table(client_, "original-profile", kTableId);
   EXPECT_EQ(table.project_id(), kProjectId);
   EXPECT_EQ(table.instance_id(), kInstanceId);
+  EXPECT_EQ(table.table_id(), kTableId);
   EXPECT_EQ(table.table_name(), TableName(kProjectId, kInstanceId, kTableId));
+  EXPECT_EQ(table.app_profile_id(), "original-profile");
 
   std::string const other_project_id = "other-project";
   std::string const other_instance_id = "other-instance";
@@ -71,6 +73,30 @@ TEST_F(TableTest, OverrideFields) {
   EXPECT_EQ(other_table.table_id(), other_table_id);
   EXPECT_EQ(other_table.table_name(),
             TableName(other_project_id, other_instance_id, other_table_id));
+  EXPECT_EQ(other_table.app_profile_id(), "original-profile");
+}
+
+TEST_F(TableTest, WithNewTargetProfile) {
+  Table table(client_, "original-profile", kTableId);
+  EXPECT_EQ(table.project_id(), kProjectId);
+  EXPECT_EQ(table.instance_id(), kInstanceId);
+  EXPECT_EQ(table.table_id(), kTableId);
+  EXPECT_EQ(table.table_name(), TableName(kProjectId, kInstanceId, kTableId));
+  EXPECT_EQ(table.app_profile_id(), "original-profile");
+
+  std::string const other_project_id = "other-project";
+  std::string const other_instance_id = "other-instance";
+  std::string const other_table_id = "other-table";
+  std::string const other_profile_id = "other-profile";
+  auto other_table = table.WithNewTarget(other_project_id, other_instance_id,
+                                         other_profile_id, other_table_id);
+
+  EXPECT_EQ(other_table.project_id(), other_project_id);
+  EXPECT_EQ(other_table.instance_id(), other_instance_id);
+  EXPECT_EQ(other_table.table_id(), other_table_id);
+  EXPECT_EQ(other_table.table_name(),
+            TableName(other_project_id, other_instance_id, other_table_id));
+  EXPECT_EQ(other_table.app_profile_id(), other_profile_id);
 }
 
 TEST_F(TableTest, TableConstructor) {


### PR DESCRIPTION
Related to #5934

We have customers that use our `Table` clients to interact with tables spread across various instances and projects. Because the project and instance ids are stored in the `DataClient`, the customer is forced to create multiple connections, which is redundant and slow. While this issue will be addressed as part of the effort to modernize the Data API, that will take time. This PR doesn't hurt, and it adds value now.

This PR stores the project and instance ids in the `Table`. Customers can now produce a copy of a `Table` with a modified resource name, without needing to make a new connection to the service.

```cc
// Old code
auto t1 = Table(MakeDataClient("project-1", "instance-A"), "table-X");
auto t2 = Table(MakeDataClient("project-2", "instance-B"), "table-Y"); // initiates an extra connection

// New code
auto t1 = Table(MakeDataClient("project-1", "instance-A"), "table-X");
auto t2 = t1.WithNewTarget("project-2", "instance-B", "table-Y"); // cheap
```

I think the PR is in line with our thread safety guarantees, but the reviewer should check this. https://github.com/googleapis/google-cloud-cpp/blob/9e5ac6776b638a123455e2c8e60b076e51252acd/google/cloud/bigtable/table.h#L86-L90

Should there be another version of this method that sets the app profile id as well?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8172)
<!-- Reviewable:end -->
