### PR TITLE
chore: allow short identifiers

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -55,6 +55,7 @@ Checks: >
   -modernize-avoid-c-arrays,
   -performance-move-const-arg,
   -readability-braces-around-statements,
+  -readability-identifier-length,
   -readability-magic-numbers,
   -readability-named-parameter,
   -readability-redundant-declaration,


### PR DESCRIPTION
Newer versions of clang-tidy include the
`readability-identifier-length`, which complains if identifiers names
are too short. This is really annoying and it would warn us on things
like:

```cc
auto x = 123;
```

This needs to be disabled.

https://clang.llvm.org/extra/clang-tidy/checks/readability-identifier-length.html#:~:text=This%20check%20finds%20variables%20and,and%20for%20exception%20variable%20names.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8269)
<!-- Reviewable:end -->
