### PR TITLE
fix(storage): missing kms key option in CopyObject()

### DIFF
--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -1012,13 +1012,13 @@ class Client {
    *     new object.
    * @param destination_object_name the name of the new object.
    * @param options a list of optional query parameters and/or request headers.
-   *     Valid types for this operation include `DestinationPredefinedAcl`,
-   *     `EncryptionKey`, `IfGenerationMatch`, `IfGenerationNotMatch`,
-   *     `IfMetagenerationMatch`, `IfMetagenerationNotMatch`,
-   *     `IfSourceGenerationMatch`, `IfSourceGenerationNotMatch`,
-   *     `IfSourceMetagenerationMatch`, `IfSourceMetagenerationNotMatch`,
-   *     `Projection`, `SourceGeneration`, `SourceEncryptionKey`, `UserProject`,
-   *     and `WithObjectMetadata`.
+   *     Valid types for this operation include `DestinationKmsKeyName`,
+   *     `DestinationPredefinedAcl`,`EncryptionKey`,`IfGenerationMatch`,
+   *     `IfGenerationNotMatch`, `IfMetagenerationMatch`,
+   *     `IfMetagenerationNotMatch`, `IfSourceGenerationMatch`,
+   *     `IfSourceGenerationNotMatch`, `IfSourceMetagenerationMatch`,
+   *     `IfSourceMetagenerationNotMatch`, `Projection`, `SourceGeneration`,
+   *     `SourceEncryptionKey`, `UserProject`, and `WithObjectMetadata`.
    *
    * @par Idempotency
    * This operation is only idempotent if restricted by pre-conditions, in this

--- a/google/cloud/storage/internal/object_requests.h
+++ b/google/cloud/storage/internal/object_requests.h
@@ -128,12 +128,13 @@ std::ostream& operator<<(std::ostream& os, InsertObjectMediaRequest const& r);
  */
 class CopyObjectRequest
     : public GenericRequest<
-          CopyObjectRequest, DestinationPredefinedAcl, EncryptionKey,
-          IfGenerationMatch, IfGenerationNotMatch, IfMetagenerationMatch,
-          IfMetagenerationNotMatch, IfSourceGenerationMatch,
-          IfSourceGenerationNotMatch, IfSourceMetagenerationMatch,
-          IfSourceMetagenerationNotMatch, Projection, SourceGeneration,
-          SourceEncryptionKey, UserProject, WithObjectMetadata> {
+          CopyObjectRequest, DestinationKmsKeyName, DestinationPredefinedAcl,
+          EncryptionKey, IfGenerationMatch, IfGenerationNotMatch,
+          IfMetagenerationMatch, IfMetagenerationNotMatch,
+          IfSourceGenerationMatch, IfSourceGenerationNotMatch,
+          IfSourceMetagenerationMatch, IfSourceMetagenerationNotMatch,
+          Projection, SourceGeneration, SourceEncryptionKey, UserProject,
+          WithObjectMetadata> {
  public:
   CopyObjectRequest() = default;
   CopyObjectRequest(std::string source_bucket, std::string source_object,

--- a/google/cloud/storage/internal/object_requests_test.cc
+++ b/google/cloud/storage/internal/object_requests_test.cc
@@ -211,6 +211,7 @@ TEST(ObjectRequestsTest, CopyAllOptions) {
   EXPECT_EQ("my-bucket", request.destination_bucket());
   EXPECT_EQ("my-object", request.destination_object());
   request.set_multiple_options(
+      DestinationKmsKeyName("test-only-kms-key"),
       DestinationPredefinedAcl("private"),
       EncryptionKey::FromBinaryKey("1234ABCD"), IfGenerationMatch(1),
       IfGenerationNotMatch(2), IfMetagenerationMatch(3),
@@ -228,6 +229,7 @@ TEST(ObjectRequestsTest, CopyAllOptions) {
   EXPECT_THAT(actual, HasSubstr("my-object"));
   EXPECT_THAT(actual, HasSubstr("source-bucket"));
   EXPECT_THAT(actual, HasSubstr("=source-object"));
+  EXPECT_THAT(actual, HasSubstr("destinationKmsKeyName=test-only-kms-key"));
   EXPECT_THAT(actual, HasSubstr("destinationPredefinedAcl=private"));
   EXPECT_THAT(actual, HasSubstr("x-goog-encryption-algorithm: AES256"));
   // /bin/echo -n ABCD1234 | openssl base64 -e


### PR DESCRIPTION
I missed `DestinationKmsKeyName` as an option for
`storage::Client::CopyObject()`.  I checked twice for any other missing
options, but then again, I thought I had checked twice already.

Part of the work for #4199 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8188)
<!-- Reviewable:end -->
