### PR TITLE
chore: gitignore .cache dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ cmake-out/
 # Used by some IDEs and LSP plugins
 compile_commands.json
 
+# clangd writes index files here
+.cache
+
 # Backup files for Emacs
 *~
 


### PR DESCRIPTION
This directory is created by clangd when indexing source code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8263)
<!-- Reviewable:end -->
