### PR TITLE
feat(impl): Create a generic helper for async continuations

### DIFF
--- a/google/cloud/CMakeLists.txt
+++ b/google/cloud/CMakeLists.txt
@@ -91,6 +91,7 @@ add_library(
     internal/future_fwd.h
     internal/future_impl.cc
     internal/future_impl.h
+    internal/future_then_async.h
     internal/future_then_impl.h
     internal/future_then_meta.h
     internal/getenv.cc
@@ -216,6 +217,7 @@ if (BUILD_TESTING)
         internal/env_test.cc
         internal/filesystem_test.cc
         internal/format_time_point_test.cc
+        internal/future_then_async_test.cc
         internal/future_impl_test.cc
         internal/invoke_result_test.cc
         internal/log_impl_test.cc

--- a/google/cloud/google_cloud_cpp_common.bzl
+++ b/google/cloud/google_cloud_cpp_common.bzl
@@ -48,6 +48,7 @@ google_cloud_cpp_common_hdrs = [
     "internal/future_base.h",
     "internal/future_fwd.h",
     "internal/future_impl.h",
+    "internal/future_then_async.h",
     "internal/future_then_impl.h",
     "internal/future_then_meta.h",
     "internal/getenv.h",

--- a/google/cloud/google_cloud_cpp_common_unit_tests.bzl
+++ b/google/cloud/google_cloud_cpp_common_unit_tests.bzl
@@ -20,6 +20,7 @@ google_cloud_cpp_common_unit_tests = [
     "common_options_test.cc",
     "future_generic_test.cc",
     "future_generic_then_test.cc",
+    "future_then_async_test.cc",
     "future_void_test.cc",
     "future_void_then_test.cc",
     "iam_bindings_test.cc",

--- a/google/cloud/internal/future_then_async.h
+++ b/google/cloud/internal/future_then_async.h
@@ -1,0 +1,89 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_FUTURE_THEN_ASYNC_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_FUTURE_THEN_ASYNC_H
+/**
+ * @file
+ *
+ * Define the `then_async` template function.
+ *
+ * This function allows for generic asynchronous continuations using
+ * google::cloud::future. In particular, it allows chaining of async
+ * operations without increasing the nesting level.
+ * 
+ * Usage of this utility would look like the below, which is a series of
+ * asynchronous operations written in an almost linear style:
+ * 
+ * future<std::string> f1 = ...
+ * future<int> f2 = then_async(std::move(f1), [](std::string value) -> future<int> {
+ *     return StartAsyncOp(std::move(value));
+ * });
+ * future<Status> f3 = then_async(std::move(f2), [](int value) -> future<Status> {
+ *     return FinishAsyncOp(value);
+ * });
+ * return f3;
+ */
+
+#include "google/cloud/future.h"
+#include "google/cloud/version.h"
+#include "google/cloud/internal/invoke_result.h"
+
+namespace google {
+namespace cloud {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+namespace internal {
+
+template <class FutureT>
+struct future_value_type;
+template <class T>
+struct future_value_type<future<T>> {
+    using type = T;
+};
+template <class T>
+using future_value_type_t = typename future_value_type<T>::type;
+
+void link_future_and_promise(future<void> fut, promise<void> p) {
+    fut.then([p]{ p.set_value(); });
+}
+
+template <class T>
+void link_future_and_promise(future<T> fut, promise<T> p) {
+    fut.then([p](T val){ p.set_value(std::move(val)); });
+}
+
+template <class Functor, class ReturnT = invoke_result_t<Functor>>
+ReturnT then_async(future<void> fut, Functor&& f) {
+    promise<future_value_type_t<ReturnT>> to_return;
+    fut.then(absl::bind_front([to_return](Functor&& f) {
+        link_future_and_promise(std::forward<Functor>(f)(), to_return);
+    }, std::forward<Functor>(f)));
+    return to_return.get_future();
+}
+
+template <class T, class Functor, class ReturnT = invoke_result_t<Functor, T>>
+ReturnT then_async(future<T> fut, Functor&& f) {
+    promise<future_value_type_t<ReturnT>> to_return;
+    fut.then(absl::bind_front([to_return](Functor&& f, T val) {
+        link_future_and_promise(std::forward<Functor>(f)(std::move(val)), to_return);
+    }, std::forward<Functor>(f)));
+    return to_return.get_future();
+}
+
+}  // namespace internal
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_FUTURE_THEN_ASYNC_H

--- a/google/cloud/internal/future_then_async_test.cc
+++ b/google/cloud/internal/future_then_async_test.cc
@@ -1,0 +1,86 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/future.h"
+#include "google/cloud/internal/future_then_async.h"
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+namespace internal {
+namespace {
+
+using ::testing::HasSubstr;
+using ::testing::MockFunction;
+using ::testing::StrictMock;
+
+// @test Verify that we can create continuations.
+TEST(FutureThenAsyncTest, VoidFutureThenVoidFuture) {
+  promise<void> source;
+  StrictMock<MockFunction<future<void>()>> callback;
+  future<void> sink = async_then(source.get_future(), callback.AsStdFunction());
+  EXPECT_FALSE(sink.is_ready());
+  promise<void> intermediate;
+  EXPECT_CALL(callback, Call()).WillOnce(Return(intermediate.get_future()));
+  source.set_value();
+  EXPECT_FALSE(sink.is_ready());
+  intermediate.set_value();
+  sink.get();
+}
+
+TEST(FutureThenAsyncTest, VoidFutureThenValueFuture) {
+  promise<void> source;
+  StrictMock<MockFunction<future<std::string>()>> callback;
+  future<std::string> sink = async_then(source.get_future(), callback.AsStdFunction());
+  EXPECT_FALSE(sink.is_ready());
+  promise<std::string> intermediate;
+  EXPECT_CALL(callback, Call()).WillOnce(Return(intermediate.get_future()));
+  source.set_value();
+  EXPECT_FALSE(sink.is_ready());
+  intermediate.set_value("abc");
+  EXPECT_EQ(sink.get(), "abc");
+}
+
+TEST(FutureThenAsyncTest, ValueFutureThenVoidFuture) {
+  promise<int> source;
+  StrictMock<MockFunction<future<void>(int)>> callback;
+  future<void> sink = async_then(source.get_future(), callback.AsStdFunction());
+  EXPECT_FALSE(sink.is_ready());
+  promise<void> intermediate;
+  EXPECT_CALL(callback, Call(42)).WillOnce(Return(intermediate.get_future()));
+  source.set_value(42);
+  EXPECT_FALSE(sink.is_ready());
+  intermediate.set_value();
+  EXPECT_EQ(sink.get(), "abc");
+}
+
+TEST(FutureThenAsyncTest, ValueFutureThenValueFuture) {
+  promise<int> source;
+  StrictMock<MockFunction<future<std::string>(int)>> callback;
+  future<std::string> sink = async_then(source.get_future(), callback.AsStdFunction());
+  EXPECT_FALSE(sink.is_ready());
+  promise<std::string> intermediate;
+  EXPECT_CALL(callback, Call(42)).WillOnce(Return(intermediate.get_future()));
+  source.set_value(42);
+  EXPECT_FALSE(sink.is_ready());
+  intermediate.set_value("abc");
+  EXPECT_EQ(sink.get(), "abc");
+}
+
+}  // namespace
+}  // namespace internal
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace cloud
+}  // namespace google


### PR DESCRIPTION
This is the equivalent of guava's Futures.transformAsync (https://guava.dev/releases/21.0/api/docs/com/google/common/util/concurrent/Futures.html#transformAsync-com.google.common.util.concurrent.ListenableFuture-com.google.common.util.concurrent.AsyncFunction-) and makes it easier to write sequences of asynchronous operations

This is intended for internal use only, not to add to the external api, even if doing so would lead to a cleaner chaining (with .then_async)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8229)
<!-- Reviewable:end -->
