### PR TITLE
fix: make quickstarts run and add to CI

### DIFF
--- a/google/cloud/composer/CMakeLists.txt
+++ b/google/cloud/composer/CMakeLists.txt
@@ -118,6 +118,22 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_composer_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
+include(CTest)
+if (BUILD_TESTING)
+    add_executable(composer_quickstart "quickstart/quickstart.cc")
+    target_link_libraries(composer_quickstart
+                          PRIVATE google-cloud-cpp::experimental-composer)
+    google_cloud_cpp_add_common_options(composer_quickstart)
+    add_test(
+        NAME composer_quickstart
+        COMMAND
+            cmake -P "${PROJECT_SOURCE_DIR}/cmake/quickstart-runner.cmake"
+            $<TARGET_FILE:composer_quickstart> GOOGLE_CLOUD_PROJECT
+            GOOGLE_CLOUD_REGION)
+    set_tests_properties(composer_quickstart
+                         PROPERTIES LABELS "integration-test;quickstart")
+endif ()
+
 # Get the destination directories based on the GNU recommendations.
 include(GNUInstallDirs)
 

--- a/google/cloud/composer/README.md
+++ b/google/cloud/composer/README.md
@@ -55,7 +55,7 @@ int main(int argc, char* argv[]) try {
       composer::EnvironmentsClient(composer::MakeEnvironmentsConnection());
 
   auto const parent =
-      std::string("projects/") + argv[0] + "/locations/" + argv[1];
+      std::string("projects/") + argv[1] + "/locations/" + argv[2];
   for (auto e : client.ListEnvironments(parent)) {
     if (!e) throw std::runtime_error(e.status().message());
     std::cout << e->DebugString() << "\n";

--- a/google/cloud/composer/quickstart/quickstart.cc
+++ b/google/cloud/composer/quickstart/quickstart.cc
@@ -27,7 +27,7 @@ int main(int argc, char* argv[]) try {
       composer::EnvironmentsClient(composer::MakeEnvironmentsConnection());
 
   auto const parent =
-      std::string("projects/") + argv[0] + "/locations/" + argv[1];
+      std::string("projects/") + argv[1] + "/locations/" + argv[2];
   for (auto e : client.ListEnvironments(parent)) {
     if (!e) throw std::runtime_error(e.status().message());
     std::cout << e->DebugString() << "\n";

--- a/google/cloud/contactcenterinsights/CMakeLists.txt
+++ b/google/cloud/contactcenterinsights/CMakeLists.txt
@@ -120,6 +120,22 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_contactcenterinsights_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
+include(CTest)
+if (BUILD_TESTING)
+    add_executable(contactcenterinsights_quickstart "quickstart/quickstart.cc")
+    target_link_libraries(contactcenterinsights_quickstart
+            PRIVATE google-cloud-cpp::experimental-contactcenterinsights)
+    google_cloud_cpp_add_common_options(contactcenterinsights_quickstart)
+    add_test(
+            NAME contactcenterinsights_quickstart
+            COMMAND
+            cmake -P "${PROJECT_SOURCE_DIR}/cmake/quickstart-runner.cmake"
+            $<TARGET_FILE:contactcenterinsights_quickstart> GOOGLE_CLOUD_PROJECT
+            GOOGLE_CLOUD_REGION)
+    set_tests_properties(contactcenterinsights_quickstart
+            PROPERTIES LABELS "integration-test;quickstart")
+endif ()
+
 # Get the destination directories based on the GNU recommendations.
 include(GNUInstallDirs)
 

--- a/google/cloud/contactcenterinsights/CMakeLists.txt
+++ b/google/cloud/contactcenterinsights/CMakeLists.txt
@@ -123,17 +123,18 @@ target_compile_options(google_cloud_cpp_contactcenterinsights_mocks
 include(CTest)
 if (BUILD_TESTING)
     add_executable(contactcenterinsights_quickstart "quickstart/quickstart.cc")
-    target_link_libraries(contactcenterinsights_quickstart
-            PRIVATE google-cloud-cpp::experimental-contactcenterinsights)
+    target_link_libraries(
+        contactcenterinsights_quickstart
+        PRIVATE google-cloud-cpp::experimental-contactcenterinsights)
     google_cloud_cpp_add_common_options(contactcenterinsights_quickstart)
     add_test(
-            NAME contactcenterinsights_quickstart
-            COMMAND
+        NAME contactcenterinsights_quickstart
+        COMMAND
             cmake -P "${PROJECT_SOURCE_DIR}/cmake/quickstart-runner.cmake"
-            $<TARGET_FILE:contactcenterinsights_quickstart> GOOGLE_CLOUD_PROJECT
-            GOOGLE_CLOUD_REGION)
+            $<TARGET_FILE:contactcenterinsights_quickstart>
+            GOOGLE_CLOUD_PROJECT GOOGLE_CLOUD_REGION)
     set_tests_properties(contactcenterinsights_quickstart
-            PROPERTIES LABELS "integration-test;quickstart")
+                         PROPERTIES LABELS "integration-test;quickstart")
 endif ()
 
 # Get the destination directories based on the GNU recommendations.

--- a/google/cloud/gkehub/CMakeLists.txt
+++ b/google/cloud/gkehub/CMakeLists.txt
@@ -118,6 +118,20 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_gkehub_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
+include(CTest)
+if (BUILD_TESTING)
+    add_executable(gkehub_quickstart "quickstart/quickstart.cc")
+    target_link_libraries(gkehub_quickstart
+                          PRIVATE google-cloud-cpp::experimental-gkehub)
+    google_cloud_cpp_add_common_options(gkehub_quickstart)
+    add_test(
+        NAME gkehub_quickstart
+        COMMAND cmake -P "${PROJECT_SOURCE_DIR}/cmake/quickstart-runner.cmake"
+                $<TARGET_FILE:gkehub_quickstart> GOOGLE_CLOUD_PROJECT)
+    set_tests_properties(gkehub_quickstart
+                         PROPERTIES LABELS "integration-test;quickstart")
+endif ()
+
 # Get the destination directories based on the GNU recommendations.
 include(GNUInstallDirs)
 

--- a/google/cloud/gkehub/README.md
+++ b/google/cloud/gkehub/README.md
@@ -45,16 +45,15 @@ this library.
 #include <stdexcept>
 
 int main(int argc, char* argv[]) try {
-  if (argc != 3) {
-    std::cerr << "Usage: " << argv[0] << " project-id location-id\n";
+  if (argc != 2) {
+    std::cerr << "Usage: " << argv[0] << " project-id\n";
     return 1;
   }
 
   namespace gkehub = ::google::cloud::gkehub;
   auto client = gkehub::GkeHubClient(gkehub::MakeGkeHubConnection());
 
-  auto const location =
-      std::string{"projects/"} + argv[1] + "/locations/" + argv[2];
+  auto const location = std::string{"projects/"} + argv[1] + "/locations/-";
   for (auto r : client.ListMemberships(location)) {
     if (!r) throw std::runtime_error(r.status().message());
     std::cout << r->DebugString() << "\n";

--- a/google/cloud/gkehub/quickstart/quickstart.cc
+++ b/google/cloud/gkehub/quickstart/quickstart.cc
@@ -17,16 +17,15 @@
 #include <stdexcept>
 
 int main(int argc, char* argv[]) try {
-  if (argc != 3) {
-    std::cerr << "Usage: " << argv[0] << " project-id location-id\n";
+  if (argc != 2) {
+    std::cerr << "Usage: " << argv[0] << " project-id\n";
     return 1;
   }
 
   namespace gkehub = ::google::cloud::gkehub;
   auto client = gkehub::GkeHubClient(gkehub::MakeGkeHubConnection());
 
-  auto const location =
-      std::string{"projects/"} + argv[1] + "/locations/" + argv[2];
+  auto const location = std::string{"projects/"} + argv[1] + "/locations/-";
   for (auto r : client.ListMemberships(location)) {
     if (!r) throw std::runtime_error(r.status().message());
     std::cout << r->DebugString() << "\n";

--- a/google/cloud/ids/CMakeLists.txt
+++ b/google/cloud/ids/CMakeLists.txt
@@ -113,6 +113,20 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_ids_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
+include(CTest)
+if (BUILD_TESTING)
+    add_executable(ids_quickstart "quickstart/quickstart.cc")
+    target_link_libraries(ids_quickstart
+                          PRIVATE google-cloud-cpp::experimental-ids)
+    google_cloud_cpp_add_common_options(ids_quickstart)
+    add_test(
+        NAME ids_quickstart
+        COMMAND cmake -P "${PROJECT_SOURCE_DIR}/cmake/quickstart-runner.cmake"
+                $<TARGET_FILE:ids_quickstart> GOOGLE_CLOUD_PROJECT)
+    set_tests_properties(ids_quickstart
+                         PROPERTIES LABELS "integration-test;quickstart")
+endif ()
+
 # Get the destination directories based on the GNU recommendations.
 include(GNUInstallDirs)
 

--- a/google/cloud/ids/README.md
+++ b/google/cloud/ids/README.md
@@ -44,21 +44,19 @@ this library.
 <!-- inject-quickstart-start -->
 ```cc
 #include "google/cloud/ids/ids_client.h"
-#include "google/cloud/project.h"
 #include <iostream>
 #include <stdexcept>
 
 int main(int argc, char* argv[]) try {
-  if (argc != 3) {
-    std::cerr << "Usage: " << argv[0] << " project-id location-id\n";
+  if (argc != 2) {
+    std::cerr << "Usage: " << argv[0] << " project-id\n";
     return 1;
   }
 
   namespace ids = ::google::cloud::ids;
   auto client = ids::IDSClient(ids::MakeIDSConnection());
 
-  auto const project = google::cloud::Project(argv[1]);
-  auto const parent = project.FullName() + "/locations/" + argv[2];
+  auto const parent = std::string{"projects/"} + argv[1] + "/locations/-";
   for (auto ep : client.ListEndpoints(parent)) {
     if (!ep) throw std::runtime_error(ep.status().message());
     std::cout << ep->DebugString() << "\n";

--- a/google/cloud/ids/quickstart/quickstart.cc
+++ b/google/cloud/ids/quickstart/quickstart.cc
@@ -13,21 +13,19 @@
 // limitations under the License.
 
 #include "google/cloud/ids/ids_client.h"
-#include "google/cloud/project.h"
 #include <iostream>
 #include <stdexcept>
 
 int main(int argc, char* argv[]) try {
-  if (argc != 3) {
-    std::cerr << "Usage: " << argv[0] << " project-id location-id\n";
+  if (argc != 2) {
+    std::cerr << "Usage: " << argv[0] << " project-id\n";
     return 1;
   }
 
   namespace ids = ::google::cloud::ids;
   auto client = ids::IDSClient(ids::MakeIDSConnection());
 
-  auto const project = google::cloud::Project(argv[1]);
-  auto const parent = project.FullName() + "/locations/" + argv[2];
+  auto const parent = std::string{"projects/"} + argv[1] + "/locations/-";
   for (auto ep : client.ListEndpoints(parent)) {
     if (!ep) throw std::runtime_error(ep.status().message());
     std::cout << ep->DebugString() << "\n";

--- a/google/cloud/kms/CMakeLists.txt
+++ b/google/cloud/kms/CMakeLists.txt
@@ -113,6 +113,22 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_kms_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
+include(CTest)
+if (BUILD_TESTING)
+    add_executable(kms_quickstart "quickstart/quickstart.cc")
+    target_link_libraries(kms_quickstart
+                          PRIVATE google-cloud-cpp::experimental-kms)
+    google_cloud_cpp_add_common_options(kms_quickstart)
+    add_test(
+        NAME kms_quickstart
+        COMMAND
+            cmake -P "${PROJECT_SOURCE_DIR}/cmake/quickstart-runner.cmake"
+            $<TARGET_FILE:kms_quickstart> GOOGLE_CLOUD_PROJECT
+            GOOGLE_CLOUD_REGION)
+    set_tests_properties(kms_quickstart
+                         PROPERTIES LABELS "integration-test;quickstart")
+endif ()
+
 # Get the destination directories based on the GNU recommendations.
 include(GNUInstallDirs)
 

--- a/google/cloud/logging/CMakeLists.txt
+++ b/google/cloud/logging/CMakeLists.txt
@@ -108,6 +108,20 @@ target_compile_options(google_cloud_cpp_logging_mocks
 
 add_subdirectory(integration_tests)
 
+include(CTest)
+if (BUILD_TESTING)
+    add_executable(logging_quickstart "quickstart/quickstart.cc")
+    target_link_libraries(logging_quickstart
+                          PRIVATE google-cloud-cpp::experimental-logging)
+    google_cloud_cpp_add_common_options(logging_quickstart)
+    add_test(
+        NAME logging_quickstart
+        COMMAND cmake -P "${PROJECT_SOURCE_DIR}/cmake/quickstart-runner.cmake"
+                $<TARGET_FILE:logging_quickstart> GOOGLE_CLOUD_PROJECT)
+    set_tests_properties(logging_quickstart
+                         PROPERTIES LABELS "integration-test;quickstart")
+endif ()
+
 # Get the destination directories based on the GNU recommendations.
 include(GNUInstallDirs)
 

--- a/google/cloud/logging/CMakeLists.txt
+++ b/google/cloud/logging/CMakeLists.txt
@@ -109,7 +109,7 @@ target_compile_options(google_cloud_cpp_logging_mocks
 add_subdirectory(integration_tests)
 
 include(CTest)
-if (BUILD_TESTING)
+if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_executable(logging_quickstart "quickstart/quickstart.cc")
     target_link_libraries(logging_quickstart
                           PRIVATE google-cloud-cpp::experimental-logging)

--- a/google/cloud/memcache/CMakeLists.txt
+++ b/google/cloud/memcache/CMakeLists.txt
@@ -116,6 +116,20 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_memcache_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
+include(CTest)
+if (BUILD_TESTING)
+    add_executable(memcache_quickstart "quickstart/quickstart.cc")
+    target_link_libraries(memcache_quickstart
+                          PRIVATE google-cloud-cpp::experimental-memcache)
+    google_cloud_cpp_add_common_options(memcache_quickstart)
+    add_test(
+        NAME memcache_quickstart
+        COMMAND cmake -P "${PROJECT_SOURCE_DIR}/cmake/quickstart-runner.cmake"
+                $<TARGET_FILE:memcache_quickstart> GOOGLE_CLOUD_PROJECT)
+    set_tests_properties(memcache_quickstart
+                         PROPERTIES LABELS "integration-test;quickstart")
+endif ()
+
 # Get the destination directories based on the GNU recommendations.
 include(GNUInstallDirs)
 

--- a/google/cloud/redis/CMakeLists.txt
+++ b/google/cloud/redis/CMakeLists.txt
@@ -115,6 +115,20 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_redis_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
+include(CTest)
+if (BUILD_TESTING)
+    add_executable(redis_quickstart "quickstart/quickstart.cc")
+    target_link_libraries(redis_quickstart
+                          PRIVATE google-cloud-cpp::experimental-redis)
+    google_cloud_cpp_add_common_options(redis_quickstart)
+    add_test(
+        NAME redis_quickstart
+        COMMAND cmake -P "${PROJECT_SOURCE_DIR}/cmake/quickstart-runner.cmake"
+                $<TARGET_FILE:redis_quickstart> GOOGLE_CLOUD_PROJECT)
+    set_tests_properties(redis_quickstart
+                         PROPERTIES LABELS "integration-test;quickstart")
+endif ()
+
 # Get the destination directories based on the GNU recommendations.
 include(GNUInstallDirs)
 

--- a/google/cloud/scheduler/CMakeLists.txt
+++ b/google/cloud/scheduler/CMakeLists.txt
@@ -116,6 +116,22 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_scheduler_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
+include(CTest)
+if (BUILD_TESTING)
+    add_executable(scheduler_quickstart "quickstart/quickstart.cc")
+    target_link_libraries(scheduler_quickstart
+                          PRIVATE google-cloud-cpp::experimental-scheduler)
+    google_cloud_cpp_add_common_options(scheduler_quickstart)
+    add_test(
+        NAME scheduler_quickstart
+        COMMAND
+            cmake -P "${PROJECT_SOURCE_DIR}/cmake/quickstart-runner.cmake"
+            $<TARGET_FILE:scheduler_quickstart> GOOGLE_CLOUD_PROJECT
+            GOOGLE_CLOUD_REGION)
+    set_tests_properties(scheduler_quickstart
+                         PROPERTIES LABELS "integration-test;quickstart")
+endif ()
+
 # Get the destination directories based on the GNU recommendations.
 include(GNUInstallDirs)
 

--- a/google/cloud/scheduler/README.md
+++ b/google/cloud/scheduler/README.md
@@ -40,21 +40,21 @@ this library.
 <!-- inject-quickstart-start -->
 ```cc
 #include "google/cloud/scheduler/cloud_scheduler_client.h"
-#include "google/cloud/project.h"
 #include <iostream>
 #include <stdexcept>
 
 int main(int argc, char* argv[]) try {
-  if (argc != 2) {
-    std::cerr << "Usage: " << argv[0] << " project-id\n";
+  if (argc != 3) {
+    std::cerr << "Usage: " << argv[0] << " project-id location-id\n";
     return 1;
   }
 
   namespace scheduler = ::google::cloud::scheduler;
   auto client = scheduler::CloudSchedulerClient(
       scheduler::MakeCloudSchedulerConnection());
-  auto const project = google::cloud::Project(argv[1]);
-  for (auto j : client.ListJobs(project.FullName())) {
+  auto const parent =
+      std::string{"projects/"} + argv[1] + "/locations/" + argv[2];
+  for (auto j : client.ListJobs(parent)) {
     if (!j) throw std::runtime_error(j.status().message());
     std::cout << j->DebugString() << "\n";
   }

--- a/google/cloud/scheduler/quickstart/quickstart.cc
+++ b/google/cloud/scheduler/quickstart/quickstart.cc
@@ -13,21 +13,21 @@
 // limitations under the License.
 
 #include "google/cloud/scheduler/cloud_scheduler_client.h"
-#include "google/cloud/project.h"
 #include <iostream>
 #include <stdexcept>
 
 int main(int argc, char* argv[]) try {
-  if (argc != 2) {
-    std::cerr << "Usage: " << argv[0] << " project-id\n";
+  if (argc != 3) {
+    std::cerr << "Usage: " << argv[0] << " project-id location-id\n";
     return 1;
   }
 
   namespace scheduler = ::google::cloud::scheduler;
   auto client = scheduler::CloudSchedulerClient(
       scheduler::MakeCloudSchedulerConnection());
-  auto const project = google::cloud::Project(argv[1]);
-  for (auto j : client.ListJobs(project.FullName())) {
+  auto const parent =
+      std::string{"projects/"} + argv[1] + "/locations/" + argv[2];
+  for (auto j : client.ListJobs(parent)) {
     if (!j) throw std::runtime_error(j.status().message());
     std::cout << j->DebugString() << "\n";
   }

--- a/google/cloud/tpu/CMakeLists.txt
+++ b/google/cloud/tpu/CMakeLists.txt
@@ -117,15 +117,14 @@ include(CTest)
 if (BUILD_TESTING)
     add_executable(tpu_quickstart "quickstart/quickstart.cc")
     target_link_libraries(tpu_quickstart
-            PRIVATE google-cloud-cpp::experimental-tpu)
+                          PRIVATE google-cloud-cpp::experimental-tpu)
     google_cloud_cpp_add_common_options(tpu_quickstart)
     add_test(
-            NAME tpu_quickstart
-            COMMAND
-            cmake -P "${PROJECT_SOURCE_DIR}/cmake/quickstart-runner.cmake"
-            $<TARGET_FILE:tpu_quickstart> GOOGLE_CLOUD_PROJECT)
+        NAME tpu_quickstart
+        COMMAND cmake -P "${PROJECT_SOURCE_DIR}/cmake/quickstart-runner.cmake"
+                $<TARGET_FILE:tpu_quickstart> GOOGLE_CLOUD_PROJECT)
     set_tests_properties(tpu_quickstart
-            PROPERTIES LABELS "integration-test;quickstart")
+                         PROPERTIES LABELS "integration-test;quickstart")
 endif ()
 
 # Get the destination directories based on the GNU recommendations.

--- a/google/cloud/tpu/CMakeLists.txt
+++ b/google/cloud/tpu/CMakeLists.txt
@@ -113,6 +113,21 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_tpu_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
+include(CTest)
+if (BUILD_TESTING)
+    add_executable(tpu_quickstart "quickstart/quickstart.cc")
+    target_link_libraries(tpu_quickstart
+            PRIVATE google-cloud-cpp::experimental-tpu)
+    google_cloud_cpp_add_common_options(tpu_quickstart)
+    add_test(
+            NAME tpu_quickstart
+            COMMAND
+            cmake -P "${PROJECT_SOURCE_DIR}/cmake/quickstart-runner.cmake"
+            $<TARGET_FILE:tpu_quickstart> GOOGLE_CLOUD_PROJECT)
+    set_tests_properties(tpu_quickstart
+            PROPERTIES LABELS "integration-test;quickstart")
+endif ()
+
 # Get the destination directories based on the GNU recommendations.
 include(GNUInstallDirs)
 

--- a/google/cloud/tpu/README.md
+++ b/google/cloud/tpu/README.md
@@ -41,21 +41,19 @@ this library.
 <!-- inject-quickstart-start -->
 ```cc
 #include "google/cloud/tpu/tpu_client.h"
-#include "google/cloud/project.h"
 #include <iostream>
 #include <stdexcept>
 
 int main(int argc, char* argv[]) try {
-  if (argc != 3) {
-    std::cerr << "Usage: " << argv[0] << " project-id location-id\n";
+  if (argc != 2) {
+    std::cerr << "Usage: " << argv[0] << " project-id\n";
     return 1;
   }
 
   namespace tpu = ::google::cloud::tpu;
   auto client = tpu::TpuClient(tpu::MakeTpuConnection());
 
-  auto const project = google::cloud::Project(argv[1]);
-  auto const parent = project.FullName() + "/locations/" + argv[2];
+  auto const parent = std::string{"projects/"} + argv[1] + "/locations/-";
   for (auto n : client.ListNodes(parent)) {
     if (!n) throw std::runtime_error(n.status().message());
     std::cout << n->DebugString() << "\n";

--- a/google/cloud/tpu/quickstart/quickstart.cc
+++ b/google/cloud/tpu/quickstart/quickstart.cc
@@ -13,21 +13,19 @@
 // limitations under the License.
 
 #include "google/cloud/tpu/tpu_client.h"
-#include "google/cloud/project.h"
 #include <iostream>
 #include <stdexcept>
 
 int main(int argc, char* argv[]) try {
-  if (argc != 3) {
-    std::cerr << "Usage: " << argv[0] << " project-id location-id\n";
+  if (argc != 2) {
+    std::cerr << "Usage: " << argv[0] << " project-id\n";
     return 1;
   }
 
   namespace tpu = ::google::cloud::tpu;
   auto client = tpu::TpuClient(tpu::MakeTpuConnection());
 
-  auto const project = google::cloud::Project(argv[1]);
-  auto const parent = project.FullName() + "/locations/" + argv[2];
+  auto const parent = std::string{"projects/"} + argv[1] + "/locations/-";
   for (auto n : client.ListNodes(parent)) {
     if (!n) throw std::runtime_error(n.status().message());
     std::cout << n->DebugString() << "\n";

--- a/google/cloud/vmmigration/CMakeLists.txt
+++ b/google/cloud/vmmigration/CMakeLists.txt
@@ -116,6 +116,20 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_vmmigration_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
+include(CTest)
+if (BUILD_TESTING)
+    add_executable(vmmigration_quickstart "quickstart/quickstart.cc")
+    target_link_libraries(vmmigration_quickstart
+                          PRIVATE google-cloud-cpp::experimental-vmmigration)
+    google_cloud_cpp_add_common_options(vmmigration_quickstart)
+    add_test(
+        NAME vmmigration_quickstart
+        COMMAND cmake -P "${PROJECT_SOURCE_DIR}/cmake/quickstart-runner.cmake"
+                $<TARGET_FILE:vmmigration_quickstart> GOOGLE_CLOUD_PROJECT)
+    set_tests_properties(vmmigration_quickstart
+                         PROPERTIES LABELS "integration-test;quickstart")
+endif ()
+
 # Get the destination directories based on the GNU recommendations.
 include(GNUInstallDirs)
 

--- a/google/cloud/vmmigration/README.md
+++ b/google/cloud/vmmigration/README.md
@@ -44,8 +44,8 @@ this library.
 #include <stdexcept>
 
 int main(int argc, char* argv[]) try {
-  if (argc != 3) {
-    std::cerr << "Usage: " << argv[0] << " project-id location-id\n";
+  if (argc != 2) {
+    std::cerr << "Usage: " << argv[0] << " project-id\n";
     return 1;
   }
 
@@ -53,11 +53,10 @@ int main(int argc, char* argv[]) try {
   auto client =
       vmmigration::VmMigrationClient(vmmigration::MakeVmMigrationConnection());
 
-  auto const parent =
-      std::string{"projects/"} + argv[1] + "/locations/" + argv[2];
-  for (auto r : client.ListCloneJobs(parent)) {
-    if (!r) throw std::runtime_error(r.status().message());
-    std::cout << r->DebugString() << "\n";
+  auto const parent = std::string{"projects/"} + argv[1] + "/locations/-";
+  for (auto s : client.ListSources(parent)) {
+    if (!s) throw std::runtime_error(s.status().message());
+    std::cout << s->DebugString() << "\n";
   }
 
   return 0;

--- a/google/cloud/vmmigration/quickstart/quickstart.cc
+++ b/google/cloud/vmmigration/quickstart/quickstart.cc
@@ -17,8 +17,8 @@
 #include <stdexcept>
 
 int main(int argc, char* argv[]) try {
-  if (argc != 3) {
-    std::cerr << "Usage: " << argv[0] << " project-id location-id\n";
+  if (argc != 2) {
+    std::cerr << "Usage: " << argv[0] << " project-id\n";
     return 1;
   }
 
@@ -26,11 +26,10 @@ int main(int argc, char* argv[]) try {
   auto client =
       vmmigration::VmMigrationClient(vmmigration::MakeVmMigrationConnection());
 
-  auto const parent =
-      std::string{"projects/"} + argv[1] + "/locations/" + argv[2];
-  for (auto r : client.ListCloneJobs(parent)) {
-    if (!r) throw std::runtime_error(r.status().message());
-    std::cout << r->DebugString() << "\n";
+  auto const parent = std::string{"projects/"} + argv[1] + "/locations/-";
+  for (auto s : client.ListSources(parent)) {
+    if (!s) throw std::runtime_error(s.status().message());
+    std::cout << s->DebugString() << "\n";
   }
 
   return 0;


### PR DESCRIPTION
Another pass cleaning up quickstart programs and adding them to the CI
builds.

I know I am not being very systematic on these, maybe I should be sending one PR per quickstart or something.  But I think speed is more important than carefully curated code archaeological records in this case.

Part of the work for #7936

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8254)
<!-- Reviewable:end -->
