### PR TITLE
ci: bootstrap quickstart runners

### DIFF
--- a/ci/cloudbuild/builds/shared.sh
+++ b/ci/cloudbuild/builds/shared.sh
@@ -43,4 +43,5 @@ quickstart::run_cmake_and_make "${INSTALL_PREFIX}"
 # Verify the quickstart programs for generated libraries run. Note
 # that most of these run against production, and are therefore
 # integration tests with the usual flakiness issues.
+io::log_h2 "Running all other quickstart programs"
 env -C cmake-out ctest --output-on-failure -L quickstart --parallel "$(nproc)"

--- a/cmake/quickstart-runner.cmake
+++ b/cmake/quickstart-runner.cmake
@@ -17,8 +17,8 @@
 # A CMake script to run the quickstart programs.
 #
 # This script runs the "quickstart" program for a given library. We use CMake as
-# a scripting language because we know CMake to be installed and usable for both
-# Windows, Linux, and macOS. At least while building with CMake.
+# a scripting language because we know (at least while building with CMake) that
+# CMake is installed and usable.
 #
 # The first two arguments for this script are always `-P` and the name of the
 # script itself.

--- a/cmake/quickstart-runner.cmake
+++ b/cmake/quickstart-runner.cmake
@@ -1,0 +1,92 @@
+# ~~~
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ~~~
+
+# A CMake script to run the quickstart programs.
+#
+# This script runs the "quickstart" program for a given library. We use CMake as
+# a scripting language because we know CMake to be installed and usable for both
+# Windows, Linux, and macOS. At least while building with CMake.
+#
+# The first two arguments for this script are always `-P` and the name of the
+# script itself.
+#
+# This script receives the path to the quickstart executable in CMAKE_ARGV3.
+#
+# The remaining arguments to the quickstart are the *names* of N environment
+# variables. The script expects that these environment variables will be set by
+# the CI system.
+#
+
+if (CMAKE_ARGC VERSION_LESS "4")
+    message(
+        FATAL_ERROR "Usage: cmake -P quickstart-runner.cmake EXE [ARGS ...]")
+elseif (CMAKE_ARGC STREQUAL "4")
+    execute_process(
+        TIMEOUT 300
+        RESULT_VARIABLE RET
+        OUTPUT_VARIABLE LOG
+        ERROR_VARIABLE LOG
+        COMMAND "${CMAKE_ARGV3}")
+elseif (CMAKE_ARGC STREQUAL "5")
+    execute_process(
+        TIMEOUT 300
+        RESULT_VARIABLE RET
+        OUTPUT_VARIABLE LOG
+        ERROR_VARIABLE LOG
+        COMMAND "${CMAKE_ARGV3}" "$ENV{${CMAKE_ARGV4}}")
+elseif (CMAKE_ARGC STREQUAL "6")
+    execute_process(
+        TIMEOUT 300
+        RESULT_VARIABLE RET
+        OUTPUT_VARIABLE LOG
+        ERROR_VARIABLE LOG
+        COMMAND "${CMAKE_ARGV3}" "$ENV{${CMAKE_ARGV4}}" "$ENV{${CMAKE_ARGV5}}")
+elseif (CMAKE_ARGC STREQUAL "7")
+    execute_process(
+        TIMEOUT 300
+        RESULT_VARIABLE RET
+        OUTPUT_VARIABLE LOG
+        ERROR_VARIABLE LOG
+        COMMAND "${CMAKE_ARGV3}" "$ENV{${CMAKE_ARGV4}}" "$ENV{${CMAKE_ARGV5}}"
+                "$ENV{${CMAKE_ARGV6}}")
+elseif (CMAKE_ARGC STREQUAL "8")
+    execute_process(
+        TIMEOUT 300
+        RESULT_VARIABLE RET
+        OUTPUT_VARIABLE LOG
+        ERROR_VARIABLE LOG
+        COMMAND "${CMAKE_ARGV3}" "$ENV{${CMAKE_ARGV4}}" "$ENV{${CMAKE_ARGV5}}"
+                "$ENV{${CMAKE_ARGV6}}" "$ENV{${CMAKE_ARGV7}}")
+elseif (CMAKE_ARGC STREQUAL "9")
+    execute_process(
+        TIMEOUT 300
+        RESULT_VARIABLE RET
+        OUTPUT_VARIABLE LOG
+        ERROR_VARIABLE LOG
+        COMMAND
+            "${CMAKE_ARGV3}" "$ENV{${CMAKE_ARGV4}}" "$ENV{${CMAKE_ARGV5}}"
+            "$ENV{${CMAKE_ARGV6}}" "$ENV{${CMAKE_ARGV7}}"
+            "$ENV{${CMAKE_ARGV8}}")
+else ()
+    message(
+        FATAL_ERROR
+            "Too many arguments (${CMAKE_ARGC}) for quickstart-runner.cmake")
+endif ()
+
+if (NOT "${RET}" STREQUAL "0")
+    message(FATAL_ERROR "Non-zero exit status (${RET}) running ${CMAKE_ARGV3}\n"
+                        "${LOG}")
+endif ()

