### PR TITLE
feat(GCS+gRPC): implement CopyObject()

### DIFF
--- a/google/cloud/storage/internal/grpc_object_request_parser.h
+++ b/google/cloud/storage/internal/grpc_object_request_parser.h
@@ -61,6 +61,9 @@ struct GrpcObjectRequestParser {
       google::storage::v2::RewriteResponse const& response,
       Options const& options);
 
+  static StatusOr<google::storage::v2::RewriteObjectRequest> ToProto(
+      CopyObjectRequest const& request);
+
   static StatusOr<google::storage::v2::StartResumableWriteRequest> ToProto(
       ResumableUploadRequest const& request);
 

--- a/google/cloud/storage/internal/grpc_object_request_parser_test.cc
+++ b/google/cloud/storage/internal/grpc_object_request_parser_test.cc
@@ -753,6 +753,130 @@ TEST(GrpcObjectRequestParser, RewriteObjectResponse) {
   EXPECT_EQ(actual.resource.name(), "object-name");
 }
 
+TEST(GrpcObjectRequestParser, CopyObjectRequestAllOptions) {
+  google::storage::v2::RewriteObjectRequest expected;
+  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(
+      R"pb(
+        destination_bucket: "projects/_/buckets/destination-bucket"
+        destination_name: "destination-object"
+        destination {
+          storage_class: "STANDARD"
+          content_encoding: "test-only-content-encoding"
+          content_disposition: "test-only-content-disposition"
+          cache_control: "test-only-cache-control"
+          content_language: "test-only-content-language"
+          content_type: "test-only-content-type"
+          kms_key: "test-only-destination-kms-key-name"
+          temporary_hold: true
+          metadata { key: "key0" value: "value0" }
+          event_based_hold: true
+          custom_time { seconds: 1643126687 nanos: 123000000 }
+        }
+        source_bucket: "projects/_/buckets/source-bucket"
+        source_object: "source-object"
+        source_generation: 7
+        destination_predefined_acl: OBJECT_ACL_PROJECT_PRIVATE
+        if_generation_match: 1
+        if_generation_not_match: 2
+        if_metageneration_match: 3
+        if_metageneration_not_match: 4
+        if_source_generation_match: 5
+        if_source_generation_not_match: 6
+        if_source_metageneration_match: 7
+        if_source_metageneration_not_match: 8
+        copy_source_encryption_algorithm: "AES256"
+        copy_source_encryption_key_bytes: "ABCDEFGH"
+        copy_source_encryption_key_sha256_bytes: "\232\302\031}\222X%{\032\350F>B\024\344\315\nW\213\301Q\177$\025\222\213\221\276B\203\374H"
+        common_object_request_params {
+          encryption_algorithm: "AES256"
+          encryption_key_bytes: "01234567"
+          encryption_key_sha256_bytes: "\222E\222\271\261\003\361O\203?\252\373g\364\200i\037\001\230\212\244W\300\006\027i\365\214\324s\021\274"
+        }
+        common_request_params { user_project: "test-user-project" }
+      )pb",
+      &expected));
+
+  CopyObjectRequest req("source-bucket", "source-object", "destination-bucket",
+                        "destination-object");
+  req.set_multiple_options(
+      DestinationKmsKeyName("test-only-destination-kms-key-name"),
+      DestinationPredefinedAcl("projectPrivate"),
+      EncryptionKey::FromBinaryKey("01234567"), IfGenerationMatch(1),
+      IfGenerationNotMatch(2), IfMetagenerationMatch(3),
+      IfMetagenerationNotMatch(4), IfSourceGenerationMatch(5),
+      IfSourceGenerationNotMatch(6), IfSourceMetagenerationMatch(7),
+      IfSourceMetagenerationNotMatch(8), Projection("full"),
+      SourceEncryptionKey::FromBinaryKey("ABCDEFGH"), SourceGeneration(7),
+      UserProject("test-user-project"), QuotaUser("test-quota-user"),
+      UserIp("test-user-ip"),
+      WithObjectMetadata(
+          ObjectMetadata()
+              .set_storage_class("STANDARD")
+              .set_content_encoding("test-only-content-encoding")
+              .set_content_disposition("test-only-content-disposition")
+              .set_cache_control("test-only-cache-control")
+              .set_content_language("test-only-content-language")
+              .upsert_metadata("key0", "value0")
+              .set_content_type("test-only-content-type")
+              .set_temporary_hold(true)
+              .set_event_based_hold(true)
+              .set_custom_time(std::chrono::system_clock::time_point{} +
+                               std::chrono::seconds(1643126687) +
+                               std::chrono::milliseconds(123))));
+
+  auto const actual = GrpcObjectRequestParser::ToProto(req);
+  ASSERT_STATUS_OK(actual);
+  EXPECT_THAT(*actual, IsProtoEqual(expected));
+}
+
+TEST(GrpcObjectRequestParser, CopyObjectRequestNoDestination) {
+  google::storage::v2::RewriteObjectRequest expected;
+  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(
+      R"pb(
+        destination_bucket: "projects/_/buckets/destination-bucket"
+        destination_name: "destination-object"
+        source_bucket: "projects/_/buckets/source-bucket"
+        source_object: "source-object"
+        source_generation: 7
+        destination_predefined_acl: OBJECT_ACL_PROJECT_PRIVATE
+        if_generation_match: 1
+        if_generation_not_match: 2
+        if_metageneration_match: 3
+        if_metageneration_not_match: 4
+        if_source_generation_match: 5
+        if_source_generation_not_match: 6
+        if_source_metageneration_match: 7
+        if_source_metageneration_not_match: 8
+        copy_source_encryption_algorithm: "AES256"
+        copy_source_encryption_key_bytes: "ABCDEFGH"
+        copy_source_encryption_key_sha256_bytes: "\232\302\031}\222X%{\032\350F>B\024\344\315\nW\213\301Q\177$\025\222\213\221\276B\203\374H"
+        common_object_request_params: {
+          encryption_algorithm: "AES256"
+          encryption_key_bytes: "01234567"
+          encryption_key_sha256_bytes: "\222E\222\271\261\003\361O\203?\252\373g\364\200i\037\001\230\212\244W\300\006\027i\365\214\324s\021\274"
+        }
+        common_request_params: { user_project: "test-user-project" }
+      )pb",
+      &expected));
+
+  CopyObjectRequest req("source-bucket", "source-object", "destination-bucket",
+                        "destination-object");
+  req.set_multiple_options(
+      DestinationPredefinedAcl("projectPrivate"),
+      EncryptionKey::FromBinaryKey("01234567"), IfGenerationMatch(1),
+      IfGenerationNotMatch(2), IfMetagenerationMatch(3),
+      IfMetagenerationNotMatch(4), IfSourceGenerationMatch(5),
+      IfSourceGenerationNotMatch(6), IfSourceMetagenerationMatch(7),
+      IfSourceMetagenerationNotMatch(8), Projection("full"),
+      SourceEncryptionKey::FromBinaryKey("ABCDEFGH"), SourceGeneration(7),
+      UserProject("test-user-project"), QuotaUser("test-quota-user"),
+      UserIp("test-user-ip"));
+
+  auto const actual = GrpcObjectRequestParser::ToProto(req);
+  ASSERT_STATUS_OK(actual);
+  EXPECT_THAT(*actual, IsProtoEqual(expected));
+}
+
 TEST(GrpcObjectRequestParser, ResumableUploadRequestSimple) {
   google::storage::v2::StartResumableWriteRequest expected;
   EXPECT_TRUE(google::protobuf::TextFormat::ParseFromString(R"""(

--- a/google/cloud/storage/tests/grpc_object_metadata_integration_test.cc
+++ b/google/cloud/storage/tests/grpc_object_metadata_integration_test.cc
@@ -56,6 +56,7 @@ TEST_F(GrpcObjectMetadataIntegrationTest, ObjectMetadataCRUD) {
 
   auto object_name = MakeRandomObjectName();
   auto rewrite_name = MakeRandomObjectName();
+  auto copy_name = MakeRandomObjectName();
 
   auto insert = client->InsertObject(bucket_name, object_name, LoremIpsum(),
                                      IfGenerationMatch(0));
@@ -81,6 +82,11 @@ TEST_F(GrpcObjectMetadataIntegrationTest, ObjectMetadataCRUD) {
                                                bucket_name, rewrite_name);
   ASSERT_STATUS_OK(rewrite);
   ScheduleForDelete(*rewrite);
+
+  auto copy =
+      client->CopyObject(bucket_name, object_name, bucket_name, rewrite_name);
+  ASSERT_STATUS_OK(copy);
+  ScheduleForDelete(*copy);
 
   auto patch = client->PatchObject(
       bucket_name, object_name,


### PR DESCRIPTION
Fixes #4199 . Note that no new `*Stub` operations are needed because there is no `CopyObject()` in gRPC, we need to emulate the existing call using `RewriteObject()`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8190)
<!-- Reviewable:end -->
