### PR TITLE
ci: quiet the cmake install steps

### DIFF
--- a/ci/cloudbuild/builds/check-api.sh
+++ b/ci/cloudbuild/builds/check-api.sh
@@ -30,11 +30,12 @@ INSTALL_PREFIX=/var/tmp/google-cloud-cpp
 # https://github.com/googleapis/google-cloud-cpp/issues/6313
 cmake "${cmake_args[@]}" \
   -DCMAKE_INSTALL_PREFIX="${INSTALL_PREFIX}" \
+  -DCMAKE_INSTALL_MESSAGE=NEVER \
   -DBUILD_SHARED_LIBS=ON \
   -DCMAKE_BUILD_TYPE=Debug \
   -DCMAKE_CXX_FLAGS="-Og -Wno-maybe-uninitialized"
 cmake --build cmake-out
-cmake --build cmake-out --target install
+cmake --install cmake-out
 
 # Uses `abi-dumper` to dump the ABI for the given library, which should be
 # installed at the given prefix. This function will be called from a subshell,

--- a/ci/cloudbuild/builds/cmake-install.sh
+++ b/ci/cloudbuild/builds/cmake-install.sh
@@ -33,9 +33,10 @@ mapfile -t cmake_args < <(cmake::common_args)
 
 # Compiles and installs all libraries and headers.
 cmake "${cmake_args[@]}" \
+  -DCMAKE_INSTALL_PREFIX="${INSTALL_PREFIX}" \
+  -DCMAKE_INSTALL_MESSAGE=NEVER \
   -DBUILD_TESTING=OFF \
   -DGOOGLE_CLOUD_CPP_ENABLE_EXAMPLES=OFF \
-  -DCMAKE_INSTALL_PREFIX="${INSTALL_PREFIX}" \
   -DGOOGLE_CLOUD_CPP_ENABLE="${ENABLED_FEATURES}"
 cmake --build cmake-out
 cmake --install cmake-out --component google_cloud_cpp_development

--- a/ci/cloudbuild/builds/demo-install.sh
+++ b/ci/cloudbuild/builds/demo-install.sh
@@ -28,13 +28,18 @@ source module ci/cloudbuild/builds/lib/cmake.sh
 source module ci/cloudbuild/builds/lib/quickstart.sh
 source module ci/lib/io.sh
 
+# We cannot use `cmake --install` below. That flag was introduced
+# in CMake == 3.15, and we use (and tell folks to use this code)
+# with versions as old as 3.5.
+
 ## [BEGIN packaging.md]
 # Pick a location to install the artifacts, e.g., `/usr/local` or `/opt`
 PREFIX="${HOME}/google-cloud-cpp-installed"
 cmake -H. -Bcmake-out \
+  -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
+  -DCMAKE_INSTALL_MESSAGE=NEVER \
   -DBUILD_TESTING=OFF \
-  -DGOOGLE_CLOUD_CPP_ENABLE_EXAMPLES=OFF \
-  -DCMAKE_INSTALL_PREFIX="${PREFIX}"
+  -DGOOGLE_CLOUD_CPP_ENABLE_EXAMPLES=OFF
 cmake --build cmake-out -- -j "$(nproc)"
 cmake --build cmake-out --target install
 ## [DONE packaging.md]

--- a/ci/cloudbuild/builds/install-gcs-grpc.sh
+++ b/ci/cloudbuild/builds/install-gcs-grpc.sh
@@ -26,12 +26,13 @@ mapfile -t cmake_args < <(cmake::common_args)
 
 INSTALL_PREFIX="/var/tmp/google-cloud-cpp"
 cmake "${cmake_args[@]}" \
+  -DCMAKE_INSTALL_PREFIX="${INSTALL_PREFIX}" \
+  -DCMAKE_INSTALL_MESSAGE=NEVER \
   -DGOOGLE_CLOUD_CPP_STORAGE_ENABLE_GRPC=ON \
-  -DBUILD_SHARED_LIBS=ON \
-  -DCMAKE_INSTALL_PREFIX="${INSTALL_PREFIX}"
+  -DBUILD_SHARED_LIBS=ON
 cmake --build cmake-out
 env -C cmake-out ctest -LE "integration-test" --parallel "$(nproc)"
