### PR TITLE
chore(generator): update generated workspace file

### DIFF
--- a/generator/internal/scaffold_generator.cc
+++ b/generator/internal/scaffold_generator.cc
@@ -1016,9 +1016,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # NOTE: Update this version and SHA256 as needed.
 http_archive(
     name = "com_github_googleapis_google_cloud_cpp",
-    sha256 = "b024dfde34efd328001d6446e1416fa008caa40d9020c424a8f8a3711061af35",
-    strip_prefix = "google-cloud-cpp-1.33.0",
-    url = "https://github.com/googleapis/google-cloud-cpp/archive/v1.33.0.tar.gz",
+    sha256 = "a7e51bfffb95a377094b2ae7e3b9f715a68ed931c48992c7273b2fae989c029c",
+    strip_prefix = "google-cloud-cpp-1.36.0",
+    url = "https://github.com/googleapis/google-cloud-cpp/archive/v1.36.0.tar.gz",
 )
 
 # Load indirect dependencies due to

--- a/generator/internal/scaffold_generator.cc
+++ b/generator/internal/scaffold_generator.cc
@@ -356,12 +356,12 @@ MOCK_HEADER_GLOB = "mocks/*.h"
 cc_library(
     name = "google_cloud_cpp_$library$",
     srcs = glob(
-        include=[SOURCE_GLOB],
-        exclude=[MOCK_SOURCE_GLOB],
+        include = [SOURCE_GLOB],
+        exclude = [MOCK_SOURCE_GLOB],
     ),
     hdrs = glob(
-        include=[HEADER_GLOB],
-        exclude=[MOCK_HEADER_GLOB],
+        include = [HEADER_GLOB],
+        exclude = [MOCK_HEADER_GLOB],
     ),
     visibility = ["//:__pkg__"],
     deps = [
@@ -374,10 +374,10 @@ cc_library(
 cc_library(
     name = "google_cloud_cpp_$library$_mocks",
     srcs = glob(
-        include=[MOCK_SOURCE_GLOB],
+        include = [MOCK_SOURCE_GLOB],
     ),
     hdrs = glob(
-        include=[MOCK_HEADER_GLOB],
+        include = [MOCK_HEADER_GLOB],
     ),
     visibility = ["//:__pkg__"],
     deps = [


### PR DESCRIPTION
Obviously this is not ideal, but it is better than waiting for renovate bot after each new library.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8224)
<!-- Reviewable:end -->
