### PR TITLE
cleanup(spanner): make the spanner::Connection interface non-pure

### DIFF
--- a/google/cloud/spanner/CMakeLists.txt
+++ b/google/cloud/spanner/CMakeLists.txt
@@ -90,6 +90,7 @@ add_library(
     commit_options.cc
     commit_options.h
     commit_result.h
+    connection.cc
     connection.h
     connection_options.cc
     connection_options.h

--- a/google/cloud/spanner/connection.cc
+++ b/google/cloud/spanner/connection.cc
@@ -1,0 +1,113 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/spanner/connection.h"
+#include "google/cloud/spanner/query_partition.h"
+#include "google/cloud/spanner/read_partition.h"
+#include "absl/memory/memory.h"
+
+namespace google {
+namespace cloud {
+namespace spanner {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+
+namespace {
+
+class StatusOnlyResultSetSource
+    : public spanner_internal::ResultSourceInterface {
+ public:
+  explicit StatusOnlyResultSetSource(Status status)
+      : status_(std::move(status)) {}
+
+  StatusOr<Row> NextRow() override { return status_; }
+  absl::optional<google::spanner::v1::ResultSetMetadata> Metadata() override {
+    return {};
+  }
+  absl::optional<google::spanner::v1::ResultSetStats> Stats() const override {
+    return {};
+  }
+
+ private:
+  Status status_;
+};
+
+}  // namespace
+
+// NOLINTNEXTLINE(performance-unnecessary-value-param)
+RowStream Connection::Read(ReadParams) {
+  return RowStream(absl::make_unique<StatusOnlyResultSetSource>(
+      Status(StatusCode::kUnimplemented, "not implemented")));
+}
+
+StatusOr<std::vector<ReadPartition>> Connection::PartitionRead(
+    PartitionReadParams) {  // NOLINT(performance-unnecessary-value-param)
+  return Status(StatusCode::kUnimplemented, "not implemented");
+}
+
+// NOLINTNEXTLINE(performance-unnecessary-value-param)
+RowStream Connection::ExecuteQuery(SqlParams) {
+  return RowStream(absl::make_unique<StatusOnlyResultSetSource>(
+      Status(StatusCode::kUnimplemented, "not implemented")));
+}
+
+// NOLINTNEXTLINE(performance-unnecessary-value-param)
+StatusOr<DmlResult> Connection::ExecuteDml(SqlParams) {
+  return Status(StatusCode::kUnimplemented, "not implemented");
+}
+
+// NOLINTNEXTLINE(performance-unnecessary-value-param)
+ProfileQueryResult Connection::ProfileQuery(SqlParams) {
+  return ProfileQueryResult(absl::make_unique<StatusOnlyResultSetSource>(
+      Status(StatusCode::kUnimplemented, "not implemented")));
+}
+
+// NOLINTNEXTLINE(performance-unnecessary-value-param)
+StatusOr<ProfileDmlResult> Connection::ProfileDml(SqlParams) {
+  return Status(StatusCode::kUnimplemented, "not implemented");
+}
+
+// NOLINTNEXTLINE(performance-unnecessary-value-param)
+StatusOr<ExecutionPlan> Connection::AnalyzeSql(SqlParams) {
+  return Status(StatusCode::kUnimplemented, "not implemented");
+}
+
+StatusOr<PartitionedDmlResult> Connection::ExecutePartitionedDml(
+    ExecutePartitionedDmlParams) {  // NOLINT(performance-unnecessary-value-param)
+  return Status(StatusCode::kUnimplemented, "not implemented");
+}
+
+StatusOr<std::vector<QueryPartition>> Connection::PartitionQuery(
+    PartitionQueryParams) {  // NOLINT(performance-unnecessary-value-param)
+  return Status(StatusCode::kUnimplemented, "not implemented");
+}
+
+// NOLINTNEXTLINE(performance-unnecessary-value-param)
+StatusOr<BatchDmlResult> Connection::ExecuteBatchDml(ExecuteBatchDmlParams) {
+  return Status(StatusCode::kUnimplemented, "not implemented");
+}
+
+// NOLINTNEXTLINE(performance-unnecessary-value-param)
+StatusOr<CommitResult> Connection::Commit(CommitParams) {
+  return Status(StatusCode::kUnimplemented, "not implemented");
+}
+
+// NOLINTNEXTLINE(performance-unnecessary-value-param)
+Status Connection::Rollback(RollbackParams) {
+  return Status(StatusCode::kUnimplemented, "not implemented");
+}
+
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace spanner
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/spanner/connection.h
+++ b/google/cloud/spanner/connection.h
@@ -132,43 +132,43 @@ class Connection {
   virtual Options options() { return Options{}; }
 
   /// Defines the interface for `Client::Read()`
-  virtual RowStream Read(ReadParams) = 0;
+  virtual RowStream Read(ReadParams);
 
   /// Defines the interface for `Client::PartitionRead()`
   virtual StatusOr<std::vector<ReadPartition>> PartitionRead(
-      PartitionReadParams) = 0;
+      PartitionReadParams);
 
   /// Defines the interface for `Client::ExecuteQuery()`
-  virtual RowStream ExecuteQuery(SqlParams) = 0;
+  virtual RowStream ExecuteQuery(SqlParams);
 
   /// Defines the interface for `Client::ExecuteDml()`
-  virtual StatusOr<DmlResult> ExecuteDml(SqlParams) = 0;
+  virtual StatusOr<DmlResult> ExecuteDml(SqlParams);
 
   /// Defines the interface for `Client::ProfileQuery()`
-  virtual ProfileQueryResult ProfileQuery(SqlParams) = 0;
+  virtual ProfileQueryResult ProfileQuery(SqlParams);
 
   /// Defines the interface for `Client::ProfileDml()`
-  virtual StatusOr<ProfileDmlResult> ProfileDml(SqlParams) = 0;
+  virtual StatusOr<ProfileDmlResult> ProfileDml(SqlParams);
 
   /// Defines the interface for `Client::AnalyzeSql()`
-  virtual StatusOr<ExecutionPlan> AnalyzeSql(SqlParams) = 0;
+  virtual StatusOr<ExecutionPlan> AnalyzeSql(SqlParams);
 
   /// Defines the interface for `Client::ExecutePartitionedDml()`
   virtual StatusOr<PartitionedDmlResult> ExecutePartitionedDml(
-      ExecutePartitionedDmlParams) = 0;
+      ExecutePartitionedDmlParams);
 
   /// Defines the interface for `Client::PartitionQuery()`
   virtual StatusOr<std::vector<QueryPartition>> PartitionQuery(
-      PartitionQueryParams) = 0;
+      PartitionQueryParams);
 
   /// Defines the interface for `Client::ExecuteBatchDml()`
-  virtual StatusOr<BatchDmlResult> ExecuteBatchDml(ExecuteBatchDmlParams) = 0;
+  virtual StatusOr<BatchDmlResult> ExecuteBatchDml(ExecuteBatchDmlParams);
 
   /// Defines the interface for `Client::Commit()`
-  virtual StatusOr<CommitResult> Commit(CommitParams) = 0;
+  virtual StatusOr<CommitResult> Commit(CommitParams);
 
   /// Defines the interface for `Client::Rollback()`
-  virtual Status Rollback(RollbackParams) = 0;
+  virtual Status Rollback(RollbackParams);
 };
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/spanner/google_cloud_cpp_spanner.bzl
+++ b/google/cloud/spanner/google_cloud_cpp_spanner.bzl
@@ -139,6 +139,7 @@ google_cloud_cpp_spanner_srcs = [
     "client.cc",
     "client_options.cc",
     "commit_options.cc",
+    "connection.cc",
     "connection_options.cc",
     "database.cc",
     "database_admin_client.cc",


### PR DESCRIPTION
We think pure virtual functions are a recipe to break backwards
compatibility as we add member functions, so, in order to make such
future additions consistent, we now give the existing functions
default implementations that all fail with `kUnimplemented`.

Fixes #5336.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8237)
<!-- Reviewable:end -->
