### PR TITLE
fix: add Options save/restore to StreamRange<T>

### DIFF
--- a/google/cloud/internal/async_long_running_operation_test.cc
+++ b/google/cloud/internal/async_long_running_operation_test.cc
@@ -155,6 +155,7 @@ TEST(AsyncLongRunningTest, RequestPollThenSuccessMetadata) {
           TestRetryPolicy(), TestBackoffPolicy(), Idempotency::kIdempotent,
           std::move(policy), "test-function")
           .get();
+  OptionsSpan overlay(Options{}.set<StringOption>("uh-oh"));
   ASSERT_THAT(actual, IsOk());
   EXPECT_THAT(*actual, IsProtoEqual(expected));
 }
@@ -208,6 +209,7 @@ TEST(AsyncLongRunningTest, RequestPollThenSuccessResponse) {
           TestRetryPolicy(), TestBackoffPolicy(), Idempotency::kIdempotent,
           std::move(policy), "test-function")
           .get();
+  OptionsSpan overlay(Options{}.set<StringOption>("uh-oh"));
   ASSERT_THAT(actual, IsOk());
   EXPECT_THAT(*actual, IsProtoEqual(expected));
 }
@@ -275,10 +277,14 @@ TEST(AsyncLongRunningTest, RequestPollThenCancel) {
   // Wait until the polling loop is backing off for a second time.
   timer.PopFront().set_value();
   auto t = timer.PopFront();
-  // cancel the long running operation
-  pending.cancel();
+  {
+    // cancel the long running operation
+    OptionsSpan overlay(Options{}.set<StringOption>("uh-oh"));
+    pending.cancel();
+  }
   // release timer
   t.set_value();
+  OptionsSpan overlay(Options{}.set<StringOption>("uh-oh"));
   auto actual = pending.get();
   EXPECT_THAT(actual, StatusIs(StatusCode::kCancelled));
 }

--- a/google/cloud/internal/async_polling_loop.cc
+++ b/google/cloud/internal/async_polling_loop.cc
@@ -46,7 +46,7 @@ class AsyncPollingLoopImpl
     auto self = shared_from_this();
     auto w = WeakFromThis();
     auto const& options = CurrentOptions();
