### PR TITLE
ci: hide docker output for manual builds

### DIFF
--- a/ci/cloudbuild/build.sh
+++ b/ci/cloudbuild/build.sh
@@ -295,7 +295,7 @@ if [[ "${DOCKER_FLAG}" = "true" ]]; then
   if [[ "${TRIGGER_TYPE}" == "manual" ]]; then
     build_flags+=("--quiet")
   fi
-  io::run docker build "${build_flags[@]}"  ci
+  io::run docker build "${build_flags[@]}" ci
   io::log_h2 "Starting docker container: ${image}"
   run_flags=(
     "--interactive"

--- a/ci/cloudbuild/build.sh
+++ b/ci/cloudbuild/build.sh
@@ -287,9 +287,15 @@ if [[ "${DOCKER_FLAG}" = "true" ]]; then
   mkdir -p "${out_cmake}" "${out_home}/.config/gcloud"
   image="gcb-${DISTRO_FLAG}:latest"
   io::log_h2 "Building docker image: ${image}"
-  io::run \
-    docker build -t "${image}" "--build-arg=NCPU=$(nproc)" \
-    -f "ci/cloudbuild/dockerfiles/${DISTRO_FLAG}.Dockerfile" ci
+  build_flags=(
+    -t "${image}"
+    "--build-arg=NCPU=$(nproc)"
+    -f "ci/cloudbuild/dockerfiles/${DISTRO_FLAG}.Dockerfile"
+  )
+  if [[ "${TRIGGER_TYPE}" == "manual" ]]; then
+    build_flags+=("--quiet")
+  fi
+  io::run docker build "${build_flags[@]}"  ci
   io::log_h2 "Starting docker container: ${image}"
   run_flags=(
     "--interactive"


### PR DESCRIPTION
I tested locally, when the `docker build` step fails we get the full output. If it succeeds we get only the SHA of the created image.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8238)
<!-- Reviewable:end -->
