### PR TITLE
ci: reduce Bazel's remote cache timeout

### DIFF
--- a/ci/kokoro/macos/builds/bazel.sh
+++ b/ci/kokoro/macos/builds/bazel.sh
@@ -48,7 +48,14 @@ readonly BAZEL_CACHE="https://storage.googleapis.com/cloud-cpp-bazel-cache"
 # not hit this cache.
 if [[ -r "${TEST_KEY_FILE_JSON}" ]]; then
   io::log "Using bazel remote cache: ${BAZEL_CACHE}/macos/${BUILD_NAME:-}"
-  bazel_args+=("--remote_cache=${BAZEL_CACHE}/macos/${BUILD_NAME:-}")
+  bazel_args+=(
+    "--remote_cache=${BAZEL_CACHE}/macos/${BUILD_NAME:-}"
+    # Reduce the timeout for the remote cache from the 60s default:
+    #     https://docs.bazel.build/versions/main/command-line-reference.html#flag--remote_timeout
+    # If the build machine has network problems we would rather build locally
+    # over blocking the build for 60s
+    "--remote_timeout=3"
+  )
   bazel_args+=("--google_credentials=${TEST_KEY_FILE_JSON}")
   # See https://docs.bazel.build/versions/main/remote-caching.html#known-issues
   # and https://github.com/bazelbuild/bazel/issues/3360

--- a/ci/kokoro/macos/builds/quickstart-bazel.sh
+++ b/ci/kokoro/macos/builds/quickstart-bazel.sh
@@ -50,7 +50,14 @@ readonly BAZEL_CACHE="https://storage.googleapis.com/cloud-cpp-bazel-cache"
 
 if [[ -r "${CREDENTIALS_FILE}" ]]; then
   io::log "Using bazel remote cache: ${BAZEL_CACHE}/macos/${BUILD_NAME:-}"
-  bazel_args+=("--remote_cache=${BAZEL_CACHE}/macos/${BUILD_NAME:-}")
+  bazel_args+=(
+    "--remote_cache=${BAZEL_CACHE}/macos/${BUILD_NAME:-}"
+    # Reduce the timeout for the remote cache from the 60s default:
+    #     https://docs.bazel.build/versions/main/command-line-reference.html#flag--remote_timeout
+    # If the build machine has network problems we would rather build locally
+    # over blocking the build for 60s
+    "--remote_timeout=3"
+  )
   bazel_args+=("--google_credentials=${CREDENTIALS_FILE}")
   # See https://docs.bazel.build/versions/main/remote-caching.html#known-issues
   # and https://github.com/bazelbuild/bazel/issues/3360

--- a/ci/kokoro/windows/build-bazel.ps1
+++ b/ci/kokoro/windows/build-bazel.ps1
@@ -75,7 +75,14 @@ $BAZEL_CACHE="https://storage.googleapis.com/cloud-cpp-bazel-cache"
 if ((Test-Path env:KOKORO_GFILE_DIR) -and
     (Test-Path "${env:KOKORO_GFILE_DIR}/kokoro-run-key.json")) {
     Write-Host -ForegroundColor Yellow "Using bazel remote cache: ${BAZEL_CACHE}/windows/${BuildName}"
-    $build_flags += @("--remote_cache=${BAZEL_CACHE}/windows/${BuildName}")
+    $build_flags += @(
+        "--remote_cache=${BAZEL_CACHE}/windows/${BuildName}",
+        # Reduce the timeout for the remote cache from the 60s default:
+        #     https://docs.bazel.build/versions/main/command-line-reference.html#flag--remote_timeout
+        # If the build machine has network problems we would rather build locally
+        # over blocking the build for 60s
+        "--remote_timeout=3"
+      )
     $build_flags += @("--google_credentials=${env:KOKORO_GFILE_DIR}/kokoro-run-key.json")
     # See https://docs.bazel.build/versions/main/remote-caching.html#known-issues
     # and https://github.com/bazelbuild/bazel/issues/3360

--- a/ci/kokoro/windows/build-quickstart-bazel.ps1
+++ b/ci/kokoro/windows/build-quickstart-bazel.ps1
@@ -62,7 +62,14 @@ $build_flags=@()
 if ((Test-Path env:KOKORO_GFILE_DIR) -and
     (Test-Path "${env:KOKORO_GFILE_DIR}/kokoro-run-key.json")) {
     Write-Host -ForegroundColor Yellow "Using bazel remote cache: ${BAZEL_CACHE}/windows/${BuildName}"
-    $build_flags += @("--remote_cache=${BAZEL_CACHE}/windows/${BuildName}")
+    $build_flags += @(
+        "--remote_cache=${BAZEL_CACHE}/windows/${BuildName}",
+        # Reduce the timeout for the remote cache from the 60s default:
+        #     https://docs.bazel.build/versions/main/command-line-reference.html#flag--remote_timeout
+        # If the build machine has network problems we would rather build locally
+        # over blocking the build for 60s
+        "--remote_timeout=3"
+        )
     $build_flags += @("--google_credentials=${env:KOKORO_GFILE_DIR}/kokoro-run-key.json")
     # See https://docs.bazel.build/versions/main/remote-caching.html#known-issues
     # and https://github.com/bazelbuild/bazel/issues/3360


### PR DESCRIPTION
I am hoping this will reduce the impact of #3645

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8242)
<!-- Reviewable:end -->
