### PR TITLE
fix: correct uses of `target_compatible_with`

### DIFF
--- a/bazel/google_cloud_cpp_deps.bzl
+++ b/bazel/google_cloud_cpp_deps.bzl
@@ -26,6 +26,17 @@ def google_cloud_cpp_deps():
     override the version of the dependencies they want to use.
     """
 
+    # Load platforms, we use it directly
+    if "platforms" not in native.existing_rules():
+        http_archive(
+            name = "platforms",
+            urls = [
+                "https://mirror.bazel.build/github.com/bazelbuild/platforms/releases/download/0.0.4/platforms-0.0.4.tar.gz",
+                "https://github.com/bazelbuild/platforms/releases/download/0.0.4/platforms-0.0.4.tar.gz",
+            ],
+            sha256 = "079945598e4b6cc075846f7fd6a9d0857c33a7afc0de868c2ccb96405225135d",
+        )
+
     # Load rules_cc, used by googletest
     if "rules_cc" not in native.existing_rules():
         http_archive(

--- a/google/cloud/asset/BUILD.bazel
+++ b/google/cloud/asset/BUILD.bazel
@@ -34,11 +34,11 @@ cc_library(
         include = [HEADER_GLOB],
         exclude = [MOCK_HEADER_GLOB],
     ),
-    # TODO(8145): Enable on macOS.
-    target_compatible_with = [
-        "@platforms//os:linux",
-        "@platforms//os:windows",
-    ],
+    # TODO(#8145): Enable on macOS.
+    target_compatible_with = select({
+        "@platforms//os:macos": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
     visibility = ["//:__pkg__"],
     deps = [
         "//google/cloud:google_cloud_cpp_common",
@@ -55,11 +55,6 @@ cc_library(
     hdrs = glob(
         include = [MOCK_HEADER_GLOB],
     ),
-    # TODO(8145): Enable on macOS.
-    target_compatible_with = [
-        "@platforms//os:linux",
-        "@platforms//os:windows",
-    ],
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_asset",

--- a/google/cloud/asset/BUILD.bazel
+++ b/google/cloud/asset/BUILD.bazel
@@ -34,9 +34,10 @@ cc_library(
         include = [HEADER_GLOB],
         exclude = [MOCK_HEADER_GLOB],
     ),
-    # TODO(#8145): Enable on macOS.
+    # TODO(#8145): Enable on macOS and windows.
     target_compatible_with = select({
         "@platforms//os:macos": ["@platforms//:incompatible"],
+        "@platforms//os:windows": ["@platforms//:incompatible"],
         "//conditions:default": [],
     }),
     visibility = ["//:__pkg__"],

--- a/google/cloud/assuredworkloads/BUILD.bazel
+++ b/google/cloud/assuredworkloads/BUILD.bazel
@@ -34,11 +34,11 @@ cc_library(
         include = [HEADER_GLOB],
         exclude = [MOCK_HEADER_GLOB],
     ),
-    # TODO(#8198): Re-enable the macos build.
-    target_compatible_with = [
-        "@platforms//os:linux",
-        "@platforms//os:macos",
-    ],
+    # TODO(#8198): Re-enable the Windows build.
+    target_compatible_with = select({
+        "@platforms//os:windows": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
     visibility = ["//:__pkg__"],
     deps = [
         "//google/cloud:google_cloud_cpp_common",

--- a/google/cloud/channel/BUILD.bazel
+++ b/google/cloud/channel/BUILD.bazel
@@ -34,9 +34,10 @@ cc_library(
         include = [HEADER_GLOB],
         exclude = [MOCK_HEADER_GLOB],
     ),
-    # TODO(#8125): Re-enable the macos build.
+    # TODO(#8125): Re-enable the macos and Windows builds.
     target_compatible_with = select({
         "@platforms//os:macos": ["@platforms//:incompatible"],
+        "@platforms//os:windows": ["@platforms//:incompatible"],
         "//conditions:default": [],
     }),
     visibility = ["//:__pkg__"],

--- a/google/cloud/channel/BUILD.bazel
+++ b/google/cloud/channel/BUILD.bazel
@@ -34,11 +34,11 @@ cc_library(
         include = [HEADER_GLOB],
         exclude = [MOCK_HEADER_GLOB],
     ),
-    # TODO(8125): Re-enable the macos build.
-    target_compatible_with = [
-        "@platforms//os:linux",
-        "@platforms//os:windows",
-    ],
+    # TODO(#8125): Re-enable the macos build.
+    target_compatible_with = select({
+        "@platforms//os:macos": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
     visibility = ["//:__pkg__"],
     deps = [
         "//google/cloud:google_cloud_cpp_common",


### PR DESCRIPTION
Perhaps misleadingly, the list of constraints provided to
`target_compatible_with` form a conjunction: all these constraints must
be satisfied for the rule to be compatible:

> A list of constraint_values that **must** be present

https://docs.bazel.build/versions/main/be/common-definitions.html#common.target_compatible_with

What wanted to do in all cases was to exclude one platform, and
fortunately Bazel provides `@platforms//:incompatible` for that purpose.

Part of the work for #7936

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8257)
<!-- Reviewable:end -->
