### PR TITLE
feat(generator): *Client with bidir streaming RPCs

### DIFF
--- a/generator/integration_tests/golden/golden_kitchen_sink_client.cc
+++ b/generator/integration_tests/golden/golden_kitchen_sink_client.cc
@@ -133,6 +133,15 @@ GoldenKitchenSinkClient::DoNothing(google::protobuf::Empty const& request, Optio
   return connection_->DoNothing(request);
 }
 
+std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
+    google::test::admin::database::v1::AppendRowsRequest,
+    google::test::admin::database::v1::AppendRowsResponse>>
+GoldenKitchenSinkClient::AsyncAppendRows(::google::cloud::Options options) {
+  ::google::cloud::internal::OptionsSpan span(
+      ::google::cloud::internal::MergeOptions(std::move(options), options_));
+  return connection_->AsyncAppendRows();
+}
+
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace golden
 }  // namespace cloud

--- a/generator/integration_tests/golden/golden_kitchen_sink_client.h
+++ b/generator/integration_tests/golden/golden_kitchen_sink_client.h
@@ -354,6 +354,11 @@ class GoldenKitchenSinkClient {
   Status
   DoNothing(google::protobuf::Empty const& request, Options options = {});
 
+  std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
+      google::test::admin::database::v1::AppendRowsRequest,
+      google::test::admin::database::v1::AppendRowsResponse>>
+  AsyncAppendRows(::google::cloud::Options options = {});
+
  private:
   std::shared_ptr<GoldenKitchenSinkConnection> connection_;
   Options options_;

--- a/generator/integration_tests/golden/tests/golden_kitchen_sink_client_test.cc
+++ b/generator/integration_tests/golden/tests/golden_kitchen_sink_client_test.cc
@@ -31,14 +31,30 @@ namespace {
 
 using ::google::cloud::testing_util::IsProtoEqual;
 using ::google::cloud::testing_util::StatusIs;
+using ::google::test::admin::database::v1::AppendRowsRequest;
+using ::google::test::admin::database::v1::AppendRowsResponse;
 using ::testing::ElementsAreArray;
 using ::testing::UnorderedElementsAreArray;
+
+class MockAppendRowsStream
+    : public AsyncStreamingReadWriteRpc<AppendRowsRequest, AppendRowsResponse> {
+ public:
+  MOCK_METHOD(void, Cancel, (), (override));
+  MOCK_METHOD(future<bool>, Start, (), (override));
+  MOCK_METHOD(future<absl::optional<AppendRowsResponse>>, Read, (), (override));
+  MOCK_METHOD(future<bool>, Write,
+              (AppendRowsRequest const&, grpc::WriteOptions), (override));
+  MOCK_METHOD(future<bool>, WritesDone, (), (override));
+  MOCK_METHOD(future<Status>, Finish, (), (override));
+};
 
 TEST(GoldenKitchenSinkClientTest, CopyMoveEquality) {
   auto conn1 =
       std::make_shared<golden_mocks::MockGoldenKitchenSinkConnection>();
   auto conn2 =
       std::make_shared<golden_mocks::MockGoldenKitchenSinkConnection>();
+  EXPECT_CALL(*conn1, options);
+  EXPECT_CALL(*conn2, options);
 
   GoldenKitchenSinkClient c1(conn1);
   GoldenKitchenSinkClient c2(conn2);
@@ -64,6 +80,8 @@ TEST(GoldenKitchenSinkClientTest, CopyMoveEquality) {
 
 TEST(GoldenKitchenSinkClientTest, GenerateAccessToken) {
   auto mock = std::make_shared<golden_mocks::MockGoldenKitchenSinkConnection>();
+  EXPECT_CALL(*mock, options);
+
   std::string expected_name = "/projects/-/serviceAccounts/foo@bar.com";
   std::vector<std::string> expected_delegates = {"Tom", "Dick", "Harry"};
   std::vector<std::string> expected_scope = {"admin"};
@@ -99,6 +117,8 @@ TEST(GoldenKitchenSinkClientTest, GenerateAccessToken) {
 
 TEST(GoldenKitchenSinkClientTest, GenerateIdToken) {
   auto mock = std::make_shared<golden_mocks::MockGoldenKitchenSinkConnection>();
+  EXPECT_CALL(*mock, options);
+
   std::string expected_name = "/projects/-/serviceAccounts/foo@bar.com";
   std::vector<std::string> expected_delegates = {"Tom", "Dick", "Harry"};
   std::string expected_audience = "Everyone";
@@ -134,6 +154,8 @@ TEST(GoldenKitchenSinkClientTest, GenerateIdToken) {
 
 TEST(GoldenKitchenSinkClientTest, WriteLogEntries) {
   auto mock = std::make_shared<golden_mocks::MockGoldenKitchenSinkConnection>();
+  EXPECT_CALL(*mock, options);
+
   std::string expected_log_name = "projects/my_project/logs/my_log";
   std::map<std::string, std::string> expected_labels = {
       {"key1", "Tom"}, {"key2", "Dick"}, {"key3", "Harry"}};
@@ -162,6 +184,8 @@ TEST(GoldenKitchenSinkClientTest, WriteLogEntries) {
 
 TEST(GoldenKitchenSinkClientTest, ListLogs) {
   auto mock = std::make_shared<golden_mocks::MockGoldenKitchenSinkConnection>();
+  EXPECT_CALL(*mock, options);
+
   std::string expected_parent = "projects/my-project";
   EXPECT_CALL(*mock, ListLogs)
       .Times(2)
@@ -195,6 +219,8 @@ TEST(GoldenKitchenSinkClientTest, ListLogs) {
 
 TEST(GoldenKitchenSinkClientTest, TailLogEntries) {
   auto mock = std::make_shared<golden_mocks::MockGoldenKitchenSinkConnection>();
+  EXPECT_CALL(*mock, options);
+
   std::vector<std::string> expected_resource_names = {"projects/my-project"};
   EXPECT_CALL(*mock, TailLogEntries)
       .Times(2)
@@ -227,6 +253,8 @@ TEST(GoldenKitchenSinkClientTest, TailLogEntries) {
 
 TEST(GoldenKitchenSinkClientTest, ListServiceAccountKeys) {
   auto mock = std::make_shared<golden_mocks::MockGoldenKitchenSinkConnection>();
+  EXPECT_CALL(*mock, options);
+
   std::string expected_name =
       "/projects/my-project/serviceAccounts/foo@bar.com";
   std::vector<::google::test::admin::database::v1::
@@ -255,6 +283,49 @@ TEST(GoldenKitchenSinkClientTest, ListServiceAccountKeys) {
                                   expected_key_types.end()};
   response = client.ListServiceAccountKeys(request);
   EXPECT_STATUS_OK(response);
+}
+
+TEST(GoldenKitchenSinkClientTest, AsyncAppendRows) {
+  auto mock = std::make_shared<golden_mocks::MockGoldenKitchenSinkConnection>();
+  EXPECT_CALL(*mock, options);
+
+  EXPECT_CALL(*mock, AsyncAppendRows).WillOnce([] {
+    auto stream = absl::make_unique<MockAppendRowsStream>();
+    EXPECT_CALL(*stream, Start).WillOnce([] {
+      return make_ready_future(true);
+    });
+    EXPECT_CALL(*stream, Write)
+        .WillOnce([](AppendRowsRequest const& r, grpc::WriteOptions) {
+          EXPECT_EQ(r.stream(), "test-only-request-stream");
+          return make_ready_future(true);
+        });
+    EXPECT_CALL(*stream, Read)
+        .WillOnce([] {
+          AppendRowsResponse response;
+          response.set_response("test-only-response");
+          return make_ready_future(absl::make_optional(response));
+        })
+        .WillOnce([] {
+          return make_ready_future(absl::optional<AppendRowsResponse>());
+        });
+    EXPECT_CALL(*stream, Finish).WillOnce([] {
+      return make_ready_future(Status(StatusCode::kUnavailable, "try-again"));
+    });
+    return stream;
+  });
+  GoldenKitchenSinkClient client(std::move(mock));
+  auto stream = client.AsyncAppendRows();
+  ASSERT_TRUE(stream->Start().get());
+  AppendRowsRequest request;
+  request.set_stream("test-only-request-stream");
+  ASSERT_TRUE(stream->Write(request, grpc::WriteOptions()).get());
+  auto read = stream->Read().get();
+  ASSERT_TRUE(read.has_value());
+  EXPECT_EQ(read->response(), "test-only-response");
+  read = stream->Read().get();
+  EXPECT_FALSE(read.has_value());
+  EXPECT_THAT(stream->Finish().get(),
+              StatusIs(StatusCode::kUnavailable, "try-again"));
 }
 
 }  // namespace

--- a/generator/internal/client_generator.cc
+++ b/generator/internal/client_generator.cc
@@ -115,6 +115,16 @@ Status ClientGenerator::GenerateHeader() {
   // clang-format on
 
   for (google::protobuf::MethodDescriptor const& method : methods()) {
+    if (IsBidirStreaming(method)) {
+      HeaderPrintMethod(method, __FILE__, __LINE__,
+                        R"""(
+  std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
+      $request_type$,
+      $response_type$>>
+  Async$method_name$(::google::cloud::Options options = {});
+)""");
+      continue;
+    }
     auto method_signature_extension =
         method.options().GetRepeatedExtension(google::api::method_signature);
     for (int i = 0; i < method_signature_extension.size(); ++i) {
@@ -343,6 +353,20 @@ Status ClientGenerator::GenerateCc() {
   // clang-format on
 
   for (google::protobuf::MethodDescriptor const& method : methods()) {
+    if (IsBidirStreaming(method)) {
+      CcPrintMethod(method, __FILE__, __LINE__,
+                    R"""(
+std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
+    $request_type$,
+    $response_type$>>
+$client_class_name$::Async$method_name$(::google::cloud::Options options) {
+  ::google::cloud::internal::OptionsSpan span(
+      ::google::cloud::internal::MergeOptions(std::move(options), options_));
+  return connection_->Async$method_name$();
+}
+)""");
+      continue;
+    }
     auto method_signature_extension =
         method.options().GetRepeatedExtension(google::api::method_signature);
     for (int i = 0; i < method_signature_extension.size(); ++i) {

--- a/google/cloud/logging/logging_service_v2_client.cc
+++ b/google/cloud/logging/logging_service_v2_client.cc
@@ -121,6 +121,15 @@ StreamRange<std::string> LoggingServiceV2Client::ListLogs(
   return connection_->ListLogs(std::move(request));
 }
 
+std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
+    google::logging::v2::TailLogEntriesRequest,
+    google::logging::v2::TailLogEntriesResponse>>
+LoggingServiceV2Client::AsyncTailLogEntries(::google::cloud::Options options) {
+  ::google::cloud::internal::OptionsSpan span(
+      ::google::cloud::internal::MergeOptions(std::move(options), options_));
+  return connection_->AsyncTailLogEntries();
+}
+
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace logging
 }  // namespace cloud

--- a/google/cloud/logging/logging_service_v2_client.h
+++ b/google/cloud/logging/logging_service_v2_client.h
@@ -342,6 +342,11 @@ class LoggingServiceV2Client {
   StreamRange<std::string> ListLogs(
       google::logging::v2::ListLogsRequest request, Options options = {});
 
+  std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
+      google::logging::v2::TailLogEntriesRequest,
+      google::logging::v2::TailLogEntriesResponse>>
+  AsyncTailLogEntries(::google::cloud::Options options = {});
+
  private:
   std::shared_ptr<LoggingServiceV2Connection> connection_;
   Options options_;


### PR DESCRIPTION
For simple uses of bidirectional streaming RPCs we can generate a
`*Client` function for bidirectional streaming RPCs. For more complex
cases we will need to write a custom `*Client` class anyway. Recall that
there are about 10 services that use these RPCs, and some of these
services (Pub/Sub, Pub/Sub Lite, Firestore) are fully hand-crafted
anyway.

Fixes #7795 