### PR TITLE
chore: upgrade and fix typos-cli

### DIFF
--- a/ci/cloudbuild/builds/checkers.sh
+++ b/ci/cloudbuild/builds/checkers.sh
@@ -121,7 +121,7 @@ time {
   # Removes trailing whitespace on lines
   expressions=("-e" "'s/[[:blank:]]\+$//'")
   # Removes trailing blank lines (see http://sed.sourceforge.net/sed1line.txt)
-  expressions+=("-e" "':a;/^\n*$/{\$d;N;ba;}'")
+  expressions+=("-e" "':x;/^\n*$/{\$d;N;bx;}'")
   git ls-files -z | grep -zv '\.gz$' |
     (xargs -P "$(nproc)" -n 50 -0 grep -ZPL "\b[D]O NOT EDIT\b" || true) |
     xargs -P "$(nproc)" -n 50 -0 bash -c "sed_edit ${expressions[*]} \"\$0\" \"\$@\""

--- a/ci/cloudbuild/dockerfiles/checkers.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/checkers.Dockerfile
@@ -40,4 +40,4 @@ RUN pip3 install --upgrade pip
 RUN pip3 install cmake_format==0.6.8
 RUN pip3 install black==19.3b0
 
-RUN cargo install typos-cli --version 1.3.1 --root /usr/local
+RUN cargo install typos-cli --version 1.3.9 --root /usr/local


### PR DESCRIPTION
This upgrades us to the newest version of typos-cli. The previous
version we were using (1.3.1) was also broken, but we didn't notice
because I think all of our `gcb-checkers` docker images had an old
version that worked. Aside: I think somehow the cached docker images
don't get invalidated properly.

Anyway, the string "ba" showed up as a typo (in the old and new
version). I changed it to "bx", which I think makes the word weird
enough that `typos` doesn't flag it as a typo. I also upgrade to a newer
version of typos to make sure all the docker images get rebuilt.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8267)
<!-- Reviewable:end -->