--- a/doc/contributor/howto-guide-adding-generated-libraries.md
+++ b/doc/contributor/howto-guide-adding-generated-libraries.md
@@ -166,6 +166,11 @@ The generated quickstart will need some editing. Use a simple operation, maybe
 an admin operation listing top-level resources, to demonstrate how to use the
 API.
 
+Also edit the tests so this new quickstart receives the right command-line
+arguments in the CI builds.
+
+- `google/cloud/${library}/CMakeLists.txt`
+
 ## Update the README files
 
 The following files probably need some light copy-editing to read less like they

--- a/generator/internal/scaffold_generator.cc
+++ b/generator/internal/scaffold_generator.cc
@@ -498,6 +498,22 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_$library$_mocks
                        INTERFACE $${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
+include(CTest)
+if (BUILD_TESTING)
+    add_executable($library$_quickstart "quickstart/quickstart.cc")
+    target_link_libraries($library$_quickstart
+                          PRIVATE google-cloud-cpp::experimental-$library$)
+    google_cloud_cpp_add_common_options($library$_quickstart)
+    add_test(
+        NAME $library$_quickstart
+        COMMAND cmake -P "$${PROJECT_SOURCE_DIR}/cmake/quickstart-runner.cmake"
+                $$<TARGET_FILE:$library$_quickstart> GOOGLE_CLOUD_PROJECT
+                # EDIT HERE
+                )
+    set_tests_properties($library$_quickstart
+                         PROPERTIES LABELS "integration-test;quickstart")
+endif ()
+
 # Get the destination directories based on the GNU recommendations.
 include(GNUInstallDirs)
 
@@ -1050,8 +1066,6 @@ grpc_extra_deps()
 
 void GenerateQuickstartBuild(
     std::ostream& os, std::map<std::string, std::string> const& variables) {
-  // The version and SHA are hardcoded in this template, but it does not matter
-  // too much, renovate bot would update it as soon as it is merged.
   auto constexpr kText = R"""(# Copyright $copyright_year$ Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/generator/internal/scaffold_generator_test.cc
+++ b/generator/internal/scaffold_generator_test.cc
@@ -201,6 +201,9 @@ target_link_libraries(google_cloud_cpp_test_protos PUBLIC #
     google-cloud-cpp::api_annotations_protos
     google-cloud-cpp::api_http_protos)
 )"""));
+
+  EXPECT_THAT(actual, HasSubstr(R"""(add_executable(test_quickstart)"""));
+  EXPECT_THAT(actual, HasSubstr(R"""(EDIT HERE)"""));
 }
 
 TEST_F(ScaffoldGenerator, DoxygenMainPage) {

--- a/google/cloud/filestore/CMakeLists.txt
+++ b/google/cloud/filestore/CMakeLists.txt
@@ -116,6 +116,20 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_filestore_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
+include(CTest)
+if (BUILD_TESTING)
+    add_executable(filestore_quickstart "quickstart/quickstart.cc")
+    target_link_libraries(filestore_quickstart
+                          PRIVATE google-cloud-cpp::experimental-filestore)
+    google_cloud_cpp_add_common_options(filestore_quickstart)
+    add_test(
+        NAME filestore_quickstart
+        COMMAND cmake -P "${PROJECT_SOURCE_DIR}/cmake/quickstart-runner.cmake"
+                $<TARGET_FILE:filestore_quickstart> GOOGLE_CLOUD_PROJECT)
+    set_tests_properties(filestore_quickstart
+                         PROPERTIES LABELS "integration-test;quickstart")
+endif ()
+
 # Get the destination directories based on the GNU recommendations.
 include(GNUInstallDirs)
 


### PR DESCRIPTION
This PR introduces scripts to run the quickstart programs in all
generated libraries. It also changes the scaffold to generate these new
fragments in the generated `CMakeLists.txt` and `BUILD.bazel` files.

Part of the work for #7936

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8221)
<!-- Reviewable:end -->