-cmake --build cmake-out --target install
+cmake --install cmake-out
 
 # Tests the installed artifacts by building and running the quickstarts.
 quickstart::build_gcs_grpc_quickstart "${INSTALL_PREFIX}"

--- a/ci/cloudbuild/builds/shared.sh
+++ b/ci/cloudbuild/builds/shared.sh
@@ -26,11 +26,12 @@ mapfile -t cmake_args < <(cmake::common_args)
 
 INSTALL_PREFIX="/var/tmp/google-cloud-cpp"
 cmake "${cmake_args[@]}" \
-  -DBUILD_SHARED_LIBS=ON \
-  -DCMAKE_INSTALL_PREFIX="${INSTALL_PREFIX}"
+  -DCMAKE_INSTALL_PREFIX="${INSTALL_PREFIX}" \
+  -DCMAKE_INSTALL_MESSAGE=NEVER \
+  -DBUILD_SHARED_LIBS=ON
 cmake --build cmake-out
 env -C cmake-out ctest -LE "integration-test" --parallel "$(nproc)"
-cmake --build cmake-out --target install
+cmake --install cmake-out
 
 # Tests the installed artifacts by building and running the quickstarts.
 quickstart::build_cmake_and_make "${INSTALL_PREFIX}"

--- a/doc/packaging.md
+++ b/doc/packaging.md
@@ -285,9 +285,10 @@ We can now compile and install `google-cloud-cpp`
 # Pick a location to install the artifacts, e.g., `/usr/local` or `/opt`
 PREFIX="${HOME}/google-cloud-cpp-installed"
 cmake -H. -Bcmake-out \
+  -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
+  -DCMAKE_INSTALL_MESSAGE=NEVER \
   -DBUILD_TESTING=OFF \
-  -DGOOGLE_CLOUD_CPP_ENABLE_EXAMPLES=OFF \
-  -DCMAKE_INSTALL_PREFIX="${PREFIX}"
+  -DGOOGLE_CLOUD_CPP_ENABLE_EXAMPLES=OFF
 cmake --build cmake-out -- -j "$(nproc)"
 cmake --build cmake-out --target install
 ```
@@ -449,9 +450,10 @@ We can now compile and install `google-cloud-cpp`
 # Pick a location to install the artifacts, e.g., `/usr/local` or `/opt`
 PREFIX="${HOME}/google-cloud-cpp-installed"
 cmake -H. -Bcmake-out \
+  -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
+  -DCMAKE_INSTALL_MESSAGE=NEVER \
   -DBUILD_TESTING=OFF \
-  -DGOOGLE_CLOUD_CPP_ENABLE_EXAMPLES=OFF \
-  -DCMAKE_INSTALL_PREFIX="${PREFIX}"
+  -DGOOGLE_CLOUD_CPP_ENABLE_EXAMPLES=OFF
 cmake --build cmake-out -- -j "$(nproc)"
 cmake --build cmake-out --target install
 ```
@@ -587,9 +589,10 @@ We can now compile and install `google-cloud-cpp`
 # Pick a location to install the artifacts, e.g., `/usr/local` or `/opt`
 PREFIX="${HOME}/google-cloud-cpp-installed"
 cmake -H. -Bcmake-out \
+  -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
+  -DCMAKE_INSTALL_MESSAGE=NEVER \
   -DBUILD_TESTING=OFF \
-  -DGOOGLE_CLOUD_CPP_ENABLE_EXAMPLES=OFF \
-  -DCMAKE_INSTALL_PREFIX="${PREFIX}"
+  -DGOOGLE_CLOUD_CPP_ENABLE_EXAMPLES=OFF
 cmake --build cmake-out -- -j "$(nproc)"
 cmake --build cmake-out --target install
 ```
@@ -741,9 +744,10 @@ We can now compile and install `google-cloud-cpp`
 # Pick a location to install the artifacts, e.g., `/usr/local` or `/opt`
 PREFIX="${HOME}/google-cloud-cpp-installed"
 cmake -H. -Bcmake-out \
+  -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
+  -DCMAKE_INSTALL_MESSAGE=NEVER \
   -DBUILD_TESTING=OFF \
-  -DGOOGLE_CLOUD_CPP_ENABLE_EXAMPLES=OFF \
-  -DCMAKE_INSTALL_PREFIX="${PREFIX}"
+  -DGOOGLE_CLOUD_CPP_ENABLE_EXAMPLES=OFF
 cmake --build cmake-out -- -j "$(nproc)"
 cmake --build cmake-out --target install
 ```
