### PR TITLE
ci: pass the --disable-pip-version-check flag to "pip install"

### DIFF
--- a/ci/cloudbuild/builds/lib/integration.sh
+++ b/ci/cloudbuild/builds/lib/integration.sh
@@ -22,14 +22,14 @@ if ((CI_CLOUDBUILD_BUILDS_LIB_INTEGRATION_SH__++ != 0)); then
   return 0
 fi # include guard
 
-source module ci/lib/io.sh
 source module ci/etc/integration-tests-config.sh
 source module ci/lib/io.sh
 
 # To run the integration tests we need to install the dependencies for the storage emulator
 export PATH="${HOME}/.local/bin:${PATH}"
 python3 -m pip uninstall -y --quiet googleapis-storage-testbench
-python3 -m pip install --upgrade --user --quiet "git+https://github.com/googleapis/storage-testbench@v0.14.0"
+python3 -m pip install --upgrade --user --quiet --disable-pip-version-check \
+  "git+https://github.com/googleapis/storage-testbench@v0.14.0"
 
 # Some of the tests will need a valid roots.pem file.
 rm -f /dev/shm/roots.pem

--- a/ci/cloudbuild/builds/publish-docs.sh
+++ b/ci/cloudbuild/builds/publish-docs.sh
@@ -67,9 +67,15 @@ cmake -GNinja "${doc_args[@]}" -S . -B cmake-out
 cmake --build cmake-out --target google-cloud-cpp-protos
 cmake --build cmake-out --target doxygen-docs
 
-io::log_h2 "Installing the docuploader package $(date)"
-python3 -m pip install --user gcp-docuploader protobuf \
-  --upgrade --no-warn-script-location
+if [[ "${PROJECT_ID:-}" != "cloud-cpp-testing-resources" ]]; then
+  io::log_h2 "Skipping upload of docs," \
+    "which can only be done in GCB project 'cloud-cpp-testing-resources'"
+  exit 0
+fi
+
+io::log_h2 "Installing the docuploader package"
+python3 -m pip install --upgrade --user --quiet --disable-pip-version-check \
+  --no-warn-script-location gcp-docuploader protobuf
 
 # For docuploader to work
 export LC_ALL=C.UTF-8
@@ -94,12 +100,6 @@ function upload_docs() {
     --language cpp
   env -C "${docs_dir}" python3 -m docuploader upload . --staging-bucket "${bucket}"
 }
-
-if [[ "${PROJECT_ID:-}" != "cloud-cpp-testing-resources" ]]; then
-  io::log_h2 "Skipping upload of docs," \
-    "which can only be done in GCB project 'cloud-cpp-testing-resources'"
-  exit 0
-fi
 
 io::log_h2 "Publishing docs"
 io::log "version: ${version}"


### PR DESCRIPTION
To continue the effort to eliminate uninteresting build output,
and particularly when it is highlighted somehow, quash the "You
are using pip version X; however, version Y is available" warning.

Also, we might as well skip installing the docuploader package
when we're going to skip uploading the docs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8261)
<!-- Reviewable:end -->
