### PR TITLE
fix(generator): fix options handling in SetIamPolicy() OCC loop

### DIFF
--- a/generator/internal/client_generator.cc
+++ b/generator/internal/client_generator.cc
@@ -456,11 +456,22 @@ $client_class_name$::Async$method_name$(Options options) {
              "  internal::CheckExpectedOptions<$service_name$"
              "BackoffPolicyOption>(options, __func__);\n"
              "  internal::OptionsSpan span(internal::MergeOptions("
-             "std::move(options), options_));\n"
+             "std::move(options), options_));\n"},
+            {"  "},
+            {ProtoNameToCppName(
+                get_iam_policy_extension_->input_type()->full_name())},
+            {" get_request;\n"},
+            {"  get_request.set_resource(resource);\n"},
+            {"  "},
+            {ProtoNameToCppName(
+                set_iam_policy_extension_->input_type()->full_name())},
+            {" set_request;\n"
+             "  set_request.set_resource(resource);\n"
              "  auto backoff_policy = internal::CurrentOptions()"
              ".get<$service_name$BackoffPolicyOption>()->clone();\n"
-             "  for (;;) {\n"},
-            {"    auto recent = " + get_method_name + "(resource);\n"},
+             "  for (;;) {\n"
+             "    auto recent = connection_->"},
+            {get_method_name + "(get_request);\n"},
             {"    if (!recent) {\n"
              "      return recent.status();\n"
              "    }\n"
@@ -468,9 +479,10 @@ $client_class_name$::Async$method_name$(Options options) {
              "    if (!policy) {\n"
              "      return Status(StatusCode::kCancelled,"
              " \"updater did not yield a policy\");\n"
-             "    }\n"},
-            {"    auto result = " + set_method_name +
-             "(resource, *std::move(policy));\n"},
+             "    }\n"
+             "    *set_request.mutable_policy() = *std::move(policy);\n"
+             "    auto result = connection_->"},
+            {set_method_name + "(set_request);\n"},
             {"    if (result || result.status().code() != StatusCode::kAborted)"
              " {\n"
              "      return result;\n"

--- a/google/cloud/bigtable/admin/bigtable_instance_admin_client.cc
+++ b/google/cloud/bigtable/admin/bigtable_instance_admin_client.cc
@@ -384,11 +384,15 @@ StatusOr<google::iam::v1::Policy> BigtableInstanceAdminClient::SetIamPolicy(
       options, __func__);
   internal::OptionsSpan span(
       internal::MergeOptions(std::move(options), options_));
+  google::iam::v1::GetIamPolicyRequest get_request;
+  get_request.set_resource(resource);
+  google::iam::v1::SetIamPolicyRequest set_request;
+  set_request.set_resource(resource);
   auto backoff_policy = internal::CurrentOptions()
                             .get<BigtableInstanceAdminBackoffPolicyOption>()
                             ->clone();
   for (;;) {
-    auto recent = GetIamPolicy(resource);
+    auto recent = connection_->GetIamPolicy(get_request);
     if (!recent) {
       return recent.status();
     }
@@ -396,7 +400,8 @@ StatusOr<google::iam::v1::Policy> BigtableInstanceAdminClient::SetIamPolicy(
     if (!policy) {
       return Status(StatusCode::kCancelled, "updater did not yield a policy");
     }
-    auto result = SetIamPolicy(resource, *std::move(policy));
+    *set_request.mutable_policy() = *std::move(policy);
+    auto result = connection_->SetIamPolicy(set_request);
     if (result || result.status().code() != StatusCode::kAborted) {
       return result;
     }

--- a/google/cloud/billing/cloud_billing_client.cc
+++ b/google/cloud/billing/cloud_billing_client.cc
@@ -206,11 +206,15 @@ StatusOr<google::iam::v1::Policy> CloudBillingClient::SetIamPolicy(
                                                                   __func__);
   internal::OptionsSpan span(
       internal::MergeOptions(std::move(options), options_));
+  google::iam::v1::GetIamPolicyRequest get_request;
+  get_request.set_resource(resource);
+  google::iam::v1::SetIamPolicyRequest set_request;
+  set_request.set_resource(resource);
   auto backoff_policy = internal::CurrentOptions()
                             .get<CloudBillingBackoffPolicyOption>()
                             ->clone();
   for (;;) {
-    auto recent = GetIamPolicy(resource);
+    auto recent = connection_->GetIamPolicy(get_request);
     if (!recent) {
       return recent.status();
     }
@@ -218,7 +222,8 @@ StatusOr<google::iam::v1::Policy> CloudBillingClient::SetIamPolicy(
     if (!policy) {
       return Status(StatusCode::kCancelled, "updater did not yield a policy");
     }
-    auto result = SetIamPolicy(resource, *std::move(policy));
+    *set_request.mutable_policy() = *std::move(policy);
+    auto result = connection_->SetIamPolicy(set_request);
     if (result || result.status().code() != StatusCode::kAborted) {
       return result;
     }

--- a/google/cloud/containeranalysis/container_analysis_client.cc
+++ b/google/cloud/containeranalysis/container_analysis_client.cc
@@ -53,11 +53,15 @@ StatusOr<google::iam::v1::Policy> ContainerAnalysisClient::SetIamPolicy(
       options, __func__);
   internal::OptionsSpan span(
       internal::MergeOptions(std::move(options), options_));
+  google::iam::v1::GetIamPolicyRequest get_request;
+  get_request.set_resource(resource);
+  google::iam::v1::SetIamPolicyRequest set_request;
+  set_request.set_resource(resource);
   auto backoff_policy = internal::CurrentOptions()
                             .get<ContainerAnalysisBackoffPolicyOption>()
                             ->clone();
   for (;;) {
-    auto recent = GetIamPolicy(resource);
+    auto recent = connection_->GetIamPolicy(get_request);
     if (!recent) {
       return recent.status();
     }
@@ -65,7 +69,8 @@ StatusOr<google::iam::v1::Policy> ContainerAnalysisClient::SetIamPolicy(
     if (!policy) {
       return Status(StatusCode::kCancelled, "updater did not yield a policy");
     }
-    auto result = SetIamPolicy(resource, *std::move(policy));
+    *set_request.mutable_policy() = *std::move(policy);
+    auto result = connection_->SetIamPolicy(set_request);
     if (result || result.status().code() != StatusCode::kAborted) {
       return result;
     }

--- a/google/cloud/iam/iam_client.cc
+++ b/google/cloud/iam/iam_client.cc
@@ -270,10 +270,14 @@ StatusOr<google::iam::v1::Policy> IAMClient::SetIamPolicy(
   internal::CheckExpectedOptions<IAMBackoffPolicyOption>(options, __func__);
   internal::OptionsSpan span(
       internal::MergeOptions(std::move(options), options_));
+  google::iam::v1::GetIamPolicyRequest get_request;
+  get_request.set_resource(resource);
+  google::iam::v1::SetIamPolicyRequest set_request;
+  set_request.set_resource(resource);
   auto backoff_policy =
       internal::CurrentOptions().get<IAMBackoffPolicyOption>()->clone();
   for (;;) {
-    auto recent = GetIamPolicy(resource);
+    auto recent = connection_->GetIamPolicy(get_request);
     if (!recent) {
       return recent.status();
     }
@@ -281,7 +285,8 @@ StatusOr<google::iam::v1::Policy> IAMClient::SetIamPolicy(
     if (!policy) {
       return Status(StatusCode::kCancelled, "updater did not yield a policy");
     }
-    auto result = SetIamPolicy(resource, *std::move(policy));
+    *set_request.mutable_policy() = *std::move(policy);
+    auto result = connection_->SetIamPolicy(set_request);
     if (result || result.status().code() != StatusCode::kAborted) {
       return result;
     }

--- a/google/cloud/iot/device_manager_client.cc
+++ b/google/cloud/iot/device_manager_client.cc
@@ -296,11 +296,15 @@ StatusOr<google::iam::v1::Policy> DeviceManagerClient::SetIamPolicy(
                                                                    __func__);
   internal::OptionsSpan span(
       internal::MergeOptions(std::move(options), options_));
+  google::iam::v1::GetIamPolicyRequest get_request;
+  get_request.set_resource(resource);
+  google::iam::v1::SetIamPolicyRequest set_request;
+  set_request.set_resource(resource);
   auto backoff_policy = internal::CurrentOptions()
                             .get<DeviceManagerBackoffPolicyOption>()
                             ->clone();
   for (;;) {
-    auto recent = GetIamPolicy(resource);
+    auto recent = connection_->GetIamPolicy(get_request);
     if (!recent) {
       return recent.status();
     }
@@ -308,7 +312,8 @@ StatusOr<google::iam::v1::Policy> DeviceManagerClient::SetIamPolicy(
     if (!policy) {
       return Status(StatusCode::kCancelled, "updater did not yield a policy");
     }
-    auto result = SetIamPolicy(resource, *std::move(policy));
+    *set_request.mutable_policy() = *std::move(policy);
+    auto result = connection_->SetIamPolicy(set_request);
     if (result || result.status().code() != StatusCode::kAborted) {
       return result;
     }

--- a/google/cloud/resourcemanager/folders_client.cc
+++ b/google/cloud/resourcemanager/folders_client.cc
@@ -217,10 +217,14 @@ StatusOr<google::iam::v1::Policy> FoldersClient::SetIamPolicy(
   internal::CheckExpectedOptions<FoldersBackoffPolicyOption>(options, __func__);
   internal::OptionsSpan span(
       internal::MergeOptions(std::move(options), options_));
+  google::iam::v1::GetIamPolicyRequest get_request;
+  get_request.set_resource(resource);
+  google::iam::v1::SetIamPolicyRequest set_request;
+  set_request.set_resource(resource);
   auto backoff_policy =
       internal::CurrentOptions().get<FoldersBackoffPolicyOption>()->clone();
   for (;;) {
-    auto recent = GetIamPolicy(resource);
+    auto recent = connection_->GetIamPolicy(get_request);
     if (!recent) {
       return recent.status();
     }
@@ -228,7 +232,8 @@ StatusOr<google::iam::v1::Policy> FoldersClient::SetIamPolicy(
     if (!policy) {
       return Status(StatusCode::kCancelled, "updater did not yield a policy");
     }
-    auto result = SetIamPolicy(resource, *std::move(policy));
+    *set_request.mutable_policy() = *std::move(policy);
+    auto result = connection_->SetIamPolicy(set_request);
     if (result || result.status().code() != StatusCode::kAborted) {
       return result;
     }

--- a/google/cloud/securitycenter/security_center_client.cc
+++ b/google/cloud/securitycenter/security_center_client.cc
@@ -487,11 +487,15 @@ StatusOr<google::iam::v1::Policy> SecurityCenterClient::SetIamPolicy(
                                                                     __func__);
   internal::OptionsSpan span(
       internal::MergeOptions(std::move(options), options_));
+  google::iam::v1::GetIamPolicyRequest get_request;
+  get_request.set_resource(resource);
+  google::iam::v1::SetIamPolicyRequest set_request;
+  set_request.set_resource(resource);
   auto backoff_policy = internal::CurrentOptions()
                             .get<SecurityCenterBackoffPolicyOption>()
                             ->clone();
   for (;;) {
-    auto recent = GetIamPolicy(resource);
+    auto recent = connection_->GetIamPolicy(get_request);
     if (!recent) {
       return recent.status();
     }
@@ -499,7 +503,8 @@ StatusOr<google::iam::v1::Policy> SecurityCenterClient::SetIamPolicy(
     if (!policy) {
       return Status(StatusCode::kCancelled, "updater did not yield a policy");
     }
-    auto result = SetIamPolicy(resource, *std::move(policy));
+    *set_request.mutable_policy() = *std::move(policy);
+    auto result = connection_->SetIamPolicy(set_request);
     if (result || result.status().code() != StatusCode::kAborted) {
       return result;
     }

--- a/google/cloud/spanner/admin/database_admin_client.cc
+++ b/google/cloud/spanner/admin/database_admin_client.cc
@@ -170,11 +170,15 @@ StatusOr<google::iam::v1::Policy> DatabaseAdminClient::SetIamPolicy(
                                                                    __func__);
   internal::OptionsSpan span(
       internal::MergeOptions(std::move(options), options_));
+  google::iam::v1::GetIamPolicyRequest get_request;
+  get_request.set_resource(resource);
+  google::iam::v1::SetIamPolicyRequest set_request;
+  set_request.set_resource(resource);
   auto backoff_policy = internal::CurrentOptions()
                             .get<DatabaseAdminBackoffPolicyOption>()
                             ->clone();
   for (;;) {
-    auto recent = GetIamPolicy(resource);
+    auto recent = connection_->GetIamPolicy(get_request);
     if (!recent) {
       return recent.status();
     }
@@ -182,7 +186,8 @@ StatusOr<google::iam::v1::Policy> DatabaseAdminClient::SetIamPolicy(
     if (!policy) {
       return Status(StatusCode::kCancelled, "updater did not yield a policy");
     }
-    auto result = SetIamPolicy(resource, *std::move(policy));
+    *set_request.mutable_policy() = *std::move(policy);
+    auto result = connection_->SetIamPolicy(set_request);
     if (result || result.status().code() != StatusCode::kAborted) {
       return result;
     }

--- a/google/cloud/spanner/admin/instance_admin_client.cc
+++ b/google/cloud/spanner/admin/instance_admin_client.cc
@@ -189,11 +189,15 @@ StatusOr<google::iam::v1::Policy> InstanceAdminClient::SetIamPolicy(
                                                                    __func__);
   internal::OptionsSpan span(
       internal::MergeOptions(std::move(options), options_));
+  google::iam::v1::GetIamPolicyRequest get_request;
+  get_request.set_resource(resource);
+  google::iam::v1::SetIamPolicyRequest set_request;
+  set_request.set_resource(resource);
   auto backoff_policy = internal::CurrentOptions()
                             .get<InstanceAdminBackoffPolicyOption>()
                             ->clone();
   for (;;) {
-    auto recent = GetIamPolicy(resource);
+    auto recent = connection_->GetIamPolicy(get_request);
     if (!recent) {
       return recent.status();
     }
@@ -201,7 +205,8 @@ StatusOr<google::iam::v1::Policy> InstanceAdminClient::SetIamPolicy(
     if (!policy) {
       return Status(StatusCode::kCancelled, "updater did not yield a policy");
     }
-    auto result = SetIamPolicy(resource, *std::move(policy));
+    *set_request.mutable_policy() = *std::move(policy);
+    auto result = connection_->SetIamPolicy(set_request);
     if (result || result.status().code() != StatusCode::kAborted) {
       return result;
     }

--- a/google/cloud/tasks/cloud_tasks_client.cc
+++ b/google/cloud/tasks/cloud_tasks_client.cc
@@ -205,10 +205,14 @@ StatusOr<google::iam::v1::Policy> CloudTasksClient::SetIamPolicy(
                                                                 __func__);
   internal::OptionsSpan span(
       internal::MergeOptions(std::move(options), options_));
+  google::iam::v1::GetIamPolicyRequest get_request;
+  get_request.set_resource(resource);
+  google::iam::v1::SetIamPolicyRequest set_request;
+  set_request.set_resource(resource);
   auto backoff_policy =
       internal::CurrentOptions().get<CloudTasksBackoffPolicyOption>()->clone();
   for (;;) {
-    auto recent = GetIamPolicy(resource);
+    auto recent = connection_->GetIamPolicy(get_request);
     if (!recent) {
       return recent.status();
     }
@@ -216,7 +220,8 @@ StatusOr<google::iam::v1::Policy> CloudTasksClient::SetIamPolicy(
     if (!policy) {
       return Status(StatusCode::kCancelled, "updater did not yield a policy");
     }
-    auto result = SetIamPolicy(resource, *std::move(policy));
+    *set_request.mutable_policy() = *std::move(policy);
+    auto result = connection_->SetIamPolicy(set_request);
     if (result || result.status().code() != StatusCode::kAborted) {
       return result;
     }


### PR DESCRIPTION
Fix `Options` handling in the generated OCC-loop `SetIamPolicy()`
overloads.  We were failing to pass the operation options through
to the sub-`GetIamPolicy()`/`SetIamPolicy()` calls.  Continuing to
call back into the client layer from the OCC loop is suboptimal
however, as we would need to make a copy of the `Options` only to
create new `OptionsSpan`s with the same values.  So, call through
to the connection layer directly, avoiding the need to deal with
`Options` at all.

Then add tests, for each variety of generated RPC, to check that
options are correctly propagated and overridden through connection,
client, and operation layers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8203)
<!-- Reviewable:end -->
