### PR TITLE
feat(GCS+gRPC): implement `UpdateObject()`

### DIFF
--- a/google/cloud/storage/internal/grpc_client_test.cc
+++ b/google/cloud/storage/internal/grpc_client_test.cc
@@ -258,7 +258,7 @@ TEST(GrpcClient, DeleteObject) {
   EXPECT_EQ(response.status(), PermanentError());
 }
 
-TEST(GrpcClient, Update) {
+TEST(GrpcClient, UpdateObject) {
   auto mock = std::make_shared<testing::MockStorageStub>();
   EXPECT_CALL(*mock, UpdateObject)
       .WillOnce([](grpc::ClientContext& context,
@@ -276,7 +276,7 @@ TEST(GrpcClient, Update) {
   auto response = client->UpdateObject(
       UpdateObjectRequest("test-bucket", "test-object",
                           // Typically, the metadata is first read from the
-                          // service as part of an OCC loop, for this test, just
+                          // service as part of an OCC loop. For this test, just
                           // use the default values for all fields
                           ObjectMetadata{})
           .set_multiple_options(Fields("field1,field2"),

--- a/google/cloud/storage/internal/grpc_object_request_parser.cc
+++ b/google/cloud/storage/internal/grpc_object_request_parser.cc
@@ -407,10 +407,8 @@ GrpcObjectRequestParser::ToProto(UpdateObjectRequest const& request) {
   object.set_content_language(request.metadata().content_language());
   result.mutable_update_mask()->add_paths("content_type");
   object.set_content_type(request.metadata().content_type());
-
   result.mutable_update_mask()->add_paths("event_based_hold");
   object.set_event_based_hold(request.metadata().event_based_hold());
-
   result.mutable_update_mask()->add_paths("temporary_hold");
   object.set_temporary_hold(request.metadata().temporary_hold());
 

--- a/google/cloud/storage/internal/grpc_object_request_parser.cc
+++ b/google/cloud/storage/internal/grpc_object_request_parser.cc
@@ -364,6 +364,59 @@ GrpcObjectRequestParser::ToProto(PatchObjectRequest const& request) {
   return result;
 }
 
+StatusOr<google::storage::v2::UpdateObjectRequest>
+GrpcObjectRequestParser::ToProto(UpdateObjectRequest const& request) {
+  google::storage::v2::UpdateObjectRequest result;
+  auto status = SetCommonObjectParameters(result, request);
+  if (!status.ok()) return status;
+  SetGenerationConditions(result, request);
+  SetMetagenerationConditions(result, request);
+  SetCommonParameters(result, request);
+  SetPredefinedAcl(result, request);
+
+  auto& object = *result.mutable_object();
+  object.set_bucket("projects/_/buckets/" + request.bucket_name());
+  object.set_name(request.object_name());
+  object.set_generation(request.GetOption<Generation>().value_or(0));
+
+  result.mutable_update_mask()->add_paths("acl");
+  for (auto const& a : request.metadata().acl()) {
+    *object.add_acl() = GrpcObjectAccessControlParser::ToProto(a);
+  }
+
+  // The semantics in gRPC are to replace any metadata attributes
+  result.mutable_update_mask()->add_paths("metadata");
+  for (auto const& kv : request.metadata().metadata()) {
+    (*object.mutable_metadata())[kv.first] = kv.second;
+  }
+
+  if (request.metadata().has_custom_time()) {
+    result.mutable_update_mask()->add_paths("custom_time");
+    *object.mutable_custom_time() = google::cloud::internal::ToProtoTimestamp(
+        request.metadata().custom_time());
+  }
+
+  // We need to check each modifiable field.
+  result.mutable_update_mask()->add_paths("cache_control");
+  object.set_cache_control(request.metadata().cache_control());
+  result.mutable_update_mask()->add_paths("content_disposition");
+  object.set_content_disposition(request.metadata().content_disposition());
+  result.mutable_update_mask()->add_paths("content_encoding");
+  object.set_content_encoding(request.metadata().content_encoding());
+  result.mutable_update_mask()->add_paths("content_language");
+  object.set_content_language(request.metadata().content_language());
+  result.mutable_update_mask()->add_paths("content_type");
+  object.set_content_type(request.metadata().content_type());
+
+  result.mutable_update_mask()->add_paths("event_based_hold");
+  object.set_event_based_hold(request.metadata().event_based_hold());
+
+  result.mutable_update_mask()->add_paths("temporary_hold");
+  object.set_temporary_hold(request.metadata().temporary_hold());
+
+  return result;
+}
+
 StatusOr<google::storage::v2::WriteObjectRequest>
 GrpcObjectRequestParser::ToProto(InsertObjectMediaRequest const& request) {
   google::storage::v2::WriteObjectRequest r;

--- a/google/cloud/storage/internal/grpc_object_request_parser.h
+++ b/google/cloud/storage/internal/grpc_object_request_parser.h
@@ -41,6 +41,8 @@ struct GrpcObjectRequestParser {
 
   static StatusOr<google::storage::v2::UpdateObjectRequest> ToProto(
       PatchObjectRequest const& request);
+  static StatusOr<google::storage::v2::UpdateObjectRequest> ToProto(
+      UpdateObjectRequest const& request);
 
   static StatusOr<google::storage::v2::WriteObjectRequest> ToProto(
       InsertObjectMediaRequest const& request);

--- a/google/cloud/storage/internal/grpc_object_request_parser_test.cc
+++ b/google/cloud/storage/internal/grpc_object_request_parser_test.cc
@@ -359,6 +359,78 @@ TEST(GrpcObjectRequestParser, PatchObjectRequestAllOptions) {
   EXPECT_THAT(*actual, IsProtoEqual(expected));
 }
 
+TEST(GrpcObjectRequestParser, UpdateObjectRequestAllOptions) {
+  google::storage::v2::UpdateObjectRequest expected;
+  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(
+      R"pb(
+        object {
+          bucket: "projects/_/buckets/bucket-name"
+          name: "object-name"
+          generation: 7
+          acl { entity: "allUsers" role: "READER" }
+          content_encoding: "test-only-content-encoding"
+          content_disposition: "test-only-content-disposition"
+          cache_control: "test-only-cache-control"
+          content_language: "test-only-content-language"
+          content_type: "test-only-content-type"
+          temporary_hold: true
+          metadata { key: "key0" value: "value0" }
+          event_based_hold: true
+          custom_time { seconds: 1643126687 nanos: 123000000 }
+        }
+        predefined_acl: OBJECT_ACL_PROJECT_PRIVATE
+        if_generation_match: 1
+        if_generation_not_match: 2
+        if_metageneration_match: 3
+        if_metageneration_not_match: 4
+        common_object_request_params: {
+          encryption_algorithm: "AES256"
+          encryption_key_bytes: "01234567"
+          encryption_key_sha256_bytes: "\222E\222\271\261\003\361O\203?\252\373g\364\200i\037\001\230\212\244W\300\006\027i\365\214\324s\021\274"
+        }
+        common_request_params: { user_project: "test-user-project" }
+        update_mask {}
+      )pb",
+      &expected));
+
+  UpdateObjectRequest req(
+      "bucket-name", "object-name",
+      ObjectMetadata{}
+          .set_acl(
+              {ObjectAccessControl{}.set_entity("allUsers").set_role("READER")})
+          .set_content_encoding("test-only-content-encoding")
+          .set_content_disposition("test-only-content-disposition")
+          .set_cache_control("test-only-cache-control")
+          .set_content_language("test-only-content-language")
+          .set_content_type("test-only-content-type")
+          .upsert_metadata("key0", "value0")
+          .set_temporary_hold(true)
+          .set_event_based_hold(true)
+          .set_custom_time(std::chrono::system_clock::time_point{} +
+                           std::chrono::seconds(1643126687) +
+                           std::chrono::milliseconds(123)));
+  req.set_multiple_options(
+      Generation(7), IfGenerationMatch(1), IfGenerationNotMatch(2),
+      IfMetagenerationMatch(3), IfMetagenerationNotMatch(4),
+      PredefinedAcl("projectPrivate"), EncryptionKey::FromBinaryKey("01234567"),
+      Projection("full"), UserProject("test-user-project"),
+      QuotaUser("test-quota-user"), UserIp("test-user-ip"));
+
+  auto actual = GrpcObjectRequestParser::ToProto(req);
+  ASSERT_STATUS_OK(actual);
+  // First check the paths, we do not care about their order, so checking them
+  // with IsProtoEqual does not work.
+  EXPECT_THAT(
+      actual->update_mask().paths(),
+      UnorderedElementsAre("acl", "content_encoding", "content_disposition",
+                           "cache_control", "content_language", "content_type",
+                           "metadata", "temporary_hold", "event_based_hold",
+                           "custom_time"));
+  // Clear the paths, which we already compared, and test the rest
+  actual->mutable_update_mask()->clear_paths();
+  EXPECT_THAT(*actual, IsProtoEqual(expected));
+}
+
 TEST(GrpcObjectRequestParser, InsertObjectMediaRequestSimple) {
   storage_proto::WriteObjectRequest expected;
   EXPECT_TRUE(google::protobuf::TextFormat::ParseFromString(

--- a/google/cloud/storage/tests/grpc_object_metadata_integration_test.cc
+++ b/google/cloud/storage/tests/grpc_object_metadata_integration_test.cc
@@ -105,6 +105,14 @@ TEST_F(GrpcObjectMetadataIntegrationTest, ObjectMetadataCRUD) {
   ASSERT_STATUS_OK(compose);
   ScheduleForDelete(*compose);
 
+  auto custom = std::chrono::system_clock::now() + std::chrono::hours(24);
+  auto desired_metadata = ObjectMetadata(*patch).set_custom_time(custom);
+  auto updated =
+      client->UpdateObject(bucket_name, object_name, desired_metadata);
+  ASSERT_STATUS_OK(updated);
+  ASSERT_TRUE(updated->has_custom_time());
+  ASSERT_EQ(updated->custom_time(), custom);
+
   auto del = client->DeleteObject(bucket_name, object_name);
   ASSERT_STATUS_OK(del);
 


### PR DESCRIPTION
The underlying RPC is already generated, so this did not need any
changes to the `*Stub` classes.

Fixes #4196

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8278)
<!-- Reviewable:end -->
