### PR TITLE
ci: silence storage testbench set up

### DIFF
--- a/ci/lib/run_gcs_httpbin_emulator_utils.sh
+++ b/ci/lib/run_gcs_httpbin_emulator_utils.sh
@@ -113,3 +113,18 @@ start_emulator() {
   fi
   export CLOUD_STORAGE_GRPC_ENDPOINT="localhost:${grpc_port}"
 }
+
+# Create the testbench resources used in integration tests
+#
+# The google/cloud/storage integration tests assume that some resources already
+# exist in the testbench (or production). This function creates the resources.
+create_testbench_resources() {
+  printf '{"name": "%s"}' "${GOOGLE_CLOUD_CPP_STORAGE_TEST_BUCKET_NAME}" |
+    curl -s -o /dev/null -X POST --data-binary @- \
+      -H "Content-Type: application/json" \
+      "${CLOUD_STORAGE_EMULATOR_ENDPOINT}/storage/v1/b?project=${GOOGLE_CLOUD_PROJECT}"
+  printf '{"name": "%s"}' "${GOOGLE_CLOUD_CPP_STORAGE_TEST_DESTINATION_BUCKET_NAME}" |
+    curl -s -o /dev/null -X POST --data-binary @- \
+      -H "Content-Type: application/json" \
+      "${CLOUD_STORAGE_EMULATOR_ENDPOINT}/storage/v1/b?project=${GOOGLE_CLOUD_PROJECT}"
+}

--- a/google/cloud/storage/ci/run_integration_tests_emulator_bazel.sh
+++ b/google/cloud/storage/ci/run_integration_tests_emulator_bazel.sh
@@ -77,13 +77,8 @@ for target in "${production_only_targets[@]}"; do
   excluded_targets+=("-${target}")
 done
 
-# Create the test buckets in the emulator:
-printf '{"name": "%s"}' "${GOOGLE_CLOUD_CPP_STORAGE_TEST_BUCKET_NAME}" |
-  curl -X POST -H "Content-Type: application/json" --data-binary @- \
-    "${CLOUD_STORAGE_EMULATOR_ENDPOINT}/storage/v1/b?project=${GOOGLE_CLOUD_PROJECT}"
-printf '{"name": "%s"}' "${GOOGLE_CLOUD_CPP_STORAGE_TEST_DESTINATION_BUCKET_NAME}" |
-  curl -X POST -H "Content-Type: application/json" --data-binary @- \
-    "${CLOUD_STORAGE_EMULATOR_ENDPOINT}/storage/v1/b?project=${GOOGLE_CLOUD_PROJECT}"
+# Create any GCS resources needed to run the tests
+create_testbench_resources
 
 # This is just the SHA for the *description* of the testbench, it includes its
 # version and other info, but no details about the contents.

--- a/google/cloud/storage/ci/run_integration_tests_emulator_cmake.sh
+++ b/google/cloud/storage/ci/run_integration_tests_emulator_cmake.sh
@@ -36,13 +36,8 @@ ctest_args=("$@")
 cd "${BINARY_DIR}"
 start_emulator
 
-# Create the test buckets in the emulator:
-printf '{"name": "%s"}' "${GOOGLE_CLOUD_CPP_STORAGE_TEST_BUCKET_NAME}" |
-  curl -X POST -H "Content-Type: application/json" --data-binary @- \
-    "${CLOUD_STORAGE_EMULATOR_ENDPOINT}/storage/v1/b?project=${GOOGLE_CLOUD_PROJECT}"
-printf '{"name": "%s"}' "${GOOGLE_CLOUD_CPP_STORAGE_TEST_DESTINATION_BUCKET_NAME}" |
-  curl -s -X POST -H "Content-Type: application/json" --data-binary @- \
-    "${CLOUD_STORAGE_EMULATOR_ENDPOINT}/storage/v1/b?project=${GOOGLE_CLOUD_PROJECT}"
+# Create any GCS resources needed to run the tests
+create_testbench_resources
 
 ctest -R "^storage_" "${ctest_args[@]}"
 exit_status=$?


### PR DESCRIPTION
We use `curl` to create a couple of buckets in the storage testbench.
With this change the curl invocations are silent on success.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8262)
<!-- Reviewable:end -->
