### PR TITLE
cleanup: prefer @platforms rather than @bazel_tools

### DIFF
--- a/google/cloud/BUILD.bazel
+++ b/google/cloud/BUILD.bazel
@@ -55,7 +55,7 @@ load(
     name = test.replace("/", "_").replace(".cc", ""),
     srcs = [test],
     linkopts = select({
-        "@bazel_tools//src/conditions:windows": [],
+        "@platforms//os:windows": [],
         "//conditions:default": ["-lpthread"],
     }),
     deps = [
@@ -165,7 +165,7 @@ cc_library(
     srcs = google_cloud_cpp_rest_internal_srcs,
     hdrs = google_cloud_cpp_rest_internal_hdrs,
     copts = select({
-        "@bazel_tools//src/conditions:windows": [
+        "@platforms//os:windows": [
             "/DWIN32_LEAN_AND_MEAN",
         ],
         "//conditions:default": [],

--- a/google/cloud/bigtable/benchmarks/BUILD.bazel
+++ b/google/cloud/bigtable/benchmarks/BUILD.bazel
@@ -36,7 +36,7 @@ load(":bigtable_benchmark_programs.bzl", "bigtable_benchmark_programs")
     name = test.replace("/", "_").replace(".cc", ""),
     srcs = [test],
     linkopts = select({
-        "@bazel_tools//src/conditions:windows": [],
+        "@platforms//os:windows": [],
         "//conditions:default": ["-lpthread"],
     }),
     tags = [
@@ -55,7 +55,7 @@ load(":bigtable_benchmarks_unit_tests.bzl", "bigtable_benchmarks_unit_tests")
     name = test.replace("/", "_").replace(".cc", ""),
     srcs = [test],
     linkopts = select({
-        "@bazel_tools//src/conditions:windows": [],
+        "@platforms//os:windows": [],
         "//conditions:default": ["-lpthread"],
     }),
     deps = [

--- a/google/cloud/storage/BUILD.bazel
+++ b/google/cloud/storage/BUILD.bazel
@@ -31,7 +31,7 @@ cc_library(
     srcs = google_cloud_cpp_storage_grpc_srcs,
     hdrs = google_cloud_cpp_storage_grpc_hdrs,
     copts = select({
-        "@bazel_tools//src/conditions:windows": GOOGLE_CLOUD_STORAGE_WIN_COPTS,
+        "@platforms//os:windows": GOOGLE_CLOUD_STORAGE_WIN_COPTS,
         "//conditions:default": [],
     }),
     defines = ["GOOGLE_CLOUD_CPP_STORAGE_HAVE_GRPC"],
@@ -56,7 +56,7 @@ cc_library(
     srcs = google_cloud_cpp_storage_srcs,
     hdrs = google_cloud_cpp_storage_hdrs,
     copts = select({
-        "@bazel_tools//src/conditions:windows": GOOGLE_CLOUD_STORAGE_WIN_COPTS,
+        "@platforms//os:windows": GOOGLE_CLOUD_STORAGE_WIN_COPTS,
         "//conditions:default": [],
     }),
     visibility = [
@@ -94,7 +94,7 @@ cc_library(
     srcs = storage_client_testing_srcs,
     hdrs = storage_client_testing_hdrs,
     copts = select({
-        "@bazel_tools//src/conditions:windows": GOOGLE_CLOUD_STORAGE_WIN_COPTS,
+        "@platforms//os:windows": GOOGLE_CLOUD_STORAGE_WIN_COPTS,
         "//conditions:default": [],
     }),
     deps = [
@@ -116,11 +116,11 @@ load(":storage_client_unit_tests.bzl", "storage_client_unit_tests")
     name = test.replace("/", "_").replace(".cc", ""),
     srcs = [test],
     copts = select({
-        "@bazel_tools//src/conditions:windows": GOOGLE_CLOUD_STORAGE_WIN_COPTS,
+        "@platforms//os:windows": GOOGLE_CLOUD_STORAGE_WIN_COPTS,
         "//conditions:default": [],
     }),
     linkopts = select({
-        "@bazel_tools//src/conditions:windows": [],
+        "@platforms//os:windows": [],
         "//conditions:default": ["-lpthread"],
     }),
     deps = [
@@ -142,11 +142,11 @@ load(":storage_client_grpc_unit_tests.bzl", "storage_client_grpc_unit_tests")
     name = test.replace("/", "_").replace(".cc", ""),
     srcs = [test],
     copts = select({
-        "@bazel_tools//src/conditions:windows": GOOGLE_CLOUD_STORAGE_WIN_COPTS,
+        "@platforms//os:windows": GOOGLE_CLOUD_STORAGE_WIN_COPTS,
         "//conditions:default": [],
     }),
     linkopts = select({
-        "@bazel_tools//src/conditions:windows": [],
+        "@platforms//os:windows": [],
         "//conditions:default": ["-lpthread"],
     }),
     deps = [

--- a/google/cloud/storage/benchmarks/BUILD.bazel
+++ b/google/cloud/storage/benchmarks/BUILD.bazel
@@ -42,7 +42,7 @@ load(":storage_benchmark_programs.bzl", "storage_benchmark_programs")
     name = test.replace("/", "_").replace(".cc", ""),
     srcs = [test],
     linkopts = select({
-        "@bazel_tools//src/conditions:windows": [],
+        "@platforms//os:windows": [],
         "//conditions:default": ["-lpthread"],
     }),
     tags = [
@@ -67,7 +67,7 @@ load(":storage_benchmarks_unit_tests.bzl", "storage_benchmarks_unit_tests")
     name = test.replace("/", "_").replace(".cc", ""),
     srcs = [test],
     linkopts = select({
-        "@bazel_tools//src/conditions:windows": [],
+        "@platforms//os:windows": [],
         "//conditions:default": ["-lpthread"],
     }),
     deps = [

--- a/google/cloud/storage/tests/BUILD.bazel
+++ b/google/cloud/storage/tests/BUILD.bazel
@@ -39,7 +39,7 @@ cc_proto_library(
     timeout = "long",
     srcs = [test],
     linkopts = select({
-        "@bazel_tools//src/conditions:windows": [],
+        "@platforms//os:windows": [],
         "//conditions:default": [
             "-lpthread",
             "-ldl",

--- a/google/cloud/testing_util/BUILD.bazel
+++ b/google/cloud/testing_util/BUILD.bazel
@@ -16,7 +16,6 @@ package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # Apache 2.0
 
-load("@bazel_skylib//lib:selects.bzl", "selects")
 load(":google_cloud_cpp_testing.bzl", "google_cloud_cpp_testing_hdrs", "google_cloud_cpp_testing_srcs")
 
 config_setting(
@@ -44,22 +43,12 @@ cc_library(
     name = "google_cloud_cpp_testing",
     srcs = google_cloud_cpp_testing_srcs,
     hdrs = google_cloud_cpp_testing_hdrs,
-    defines = selects.with_or({
-        (
-            "@bazel_tools//src/conditions:linux_x86_64",
-            "@bazel_tools//src/conditions:linux_s390x",
-            "@bazel_tools//src/conditions:linux_ppc64le",
-            "@bazel_tools//src/conditions:linux_ppc",
-            "@bazel_tools//src/conditions:linux_aarch64",
-        ): [
+    defines = select({
+        "@platforms//os:linux": [
             "GOOGLE_CLOUD_CPP_HAVE_GETRUSAGE",
             "GOOGLE_CLOUD_CPP_HAVE_RUSAGE_THREAD",
         ],
-        (
-            "@bazel_tools//src/conditions:darwin",
-            "@bazel_tools//src/conditions:freebsd",
-            "@bazel_tools//src/conditions:openbsd",
-        ): [
+        "@platforms//os:macos": [
             "GOOGLE_CLOUD_CPP_HAVE_GETRUSAGE",
         ],
         "//conditions:default": [],


### PR DESCRIPTION
The former is the preferred way to specify platforms. Note that in the
testing_util case, I dropped the support for freebsd and openbsd. I'm
not sure why those cases were there or if we need them. We don't seem to
have those cases elsewhere. I can add them back if they are needed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8207)
<!-- Reviewable:end -->
