### PR TITLE
fix(rest): correct detection of all headers received

### DIFF
--- a/google/cloud/internal/curl_impl.h
+++ b/google/cloud/internal/curl_impl.h
@@ -150,7 +150,6 @@ class CurlImpl {
   bool paused_;
 
   // Track when status and headers from the response are received.
-  bool status_line_received_;
   bool all_headers_received_;
 
   // Track the usage of the buffer provided to Read.


### PR DESCRIPTION
Instead of trying detect by ourselves when the status and all headers have been received, rely on libcurl to signal that via the first call to WriteCallback. libcurl will invoke HeaderCallback up until that point.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8268)
<!-- Reviewable:end -->
