### PR TITLE
feat(bigtable): cheap Admin creation with different resource names

### DIFF
--- a/google/cloud/bigtable/instance_admin.h
+++ b/google/cloud/bigtable/instance_admin.h
@@ -197,6 +197,17 @@ class InstanceAdmin {
   /// The project id, i.e., `project_name()` without the `projects/` prefix.
   std::string const& project_id() const { return project_id_; }
 
+  /**
+   * Returns an InstanceAdmin that reuses the connection and configuration of
+   * this InstanceAdmin, but with a different resource name.
+   */
+  InstanceAdmin WithNewTarget(std::string project_id) const {
+    auto admin = *this;
+    admin.project_id_ = std::move(project_id);
+    admin.project_name_ = Project(admin.project_id_).FullName();
+    return admin;
+  }
+
   /// Return the fully qualified name of the given instance_id.
   std::string InstanceName(std::string const& instance_id) const {
     return google::cloud::bigtable::InstanceName(project_id_, instance_id);

--- a/google/cloud/bigtable/instance_admin_test.cc
+++ b/google/cloud/bigtable/instance_admin_test.cc
@@ -137,6 +137,13 @@ TEST_F(InstanceAdminTest, MoveAssignment) {
   EXPECT_EQ(expected, dest.project_id());
 }
 
+TEST_F(InstanceAdminTest, WithNewTarget) {
+  auto admin = InstanceAdmin(connection_, kProjectId);
+  auto other_admin = admin.WithNewTarget("other-project");
+  EXPECT_EQ(other_admin.project_id(), "other-project");
+  EXPECT_EQ(other_admin.project_name(), Project("other-project").FullName());
+}
+
 TEST_F(InstanceAdminTest, LegacyConstructorSharesConnection) {
   auto admin_client = MakeInstanceAdminClient("test-project");
   auto admin_1 = InstanceAdmin(admin_client);

--- a/google/cloud/bigtable/table_admin.h
+++ b/google/cloud/bigtable/table_admin.h
@@ -219,6 +219,19 @@ class TableAdmin {
   std::string const& instance_name() const { return instance_name_; }
 
   /**
+   * Returns a TableAdmin that reuses the connection and configuration of this
+   * TableAdmin, but with a different resource name.
+   */
+  TableAdmin WithNewTarget(std::string project_id,
+                           std::string instance_id) const {
+    auto table = *this;
+    table.project_id_ = std::move(project_id);
+    table.instance_id_ = std::move(instance_id);
+    table.instance_name_ = table.InstanceName();
+    return table;
+  }
+
+  /**
    * Create a new table in the instance.
    *
    * @param table_id the name of the table relative to the instance managed by

--- a/google/cloud/bigtable/table_admin_test.cc
+++ b/google/cloud/bigtable/table_admin_test.cc
@@ -27,15 +27,17 @@ using ::testing::ReturnRef;
 
 using MockAdminClient = ::google::cloud::bigtable::testing::MockAdminClient;
 
-std::string const kProjectId = "the-project";
-std::string const kInstanceId = "the-instance";
+auto const* const kProjectId = "the-project";
+auto const* const kInstanceId = "the-instance";
+auto const* const kInstanceName = "projects/the-project/instances/the-instance";
 
 class TableAdminTest : public ::testing::Test {
  protected:
   void SetUp() override {
-    EXPECT_CALL(*client_, project()).WillRepeatedly(ReturnRef(kProjectId));
+    EXPECT_CALL(*client_, project()).WillRepeatedly(ReturnRef(project_id_));
   }
 
+  std::string project_id_ = kProjectId;
   std::shared_ptr<MockAdminClient> client_ =
       std::make_shared<MockAdminClient>();
 };
@@ -44,7 +46,16 @@ TEST_F(TableAdminTest, ResourceNames) {
   TableAdmin tested(client_, kInstanceId);
   EXPECT_EQ(kProjectId, tested.project());
   EXPECT_EQ(kInstanceId, tested.instance_id());
-  EXPECT_EQ(InstanceName(kProjectId, kInstanceId), tested.instance_name());
+  EXPECT_EQ(kInstanceName, tested.instance_name());
+}
+
+TEST_F(TableAdminTest, WithNewTarget) {
+  auto admin = TableAdmin(client_, kInstanceId);
+  auto other_admin = admin.WithNewTarget("other-project", "other-instance");
+  EXPECT_EQ(other_admin.project(), "other-project");
+  EXPECT_EQ(other_admin.instance_id(), "other-instance");
+  EXPECT_EQ(other_admin.instance_name(),
+            InstanceName("other-project", "other-instance"));
 }
 
 }  // namespace


### PR DESCRIPTION
Same thing as #8172, but with the Admin clients.

`InstanceAdmin` has been converted. If you use the `Connection` classes with it, you don't need this function. I still think its fine to add the function now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8194)
<!-- Reviewable:end -->