@@ -867,9 +871,10 @@ We can now compile and install `google-cloud-cpp`
 # Pick a location to install the artifacts, e.g., `/usr/local` or `/opt`
 PREFIX="${HOME}/google-cloud-cpp-installed"
 cmake -H. -Bcmake-out \
+  -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
+  -DCMAKE_INSTALL_MESSAGE=NEVER \
   -DBUILD_TESTING=OFF \
-  -DGOOGLE_CLOUD_CPP_ENABLE_EXAMPLES=OFF \
-  -DCMAKE_INSTALL_PREFIX="${PREFIX}"
+  -DGOOGLE_CLOUD_CPP_ENABLE_EXAMPLES=OFF
 cmake --build cmake-out -- -j "$(nproc)"
 cmake --build cmake-out --target install
 ```
@@ -1004,9 +1009,10 @@ We can now compile and install `google-cloud-cpp`
 # Pick a location to install the artifacts, e.g., `/usr/local` or `/opt`
 PREFIX="${HOME}/google-cloud-cpp-installed"
 cmake -H. -Bcmake-out \
+  -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
+  -DCMAKE_INSTALL_MESSAGE=NEVER \
   -DBUILD_TESTING=OFF \
-  -DGOOGLE_CLOUD_CPP_ENABLE_EXAMPLES=OFF \
-  -DCMAKE_INSTALL_PREFIX="${PREFIX}"
+  -DGOOGLE_CLOUD_CPP_ENABLE_EXAMPLES=OFF
 cmake --build cmake-out -- -j "$(nproc)"
 cmake --build cmake-out --target install
 ```
@@ -1183,9 +1189,10 @@ We can now compile and install `google-cloud-cpp`
 # Pick a location to install the artifacts, e.g., `/usr/local` or `/opt`
 PREFIX="${HOME}/google-cloud-cpp-installed"
 cmake -H. -Bcmake-out \
+  -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
+  -DCMAKE_INSTALL_MESSAGE=NEVER \
   -DBUILD_TESTING=OFF \
-  -DGOOGLE_CLOUD_CPP_ENABLE_EXAMPLES=OFF \
-  -DCMAKE_INSTALL_PREFIX="${PREFIX}"
+  -DGOOGLE_CLOUD_CPP_ENABLE_EXAMPLES=OFF
 cmake --build cmake-out -- -j "$(nproc)"
 cmake --build cmake-out --target install
 ```
@@ -1350,9 +1357,10 @@ We can now compile and install `google-cloud-cpp`
 # Pick a location to install the artifacts, e.g., `/usr/local` or `/opt`
 PREFIX="${HOME}/google-cloud-cpp-installed"
 cmake -H. -Bcmake-out \
+  -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
+  -DCMAKE_INSTALL_MESSAGE=NEVER \
   -DBUILD_TESTING=OFF \
-  -DGOOGLE_CLOUD_CPP_ENABLE_EXAMPLES=OFF \
-  -DCMAKE_INSTALL_PREFIX="${PREFIX}"
+  -DGOOGLE_CLOUD_CPP_ENABLE_EXAMPLES=OFF
 cmake --build cmake-out -- -j "$(nproc)"
 cmake --build cmake-out --target install
 ```
@@ -1541,9 +1549,10 @@ We can now compile and install `google-cloud-cpp`
 # Pick a location to install the artifacts, e.g., `/usr/local` or `/opt`
 PREFIX="${HOME}/google-cloud-cpp-installed"
 cmake -H. -Bcmake-out \
+  -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
+  -DCMAKE_INSTALL_MESSAGE=NEVER \
   -DBUILD_TESTING=OFF \
-  -DGOOGLE_CLOUD_CPP_ENABLE_EXAMPLES=OFF \
-  -DCMAKE_INSTALL_PREFIX="${PREFIX}"
+  -DGOOGLE_CLOUD_CPP_ENABLE_EXAMPLES=OFF
 cmake --build cmake-out -- -j "$(nproc)"
 cmake --build cmake-out --target install
 ```


### PR DESCRIPTION
With all the new libraries this steps eats too many lines in my
terminal.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8241)
<!-- Reviewable:end -->
