### PR TITLE
fix(oauth2): use correct expiration slack value

### DIFF
--- a/google/cloud/storage/oauth2/credential_constants.h
+++ b/google/cloud/storage/oauth2/credential_constants.h
@@ -48,7 +48,7 @@ constexpr std::chrono::seconds GoogleOAuthAccessTokenLifetime() {
  * error.
  */
 constexpr std::chrono::seconds GoogleOAuthAccessTokenExpirationSlack() {
-  return std::chrono::seconds(500);
+  return std::chrono::seconds(300);
 }
 
 /// The endpoint to fetch an OAuth 2.0 access token from.


### PR DESCRIPTION
In the client library, OAuth tokens are currently cached until they have 500s of time remaining. However, as per [public documentation](https://cloud.google.com/compute/docs/access/create-enable-service-accounts-for-instances), "The metadata server caches access tokens until they have 5 minutes of remaining time..."

This leaves a 200s-window in which RefreshingCredentialsWrapper objects can repeatedly attempt to refresh credentials from the metadata server, but receive the same token each time. 

This pull request corrects the value of slack from 500s to 300s to prevent this from happening.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8255)
<!-- Reviewable:end -->