-    promise_ = promise<StatusOr<Operation>>([w, options] {
+    promise_ = promise<StatusOr<Operation>>([w, options]() mutable {
       if (auto self = w.lock()) {
         OptionsSpan span(std::move(options));
         self->DoCancel();

--- a/google/cloud/internal/async_polling_loop.cc
+++ b/google/cloud/internal/async_polling_loop.cc
@@ -45,8 +45,12 @@ class AsyncPollingLoopImpl
   future<StatusOr<Operation>> Start(future<StatusOr<Operation>> op) {
     auto self = shared_from_this();
     auto w = WeakFromThis();
-    promise_ = promise<StatusOr<Operation>>([w] {
-      if (auto self = w.lock()) self->DoCancel();
+    auto const& options = CurrentOptions();
+    promise_ = promise<StatusOr<Operation>>([w, options] {
+      if (auto self = w.lock()) {
+        OptionsSpan span(std::move(options));
+        self->DoCancel();
+      }
     });
     op.then([self](future<StatusOr<Operation>> f) { self->OnStart(f.get()); });
     return promise_.get_future();

--- a/google/cloud/internal/async_retry_loop.h
+++ b/google/cloud/internal/async_retry_loop.h
@@ -189,8 +189,12 @@ class AsyncRetryLoopImpl
 
   future<T> Start() {
     auto weak = std::weak_ptr<AsyncRetryLoopImpl>(this->shared_from_this());
-    result_ = promise<T>([weak] {
-      if (auto self = weak.lock()) self->Cancel();
+    auto const& options = CurrentOptions();
+    result_ = promise<T>([weak, options] {
+      if (auto self = weak.lock()) {
+        OptionsSpan span(std::move(options));
+        self->Cancel();
+      }
     });
 
     StartAttempt();

--- a/google/cloud/internal/async_retry_loop.h
+++ b/google/cloud/internal/async_retry_loop.h
@@ -190,7 +190,7 @@ class AsyncRetryLoopImpl
   future<T> Start() {
     auto weak = std::weak_ptr<AsyncRetryLoopImpl>(this->shared_from_this());
     auto const& options = CurrentOptions();
-    result_ = promise<T>([weak, options] {
+    result_ = promise<T>([weak, options]() mutable {
       if (auto self = weak.lock()) {
         OptionsSpan span(std::move(options));
         self->Cancel();

--- a/google/cloud/internal/pagination_range_test.cc
+++ b/google/cloud/internal/pagination_range_test.cc
@@ -97,6 +97,7 @@ TYPED_TEST(PaginationRangeTest, TypedEmpty) {
   auto range = MakePaginationRange<ItemRange>(
       Request{}, [&mock](Request const& r) { return mock.Loader(r); },
       [](ResponseType const& r) { return r.testonly_items; });
+  OptionsSpan overlay(Options{}.set<StringOption>("uh-oh"));
   EXPECT_TRUE(range.begin() == range.end());
 }
 
@@ -116,6 +117,7 @@ TYPED_TEST(PaginationRangeTest, SinglePage) {
   auto range = MakePaginationRange<ItemRange>(
       Request{}, [&mock](Request const& r) { return mock.Loader(r); },
       [](ResponseType const& r) { return r.testonly_items; });
+  OptionsSpan overlay(Options{}.set<StringOption>("uh-oh"));
   std::vector<std::string> names;
   for (auto& p : range) {
     if (!p) break;
@@ -147,6 +149,7 @@ TYPED_TEST(PaginationRangeTest, NonProtoRange) {
         }
         return v;
       });
+  OptionsSpan overlay(Options{}.set<StringOption>("uh-oh"));
 
   std::vector<std::string> names;
   for (auto& p : range) {
@@ -182,6 +185,7 @@ TYPED_TEST(PaginationRangeTest, TwoPages) {
   auto range = MakePaginationRange<ItemRange>(
       Request{}, [&mock](Request const& r) { return mock.Loader(r); },
       [](ResponseType const& r) { return r.testonly_items; });
+  OptionsSpan overlay(Options{}.set<StringOption>("uh-oh"));
   std::vector<std::string> names;
   for (auto& p : range) {
     if (!p) break;
@@ -222,6 +226,7 @@ TYPED_TEST(PaginationRangeTest, TwoPagesWithError) {
   auto range = MakePaginationRange<ItemRange>(
       Request{}, [&mock](Request const& r) { return mock.Loader(r); },
       [](ResponseType const& r) { return r.testonly_items; });
+  OptionsSpan overlay(Options{}.set<StringOption>("uh-oh"));
   std::vector<std::string> names;
   for (auto& p : range) {
     if (!p) {
@@ -256,6 +261,7 @@ TYPED_TEST(PaginationRangeTest, IteratorCoverage) {
   auto range = MakePaginationRange<ItemRange>(
       Request{}, [&mock](Request const& r) { return mock.Loader(r); },
       [](ResponseType const& r) { return r.testonly_items; });
+  OptionsSpan overlay(Options{}.set<StringOption>("uh-oh"));
   auto i0 = range.begin();
   auto i1 = i0;
   EXPECT_TRUE(i0 == i1);

--- a/google/cloud/internal/pagination_range_test.cc
+++ b/google/cloud/internal/pagination_range_test.cc
@@ -13,8 +13,10 @@
 // limitations under the License.
 
 #include "google/cloud/internal/pagination_range.h"
+#include "google/cloud/options.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
+#include <string>
 
 namespace google {
 namespace cloud {
@@ -25,6 +27,10 @@ namespace {
 using ::google::cloud::testing_util::StatusIs;
 using ::testing::ElementsAre;
 using ::testing::HasSubstr;
+
+struct StringOption {
+  using Type = std::string;
+};
 
 struct Item {
   std::string data;
@@ -83,9 +89,11 @@ TYPED_TEST(PaginationRangeTest, TypedEmpty) {
   using ResponseType = TypeParam;
   MockRpc<ResponseType> mock;
   EXPECT_CALL(mock, Loader).WillOnce([](Request const& request) {
+    EXPECT_EQ(CurrentOptions().get<StringOption>(), "TypedEmpty");
     EXPECT_TRUE(request.testonly_page_token.empty());
     return ResponseType{};
   });
+  OptionsSpan span(Options{}.set<StringOption>("TypedEmpty"));
   auto range = MakePaginationRange<ItemRange>(
       Request{}, [&mock](Request const& r) { return mock.Loader(r); },
       [](ResponseType const& r) { return r.testonly_items; });
@@ -96,6 +104,7 @@ TYPED_TEST(PaginationRangeTest, SinglePage) {
   using ResponseType = TypeParam;
   MockRpc<ResponseType> mock;
   EXPECT_CALL(mock, Loader).WillOnce([](Request const& request) {
+    EXPECT_EQ(CurrentOptions().get<StringOption>(), "SinglePage");
     EXPECT_TRUE(request.testonly_page_token.empty());
     ResponseType response;
     response.testonly_items.push_back(Item{"p1"});
@@ -103,6 +112,7 @@ TYPED_TEST(PaginationRangeTest, SinglePage) {
     return response;
   });
 
+  OptionsSpan span(Options{}.set<StringOption>("SinglePage"));
   auto range = MakePaginationRange<ItemRange>(
       Request{}, [&mock](Request const& r) { return mock.Loader(r); },
       [](ResponseType const& r) { return r.testonly_items; });
@@ -118,6 +128,7 @@ TYPED_TEST(PaginationRangeTest, NonProtoRange) {
   using ResponseType = TypeParam;
   MockRpc<ResponseType> mock;
   EXPECT_CALL(mock, Loader).WillOnce([](Request const& request) {
+    EXPECT_EQ(CurrentOptions().get<StringOption>(), "NonProtoRange");
     EXPECT_TRUE(request.testonly_page_token.empty());
     ResponseType response;
     response.testonly_items.push_back(Item{"p1"});
@@ -125,6 +136,7 @@ TYPED_TEST(PaginationRangeTest, NonProtoRange) {
     return response;
   });
 
+  OptionsSpan span(Options{}.set<StringOption>("NonProtoRange"));
   using NonProtoRange = PaginationRange<std::string>;
   auto range = MakePaginationRange<NonProtoRange>(
       Request{}, [&mock](Request const& r) { return mock.Loader(r); },
@@ -149,6 +161,7 @@ TYPED_TEST(PaginationRangeTest, TwoPages) {
   MockRpc<ResponseType> mock;
   EXPECT_CALL(mock, Loader)
       .WillOnce([](Request const& request) {
+        EXPECT_EQ(CurrentOptions().get<StringOption>(), "TwoPages");
         EXPECT_TRUE(request.testonly_page_token.empty());
         ResponseType response;
         response.testonly_set_page_token("t1");
@@ -157,6 +170,7 @@ TYPED_TEST(PaginationRangeTest, TwoPages) {
         return response;
       })
       .WillOnce([](Request const& request) {
+        EXPECT_EQ(CurrentOptions().get<StringOption>(), "TwoPages");
         EXPECT_EQ("t1", request.testonly_page_token);
         ResponseType response;
         response.testonly_items.push_back(Item{"p3"});
@@ -164,6 +178,7 @@ TYPED_TEST(PaginationRangeTest, TwoPages) {
         return response;
       });
 
+  OptionsSpan span(Options{}.set<StringOption>("TwoPages"));
   auto range = MakePaginationRange<ItemRange>(
       Request{}, [&mock](Request const& r) { return mock.Loader(r); },
       [](ResponseType const& r) { return r.testonly_items; });
@@ -180,6 +195,7 @@ TYPED_TEST(PaginationRangeTest, TwoPagesWithError) {
   MockRpc<ResponseType> mock;
   EXPECT_CALL(mock, Loader)
       .WillOnce([](Request const& request) {
+        EXPECT_EQ(CurrentOptions().get<StringOption>(), "TwoPagesWithError");
         EXPECT_TRUE(request.testonly_page_token.empty());
         ResponseType response;
         response.testonly_set_page_token("t1");
@@ -188,6 +204,7 @@ TYPED_TEST(PaginationRangeTest, TwoPagesWithError) {
         return response;
       })
       .WillOnce([](Request const& request) {
+        EXPECT_EQ(CurrentOptions().get<StringOption>(), "TwoPagesWithError");
         EXPECT_EQ("t1", request.testonly_page_token);
         ResponseType response;
         response.testonly_set_page_token("t2");
@@ -196,10 +213,12 @@ TYPED_TEST(PaginationRangeTest, TwoPagesWithError) {
         return response;
       })
       .WillOnce([](Request const& request) {
+        EXPECT_EQ(CurrentOptions().get<StringOption>(), "TwoPagesWithError");
         EXPECT_EQ("t2", request.testonly_page_token);
         return Status(StatusCode::kAborted, "bad-luck");
       });
 
+  OptionsSpan span(Options{}.set<StringOption>("TwoPagesWithError"));
   auto range = MakePaginationRange<ItemRange>(
       Request{}, [&mock](Request const& r) { return mock.Loader(r); },
       [](ResponseType const& r) { return r.testonly_items; });
@@ -220,6 +239,7 @@ TYPED_TEST(PaginationRangeTest, IteratorCoverage) {
   MockRpc<ResponseType> mock;
   EXPECT_CALL(mock, Loader)
       .WillOnce([](Request const& request) {
+        EXPECT_EQ(CurrentOptions().get<StringOption>(), "IteratorCoverage");
         EXPECT_TRUE(request.testonly_page_token.empty());
         ResponseType response;
         response.testonly_set_page_token("t1");
@@ -227,10 +247,12 @@ TYPED_TEST(PaginationRangeTest, IteratorCoverage) {
         return response;
       })
       .WillOnce([](Request const& request) {
+        EXPECT_EQ(CurrentOptions().get<StringOption>(), "IteratorCoverage");
         EXPECT_EQ("t1", request.testonly_page_token);
         return Status(StatusCode::kAborted, "bad-luck");
       });
 
+  OptionsSpan span(Options{}.set<StringOption>("IteratorCoverage"));
   auto range = MakePaginationRange<ItemRange>(
       Request{}, [&mock](Request const& r) { return mock.Loader(r); },
       [](ResponseType const& r) { return r.testonly_items; });

--- a/google/cloud/internal/retry_loop_test.cc
+++ b/google/cloud/internal/retry_loop_test.cc
@@ -57,6 +57,7 @@ TEST(RetryLoopTest, Success) {
         return StatusOr<int>(2 * request);
       },
       42, "error message");
+  OptionsSpan overlay(Options{}.set<StringOption>("uh-oh"));
   EXPECT_STATUS_OK(actual);
   EXPECT_EQ(84, *actual);
 }
@@ -74,6 +75,7 @@ TEST(RetryLoopTest, TransientThenSuccess) {
         return StatusOr<int>(2 * request);
       },
       42, "error message");
+  OptionsSpan overlay(Options{}.set<StringOption>("uh-oh"));
   EXPECT_STATUS_OK(actual);
   EXPECT_EQ(84, *actual);
 }
@@ -91,6 +93,7 @@ TEST(RetryLoopTest, ReturnJustStatus) {
         return Status();
       },
       42, "error message");
+  OptionsSpan overlay(Options{}.set<StringOption>("uh-oh"));
   EXPECT_STATUS_OK(actual);
 }
 
@@ -127,6 +130,7 @@ TEST(RetryLoopTest, UsesBackoffPolicy) {
         return StatusOr<int>(2 * request);
       },
       42, "error message", [&sleep_for](ms p) { sleep_for.push_back(p); });
+  OptionsSpan overlay(Options{}.set<StringOption>("uh-oh"));
   EXPECT_STATUS_OK(actual);
   EXPECT_EQ(84, *actual);
   EXPECT_THAT(sleep_for,
@@ -144,6 +148,7 @@ TEST(RetryLoopTest, TransientFailureNonIdempotent) {
         return StatusOr<int>(Status(StatusCode::kUnavailable, "try again"));
       },
       42, "the answer to everything");
+  OptionsSpan overlay(Options{}.set<StringOption>("uh-oh"));
   EXPECT_EQ(StatusCode::kUnavailable, actual.status().code());
   EXPECT_THAT(actual.status().message(), HasSubstr("try again"));
   EXPECT_THAT(actual.status().message(), HasSubstr("the answer to everything"));
@@ -161,6 +166,7 @@ TEST(RetryLoopTest, PermanentFailureFailureIdempotent) {
         return StatusOr<int>(Status(StatusCode::kPermissionDenied, "uh oh"));
       },
       42, "the answer to everything");
+  OptionsSpan overlay(Options{}.set<StringOption>("uh-oh"));
   EXPECT_EQ(StatusCode::kPermissionDenied, actual.status().code());
   EXPECT_THAT(actual.status().message(), HasSubstr("uh oh"));
   EXPECT_THAT(actual.status().message(), HasSubstr("the answer to everything"));
@@ -178,6 +184,7 @@ TEST(RetryLoopTest, TooManyTransientFailuresIdempotent) {
         return StatusOr<int>(Status(StatusCode::kUnavailable, "try again"));
       },
       42, "the answer to everything");
+  OptionsSpan overlay(Options{}.set<StringOption>("uh-oh"));
   EXPECT_EQ(StatusCode::kUnavailable, actual.status().code());
   EXPECT_THAT(actual.status().message(), HasSubstr("try again"));
   EXPECT_THAT(actual.status().message(), HasSubstr("the answer to everything"));

--- a/google/cloud/stream_range.h
+++ b/google/cloud/stream_range.h
@@ -15,6 +15,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STREAM_RANGE_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STREAM_RANGE_H
 
+#include "google/cloud/options.h"
 #include "google/cloud/status.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
@@ -186,6 +187,7 @@ class StreamRange {
         sr.current_ = std::move(t);
       }
     };
+    internal::OptionsSpan span(options_);
     auto v = reader_();
     absl::visit(UnpackVariant{*this}, std::move(v));
   }
@@ -225,6 +227,7 @@ class StreamRange {
   }
 
   internal::StreamReader<T> reader_;
+  Options options_ = internal::CurrentOptions();
   StatusOr<T> current_;
   bool current_ok_ = false;
   bool is_end_ = true;

--- a/google/cloud/stream_range_test.cc
+++ b/google/cloud/stream_range_test.cc
@@ -68,6 +68,7 @@ TEST(StreamRange, OneElement) {
 
   internal::OptionsSpan span(Options{}.set<StringOption>("OneElement"));
   StreamRange<int> sr = internal::MakeStreamRange<int>(std::move(reader));
+  internal::OptionsSpan overlay(Options{}.set<StringOption>("uh-oh"));
   auto it = sr.begin();
   EXPECT_NE(it, sr.end());
   EXPECT_TRUE(*it);
@@ -84,6 +85,7 @@ TEST(StreamRange, OneError) {
 
   internal::OptionsSpan span(Options{}.set<StringOption>("OneError"));
   StreamRange<int> sr = internal::MakeStreamRange<int>(std::move(reader));
+  internal::OptionsSpan overlay(Options{}.set<StringOption>("uh-oh"));
   auto it = sr.begin();
   EXPECT_NE(it, sr.end());
   EXPECT_FALSE(*it);
@@ -102,6 +104,7 @@ TEST(StreamRange, FiveElements) {
 
   internal::OptionsSpan span(Options{}.set<StringOption>("FiveElements"));
   StreamRange<int> sr = internal::MakeStreamRange<int>(std::move(reader));
+  internal::OptionsSpan overlay(Options{}.set<StringOption>("uh-oh"));
   std::vector<int> v;
   for (StatusOr<int>& x : sr) {
     EXPECT_TRUE(x);
@@ -121,6 +124,7 @@ TEST(StreamRange, PostFixIteration) {
 
   internal::OptionsSpan span(Options{}.set<StringOption>("PostFixIteration"));
   StreamRange<int> sr = internal::MakeStreamRange<int>(std::move(reader));
+  internal::OptionsSpan overlay(Options{}.set<StringOption>("uh-oh"));
   std::vector<int> v;
   // NOLINTNEXTLINE(modernize-loop-convert)
   for (auto it = sr.begin(); it != sr.end(); it++) {
@@ -144,6 +148,7 @@ TEST(StreamRange, Distance) {
         if (counter++ < 1) return counter;
         return Status{};
       });
+  internal::OptionsSpan overlay1(Options{}.set<StringOption>("uh-oh"));
   EXPECT_EQ(1, std::distance(one.begin(), one.end()));
 
   // Range of five elements
@@ -155,6 +160,7 @@ TEST(StreamRange, Distance) {
         if (counter++ < 5) return counter;
         return Status{};
       });
+  internal::OptionsSpan overlay5(Options{}.set<StringOption>("uh-oh"));
   EXPECT_EQ(5, std::distance(five.begin(), five.end()));
 }
 
@@ -166,8 +172,9 @@ TEST(StreamRange, StreamError) {
     return Status(StatusCode::kUnknown, "oops");
   };
 
-  internal::OptionsSpan span5(Options{}.set<StringOption>("StreamError"));
+  internal::OptionsSpan span(Options{}.set<StringOption>("StreamError"));
   StreamRange<int> sr = internal::MakeStreamRange<int>(std::move(reader));
+  internal::OptionsSpan overlay(Options{}.set<StringOption>("uh-oh"));
 
   auto it = sr.begin();
   EXPECT_NE(it, sr.end());

--- a/google/cloud/stream_range_test.cc
+++ b/google/cloud/stream_range_test.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/stream_range.h"
+#include "google/cloud/options.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include "absl/memory/memory.h"
 #include <gmock/gmock.h>
@@ -26,6 +27,10 @@ namespace {
 
 using ::google::cloud::testing_util::StatusIs;
 using ::testing::ElementsAre;
+
+struct StringOption {
+  using Type = std::string;
+};
 
 TEST(StreamRange, DefaultConstructed) {
   StreamRange<int> sr;
@@ -56,10 +61,12 @@ TEST(StreamRange, EmptyRange) {
 TEST(StreamRange, OneElement) {
   auto counter = 0;
   auto reader = [&counter]() -> internal::StreamReader<int>::result_type {
+    EXPECT_EQ(internal::CurrentOptions().get<StringOption>(), "OneElement");
     if (counter++ < 1) return 42;
     return Status{};
   };
 
+  internal::OptionsSpan span(Options{}.set<StringOption>("OneElement"));
   StreamRange<int> sr = internal::MakeStreamRange<int>(std::move(reader));
   auto it = sr.begin();
   EXPECT_NE(it, sr.end());
@@ -71,9 +78,11 @@ TEST(StreamRange, OneElement) {
 
 TEST(StreamRange, OneError) {
   auto reader = []() -> internal::StreamReader<int>::result_type {
+    EXPECT_EQ(internal::CurrentOptions().get<StringOption>(), "OneError");
     return Status(StatusCode::kUnknown, "oops");
   };
 
+  internal::OptionsSpan span(Options{}.set<StringOption>("OneError"));
   StreamRange<int> sr = internal::MakeStreamRange<int>(std::move(reader));
   auto it = sr.begin();
   EXPECT_NE(it, sr.end());
@@ -86,10 +95,12 @@ TEST(StreamRange, OneError) {
 TEST(StreamRange, FiveElements) {
   auto counter = 0;
   auto reader = [&counter]() -> internal::StreamReader<int>::result_type {
+    EXPECT_EQ(internal::CurrentOptions().get<StringOption>(), "FiveElements");
     if (counter++ < 5) return counter;
     return Status{};
   };
 
+  internal::OptionsSpan span(Options{}.set<StringOption>("FiveElements"));
   StreamRange<int> sr = internal::MakeStreamRange<int>(std::move(reader));
   std::vector<int> v;
   for (StatusOr<int>& x : sr) {
@@ -102,10 +113,13 @@ TEST(StreamRange, FiveElements) {
 TEST(StreamRange, PostFixIteration) {
   auto counter = 0;
   auto reader = [&counter]() -> internal::StreamReader<int>::result_type {
+    EXPECT_EQ(internal::CurrentOptions().get<StringOption>(),
+              "PostFixIteration");
     if (counter++ < 5) return counter;
     return Status{};
   };
 
+  internal::OptionsSpan span(Options{}.set<StringOption>("PostFixIteration"));
   StreamRange<int> sr = internal::MakeStreamRange<int>(std::move(reader));
   std::vector<int> v;
   // NOLINTNEXTLINE(modernize-loop-convert)
@@ -123,8 +137,10 @@ TEST(StreamRange, Distance) {
 
   // Range of one element
   auto counter = 0;
+  internal::OptionsSpan span1(Options{}.set<StringOption>("Distance1"));
   StreamRange<int> one = internal::MakeStreamRange<int>(
       [&counter]() -> internal::StreamReader<int>::result_type {
+        EXPECT_EQ(internal::CurrentOptions().get<StringOption>(), "Distance1");
         if (counter++ < 1) return counter;
         return Status{};
       });
@@ -132,8 +148,10 @@ TEST(StreamRange, Distance) {
 
   // Range of five elements
   counter = 0;
+  internal::OptionsSpan span5(Options{}.set<StringOption>("Distance5"));
   StreamRange<int> five = internal::MakeStreamRange<int>(
       [&counter]() -> internal::StreamReader<int>::result_type {
+        EXPECT_EQ(internal::CurrentOptions().get<StringOption>(), "Distance5");
         if (counter++ < 5) return counter;
         return Status{};
       });
@@ -143,10 +161,12 @@ TEST(StreamRange, Distance) {
 TEST(StreamRange, StreamError) {
   auto counter = 0;
   auto reader = [&counter]() -> internal::StreamReader<int>::result_type {
+    EXPECT_EQ(internal::CurrentOptions().get<StringOption>(), "StreamError");
     if (counter++ < 2) return counter;
     return Status(StatusCode::kUnknown, "oops");
   };
 
+  internal::OptionsSpan span5(Options{}.set<StringOption>("StreamError"));
   StreamRange<int> sr = internal::MakeStreamRange<int>(std::move(reader));
 
   auto it = sr.begin();


### PR DESCRIPTION
Save the options in force during `StreamRange<T>` construction,
and then restore them over `internal::StreamReader<T>` callbacks.
This means that streaming/paginated operations will have the right
options installed during all their RPCs.

As well as adding tests to check this behavior for `StreamRange`
and `MakePaginationRange`, also add checks to verify the matching,
existing behavior for `RetryLoop`, `AsyncLongRunningOperation`,
and `AsyncPollingLoop`.

Fixes #8248.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8256)
<!-- Reviewable:end -->
