### PR TITLE
feat(generator): support `x-goog-user-project`

### DIFF
--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_metadata_decorator.cc
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: generator/integration_tests/test.proto
 
 #include "generator/integration_tests/golden/internal/golden_kitchen_sink_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <generator/integration_tests/test.grpc.pb.h>
@@ -115,6 +116,11 @@ void GoldenKitchenSinkMetadata::SetMetadata(grpc::ClientContext& context,
 
 void GoldenKitchenSinkMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata(
+        "x-goog-user-project", options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_option_defaults.cc
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_option_defaults.cc
@@ -39,7 +39,12 @@ auto constexpr kBackoffScaling = 2.0;
 Options GoldenKitchenSinkDefaultOptions(Options options) {
   if (!options.has<EndpointOption>()) {
     auto env = internal::GetEnv("GOLDEN_KITCHEN_SINK_ENDPOINT");
-    options.set<EndpointOption>(env && !env->empty() ? *env : "goldenkitchensink.googleapis.com");
+    options.set<EndpointOption>(
+        env && !env->empty() ? *env : "goldenkitchensink.googleapis.com");
+  }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
   }
   if (auto emulator = internal::GetEnv("GOLDEN_KITCHEN_SINK_EMULATOR_HOST")) {
     options.set<EndpointOption>(*emulator).set<GrpcCredentialOption>(

--- a/generator/integration_tests/golden/internal/golden_thing_admin_metadata_decorator.cc
+++ b/generator/integration_tests/golden/internal/golden_thing_admin_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: generator/integration_tests/test.proto
 
 #include "generator/integration_tests/golden/internal/golden_thing_admin_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <generator/integration_tests/test.grpc.pb.h>
@@ -224,6 +225,11 @@ void GoldenThingAdminMetadata::SetMetadata(grpc::ClientContext& context,
 
 void GoldenThingAdminMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata(
+        "x-goog-user-project", options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/generator/integration_tests/golden/internal/golden_thing_admin_option_defaults.cc
+++ b/generator/integration_tests/golden/internal/golden_thing_admin_option_defaults.cc
@@ -39,7 +39,12 @@ auto constexpr kBackoffScaling = 2.0;
 Options GoldenThingAdminDefaultOptions(Options options) {
   if (!options.has<EndpointOption>()) {
     auto env = internal::GetEnv("GOLDEN_KITCHEN_SINK_ENDPOINT");
-    options.set<EndpointOption>(env && !env->empty() ? *env : "test.googleapis.com");
+    options.set<EndpointOption>(
+        env && !env->empty() ? *env : "test.googleapis.com");
+  }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
   }
   if (auto emulator = internal::GetEnv("GOLDEN_KITCHEN_SINK_EMULATOR_HOST")) {
     options.set<EndpointOption>(*emulator).set<GrpcCredentialOption>(

--- a/generator/integration_tests/golden/tests/golden_kitchen_sink_option_defaults_test.cc
+++ b/generator/integration_tests/golden/tests/golden_kitchen_sink_option_defaults_test.cc
@@ -15,7 +15,7 @@
 #include "generator/integration_tests/golden/internal/golden_kitchen_sink_option_defaults.h"
 #include "google/cloud/common_options.h"
 #include "google/cloud/grpc_options.h"
-#include "google/cloud/internal/setenv.h"
+#include "google/cloud/testing_util/scoped_environment.h"
 #include <gtest/gtest.h>
 #include <memory>
 
@@ -25,7 +25,10 @@ namespace golden_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
+using ::google::cloud::testing_util::ScopedEnvironment;
+
 TEST(GoldenKitchenSinkDefaultOptions, DefaultEndpoint) {
+  auto env = ScopedEnvironment("GOLDEN_KITCHEN_SINK_ENDPOINT", absl::nullopt);
   Options options;
   auto updated_options = GoldenKitchenSinkDefaultOptions(options);
   EXPECT_EQ("goldenkitchensink.googleapis.com",
@@ -33,18 +36,42 @@ TEST(GoldenKitchenSinkDefaultOptions, DefaultEndpoint) {
 }
 
 TEST(GoldenKitchenSinkDefaultOptions, EnvVarEndpoint) {
-  internal::SetEnv("GOLDEN_KITCHEN_SINK_ENDPOINT", "foo.googleapis.com");
+  auto env =
+      ScopedEnvironment("GOLDEN_KITCHEN_SINK_ENDPOINT", "foo.googleapis.com");
   Options options;
   auto updated_options = GoldenKitchenSinkDefaultOptions(options);
   EXPECT_EQ("foo.googleapis.com", updated_options.get<EndpointOption>());
 }
 
 TEST(GoldenKitchenSinkDefaultOptions, OptionEndpoint) {
-  internal::SetEnv("GOLDEN_KITCHEN_SINK_ENDPOINT", "foo.googleapis.com");
+  auto env =
+      ScopedEnvironment("GOLDEN_KITCHEN_SINK_ENDPOINT", "foo.googleapis.com");
   Options options;
   options.set<EndpointOption>("bar.googleapis.com");
   auto updated_options = GoldenKitchenSinkDefaultOptions(options);
   EXPECT_EQ("bar.googleapis.com", updated_options.get<EndpointOption>());
+}
+
+TEST(GoldenKitchenSinkDefaultOptions, DefaultUserProject) {
+  auto env = ScopedEnvironment("GOOGLE_CLOUD_CPP_USER_PROJECT", absl::nullopt);
+  Options options;
+  auto updated_options = GoldenKitchenSinkDefaultOptions(options);
+  EXPECT_FALSE(updated_options.has<UserProjectOption>());
+  EXPECT_EQ("", updated_options.get<UserProjectOption>());
+}
+
+TEST(GoldenKitchenSinkDefaultOptions, EnvVarUserProject) {
+  auto env = ScopedEnvironment("GOOGLE_CLOUD_CPP_USER_PROJECT", "test-project");
+  Options options;
+  auto updated_options = GoldenKitchenSinkDefaultOptions(options);
+  EXPECT_EQ("test-project", updated_options.get<UserProjectOption>());
+}
+
+TEST(GoldenKitchenSinkDefaultOptions, OptionUserProject) {
+  auto env = ScopedEnvironment("GOOGLE_CLOUD_CPP_USER_PROJECT", "test-project");
+  auto options = Options{}.set<UserProjectOption>("another-project");
+  auto updated_options = GoldenKitchenSinkDefaultOptions(options);
+  EXPECT_EQ("another-project", updated_options.get<UserProjectOption>());
 }
 
 }  // namespace

--- a/generator/internal/metadata_decorator_generator.cc
+++ b/generator/internal/metadata_decorator_generator.cc
@@ -181,6 +181,7 @@ Status MetadataDecoratorGenerator::GenerateCc() {
   CcPrint("\n");
   CcLocalIncludes({vars("metadata_header_path"),
                    "google/cloud/internal/api_client_header.h",
+                   "google/cloud/common_options.h",
                    "google/cloud/status_or.h"});
   CcSystemIncludes({vars("proto_grpc_header_path"), "memory"});
 
@@ -342,6 +343,11 @@ void $metadata_class_name$::SetMetadata(grpc::ClientContext& context,
 
 void $metadata_class_name$::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata(
+        "x-goog-user-project", options.get<UserProjectOption>());
+  }
 }
 )""");
 

--- a/generator/internal/option_defaults_generator.cc
+++ b/generator/internal/option_defaults_generator.cc
@@ -92,12 +92,19 @@ Status OptionDefaultsGenerator::GenerateCc() {
   //  clang-format on
 
   CcPrint(  // clang-format off
-  {{"\n"
-    "Options $service_name$DefaultOptions(Options options) {\n"
-    "  if (!options.has<EndpointOption>()) {\n"
-    "    auto env = internal::GetEnv(\"$service_endpoint_env_var$\");\n"
-    "    options.set<EndpointOption>(env && !env->empty() ? *env : \"$service_endpoint$\");\n"
-    "  }\n"},
+  {{R"""(
+Options $service_name$DefaultOptions(Options options) {
+  if (!options.has<EndpointOption>()) {
+    auto env = internal::GetEnv("$service_endpoint_env_var$");
+    options.set<EndpointOption>(
+        env && !env->empty() ? *env : "$service_endpoint$");
+  }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
+)"""
+    },
    {[this]{return vars("emulator_endpoint_env_var").empty();}, "",
     "  if (auto emulator = internal::GetEnv(\"$emulator_endpoint_env_var$\")) {\n"
     "    options.set<EndpointOption>(*emulator).set<GrpcCredentialOption>(\n"

--- a/google/cloud/accessapproval/internal/access_approval_metadata_decorator.cc
+++ b/google/cloud/accessapproval/internal/access_approval_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/cloud/accessapproval/v1/accessapproval.proto
 
 #include "google/cloud/accessapproval/internal/access_approval_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/cloud/accessapproval/v1/accessapproval.grpc.pb.h>
@@ -103,6 +104,11 @@ void AccessApprovalMetadata::SetMetadata(grpc::ClientContext& context,
 
 void AccessApprovalMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/accessapproval/internal/access_approval_option_defaults.cc
+++ b/google/cloud/accessapproval/internal/access_approval_option_defaults.cc
@@ -42,6 +42,10 @@ Options AccessApprovalDefaultOptions(Options options) {
     options.set<EndpointOption>(
         env && !env->empty() ? *env : "accessapproval.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/accesscontextmanager/internal/access_context_manager_metadata_decorator.cc
+++ b/google/cloud/accesscontextmanager/internal/access_context_manager_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/identity/accesscontextmanager/v1/access_context_manager.proto
 
 #include "google/cloud/accesscontextmanager/internal/access_context_manager_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/identity/accesscontextmanager/v1/access_context_manager.grpc.pb.h>
@@ -286,6 +287,11 @@ void AccessContextManagerMetadata::SetMetadata(
 
 void AccessContextManagerMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/accesscontextmanager/internal/access_context_manager_option_defaults.cc
+++ b/google/cloud/accesscontextmanager/internal/access_context_manager_option_defaults.cc
@@ -43,6 +43,10 @@ Options AccessContextManagerDefaultOptions(Options options) {
     options.set<EndpointOption>(
         env && !env->empty() ? *env : "accesscontextmanager.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/apigateway/internal/api_gateway_metadata_decorator.cc
+++ b/google/cloud/apigateway/internal/api_gateway_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/cloud/apigateway/v1/apigateway_service.proto
 
 #include "google/cloud/apigateway/internal/api_gateway_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/cloud/apigateway/v1/apigateway_service.grpc.pb.h>
@@ -186,6 +187,11 @@ void ApiGatewayServiceMetadata::SetMetadata(grpc::ClientContext& context,
 
 void ApiGatewayServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/apigateway/internal/api_gateway_option_defaults.cc
+++ b/google/cloud/apigateway/internal/api_gateway_option_defaults.cc
@@ -43,6 +43,10 @@ Options ApiGatewayServiceDefaultOptions(Options options) {
     options.set<EndpointOption>(
         env && !env->empty() ? *env : "apigateway.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/apigeeconnect/internal/connection_metadata_decorator.cc
+++ b/google/cloud/apigeeconnect/internal/connection_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/cloud/apigeeconnect/v1/connection.proto
 
 #include "google/cloud/apigeeconnect/internal/connection_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/cloud/apigeeconnect/v1/connection.grpc.pb.h>
@@ -49,6 +50,11 @@ void ConnectionServiceMetadata::SetMetadata(grpc::ClientContext& context,
 
 void ConnectionServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/apigeeconnect/internal/connection_option_defaults.cc
+++ b/google/cloud/apigeeconnect/internal/connection_option_defaults.cc
@@ -42,6 +42,10 @@ Options ConnectionServiceDefaultOptions(Options options) {
     options.set<EndpointOption>(
         env && !env->empty() ? *env : "apigeeconnect.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/appengine/internal/applications_metadata_decorator.cc
+++ b/google/cloud/appengine/internal/applications_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/appengine/v1/appengine.proto
 
 #include "google/cloud/appengine/internal/applications_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/appengine/v1/appengine.grpc.pb.h>
@@ -93,6 +94,11 @@ void ApplicationsMetadata::SetMetadata(grpc::ClientContext& context,
 
 void ApplicationsMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/appengine/internal/applications_option_defaults.cc
+++ b/google/cloud/appengine/internal/applications_option_defaults.cc
@@ -42,6 +42,10 @@ Options ApplicationsDefaultOptions(Options options) {
     options.set<EndpointOption>(
         env && !env->empty() ? *env : "appengine.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/appengine/internal/authorized_certificates_metadata_decorator.cc
+++ b/google/cloud/appengine/internal/authorized_certificates_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/appengine/v1/appengine.proto
 
 #include "google/cloud/appengine/internal/authorized_certificates_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/appengine/v1/appengine.grpc.pb.h>
@@ -80,6 +81,11 @@ void AuthorizedCertificatesMetadata::SetMetadata(
 
 void AuthorizedCertificatesMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/appengine/internal/authorized_certificates_option_defaults.cc
+++ b/google/cloud/appengine/internal/authorized_certificates_option_defaults.cc
@@ -43,6 +43,10 @@ Options AuthorizedCertificatesDefaultOptions(Options options) {
     options.set<EndpointOption>(
         env && !env->empty() ? *env : "appengine.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/appengine/internal/authorized_domains_metadata_decorator.cc
+++ b/google/cloud/appengine/internal/authorized_domains_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/appengine/v1/appengine.proto
 
 #include "google/cloud/appengine/internal/authorized_domains_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/appengine/v1/appengine.grpc.pb.h>
@@ -49,6 +50,11 @@ void AuthorizedDomainsMetadata::SetMetadata(grpc::ClientContext& context,
 
 void AuthorizedDomainsMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/appengine/internal/authorized_domains_option_defaults.cc
+++ b/google/cloud/appengine/internal/authorized_domains_option_defaults.cc
@@ -42,6 +42,10 @@ Options AuthorizedDomainsDefaultOptions(Options options) {
     options.set<EndpointOption>(
         env && !env->empty() ? *env : "appengine.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/appengine/internal/domain_mappings_metadata_decorator.cc
+++ b/google/cloud/appengine/internal/domain_mappings_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/appengine/v1/appengine.proto
 
 #include "google/cloud/appengine/internal/domain_mappings_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/appengine/v1/appengine.grpc.pb.h>
@@ -101,6 +102,11 @@ void DomainMappingsMetadata::SetMetadata(grpc::ClientContext& context,
 
 void DomainMappingsMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/appengine/internal/domain_mappings_option_defaults.cc
+++ b/google/cloud/appengine/internal/domain_mappings_option_defaults.cc
@@ -42,6 +42,10 @@ Options DomainMappingsDefaultOptions(Options options) {
     options.set<EndpointOption>(
         env && !env->empty() ? *env : "appengine.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/appengine/internal/firewall_metadata_decorator.cc
+++ b/google/cloud/appengine/internal/firewall_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/appengine/v1/appengine.proto
 
 #include "google/cloud/appengine/internal/firewall_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/appengine/v1/appengine.grpc.pb.h>
@@ -86,6 +87,11 @@ void FirewallMetadata::SetMetadata(grpc::ClientContext& context,
 
 void FirewallMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/appengine/internal/firewall_option_defaults.cc
+++ b/google/cloud/appengine/internal/firewall_option_defaults.cc
@@ -42,6 +42,10 @@ Options FirewallDefaultOptions(Options options) {
     options.set<EndpointOption>(
         env && !env->empty() ? *env : "appengine.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/appengine/internal/instances_metadata_decorator.cc
+++ b/google/cloud/appengine/internal/instances_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/appengine/v1/appengine.proto
 
 #include "google/cloud/appengine/internal/instances_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/appengine/v1/appengine.grpc.pb.h>
@@ -90,6 +91,11 @@ void InstancesMetadata::SetMetadata(grpc::ClientContext& context,
 
 void InstancesMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/appengine/internal/instances_option_defaults.cc
+++ b/google/cloud/appengine/internal/instances_option_defaults.cc
@@ -42,6 +42,10 @@ Options InstancesDefaultOptions(Options options) {
     options.set<EndpointOption>(
         env && !env->empty() ? *env : "appengine.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/appengine/internal/services_metadata_decorator.cc
+++ b/google/cloud/appengine/internal/services_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/appengine/v1/appengine.proto
 
 #include "google/cloud/appengine/internal/services_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/appengine/v1/appengine.grpc.pb.h>
@@ -90,6 +91,11 @@ void ServicesMetadata::SetMetadata(grpc::ClientContext& context,
 
 void ServicesMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/appengine/internal/services_option_defaults.cc
+++ b/google/cloud/appengine/internal/services_option_defaults.cc
@@ -42,6 +42,10 @@ Options ServicesDefaultOptions(Options options) {
     options.set<EndpointOption>(
         env && !env->empty() ? *env : "appengine.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/appengine/internal/versions_metadata_decorator.cc
+++ b/google/cloud/appengine/internal/versions_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/appengine/v1/appengine.proto
 
 #include "google/cloud/appengine/internal/versions_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/appengine/v1/appengine.grpc.pb.h>
@@ -99,6 +100,11 @@ void VersionsMetadata::SetMetadata(grpc::ClientContext& context,
 
 void VersionsMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/appengine/internal/versions_option_defaults.cc
+++ b/google/cloud/appengine/internal/versions_option_defaults.cc
@@ -42,6 +42,10 @@ Options VersionsDefaultOptions(Options options) {
     options.set<EndpointOption>(
         env && !env->empty() ? *env : "appengine.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/artifactregistry/internal/artifact_registry_metadata_decorator.cc
+++ b/google/cloud/artifactregistry/internal/artifact_registry_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/devtools/artifactregistry/v1/service.proto
 
 #include "google/cloud/artifactregistry/internal/artifact_registry_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/devtools/artifactregistry/v1/service.grpc.pb.h>
@@ -68,6 +69,11 @@ void ArtifactRegistryMetadata::SetMetadata(grpc::ClientContext& context,
 
 void ArtifactRegistryMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/artifactregistry/internal/artifact_registry_option_defaults.cc
+++ b/google/cloud/artifactregistry/internal/artifact_registry_option_defaults.cc
@@ -42,6 +42,10 @@ Options ArtifactRegistryDefaultOptions(Options options) {
     options.set<EndpointOption>(
         env && !env->empty() ? *env : "artifactregistry.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/asset/internal/asset_metadata_decorator.cc
+++ b/google/cloud/asset/internal/asset_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/cloud/asset/v1/asset_service.proto
 
 #include "google/cloud/asset/internal/asset_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/cloud/asset/v1/asset_service.grpc.pb.h>
@@ -164,6 +165,11 @@ void AssetServiceMetadata::SetMetadata(grpc::ClientContext& context,
 
 void AssetServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/asset/internal/asset_option_defaults.cc
+++ b/google/cloud/asset/internal/asset_option_defaults.cc
@@ -42,6 +42,10 @@ Options AssetServiceDefaultOptions(Options options) {
     options.set<EndpointOption>(
         env && !env->empty() ? *env : "cloudasset.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/assuredworkloads/internal/assured_workloads_metadata_decorator.cc
+++ b/google/cloud/assuredworkloads/internal/assured_workloads_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/cloud/assuredworkloads/v1/assuredworkloads.proto
 
 #include "google/cloud/assuredworkloads/internal/assured_workloads_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/cloud/assuredworkloads/v1/assuredworkloads.grpc.pb.h>
@@ -99,6 +100,11 @@ void AssuredWorkloadsServiceMetadata::SetMetadata(
 void AssuredWorkloadsServiceMetadata::SetMetadata(
     grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/assuredworkloads/internal/assured_workloads_option_defaults.cc
+++ b/google/cloud/assuredworkloads/internal/assured_workloads_option_defaults.cc
@@ -43,6 +43,10 @@ Options AssuredWorkloadsServiceDefaultOptions(Options options) {
     options.set<EndpointOption>(
         env && !env->empty() ? *env : "assuredworkloads.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/automl/internal/auto_ml_metadata_decorator.cc
+++ b/google/cloud/automl/internal/auto_ml_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/cloud/automl/v1/service.proto
 
 #include "google/cloud/automl/internal/auto_ml_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/cloud/automl/v1/service.grpc.pb.h>
@@ -206,6 +207,11 @@ void AutoMlMetadata::SetMetadata(grpc::ClientContext& context,
 
 void AutoMlMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/automl/internal/auto_ml_option_defaults.cc
+++ b/google/cloud/automl/internal/auto_ml_option_defaults.cc
@@ -42,6 +42,10 @@ Options AutoMlDefaultOptions(Options options) {
     options.set<EndpointOption>(env && !env->empty() ? *env
                                                      : "automl.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/automl/internal/prediction_metadata_decorator.cc
+++ b/google/cloud/automl/internal/prediction_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/cloud/automl/v1/prediction_service.proto
 
 #include "google/cloud/automl/internal/prediction_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/cloud/automl/v1/prediction_service.grpc.pb.h>
@@ -75,6 +76,11 @@ void PredictionServiceMetadata::SetMetadata(grpc::ClientContext& context,
 
 void PredictionServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/automl/internal/prediction_option_defaults.cc
+++ b/google/cloud/automl/internal/prediction_option_defaults.cc
@@ -42,6 +42,10 @@ Options PredictionServiceDefaultOptions(Options options) {
     options.set<EndpointOption>(env && !env->empty() ? *env
                                                      : "automl.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/bigquery/internal/bigquery_read_metadata_decorator.cc
+++ b/google/cloud/bigquery/internal/bigquery_read_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/cloud/bigquery/storage/v1/storage.proto
 
 #include "google/cloud/bigquery/internal/bigquery_read_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/cloud/bigquery/storage/v1/storage.grpc.pb.h>
@@ -68,6 +69,11 @@ void BigQueryReadMetadata::SetMetadata(grpc::ClientContext& context,
 
 void BigQueryReadMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/bigquery/internal/bigquery_read_option_defaults.cc
+++ b/google/cloud/bigquery/internal/bigquery_read_option_defaults.cc
@@ -42,6 +42,10 @@ Options BigQueryReadDefaultOptions(Options options) {
     options.set<EndpointOption>(
         env && !env->empty() ? *env : "bigquerystorage.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/bigtable/admin/internal/bigtable_instance_admin_metadata_decorator.cc
+++ b/google/cloud/bigtable/admin/internal/bigtable_instance_admin_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/bigtable/admin/v2/bigtable_instance_admin.proto
 
 #include "google/cloud/bigtable/admin/internal/bigtable_instance_admin_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/bigtable/admin/v2/bigtable_instance_admin.grpc.pb.h>
@@ -219,6 +220,11 @@ void BigtableInstanceAdminMetadata::SetMetadata(
 
 void BigtableInstanceAdminMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/bigtable/admin/internal/bigtable_instance_admin_option_defaults.cc
+++ b/google/cloud/bigtable/admin/internal/bigtable_instance_admin_option_defaults.cc
@@ -43,6 +43,10 @@ Options BigtableInstanceAdminDefaultOptions(Options options) {
     options.set<EndpointOption>(
         env && !env->empty() ? *env : "bigtableadmin.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (auto emulator =
           internal::GetEnv("BIGTABLE_INSTANCE_ADMIN_EMULATOR_HOST")) {
     options.set<EndpointOption>(*emulator).set<GrpcCredentialOption>(

--- a/google/cloud/bigtable/admin/internal/bigtable_table_admin_metadata_decorator.cc
+++ b/google/cloud/bigtable/admin/internal/bigtable_table_admin_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/bigtable/admin/v2/bigtable_table_admin.proto
 
 #include "google/cloud/bigtable/admin/internal/bigtable_table_admin_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/bigtable/admin/v2/bigtable_table_admin.grpc.pb.h>
@@ -201,6 +202,11 @@ void BigtableTableAdminMetadata::SetMetadata(
 
 void BigtableTableAdminMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/bigtable/admin/internal/bigtable_table_admin_option_defaults.cc
+++ b/google/cloud/bigtable/admin/internal/bigtable_table_admin_option_defaults.cc
@@ -43,6 +43,10 @@ Options BigtableTableAdminDefaultOptions(Options options) {
     options.set<EndpointOption>(
         env && !env->empty() ? *env : "bigtableadmin.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (auto emulator = internal::GetEnv("BIGTABLE_EMULATOR_HOST")) {
     options.set<EndpointOption>(*emulator).set<GrpcCredentialOption>(
         grpc::InsecureChannelCredentials());

--- a/google/cloud/billing/internal/budget_metadata_decorator.cc
+++ b/google/cloud/billing/internal/budget_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/cloud/billing/budgets/v1/budget_service.proto
 
 #include "google/cloud/billing/internal/budget_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/cloud/billing/budgets/v1/budget_service.grpc.pb.h>
@@ -80,6 +81,11 @@ void BudgetServiceMetadata::SetMetadata(grpc::ClientContext& context,
 
 void BudgetServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/billing/internal/budget_option_defaults.cc
+++ b/google/cloud/billing/internal/budget_option_defaults.cc
@@ -42,6 +42,10 @@ Options BudgetServiceDefaultOptions(Options options) {
     options.set<EndpointOption>(
         env && !env->empty() ? *env : "billingbudgets.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/billing/internal/cloud_billing_metadata_decorator.cc
+++ b/google/cloud/billing/internal/cloud_billing_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/cloud/billing/v1/cloud_billing.proto
 
 #include "google/cloud/billing/internal/cloud_billing_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/cloud/billing/v1/cloud_billing.grpc.pb.h>
@@ -120,6 +121,11 @@ void CloudBillingMetadata::SetMetadata(grpc::ClientContext& context,
 
 void CloudBillingMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/billing/internal/cloud_billing_option_defaults.cc
+++ b/google/cloud/billing/internal/cloud_billing_option_defaults.cc
@@ -42,6 +42,10 @@ Options CloudBillingDefaultOptions(Options options) {
     options.set<EndpointOption>(
         env && !env->empty() ? *env : "cloudbilling.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/billing/internal/cloud_catalog_metadata_decorator.cc
+++ b/google/cloud/billing/internal/cloud_catalog_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/cloud/billing/v1/cloud_catalog.proto
 
 #include "google/cloud/billing/internal/cloud_catalog_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/cloud/billing/v1/cloud_catalog.grpc.pb.h>
@@ -57,6 +58,11 @@ void CloudCatalogMetadata::SetMetadata(grpc::ClientContext& context,
 
 void CloudCatalogMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/billing/internal/cloud_catalog_option_defaults.cc
+++ b/google/cloud/billing/internal/cloud_catalog_option_defaults.cc
@@ -42,6 +42,10 @@ Options CloudCatalogDefaultOptions(Options options) {
     options.set<EndpointOption>(
         env && !env->empty() ? *env : "cloudbilling.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/binaryauthorization/internal/binauthz_management_service_v1_metadata_decorator.cc
+++ b/google/cloud/binaryauthorization/internal/binauthz_management_service_v1_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/cloud/binaryauthorization/v1/service.proto
 
 #include "google/cloud/binaryauthorization/internal/binauthz_management_service_v1_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/cloud/binaryauthorization/v1/service.grpc.pb.h>
@@ -102,6 +103,11 @@ void BinauthzManagementServiceV1Metadata::SetMetadata(
 void BinauthzManagementServiceV1Metadata::SetMetadata(
     grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/binaryauthorization/internal/binauthz_management_service_v1_option_defaults.cc
+++ b/google/cloud/binaryauthorization/internal/binauthz_management_service_v1_option_defaults.cc
@@ -43,6 +43,10 @@ Options BinauthzManagementServiceV1DefaultOptions(Options options) {
     options.set<EndpointOption>(
         env && !env->empty() ? *env : "binaryauthorization.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/binaryauthorization/internal/system_policy_v1_metadata_decorator.cc
+++ b/google/cloud/binaryauthorization/internal/system_policy_v1_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/cloud/binaryauthorization/v1/service.proto
 
 #include "google/cloud/binaryauthorization/internal/system_policy_v1_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/cloud/binaryauthorization/v1/service.grpc.pb.h>
@@ -50,6 +51,11 @@ void SystemPolicyV1Metadata::SetMetadata(grpc::ClientContext& context,
 
 void SystemPolicyV1Metadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/binaryauthorization/internal/system_policy_v1_option_defaults.cc
+++ b/google/cloud/binaryauthorization/internal/system_policy_v1_option_defaults.cc
@@ -42,6 +42,10 @@ Options SystemPolicyV1DefaultOptions(Options options) {
     options.set<EndpointOption>(
         env && !env->empty() ? *env : "binaryauthorization.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/binaryauthorization/internal/validation_helper_v1_metadata_decorator.cc
+++ b/google/cloud/binaryauthorization/internal/validation_helper_v1_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/cloud/binaryauthorization/v1/service.proto
 
 #include "google/cloud/binaryauthorization/internal/validation_helper_v1_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/cloud/binaryauthorization/v1/service.grpc.pb.h>
@@ -51,6 +52,11 @@ void ValidationHelperV1Metadata::SetMetadata(
 
 void ValidationHelperV1Metadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/binaryauthorization/internal/validation_helper_v1_option_defaults.cc
+++ b/google/cloud/binaryauthorization/internal/validation_helper_v1_option_defaults.cc
@@ -43,6 +43,10 @@ Options ValidationHelperV1DefaultOptions(Options options) {
     options.set<EndpointOption>(
         env && !env->empty() ? *env : "binaryauthorization.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/channel/internal/cloud_channel_metadata_decorator.cc
+++ b/google/cloud/channel/internal/cloud_channel_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/cloud/channel/v1/service.proto
 
 #include "google/cloud/channel/internal/cloud_channel_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/cloud/channel/v1/service.grpc.pb.h>
@@ -353,6 +354,11 @@ void CloudChannelServiceMetadata::SetMetadata(
 
 void CloudChannelServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/channel/internal/cloud_channel_option_defaults.cc
+++ b/google/cloud/channel/internal/cloud_channel_option_defaults.cc
@@ -43,6 +43,10 @@ Options CloudChannelServiceDefaultOptions(Options options) {
     options.set<EndpointOption>(
         env && !env->empty() ? *env : "cloudchannel.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/cloudbuild/internal/cloud_build_metadata_decorator.cc
+++ b/google/cloud/cloudbuild/internal/cloud_build_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/devtools/cloudbuild/v1/cloudbuild.proto
 
 #include "google/cloud/cloudbuild/internal/cloud_build_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/devtools/cloudbuild/v1/cloudbuild.grpc.pb.h>
@@ -210,6 +211,11 @@ void CloudBuildMetadata::SetMetadata(grpc::ClientContext& context,
 
 void CloudBuildMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/cloudbuild/internal/cloud_build_option_defaults.cc
+++ b/google/cloud/cloudbuild/internal/cloud_build_option_defaults.cc
@@ -42,6 +42,10 @@ Options CloudBuildDefaultOptions(Options options) {
     options.set<EndpointOption>(
         env && !env->empty() ? *env : "cloudbuild.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/common_options.h
+++ b/google/cloud/common_options.h
@@ -66,10 +66,24 @@ struct TracingComponentsOption {
 };
 
 /**
+ * Specifies a project for quota and billing purposes.
+ *
+ * The caller must have `serviceusage.services.use` permission on the project.
+ *
+ * @see https://cloud.google.com/iam/docs/permissions-reference for more
+ *     information about the `seviceusage.services.use` permission, including
+ *     default roles that grant it.
+ * @see https://cloud.google.com/apis/docs/system-parameters
+ */
+struct UserProjectOption {
+  using Type = std::string;
+};
+
+/**
  * A list of all the common options.
  */
 using CommonOptionList = OptionList<EndpointOption, UserAgentProductsOption,
-                                    TracingComponentsOption>;
+                                    TracingComponentsOption, UserProjectOption>;
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace cloud

--- a/google/cloud/composer/internal/environments_metadata_decorator.cc
+++ b/google/cloud/composer/internal/environments_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/cloud/orchestration/airflow/service/v1/environments.proto
 
 #include "google/cloud/composer/internal/environments_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/cloud/orchestration/airflow/service/v1/environments.grpc.pb.h>
@@ -107,6 +108,11 @@ void EnvironmentsMetadata::SetMetadata(grpc::ClientContext& context,
 
 void EnvironmentsMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/composer/internal/environments_option_defaults.cc
+++ b/google/cloud/composer/internal/environments_option_defaults.cc
@@ -42,6 +42,10 @@ Options EnvironmentsDefaultOptions(Options options) {
     options.set<EndpointOption>(
         env && !env->empty() ? *env : "composer.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/composer/internal/image_versions_metadata_decorator.cc
+++ b/google/cloud/composer/internal/image_versions_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/cloud/orchestration/airflow/service/v1/image_versions.proto
 
 #include "google/cloud/composer/internal/image_versions_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/cloud/orchestration/airflow/service/v1/image_versions.grpc.pb.h>
@@ -51,6 +52,11 @@ void ImageVersionsMetadata::SetMetadata(grpc::ClientContext& context,
 
 void ImageVersionsMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/composer/internal/image_versions_option_defaults.cc
+++ b/google/cloud/composer/internal/image_versions_option_defaults.cc
@@ -42,6 +42,10 @@ Options ImageVersionsDefaultOptions(Options options) {
     options.set<EndpointOption>(
         env && !env->empty() ? *env : "composer.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/contactcenterinsights/internal/contact_center_insights_metadata_decorator.cc
+++ b/google/cloud/contactcenterinsights/internal/contact_center_insights_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/cloud/contactcenterinsights/v1/contact_center_insights.proto
 
 #include "google/cloud/contactcenterinsights/internal/contact_center_insights_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/cloud/contactcenterinsights/v1/contact_center_insights.grpc.pb.h>
@@ -365,6 +366,11 @@ void ContactCenterInsightsMetadata::SetMetadata(
 
 void ContactCenterInsightsMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/contactcenterinsights/internal/contact_center_insights_option_defaults.cc
+++ b/google/cloud/contactcenterinsights/internal/contact_center_insights_option_defaults.cc
@@ -43,6 +43,10 @@ Options ContactCenterInsightsDefaultOptions(Options options) {
     options.set<EndpointOption>(
         env && !env->empty() ? *env : "contactcenterinsights.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/container/internal/cluster_manager_metadata_decorator.cc
+++ b/google/cloud/container/internal/cluster_manager_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/container/v1/cluster_service.proto
 
 #include "google/cloud/container/internal/cluster_manager_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/container/v1/cluster_service.grpc.pb.h>
@@ -290,6 +291,11 @@ void ClusterManagerMetadata::SetMetadata(grpc::ClientContext& context,
 
 void ClusterManagerMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/container/internal/cluster_manager_option_defaults.cc
+++ b/google/cloud/container/internal/cluster_manager_option_defaults.cc
@@ -42,6 +42,10 @@ Options ClusterManagerDefaultOptions(Options options) {
     options.set<EndpointOption>(
         env && !env->empty() ? *env : "container.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/containeranalysis/internal/container_analysis_metadata_decorator.cc
+++ b/google/cloud/containeranalysis/internal/container_analysis_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/devtools/containeranalysis/v1/containeranalysis.proto
 
 #include "google/cloud/containeranalysis/internal/container_analysis_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/devtools/containeranalysis/v1/containeranalysis.grpc.pb.h>
@@ -73,6 +74,11 @@ void ContainerAnalysisMetadata::SetMetadata(grpc::ClientContext& context,
 
 void ContainerAnalysisMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/containeranalysis/internal/container_analysis_option_defaults.cc
+++ b/google/cloud/containeranalysis/internal/container_analysis_option_defaults.cc
@@ -42,6 +42,10 @@ Options ContainerAnalysisDefaultOptions(Options options) {
     options.set<EndpointOption>(
         env && !env->empty() ? *env : "containeranalysis.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/containeranalysis/internal/grafeas_metadata_decorator.cc
+++ b/google/cloud/containeranalysis/internal/grafeas_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: grafeas/v1/grafeas.proto
 
 #include "google/cloud/containeranalysis/internal/grafeas_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <grafeas/v1/grafeas.grpc.pb.h>
@@ -140,6 +141,11 @@ void GrafeasMetadata::SetMetadata(grpc::ClientContext& context,
 
 void GrafeasMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/containeranalysis/internal/grafeas_option_defaults.cc
+++ b/google/cloud/containeranalysis/internal/grafeas_option_defaults.cc
@@ -42,6 +42,10 @@ Options GrafeasDefaultOptions(Options options) {
     options.set<EndpointOption>(
         env && !env->empty() ? *env : "containeranalysis.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/datacatalog/internal/data_catalog_metadata_decorator.cc
+++ b/google/cloud/datacatalog/internal/data_catalog_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/cloud/datacatalog/v1/datacatalog.proto
 
 #include "google/cloud/datacatalog/internal/data_catalog_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/cloud/datacatalog/v1/datacatalog.grpc.pb.h>
@@ -259,6 +260,11 @@ void DataCatalogMetadata::SetMetadata(grpc::ClientContext& context,
 
 void DataCatalogMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/datacatalog/internal/data_catalog_option_defaults.cc
+++ b/google/cloud/datacatalog/internal/data_catalog_option_defaults.cc
@@ -42,6 +42,10 @@ Options DataCatalogDefaultOptions(Options options) {
     options.set<EndpointOption>(
         env && !env->empty() ? *env : "datacatalog.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/datacatalog/internal/policy_tag_manager_metadata_decorator.cc
+++ b/google/cloud/datacatalog/internal/policy_tag_manager_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/cloud/datacatalog/v1/policytagmanager.proto
 
 #include "google/cloud/datacatalog/internal/policy_tag_manager_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/cloud/datacatalog/v1/policytagmanager.grpc.pb.h>
@@ -141,6 +142,11 @@ void PolicyTagManagerMetadata::SetMetadata(grpc::ClientContext& context,
 
 void PolicyTagManagerMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/datacatalog/internal/policy_tag_manager_option_defaults.cc
+++ b/google/cloud/datacatalog/internal/policy_tag_manager_option_defaults.cc
@@ -42,6 +42,10 @@ Options PolicyTagManagerDefaultOptions(Options options) {
     options.set<EndpointOption>(
         env && !env->empty() ? *env : "datacatalog.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/datacatalog/internal/policy_tag_manager_serialization_metadata_decorator.cc
+++ b/google/cloud/datacatalog/internal/policy_tag_manager_serialization_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/cloud/datacatalog/v1/policytagmanagerserialization.proto
 
 #include "google/cloud/datacatalog/internal/policy_tag_manager_serialization_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/cloud/datacatalog/v1/policytagmanagerserialization.grpc.pb.h>
@@ -66,6 +67,11 @@ void PolicyTagManagerSerializationMetadata::SetMetadata(
 void PolicyTagManagerSerializationMetadata::SetMetadata(
     grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/datacatalog/internal/policy_tag_manager_serialization_option_defaults.cc
+++ b/google/cloud/datacatalog/internal/policy_tag_manager_serialization_option_defaults.cc
@@ -43,6 +43,10 @@ Options PolicyTagManagerSerializationDefaultOptions(Options options) {
     options.set<EndpointOption>(
         env && !env->empty() ? *env : "datacatalog.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/datamigration/internal/data_migration_metadata_decorator.cc
+++ b/google/cloud/datamigration/internal/data_migration_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/cloud/clouddms/v1/clouddms.proto
 
 #include "google/cloud/datamigration/internal/data_migration_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/cloud/clouddms/v1/clouddms.grpc.pb.h>
@@ -210,6 +211,11 @@ void DataMigrationServiceMetadata::SetMetadata(
 
 void DataMigrationServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/datamigration/internal/data_migration_option_defaults.cc
+++ b/google/cloud/datamigration/internal/data_migration_option_defaults.cc
@@ -43,6 +43,10 @@ Options DataMigrationServiceDefaultOptions(Options options) {
     options.set<EndpointOption>(
         env && !env->empty() ? *env : "datamigration.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/debugger/internal/controller2_metadata_decorator.cc
+++ b/google/cloud/debugger/internal/controller2_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/devtools/clouddebugger/v2/controller.proto
 
 #include "google/cloud/debugger/internal/controller2_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/devtools/clouddebugger/v2/controller.grpc.pb.h>
@@ -67,6 +68,11 @@ void Controller2Metadata::SetMetadata(grpc::ClientContext& context,
 
 void Controller2Metadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/debugger/internal/controller2_option_defaults.cc
+++ b/google/cloud/debugger/internal/controller2_option_defaults.cc
@@ -42,6 +42,10 @@ Options Controller2DefaultOptions(Options options) {
     options.set<EndpointOption>(
         env && !env->empty() ? *env : "clouddebugger.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/debugger/internal/debugger2_metadata_decorator.cc
+++ b/google/cloud/debugger/internal/debugger2_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/devtools/clouddebugger/v2/debugger.proto
 
 #include "google/cloud/debugger/internal/debugger2_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/devtools/clouddebugger/v2/debugger.grpc.pb.h>
@@ -81,6 +82,11 @@ void Debugger2Metadata::SetMetadata(grpc::ClientContext& context,
 
 void Debugger2Metadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/debugger/internal/debugger2_option_defaults.cc
+++ b/google/cloud/debugger/internal/debugger2_option_defaults.cc
@@ -42,6 +42,10 @@ Options Debugger2DefaultOptions(Options options) {
     options.set<EndpointOption>(
         env && !env->empty() ? *env : "clouddebugger.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/dlp/internal/dlp_metadata_decorator.cc
+++ b/google/cloud/dlp/internal/dlp_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/privacy/dlp/v2/dlp.proto
 
 #include "google/cloud/dlp/internal/dlp_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/privacy/dlp/v2/dlp.grpc.pb.h>
@@ -303,6 +304,11 @@ void DlpServiceMetadata::SetMetadata(grpc::ClientContext& context,
 
 void DlpServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/dlp/internal/dlp_option_defaults.cc
+++ b/google/cloud/dlp/internal/dlp_option_defaults.cc
@@ -42,6 +42,10 @@ Options DlpServiceDefaultOptions(Options options) {
     options.set<EndpointOption>(env && !env->empty() ? *env
                                                      : "dlp.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/eventarc/internal/eventarc_metadata_decorator.cc
+++ b/google/cloud/eventarc/internal/eventarc_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/cloud/eventarc/v1/eventarc.proto
 
 #include "google/cloud/eventarc/internal/eventarc_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/cloud/eventarc/v1/eventarc.grpc.pb.h>
@@ -99,6 +100,11 @@ void EventarcMetadata::SetMetadata(grpc::ClientContext& context,
 
 void EventarcMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/eventarc/internal/eventarc_option_defaults.cc
+++ b/google/cloud/eventarc/internal/eventarc_option_defaults.cc
@@ -42,6 +42,10 @@ Options EventarcDefaultOptions(Options options) {
     options.set<EndpointOption>(
         env && !env->empty() ? *env : "eventarc.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/eventarc/internal/publisher_metadata_decorator.cc
+++ b/google/cloud/eventarc/internal/publisher_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/cloud/eventarc/publishing/v1/publisher.proto
 
 #include "google/cloud/eventarc/internal/publisher_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/cloud/eventarc/publishing/v1/publisher.grpc.pb.h>
@@ -50,6 +51,11 @@ void PublisherMetadata::SetMetadata(grpc::ClientContext& context,
 
 void PublisherMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/eventarc/internal/publisher_option_defaults.cc
+++ b/google/cloud/eventarc/internal/publisher_option_defaults.cc
@@ -42,6 +42,10 @@ Options PublisherDefaultOptions(Options options) {
     options.set<EndpointOption>(
         env && !env->empty() ? *env : "eventarcpublishing.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/filestore/internal/cloud_filestore_manager_metadata_decorator.cc
+++ b/google/cloud/filestore/internal/cloud_filestore_manager_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/cloud/filestore/v1/cloud_filestore_service.proto
 
 #include "google/cloud/filestore/internal/cloud_filestore_manager_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/cloud/filestore/v1/cloud_filestore_service.grpc.pb.h>
@@ -153,6 +154,11 @@ void CloudFilestoreManagerMetadata::SetMetadata(
 
 void CloudFilestoreManagerMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/filestore/internal/cloud_filestore_manager_option_defaults.cc
+++ b/google/cloud/filestore/internal/cloud_filestore_manager_option_defaults.cc
@@ -43,6 +43,10 @@ Options CloudFilestoreManagerDefaultOptions(Options options) {
     options.set<EndpointOption>(env && !env->empty() ? *env
                                                      : "file.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/functions/internal/cloud_functions_metadata_decorator.cc
+++ b/google/cloud/functions/internal/cloud_functions_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/cloud/functions/v1/functions.proto
 
 #include "google/cloud/functions/internal/cloud_functions_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/cloud/functions/v1/functions.grpc.pb.h>
@@ -147,6 +148,11 @@ void CloudFunctionsServiceMetadata::SetMetadata(
 
 void CloudFunctionsServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/functions/internal/cloud_functions_option_defaults.cc
+++ b/google/cloud/functions/internal/cloud_functions_option_defaults.cc
@@ -43,6 +43,10 @@ Options CloudFunctionsServiceDefaultOptions(Options options) {
     options.set<EndpointOption>(
         env && !env->empty() ? *env : "cloudfunctions.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/gameservices/internal/game_server_clusters_metadata_decorator.cc
+++ b/google/cloud/gameservices/internal/game_server_clusters_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/cloud/gaming/v1/game_server_clusters_service.proto
 
 #include "google/cloud/gameservices/internal/game_server_clusters_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/cloud/gaming/v1/game_server_clusters_service.grpc.pb.h>
@@ -131,6 +132,11 @@ void GameServerClustersServiceMetadata::SetMetadata(
 void GameServerClustersServiceMetadata::SetMetadata(
     grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/gameservices/internal/game_server_clusters_option_defaults.cc
+++ b/google/cloud/gameservices/internal/game_server_clusters_option_defaults.cc
@@ -43,6 +43,10 @@ Options GameServerClustersServiceDefaultOptions(Options options) {
     options.set<EndpointOption>(
         env && !env->empty() ? *env : "gameservices.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/gameservices/internal/game_server_configs_metadata_decorator.cc
+++ b/google/cloud/gameservices/internal/game_server_configs_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/cloud/gaming/v1/game_server_configs_service.proto
 
 #include "google/cloud/gameservices/internal/game_server_configs_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/cloud/gaming/v1/game_server_configs_service.grpc.pb.h>
@@ -93,6 +94,11 @@ void GameServerConfigsServiceMetadata::SetMetadata(
 void GameServerConfigsServiceMetadata::SetMetadata(
     grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/gameservices/internal/game_server_configs_option_defaults.cc
+++ b/google/cloud/gameservices/internal/game_server_configs_option_defaults.cc
@@ -43,6 +43,10 @@ Options GameServerConfigsServiceDefaultOptions(Options options) {
     options.set<EndpointOption>(
         env && !env->empty() ? *env : "gameservices.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/gameservices/internal/game_server_deployments_metadata_decorator.cc
+++ b/google/cloud/gameservices/internal/game_server_deployments_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/cloud/gaming/v1/game_server_deployments_service.proto
 
 #include "google/cloud/gameservices/internal/game_server_deployments_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/cloud/gaming/v1/game_server_deployments_service.grpc.pb.h>
@@ -147,6 +148,11 @@ void GameServerDeploymentsServiceMetadata::SetMetadata(
 void GameServerDeploymentsServiceMetadata::SetMetadata(
     grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/gameservices/internal/game_server_deployments_option_defaults.cc
+++ b/google/cloud/gameservices/internal/game_server_deployments_option_defaults.cc
@@ -43,6 +43,10 @@ Options GameServerDeploymentsServiceDefaultOptions(Options options) {
     options.set<EndpointOption>(
         env && !env->empty() ? *env : "gameservices.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/gameservices/internal/realms_metadata_decorator.cc
+++ b/google/cloud/gameservices/internal/realms_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/cloud/gaming/v1/realms_service.proto
 
 #include "google/cloud/gameservices/internal/realms_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/cloud/gaming/v1/realms_service.grpc.pb.h>
@@ -108,6 +109,11 @@ void RealmsServiceMetadata::SetMetadata(grpc::ClientContext& context,
 
 void RealmsServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/gameservices/internal/realms_option_defaults.cc
+++ b/google/cloud/gameservices/internal/realms_option_defaults.cc
@@ -42,6 +42,10 @@ Options RealmsServiceDefaultOptions(Options options) {
     options.set<EndpointOption>(
         env && !env->empty() ? *env : "gameservices.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/gkehub/internal/gke_hub_metadata_decorator.cc
+++ b/google/cloud/gkehub/internal/gke_hub_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/cloud/gkehub/v1/service.proto
 
 #include "google/cloud/gkehub/internal/gke_hub_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/cloud/gkehub/v1/service.grpc.pb.h>
@@ -149,6 +150,11 @@ void GkeHubMetadata::SetMetadata(grpc::ClientContext& context,
 
 void GkeHubMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/gkehub/internal/gke_hub_option_defaults.cc
+++ b/google/cloud/gkehub/internal/gke_hub_option_defaults.cc
@@ -42,6 +42,10 @@ Options GkeHubDefaultOptions(Options options) {
     options.set<EndpointOption>(env && !env->empty() ? *env
                                                      : "gkehub.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/iam/internal/iam_credentials_metadata_decorator.cc
+++ b/google/cloud/iam/internal/iam_credentials_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/iam/credentials/v1/iamcredentials.proto
 
 #include "google/cloud/iam/internal/iam_credentials_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/iam/credentials/v1/iamcredentials.grpc.pb.h>
@@ -73,6 +74,11 @@ void IAMCredentialsMetadata::SetMetadata(grpc::ClientContext& context,
 
 void IAMCredentialsMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/iam/internal/iam_credentials_option_defaults.cc
+++ b/google/cloud/iam/internal/iam_credentials_option_defaults.cc
@@ -42,6 +42,10 @@ Options IAMCredentialsDefaultOptions(Options options) {
     options.set<EndpointOption>(
         env && !env->empty() ? *env : "iamcredentials.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/iam/internal/iam_metadata_decorator.cc
+++ b/google/cloud/iam/internal/iam_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/iam/admin/v1/iam.proto
 
 #include "google/cloud/iam/internal/iam_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/iam/admin/v1/iam.grpc.pb.h>
@@ -235,6 +236,11 @@ void IAMMetadata::SetMetadata(grpc::ClientContext& context,
 
 void IAMMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/iam/internal/iam_option_defaults.cc
+++ b/google/cloud/iam/internal/iam_option_defaults.cc
@@ -42,6 +42,10 @@ Options IAMDefaultOptions(Options options) {
     options.set<EndpointOption>(env && !env->empty() ? *env
                                                      : "iam.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/iap/internal/identity_aware_proxy_admin_metadata_decorator.cc
+++ b/google/cloud/iap/internal/identity_aware_proxy_admin_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/cloud/iap/v1/service.proto
 
 #include "google/cloud/iap/internal/identity_aware_proxy_admin_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/cloud/iap/v1/service.grpc.pb.h>
@@ -82,6 +83,11 @@ void IdentityAwareProxyAdminServiceMetadata::SetMetadata(
 void IdentityAwareProxyAdminServiceMetadata::SetMetadata(
     grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/iap/internal/identity_aware_proxy_admin_option_defaults.cc
+++ b/google/cloud/iap/internal/identity_aware_proxy_admin_option_defaults.cc
@@ -43,6 +43,10 @@ Options IdentityAwareProxyAdminServiceDefaultOptions(Options options) {
     options.set<EndpointOption>(env && !env->empty() ? *env
                                                      : "iap.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/iap/internal/identity_aware_proxy_o_auth_metadata_decorator.cc
+++ b/google/cloud/iap/internal/identity_aware_proxy_o_auth_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/cloud/iap/v1/service.proto
 
 #include "google/cloud/iap/internal/identity_aware_proxy_o_auth_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/cloud/iap/v1/service.grpc.pb.h>
@@ -109,6 +110,11 @@ void IdentityAwareProxyOAuthServiceMetadata::SetMetadata(
 void IdentityAwareProxyOAuthServiceMetadata::SetMetadata(
     grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/iap/internal/identity_aware_proxy_o_auth_option_defaults.cc
+++ b/google/cloud/iap/internal/identity_aware_proxy_o_auth_option_defaults.cc
@@ -43,6 +43,10 @@ Options IdentityAwareProxyOAuthServiceDefaultOptions(Options options) {
     options.set<EndpointOption>(env && !env->empty() ? *env
                                                      : "iap.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/ids/internal/ids_metadata_decorator.cc
+++ b/google/cloud/ids/internal/ids_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/cloud/ids/v1/ids.proto
 
 #include "google/cloud/ids/internal/ids_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/cloud/ids/v1/ids.grpc.pb.h>
@@ -89,6 +90,11 @@ void IDSMetadata::SetMetadata(grpc::ClientContext& context,
 
 void IDSMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/ids/internal/ids_option_defaults.cc
+++ b/google/cloud/ids/internal/ids_option_defaults.cc
@@ -42,6 +42,10 @@ Options IDSDefaultOptions(Options options) {
     options.set<EndpointOption>(env && !env->empty() ? *env
                                                      : "ids.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/iot/internal/device_manager_metadata_decorator.cc
+++ b/google/cloud/iot/internal/device_manager_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/cloud/iot/v1/device_manager.proto
 
 #include "google/cloud/iot/internal/device_manager_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/cloud/iot/v1/device_manager.grpc.pb.h>
@@ -187,6 +188,11 @@ void DeviceManagerMetadata::SetMetadata(grpc::ClientContext& context,
 
 void DeviceManagerMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/iot/internal/device_manager_option_defaults.cc
+++ b/google/cloud/iot/internal/device_manager_option_defaults.cc
@@ -42,6 +42,10 @@ Options DeviceManagerDefaultOptions(Options options) {
     options.set<EndpointOption>(
         env && !env->empty() ? *env : "cloudiot.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/kms/internal/key_management_metadata_decorator.cc
+++ b/google/cloud/kms/internal/key_management_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/cloud/kms/v1/service.proto
 
 #include "google/cloud/kms/internal/key_management_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/cloud/kms/v1/service.grpc.pb.h>
@@ -251,6 +252,11 @@ void KeyManagementServiceMetadata::SetMetadata(
 
 void KeyManagementServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/kms/internal/key_management_option_defaults.cc
+++ b/google/cloud/kms/internal/key_management_option_defaults.cc
@@ -43,6 +43,10 @@ Options KeyManagementServiceDefaultOptions(Options options) {
     options.set<EndpointOption>(
         env && !env->empty() ? *env : "cloudkms.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/language/internal/language_metadata_decorator.cc
+++ b/google/cloud/language/internal/language_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/cloud/language/v1/language_service.proto
 
 #include "google/cloud/language/internal/language_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/cloud/language/v1/language_service.grpc.pb.h>
@@ -89,6 +90,11 @@ void LanguageServiceMetadata::SetMetadata(grpc::ClientContext& context,
 
 void LanguageServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/language/internal/language_option_defaults.cc
+++ b/google/cloud/language/internal/language_option_defaults.cc
@@ -42,6 +42,10 @@ Options LanguageServiceDefaultOptions(Options options) {
     options.set<EndpointOption>(
         env && !env->empty() ? *env : "language.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/logging/internal/logging_service_v2_metadata_decorator.cc
+++ b/google/cloud/logging/internal/logging_service_v2_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/logging/v2/logging.proto
 
 #include "google/cloud/logging/internal/logging_service_v2_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/logging/v2/logging.grpc.pb.h>
@@ -91,6 +92,11 @@ void LoggingServiceV2Metadata::SetMetadata(grpc::ClientContext& context,
 
 void LoggingServiceV2Metadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/logging/internal/logging_service_v2_option_defaults.cc
+++ b/google/cloud/logging/internal/logging_service_v2_option_defaults.cc
@@ -42,6 +42,10 @@ Options LoggingServiceV2DefaultOptions(Options options) {
     options.set<EndpointOption>(
         env && !env->empty() ? *env : "logging.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/managedidentities/internal/managed_identities_metadata_decorator.cc
+++ b/google/cloud/managedidentities/internal/managed_identities_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/cloud/managedidentities/v1/managed_identities_service.proto
 
 #include "google/cloud/managedidentities/internal/managed_identities_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/cloud/managedidentities/v1/managed_identities_service.grpc.pb.h>
@@ -149,6 +150,11 @@ void ManagedIdentitiesServiceMetadata::SetMetadata(
 void ManagedIdentitiesServiceMetadata::SetMetadata(
     grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/managedidentities/internal/managed_identities_option_defaults.cc
+++ b/google/cloud/managedidentities/internal/managed_identities_option_defaults.cc
@@ -43,6 +43,10 @@ Options ManagedIdentitiesServiceDefaultOptions(Options options) {
     options.set<EndpointOption>(
         env && !env->empty() ? *env : "managedidentities.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/memcache/internal/cloud_memcache_metadata_decorator.cc
+++ b/google/cloud/memcache/internal/cloud_memcache_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/cloud/memcache/v1/cloud_memcache.proto
 
 #include "google/cloud/memcache/internal/cloud_memcache_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/cloud/memcache/v1/cloud_memcache.grpc.pb.h>
@@ -119,6 +120,11 @@ void CloudMemcacheMetadata::SetMetadata(grpc::ClientContext& context,
 
 void CloudMemcacheMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/memcache/internal/cloud_memcache_option_defaults.cc
+++ b/google/cloud/memcache/internal/cloud_memcache_option_defaults.cc
@@ -42,6 +42,10 @@ Options CloudMemcacheDefaultOptions(Options options) {
     options.set<EndpointOption>(
         env && !env->empty() ? *env : "memcache.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/monitoring/internal/alert_policy_metadata_decorator.cc
+++ b/google/cloud/monitoring/internal/alert_policy_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/monitoring/v3/alert_service.proto
 
 #include "google/cloud/monitoring/internal/alert_policy_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/monitoring/v3/alert_service.grpc.pb.h>
@@ -80,6 +81,11 @@ void AlertPolicyServiceMetadata::SetMetadata(
 
 void AlertPolicyServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/monitoring/internal/alert_policy_option_defaults.cc
+++ b/google/cloud/monitoring/internal/alert_policy_option_defaults.cc
@@ -43,6 +43,10 @@ Options AlertPolicyServiceDefaultOptions(Options options) {
     options.set<EndpointOption>(
         env && !env->empty() ? *env : "monitoring.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/monitoring/internal/dashboards_metadata_decorator.cc
+++ b/google/cloud/monitoring/internal/dashboards_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/monitoring/dashboard/v1/dashboards_service.proto
 
 #include "google/cloud/monitoring/internal/dashboards_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/monitoring/dashboard/v1/dashboards_service.grpc.pb.h>
@@ -80,6 +81,11 @@ void DashboardsServiceMetadata::SetMetadata(grpc::ClientContext& context,
 
 void DashboardsServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/monitoring/internal/dashboards_option_defaults.cc
+++ b/google/cloud/monitoring/internal/dashboards_option_defaults.cc
@@ -42,6 +42,10 @@ Options DashboardsServiceDefaultOptions(Options options) {
     options.set<EndpointOption>(
         env && !env->empty() ? *env : "monitoring.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/monitoring/internal/group_metadata_decorator.cc
+++ b/google/cloud/monitoring/internal/group_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/monitoring/v3/group_service.proto
 
 #include "google/cloud/monitoring/internal/group_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/monitoring/v3/group_service.grpc.pb.h>
@@ -85,6 +86,11 @@ void GroupServiceMetadata::SetMetadata(grpc::ClientContext& context,
 
 void GroupServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/monitoring/internal/group_option_defaults.cc
+++ b/google/cloud/monitoring/internal/group_option_defaults.cc
@@ -42,6 +42,10 @@ Options GroupServiceDefaultOptions(Options options) {
     options.set<EndpointOption>(
         env && !env->empty() ? *env : "monitoring.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/monitoring/internal/metric_metadata_decorator.cc
+++ b/google/cloud/monitoring/internal/metric_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/monitoring/v3/metric_service.proto
 
 #include "google/cloud/monitoring/internal/metric_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/monitoring/v3/metric_service.grpc.pb.h>
@@ -112,6 +113,11 @@ void MetricServiceMetadata::SetMetadata(grpc::ClientContext& context,
 
 void MetricServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/monitoring/internal/metric_option_defaults.cc
+++ b/google/cloud/monitoring/internal/metric_option_defaults.cc
@@ -42,6 +42,10 @@ Options MetricServiceDefaultOptions(Options options) {
     options.set<EndpointOption>(
         env && !env->empty() ? *env : "monitoring.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/monitoring/internal/metrics_scopes_metadata_decorator.cc
+++ b/google/cloud/monitoring/internal/metrics_scopes_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/monitoring/metricsscope/v1/metrics_scopes.proto
 
 #include "google/cloud/monitoring/internal/metrics_scopes_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/monitoring/metricsscope/v1/metrics_scopes.grpc.pb.h>
@@ -97,6 +98,11 @@ void MetricsScopesMetadata::SetMetadata(grpc::ClientContext& context,
 
 void MetricsScopesMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/monitoring/internal/metrics_scopes_option_defaults.cc
+++ b/google/cloud/monitoring/internal/metrics_scopes_option_defaults.cc
@@ -42,6 +42,10 @@ Options MetricsScopesDefaultOptions(Options options) {
     options.set<EndpointOption>(
         env && !env->empty() ? *env : "monitoring.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/monitoring/internal/notification_channel_metadata_decorator.cc
+++ b/google/cloud/monitoring/internal/notification_channel_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/monitoring/v3/notification_service.proto
 
 #include "google/cloud/monitoring/internal/notification_channel_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/monitoring/v3/notification_service.grpc.pb.h>
@@ -126,6 +127,11 @@ void NotificationChannelServiceMetadata::SetMetadata(
 void NotificationChannelServiceMetadata::SetMetadata(
     grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/monitoring/internal/notification_channel_option_defaults.cc
+++ b/google/cloud/monitoring/internal/notification_channel_option_defaults.cc
@@ -43,6 +43,10 @@ Options NotificationChannelServiceDefaultOptions(Options options) {
     options.set<EndpointOption>(
         env && !env->empty() ? *env : "monitoring.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/monitoring/internal/query_metadata_decorator.cc
+++ b/google/cloud/monitoring/internal/query_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/monitoring/v3/query_service.proto
 
 #include "google/cloud/monitoring/internal/query_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/monitoring/v3/query_service.grpc.pb.h>
@@ -49,6 +50,11 @@ void QueryServiceMetadata::SetMetadata(grpc::ClientContext& context,
 
 void QueryServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/monitoring/internal/query_option_defaults.cc
+++ b/google/cloud/monitoring/internal/query_option_defaults.cc
@@ -42,6 +42,10 @@ Options QueryServiceDefaultOptions(Options options) {
     options.set<EndpointOption>(
         env && !env->empty() ? *env : "monitoring.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/monitoring/internal/service_monitoring_metadata_decorator.cc
+++ b/google/cloud/monitoring/internal/service_monitoring_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/monitoring/v3/service_service.proto
 
 #include "google/cloud/monitoring/internal/service_monitoring_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/monitoring/v3/service_service.grpc.pb.h>
@@ -121,6 +122,11 @@ void ServiceMonitoringServiceMetadata::SetMetadata(
 void ServiceMonitoringServiceMetadata::SetMetadata(
     grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/monitoring/internal/service_monitoring_option_defaults.cc
+++ b/google/cloud/monitoring/internal/service_monitoring_option_defaults.cc
@@ -43,6 +43,10 @@ Options ServiceMonitoringServiceDefaultOptions(Options options) {
     options.set<EndpointOption>(
         env && !env->empty() ? *env : "monitoring.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/monitoring/internal/uptime_check_metadata_decorator.cc
+++ b/google/cloud/monitoring/internal/uptime_check_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/monitoring/v3/uptime_service.proto
 
 #include "google/cloud/monitoring/internal/uptime_check_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/monitoring/v3/uptime_service.grpc.pb.h>
@@ -89,6 +90,11 @@ void UptimeCheckServiceMetadata::SetMetadata(
 
 void UptimeCheckServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/monitoring/internal/uptime_check_option_defaults.cc
+++ b/google/cloud/monitoring/internal/uptime_check_option_defaults.cc
@@ -43,6 +43,10 @@ Options UptimeCheckServiceDefaultOptions(Options options) {
     options.set<EndpointOption>(
         env && !env->empty() ? *env : "monitoring.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/networkmanagement/internal/reachability_metadata_decorator.cc
+++ b/google/cloud/networkmanagement/internal/reachability_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/cloud/networkmanagement/v1/reachability.proto
 
 #include "google/cloud/networkmanagement/internal/reachability_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/cloud/networkmanagement/v1/reachability.grpc.pb.h>
@@ -116,6 +117,11 @@ void ReachabilityServiceMetadata::SetMetadata(
 
 void ReachabilityServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/networkmanagement/internal/reachability_option_defaults.cc
+++ b/google/cloud/networkmanagement/internal/reachability_option_defaults.cc
@@ -43,6 +43,10 @@ Options ReachabilityServiceDefaultOptions(Options options) {
     options.set<EndpointOption>(
         env && !env->empty() ? *env : "networkmanagement.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/notebooks/internal/managed_notebook_metadata_decorator.cc
+++ b/google/cloud/notebooks/internal/managed_notebook_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/cloud/notebooks/v1/managed_service.proto
 
 #include "google/cloud/notebooks/internal/managed_notebook_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/cloud/notebooks/v1/managed_service.grpc.pb.h>
@@ -137,6 +138,11 @@ void ManagedNotebookServiceMetadata::SetMetadata(
 
 void ManagedNotebookServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/notebooks/internal/managed_notebook_option_defaults.cc
+++ b/google/cloud/notebooks/internal/managed_notebook_option_defaults.cc
@@ -43,6 +43,10 @@ Options ManagedNotebookServiceDefaultOptions(Options options) {
     options.set<EndpointOption>(
         env && !env->empty() ? *env : "notebooks.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/notebooks/internal/notebook_metadata_decorator.cc
+++ b/google/cloud/notebooks/internal/notebook_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/cloud/notebooks/v1/service.proto
 
 #include "google/cloud/notebooks/internal/notebook_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/cloud/notebooks/v1/service.grpc.pb.h>
@@ -341,6 +342,11 @@ void NotebookServiceMetadata::SetMetadata(grpc::ClientContext& context,
 
 void NotebookServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/notebooks/internal/notebook_option_defaults.cc
+++ b/google/cloud/notebooks/internal/notebook_option_defaults.cc
@@ -42,6 +42,10 @@ Options NotebookServiceDefaultOptions(Options options) {
     options.set<EndpointOption>(
         env && !env->empty() ? *env : "notebooks.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/orgpolicy/internal/org_policy_metadata_decorator.cc
+++ b/google/cloud/orgpolicy/internal/org_policy_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/cloud/orgpolicy/v2/orgpolicy.proto
 
 #include "google/cloud/orgpolicy/internal/org_policy_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/cloud/orgpolicy/v2/orgpolicy.grpc.pb.h>
@@ -92,6 +93,11 @@ void OrgPolicyMetadata::SetMetadata(grpc::ClientContext& context,
 
 void OrgPolicyMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/orgpolicy/internal/org_policy_option_defaults.cc
+++ b/google/cloud/orgpolicy/internal/org_policy_option_defaults.cc
@@ -42,6 +42,10 @@ Options OrgPolicyDefaultOptions(Options options) {
     options.set<EndpointOption>(
         env && !env->empty() ? *env : "orgpolicy.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/osconfig/internal/agent_endpoint_metadata_decorator.cc
+++ b/google/cloud/osconfig/internal/agent_endpoint_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/cloud/osconfig/agentendpoint/v1/agentendpoint.proto
 
 #include "google/cloud/osconfig/internal/agent_endpoint_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/cloud/osconfig/agentendpoint/v1/agentendpoint.grpc.pb.h>
@@ -97,6 +98,11 @@ void AgentEndpointServiceMetadata::SetMetadata(
 
 void AgentEndpointServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/osconfig/internal/agent_endpoint_option_defaults.cc
+++ b/google/cloud/osconfig/internal/agent_endpoint_option_defaults.cc
@@ -43,6 +43,10 @@ Options AgentEndpointServiceDefaultOptions(Options options) {
     options.set<EndpointOption>(
         env && !env->empty() ? *env : "osconfig.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/osconfig/internal/os_config_metadata_decorator.cc
+++ b/google/cloud/osconfig/internal/os_config_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/cloud/osconfig/v1/osconfig_service.proto
 
 #include "google/cloud/osconfig/internal/os_config_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/cloud/osconfig/v1/osconfig_service.grpc.pb.h>
@@ -113,6 +114,11 @@ void OsConfigServiceMetadata::SetMetadata(grpc::ClientContext& context,
 
 void OsConfigServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/osconfig/internal/os_config_option_defaults.cc
+++ b/google/cloud/osconfig/internal/os_config_option_defaults.cc
@@ -42,6 +42,10 @@ Options OsConfigServiceDefaultOptions(Options options) {
     options.set<EndpointOption>(
         env && !env->empty() ? *env : "osconfig.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/oslogin/internal/os_login_metadata_decorator.cc
+++ b/google/cloud/oslogin/internal/os_login_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/cloud/oslogin/v1/oslogin.proto
 
 #include "google/cloud/oslogin/internal/os_login_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/cloud/oslogin/v1/oslogin.grpc.pb.h>
@@ -87,6 +88,11 @@ void OsLoginServiceMetadata::SetMetadata(grpc::ClientContext& context,
 
 void OsLoginServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/oslogin/internal/os_login_option_defaults.cc
+++ b/google/cloud/oslogin/internal/os_login_option_defaults.cc
@@ -42,6 +42,10 @@ Options OsLoginServiceDefaultOptions(Options options) {
     options.set<EndpointOption>(
         env && !env->empty() ? *env : "oslogin.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/policytroubleshooter/internal/iam_checker_metadata_decorator.cc
+++ b/google/cloud/policytroubleshooter/internal/iam_checker_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/cloud/policytroubleshooter/v1/checker.proto
 
 #include "google/cloud/policytroubleshooter/internal/iam_checker_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/cloud/policytroubleshooter/v1/checker.grpc.pb.h>
@@ -49,6 +50,11 @@ void IamCheckerMetadata::SetMetadata(grpc::ClientContext& context,
 
 void IamCheckerMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/policytroubleshooter/internal/iam_checker_option_defaults.cc
+++ b/google/cloud/policytroubleshooter/internal/iam_checker_option_defaults.cc
@@ -42,6 +42,10 @@ Options IamCheckerDefaultOptions(Options options) {
     options.set<EndpointOption>(
         env && !env->empty() ? *env : "policytroubleshooter.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/privateca/internal/certificate_authority_metadata_decorator.cc
+++ b/google/cloud/privateca/internal/certificate_authority_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/cloud/security/privateca/v1/service.proto
 
 #include "google/cloud/privateca/internal/certificate_authority_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/cloud/security/privateca/v1/service.grpc.pb.h>
@@ -350,6 +351,11 @@ void CertificateAuthorityServiceMetadata::SetMetadata(
 void CertificateAuthorityServiceMetadata::SetMetadata(
     grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/privateca/internal/certificate_authority_option_defaults.cc
+++ b/google/cloud/privateca/internal/certificate_authority_option_defaults.cc
@@ -43,6 +43,10 @@ Options CertificateAuthorityServiceDefaultOptions(Options options) {
     options.set<EndpointOption>(
         env && !env->empty() ? *env : "privateca.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/pubsublite/internal/admin_metadata_decorator.cc
+++ b/google/cloud/pubsublite/internal/admin_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/cloud/pubsublite/v1/admin.proto
 
 #include "google/cloud/pubsublite/internal/admin_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/cloud/pubsublite/v1/admin.grpc.pb.h>
@@ -209,6 +210,11 @@ void AdminServiceMetadata::SetMetadata(grpc::ClientContext& context,
 
 void AdminServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/pubsublite/internal/admin_option_defaults.cc
+++ b/google/cloud/pubsublite/internal/admin_option_defaults.cc
@@ -42,6 +42,10 @@ Options AdminServiceDefaultOptions(Options options) {
     options.set<EndpointOption>(
         env && !env->empty() ? *env : "pubsublite.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/pubsublite/internal/cursor_metadata_decorator.cc
+++ b/google/cloud/pubsublite/internal/cursor_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/cloud/pubsublite/v1/cursor.proto
 
 #include "google/cloud/pubsublite/internal/cursor_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/cloud/pubsublite/v1/cursor.grpc.pb.h>
@@ -67,6 +68,11 @@ void CursorServiceMetadata::SetMetadata(grpc::ClientContext& context,
 
 void CursorServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/pubsublite/internal/partition_assignment_metadata_decorator.cc
+++ b/google/cloud/pubsublite/internal/partition_assignment_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/cloud/pubsublite/v1/subscriber.proto
 
 #include "google/cloud/pubsublite/internal/partition_assignment_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/cloud/pubsublite/v1/subscriber.grpc.pb.h>
@@ -52,6 +53,11 @@ void PartitionAssignmentServiceMetadata::SetMetadata(
 void PartitionAssignmentServiceMetadata::SetMetadata(
     grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/pubsublite/internal/publisher_metadata_decorator.cc
+++ b/google/cloud/pubsublite/internal/publisher_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/cloud/pubsublite/v1/publisher.proto
 
 #include "google/cloud/pubsublite/internal/publisher_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/cloud/pubsublite/v1/publisher.grpc.pb.h>
@@ -51,6 +52,11 @@ void PublisherServiceMetadata::SetMetadata(grpc::ClientContext& context,
 
 void PublisherServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/pubsublite/internal/subscriber_metadata_decorator.cc
+++ b/google/cloud/pubsublite/internal/subscriber_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/cloud/pubsublite/v1/subscriber.proto
 
 #include "google/cloud/pubsublite/internal/subscriber_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/cloud/pubsublite/v1/subscriber.grpc.pb.h>
@@ -51,6 +52,11 @@ void SubscriberServiceMetadata::SetMetadata(grpc::ClientContext& context,
 
 void SubscriberServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/pubsublite/internal/topic_stats_metadata_decorator.cc
+++ b/google/cloud/pubsublite/internal/topic_stats_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/cloud/pubsublite/v1/topic_stats.proto
 
 #include "google/cloud/pubsublite/internal/topic_stats_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/cloud/pubsublite/v1/topic_stats.grpc.pb.h>
@@ -65,6 +66,11 @@ void TopicStatsServiceMetadata::SetMetadata(grpc::ClientContext& context,
 
 void TopicStatsServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/pubsublite/internal/topic_stats_option_defaults.cc
+++ b/google/cloud/pubsublite/internal/topic_stats_option_defaults.cc
@@ -43,6 +43,10 @@ Options TopicStatsServiceDefaultOptions(Options options) {
     options.set<EndpointOption>(
         env && !env->empty() ? *env : "pubsublite.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/recommender/internal/recommender_metadata_decorator.cc
+++ b/google/cloud/recommender/internal/recommender_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/cloud/recommender/v1/recommender_service.proto
 
 #include "google/cloud/recommender/internal/recommender_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/cloud/recommender/v1/recommender_service.grpc.pb.h>
@@ -107,6 +108,11 @@ void RecommenderMetadata::SetMetadata(grpc::ClientContext& context,
 
 void RecommenderMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/recommender/internal/recommender_option_defaults.cc
+++ b/google/cloud/recommender/internal/recommender_option_defaults.cc
@@ -42,6 +42,10 @@ Options RecommenderDefaultOptions(Options options) {
     options.set<EndpointOption>(
         env && !env->empty() ? *env : "recommender.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/redis/internal/cloud_redis_metadata_decorator.cc
+++ b/google/cloud/redis/internal/cloud_redis_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/cloud/redis/v1/cloud_redis.proto
 
 #include "google/cloud/redis/internal/cloud_redis_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/cloud/redis/v1/cloud_redis.grpc.pb.h>
@@ -135,6 +136,11 @@ void CloudRedisMetadata::SetMetadata(grpc::ClientContext& context,
 
 void CloudRedisMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/redis/internal/cloud_redis_option_defaults.cc
+++ b/google/cloud/redis/internal/cloud_redis_option_defaults.cc
@@ -42,6 +42,10 @@ Options CloudRedisDefaultOptions(Options options) {
     options.set<EndpointOption>(env && !env->empty() ? *env
                                                      : "redis.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/resourcemanager/internal/folders_metadata_decorator.cc
+++ b/google/cloud/resourcemanager/internal/folders_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/cloud/resourcemanager/v3/folders.proto
 
 #include "google/cloud/resourcemanager/internal/folders_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/cloud/resourcemanager/v3/folders.grpc.pb.h>
@@ -147,6 +148,11 @@ void FoldersMetadata::SetMetadata(grpc::ClientContext& context,
 
 void FoldersMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/resourcemanager/internal/folders_option_defaults.cc
+++ b/google/cloud/resourcemanager/internal/folders_option_defaults.cc
@@ -42,6 +42,10 @@ Options FoldersDefaultOptions(Options options) {
     options.set<EndpointOption>(
         env && !env->empty() ? *env : "cloudresourcemanager.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/resourcemanager/internal/organizations_metadata_decorator.cc
+++ b/google/cloud/resourcemanager/internal/organizations_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/cloud/resourcemanager/v3/organizations.proto
 
 #include "google/cloud/resourcemanager/internal/organizations_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/cloud/resourcemanager/v3/organizations.grpc.pb.h>
@@ -80,6 +81,11 @@ void OrganizationsMetadata::SetMetadata(grpc::ClientContext& context,
 
 void OrganizationsMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/resourcemanager/internal/organizations_option_defaults.cc
+++ b/google/cloud/resourcemanager/internal/organizations_option_defaults.cc
@@ -42,6 +42,10 @@ Options OrganizationsDefaultOptions(Options options) {
     options.set<EndpointOption>(
         env && !env->empty() ? *env : "cloudresourcemanager.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/resourcemanager/internal/projects_metadata_decorator.cc
+++ b/google/cloud/resourcemanager/internal/projects_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/cloud/resourcemanager/v3/projects.proto
 
 #include "google/cloud/resourcemanager/internal/projects_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/cloud/resourcemanager/v3/projects.grpc.pb.h>
@@ -148,6 +149,11 @@ void ProjectsMetadata::SetMetadata(grpc::ClientContext& context,
 
 void ProjectsMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/resourcemanager/internal/projects_option_defaults.cc
+++ b/google/cloud/resourcemanager/internal/projects_option_defaults.cc
@@ -42,6 +42,10 @@ Options ProjectsDefaultOptions(Options options) {
     options.set<EndpointOption>(
         env && !env->empty() ? *env : "cloudresourcemanager.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/resourcesettings/internal/resource_settings_metadata_decorator.cc
+++ b/google/cloud/resourcesettings/internal/resource_settings_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/cloud/resourcesettings/v1/resource_settings.proto
 
 #include "google/cloud/resourcesettings/internal/resource_settings_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/cloud/resourcesettings/v1/resource_settings.grpc.pb.h>
@@ -66,6 +67,11 @@ void ResourceSettingsServiceMetadata::SetMetadata(
 void ResourceSettingsServiceMetadata::SetMetadata(
     grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/resourcesettings/internal/resource_settings_option_defaults.cc
+++ b/google/cloud/resourcesettings/internal/resource_settings_option_defaults.cc
@@ -43,6 +43,10 @@ Options ResourceSettingsServiceDefaultOptions(Options options) {
     options.set<EndpointOption>(
         env && !env->empty() ? *env : "resourcesettings.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/retail/internal/catalog_metadata_decorator.cc
+++ b/google/cloud/retail/internal/catalog_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/cloud/retail/v2/catalog_service.proto
 
 #include "google/cloud/retail/internal/catalog_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/cloud/retail/v2/catalog_service.grpc.pb.h>
@@ -72,6 +73,11 @@ void CatalogServiceMetadata::SetMetadata(grpc::ClientContext& context,
 
 void CatalogServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/retail/internal/catalog_option_defaults.cc
+++ b/google/cloud/retail/internal/catalog_option_defaults.cc
@@ -42,6 +42,10 @@ Options CatalogServiceDefaultOptions(Options options) {
     options.set<EndpointOption>(env && !env->empty() ? *env
                                                      : "retail.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/retail/internal/completion_metadata_decorator.cc
+++ b/google/cloud/retail/internal/completion_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/cloud/retail/v2/completion_service.proto
 
 #include "google/cloud/retail/internal/completion_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/cloud/retail/v2/completion_service.grpc.pb.h>
@@ -75,6 +76,11 @@ void CompletionServiceMetadata::SetMetadata(grpc::ClientContext& context,
 
 void CompletionServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/retail/internal/completion_option_defaults.cc
+++ b/google/cloud/retail/internal/completion_option_defaults.cc
@@ -42,6 +42,10 @@ Options CompletionServiceDefaultOptions(Options options) {
     options.set<EndpointOption>(env && !env->empty() ? *env
                                                      : "retail.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/retail/internal/prediction_metadata_decorator.cc
+++ b/google/cloud/retail/internal/prediction_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/cloud/retail/v2/prediction_service.proto
 
 #include "google/cloud/retail/internal/prediction_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/cloud/retail/v2/prediction_service.grpc.pb.h>
@@ -49,6 +50,11 @@ void PredictionServiceMetadata::SetMetadata(grpc::ClientContext& context,
 
 void PredictionServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/retail/internal/prediction_option_defaults.cc
+++ b/google/cloud/retail/internal/prediction_option_defaults.cc
@@ -42,6 +42,10 @@ Options PredictionServiceDefaultOptions(Options options) {
     options.set<EndpointOption>(env && !env->empty() ? *env
                                                      : "retail.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/retail/internal/product_metadata_decorator.cc
+++ b/google/cloud/retail/internal/product_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/cloud/retail/v2/product_service.proto
 
 #include "google/cloud/retail/internal/product_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/cloud/retail/v2/product_service.grpc.pb.h>
@@ -132,6 +133,11 @@ void ProductServiceMetadata::SetMetadata(grpc::ClientContext& context,
 
 void ProductServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/retail/internal/product_option_defaults.cc
+++ b/google/cloud/retail/internal/product_option_defaults.cc
@@ -42,6 +42,10 @@ Options ProductServiceDefaultOptions(Options options) {
     options.set<EndpointOption>(env && !env->empty() ? *env
                                                      : "retail.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/retail/internal/search_metadata_decorator.cc
+++ b/google/cloud/retail/internal/search_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/cloud/retail/v2/search_service.proto
 
 #include "google/cloud/retail/internal/search_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/cloud/retail/v2/search_service.grpc.pb.h>
@@ -49,6 +50,11 @@ void SearchServiceMetadata::SetMetadata(grpc::ClientContext& context,
 
 void SearchServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/retail/internal/search_option_defaults.cc
+++ b/google/cloud/retail/internal/search_option_defaults.cc
@@ -42,6 +42,10 @@ Options SearchServiceDefaultOptions(Options options) {
     options.set<EndpointOption>(env && !env->empty() ? *env
                                                      : "retail.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/retail/internal/user_event_metadata_decorator.cc
+++ b/google/cloud/retail/internal/user_event_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/cloud/retail/v2/user_event_service.proto
 
 #include "google/cloud/retail/internal/user_event_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/cloud/retail/v2/user_event_service.grpc.pb.h>
@@ -100,6 +101,11 @@ void UserEventServiceMetadata::SetMetadata(grpc::ClientContext& context,
 
 void UserEventServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/retail/internal/user_event_option_defaults.cc
+++ b/google/cloud/retail/internal/user_event_option_defaults.cc
@@ -42,6 +42,10 @@ Options UserEventServiceDefaultOptions(Options options) {
     options.set<EndpointOption>(env && !env->empty() ? *env
                                                      : "retail.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/scheduler/internal/cloud_scheduler_metadata_decorator.cc
+++ b/google/cloud/scheduler/internal/cloud_scheduler_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/cloud/scheduler/v1/cloudscheduler.proto
 
 #include "google/cloud/scheduler/internal/cloud_scheduler_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/cloud/scheduler/v1/cloudscheduler.grpc.pb.h>
@@ -98,6 +99,11 @@ void CloudSchedulerMetadata::SetMetadata(grpc::ClientContext& context,
 
 void CloudSchedulerMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/scheduler/internal/cloud_scheduler_option_defaults.cc
+++ b/google/cloud/scheduler/internal/cloud_scheduler_option_defaults.cc
@@ -42,6 +42,10 @@ Options CloudSchedulerDefaultOptions(Options options) {
     options.set<EndpointOption>(
         env && !env->empty() ? *env : "cloudscheduler.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/secretmanager/internal/secret_manager_metadata_decorator.cc
+++ b/google/cloud/secretmanager/internal/secret_manager_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/cloud/secretmanager/v1/service.proto
 
 #include "google/cloud/secretmanager/internal/secret_manager_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/cloud/secretmanager/v1/service.grpc.pb.h>
@@ -163,6 +164,11 @@ void SecretManagerServiceMetadata::SetMetadata(
 
 void SecretManagerServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/secretmanager/internal/secret_manager_option_defaults.cc
+++ b/google/cloud/secretmanager/internal/secret_manager_option_defaults.cc
@@ -43,6 +43,10 @@ Options SecretManagerServiceDefaultOptions(Options options) {
     options.set<EndpointOption>(
         env && !env->empty() ? *env : "secretmanager.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/securitycenter/internal/security_center_metadata_decorator.cc
+++ b/google/cloud/securitycenter/internal/security_center_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/cloud/securitycenter/v1/securitycenter_service.proto
 
 #include "google/cloud/securitycenter/internal/security_center_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/cloud/securitycenter/v1/securitycenter_service.grpc.pb.h>
@@ -318,6 +319,11 @@ void SecurityCenterMetadata::SetMetadata(grpc::ClientContext& context,
 
 void SecurityCenterMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/securitycenter/internal/security_center_option_defaults.cc
+++ b/google/cloud/securitycenter/internal/security_center_option_defaults.cc
@@ -42,6 +42,10 @@ Options SecurityCenterDefaultOptions(Options options) {
     options.set<EndpointOption>(
         env && !env->empty() ? *env : "securitycenter.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/servicecontrol/internal/quota_controller_metadata_decorator.cc
+++ b/google/cloud/servicecontrol/internal/quota_controller_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/api/servicecontrol/v1/quota_controller.proto
 
 #include "google/cloud/servicecontrol/internal/quota_controller_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/api/servicecontrol/v1/quota_controller.grpc.pb.h>
@@ -49,6 +50,11 @@ void QuotaControllerMetadata::SetMetadata(grpc::ClientContext& context,
 
 void QuotaControllerMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/servicecontrol/internal/quota_controller_option_defaults.cc
+++ b/google/cloud/servicecontrol/internal/quota_controller_option_defaults.cc
@@ -42,6 +42,10 @@ Options QuotaControllerDefaultOptions(Options options) {
     options.set<EndpointOption>(
         env && !env->empty() ? *env : "servicecontrol.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/servicecontrol/internal/service_controller_metadata_decorator.cc
+++ b/google/cloud/servicecontrol/internal/service_controller_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/api/servicecontrol/v1/service_controller.proto
 
 #include "google/cloud/servicecontrol/internal/service_controller_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/api/servicecontrol/v1/service_controller.grpc.pb.h>
@@ -57,6 +58,11 @@ void ServiceControllerMetadata::SetMetadata(grpc::ClientContext& context,
 
 void ServiceControllerMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/servicecontrol/internal/service_controller_option_defaults.cc
+++ b/google/cloud/servicecontrol/internal/service_controller_option_defaults.cc
@@ -42,6 +42,10 @@ Options ServiceControllerDefaultOptions(Options options) {
     options.set<EndpointOption>(
         env && !env->empty() ? *env : "servicecontrol.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/servicedirectory/internal/lookup_metadata_decorator.cc
+++ b/google/cloud/servicedirectory/internal/lookup_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/cloud/servicedirectory/v1/lookup_service.proto
 
 #include "google/cloud/servicedirectory/internal/lookup_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/cloud/servicedirectory/v1/lookup_service.grpc.pb.h>
@@ -49,6 +50,11 @@ void LookupServiceMetadata::SetMetadata(grpc::ClientContext& context,
 
 void LookupServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/servicedirectory/internal/lookup_option_defaults.cc
+++ b/google/cloud/servicedirectory/internal/lookup_option_defaults.cc
@@ -42,6 +42,10 @@ Options LookupServiceDefaultOptions(Options options) {
     options.set<EndpointOption>(
         env && !env->empty() ? *env : "servicedirectory.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/servicedirectory/internal/registration_metadata_decorator.cc
+++ b/google/cloud/servicedirectory/internal/registration_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/cloud/servicedirectory/v1/registration_service.proto
 
 #include "google/cloud/servicedirectory/internal/registration_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/cloud/servicedirectory/v1/registration_service.grpc.pb.h>
@@ -183,6 +184,11 @@ void RegistrationServiceMetadata::SetMetadata(
 
 void RegistrationServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/servicedirectory/internal/registration_option_defaults.cc
+++ b/google/cloud/servicedirectory/internal/registration_option_defaults.cc
@@ -43,6 +43,10 @@ Options RegistrationServiceDefaultOptions(Options options) {
     options.set<EndpointOption>(
         env && !env->empty() ? *env : "servicedirectory.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/servicemanagement/internal/service_manager_metadata_decorator.cc
+++ b/google/cloud/servicemanagement/internal/service_manager_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/api/servicemanagement/v1/servicemanager.proto
 
 #include "google/cloud/servicemanagement/internal/service_manager_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/api/servicemanagement/v1/servicemanager.grpc.pb.h>
@@ -191,6 +192,11 @@ void ServiceManagerMetadata::SetMetadata(grpc::ClientContext& context,
 
 void ServiceManagerMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/servicemanagement/internal/service_manager_option_defaults.cc
+++ b/google/cloud/servicemanagement/internal/service_manager_option_defaults.cc
@@ -42,6 +42,10 @@ Options ServiceManagerDefaultOptions(Options options) {
     options.set<EndpointOption>(
         env && !env->empty() ? *env : "servicemanagement.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/serviceusage/internal/service_usage_metadata_decorator.cc
+++ b/google/cloud/serviceusage/internal/service_usage_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/api/serviceusage/v1/serviceusage.proto
 
 #include "google/cloud/serviceusage/internal/service_usage_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/api/serviceusage/v1/serviceusage.grpc.pb.h>
@@ -109,6 +110,11 @@ void ServiceUsageMetadata::SetMetadata(grpc::ClientContext& context,
 
 void ServiceUsageMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/serviceusage/internal/service_usage_option_defaults.cc
+++ b/google/cloud/serviceusage/internal/service_usage_option_defaults.cc
@@ -42,6 +42,10 @@ Options ServiceUsageDefaultOptions(Options options) {
     options.set<EndpointOption>(
         env && !env->empty() ? *env : "serviceusage.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/shell/internal/cloud_shell_metadata_decorator.cc
+++ b/google/cloud/shell/internal/cloud_shell_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/cloud/shell/v1/cloudshell.proto
 
 #include "google/cloud/shell/internal/cloud_shell_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/cloud/shell/v1/cloudshell.grpc.pb.h>
@@ -102,6 +103,11 @@ void CloudShellServiceMetadata::SetMetadata(grpc::ClientContext& context,
 
 void CloudShellServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/shell/internal/cloud_shell_option_defaults.cc
+++ b/google/cloud/shell/internal/cloud_shell_option_defaults.cc
@@ -43,6 +43,10 @@ Options CloudShellServiceDefaultOptions(Options options) {
     options.set<EndpointOption>(
         env && !env->empty() ? *env : "cloudshell.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/spanner/admin/internal/database_admin_metadata_decorator.cc
+++ b/google/cloud/spanner/admin/internal/database_admin_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/spanner/admin/database/v1/spanner_database_admin.proto
 
 #include "google/cloud/spanner/admin/internal/database_admin_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/spanner/admin/database/v1/spanner_database_admin.grpc.pb.h>
@@ -200,6 +201,11 @@ void DatabaseAdminMetadata::SetMetadata(grpc::ClientContext& context,
 
 void DatabaseAdminMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/spanner/admin/internal/database_admin_option_defaults.cc
+++ b/google/cloud/spanner/admin/internal/database_admin_option_defaults.cc
@@ -42,6 +42,10 @@ Options DatabaseAdminDefaultOptions(Options options) {
     options.set<EndpointOption>(
         env && !env->empty() ? *env : "spanner.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (auto emulator = internal::GetEnv("SPANNER_EMULATOR_HOST")) {
     options.set<EndpointOption>(*emulator).set<GrpcCredentialOption>(
         grpc::InsecureChannelCredentials());

--- a/google/cloud/spanner/admin/internal/instance_admin_metadata_decorator.cc
+++ b/google/cloud/spanner/admin/internal/instance_admin_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/spanner/admin/instance/v1/spanner_instance_admin.proto
 
 #include "google/cloud/spanner/admin/internal/instance_admin_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/spanner/admin/instance/v1/spanner_instance_admin.grpc.pb.h>
@@ -142,6 +143,11 @@ void InstanceAdminMetadata::SetMetadata(grpc::ClientContext& context,
 
 void InstanceAdminMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/spanner/admin/internal/instance_admin_option_defaults.cc
+++ b/google/cloud/spanner/admin/internal/instance_admin_option_defaults.cc
@@ -42,6 +42,10 @@ Options InstanceAdminDefaultOptions(Options options) {
     options.set<EndpointOption>(
         env && !env->empty() ? *env : "spanner.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (auto emulator = internal::GetEnv("SPANNER_EMULATOR_HOST")) {
     options.set<EndpointOption>(*emulator).set<GrpcCredentialOption>(
         grpc::InsecureChannelCredentials());

--- a/google/cloud/storage/internal/storage_metadata_decorator.cc
+++ b/google/cloud/storage/internal/storage_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/storage/v2/storage.proto
 
 #include "google/cloud/storage/internal/storage_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/storage/v2/storage.grpc.pb.h>
@@ -130,6 +131,11 @@ void StorageMetadata::SetMetadata(grpc::ClientContext& context,
 
 void StorageMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/storagetransfer/internal/storage_transfer_metadata_decorator.cc
+++ b/google/cloud/storagetransfer/internal/storage_transfer_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/storagetransfer/v1/transfer.proto
 
 #include "google/cloud/storagetransfer/internal/storage_transfer_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/storagetransfer/v1/transfer.grpc.pb.h>
@@ -123,6 +124,11 @@ void StorageTransferServiceMetadata::SetMetadata(
 
 void StorageTransferServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/storagetransfer/internal/storage_transfer_option_defaults.cc
+++ b/google/cloud/storagetransfer/internal/storage_transfer_option_defaults.cc
@@ -43,6 +43,10 @@ Options StorageTransferServiceDefaultOptions(Options options) {
     options.set<EndpointOption>(
         env && !env->empty() ? *env : "storagetransfer.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/talent/internal/company_metadata_decorator.cc
+++ b/google/cloud/talent/internal/company_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/cloud/talent/v4/company_service.proto
 
 #include "google/cloud/talent/internal/company_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/cloud/talent/v4/company_service.grpc.pb.h>
@@ -79,6 +80,11 @@ void CompanyServiceMetadata::SetMetadata(grpc::ClientContext& context,
 
 void CompanyServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/talent/internal/company_option_defaults.cc
+++ b/google/cloud/talent/internal/company_option_defaults.cc
@@ -42,6 +42,10 @@ Options CompanyServiceDefaultOptions(Options options) {
     options.set<EndpointOption>(env && !env->empty() ? *env
                                                      : "jobs.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/talent/internal/completion_metadata_decorator.cc
+++ b/google/cloud/talent/internal/completion_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/cloud/talent/v4/completion_service.proto
 
 #include "google/cloud/talent/internal/completion_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/cloud/talent/v4/completion_service.grpc.pb.h>
@@ -48,6 +49,11 @@ void CompletionMetadata::SetMetadata(grpc::ClientContext& context,
 
 void CompletionMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/talent/internal/completion_option_defaults.cc
+++ b/google/cloud/talent/internal/completion_option_defaults.cc
@@ -42,6 +42,10 @@ Options CompletionDefaultOptions(Options options) {
     options.set<EndpointOption>(env && !env->empty() ? *env
                                                      : "jobs.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/talent/internal/event_metadata_decorator.cc
+++ b/google/cloud/talent/internal/event_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/cloud/talent/v4/event_service.proto
 
 #include "google/cloud/talent/internal/event_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/cloud/talent/v4/event_service.grpc.pb.h>
@@ -49,6 +50,11 @@ void EventServiceMetadata::SetMetadata(grpc::ClientContext& context,
 
 void EventServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/talent/internal/event_option_defaults.cc
+++ b/google/cloud/talent/internal/event_option_defaults.cc
@@ -42,6 +42,10 @@ Options EventServiceDefaultOptions(Options options) {
     options.set<EndpointOption>(env && !env->empty() ? *env
                                                      : "jobs.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/talent/internal/job_metadata_decorator.cc
+++ b/google/cloud/talent/internal/job_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/cloud/talent/v4/job_service.proto
 
 #include "google/cloud/talent/internal/job_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/cloud/talent/v4/job_service.grpc.pb.h>
@@ -136,6 +137,11 @@ void JobServiceMetadata::SetMetadata(grpc::ClientContext& context,
 
 void JobServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/talent/internal/job_option_defaults.cc
+++ b/google/cloud/talent/internal/job_option_defaults.cc
@@ -42,6 +42,10 @@ Options JobServiceDefaultOptions(Options options) {
     options.set<EndpointOption>(env && !env->empty() ? *env
                                                      : "jobs.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/talent/internal/tenant_metadata_decorator.cc
+++ b/google/cloud/talent/internal/tenant_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/cloud/talent/v4/tenant_service.proto
 
 #include "google/cloud/talent/internal/tenant_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/cloud/talent/v4/tenant_service.grpc.pb.h>
@@ -77,6 +78,11 @@ void TenantServiceMetadata::SetMetadata(grpc::ClientContext& context,
 
 void TenantServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/talent/internal/tenant_option_defaults.cc
+++ b/google/cloud/talent/internal/tenant_option_defaults.cc
@@ -42,6 +42,10 @@ Options TenantServiceDefaultOptions(Options options) {
     options.set<EndpointOption>(env && !env->empty() ? *env
                                                      : "jobs.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/tasks/internal/cloud_tasks_metadata_decorator.cc
+++ b/google/cloud/tasks/internal/cloud_tasks_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/cloud/tasks/v2/cloudtasks.proto
 
 #include "google/cloud/tasks/internal/cloud_tasks_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/cloud/tasks/v2/cloudtasks.grpc.pb.h>
@@ -155,6 +156,11 @@ void CloudTasksMetadata::SetMetadata(grpc::ClientContext& context,
 
 void CloudTasksMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/tasks/internal/cloud_tasks_option_defaults.cc
+++ b/google/cloud/tasks/internal/cloud_tasks_option_defaults.cc
@@ -42,6 +42,10 @@ Options CloudTasksDefaultOptions(Options options) {
     options.set<EndpointOption>(
         env && !env->empty() ? *env : "cloudtasks.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/texttospeech/internal/text_to_speech_metadata_decorator.cc
+++ b/google/cloud/texttospeech/internal/text_to_speech_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/cloud/texttospeech/v1/cloud_tts.proto
 
 #include "google/cloud/texttospeech/internal/text_to_speech_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/cloud/texttospeech/v1/cloud_tts.grpc.pb.h>
@@ -57,6 +58,11 @@ void TextToSpeechMetadata::SetMetadata(grpc::ClientContext& context,
 
 void TextToSpeechMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/texttospeech/internal/text_to_speech_option_defaults.cc
+++ b/google/cloud/texttospeech/internal/text_to_speech_option_defaults.cc
@@ -42,6 +42,10 @@ Options TextToSpeechDefaultOptions(Options options) {
     options.set<EndpointOption>(
         env && !env->empty() ? *env : "texttospeech.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/tpu/internal/tpu_metadata_decorator.cc
+++ b/google/cloud/tpu/internal/tpu_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/cloud/tpu/v1/cloud_tpu.proto
 
 #include "google/cloud/tpu/internal/tpu_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/cloud/tpu/v1/cloud_tpu.grpc.pb.h>
@@ -142,6 +143,11 @@ void TpuMetadata::SetMetadata(grpc::ClientContext& context,
 
 void TpuMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/tpu/internal/tpu_option_defaults.cc
+++ b/google/cloud/tpu/internal/tpu_option_defaults.cc
@@ -42,6 +42,10 @@ Options TpuDefaultOptions(Options options) {
     options.set<EndpointOption>(env && !env->empty() ? *env
                                                      : "tpu.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/trace/internal/trace_metadata_decorator.cc
+++ b/google/cloud/trace/internal/trace_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/devtools/cloudtrace/v2/tracing.proto
 
 #include "google/cloud/trace/internal/trace_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/devtools/cloudtrace/v2/tracing.grpc.pb.h>
@@ -56,6 +57,11 @@ void TraceServiceMetadata::SetMetadata(grpc::ClientContext& context,
 
 void TraceServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/trace/internal/trace_option_defaults.cc
+++ b/google/cloud/trace/internal/trace_option_defaults.cc
@@ -42,6 +42,10 @@ Options TraceServiceDefaultOptions(Options options) {
     options.set<EndpointOption>(
         env && !env->empty() ? *env : "cloudtrace.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/translate/internal/translation_metadata_decorator.cc
+++ b/google/cloud/translate/internal/translation_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/cloud/translate/v3/translation_service.proto
 
 #include "google/cloud/translate/internal/translation_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/cloud/translate/v3/translation_service.grpc.pb.h>
@@ -144,6 +145,11 @@ void TranslationServiceMetadata::SetMetadata(
 
 void TranslationServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/translate/internal/translation_option_defaults.cc
+++ b/google/cloud/translate/internal/translation_option_defaults.cc
@@ -43,6 +43,10 @@ Options TranslationServiceDefaultOptions(Options options) {
     options.set<EndpointOption>(
         env && !env->empty() ? *env : "translate.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/videointelligence/internal/video_intelligence_metadata_decorator.cc
+++ b/google/cloud/videointelligence/internal/video_intelligence_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/cloud/videointelligence/v1/video_intelligence.proto
 
 #include "google/cloud/videointelligence/internal/video_intelligence_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/cloud/videointelligence/v1/video_intelligence.grpc.pb.h>
@@ -68,6 +69,11 @@ void VideoIntelligenceServiceMetadata::SetMetadata(
 void VideoIntelligenceServiceMetadata::SetMetadata(
     grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/videointelligence/internal/video_intelligence_option_defaults.cc
+++ b/google/cloud/videointelligence/internal/video_intelligence_option_defaults.cc
@@ -43,6 +43,10 @@ Options VideoIntelligenceServiceDefaultOptions(Options options) {
     options.set<EndpointOption>(
         env && !env->empty() ? *env : "videointelligence.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/vision/internal/image_annotator_metadata_decorator.cc
+++ b/google/cloud/vision/internal/image_annotator_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/cloud/vision/v1/image_annotator.proto
 
 #include "google/cloud/vision/internal/image_annotator_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/cloud/vision/v1/image_annotator.grpc.pb.h>
@@ -92,6 +93,11 @@ void ImageAnnotatorMetadata::SetMetadata(grpc::ClientContext& context,
 
 void ImageAnnotatorMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/vision/internal/image_annotator_option_defaults.cc
+++ b/google/cloud/vision/internal/image_annotator_option_defaults.cc
@@ -42,6 +42,10 @@ Options ImageAnnotatorDefaultOptions(Options options) {
     options.set<EndpointOption>(env && !env->empty() ? *env
                                                      : "vision.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/vision/internal/product_search_metadata_decorator.cc
+++ b/google/cloud/vision/internal/product_search_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/cloud/vision/v1/product_search_service.proto
 
 #include "google/cloud/vision/internal/product_search_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/cloud/vision/v1/product_search_service.grpc.pb.h>
@@ -207,6 +208,11 @@ void ProductSearchMetadata::SetMetadata(grpc::ClientContext& context,
 
 void ProductSearchMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/vision/internal/product_search_option_defaults.cc
+++ b/google/cloud/vision/internal/product_search_option_defaults.cc
@@ -42,6 +42,10 @@ Options ProductSearchDefaultOptions(Options options) {
     options.set<EndpointOption>(env && !env->empty() ? *env
                                                      : "vision.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/vmmigration/internal/vm_migration_metadata_decorator.cc
+++ b/google/cloud/vmmigration/internal/vm_migration_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/cloud/vmmigration/v1/vmmigration.proto
 
 #include "google/cloud/vmmigration/internal/vm_migration_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/cloud/vmmigration/v1/vmmigration.grpc.pb.h>
@@ -437,6 +438,11 @@ void VmMigrationMetadata::SetMetadata(grpc::ClientContext& context,
 
 void VmMigrationMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/vmmigration/internal/vm_migration_option_defaults.cc
+++ b/google/cloud/vmmigration/internal/vm_migration_option_defaults.cc
@@ -42,6 +42,10 @@ Options VmMigrationDefaultOptions(Options options) {
     options.set<EndpointOption>(
         env && !env->empty() ? *env : "vmmigration.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/vpcaccess/internal/vpc_access_metadata_decorator.cc
+++ b/google/cloud/vpcaccess/internal/vpc_access_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/cloud/vpcaccess/v1/vpc_access.proto
 
 #include "google/cloud/vpcaccess/internal/vpc_access_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/cloud/vpcaccess/v1/vpc_access.grpc.pb.h>
@@ -92,6 +93,11 @@ void VpcAccessServiceMetadata::SetMetadata(grpc::ClientContext& context,
 
 void VpcAccessServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/vpcaccess/internal/vpc_access_option_defaults.cc
+++ b/google/cloud/vpcaccess/internal/vpc_access_option_defaults.cc
@@ -42,6 +42,10 @@ Options VpcAccessServiceDefaultOptions(Options options) {
     options.set<EndpointOption>(
         env && !env->empty() ? *env : "vpcaccess.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/webrisk/internal/web_risk_metadata_decorator.cc
+++ b/google/cloud/webrisk/internal/web_risk_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/cloud/webrisk/v1/webrisk.proto
 
 #include "google/cloud/webrisk/internal/web_risk_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/cloud/webrisk/v1/webrisk.grpc.pb.h>
@@ -73,6 +74,11 @@ void WebRiskServiceMetadata::SetMetadata(grpc::ClientContext& context,
 
 void WebRiskServiceMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/webrisk/internal/web_risk_option_defaults.cc
+++ b/google/cloud/webrisk/internal/web_risk_option_defaults.cc
@@ -42,6 +42,10 @@ Options WebRiskServiceDefaultOptions(Options options) {
     options.set<EndpointOption>(
         env && !env->empty() ? *env : "webrisk.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/websecurityscanner/internal/web_security_scanner_metadata_decorator.cc
+++ b/google/cloud/websecurityscanner/internal/web_security_scanner_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/cloud/websecurityscanner/v1/web_security_scanner.proto
 
 #include "google/cloud/websecurityscanner/internal/web_security_scanner_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/cloud/websecurityscanner/v1/web_security_scanner.grpc.pb.h>
@@ -151,6 +152,11 @@ void WebSecurityScannerMetadata::SetMetadata(
 
 void WebSecurityScannerMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/websecurityscanner/internal/web_security_scanner_option_defaults.cc
+++ b/google/cloud/websecurityscanner/internal/web_security_scanner_option_defaults.cc
@@ -43,6 +43,10 @@ Options WebSecurityScannerDefaultOptions(Options options) {
     options.set<EndpointOption>(
         env && !env->empty() ? *env : "websecurityscanner.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/workflows/internal/executions_metadata_decorator.cc
+++ b/google/cloud/workflows/internal/executions_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/cloud/workflows/executions/v1/executions.proto
 
 #include "google/cloud/workflows/internal/executions_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/cloud/workflows/executions/v1/executions.grpc.pb.h>
@@ -76,6 +77,11 @@ void ExecutionsMetadata::SetMetadata(grpc::ClientContext& context,
 
 void ExecutionsMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/workflows/internal/executions_option_defaults.cc
+++ b/google/cloud/workflows/internal/executions_option_defaults.cc
@@ -42,6 +42,10 @@ Options ExecutionsDefaultOptions(Options options) {
     options.set<EndpointOption>(
         env && !env->empty() ? *env : "workflowexecutions.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }

--- a/google/cloud/workflows/internal/workflows_metadata_decorator.cc
+++ b/google/cloud/workflows/internal/workflows_metadata_decorator.cc
@@ -17,6 +17,7 @@
 // source: google/cloud/workflows/v1/workflows.proto
 
 #include "google/cloud/workflows/internal/workflows_metadata_decorator.h"
+#include "google/cloud/common_options.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status_or.h"
 #include <google/cloud/workflows/v1/workflows.grpc.pb.h>
@@ -99,6 +100,11 @@ void WorkflowsMetadata::SetMetadata(grpc::ClientContext& context,
 
 void WorkflowsMetadata::SetMetadata(grpc::ClientContext& context) {
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/workflows/internal/workflows_option_defaults.cc
+++ b/google/cloud/workflows/internal/workflows_option_defaults.cc
@@ -42,6 +42,10 @@ Options WorkflowsDefaultOptions(Options options) {
     options.set<EndpointOption>(
         env && !env->empty() ? *env : "workflows.googleapis.com");
   }
+  if (!options.has<UserProjectOption>()) {
+    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+    if (env.has_value() && !env->empty()) options.set<UserProjectOption>(*env);
+  }
   if (!options.has<GrpcCredentialOption>()) {
     options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
   }


### PR DESCRIPTION
Many services cannot be used directly from a user account. User accounts
have no default project associated with them for quota and billing, and
some services do not have any resources attached to a specific project
either. For example, compute-only services like Text-to-Speech. In this
case the recommendation is to use the x-goog-user-project header, or use
service account impersonation. The latter is fairly difficult, and would
make the "quickstart" not very quick.

This PR introduces a new option to configure this header. The default
comes from an environment variable.

Part of the work for #7936, or at least motivated by it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8245)
<!-- Reviewable:end -->
